### PR TITLE
timescaleDB: implement digital shadow tables + changes

### DIFF
--- a/deployment/factorycube-server/templates/timescale-configmap.yaml
+++ b/deployment/factorycube-server/templates/timescale-configmap.yaml
@@ -183,6 +183,7 @@ data:
     ALTER TABLE uniqueProductTable ADD IF NOT EXISTS aid TEXT NOT NULL;
     ALTER TABLE uniqueProductTable DROP IF EXISTS quality_class RESTRICT;
     ALTER TABLE uniqueProductTable RENAME COLUMN station_id TO step_id;
+    ALTER TABLE uniqueProductTable ALTER COLUMN uid TYPE SERIAL;
     ALTER TABLE uniqueProductTable ADD PRIMARY KEY (uid);
 
     -------------------- TimescaleDB table for product tags --------------------

--- a/deployment/factorycube-server/templates/timescale-configmap.yaml
+++ b/deployment/factorycube-server/templates/timescale-configmap.yaml
@@ -178,8 +178,6 @@ data:
         value                   DOUBLE PRECISION                    NULL,
         UNIQUE(uid, valueName)
     );
-    -- creating hypertable
-    SELECT create_hypertable('productTagTable', 'timestamp');
 
 
     -------------------- TimescaleDB table for product tags strings --------------------
@@ -191,8 +189,7 @@ data:
         value                   TEXT                                NULL,
         UNIQUE(uid, valueName)
     );
-    -- creating hypertable
-    SELECT create_hypertable('productTagStringTable', 'timestamp');
+
 
     -------------------- TimescaleDB table for product inheritance info --------------------
     CREATE TABLE IF NOT EXISTS productInheritanceTable
@@ -202,8 +199,7 @@ data:
         child_uid               TEXT                                REFERENCES uniqueProductTable (uid),
         UNIQUE(parent_uid, child_uid)
     );
-    -- creating hypertable
-    SELECT create_hypertable('productInheritanceTable', 'timestamp');
+
     CREATE INDEX ON productInheritanceTable (parent_uid, timestamp DESC);
     CREATE INDEX ON productInheritanceTable (child_uid, timestamp DESC);
 

--- a/deployment/factorycube-server/templates/timescale-configmap.yaml
+++ b/deployment/factorycube-server/templates/timescale-configmap.yaml
@@ -213,7 +213,7 @@ data:
     -- #74
     ALTER TABLE counttable ADD IF NOT EXISTS scrap INTEGER DEFAULT 0;
 
-    -- #??
+    -- #297
     ALTER TABLE uniqueProductTable ADD IF NOT EXISTS aid TEXT NOT NULL;
     ALTER TABLE uniqueProductTable DROP IF EXISTS quality_class RESTRICT;
     ALTER TABLE uniqueProductTable RENAME COLUMN station_id TO step_id;

--- a/deployment/factorycube-server/templates/timescale-configmap.yaml
+++ b/deployment/factorycube-server/templates/timescale-configmap.yaml
@@ -169,6 +169,22 @@ data:
         PerformanceLossStates INTEGER[] DEFAULT '{20000, 50000, 60000, 70000, 80000, 90000, 100000, 110000, 120000, 130000, 140000, 150000}'
     );
      
+
+    --- MIGRATIONS
+    -- Add here your migrations
+
+    -- #2
+    ALTER TABLE configurationTable ADD IF NOT EXISTS AutomaticallyIdentifyChangeovers BOOLEAN DEFAULT true;
+
+    -- #74
+    ALTER TABLE counttable ADD IF NOT EXISTS scrap INTEGER DEFAULT 0;
+
+    -- #297
+    ALTER TABLE uniqueProductTable ADD IF NOT EXISTS aid TEXT NOT NULL;
+    ALTER TABLE uniqueProductTable DROP IF EXISTS quality_class RESTRICT;
+    ALTER TABLE uniqueProductTable RENAME COLUMN station_id TO step_id;
+    ALTER TABLE uniqueProductTable ADD PRIMARY KEY (uid);
+
     -------------------- TimescaleDB table for product tags --------------------
     CREATE TABLE IF NOT EXISTS productTagTable
     (
@@ -202,22 +218,6 @@ data:
 
     CREATE INDEX ON productInheritanceTable (parent_uid, timestamp DESC);
     CREATE INDEX ON productInheritanceTable (child_uid, timestamp DESC);
-
-
-    --- MIGRATIONS
-    -- Add here your migrations
-
-    -- #2
-    ALTER TABLE configurationTable ADD IF NOT EXISTS AutomaticallyIdentifyChangeovers BOOLEAN DEFAULT true;
-
-    -- #74
-    ALTER TABLE counttable ADD IF NOT EXISTS scrap INTEGER DEFAULT 0;
-
-    -- #297
-    ALTER TABLE uniqueProductTable ADD IF NOT EXISTS aid TEXT NOT NULL;
-    ALTER TABLE uniqueProductTable DROP IF EXISTS quality_class RESTRICT;
-    ALTER TABLE uniqueProductTable RENAME COLUMN station_id TO step_id;
-    ALTER TABLE uniqueProductTable ADD PRIMARY KEY (uid);
 
 
     GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO {{ .Values.factoryinsight.db_user }};

--- a/deployment/factorycube-server/templates/timescale-configmap.yaml
+++ b/deployment/factorycube-server/templates/timescale-configmap.yaml
@@ -169,6 +169,31 @@ data:
         PerformanceLossStates INTEGER[] DEFAULT '{20000, 50000, 60000, 70000, 80000, 90000, 100000, 110000, 120000, 130000, 140000, 150000}'
     );
      
+    -------------------- TimescaleDB table for product tags --------------------
+    CREATE TABLE IF NOT EXISTS productTagTable
+    (
+        timestamp               TIMESTAMPTZ                         NOT NULL,
+        uid                     TEXT                                REFERENCES uniqueProductTable (uid),
+        valueName               TEXT                                NOT NULL,
+        value                   DOUBLE PRECISION                    NULL,
+        UNIQUE(uid, valueName)
+    );
+    -- creating hypertable
+    SELECT create_hypertable('productTagTable', 'timestamp');
+
+
+    -------------------- TimescaleDB table for product tags strings --------------------
+    CREATE TABLE IF NOT EXISTS productTagStringTable
+    (
+        timestamp               TIMESTAMPTZ                         NOT NULL,
+        uid                     TEXT                                REFERENCES uniqueProductTable (uid),
+        valueName               TEXT                                NOT NULL,
+        value                   TEXT                                NULL,
+        UNIQUE(uid, valueName)
+    );
+    -- creating hypertable
+    SELECT create_hypertable('productTagStringTable', 'timestamp');
+
 
     --- MIGRATIONS
     -- Add here your migrations

--- a/deployment/factorycube-server/templates/timescale-configmap.yaml
+++ b/deployment/factorycube-server/templates/timescale-configmap.yaml
@@ -194,6 +194,19 @@ data:
     -- creating hypertable
     SELECT create_hypertable('productTagStringTable', 'timestamp');
 
+    -------------------- TimescaleDB table for product inheritance info --------------------
+    CREATE TABLE IF NOT EXISTS productInheritanceTable
+    (
+        timestamp               TIMESTAMPTZ                         NOT NULL,
+        parent_uid              TEXT                                REFERENCES uniqueProductTable (uid),
+        child_uid               TEXT                                REFERENCES uniqueProductTable (uid),
+        UNIQUE(parent_uid, child_uid)
+    );
+    -- creating hypertable
+    SELECT create_hypertable('productInheritanceTable', 'timestamp');
+    CREATE INDEX ON productInheritanceTable (parent_uid, timestamp DESC);
+    CREATE INDEX ON productInheritanceTable (child_uid, timestamp DESC);
+
 
     --- MIGRATIONS
     -- Add here your migrations

--- a/deployment/factorycube-server/templates/timescale-configmap.yaml
+++ b/deployment/factorycube-server/templates/timescale-configmap.yaml
@@ -190,33 +190,35 @@ data:
     CREATE TABLE IF NOT EXISTS productTagTable
     (
         timestamp               TIMESTAMPTZ                         NOT NULL,
-        uid                     TEXT                                REFERENCES uniqueProductTable (uid),
+        product_uid             SERIAL                              REFERENCES uniqueProductTable (uid),
         valueName               TEXT                                NOT NULL,
         value                   DOUBLE PRECISION                    NULL,
-        UNIQUE(uid, valueName)
+        UNIQUE(product_uid, valueName)
     );
-
+    -- creating hypertable
+    SELECT create_hypertable('productTagTable', 'product_uid', chunk_time_interval => 100000);
 
     -------------------- TimescaleDB table for product tags strings --------------------
     CREATE TABLE IF NOT EXISTS productTagStringTable
     (
         timestamp               TIMESTAMPTZ                         NOT NULL,
-        uid                     TEXT                                REFERENCES uniqueProductTable (uid),
+        product_uid             SERIAL                              REFERENCES uniqueProductTable (uid),
         valueName               TEXT                                NOT NULL,
         value                   TEXT                                NULL,
-        UNIQUE(uid, valueName)
+        UNIQUE(product_uid, valueName)
     );
-
+    -- creating hypertable
+    SELECT create_hypertable('productTagStringTable', 'product_uid', chunk_time_interval => 100000);
 
     -------------------- TimescaleDB table for product inheritance info --------------------
     CREATE TABLE IF NOT EXISTS productInheritanceTable
     (
         timestamp               TIMESTAMPTZ                         NOT NULL,
-        parent_uid              TEXT                                REFERENCES uniqueProductTable (uid),
-        child_uid               TEXT                                REFERENCES uniqueProductTable (uid),
+        parent_uid              SERIAL                                REFERENCES uniqueProductTable (uid),
+        child_uid               SERIAL                                REFERENCES uniqueProductTable (uid),
         UNIQUE(parent_uid, child_uid)
     );
-
+    -- creating hypertable
     CREATE INDEX ON productInheritanceTable (parent_uid, timestamp DESC);
     CREATE INDEX ON productInheritanceTable (child_uid, timestamp DESC);
 

--- a/deployment/factorycube-server/templates/timescale-configmap.yaml
+++ b/deployment/factorycube-server/templates/timescale-configmap.yaml
@@ -221,6 +221,7 @@ data:
     ALTER TABLE uniqueProductTable ADD IF NOT EXISTS aid TEXT NOT NULL;
     ALTER TABLE uniqueProductTable DROP IF EXISTS quality_class RESTRICT;
     ALTER TABLE uniqueProductTable RENAME COLUMN station_id TO step_id;
+    ALTER TABLE uniqueProductTablev ADD PRIMARY KEY (uid);
 
 
     GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO {{ .Values.factoryinsight.db_user }};

--- a/deployment/factorycube-server/templates/timescale-configmap.yaml
+++ b/deployment/factorycube-server/templates/timescale-configmap.yaml
@@ -221,7 +221,7 @@ data:
     ALTER TABLE uniqueProductTable ADD IF NOT EXISTS aid TEXT NOT NULL;
     ALTER TABLE uniqueProductTable DROP IF EXISTS quality_class RESTRICT;
     ALTER TABLE uniqueProductTable RENAME COLUMN station_id TO step_id;
-    ALTER TABLE uniqueProductTablev ADD PRIMARY KEY (uid);
+    ALTER TABLE uniqueProductTable ADD PRIMARY KEY (uid);
 
 
     GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO {{ .Values.factoryinsight.db_user }};

--- a/deployment/factorycube-server/templates/timescale-configmap.yaml
+++ b/deployment/factorycube-server/templates/timescale-configmap.yaml
@@ -178,7 +178,13 @@ data:
 
     -- #74
     ALTER TABLE counttable ADD IF NOT EXISTS scrap INTEGER DEFAULT 0;
-    
+
+    -- #??
+    ALTER TABLE uniqueProductTable ADD IF NOT EXISTS aid TEXT NOT NULL;
+    ALTER TABLE uniqueProductTable DROP IF EXISTS quality_class RESTRICT;
+    ALTER TABLE uniqueProductTable RENAME COLUMN station_id TO step_id;
+
+
     GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO {{ .Values.factoryinsight.db_user }};
     GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO {{ .Values.factoryinsight.db_user }};
 


### PR DESCRIPTION
Fixes issue #396 
*Not ready yet!*


General issue: digital shadow: #297.


**Open questions:**
- `#??` -> what number should be directly over the `ALTER TABLE` statements?
- `uid` in `uniqueProductTable` is `TEXT` type. Is that correct (not `SERIAL`)?
- For the productTag tables I only used the `SELECT create_hypertable` function. Should I also index them?


![timescaleDB_image](https://user-images.githubusercontent.com/87082063/127497171-506783b6-774c-40ae-9973-ea085f630cf3.png)
