### PR TITLE
409 add cameraconnect mqtt message

### DIFF
--- a/cameraconnect/src/cameras.py
+++ b/cameraconnect/src/cameras.py
@@ -94,7 +94,8 @@ class CamGeneral(ABC):
             {
             'timestamp_ms': timestamp_ms,
             'image':
-                    {'image_bytes': encoded_image,
+                    {'image_id':"<mac_address>_<timestamp>"
+                    'image_bytes': encoded_image,
                     'image_height': image.shape[0],
                     'image_width': image.shape[1],
                     'image_channels':image.shape[2]},
@@ -126,10 +127,11 @@ class CamGeneral(ABC):
         prepared_message = {
             'timestamp_ms': str(timestamp_ms),
             'image':
-                {'image_bytes': encoded_image,
-                 'image_height': image.shape[0],
-                 'image_width': image.shape[1],
-                 'image_channels': image.shape[2]},
+                {'image_id':(str(self.mac_address)+"_"+str(timestamp_ms)),
+                'image_bytes': encoded_image,
+                'image_height': image.shape[0],
+                'image_width': image.shape[1],
+                'image_channels': image.shape[2]},
         }
 
         # Get json formatted string, convert python object into

--- a/docs/content/en/docs/Concepts/mqtt/index.md
+++ b/docs/content/en/docs/Concepts/mqtt/index.md
@@ -48,9 +48,9 @@ This means that the transmitter with the serial number `2020-0102` has one ifm g
 ### Topic: `ia/rawImage/`
 All raw data coming in via [cameraconnect].
 
-Topic structure: `ia/rawImage/<TransmitterID>/<SerialNumberCamera>`
+Topic structure: `ia/rawImage/<TransmitterID>/<MAC Adress of Camera>`
 
-`image_id:` a unique identifier for every image acquired
+`image_id:` a unique identifier for every image acquired\
 `image_bytes:` base64 encoded image in JPG format in bytes\
 `image_height:` height of the image in pixel\
 `image_width:` width of the image in pixel\
@@ -65,7 +65,7 @@ This means that the transmitter with the serial number 2020-0102 has one camera 
 {
 	"timestamp_ms": 214423040823,
 	"image":  {
-		"image_id": "<SerialNumberCamera>_<timestamp_ms>",
+		"image_id": "<MACaddress>_<timestamp_ms>",
 		"image_bytes": 3495ask484...,
 		"image_heigth": 800,
 		"image_width": 1203,


### PR DESCRIPTION
Fixes #409

1. added image_id to mqtt message 
2. adjusted docs

Serial number of cameras will not be used anymore, only mac address