### PR TITLE
Revert "471 fixed busybox not being available after reboot"

### DIFF
--- a/deployment/factorycube-server/values.yaml
+++ b/deployment/factorycube-server/values.yaml
@@ -1019,7 +1019,6 @@ grafana:
     - /bin/sh
     - -c
     image: busybox
-    pullPolicy: IfNotPresent
     name: init-umh-datasource
     volumeMounts:
     - mountPath: /var/lib/grafana


### PR DESCRIPTION
Reverts united-manufacturing-hub/united-manufacturing-hub#602

Apparently "pullPolicy" is not available for extraInitContainers

```
Error: UPGRADE FAILED: error validating "": error validating data: ValidationError(Deployment.spec.template.spec.initContainers[0]): unknown field "pullPolicy" in io.k8s.api.core.v1.Container
```