### PR TITLE
feat: Added function for easy backoff calculation

### DIFF
--- a/golang/go.mod
+++ b/golang/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/prometheus/client_golang v1.11.0
 	github.com/rung/go-safecast v1.0.1
+	github.com/sbinet/go-gnuplot v0.0.0-20130514120836-9167d8eb1ac4
 	github.com/syndtr/goleveldb v1.0.0 // indirect
 	github.com/uber/jaeger-client-go v2.29.1+incompatible
 	go.uber.org/zap v1.19.1

--- a/golang/go.sum
+++ b/golang/go.sum
@@ -189,6 +189,8 @@ github.com/prometheus/procfs v0.6.0 h1:mxy4L2jP6qMonqmq+aTtOx1ifVWUgG/TAmntgbh3x
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/rung/go-safecast v1.0.1 h1:7rkt2qO4JGdOkWKdPEBFLaEwQy20y0IhhWJNFxmH0p0=
 github.com/rung/go-safecast v1.0.1/go.mod h1:dzUcUS2UMtbfVc7w6mx/Ur3UYcpXEZC+WilISksJ4P8=
+github.com/sbinet/go-gnuplot v0.0.0-20130514120836-9167d8eb1ac4 h1:DjPYuV8FWDg57bkdJ2DQUB6PMQJUapXdJ1uCvPC7XT0=
+github.com/sbinet/go-gnuplot v0.0.0-20130514120836-9167d8eb1ac4/go.mod h1:cBjaN6xLFdcYFeCkvNXnUCPPeHA23BR6Yg6liSwsLjE=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=

--- a/golang/internal/exponential_backoff.go
+++ b/golang/internal/exponential_backoff.go
@@ -1,0 +1,41 @@
+package internal
+
+import (
+	"math/rand"
+	"time"
+)
+
+const Int64Max = 1<<63 - 1
+
+func GetBackoffTime(retries int64, slotTime time.Duration, maximum time.Duration) (backoff time.Duration) {
+
+	defer func() {
+		if r := recover(); r != nil {
+			backoff = maximum
+		}
+	}()
+
+	if slotTime <= 0 || retries <= 0 {
+		return time.Duration(0)
+	}
+	//2^retries - 1
+	// -1 is ommitted here, because the random function is [min, max)
+	umax := uint64(uint64(1) << retries)
+	if umax > Int64Max || umax == 0 {
+		return maximum
+	}
+	max := int64(umax)
+	n := rand.Int63n(max)
+
+	//Prevents overflow
+	u64Time := uint64(slotTime.Nanoseconds()) * uint64(n)
+	if u64Time > Int64Max {
+		return maximum
+	}
+
+	backoff = time.Duration(n) * slotTime
+	if backoff > maximum {
+		backoff = maximum
+	}
+	return backoff
+}

--- a/golang/internal/exponential_backoff_test.go
+++ b/golang/internal/exponential_backoff_test.go
@@ -1,0 +1,41 @@
+package internal
+
+import (
+	"testing"
+	"time"
+)
+
+func TestGetBackoffTime(t *testing.T) {
+	for i := int64(0); i < 1024; i++ {
+		max := 10 * time.Second
+		btime := GetBackoffTime(i, 1*time.Nanosecond, max)
+		if btime < 0 || btime > max {
+			t.Logf("BTime: %s", btime)
+			t.Logf("I: %d", i)
+			t.FailNow()
+		}
+	}
+}
+
+func TestPlotBackoffTime(t *testing.T) {
+	/*
+		fname := ""
+		persist := false
+		debug := true
+
+		p, err := gnuplot.NewPlotter(fname, persist, debug)
+		if err != nil {
+			err_string := fmt.Sprintf("** err: %v\n", err)
+			panic(err_string)
+		}
+		defer p.Close()
+
+		p.PlotX([]float64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, "some data")
+		p.CheckedCmd("set terminal pdf")
+		p.CheckedCmd("set output 'plot002.pdf'")
+		p.CheckedCmd("replot")
+
+		p.CheckedCmd("q")
+
+	*/
+}


### PR DESCRIPTION
This adds an internal helper to return a backoff time.

In the future this should be used for any sleep calculation.

See #671