### PR TITLE
fix: lint when no upstream is present

### DIFF
--- a/.githooks/functions/libhelmlint.py
+++ b/.githooks/functions/libhelmlint.py
@@ -27,8 +27,8 @@ class LibHelmLint(LibInterface):
         # Check if current branch has upstream
         # If so, only include changed Charts
         # If not check all Charts
+        self.chart_files = []
         if Git.has_upstream():
-            self.chart_files = []
             changes = Git.get_committed_changes()
             for change in changes:
                 if change.endswith("Chart.yaml"):

--- a/.githooks/functions/libyamllint.py
+++ b/.githooks/functions/libyamllint.py
@@ -38,8 +38,8 @@ class LibYamlLint(LibInterface):
         # Check if current branch has upstream
         # If so, only include changed yaml files
         # If not check all yaml files
+        self.yaml_files = []
         if Git.has_upstream():
-            self.yaml_files = []
             changes = Git.get_committed_changes()
             for change in changes:
                 if change.endswith(".yaml"):


### PR DESCRIPTION
While refactoring i have moved the init of the file list inside the has_upstream check, this is incorrect.