### PR TITLE
fix: default values for productTable are inserted incorrectly

### DIFF
--- a/deployment/factorycube-server/templates/timescale-configmap.yaml
+++ b/deployment/factorycube-server/templates/timescale-configmap.yaml
@@ -307,18 +307,18 @@ data:
     INSERT INTO assetTable(assetID,location,customer) VALUES ('testMachine', 'testLocation', 'factoryinsight');
 
     -- productTable
-    INSERT INTO productTable(product_id,product_name,asset_id,time_per_unit_in_seconds) VALUES (1,'product107782',1,600);
-    INSERT INTO productTable(product_id,product_name,asset_id,time_per_unit_in_seconds) VALUES (2,'product107118',1,2946);
-    INSERT INTO productTable(product_id,product_name,asset_id,time_per_unit_in_seconds) VALUES (3,'product107793',1,7290);
-    INSERT INTO productTable(product_id,product_name,asset_id,time_per_unit_in_seconds) VALUES (4,'product107791',1,16872);
-    INSERT INTO productTable(product_id,product_name,asset_id,time_per_unit_in_seconds) VALUES (5,'product107119',1,1908);
-    INSERT INTO productTable(product_id,product_name,asset_id,time_per_unit_in_seconds) VALUES (6,'product107117',1,2946);
-    INSERT INTO productTable(product_id,product_name,asset_id,time_per_unit_in_seconds) VALUES (7,'product107829',1,478);
-    INSERT INTO productTable(product_id,product_name,asset_id,time_per_unit_in_seconds) VALUES (8,'product107823',1,2544);
-    INSERT INTO productTable(product_id,product_name,asset_id,time_per_unit_in_seconds) VALUES (9,'product107765',1,4098);
-    INSERT INTO productTable(product_id,product_name,asset_id,time_per_unit_in_seconds) VALUES (10,'product107796',1,6576);
-    INSERT INTO productTable(product_id,product_name,asset_id,time_per_unit_in_seconds) VALUES (11,'product107792',1,5112);
-    INSERT INTO productTable(product_id,product_name,asset_id,time_per_unit_in_seconds) VALUES (12,'product107799',1,4008);
+    INSERT INTO productTable(product_name,asset_id,time_per_unit_in_seconds) VALUES ('product107782',1,600);
+    INSERT INTO productTable(product_name,asset_id,time_per_unit_in_seconds) VALUES ('product107118',1,2946);
+    INSERT INTO productTable(product_name,asset_id,time_per_unit_in_seconds) VALUES ('product107793',1,7290);
+    INSERT INTO productTable(product_name,asset_id,time_per_unit_in_seconds) VALUES ('product107791',1,16872);
+    INSERT INTO productTable(product_name,asset_id,time_per_unit_in_seconds) VALUES ('product107119',1,1908);
+    INSERT INTO productTable(product_name,asset_id,time_per_unit_in_seconds) VALUES ('product107117',1,2946);
+    INSERT INTO productTable(product_name,asset_id,time_per_unit_in_seconds) VALUES ('product107829',1,478);
+    INSERT INTO productTable(product_name,asset_id,time_per_unit_in_seconds) VALUES ('product107823',1,2544);
+    INSERT INTO productTable(product_name,asset_id,time_per_unit_in_seconds) VALUES ('product107765',1,4098);
+    INSERT INTO productTable(product_name,asset_id,time_per_unit_in_seconds) VALUES ('product107796',1,6576);
+    INSERT INTO productTable(product_name,asset_id,time_per_unit_in_seconds) VALUES ('product107792',1,5112);
+    INSERT INTO productTable(product_name,asset_id,time_per_unit_in_seconds) VALUES ('product107799',1,4008);
 
     -- orderTable
     INSERT INTO orderTable(order_name,product_id,target_units,asset_id,begin_timestamp,end_timestamp) VALUES (107117,6,1,1,'2020-11-23 00:05:43+00','2020-11-23 01:25:11+00');


### PR DESCRIPTION
# Description

Our test data inserted products, while also setting there ID.
Doing this, won't change the postgres sequence, resulting in errors, when inserting new values afterwards.

Fixes #771 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I have created a local table, with an id (serial) and name.

### Test A
Select currect sequence ID -> 1
`SELECT last_value FROM test_table_id_seq;`

Insert 3 times by specifing the id to insert at.
`INSERT INTO test_table (id,name) VALUES (1, 'test1');`
`INSERT INTO test_table (id,name) VALUES (2, 'test2');`
`INSERT INTO test_table (id,name) VALUES (3, 'test2');`

Select currect sequence ID -> 1
`SELECT last_value FROM test_table_id_seq;`

### Test B
Select currect sequence ID -> 1
`SELECT last_value FROM test_table_id_seq;`

Insert 3 times by specifing the id to insert at.
`INSERT INTO test_table (name) VALUES ('test1');`
`INSERT INTO test_table (name) VALUES ('test2');`
`INSERT INTO test_table (name) VALUES ('test2');`

Select currect sequence ID -> 3
`SELECT last_value FROM test_table_id_seq;`


**Test Configuration**:
* PostgreSQL: 13.3

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] I have checked that my issue complies with the [Contributing guidelines](https://github.com/united-manufacturing-hub/united-manufacturing-hub/blob/main/CONTRIBUTING.md)
