### PR TITLE
fix: fixed deprecation warnings

### DIFF
--- a/deployment/factorycube-server/templates/factoryinput-pdb.yaml
+++ b/deployment/factorycube-server/templates/factoryinput-pdb.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.factoryinput.enabled -}}
 {{- if .Values.factoryinput.pdb.enabled -}}
 
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "factorycube-server.fullname" . }}-factoryinput-pdb

--- a/deployment/factorycube-server/templates/factoryinsight-hpa.yaml
+++ b/deployment/factorycube-server/templates/factoryinsight-hpa.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.factoryinsight.enabled -}}
 {{- if .Values.factoryinsight.hpa.enabled -}}
 
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "factorycube-server.fullname" . }}-factoryinsight-hpa

--- a/deployment/factorycube-server/templates/factoryinsight-pdb.yaml
+++ b/deployment/factorycube-server/templates/factoryinsight-pdb.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.factoryinsight.enabled -}}
 {{- if .Values.factoryinsight.pdb.enabled -}}
 
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "factorycube-server.fullname" . }}-factoryinsight-pdb

--- a/deployment/factorycube-server/templates/kafkatoblob-pdb.yaml
+++ b/deployment/factorycube-server/templates/kafkatoblob-pdb.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.kafkatoblob.enabled -}}
 {{- if .Values.kafkatoblob.pdb.enabled -}}
 
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "factorycube-server.fullname" . }}-kafkatoblob-pdb

--- a/deployment/factorycube-server/templates/mqtt-kafka-bridge-pdb.yaml
+++ b/deployment/factorycube-server/templates/mqtt-kafka-bridge-pdb.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.mqttkafkabridge.enabled -}}
 {{- if .Values.mqttkafkabridge.pdb.enabled -}}
 
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "factorycube-server.fullname" . }}-mqttkafkabridge-pdb

--- a/deployment/factorycube-server/templates/mqtttoblob-pdb.yaml
+++ b/deployment/factorycube-server/templates/mqtttoblob-pdb.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.mqtttoblob.enabled -}}
 {{- if .Values.mqtttoblob.pdb.enabled -}}
 
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "factorycube-server.fullname" . }}-mqtttoblob-pdb

--- a/deployment/factorycube-server/templates/mqtttopostgresql-pdb.yaml
+++ b/deployment/factorycube-server/templates/mqtttopostgresql-pdb.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.mqtttopostgresql.enabled -}}
 {{- if .Values.mqtttopostgresql.pdb.enabled -}}
 
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "factorycube-server.fullname" . }}-mqtttopostgresql-pdb


### PR DESCRIPTION
# Description

This PR removes deprecation warnings, by upgrading to the new pod apiVersions

Fixes #807 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Helm runs with less warnings

# Checklist:

- [X] My changes generate no new warnings
- [X] I have checked that my issue complies with the [Contributing guidelines](https://github.com/united-manufacturing-hub/united-manufacturing-hub/blob/main/CONTRIBUTING.md)
