### PR TITLE
Removed redis requirement from mqtt-kafka-bdirge

### DIFF
--- a/deployment/united-manufacturing-hub/templates/mqtt-kafka-bridge-deployment.yaml
+++ b/deployment/united-manufacturing-hub/templates/mqtt-kafka-bridge-deployment.yaml
@@ -64,16 +64,6 @@ spec:
             - name: KAFKA_BASE_TOPIC
               value: "ia"
 
-            - name: REDIS_URI
-              value: {{.Values.factoryinsight.redis.URI1}}
-            - name: REDIS_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: redis-secret
-                  key: redispassword
-
-
-
 
             - name: MY_POD_NAME
               valueFrom:

--- a/golang/cmd/mqtt-kafka-bridge/hash.go
+++ b/golang/cmd/mqtt-kafka-bridge/hash.go
@@ -10,11 +10,11 @@ import (
 func CheckIfNewMessageOrStore(message []byte) (new bool) {
 	hashString := xxh3.Hash(message)
 	zap.S().Debugf("Hash: %d", hashString)
-	old, _ := internal.GetTiered(strconv.FormatUint(hashString, 10))
+	_, old := internal.GetMemcached(strconv.FormatUint(hashString, 10))
 	new = !old
 	zap.S().Debugf("New: %s", new)
 	if new {
-		go internal.SetTieredShortTerm(strconv.FormatUint(hashString, 10), "")
+		go internal.SetMemcached(strconv.FormatUint(hashString, 10), "")
 	}
 	return
 }

--- a/golang/cmd/mqtt-kafka-bridge/main.go
+++ b/golang/cmd/mqtt-kafka-bridge/main.go
@@ -41,16 +41,8 @@ func main() {
 	KafkaTopic := os.Getenv("KAFKA_LISTEN_TOPIC")
 	KafkaBaseTopic := os.Getenv("KAFKA_BASE_TOPIC")
 
-	// Redis cache
-	redisURI := os.Getenv("REDIS_URI")
-	redisURI2 := os.Getenv("REDIS_URI2")
-	redisURI3 := os.Getenv("REDIS_URI3")
-	redisPassword := os.Getenv("REDIS_PASSWORD")
-	dryRun := os.Getenv("DRY_RUN")
-
-	redisDB := 0 // default database
-	zap.S().Debugf("Setting up redis")
-	internal.InitCache(redisURI, redisURI2, redisURI3, redisPassword, redisDB, dryRun)
+	zap.S().Debugf("Setting up memorycache")
+	internal.InitMemcache()
 
 	zap.S().Debugf("Setting up Queues")
 	var err error


### PR DESCRIPTION
# Description

Fixes #876 by removing redis requirement from mqtt-kafka-bridge

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] Starts without redis enabled

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] I have checked that my issue complies with the [Contributing guidelines](https://github.com/united-manufacturing-hub/united-manufacturing-hub/blob/main/CONTRIBUTING.md)
