### PR TITLE
Moved mqtt setup after queue initialization

### DIFF
--- a/golang/cmd/mqtt-to-postgresql/main.go
+++ b/golang/cmd/mqtt-to-postgresql/main.go
@@ -103,7 +103,6 @@ func main() {
 	zap.S().Debugf("Setting up MQTT")
 	podName := os.Getenv("MY_POD_NAME")
 	mqttTopic := os.Getenv("MQTT_TOPIC")
-	SetupMQTT(certificateName, mqttBrokerURL, mqttTopic, health, podName)
 
 	zap.S().Debugf("Setting up redis")
 	internal.InitCache(redisURI, redisURI2, redisURI3, redisPassword, redisDB, dryRun)
@@ -167,6 +166,9 @@ func main() {
 
 	//Only try to process old messages, once redis and pg are available !
 	storedRawMQTTHandler.Setup()
+
+	time.Sleep(1 * time.Second)
+	SetupMQTT(certificateName, mqttBrokerURL, mqttTopic, health, podName)
 
 	// Allow graceful shutdown
 	sigs := make(chan os.Signal, 1)


### PR DESCRIPTION
# Description

Fixes #878 by moving SetupMQTT after queue initialization

## Type of change


- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] MQTT-to-postgresql starts up successfully on minikube after storage deletion

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] I have checked that my issue complies with the [Contributing guidelines](https://github.com/united-manufacturing-hub/united-manufacturing-hub/blob/main/CONTRIBUTING.md)
