### PR TITLE
Added missing documentation step when using lens

### DIFF
--- a/docs/content/en/docs/Tutorials/united-manufacturing-hub/working-with-helm-and-lens/index.md
+++ b/docs/content/en/docs/Tutorials/united-manufacturing-hub/working-with-helm-and-lens/index.md
@@ -153,3 +153,10 @@ export VERIFY_CHECKSUM=false && curl -fsSL -o get_helm.sh https://raw.githubuser
 ```bash
 helm repo add united-manufacturing-hub https://repo.umh.app
 ```
+
+3. Get repository updates
+```bash
+helm repo update
+```
+
+4. Restart Lens (make sure to also close it in the system tray)


### PR DESCRIPTION
# Description

This pr adds ```helm repo update``` and restarting Lens to the lens usage tutorial

Fixes #912 
