### PR TITLE
Added and operator to only start kafka-to-postgresql if datastorage & kafka are enabled

### DIFF
--- a/deployment/united-manufacturing-hub/templates/kafkatopostgresql-deployment.yaml
+++ b/deployment/united-manufacturing-hub/templates/kafkatopostgresql-deployment.yaml
@@ -1,5 +1,5 @@
 ---
-{{if or .Values.kafkatopostgresql.enabled .Values._000_commonConfig.infrastructure.kafka.enabled}}
+{{if or .Values.kafkatopostgresql.enabled (and .Values._000_commonConfig.infrastructure.kafka.enabled .Values._000_commonConfig.datastorage.enabled)}}
 
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
# Description

This pr adds an and operator to check if datastorage (postgres) and kafka are enabled, before starting kafka-to-postgresql

Fixes #982 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Tested on minikube

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] I have checked that my issue complies with the [Contributing guidelines](https://github.com/united-manufacturing-hub/united-manufacturing-hub/blob/main/CONTRIBUTING.md)
