### PR TITLE
Redirect failing messages to there own queue, added init container for kafka-bridge.

### DIFF
--- a/deployment/united-manufacturing-hub/templates/kafkabridge-deployment.yaml
+++ b/deployment/united-manufacturing-hub/templates/kafkabridge-deployment.yaml
@@ -35,6 +35,31 @@ spec:
                   matchLabels:
                     name: {{include "united-manufacturing-hub.fullname" .}}-kafkabridge
                 topologyKey: "kubernetes.io/hostname"
+      initContainers:
+        - name: {{include "united-manufacturing-hub.fullname" .}}-kafkabridge-init-topics-local
+          {{if .Values.kafkabridge.image.tag}}
+          image: {{.Values.kafkabridge.initContainer.repository}}:{{.Values.kafkabridge.initContainer.tag}}
+          {{- else}}
+          image: {{.Values.kafkabridge.initContainer.repository}}:{{.Chart.AppVersion}}
+          {{end}}
+          imagePullPolicy: {{.Values.kafkabridge.initContainer.pullPolicy}}
+          env:
+            - name: KAFKA_BOOSTRAP_SERVER
+              value: {{include "united-manufacturing-hub.fullname" .}}-kafka:9092
+            - name: KAFKA_TOPICS
+              value: {{.Values._000_commonConfig.kafkaBridge.topicCreationLocalList}}
+        - name: {{include "united-manufacturing-hub.fullname" .}}-kafkabridge-init-topics-remote
+          {{if .Values.kafkabridge.image.tag}}
+          image: {{.Values.kafkabridge.initContainer.repository}}:{{.Values.kafkabridge.initContainer.tag}}
+          {{- else}}
+          image: {{.Values.kafkabridge.initContainer.repository}}:{{.Chart.AppVersion}}
+          {{end}}
+          imagePullPolicy: {{.Values.kafkabridge.initContainer.pullPolicy}}
+          env:
+            - name: KAFKA_BOOSTRAP_SERVER
+              value: {{.Values._000_commonConfig.kafkaBridge.remotebootstrapServer}}
+            - name: KAFKA_TOPICS
+              value: {{.Values._000_commonConfig.kafkaBridge.topicCreationRemoteList}}
       containers:
         - name: {{include "united-manufacturing-hub.fullname" .}}-kafkabridge
           {{if .Values.kafkabridge.image.tag}}

--- a/deployment/united-manufacturing-hub/values.yaml
+++ b/deployment/united-manufacturing-hub/values.yaml
@@ -184,6 +184,8 @@ _000_commonConfig:
   kafkaBridge:
     enabled: false
     remotebootstrapServer: ""
+    topicCreationLocalList: ia.test.test.test.processValue;ia.test.test.test.count # ; seperated list of topics to create on local broker, if they do not exist
+    topicCreationRemoteList: ia.test.test.test.processValue;ia.test.test.test.count # ; seperated list of topics to create on local broker, if they do not exist
     topicmap:
 # Example topic map
 #      - name: HighIntegrity
@@ -272,6 +274,9 @@ kafkabridge:
     repository: unitedmanufacturinghub/kafka-bridge
     pullPolicy: IfNotPresent
   # tag: development
+  initContainer:
+    repository: unitedmanufacturinghub/kafka-init
+    pullPolicy: IfNotPresent
 
 
 ### nodered ###

--- a/deployment/united-manufacturing-hub/values.yaml
+++ b/deployment/united-manufacturing-hub/values.yaml
@@ -185,7 +185,7 @@ _000_commonConfig:
     enabled: false
     remotebootstrapServer: ""
     topicCreationLocalList: ia.test.test.test.processValue;ia.test.test.test.count # ; seperated list of topics to create on local broker, if they do not exist
-    topicCreationRemoteList: ia.test.test.test.processValue;ia.test.test.test.count # ; seperated list of topics to create on local broker, if they do not exist
+    topicCreationRemoteList: ia.test.test.test.processValue;ia.test.test.test.count # ; seperated list of topics to create on remote broker, if they do not exist
     topicmap:
 # Example topic map
 #      - name: HighIntegrity

--- a/golang/cmd/kafka-bridge/kafka.go
+++ b/golang/cmd/kafka-bridge/kafka.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/confluentinc/confluent-kafka-go/kafka"
 	jsoniter "github.com/json-iterator/go"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/internal"
 	"go.uber.org/zap"
 	"time"
 )
@@ -50,6 +51,8 @@ func processKafkaQueue(identifier string, topic string, processorChannel chan *k
 		msg, err = kafkaConsumer.ReadMessage(5000)
 		if err != nil {
 			if err.(kafka.Error).Code() == kafka.ErrTimedOut {
+				// Sleep to reduce CPU usage
+				time.Sleep(internal.OneSecond)
 				continue
 			} else if err.(kafka.Error).Code() == kafka.ErrUnknownTopicOrPart {
 				// This will occur when no topic for the regex is available !

--- a/golang/cmd/kafka-debug/kafka.go
+++ b/golang/cmd/kafka-debug/kafka.go
@@ -14,6 +14,8 @@ func startDebugger() {
 		msg, err := internal.KafkaConsumer.ReadMessage(5) //No infinitive timeout to be able to cleanly shut down
 		if err != nil {
 			if err.(kafka.Error).Code() == kafka.ErrTimedOut {
+				// Sleep to reduce CPU usage
+				time.Sleep(internal.OneSecond)
 				continue
 			} else {
 				zap.S().Errorf("Failed to read kafka message: %s", err)

--- a/golang/cmd/kafka-to-blob/kafka.go
+++ b/golang/cmd/kafka-to-blob/kafka.go
@@ -27,6 +27,8 @@ func processKafkaQueue(topic string, bucketName string) {
 		msg, err = internal.KafkaConsumer.ReadMessage(5) //No infinitive timeout to be able to cleanly shut down
 		if err != nil {
 			if err.(kafka.Error).Code() == kafka.ErrTimedOut {
+				// Sleep to reduce CPU usage
+				time.Sleep(internal.OneSecond)
 				continue
 			} else if err.(kafka.Error).Code() == kafka.ErrUnknownTopicOrPart {
 				time.Sleep(5 * time.Second)

--- a/golang/cmd/kafka-to-postgresql/database.go
+++ b/golang/cmd/kafka-to-postgresql/database.go
@@ -130,7 +130,7 @@ func GetAssetTableID(customerID string, location string, assetID string) (AssetT
 
 	err := statement.SelectIdFromAssetTableByAssetIdAndLocationIdAndCustomerId.QueryRow(assetID, location, customerID).Scan(&AssetTableID)
 	if err == sql.ErrNoRows {
-		zap.S().Errorf("[GetAssetTableID] No Results Found for assetID: %s, location: %s, customerID: %s", assetID, location, customerID)
+		zap.S().Debugf("[GetAssetTableID] No Results Found for assetID: %s, location: %s, customerID: %s", assetID, location, customerID)
 		// This can potentially lead to race conditions, if another thread adds the same asset too
 		err = AddAsset(assetID, location, customerID)
 		if err != nil {
@@ -195,7 +195,7 @@ func GetProductTableId(productName string, AssetTableId uint32) (ProductTableId 
 
 	err := statement.SelectProductIdFromProductTableByAssetIdAndProductName.QueryRow(AssetTableId, productName).Scan(&ProductTableId)
 	if err == sql.ErrNoRows {
-		zap.S().Errorf("[GetProductTableId] No Results Found for productName: %s, AssetTableId: %d", productName, AssetTableId)
+		zap.S().Debugf("[GetProductTableId] No Results Found for productName: %s, AssetTableId: %d", productName, AssetTableId)
 		return 0, false
 	} else if err != nil {
 		zap.S().Debugf("[GetProductTableId] Error: %s", err)
@@ -234,7 +234,7 @@ func GetUniqueProductID(UniqueProductAlternativeId string, AssetTableId uint32) 
 
 	err := statement.SelectUniqueProductIdFromUniqueProductTableByUniqueProductAlternativeIdAndAssetIdOrderedByTimeStampDesc.QueryRow(UniqueProductAlternativeId, AssetTableId).Scan(&UniqueProductTableId)
 	if err == sql.ErrNoRows {
-		zap.S().Errorf("[GetUniqueProductID] No Results Found for UniqueProductAlternativeId: %s, AssetTableId: %d", UniqueProductAlternativeId, AssetTableId)
+		zap.S().Debugf("[GetUniqueProductID] No Results Found for UniqueProductAlternativeId: %s, AssetTableId: %d", UniqueProductAlternativeId, AssetTableId)
 
 		return 0, false
 	} else if err != nil {
@@ -259,7 +259,7 @@ func GetLatestParentUniqueProductID(ParentID string, DBAssetID uint32) (Latestpa
 
 	err := statement.SelectUniqueProductIdFromUniqueProductTableByUniqueProductAlternativeIdAndNotAssetId.QueryRow(ParentID, DBAssetID).Scan(&LatestparentUniqueProductId)
 	if err == sql.ErrNoRows {
-		zap.S().Errorf("[GetUniqueProductID] No Results Found for ChildID: %s, DBAssetID: %d", ParentID, DBAssetID)
+		zap.S().Debugf("[GetUniqueProductID] No Results Found for ChildID: %s, DBAssetID: %d", ParentID, DBAssetID)
 
 		return 0, false
 	} else if err != nil {

--- a/golang/cmd/kafka-to-postgresql/highIntegrityProcessor.go
+++ b/golang/cmd/kafka-to-postgresql/highIntegrityProcessor.go
@@ -102,23 +102,23 @@ func startHighIntegrityQueueProcessor() {
 			switch GetPostgresErrorRecoveryOptions(err) {
 			case DatabaseDown:
 				if putback {
-					zap.S().Errorf("[HI][DatabaseDown] Failed to execute Kafka message. CustomerID: %s, Location: %s, AssetId: %s, payload: %s. Error: %v. Putting back to queue", parsedMessage.CustomerId, parsedMessage.Location, parsedMessage.AssetId, payloadStr, err)
+					zap.S().Debugf("[HI][DatabaseDown] Failed to execute Kafka message. CustomerID: %s, Location: %s, AssetId: %s, payload: %s. Error: %v. Putting back to queue", parsedMessage.CustomerId, parsedMessage.Location, parsedMessage.AssetId, payloadStr, err)
 					highIntegrityPutBackChannel <- PutBackChanMsg{msg: msg, reason: "DatabaseDown", errorString: &errStr}
 				} else {
-					zap.S().Errorf("[HI][DatabaseDown] Failed to execute Kafka message. CustomerID: %s, Location: %s, AssetId: %s, payload: %s. Error: %v. Discarding message", parsedMessage.CustomerId, parsedMessage.Location, parsedMessage.AssetId, payloadStr, err)
+					zap.S().Debugf("[HI][DatabaseDown] Failed to execute Kafka message. CustomerID: %s, Location: %s, AssetId: %s, payload: %s. Error: %v. Discarding message", parsedMessage.CustomerId, parsedMessage.Location, parsedMessage.AssetId, payloadStr, err)
 					highIntegrityCommitChannel <- msg
 				}
 				break
 			case DiscardValue:
-				zap.S().Errorf("[HI][DiscardValue] Failed to execute Kafka message. CustomerID: %s, Location: %s, AssetId: %s, payload: %s. Error: %v. Discarding message", parsedMessage.CustomerId, parsedMessage.Location, parsedMessage.AssetId, payloadStr, err)
+				zap.S().Debugf("[HI][DiscardValue] Failed to execute Kafka message. CustomerID: %s, Location: %s, AssetId: %s, payload: %s. Error: %v. Discarding message", parsedMessage.CustomerId, parsedMessage.Location, parsedMessage.AssetId, payloadStr, err)
 				highIntegrityCommitChannel <- msg
 				break
 			case Other:
 				if putback {
-					zap.S().Errorf("[HI][Other] Failed to execute Kafka message. CustomerID: %s, Location: %s, AssetId: %s, payload: %s. Error: %v. Putting back to queue", parsedMessage.CustomerId, parsedMessage.Location, parsedMessage.AssetId, payloadStr, err)
+					zap.S().Debugf("[HI][Other] Failed to execute Kafka message. CustomerID: %s, Location: %s, AssetId: %s, payload: %s. Error: %v. Putting back to queue", parsedMessage.CustomerId, parsedMessage.Location, parsedMessage.AssetId, payloadStr, err)
 					highIntegrityPutBackChannel <- PutBackChanMsg{msg: msg, reason: "Other", errorString: &errStr}
 				} else {
-					zap.S().Errorf("[HI][Other] Failed to execute Kafka message. CustomerID: %s, Location: %s, AssetId: %s, payload: %s. Error: %v. Discarding message", parsedMessage.CustomerId, parsedMessage.Location, parsedMessage.AssetId, payloadStr, err)
+					zap.S().Debugf("[HI][Other] Failed to execute Kafka message. CustomerID: %s, Location: %s, AssetId: %s, payload: %s. Error: %v. Discarding message", parsedMessage.CustomerId, parsedMessage.Location, parsedMessage.AssetId, payloadStr, err)
 					highIntegrityCommitChannel <- msg
 				}
 				break
@@ -126,7 +126,7 @@ func startHighIntegrityQueueProcessor() {
 		} else {
 			if putback {
 				payloadStr := string(parsedMessage.Payload)
-				zap.S().Errorf("[HI][No-Error Putback] Failed to execute Kafka message. CustomerID: %s, Location: %s, AssetId: %s, payload: %s. Putting back to queue", parsedMessage.CustomerId, parsedMessage.Location, parsedMessage.AssetId, payloadStr)
+				zap.S().Debugf("[HI][No-Error Putback] Failed to execute Kafka message. CustomerID: %s, Location: %s, AssetId: %s, payload: %s. Putting back to queue", parsedMessage.CustomerId, parsedMessage.Location, parsedMessage.AssetId, payloadStr)
 				highIntegrityPutBackChannel <- PutBackChanMsg{msg: msg, reason: "Other", errorString: nil}
 			} else {
 				highIntegrityCommitChannel <- msg

--- a/golang/cmd/kafka-to-postgresql/highThroughputProcessor.go
+++ b/golang/cmd/kafka-to-postgresql/highThroughputProcessor.go
@@ -41,7 +41,7 @@ func startHighThroughputQueueProcessor() {
 
 		if putback {
 			payloadStr := string(parsedMessage.Payload)
-			zap.S().Errorf("[HT][No-Error Putback] Failed to execute Kafka message. CustomerID: %s, Location: %s, AssetId: %s, payload: %s. Putting back to queue", parsedMessage.CustomerId, parsedMessage.Location, parsedMessage.AssetId, payloadStr)
+			zap.S().Debugf("[HT][No-Error Putback] Failed to execute Kafka message. CustomerID: %s, Location: %s, AssetId: %s, payload: %s. Putting back to queue", parsedMessage.CustomerId, parsedMessage.Location, parsedMessage.AssetId, payloadStr)
 			highThroughputPutBackChannel <- PutBackChanMsg{msg: msg, reason: "Other", errorString: nil}
 		}
 	}

--- a/golang/cmd/kafka-to-postgresql/main.go
+++ b/golang/cmd/kafka-to-postgresql/main.go
@@ -32,12 +32,11 @@ func main() {
 	// Setup logger and set as global
 	var logger *zap.Logger
 
-	//if os.Getenv("LOGGING_LEVEL") == "DEVELOPMENT" {
-	logger, _ = zap.NewDevelopment()
-	//} else {
-
-	//	logger, _ = zap.NewProduction()
-	//}
+	if os.Getenv("LOGGING_LEVEL") == "DEVELOPMENT" {
+		logger, _ = zap.NewDevelopment()
+	} else {
+		logger, _ = zap.NewProduction()
+	}
 	zap.ReplaceGlobals(logger)
 	defer logger.Sync()
 
@@ -151,7 +150,7 @@ func main() {
 		highIntegrityPutBackChannel = make(chan PutBackChanMsg, 200)
 		highIntegrityCommitChannel = make(chan *kafka.Message)
 		highIntegrityEventChannel := HIKafkaProducer.Events()
-		go startPutbackProcessor("[HI]", highIntegrityPutBackChannel, HIKafkaProducer)
+		go startPutbackProcessor("[HI]", highIntegrityPutBackChannel, HIKafkaProducer, highIntegrityCommitChannel)
 		go processKafkaQueue("[HI]", HITopic, highIntegrityProcessorChannel, HIKafkaConsumer, highIntegrityPutBackChannel)
 		go startCommitProcessor("[HI]", highIntegrityCommitChannel, HIKafkaConsumer)
 		go startHighIntegrityQueueProcessor()
@@ -166,7 +165,7 @@ func main() {
 		highThroughputPutBackChannel = make(chan PutBackChanMsg, 200)
 		highThroughputEventChannel := HIKafkaProducer.Events()
 		// HT has no commit channel, it uses auto commit
-		go startPutbackProcessor("[HT]", highThroughputPutBackChannel, HTKafkaProducer)
+		go startPutbackProcessor("[HT]", highThroughputPutBackChannel, HTKafkaProducer, nil)
 		go processKafkaQueue("[HT]", HTTopic, highThroughputProcessorChannel, HTKafkaConsumer, highThroughputPutBackChannel)
 		go startHighThroughputQueueProcessor()
 		go startEventHandler("[HI]", highThroughputEventChannel, highIntegrityPutBackChannel)

--- a/golang/cmd/mqtt-kafka-bridge/kafka.go
+++ b/golang/cmd/mqtt-kafka-bridge/kafka.go
@@ -59,7 +59,10 @@ func kafkaToQueue(topic string) {
 	for !ShuttingDown {
 		msg, err := internal.KafkaConsumer.ReadMessage(5) //No infinitive timeout to be able to cleanly shut down
 		if err != nil {
+			// This is fine, and expected behaviour
 			if err.(kafka.Error).Code() == kafka.ErrTimedOut {
+				// Sleep to reduce CPU usage
+				time.Sleep(internal.OneSecond)
 				continue
 			} else if err.(kafka.Error).Code() == kafka.ErrUnknownTopicOrPart {
 				time.Sleep(5 * time.Second)


### PR DESCRIPTION
# Description

This pr redirects messages, which either fail >= 50 times or (>= 2 times and are older then 5 minutes).
It also adds an sleep, if no new messages are available for processing by any Kafka microservices, preventing high idle loads.
Also adds an init container to kafka-bridge allowing for creating of dummy topics, to prevent crashes

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [X] Redirect to special queue runs on Venice

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have checked that my issue complies with the [Contributing guidelines](https://github.com/united-manufacturing-hub/united-manufacturing-hub/blob/main/CONTRIBUTING.md)
