### PR TITLE
Log deletion in kafka cannot work properly

### DIFF
--- a/deployment/united-manufacturing-hub/values.yaml
+++ b/deployment/united-manufacturing-hub/values.yaml
@@ -2045,6 +2045,9 @@ kafka:
     requests:
       cpu: 500m
       memory: 250Mi
+  logRetentionHours: 168
+  logSegmentBytes: _10485760 # 10MiB
+  logRetentionBytes: _1073741824 # 1GiB
 
 ##### CONFIG FOR REDIS #####
 redis:

--- a/deployment/united-manufacturing-hub/values.yaml
+++ b/deployment/united-manufacturing-hub/values.yaml
@@ -2047,7 +2047,7 @@ kafka:
       memory: 250Mi
   logRetentionHours: 168
   logSegmentBytes: _10485760 # 10MiB
-  logRetentionBytes: _524288000 # 500MiB
+  logRetentionBytes: _26214400 # 25MiB
 
 ##### CONFIG FOR REDIS #####
 redis:

--- a/deployment/united-manufacturing-hub/values.yaml
+++ b/deployment/united-manufacturing-hub/values.yaml
@@ -2047,7 +2047,7 @@ kafka:
       memory: 250Mi
   logRetentionHours: 168
   logSegmentBytes: _10485760 # 10MiB
-  logRetentionBytes: _1073741824 # 1GiB
+  logRetentionBytes: _524288000 # 500MiB
 
 ##### CONFIG FOR REDIS #####
 redis:


### PR DESCRIPTION
# Description

This pr reduces the log.segment.bytes to 10MiB and the log.retention.bytes to 500MiB.
Further reduction of log.retention.bytes might be nessecary if disk space is an issue.

The current log.segment.bytes would hold ~100k messages per log.

Fixes #989 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Configuration is accepted by Kafka

# Checklist:
- [X] I have checked that my issue complies with the [Contributing guidelines](https://github.com/united-manufacturing-hub/united-manufacturing-hub/blob/main/CONTRIBUTING.md)
