### PR TITLE
Added index for processValueTable & processValueStringTable on valuename to massively increase speed

### DIFF
--- a/deployment/united-manufacturing-hub/templates/timescale-configmap.yaml
+++ b/deployment/united-manufacturing-hub/templates/timescale-configmap.yaml
@@ -79,6 +79,9 @@ data:
     -- creating an index to increase performance
     CREATE INDEX ON processValueTable (asset_id, timestamp DESC);
 
+    -- creating an index to increase performance
+    CREATE INDEX ON processValueTable (valuename);
+
     -------------------- TimescaleDB table for uniqueProduct --------------------
     CREATE TABLE IF NOT EXISTS uniqueProductTable
     (
@@ -243,6 +246,9 @@ data:
     SELECT create_hypertable('processValueStringTable', 'timestamp');
     -- creating an index to increase performance
     CREATE INDEX ON processValueStringTable (asset_id, timestamp DESC);
+    
+    -- creating an index to increase performance
+    CREATE INDEX ON processValueStringTable (valueName);
 
 
     -------------------- TimescaleDB table for components --------------------


### PR DESCRIPTION
# Description

This pr decreases lookup times for distinct queries on processValueTable and processValueStringTable from ~5s to 50-200ms on 10m datasets.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Tested on dev cluster 
