### PR TITLE
Better error handling for create topic timeout

### DIFF
--- a/golang/cmd/sensorconnect/iolinkDeviceFinder.go
+++ b/golang/cmd/sensorconnect/iolinkDeviceFinder.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"os"
 	"sync"
 	"time"
 
@@ -95,8 +96,10 @@ func GetDiscoveredDeviceInformation(wg *sync.WaitGroup, i uint32) {
 		}
 		err := internal.CreateTopicIfNotExists(kafkaTopic)
 		if err != nil {
-			zap.S().Errorf("Failed to create topic %s", err)
-			return
+			zap.S().Errorf("Failed to create topic %s, this can happen during initial startup, it might take up to 5 minutes for Kafka to startup. If you encounter this error, while Kafka is already running, please investigate further", err)
+			internal.ShuttingDownKafka = true
+			time.Sleep(internal.FiveSeconds)
+			os.Exit(1)
 		}
 	}
 


### PR DESCRIPTION
# Description

Fixes #1072 by providing a better a error message and then cleanly restarting

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
