### PR TITLE
feat: Init container for kafkatopostgresql

### DIFF
--- a/deployment/united-manufacturing-hub/templates/kafkatopostgresql/deployment.yaml
+++ b/deployment/united-manufacturing-hub/templates/kafkatopostgresql/deployment.yaml
@@ -35,6 +35,28 @@ spec:
                 topologyKey: "kubernetes.io/hostname"
       # Be nice to kafka & the db
       terminationGracePeriodSeconds: 180
+      initContainers:
+        - name: {{include "united-manufacturing-hub.fullname" .}}-kafkabridge-init
+          {{if .Values.kafkabridge.image.tag}}
+          image: {{.Values.kafkabridge.initContainer.repository}}:{{.Values.kafkabridge.initContainer.tag}}
+          {{- else}}
+          image: {{.Values.kafkabridge.initContainer.repository}}:{{.Chart.AppVersion}}
+          volumeMounts:
+            - name: {{include "united-manufacturing-hub.fullname" .}}-kafkatopostgresql-certificates
+              mountPath: /SSL_certs
+              readOnly: true
+          {{end}}
+          imagePullPolicy: {{.Values.kafkabridge.initContainer.pullPolicy}}
+          env:
+            - name: KAFKA_BOOSTRAP_SERVER
+              value: {{include "united-manufacturing-hub.fullname" .}}-kafka:9092
+            - name: KAFKA_TOPICS
+              value: {{.Values._000_commonConfig.infrastructure.kafka.defaultTopics}}
+
+            - name: KAFKA_USE_SSL
+              value: {{.Values._000_commonConfig.infrastructure.kafka.useSSL | quote}}
+            - name: KAFKA_SSL_KEY_PASSWORD
+              value: {{.Values._000_commonConfig.certificates.kafkatopostgresql.sslKeyPassword | quote}}
       containers:
         - name: {{include "united-manufacturing-hub.fullname" .}}-kafkatopostgresql
           {{if .Values.kafkatopostgresql.image.tag}}

--- a/deployment/united-manufacturing-hub/values.yaml
+++ b/deployment/united-manufacturing-hub/values.yaml
@@ -140,6 +140,7 @@ _000_commonConfig:
     kafka:
       enabled: true
       useSSL: true
+      defaultTopics: ia.test.test.test.processValue;ia.test.test.test.count
 
 
   certificates:


### PR DESCRIPTION
# Description

This pr adds an init container for kafkatopostgresql, to prevent crashes on startup, by suppling a dummy topic for both workers.