### PR TITLE
fix: mqtt-kafka-bridge not starting with kafka mtls

### DIFF
--- a/deployment/united-manufacturing-hub/templates/mqtt-kafka-bridge/deployment.yaml
+++ b/deployment/united-manufacturing-hub/templates/mqtt-kafka-bridge/deployment.yaml
@@ -104,6 +104,14 @@ spec:
             - name: kubernetes-ca
               mountPath: /certs/kubernetes-ca.pem
               subPath: ca.crt
+            - name: {{include "united-manufacturing-hub.fullname" .}}-kafkatopostgresql-certificates
+              mountPath: /SSL_certs
+              readOnly: true
+
+      volumes:
+        - name: {{include "united-manufacturing-hub.fullname" .}}-mqttkafkabridge-certificates
+          secret:
+            secretName: {{include "united-manufacturing-hub.fullname" .}}-mqttkafkabridge-secrets
 
       serviceAccountName: ""
       restartPolicy: Always


### PR DESCRIPTION
# Description

mqtt-kafka-bridge fails to startup in SSL mode, due to missing volume

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

