### PR TITLE
Fixes incorrect url in install script and duplicate volumes definition for kafkabridge

### DIFF
--- a/deployment/united-manufacturing-hub/templates/kafkabridge/deployment.yaml
+++ b/deployment/united-manufacturing-hub/templates/kafkabridge/deployment.yaml
@@ -22,10 +22,6 @@ spec:
         name: {{include "united-manufacturing-hub.fullname" .}}-kafkabridge
         {{- include "united-manufacturing-hub.labels.kafkabridge" . | nindent 8}}
     spec:
-      volumes:
-        - name: kubernetes-ca
-          configMap:
-            name: kube-root-ca.crt
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -128,6 +124,9 @@ spec:
               mountPath: /SSL_certs/remote
               readOnly: true
       volumes:
+        - name: kubernetes-ca
+          configMap:
+            name: kube-root-ca.crt
         - name: {{include "united-manufacturing-hub.fullname" .}}-kafkabridge-certificates-local
           secret:
             secretName: {{include "united-manufacturing-hub.fullname" .}}-kafkabridge-secrets-local

--- a/docs/static/examples/development.yaml
+++ b/docs/static/examples/development.yaml
@@ -1092,7 +1092,7 @@ write_files:
       echo "Helm installed!"
 
       echo "Adding helm repo..."
-      if ! helm repo add united-manufacturing-hub https://rep.umh.app/; then
+      if ! helm repo add united-manufacturing-hub https://repo.umh.app/; then
       echo "Failed to add umh repository, aborting setup"
       exit
       fi


### PR DESCRIPTION
# Description

In the last pre-release the url of the repo was incorrect.
Also it hat duplicate volumes definition in kafkabridge

## Type of change


- [X] Bug fix (non-breaking change which fixes an issue)
