### PR TITLE
Renamed ModifyProducesPieces to ModifyProducedPieces and added timestamp to message and db query

### DIFF
--- a/golang/cmd/kafka-to-postgresql/highIntegrityProcessor.go
+++ b/golang/cmd/kafka-to-postgresql/highIntegrityProcessor.go
@@ -67,9 +67,9 @@ func startHighIntegrityQueueProcessor() {
 			case Prefix.ModifyState:
 				zap.S().Errorf("[HI]ModifyState is unstable")
 				putback, err, forcePBTopic = ModifyState{}.ProcessMessages(parsedMessage)
-			case Prefix.ModifyProducesPieces:
-				zap.S().Errorf("[HI]ModifyProducesPieces is unstable")
-				putback, err, forcePBTopic = ModifyProducesPieces{}.ProcessMessages(parsedMessage)
+			case Prefix.ModifyProducedPieces:
+				zap.S().Errorf("[HI]ModifyProducedPieces is unstable")
+				putback, err, forcePBTopic = ModifyProducedPieces{}.ProcessMessages(parsedMessage)
 			case Prefix.DeleteShiftById:
 				zap.S().Errorf("[HI]DeleteShiftById is unstable")
 				putback, err, forcePBTopic = DeleteShiftById{}.ProcessMessages(parsedMessage)

--- a/golang/cmd/kafka-to-postgresql/prefix.go
+++ b/golang/cmd/kafka-to-postgresql/prefix.go
@@ -18,7 +18,7 @@ func newPrefixRegistry() *prefixRegistry {
 		DeleteShiftById: "deleteshiftbyid",
 		EndOrder:        "endorder",
 		// Undocumented
-		ModifyProducesPieces: "modifyproducedpieces",
+		ModifyProducedPieces: "modifyproducedpieces",
 		// Undocumented
 		ModifyState:  "modifystate",
 		ProcessValue: "processvalue",
@@ -48,7 +48,7 @@ type prefixRegistry struct {
 	DeleteShiftByAssetIdAndBeginTimestamp string
 	DeleteShiftById                       string
 	EndOrder                              string
-	ModifyProducesPieces                  string
+	ModifyProducedPieces                  string
 	ModifyState                           string
 	ProcessValue                          string
 	ProcessValueFloat64                   string

--- a/golang/cmd/kafka-to-postgresql/statements.go
+++ b/golang/cmd/kafka-to-postgresql/statements.go
@@ -53,10 +53,10 @@ type StatementRegistry struct {
 
 	InsertIntoAssetTable *sql.Stmt
 
-	UpdateCountTableSetCountAndScrapByAssetId *sql.Stmt
+	UpdateCountTableSetCountAndScrapByAssetIdAndTs *sql.Stmt
 
-	UpdateCountTableSetCountByAssetId *sql.Stmt
-	UpdateCountTableSetScrapByAssetId *sql.Stmt
+	UpdateCountTableSetCountByAssetIdAndTs *sql.Stmt
+	UpdateCountTableSetScrapByAssetIdAndTs *sql.Stmt
 
 	SelectIdFromAssetTableByAssetIdAndLocationIdAndCustomerId *sql.Stmt
 
@@ -124,11 +124,11 @@ func (r StatementRegistry) Shutdown() (err error) {
 
 	_ = r.InsertIntoAssetTable.Close()
 
-	_ = r.UpdateCountTableSetCountAndScrapByAssetId.Close()
+	_ = r.UpdateCountTableSetCountAndScrapByAssetIdAndTs.Close()
 
-	_ = r.UpdateCountTableSetCountByAssetId.Close()
+	_ = r.UpdateCountTableSetCountByAssetIdAndTs.Close()
 
-	_ = r.UpdateCountTableSetScrapByAssetId.Close()
+	_ = r.UpdateCountTableSetScrapByAssetIdAndTs.Close()
 
 	_ = r.SelectIdFromAssetTableByAssetIdAndLocationIdAndCustomerId.Close()
 
@@ -267,11 +267,11 @@ func NewStatementRegistry() *StatementRegistry {
 		VALUES ($1,$2,$3) 
 		ON CONFLICT DO NOTHING;`),
 
-		UpdateCountTableSetCountAndScrapByAssetId: prep(`UPDATE counttable SET count = $1, scrap = $2 WHERE asset_id = $3`),
+		UpdateCountTableSetCountAndScrapByAssetIdAndTs: prep(`UPDATE counttable SET count = $1, scrap = $2 WHERE asset_id = $3 AND timestamp = to_timestamp($4 / 1000.0);`),
 
-		UpdateCountTableSetCountByAssetId: prep(`UPDATE counttable SET count = $1 WHERE asset_id = $2`),
+		UpdateCountTableSetCountByAssetIdAndTs: prep(`UPDATE counttable SET count = $1 WHERE asset_id = $2 AND timestamp = to_timestamp($3 / 1000.0);`),
 
-		UpdateCountTableSetScrapByAssetId: prep(`UPDATE counttable SET scrap = $1 WHERE asset_id = $2`),
+		UpdateCountTableSetScrapByAssetIdAndTs: prep(`UPDATE counttable SET scrap = $1 WHERE asset_id = $2 AND timestamp = to_timestamp($3 / 1000.0);`),
 
 		SelectIdFromAssetTableByAssetIdAndLocationIdAndCustomerId: prep(`SELECT id FROM assetTable WHERE assetid=$1 AND location=$2 AND customer=$3;`),
 

--- a/golang/cmd/mqtt-to-postgresql/mqtt.go
+++ b/golang/cmd/mqtt-to-postgresql/mqtt.go
@@ -156,7 +156,7 @@ func processMessage(customerID string, location string, assetID string, payloadT
 		case Prefix.DeleteShiftByAssetIdAndBeginTimestamp:
 			deleteShiftByAssetIdAndBeginTimestampHandler.EnqueueMQTT(customerID, location, assetID, payload, 0)
 
-		case Prefix.ModifyProducesPieces:
+		case Prefix.ModifyProducedPieces:
 			modifyProducedPieceHandler.EnqueueMQTT(customerID, location, assetID, payload, 0)
 
 		default:

--- a/golang/cmd/mqtt-to-postgresql/prefix.go
+++ b/golang/cmd/mqtt-to-postgresql/prefix.go
@@ -24,7 +24,7 @@ func newPrefixRegistry() *prefixRegistry {
 		ProductTagString:                      "productTagString",
 		AddParentToChild:                      "addParentToChild",
 		ModifyState:                           "modifyState",
-		ModifyProducesPieces:                  "modifyProducedPieces",
+		ModifyProducedPieces:                  "modifyProducedPieces",
 		DeleteShiftById:                       "deleteShiftById",
 		DeleteShiftByAssetIdAndBeginTimestamp: "deleteShiftByAssetIdAndBeginTimestamp",
 		//For internal use only !
@@ -52,7 +52,7 @@ type prefixRegistry struct {
 	ProductTagString                      string
 	AddParentToChild                      string
 	ModifyState                           string
-	ModifyProducesPieces                  string
+	ModifyProducedPieces                  string
 	DeleteShiftById                       string
 	DeleteShiftByAssetIdAndBeginTimestamp string
 	RawMQTTRequeue                        string


### PR DESCRIPTION
# Description

This pr fixes naming issues with ModifyProducedPieces and adds an timestamp_ms field to the message to prevent overwriting all count entries

Fixes #1131 

Note: The timestamp_ms change was only introduced to kafka-to-postgres, since mqtt-to-postgres is deprecated at this time.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] I have checked that my issue complies with the [Contributing guidelines](https://github.com/united-manufacturing-hub/united-manufacturing-hub/blob/main/CONTRIBUTING.md)
