### PR TITLE
Return unix epoch instead of go epoch

### DIFF
--- a/golang/cmd/factoryinsight/database.go
+++ b/golang/cmd/factoryinsight/database.go
@@ -318,7 +318,7 @@ func GetShiftsRaw(c *gin.Context, customerID string, location string, asset stri
 
 			// First entry is always noShift
 			fullRow := datamodel.ShiftEntry{
-				TimestampBegin: time.Time{},
+				TimestampBegin: internal.UnixEpoch,
 				TimestampEnd:   from,
 				ShiftType:      0,
 			}
@@ -330,7 +330,7 @@ func GetShiftsRaw(c *gin.Context, customerID string, location string, asset stri
 		} else {
 			// First entry is always noShift
 			fullRow := datamodel.ShiftEntry{
-				TimestampBegin: time.Time{},
+				TimestampBegin: internal.UnixEpoch,
 				TimestampEnd:   timestampStart, //.Add(time.Duration(-1) * time.Millisecond)
 				ShiftType:      0,
 			}

--- a/golang/cmd/factoryinsight/dataprocessing_shifts.go
+++ b/golang/cmd/factoryinsight/dataprocessing_shifts.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/gin-gonic/gin"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/internal"
 	"time"
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/pkg/datamodel"
@@ -142,7 +143,7 @@ func cleanRawShiftData(shiftArray []datamodel.ShiftEntry, from time.Time, to tim
 		}
 
 		// set timestampBegin and timestampEnd if not set yet
-		if timestampBegin == (time.Time{}) || timestampEnd == (time.Time{}) {
+		if timestampBegin == (internal.UnixEpoch) || timestampEnd == (internal.UnixEpoch) {
 			timestampBegin = dataPoint.TimestampBegin
 			timestampEnd = dataPoint.TimestampEnd
 		}
@@ -173,14 +174,14 @@ func cleanRawShiftData(shiftArray []datamodel.ShiftEntry, from time.Time, to tim
 				processedShifts = append(processedShifts, fullRow)
 
 				// reset timestampBegin and timestampEnd
-				timestampBegin = (time.Time{})
-				timestampEnd = (time.Time{})
+				timestampBegin = (internal.UnixEpoch)
+				timestampEnd = (internal.UnixEpoch)
 			}
 
 		} else { // if last entry
 
 			// add ongoing shift
-			if timestampBegin != (time.Time{}) || timestampEnd != (time.Time{}) {
+			if timestampBegin != (internal.UnixEpoch) || timestampEnd != (internal.UnixEpoch) {
 				// add no shift at the end
 				fullRow := datamodel.ShiftEntry{
 					TimestampBegin: timestampBegin,

--- a/golang/internal/constants.go
+++ b/golang/internal/constants.go
@@ -6,3 +6,6 @@ var OneSecond = 1 * time.Second
 var FiveSeconds = 5 * time.Second
 var TenSeconds = 10 * time.Second
 var FifteenSeconds = 15 * time.Second
+
+var FirstJan1970 = time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
+var UnixEpoch = FirstJan1970


### PR DESCRIPTION
# Description

This pr fixes an issue, where the wrong time is returned (time.Time{} instead of the unix epoch)
go epoch will return a negative number, confusing grafana. (https://github.com/golang/go/issues/10906)
Fixes #1143 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Test script with unix epoch returns correct time


# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have checked that my issue complies with the [Contributing guidelines](https://github.com/united-manufacturing-hub/united-manufacturing-hub/blob/main/CONTRIBUTING.md)
