### PR TITLE
Initialized begin and end time to unix epoch to pass tests

### DIFF
--- a/golang/cmd/factoryinsight/dataprocessing_shifts.go
+++ b/golang/cmd/factoryinsight/dataprocessing_shifts.go
@@ -129,6 +129,8 @@ func cleanRawShiftData(shiftArray []datamodel.ShiftEntry, from time.Time, to tim
 	var timestampBegin time.Time
 	var timestampEnd time.Time
 	var shiftType int
+	timestampBegin = internal.UnixEpoch
+	timestampEnd = internal.UnixEpoch
 
 	for index, dataPoint := range shiftArray {
 		// first and last shift are always of type noShift. Therefore, ignore them here
@@ -143,7 +145,7 @@ func cleanRawShiftData(shiftArray []datamodel.ShiftEntry, from time.Time, to tim
 		}
 
 		// set timestampBegin and timestampEnd if not set yet
-		if timestampBegin == (internal.UnixEpoch) || timestampEnd == (internal.UnixEpoch) {
+		if timestampBegin == internal.UnixEpoch || timestampEnd == internal.UnixEpoch {
 			timestampBegin = dataPoint.TimestampBegin
 			timestampEnd = dataPoint.TimestampEnd
 		}
@@ -174,14 +176,14 @@ func cleanRawShiftData(shiftArray []datamodel.ShiftEntry, from time.Time, to tim
 				processedShifts = append(processedShifts, fullRow)
 
 				// reset timestampBegin and timestampEnd
-				timestampBegin = (internal.UnixEpoch)
-				timestampEnd = (internal.UnixEpoch)
+				timestampBegin = internal.UnixEpoch
+				timestampEnd = internal.UnixEpoch
 			}
 
 		} else { // if last entry
 
 			// add ongoing shift
-			if timestampBegin != (internal.UnixEpoch) || timestampEnd != (internal.UnixEpoch) {
+			if timestampBegin != internal.UnixEpoch || timestampEnd != internal.UnixEpoch {
 				// add no shift at the end
 				fullRow := datamodel.ShiftEntry{
 					TimestampBegin: timestampBegin,


### PR DESCRIPTION
# Description

This pr fixes an issue, where the timestampBegin and timestampEnd where not correctly initialized, resulting in failed tests
Fixes #1143 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] Local tests pass

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
- [X] I have checked that my issue complies with the [Contributing guidelines](https://github.com/united-manufacturing-hub/united-manufacturing-hub/blob/main/CONTRIBUTING.md)
