### PR TITLE
Replace initialDelay with startup probe

### DIFF
--- a/deployment/united-manufacturing-hub/templates/factoryinput/statefulset.yaml
+++ b/deployment/united-manufacturing-hub/templates/factoryinput/statefulset.yaml
@@ -101,13 +101,19 @@ spec:
               # - name: secret-volume
               #   mountPath: /SSL_certs
 
-          # define a liveness probe that checks every 5 seconds, starting after 5 seconds
+
           livenessProbe:
             httpGet:
               path: /live
               port: 8086
-            initialDelaySeconds: 30
             periodSeconds: 5
+          startupProbe:
+            httpGet:
+              path: /live
+              port: 8086
+            periodSeconds: 10
+            failureThreshold: 5 # 5*periodSeconds (10) => 50 sec max startup time
+
 
           # define a readiness probe that checks every 5 seconds
           #readinessProbe:

--- a/deployment/united-manufacturing-hub/templates/factoryinsight/deployment.yaml
+++ b/deployment/united-manufacturing-hub/templates/factoryinsight/deployment.yaml
@@ -96,13 +96,17 @@ spec:
             - name: VERSION
               value: "1"
 
-          # define a liveness probe that checks every 1 seconds, starting after 30 seconds
           livenessProbe:
             httpGet:
               path: /live
               port: 8086
-            initialDelaySeconds: 30
-            periodSeconds: 1
+            periodSeconds: 5
+          startupProbe:
+            httpGet:
+              path: /live
+              port: 8086
+            periodSeconds: 10
+            failureThreshold: 5 # 5*periodSeconds (10) => 50 sec max startup time
 
           # define a readiness probe that checks every 15 seconds
           readinessProbe:

--- a/deployment/united-manufacturing-hub/templates/grafanaproxy/deployment.yaml
+++ b/deployment/united-manufacturing-hub/templates/grafanaproxy/deployment.yaml
@@ -82,8 +82,13 @@ spec:
             httpGet:
               path: /
               port: 80
-            initialDelaySeconds: 30
             periodSeconds: 1
+          startupProbe:
+            httpGet:
+              path: /
+              port: 80
+            periodSeconds: 10
+            failureThreshold: 5 # 5*periodSeconds (10) => 50 sec max startup time
 
           # define a readiness probe that checks every 15 seconds
           readinessProbe:

--- a/deployment/united-manufacturing-hub/templates/kafkatopostgresql/deployment.yaml
+++ b/deployment/united-manufacturing-hub/templates/kafkatopostgresql/deployment.yaml
@@ -110,8 +110,14 @@ spec:
             httpGet:
               path: /live
               port: 8086
-            initialDelaySeconds: 30
             periodSeconds: 5
+          startupProbe:
+            httpGet:
+              path: /live
+              port: 8086
+            periodSeconds: 10
+            failureThreshold: 5 # 5*periodSeconds (10) => 50 sec max startup time
+
 
           resources:
             limits:

--- a/deployment/united-manufacturing-hub/templates/mqtttopostgresql/statefulset.yaml
+++ b/deployment/united-manufacturing-hub/templates/mqtttopostgresql/statefulset.yaml
@@ -105,8 +105,14 @@ spec:
             httpGet:
               path: /live
               port: 8086
-            initialDelaySeconds: 30
             periodSeconds: 5
+          startupProbe:
+            httpGet:
+              path: /live
+              port: 8086
+            periodSeconds: 10
+            failureThreshold: 5 # 5*periodSeconds (10) => 50 sec max startup time
+
 
           # define a readiness probe that checks every 5 seconds
           #readinessProbe:

--- a/deployment/united-manufacturing-hub/templates/nodered/statefulset.yaml
+++ b/deployment/united-manufacturing-hub/templates/nodered/statefulset.yaml
@@ -42,6 +42,12 @@ spec:
         ports:
         - containerPort: 1880
           name: nodered-ui
+        startupProbe:
+          periodSeconds: 10
+          failureThreshold: 30 # 30*periodSeconds (10) -> 300 seconds max startup time
+          httpGet:
+            path: /nodered
+            port: 1880
         livenessProbe:
           httpGet:
             path: /nodered

--- a/deployment/united-manufacturing-hub/values.yaml
+++ b/deployment/united-manufacturing-hub/values.yaml
@@ -2805,8 +2805,11 @@ kafkatoblob:
 ##### CONFIG FOR APACHE KAFKA #####
 kafka:
   livenessProbe:
-    initialDelaySeconds: 600
     failureThreshold: 10
+    timeoutSeconds: 10
+  startupProbe:
+    failureThreshold: 600
+    periodSeconds: 10
     timeoutSeconds: 10
   replicas: 1
   storageRequest: 1Gi

--- a/deployment/united-manufacturing-hub/values.yaml
+++ b/deployment/united-manufacturing-hub/values.yaml
@@ -2808,6 +2808,7 @@ kafka:
     failureThreshold: 10
     timeoutSeconds: 10
   startupProbe:
+    enabled: true
     failureThreshold: 600
     periodSeconds: 10
     timeoutSeconds: 10


### PR DESCRIPTION
# Description

This pr replaces startup delays with startup probes, in accordance with https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-startup-probes

This will allow for slow container startup, but also for fast issue detection and killing of the container, in case of unresponsiveness.

Fixes #1161 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have checked that my issue complies with the [Contributing guidelines](https://github.com/united-manufacturing-hub/united-manufacturing-hub/blob/main/CONTRIBUTING.md)
