### PR TITLE
Turkish Language Support

### DIFF
--- a/golang/pkg/datamodel/stateModelString.go
+++ b/golang/pkg/datamodel/stateModelString.go
@@ -90,6 +90,79 @@ func ConvertStateToString(state int, languageCode LanguageCode) (stateString str
 		default:
 			stateString = fmt.Sprintf("Unbekannter Zustand %d", state)
 		}
+	} else if languageCode == 1 { // TURKISH
+		switch state {
+		case ProducingAtFullSpeedState:
+			stateString = "Makine Çalışıyor"
+		case ProducingAtLowerThanFullSpeedState:
+			stateString = "Makine Düşük Hızda Çalışıyor"
+		case UnknownState:
+			stateString = "Veri Yok"
+		case IdleState:
+			stateString = "Hazır"
+		case OperatorInteractionState:
+			stateString = "Operatör Müdahalesi"
+		case UnspecifiedStopState:
+			stateString = "Bilinmeyen Duruş"
+		case MicrostopState:
+			stateString = "Kısa Duruş"
+		case InletJamState:
+			stateString = "Mangel am Einlauf"
+		case OutletJamState:
+			stateString = "Mangel am Auslauf"
+		case CongestionBypassState:
+			stateString = "Yarı Mamül Eksikliği"
+		case MissingBottleCapsRinneState:
+			stateString = "Mangel an Kronkorken (Rinne)"
+		case MissingBottleCapsUebergabeState:
+			stateString = "Mangel an Kronkorken (Übergabe)"
+		case MaterialIssueOtherState:
+			stateString = "Diğer Hammadde Sorunları"
+		case ChangeoverState:
+			stateString = "Model Değişimi"
+		case ChangeoverPreparationState:
+			stateString = "Model Değişim Hazırlık"
+		case ChangeoverPostprocessingState:
+			stateString = "Model Değişim Son Kontrol"
+		case CleaningState:
+			stateString = "Temizlik"
+		case EmptyingState:
+			stateString = "Boşaltma"
+		case SettingUpState:
+			stateString = "Hazırlama"
+		case OperatorNotAtMachineState:
+			stateString = "Operatör Makinede Değil"
+		case OperatorBreakState:
+			stateString = "Mola"
+		case NoShiftState:
+			stateString = "Vardiya Yok"
+		case NoOrderState:
+			stateString = "Sipariş Yok"
+		case EquipmentFailureState:
+			stateString = "Makine Arızası"
+		case EquipmentFailureStateWelder:
+			stateString = "Makine Arızası - Kaynak"
+		case EquipmentFailureStateExpender:
+			stateString = "Makine Arızası - Tutucu"
+		case EquipmentFailureStatePalletizer:
+			stateString = "Makine Arızası - Palet"
+		case EquipmentFailureStateUnderbody:
+			stateString = "Makine Arızası - Gövde"
+		case EquipmentFailureStateTopcover:
+			stateString = "Makine Arızası - Üst Taraf"
+		case ExternalFailureState:
+			stateString = "Harici Arıza"
+		case ExternalInterferenceState:
+			stateString = "Dış Müdahale"
+		case CraneNotAvailableState:
+			stateString = "Vinç Mevcut Değil"
+		case PreventiveMaintenanceStop:
+			stateString = "Bakım"
+		case TechnicalOtherStop:
+			stateString = "Diğer Teknik Arızalar"
+		default:
+			stateString = fmt.Sprintf("Bilinmeyen Durum %d", state)
+		}
 	} else { //ENGLISH
 		switch state {
 		case ProducingAtFullSpeedState:

--- a/golang/pkg/datamodel/stateModelString.go
+++ b/golang/pkg/datamodel/stateModelString.go
@@ -9,8 +9,8 @@ type LanguageCode int
 
 const (
 	LanguageGerman  LanguageCode = 0
-	LanguageTurkish  LanguageCode = 1
-	LanguageEnglish LanguageCode = 2
+	LanguageEnglish LanguageCode = 1
+	LanguageTurkish  LanguageCode = 2
 )
 
 // ConvertStateToString converts a state in integer format to a human readable string
@@ -91,7 +91,7 @@ func ConvertStateToString(state int, languageCode LanguageCode) (stateString str
 		default:
 			stateString = fmt.Sprintf("Unbekannter Zustand %d", state)
 		}
-	} else if languageCode == 1 { // TURKISH
+	} else if languageCode == 2 { // TURKISH
 		switch state {
 		case ProducingAtFullSpeedState:
 			stateString = "Makine Çalışıyor"

--- a/golang/pkg/datamodel/stateModelString.go
+++ b/golang/pkg/datamodel/stateModelString.go
@@ -9,7 +9,8 @@ type LanguageCode int
 
 const (
 	LanguageGerman  LanguageCode = 0
-	LanguageEnglish LanguageCode = 1
+	LanguageTurkish  LanguageCode = 1
+	LanguageEnglish LanguageCode = 2
 )
 
 // ConvertStateToString converts a state in integer format to a human readable string


### PR DESCRIPTION
I added the Turkish language to make the dashboars more understandable in Turkey. In this way, employees can monitor the machine's status, etc. can see in the local language.

# Description

It's not a merge I did against a problem. I just added the translation of the Turkish language. For this, I set up an else if structure between the existing if - else structure.

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
I haven't done any testing.

**Test Configuration**:
* Kubernetes Version: 
* Helm Version:
* Hardware:

# Checklist:

- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding changes to the changelog (if needed).
- [ ] I have made corresponding notices to the upgrade instructions (if needed)

