### PR TITLE
feat: add push based subscription for new topics

### DIFF
--- a/golang/cmd/kafka-to-blob/main.go
+++ b/golang/cmd/kafka-to-blob/main.go
@@ -75,6 +75,21 @@ func main() {
 		"group.id":                 "kafka-to-blob",
 	})
 
+	// KafkaTopicProbeConsumer recieves a message when a new topic is created
+	internal.SetupKafkaTopicProbeConsumer(kafka.ConfigMap{
+		"bootstrap.servers":        KafkaBoostrapServer,
+		"security.protocol":        securityProtocol,
+		"ssl.key.location":         "/SSL_certs/tls.key",
+		"ssl.key.password":         os.Getenv("KAFKA_SSL_KEY_PASSWORD"),
+		"ssl.certificate.location": "/SSL_certs/tls.crt",
+		"ssl.ca.location":          "/SSL_certs/ca.crt",
+		"group.id":                 "kafka-to-blob-topic-probe",
+		"enable.auto.commit":       true,
+		"auto.offset.reset":        "earliest",
+		//"debug":                    "security,broker",
+		"topic.metadata.refresh.interval.ms": "30000",
+	})
+
 	err := internal.CreateTopicIfNotExists(KafkaBaseTopic)
 	if err != nil {
 		panic(err)
@@ -86,6 +101,16 @@ func main() {
 	zap.S().Debugf("Start Queue processors")
 	go processKafkaQueue(KafkaTopic, MinioBucketName)
 	go reconnectMinio()
+
+	// Start topic probe processor
+	zap.S().Debugf("Starting TP queue processor")
+	topicProbeProcessorChannel := make(chan *kafka.Message, 100)
+
+	go internal.ProcessKafkaTopicProbeQueue("[TP]", topicProbeProcessorChannel, nil)
+	go internal.StartEventHandler("[TP]", internal.KafkaTopicProbeConsumer.Events(), nil)
+
+	go internal.StartTopicProbeQueueProcessor(topicProbeProcessorChannel)
+	zap.S().Debugf("Started TP queue processor")
 
 	// Allow graceful shutdown
 	sigs := make(chan os.Signal, 1)

--- a/golang/cmd/mqtt-kafka-bridge/main.go
+++ b/golang/cmd/mqtt-kafka-bridge/main.go
@@ -104,6 +104,22 @@ func main() {
 		"bootstrap.servers":        KafkaBoostrapServer,
 		"group.id":                 "mqtt-kafka-bridge",
 	})
+
+	// KafkaTopicProbeConsumer recieves a message when a new topic is created
+	internal.SetupKafkaTopicProbeConsumer(kafka.ConfigMap{
+		"bootstrap.servers":        KafkaBoostrapServer,
+		"security.protocol":        securityProtocol,
+		"ssl.key.location":         "/SSL_certs/tls.key",
+		"ssl.key.password":         os.Getenv("KAFKA_SSL_KEY_PASSWORD"),
+		"ssl.certificate.location": "/SSL_certs/tls.crt",
+		"ssl.ca.location":          "/SSL_certs/ca.crt",
+		"group.id":                 "kafka-to-blob-topic-probe",
+		"enable.auto.commit":       true,
+		"auto.offset.reset":        "earliest",
+		//"debug":                    "security,broker",
+		"topic.metadata.refresh.interval.ms": "30000",
+	})
+
 	err = internal.CreateTopicIfNotExists(KafkaBaseTopic)
 	if err != nil {
 		panic(err)
@@ -114,6 +130,16 @@ func main() {
 	go processIncomingMessages()
 	go processOutgoingMessages()
 	go kafkaToQueue(KafkaTopic)
+
+	// Start topic probe processor
+	zap.S().Debugf("Starting TP queue processor")
+	topicProbeProcessorChannel := make(chan *kafka.Message, 100)
+
+	go internal.ProcessKafkaTopicProbeQueue("[TP]", topicProbeProcessorChannel, nil)
+	go internal.StartEventHandler("[TP]", internal.KafkaTopicProbeConsumer.Events(), nil)
+
+	go internal.StartTopicProbeQueueProcessor(topicProbeProcessorChannel)
+	zap.S().Debugf("Started TP queue processor")
 
 	// Allow graceful shutdown
 	sigs := make(chan os.Signal, 1)

--- a/golang/go.mod
+++ b/golang/go.mod
@@ -32,7 +32,6 @@ require (
 	github.com/syndtr/goleveldb v1.0.0 // indirect
 	github.com/united-manufacturing-hub/umh-utils v0.0.3
 	github.com/zeebo/xxh3 v1.0.2
-	go.elastic.co/ecszap v1.0.1
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
 	go.uber.org/zap v1.23.0

--- a/golang/internal/kafka.go
+++ b/golang/internal/kafka.go
@@ -6,6 +6,7 @@ package internal
 import (
 	"context"
 	"github.com/confluentinc/confluent-kafka-go/kafka"
+	jsoniter "github.com/json-iterator/go"
 	"go.uber.org/zap"
 	"strings"
 	"time"
@@ -14,6 +15,7 @@ import (
 var KafkaConsumer *kafka.Consumer
 var KafkaProducer *kafka.Producer
 var KafkaAdminClient *kafka.AdminClient
+var KafkaTopicProbeConsumer *kafka.Consumer
 
 func SetupKafka(configMap kafka.ConfigMap) {
 	zap.S().Debugf("Configmap: %v", configMap)
@@ -40,6 +42,25 @@ func SetupKafka(configMap kafka.ConfigMap) {
 	return
 }
 
+// SetupKafkaTopicProbeConsumer sets up a consumer for detecting new topics
+func SetupKafkaTopicProbeConsumer(configMap kafka.ConfigMap) {
+	zap.S().Debugf("Configmap: %v", configMap)
+
+	var err error
+	KafkaTopicProbeConsumer, err = kafka.NewConsumer(&configMap)
+	if err != nil {
+		panic(err)
+	}
+
+	err = KafkaTopicProbeConsumer.Subscribe("umh.kafka.topic.created", nil)
+	if err != nil {
+		return
+	}
+
+	zap.S().Debugf("KafkaTopicProbeConsumer: %+v", KafkaTopicProbeConsumer)
+	return
+}
+
 func CloseKafka() {
 	err := KafkaConsumer.Close()
 	if err != nil {
@@ -50,6 +71,13 @@ func CloseKafka() {
 	KafkaProducer.Close()
 
 	KafkaAdminClient.Close()
+}
+
+func CloseKafkaTopicProbeConsumer() {
+	err := KafkaTopicProbeConsumer.Close()
+	if err != nil {
+		panic("Failed do close KafkaTopicProbeConsumer client !")
+	}
 }
 
 var lastMetaData *kafka.Metadata
@@ -120,6 +148,27 @@ func CreateTopicIfNotExists(kafkaTopicName string) (err error) {
 	if err != nil || len(topics) != 1 {
 		zap.S().Errorf("Failed to create Topic %s : %s", kafkaTopicName, err)
 		return
+	}
+
+	// send a message to the "umh.kafka.topic.created" topic with the new topic name
+	// to trigger the subsrciption of the other consumers to the newly created topic
+	payload := make(map[string]string)
+	payload["topic"] = kafkaTopicName
+	jsonString, err := jsoniter.Marshal(payload)
+	if err != nil {
+		zap.S().Errorf("Failed to marshal payload: %s", err)
+		return
+	}
+	var probeTopicName = "umh.kafka.topic.created"
+	err = KafkaProducer.Produce(&kafka.Message{
+		TopicPartition: kafka.TopicPartition{
+			Topic:     &probeTopicName,
+			Partition: kafka.PartitionAny,
+		},
+		Value: jsonString,
+	}, nil)
+	if err != nil {
+		return err
 	}
 
 	select {

--- a/golang/internal/kafkaMessageProcessing.go
+++ b/golang/internal/kafkaMessageProcessing.go
@@ -6,6 +6,7 @@ package internal
 import (
 	"bytes"
 	"encoding/gob"
+	"encoding/json"
 	"github.com/confluentinc/confluent-kafka-go/kafka"
 	"github.com/coocood/freecache"
 	"go.uber.org/zap"
@@ -19,6 +20,10 @@ type ParsedMessage struct {
 	CustomerId  string
 	PayloadType string
 	Payload     []byte
+}
+
+type TopicProbeMessage struct {
+	Topic string
 }
 
 // ParseMessage parses a kafka message and returns a ParsedMessage struct or false if the message is not a valid message
@@ -109,4 +114,28 @@ func GetCacheParsedMessage(msg *kafka.Message) (valid bool, found bool, message 
 	}
 
 	return true, true, pm
+}
+
+// StartTopicProbeQueueProcessor processes the messages from the topic probe queue and triggeers
+// the refresh of the metadata for the consumers to discover the new created topic
+func StartTopicProbeQueueProcessor(topicProbeProcessorChannel chan *kafka.Message) {
+	zap.S().Debugf("[TP] Starting queue processor")
+	for !ShuttingDownKafka {
+		msg := <-topicProbeProcessorChannel
+		if msg == nil {
+			continue
+		}
+
+		var topicProbeMessage TopicProbeMessage
+		err := json.Unmarshal(msg.Value, &topicProbeMessage)
+		if err != nil {
+			zap.S().Errorf("[TP] Failed to unmarshal topic probe message: %s", err)
+			continue
+		}
+
+		_, err = KafkaConsumer.GetMetadata(&topicProbeMessage.Topic, false, 1000)
+		if err != nil {
+			zap.S().Errorf("[TP] Failed to get metadata for topic: %s", topicProbeMessage.Topic)
+		}
+	}
 }

--- a/golang/internal/kafkaMessageProcessing.go
+++ b/golang/internal/kafkaMessageProcessing.go
@@ -6,9 +6,9 @@ package internal
 import (
 	"bytes"
 	"encoding/gob"
-	"encoding/json"
 	"github.com/confluentinc/confluent-kafka-go/kafka"
 	"github.com/coocood/freecache"
+	jsoniter "github.com/json-iterator/go"
 	"go.uber.org/zap"
 	"strings"
 )
@@ -127,7 +127,7 @@ func StartTopicProbeQueueProcessor(topicProbeProcessorChannel chan *kafka.Messag
 		}
 
 		var topicProbeMessage TopicProbeMessage
-		err := json.Unmarshal(msg.Value, &topicProbeMessage)
+		err := jsoniter.Unmarshal(msg.Value, &topicProbeMessage)
 		if err != nil {
 			zap.S().Errorf("[TP] Failed to unmarshal topic probe message: %s", err)
 			continue


### PR DESCRIPTION
# Description

Adds a specific topic to which all consumer services subscribe. Messages in this topic contain the names of any new topics created by publishers, and consumers will automatically add the new topics to their subscription list.
In this way we can reduce the time needed to add a new topic to a couple of seconds, instead of relying on the `metadata.max.age.ms` parameter (#1223)

Fixes #1253 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Full deployment of the stack on my local minikube cluster

- [x] Create new topics with MQTTExplorer. The new topics are received by `kafka-to-postgresql` in the matter of seconds
- [ ] Injecting new topics via NodeRed does not work, but that is probably NodeRed's problem. In a production environment all the new topics will eventually pass through MQTT.

# Checklist:

- [ ] I have made corresponding changes to the documentation
- [x] I have made corresponding changes to the changelog (if needed).
- [ ] I have made corresponding notices to the upgrade instructions (if needed)

# Changelog changes

Added push-based detection of new topics

# Upgrade instructions

*not needed*
