### PR TITLE
Feat: change topic name for KafkaTopicProbeConsumer

### DIFF
--- a/golang/internal/kafka.go
+++ b/golang/internal/kafka.go
@@ -17,6 +17,8 @@ var KafkaProducer *kafka.Producer
 var KafkaAdminClient *kafka.AdminClient
 var KafkaTopicProbeConsumer *kafka.Consumer
 
+var probeTopicName = "umh.v1.kafka.newTopic"
+
 func SetupKafka(configMap kafka.ConfigMap) {
 	zap.S().Debugf("Configmap: %v", configMap)
 
@@ -52,7 +54,7 @@ func SetupKafkaTopicProbeConsumer(configMap kafka.ConfigMap) {
 		panic(err)
 	}
 
-	err = KafkaTopicProbeConsumer.Subscribe("umh.kafka.topic.created", nil)
+	err = KafkaTopicProbeConsumer.Subscribe(probeTopicName, nil)
 	if err != nil {
 		return
 	}
@@ -159,7 +161,6 @@ func CreateTopicIfNotExists(kafkaTopicName string) (err error) {
 		zap.S().Errorf("Failed to marshal payload: %s", err)
 		return
 	}
-	var probeTopicName = "umh.kafka.topic.created"
 	err = KafkaProducer.Produce(&kafka.Message{
 		TopicPartition: kafka.TopicPartition{
 			Topic:     &probeTopicName,


### PR DESCRIPTION
# Description

Rename the topic for KafkaTopicProbeConsumer from `umh.kafka.topic.created` to `umh.v1.kafka.newTopic`. This way it will fit the new convention that its being discussed for the rework of the datamodel

Fixes #1269

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

*not needed*

# Checklist:

- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding changes to the changelog (if needed).
- [ ] I have made corresponding notices to the upgrade instructions (if needed)

# Changelog changes

*not needed*

# Upgrade instructions

*not needed*
