### PR TITLE
Try convert string to float64 in kafka-to-postgresql

### DIFF
--- a/golang/cmd/kafka-to-postgresql/pxProcessValue.go
+++ b/golang/cmd/kafka-to-postgresql/pxProcessValue.go
@@ -226,6 +226,10 @@ func writeProcessValueToDatabase(messages []*kafka.Message) (
 									continue
 								}
 								value = float64(parseInt)
+							} else if valAsStr == "true" {
+								value = 1
+							} else if valAsStr == "false" {
+								value = 0
 							} else {
 								zap.S().Warnf("error parsing %s as float64: %s\n", valAsStr, err)
 								discardCounter++


### PR DESCRIPTION
# Description

This pr adds functionality to kafka-to-postgres, to try parse non-float64 values as float64. (for example strings containing floats).
It also increases the log level for incorrect messages to WARN

See: 
 - https://go.dev/ref/spec#Integer_literals
 - https://go.dev/ref/spec#Floating-point_literals
 - https://forum.golangbridge.org/t/potential-bug-in-strconv-parsefloat/29079

Fixes #1266 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Test nodered flow with floats as string

# Checklist:

- [x] I have made corresponding changes to the documentation
- [X] I have made corresponding changes to the changelog (if needed).
