### PR TITLE
Support for multiple tag splitting

### DIFF
--- a/golang/cmd/factoryinsight/v2/controllers/controller-tags.go
+++ b/golang/cmd/factoryinsight/v2/controllers/controller-tags.go
@@ -41,9 +41,7 @@ func GetTagGroupsHandler(c *gin.Context) {
 
 func GetTagsHandler(c *gin.Context) {
 	var request models.GetTagsRequest
-	var tags []string
-	var grouping map[string][]string
-	var response any
+	var response models.GetTagsResponse
 
 	err := c.BindUri(&request)
 	if err != nil {
@@ -66,16 +64,9 @@ func GetTagsHandler(c *gin.Context) {
 
 	switch request.TagGroupName {
 	case models.CustomTagGroup:
-		grouping, err = services.GetCustomTags(workCellId)
-		var r models.GetTagsResponse[map[string][]string]
-		r.Tags = make(map[string][]string)
-		r.Tags = grouping
-		response = r
+		response.Tags, err = services.GetCustomTags(workCellId)
 	case models.StandardTagGroup:
-		tags, err = services.GetStandardTags(request.EnterpriseName, request.SiteName, request.WorkCellName)
-		var r models.GetTagsResponse[[]string]
-		r.Tags = tags
-		response = r
+		response.Tags, err = services.GetStandardTags(request.EnterpriseName, request.SiteName, request.WorkCellName)
 	default:
 		helpers.HandleTypeNotFound(c, request.TagGroupName)
 		return

--- a/golang/cmd/factoryinsight/v2/models/dto-tags.go
+++ b/golang/cmd/factoryinsight/v2/models/dto-tags.go
@@ -2,8 +2,8 @@ package models
 
 import "time"
 
-type GetTagsResponse[T []string | map[string][]string] struct {
-	Tags T
+type GetTagsResponse struct {
+	Tags []string
 }
 type GetTagGroupsRequest struct {
 	EnterpriseName     string `uri:"enterpriseName" binding:"required"`

--- a/golang/cmd/factoryinsight/v2/models/dto-tree.go
+++ b/golang/cmd/factoryinsight/v2/models/dto-tree.go
@@ -32,9 +32,9 @@ type TreeStructureTags struct {
 }*/
 
 type TreeEntryFormat struct {
-	Label   string        `json:"label"`
-	Value   string        `json:"value"`
-	Entries []interface{} `json:"entries"`
+	Label   string                      `json:"label"`
+	Value   string                      `json:"value"`
+	Entries map[string]*TreeEntryFormat `json:"entries"`
 }
 
 type TreeEntryValues struct {

--- a/golang/cmd/factoryinsight/v2/services/service-tags.go
+++ b/golang/cmd/factoryinsight/v2/services/service-tags.go
@@ -114,7 +114,7 @@ func GetStandardTags(enterpriseName, siteName, workCellName string) (tags []stri
 
 func GetCustomTags(workCellId uint32) (tags []string, err error) {
 	zap.S().Infof(
-		"[GetTags] Getting custom tags for work cell %s", workCellId)
+		"[GetTags] Getting custom tags for work cell %d", workCellId)
 
 	sqlStatement := `SELECT DISTINCT valueName FROM processValueTable WHERE asset_id = $1`
 

--- a/golang/cmd/factoryinsight/v2/services/service-tags.go
+++ b/golang/cmd/factoryinsight/v2/services/service-tags.go
@@ -112,8 +112,8 @@ func GetStandardTags(enterpriseName, siteName, workCellName string) (tags []stri
 	return
 }
 
-func GetCustomTags(workCellId uint32) (grouping map[string][]string, err error) {
-	grouping = make(map[string][]string)
+func GetCustomTags(workCellId uint32) (tags []string, err error) {
+	//tags = make(map[string][]string)
 	zap.S().Infof(
 		"[GetTags] Getting custom tags for work cell %s", workCellId)
 
@@ -135,17 +135,50 @@ func GetCustomTags(workCellId uint32) (grouping map[string][]string, err error) 
 			return
 		}
 
-		if strings.Count(valueName, "_") == 1 {
-			if !strings.HasPrefix(valueName, "_") && !strings.HasSuffix(valueName, "_") {
-				left, right, _ := strings.Cut(valueName, "_")
-				grouping[left] = append(grouping[left], right)
-			}
-		} else if strings.Count(valueName, "_") == 0 {
-			grouping[valueName] = []string{}
-		}
+		tags = append(tags, valueName)
+
+		//if strings.Count(valueName, "_") == 1 && (strings.HasPrefix(valueName, "_") || strings.HasSuffix(valueName, "_")) {
+		//
+		//}
+		//if (strings.HasPrefix(valueName, "_") && strings.Count(valueName, "_") == 1) ||
+		//	(strings.HasSuffix(valueName, "_") && strings.Count(valueName, "_") == 1) ||
+		//	(strings.HasPrefix(valueName, "_") && strings.HasSuffix(valueName, "_")) {
+		//	strings.spl
+		//}
+		//if strings.Count(valueName, "_") == 1 {
+		//	if !strings.HasPrefix(valueName, "_") && !strings.HasSuffix(valueName, "_") {
+		//		left, right, _ := strings.Cut(valueName, "_")
+		//		tags[left] = append(tags[left], right)
+		//	}
+		//} else if strings.Count(valueName, "_") == 0 {
+		//	tags[valueName] = []string{}
+		//}
+
+		//if strings.Count(valueName, "_") == 0 {
+		//	groupingNew = append(groupingNew, models.TreeEntryFormat{
+		//		Value:    valueName,
+		//	})
+		//} else {
+		//	splitValues := strings.Split(valueName, "_")
+		//	for i, value := range splitValues {
+		//		if value == "" {
+		//
+		//		} else {
+		//			parentIdx := slices.IndexFunc(groupingNew, func(p Parent) bool { return p.Value == value })
+		//			if parentIdx == -1 {
+		//				groupingNew[parentIdx].Children = append(groupingNew[parentIdx].Children, Parent{Value: value, Children: nil})
+		//			}
+		//		}
+		//	}
+		//}
 	}
 
 	return
+}
+
+type Parent struct {
+	Value    string
+	Children []Parent
 }
 
 func ProcessJobTagRequest(c *gin.Context, request models.GetTagsDataRequest) {

--- a/golang/cmd/factoryinsight/v2/services/service-tags.go
+++ b/golang/cmd/factoryinsight/v2/services/service-tags.go
@@ -113,7 +113,6 @@ func GetStandardTags(enterpriseName, siteName, workCellName string) (tags []stri
 }
 
 func GetCustomTags(workCellId uint32) (tags []string, err error) {
-	//tags = make(map[string][]string)
 	zap.S().Infof(
 		"[GetTags] Getting custom tags for work cell %s", workCellId)
 
@@ -136,41 +135,6 @@ func GetCustomTags(workCellId uint32) (tags []string, err error) {
 		}
 
 		tags = append(tags, valueName)
-
-		//if strings.Count(valueName, "_") == 1 && (strings.HasPrefix(valueName, "_") || strings.HasSuffix(valueName, "_")) {
-		//
-		//}
-		//if (strings.HasPrefix(valueName, "_") && strings.Count(valueName, "_") == 1) ||
-		//	(strings.HasSuffix(valueName, "_") && strings.Count(valueName, "_") == 1) ||
-		//	(strings.HasPrefix(valueName, "_") && strings.HasSuffix(valueName, "_")) {
-		//	strings.spl
-		//}
-		//if strings.Count(valueName, "_") == 1 {
-		//	if !strings.HasPrefix(valueName, "_") && !strings.HasSuffix(valueName, "_") {
-		//		left, right, _ := strings.Cut(valueName, "_")
-		//		tags[left] = append(tags[left], right)
-		//	}
-		//} else if strings.Count(valueName, "_") == 0 {
-		//	tags[valueName] = []string{}
-		//}
-
-		//if strings.Count(valueName, "_") == 0 {
-		//	groupingNew = append(groupingNew, models.TreeEntryFormat{
-		//		Value:    valueName,
-		//	})
-		//} else {
-		//	splitValues := strings.Split(valueName, "_")
-		//	for i, value := range splitValues {
-		//		if value == "" {
-		//
-		//		} else {
-		//			parentIdx := slices.IndexFunc(groupingNew, func(p Parent) bool { return p.Value == value })
-		//			if parentIdx == -1 {
-		//				groupingNew[parentIdx].Children = append(groupingNew[parentIdx].Children, Parent{Value: value, Children: nil})
-		//			}
-		//		}
-		//	}
-		//}
 	}
 
 	return

--- a/golang/cmd/factoryinsight/v2/services/service-tree.go
+++ b/golang/cmd/factoryinsight/v2/services/service-tree.go
@@ -281,13 +281,14 @@ func GetTagsTreeStructure(customer string, site string, area string, line string
 	te []models.TreeEntryFormat,
 	err error) {
 
+	zap.S().Infof("[GetTagsTreeStructure] customer: %s, site: %s, area: %s, line: %s, cell: %s", customer, site, area, line, cell)
 	var tags []string
 	tags, err = GetTagGroups(customer, site, area, line, cell)
 	if err != nil {
 		return nil, err
 	}
 	for _, tagGroup := range tags {
-		var structure map[string]*models.TreeEntryFormat
+		var structure = make(map[string]*models.TreeEntryFormat)
 		if tagGroup == models.StandardTagGroup {
 			structure, err = GetStandardTagsTree(customer, site, area, line, cell, tagGroup)
 		} else if tagGroup == models.CustomTagGroup {
@@ -316,8 +317,8 @@ func GetCustomTagsTree(
 	line string,
 	cell string,
 	group string) (te map[string]*models.TreeEntryFormat, err error) {
-	te = make(map[string]*models.TreeEntryFormat)
 
+	te = make(map[string]*models.TreeEntryFormat)
 	var id uint32
 	id, err = GetWorkCellId(customer, site, cell)
 	if err != nil {
@@ -359,11 +360,11 @@ func mapTagGrouping(pte map[string]*models.TreeEntryFormat, st []string, value s
 	if !exists {
 		a = &models.TreeEntryFormat{
 			Label:   st[0],
-			Value:   "",
+			Value:   st[0],
 			Entries: map[string]*models.TreeEntryFormat{},
 		}
 	}
-	// if the tag group is a leaf, set the value
+	// if the tag group is a leaf, set value and end the recursion
 	if len(st) > 1 {
 		a.Entries[st[1]] = mapTagGrouping(a.Entries, st[1:], value)
 	} else {
@@ -388,6 +389,7 @@ func GetStandardTagsTree(customer string, site string, area string, line string,
 	te map[string]*models.TreeEntryFormat,
 	err error) {
 
+	te = make(map[string]*models.TreeEntryFormat)
 	var tags []string
 	tags, err = GetStandardTags(customer, site, cell)
 	if err != nil {
@@ -407,6 +409,7 @@ func GetKPITreeStructure(customer string, site string, area string, line string,
 	te []models.TreeEntryFormat,
 	err error) {
 
+	zap.S().Infof("[GetKPITreeStructure] customer: %s, site: %s, area: %s, line: %s, cell: %s", customer, site, area, line, cell)
 	var kpis models.GetKpisMethodsResponse
 	kpis, err = GetKpisMethods(customer, site, cell)
 	if err != nil {
@@ -426,6 +429,7 @@ func GetTableTreeStructure(customer string, site string, area string, line strin
 	te []models.TreeEntryFormat,
 	err error) {
 
+	zap.S().Infof("[GetTableTreeStructure] customer: %s, site: %s, area: %s, line: %s, cell: %s", customer, site, area, line, cell)
 	var types models.GetTableTypesResponse
 	types, err = GetTableTypes(customer, site, cell)
 	if err != nil {

--- a/golang/cmd/factoryinsight/v2/services/service-tree.go
+++ b/golang/cmd/factoryinsight/v2/services/service-tree.go
@@ -191,6 +191,7 @@ func GetEnterpriseTreeStructure() (te []interface{}, err error) {
 
 func GetSiteTreeStructure(customer string) (te map[string]*models.TreeEntryFormat, err error) {
 	var sites []string
+	te = make(map[string]*models.TreeEntryFormat)
 	sites, err = GetSites(customer)
 	if err != nil {
 		return nil, err
@@ -213,6 +214,7 @@ func GetSiteTreeStructure(customer string) (te map[string]*models.TreeEntryForma
 
 func GetAreaTreeStructure(customer string, site string) (te map[string]*models.TreeEntryFormat, err error) {
 	var areas []string
+	te = make(map[string]*models.TreeEntryFormat)
 	areas, err = GetAreas(customer, site)
 	if err != nil {
 		return nil, err
@@ -235,6 +237,7 @@ func GetAreaTreeStructure(customer string, site string) (te map[string]*models.T
 
 func GetLineTreeStructure(customer string, site string, area string) (te map[string]*models.TreeEntryFormat, err error) {
 	var lines []string
+	te = make(map[string]*models.TreeEntryFormat)
 	lines, err = GetProductionLines(customer, site, area)
 	if err != nil {
 		return nil, err
@@ -259,6 +262,7 @@ func GetWorkCellTreeStructure(customer string, site string, area string, line st
 	te map[string]*models.TreeEntryFormat,
 	err error) {
 	var workCells []string
+	te = make(map[string]*models.TreeEntryFormat)
 	workCells, err = GetWorkCells(customer, site, area, line)
 	if err != nil {
 		return nil, err
@@ -312,6 +316,7 @@ func GetCustomTagsTree(
 	line string,
 	cell string,
 	group string) (te map[string]*models.TreeEntryFormat, err error) {
+	te = make(map[string]*models.TreeEntryFormat)
 
 	var id uint32
 	id, err = GetWorkCellId(customer, site, cell)
@@ -323,6 +328,8 @@ func GetCustomTagsTree(
 	if err != nil {
 		return nil, err
 	}
+
+	slices.Sort(tags)
 
 	for _, tag := range tags {
 

--- a/golang/go.mod
+++ b/golang/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/united-manufacturing-hub/umh-utils v0.0.3
 	github.com/zeebo/xxh3 v1.0.2
 	go.uber.org/zap v1.23.0
+	golang.org/x/exp v0.0.0-20221106115401-f9659909a136
 	gonum.org/v1/gonum v0.12.0
 	k8s.io/apimachinery v0.25.3
 )
@@ -73,7 +74,7 @@ require (
 	golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90 // indirect
 	golang.org/x/net v0.0.0-20220907135653-1e95f45603a7 // indirect
 	golang.org/x/sync v0.0.0-20220907140024-f12130a52804 // indirect
-	golang.org/x/sys v0.0.0-20220908164124-27713097b956 // indirect
+	golang.org/x/sys v0.1.0 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0 // indirect

--- a/golang/go.sum
+++ b/golang/go.sum
@@ -423,8 +423,9 @@ golang.org/x/exp v0.0.0-20191129062945-2f5052295587/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
-golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6 h1:QE6XYQK6naiK1EPAe1g/ILLxN5RBoH5xkJk3CqlMI/Y=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20221106115401-f9659909a136 h1:Fq7F/w7MAa1KJ5bt2aJ62ihqp9HDcRuyILskkpIAurw=
+golang.org/x/exp v0.0.0-20221106115401-f9659909a136/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -555,8 +556,8 @@ golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220704084225-05e143d24a9e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220908164124-27713097b956 h1:XeJjHH1KiLpKGb6lvMiksZ9l0fVUh+AmGcm0nOMEBOY=
-golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
+golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
# Description

Add support to split custom tags containing `_` and aggregates them 

Fixes #1330 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested with random data and umh-datsource-v2 v1.0.74

# Checklist:

- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding changes to the changelog (if needed).
