### PR TITLE
Add tulip connector to helm chart

### DIFF
--- a/deployment/united-manufacturing-hub/templates/_helpers.tpl
+++ b/deployment/united-manufacturing-hub/templates/_helpers.tpl
@@ -245,6 +245,14 @@ app.kubernetes.io/name: {{ include "united-manufacturing-hub.name" . }}-kowl
 {{- end }}
 
 {{/*
+Labels for tulip-connector
+*/}}
+{{- define "united-manufacturing-hub.labels.tulip-connector" -}}
+app.kubernetes.io/name: {{ include "united-manufacturing-hub.name" . }}-tulip-connector
+{{ include "united-manufacturing-hub.labels.common" . }}
+{{- end }}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "united-manufacturing-hub.serviceAccountName" -}}

--- a/deployment/united-manufacturing-hub/templates/tulip-connector/deployment.yaml
+++ b/deployment/united-manufacturing-hub/templates/tulip-connector/deployment.yaml
@@ -1,0 +1,41 @@
+---
+{{if or .Values._000_commonConfig.tulipconnector.enabled}}
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{include "united-manufacturing-hub.fullname" .}}-tulip-connector-deployment
+  labels:
+    {{- include "united-manufacturing-hub.labels.tulip-connector" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.tulipconnector.replicas }}
+  selector:
+    matchLabels:
+      name: {{include "united-manufacturing-hub.fullname" .}}-tulip-connector-deployment
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: {{include "united-manufacturing-hub.fullname" .}}-tulip-connector-deployment
+        {{- include "united-manufacturing-hub.labels.tulip-connector" . | nindent 8 }}
+    spec:
+      restartPolicy: Always
+      containers:
+        - name: {{include "united-manufacturing-hub.fullname" .}}-tulip-connector
+        {{if .Values.tulipconnector.image.tag}}
+          image: {{ .Values.tulipconnector.image.repository }}:{{ .Values.tulipconnector.image.tag }}
+        {{else}}
+          image: {{ .Values.tulipconnector.image.repository }}:latest
+        {{end}}
+          imagePullPolicy: {{ .Values.tulipconnector.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          resources:
+            limits:
+              cpu: {{ .Values.tulipconnector.resources.limits.cpu }}
+            requests:
+              cpu: {{ .Values.tulipconnector.resources.requests.cpu }}
+  {{end}}

--- a/deployment/united-manufacturing-hub/templates/tulip-connector/deployment.yaml
+++ b/deployment/united-manufacturing-hub/templates/tulip-connector/deployment.yaml
@@ -29,6 +29,9 @@ spec:
           image: {{ .Values.tulipconnector.image.repository }}:latest
         {{end}}
           imagePullPolicy: {{ .Values.tulipconnector.image.pullPolicy }}
+          env:
+            - name: MODE
+              value: {{ .Values.tulipconnector.env.mode }}
           ports:
             - name: http
               containerPort: 80

--- a/deployment/united-manufacturing-hub/templates/tulip-connector/ingress.yaml
+++ b/deployment/united-manufacturing-hub/templates/tulip-connector/ingress.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{include "united-manufacturing-hub.fullname" .}}-tulip-connector-ingress
+  labels:
+    {{- include "united-manufacturing-hub.labels.tulip-connector" . | nindent 4 }}
+spec:
+  rules:
+    - host: {{ .Values._000_commonConfig.tulipconnector.domain }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "united-manufacturing-hub.fullname" . }}-tulip-connector-service
+                port:
+                  number: 80

--- a/deployment/united-manufacturing-hub/templates/tulip-connector/service.yaml
+++ b/deployment/united-manufacturing-hub/templates/tulip-connector/service.yaml
@@ -1,0 +1,18 @@
+---
+{{if or .Values._000_commonConfig.tulipconnector.enabled}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{include "united-manufacturing-hub.fullname" . }}-tulip-connector-service
+  labels:
+    {{- include "united-manufacturing-hub.labels.tulip-connector" . | nindent 4 }}
+spec:
+  selector:
+    {{- include "united-manufacturing-hub.labels.tulip-connector" . | nindent 4 }}
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 80
+      protocol: TCP
+      name: http
+{{end}}

--- a/deployment/united-manufacturing-hub/values.yaml
+++ b/deployment/united-manufacturing-hub/values.yaml
@@ -258,6 +258,10 @@ _000_commonConfig:
   kafkaStateDetector:
     enabled: false
 
+  tulipconnector:
+    enabled: true
+    domain: "tulip-connector.changeme.com"
+
 _001_customMicroservices:
   -
       name: example
@@ -2197,6 +2201,22 @@ packmlmqttsimulator:
     limits:
       cpu: "100m"
       memory: "100Mi"
+
+### tulip-connector ###
+tulipconnector:
+  image:
+    repository: unitedmanufacturinghub/tulip-connector
+    pullPolicy: IfNotPresent
+    # Only specify tag if you want to use a specific version. If not specified the latest stable version is automatically selected
+    tag: main
+  replicas: 2
+  resources:
+    limits:
+      cpu: 200m
+      memory: 200Mi
+    requests:
+      cpu: 50m
+      memory: 50Mi
 
 ### mqtt-kafka-bridge ###
 mqttkafkabridge:

--- a/deployment/united-manufacturing-hub/values.yaml
+++ b/deployment/united-manufacturing-hub/values.yaml
@@ -2210,6 +2210,8 @@ tulipconnector:
     # Only specify tag if you want to use a specific version. If not specified the latest stable version is automatically selected
     tag: main
   replicas: 2
+  env:
+    mode: dev
   resources:
     limits:
       cpu: 200m

--- a/deployment/united-manufacturing-hub/values.yaml
+++ b/deployment/united-manufacturing-hub/values.yaml
@@ -2208,17 +2208,17 @@ tulipconnector:
     repository: unitedmanufacturinghub/tulip-connector
     pullPolicy: IfNotPresent
     # Only specify tag if you want to use a specific version. If not specified the latest stable version is automatically selected
-    tag: main
-  replicas: 2
+    # tag: main
+  replicas: 1
   env:
-    mode: dev
+    mode: prod
   resources:
     limits:
       cpu: 200m
-      memory: 200Mi
+      memory: 100Mi
     requests:
-      cpu: 50m
-      memory: 50Mi
+      cpu: 100m
+      memory: 20Mi
 
 ### mqtt-kafka-bridge ###
 mqttkafkabridge:

--- a/deployment/united-manufacturing-hub/values.yaml
+++ b/deployment/united-manufacturing-hub/values.yaml
@@ -259,7 +259,7 @@ _000_commonConfig:
     enabled: false
 
   tulipconnector:
-    enabled: true
+    enabled: false
     domain: "tulip-connector.changeme.com"
 
 _001_customMicroservices:


### PR DESCRIPTION
# Description

Add the new tulip-connector service to the Helm chart

Fixes #1369 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Deployed via k3d, service is functioning and accessible via port forwarding

**Test Configuration**:
* Kubernetes Version: 
* Helm Version: v3.9.3
* k3d Version: v5.4.6
* k3s version: v1.24.4-k3s1
* Hardware: Company laptop

# Checklist:

- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding changes to the changelog (if needed).
- [ ] I have made corresponding notices to the upgrade instructions (if needed)

# Changelog changes

Enter here your text for the changelog (or fill it out directly in Notion if you are internal)

# Upgrade instructions

Enter here your tutorial for upgrading from a previous version (or fill it out directly in Notion if you are internal). This can include changing the values.yaml, database migrations or other manual changes that are not automatically handled by the PR
