### PR TITLE
inconsistency #92 ReturnTimestampsInRFC3339InProductionSpeed

### DIFF
--- a/golang/cmd/factoryinsight/v1/database.go
+++ b/golang/cmd/factoryinsight/v1/database.go
@@ -428,8 +428,11 @@ func GetShifts(
 	// Loop through all datapoints
 	for _, dataPoint := range processedShifts {
 		// TODO: #86 Return timestamps in RFC3339 in /shifts
+		unixTimestampBegin := dataPoint.TimestampBegin.UnixNano() / (int64(time.Millisecond) / int64(time.Nanosecond))
+		tBegin := time.Unix(unixTimestampBegin, 0)
+		formattedBegin := tBegin.Format(time.RFC3339) //formatting the Unix time to RFC3339
 		fullRow := []interface{}{
-			float64(dataPoint.TimestampBegin.UnixNano() / (int64(time.Millisecond) / int64(time.Nanosecond))),
+			formattedBegin,
 			dataPoint.ShiftType}
 		data.Datapoints = append(data.Datapoints, fullRow)
 	}
@@ -488,8 +491,11 @@ func GetProcessValue(
 			database.ErrorHandling(sqlStatement, err, false)
 			return
 		}
+		unixTimestamp := timestamp.UnixNano() / (int64(time.Millisecond) / int64(time.Nanosecond))
+		t := time.Unix(unixTimestamp, 0)
+		formatted := t.Format(time.RFC3339) //formatting the Unix time to RFC3339
 		fullRow := []interface{}{
-			float64(timestamp.UnixNano() / (int64(time.Millisecond) / int64(time.Nanosecond))),
+			formatted,
 			dataPoint}
 		data.Datapoints = append(data.Datapoints, fullRow)
 	}
@@ -556,8 +562,11 @@ func GetProcessValueString(
 
 			return
 		}
+		unixTimestamp := timestamp.UnixNano() / (int64(time.Millisecond) / int64(time.Nanosecond))
+		t := time.Unix(unixTimestamp, 0)
+		formatted := t.Format(time.RFC3339) //formatting the Unix time to RFC3339
 		fullRow := []interface{}{
-			float64(timestamp.UnixNano() / (int64(time.Millisecond) / int64(time.Nanosecond))),
+			formatted,
 			dataPoint}
 		data.Datapoints = append(data.Datapoints, fullRow)
 	}
@@ -625,14 +634,20 @@ func GetCurrentState(
 	dataPoint = datamodel.ConvertOldToNew(dataPoint)
 
 	if keepStatesInteger {
+		unixTimestamp := timestamp.UnixNano() / (int64(time.Millisecond) / int64(time.Nanosecond))
+		t := time.Unix(unixTimestamp, 0)
+		formatted := t.Format(time.RFC3339) //formatting the Unix time to RFC3339
 		fullRow := []interface{}{
 			dataPoint,
-			float64(timestamp.UnixNano() / (int64(time.Millisecond) / int64(time.Nanosecond)))}
+			formatted}
 		data.Datapoints = append(data.Datapoints, fullRow)
 	} else {
+		unixTimestamp := timestamp.UnixNano() / (int64(time.Millisecond) / int64(time.Nanosecond))
+		t := time.Unix(unixTimestamp, 0)
+		formatted := t.Format(time.RFC3339) //formatting the Unix time to RFC3339
 		fullRow := []interface{}{
 			ConvertStateToString(dataPoint, configuration),
-			float64(timestamp.UnixNano() / (int64(time.Millisecond) / int64(time.Nanosecond)))}
+			formatted}
 		data.Datapoints = append(data.Datapoints, fullRow)
 	}
 
@@ -806,10 +821,13 @@ func GetCounts(
 
 	// Loop through all datapoints
 	for _, dataPoint := range countSlice {
+		unixTimestamp := dataPoint.Timestamp.UnixNano() / (int64(time.Millisecond) / int64(time.Nanosecond))
+		t := time.Unix(unixTimestamp, 0)
+		formatted := t.Format(time.RFC3339) //formatting the Unix time to RFC3339
 		fullRow := []interface{}{
 			dataPoint.Count,
 			dataPoint.Scrap,
-			float64(dataPoint.Timestamp.UnixNano() / (int64(time.Millisecond) / int64(time.Nanosecond)))}
+			formatted}
 		data.Datapoints = append(data.Datapoints, fullRow)
 	}
 
@@ -1231,8 +1249,11 @@ func GetRecommendations(customerID string, location string, asset string) (
 		}
 
 		// TODO: #87 Return timestamps in RFC3339 in /recommendations
+		unixTimestamp4 := timestamp.UnixNano() / (int64(time.Millisecond) / int64(time.Nanosecond))
+		t4 := time.Unix(unixTimestamp4, 0)
+		formatted4 := t4.Format(time.RFC3339) //formatting the Unix time to RFC3339
 		fullRow := []interface{}{
-			float64(timestamp.UnixNano() / (int64(time.Millisecond) / int64(time.Nanosecond))),
+			formatted4,
 			recommendationType,
 			recommendationValues,
 			recommendationTextEN,

--- a/golang/cmd/factoryinsight/v1/database.go
+++ b/golang/cmd/factoryinsight/v1/database.go
@@ -931,23 +931,34 @@ func GetProductionSpeed(
 			timeDifference := timestamp.Unix() - previousTimestamp.Unix()
 
 			if timeDifference > 60 { // bigger than one minute
+				unixTimestamp1 := previousTimestamp.UnixNano()/(int64(time.Millisecond)/int64(time.Nanosecond)) + 60*1000 // 60 = adding 60 seconds
+				t1 := time.Unix(unixTimestamp1, 0)
+				formatted1 := t1.Format(time.RFC3339) //formatting the Unix time to RFC3339
+
+				unixTimestamp2 := timestamp.UnixNano()/(int64(time.Millisecond)/int64(time.Nanosecond)) - 1 // -1 = subtracting one s
+				t2 := time.Unix(unixTimestamp2, 0)
+				formatted2 := t2.Format(time.RFC3339) //formatting the Unix time to RFC3339
+
 				// add zero speed one minute after previous timestamp
 				fullRow := []interface{}{
 					0,
-					float64(previousTimestamp.UnixNano()/(int64(time.Millisecond)/int64(time.Nanosecond)) + 60*1000)} // 60 = adding 60 seconds
+					formatted1}
 				data.Datapoints = append(data.Datapoints, fullRow)
 
 				// add zero speed one ms before timestamp
 				fullRow = []interface{}{
 					0,
-					float64(timestamp.UnixNano()/(int64(time.Millisecond)/int64(time.Nanosecond)) - 1)} // -1 = subtracting one s
+					formatted2}
 				data.Datapoints = append(data.Datapoints, fullRow)
 			}
 		}
 		// add datapoint
+		unixTimestamp3 := timestamp.UnixNano() / (int64(time.Millisecond) / int64(time.Nanosecond))
+		t3 := time.Unix(unixTimestamp3, 0)
+		formatted3 := t3.Format(time.RFC3339) //formatting the Unix time to RFC3339
 		fullRow := []interface{}{
 			dataPoint * 60,
-			float64(timestamp.UnixNano() / (int64(time.Millisecond) / int64(time.Nanosecond)))} // *60 to get the production speed per hour
+			formatted3} // *60 to get the production speed per hour
 		data.Datapoints = append(data.Datapoints, fullRow)
 
 		previousTimestamp = timestamp

--- a/golang/cmd/factoryinsight/v1/dataprocessing.go
+++ b/golang/cmd/factoryinsight/v1/dataprocessing.go
@@ -758,8 +758,11 @@ func GetOrdersTimeline(
 
 	// Loop through all datapoints
 	for _, dataPoint := range processedOrders {
+		unixTimestamp := dataPoint.TimestampBegin.UnixNano() / (int64(time.Millisecond) / int64(time.Nanosecond))
+		t := time.Unix(unixTimestamp, 0)
+		formatted := t.Format(time.RFC3339) //formatting the Unix time to RFC3339
 		fullRow := []interface{}{
-			float64(dataPoint.TimestampBegin.UnixNano() / (int64(time.Millisecond) / int64(time.Nanosecond))),
+			formatted,
 			dataPoint.OrderType}
 		data.Datapoints = append(data.Datapoints, fullRow)
 	}

--- a/golang/cmd/factoryinsight/v1/dataprocessing.go
+++ b/golang/cmd/factoryinsight/v1/dataprocessing.go
@@ -934,12 +934,17 @@ func calculateOrderInformation(
 			}
 
 		}
+		UnixBeginTimestampMs := time.Unix(int64(beginTimestampInMs), 0)
+		formattedBeginTimestampMs := UnixBeginTimestampMs.Format(time.RFC3339)
+
+		UnixEndTimestampMs := time.Unix(int64(endTimestampInMs), 0)
+		formattedEndTimestampMs := UnixEndTimestampMs.Format(time.RFC3339)
 
 		fullRow := []interface{}{
 			rawOrder.OrderName,
 			rawOrder.ProductName,
-			beginTimestampInMs,
-			endTimestampInMs,
+			formattedBeginTimestampMs,
+			formattedEndTimestampMs,
 			rawOrder.TargetUnits,
 			actualUnits,
 			targetDuration,

--- a/golang/cmd/factoryinsight/v1/http.go
+++ b/golang/cmd/factoryinsight/v1/http.go
@@ -380,14 +380,20 @@ func processStatesRequest(c *gin.Context, getDataRequest getDataRequest) {
 	// Loop through all datapoints
 	for _, dataPoint := range processedStates {
 		if keepStatesInteger {
+			unixTimestamp := dataPoint.Timestamp.UnixNano() / (int64(time.Millisecond) / int64(time.Nanosecond))
+			t := time.Unix(unixTimestamp, 0)
+			formatted := t.Format(time.RFC3339) //formatting the Unix time to RFC3339
 			fullRow := []interface{}{
 				dataPoint.State,
-				float64(dataPoint.Timestamp.UnixNano() / (int64(time.Millisecond) / int64(time.Nanosecond)))}
+				formatted}
 			data.Datapoints = append(data.Datapoints, fullRow)
 		} else {
+			unixTimestamp := dataPoint.Timestamp.UnixNano() / (int64(time.Millisecond) / int64(time.Nanosecond))
+			t := time.Unix(unixTimestamp, 0)
+			formatted := t.Format(time.RFC3339) //formatting the Unix time to RFC3339
 			fullRow := []interface{}{
 				ConvertStateToString(dataPoint.State, configuration),
-				float64(dataPoint.Timestamp.UnixNano() / (int64(time.Millisecond) / int64(time.Nanosecond)))}
+				formatted}
 			data.Datapoints = append(data.Datapoints, fullRow)
 		}
 	}


### PR DESCRIPTION
# Description

Fixes #92 #90 #89 #88 #87 #86 #97 #96 #98

## Type of change

now returns the timestamps in RFC3339. It converts an int64 to unix to RFC3339

# How Has This Been Tested?

Conversion was tested separately and converts correctly.
 **Note**: The equation (previousTimestamp.UnixNano()/(int64(time.Millisecond)/int64(time.Nanosecond))) makes no sense mathematically; it is off by a factor of 1000  -> Maybe intended?