### PR TITLE
Fix/1404/factoryinsight returns thousands of duplicate values

### DIFF
--- a/golang/cmd/factoryinsight/v2/services/service-tags.go
+++ b/golang/cmd/factoryinsight/v2/services/service-tags.go
@@ -469,7 +469,7 @@ func ProcessCustomTagRequest(c *gin.Context, request models.GetTagsDataRequest) 
 
 	var sqlStatement string
 	if timeBucket == "none" {
-
+		zap.S().Debug("timeBucket: none")
 		JSONColumnName := enterpriseName + "-" + siteName + "-" + areaName + "-" + productionLineName + "-" + workCellName + "-" + tagName + "-values"
 		data.ColumnNames = []string{"timestamp", JSONColumnName}
 
@@ -694,17 +694,25 @@ ORDER BY bucket;
 		}
 
 		// row without asset_id
+		hasValue := false
 		n := 0
 		for i := range row {
-			if i == internal.IndexOf(cols, "asset_id") {
+			if i == internal.IndexOf(cols, "asset_id") { //This skips row 0
 				continue
 			}
 			rowX[n] = row[i]
 			n++
+			if row[i] != nil {
+				hasValue = true
+			}
 		}
 
-		data.Datapoints = append(data.Datapoints, rowX)
+		// Prevents null value inclusion
+		if hasValue {
+			data.Datapoints = append(data.Datapoints, rowX)
+		}
 	}
+
 	c.JSON(http.StatusOK, data)
 }
 

--- a/golang/cmd/factoryinsight/v2/services/service-tree.go
+++ b/golang/cmd/factoryinsight/v2/services/service-tree.go
@@ -288,7 +288,7 @@ func GetTagsTreeStructure(customer string, site string, area string, line string
 		return nil, err
 	}
 	for _, tagGroup := range tags {
-		var structure = make(map[string]*models.TreeEntryFormat)
+		var structure map[string]*models.TreeEntryFormat
 		if tagGroup == models.StandardTagGroup {
 			structure, err = GetStandardTagsTree(customer, site, area, line, cell, tagGroup)
 		} else if tagGroup == models.CustomTagGroup {
@@ -345,10 +345,10 @@ func GetCustomTagsTree(
 		// ignore underscores at the beginning or end of the tag or if there are multiple underscores in a row
 		sanitizedSplitTag := removeEmpty(splitTag)
 		// remove unused capacity to save memory
-		sanitizedSplitTag = slices.Clip(sanitizedSplitTag)
+		sanitizedSplitTag = slices.Clip(sanitizedSplitTag) // WTF is this?
 
 		// create the mapping
-		te[splitTag[0]] = mapTagGrouping(te, splitTag, value)
+		te[splitTag[0]] = mapTagGrouping(te, sanitizedSplitTag, value)
 	}
 
 	return te, err
@@ -376,8 +376,7 @@ func mapTagGrouping(pte map[string]*models.TreeEntryFormat, st []string, value s
 
 func removeEmpty(s []string) []string {
 	var r []string
-	idx := slices.Index(s, "")
-	if idx != -1 {
+	if idx := slices.Index(s, ""); idx != -1 {
 		r = append(s[:idx], s[idx+1:]...)
 		// recursively remove empty strings
 		return removeEmpty(r)


### PR DESCRIPTION
# Description

This pr checks if a datapoint only contains null values, and if so, skips it.

Fixes #1404 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
