### PR TITLE
Removed duplicate mapping in mqtt-kafka-bridge

### DIFF
--- a/deployment/united-manufacturing-hub/templates/mqtt-kafka-bridge/deployment.yaml
+++ b/deployment/united-manufacturing-hub/templates/mqtt-kafka-bridge/deployment.yaml
@@ -73,10 +73,6 @@ spec:
             periodSeconds: 10
             failureThreshold: 5 # 5*periodSeconds (10) => 50 sec max startup time
 
-          volumeMounts:
-            - name: {{include "united-manufacturing-hub.fullname" .}}-mqttkafkabridge-kafka-certificates
-              mountPath: /SSL_certs/kafka
-              readOnly: true
           env:
             - name: MQTT_BROKER_URL
               {{- if .Values._000_commonConfig.infrastructure.mqtt.tls.useTLS}}


### PR DESCRIPTION
# Description

This pr removes a duplicate volumeMounts mapping inside mqtt-kafka-bridge

Fixes #1416 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)