### PR TITLE
Feat/21/add read only configuration widget to grafana so the customer can see their customer specific configuration

### DIFF
--- a/deployment/united-manufacturing-hub/templates/factoryinsight/deployment.yaml
+++ b/deployment/united-manufacturing-hub/templates/factoryinsight/deployment.yaml
@@ -95,6 +95,8 @@ spec:
                   key: password
             - name: VERSION
               value: {{.Values.factoryinsight.version | default 2 | quote}}
+            - name: INSECURE_NO_AUTH
+              value: {{.Values.factoryinsight.insecure_no_auth | default "false" | quote}}
 
           livenessProbe:
             httpGet:

--- a/deployment/united-manufacturing-hub/values.yaml
+++ b/deployment/united-manufacturing-hub/values.yaml
@@ -790,6 +790,7 @@ factoryinsight:
       requests:
         cpu: 50m
         memory: 50Mi
+  insecure_no_auth: false # DO NOT ENABLE IN PRODUCTION. This will disable authentication and authorization
 
 ### factoryinput ###
 factoryinput:

--- a/golang/cmd/factoryinsight/helpers/request-helper.go
+++ b/golang/cmd/factoryinsight/helpers/request-helper.go
@@ -12,6 +12,8 @@ import (
 	"runtime/debug"
 )
 
+var InsecureNoAuth bool
+
 func HandleInternalServerError(c *gin.Context, err error) {
 	if c == nil {
 		zap.S().Fatal("context is nil")
@@ -103,6 +105,10 @@ func HandleInvalidInputError(c *gin.Context, err error) {
 
 // CheckIfUserIsAllowed checks if the user is allowed to access the data for the given customer
 func CheckIfUserIsAllowed(c *gin.Context, customer string) error {
+	if InsecureNoAuth {
+		zap.S().Debug("InsecureNoAuth is set to true. Skipping user check.")
+		return nil
+	}
 
 	user := c.MustGet(gin.AuthUserKey)
 	if user != customer {

--- a/golang/cmd/factoryinsight/main.go
+++ b/golang/cmd/factoryinsight/main.go
@@ -261,6 +261,7 @@ func setupRestAPI(accounts gin.Accounts, version int) {
 			v2.GET("/treeStructure", v2controllers.GetTreeStructureHandler)
 			v2.GET("/:enterpriseName", v2controllers.GetSitesHandler)
 			v2.GET("/:enterpriseName/configuration", v2controllers.GetConfigurationHandler)
+			v2.GET("/:enterpriseName/database-stats", v2controllers.GetDatabaseStatisticsHandler)
 			v2.GET("/:enterpriseName/:siteName", v2controllers.GetAreasHandler)
 			v2.GET("/:enterpriseName/:siteName/:areaName", v2controllers.GetProductionLinesHandler)
 			v2.GET("/:enterpriseName/:siteName/:areaName/:productionLineName", v2controllers.GetWorkCellsHandler)

--- a/golang/cmd/factoryinsight/main.go
+++ b/golang/cmd/factoryinsight/main.go
@@ -238,6 +238,7 @@ func setupRestAPI(accounts gin.Accounts, version int) {
 		{
 			v2.GET("/treeStructure", v2controllers.GetTreeStructureHandler)
 			v2.GET("/:enterpriseName", v2controllers.GetSitesHandler)
+			v2.GET("/:enterpriseName/configuration", v2controllers.GetConfigurationHandler)
 			v2.GET("/:enterpriseName/:siteName", v2controllers.GetAreasHandler)
 			v2.GET("/:enterpriseName/:siteName/:areaName", v2controllers.GetProductionLinesHandler)
 			v2.GET("/:enterpriseName/:siteName/:areaName/:productionLineName", v2controllers.GetWorkCellsHandler)

--- a/golang/cmd/factoryinsight/main.go
+++ b/golang/cmd/factoryinsight/main.go
@@ -20,6 +20,7 @@ import (
 	ginzap "github.com/gin-contrib/zap"
 	"github.com/united-manufacturing-hub/umh-utils/logger"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/cmd/factoryinsight/database"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/cmd/factoryinsight/helpers"
 	apiV1 "github.com/united-manufacturing-hub/united-manufacturing-hub/cmd/factoryinsight/v1"
 	v2controllers "github.com/united-manufacturing-hub/united-manufacturing-hub/cmd/factoryinsight/v2/controllers"
 	"net/http"
@@ -145,6 +146,21 @@ func main() {
 
 	zap.S().Debugf("DB initialized..", PQHost)
 
+	insecureNoAuthString, insecureNotAuthSet := os.LookupEnv("INSECURE_NO_AUTH")
+	if insecureNotAuthSet {
+		helpers.InsecureNoAuth, err = strconv.ParseBool(insecureNoAuthString)
+		if err != nil {
+			zap.S().Errorf("Cannot parse INSECURE_NO_AUTH: %s (%s)", err, insecureNoAuthString)
+		}
+		if helpers.InsecureNoAuth {
+			for i := 0; i < 50; i++ {
+				zap.S().Warnf("INSECURE_NO_AUTH is set to true. This is a security risk. Do not use in production.")
+			}
+			zap.S().Warnf("Sleeping for 10 seconds to allow you to cancel the program.")
+			time.Sleep(10 * time.Second)
+		}
+	}
+
 	setupRestAPI(accounts, currentVersion)
 
 	// Allow graceful shutdown
@@ -223,6 +239,9 @@ func setupRestAPI(accounts gin.Accounts, version int) {
 	if version >= 1 {
 		zap.S().Infof("Starting API version 1")
 		v1 := router.Group("/api/v1", gin.BasicAuth(accounts))
+		if helpers.InsecureNoAuth {
+			v1 = router.Group("/api/v1")
+		}
 		{
 			// WARNING: Need to check in each specific handler whether the user is actually allowed to access it, so that valid user "ia" cannot access data for customer "abc"
 			v1.GET("/:customer", apiV1.GetLocationsHandler)
@@ -235,6 +254,9 @@ func setupRestAPI(accounts gin.Accounts, version int) {
 	if version >= 2 {
 		zap.S().Infof("Starting API version 2")
 		v2 := router.Group("/api/v2", gin.BasicAuth(accounts))
+		if helpers.InsecureNoAuth {
+			v2 = router.Group("/api/v2")
+		}
 		{
 			v2.GET("/treeStructure", v2controllers.GetTreeStructureHandler)
 			v2.GET("/:enterpriseName", v2controllers.GetSitesHandler)
@@ -274,6 +296,9 @@ func setupRestAPI(accounts gin.Accounts, version int) {
 
 	/*
 		v3 := router.Group("/api/v3", gin.BasicAuth(accounts))
+		if helpers.InsecureNoAuth {
+			v2 = router.Group("/api/v3")
+		}
 		{
 			// Get all sites for a given enterprise
 			v3.GET("/:enterpriseName", v3controllers.GetSitesHandler)

--- a/golang/cmd/factoryinsight/v2/controllers/controller-configuration.go
+++ b/golang/cmd/factoryinsight/v2/controllers/controller-configuration.go
@@ -1,0 +1,41 @@
+package controllers
+
+import (
+	"database/sql"
+	"errors"
+	"github.com/gin-gonic/gin"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/cmd/factoryinsight/helpers"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/cmd/factoryinsight/v2/models"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/cmd/factoryinsight/v2/services"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/pkg/datamodel"
+	"net/http"
+)
+
+// GetConfigurationHandler handles a GET request to /api/v2/{enterprise}/configuration
+func GetConfigurationHandler(c *gin.Context) {
+	var request models.GetSitesRequest
+	var configuration datamodel.EnterpriseConfiguration
+
+	err := c.BindUri(&request)
+	if err != nil {
+		helpers.HandleInvalidInputError(c, err)
+		return
+	}
+
+	// Check if the user has access to that resource
+	err = helpers.CheckIfUserIsAllowed(c, request.EnterpriseName)
+	if err != nil {
+		return
+	}
+
+	// Fetch data from database
+	configuration, err = services.GetEnterpriseConfiguration(request.EnterpriseName)
+	if errors.Is(err, sql.ErrNoRows) {
+		c.JSON(http.StatusNotFound, gin.H{"error": "No configuration found"})
+	} else if err != nil {
+		helpers.HandleInternalServerError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, configuration)
+}

--- a/golang/cmd/factoryinsight/v2/controllers/controller-database-statistics.go
+++ b/golang/cmd/factoryinsight/v2/controllers/controller-database-statistics.go
@@ -1,0 +1,41 @@
+package controllers
+
+import (
+	"database/sql"
+	"errors"
+	"github.com/gin-gonic/gin"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/cmd/factoryinsight/helpers"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/cmd/factoryinsight/v2/models"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/cmd/factoryinsight/v2/services"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/pkg/datamodel"
+	"net/http"
+)
+
+// GetConfigurationHandler handles a GET request to /api/v2/{enterprise}/database-stats
+func GetDatabaseStatisticsHandler(c *gin.Context) {
+	var request models.GetSitesRequest
+	var statistics datamodel.DatabaseStatistics
+
+	err := c.BindUri(&request)
+	if err != nil {
+		helpers.HandleInvalidInputError(c, err)
+		return
+	}
+
+	// Check if the user has access to that resource
+	err = helpers.CheckIfUserIsAllowed(c, request.EnterpriseName)
+	if err != nil {
+		return
+	}
+
+	// Fetch data from database
+	statistics, err = services.GetDatabaseStatistics()
+	if errors.Is(err, sql.ErrNoRows) {
+		c.JSON(http.StatusNotFound, gin.H{"error": "No statistics found"})
+	} else if err != nil {
+		helpers.HandleInternalServerError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, statistics)
+}

--- a/golang/cmd/factoryinsight/v2/services/service-stats.go
+++ b/golang/cmd/factoryinsight/v2/services/service-stats.go
@@ -190,7 +190,7 @@ func GetDatabaseSizeInBytes() (size int64) {
 	return size
 }
 
-func GetVacuumAndAnalyzeStats(tableName string) (lastAutoanalyze, lastAnalyze, lastVacuum, lastAutovacuum string) {
+func GetVacuumAndAnalyzeStats(tableName string) (lastAutoanalyze, lastAnalyze, lastVacuum, lastAutovacuum sql.NullString) {
 	sqlStatement := `-- noinspection SqlResolveForFile @ table/"pg_stat_all_tables"
 
 		SELECT schemaname, relname, last_autoanalyze, last_analyze, last_vacuum, last_autovacuum FROM pg_stat_all_tables WHERE relname = $1;`

--- a/golang/cmd/factoryinsight/v2/services/service-stats.go
+++ b/golang/cmd/factoryinsight/v2/services/service-stats.go
@@ -34,10 +34,9 @@ func GetDatabaseStatistics() (datamodel.DatabaseStatistics, error) {
 }
 
 func GetApproximateHyperRows(tableName string) (approximateRows int64) {
-	sqlStatement := `-- noinspection SqlResolveForFile
-	
-	-- noinspection SqlResolveForFile @ routine/"hypertable_approximate_row_count"
-			SELECT approximate_row_count FROM hypertable_approximate_row_count($1);`
+	sqlStatement := `
+				-- noinspection SqlResolve
+	SELECT approximate_row_count FROM approximate_row_count($1);`
 
 	err := database.Db.QueryRow(sqlStatement, tableName).Scan(&approximateRows)
 	if errors.Is(err, sql.ErrNoRows) {

--- a/golang/cmd/factoryinsight/v2/services/service-stats.go
+++ b/golang/cmd/factoryinsight/v2/services/service-stats.go
@@ -200,11 +200,12 @@ func GetVacuumAndAnalyzeStats(tableName string) (lastAutoanalyze, lastAnalyze, l
 	if errors.Is(err, sql.ErrNoRows) {
 		// it can happen, no need to escalate error
 		zap.S().Debugf("No Results Found")
-		return "", "", "", ""
+		return lastAutoanalyze, lastAnalyze, lastVacuum, lastAutovacuum
 	} else if err != nil {
 		database.ErrorHandling(sqlStatement, err, false)
 
-		return "", "", "", ""
+		return lastAutoanalyze, lastAnalyze, lastVacuum, lastAutovacuum
+
 	}
 
 	return lastAutoanalyze, lastAnalyze, lastVacuum, lastAutovacuum

--- a/golang/cmd/factoryinsight/v2/services/service-stats.go
+++ b/golang/cmd/factoryinsight/v2/services/service-stats.go
@@ -1,0 +1,211 @@
+package services
+
+import (
+	"database/sql"
+	"errors"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/cmd/factoryinsight/database"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/pkg/datamodel"
+	"go.uber.org/zap"
+)
+
+// GetDatabaseStatistics returns the database statistics
+func GetDatabaseStatistics() (datamodel.DatabaseStatistics, error) {
+	var dbStats datamodel.DatabaseStatistics
+	dbStats.DatabaseSizeInBytes = GetDatabaseSizeInBytes()
+	tableNames := GetAllTableNamesInPublic()
+	dbStats.TableStatistics = make(map[string]datamodel.DatabaseTableStatistics, len(tableNames))
+	for _, tableName := range tableNames {
+		var dbTableStats datamodel.DatabaseTableStatistics
+		dbTableStats.IsHyperTable = IsTableHyperTable(tableName)
+		dbTableStats.LastAutoAnalyze, dbTableStats.LastAnalyze, dbTableStats.LastVacuum, dbTableStats.LastAutoVacuum = GetVacuumAndAnalyzeStats(tableName)
+		dbTableStats.NormalStats = GetNormalTableStatistics(tableName)
+		if dbTableStats.IsHyperTable {
+			dbTableStats.HyperStats = GetHypertableStats(tableName)
+			dbTableStats.HyperRetention = GetHyperRetentionSettings(tableName)
+			dbTableStats.HyperCompression = GetHyperCompressionSettings(tableName)
+		}
+
+		dbStats.TableStatistics[tableName] = dbTableStats
+	}
+	return dbStats, nil
+}
+
+func GetNormalTableStatistics(tableName string) datamodel.DatabaseNormalTableStatistics {
+	// using pg_table_size, pg_total_relation_size, pg_indexes_size, pg_relation_size (main, fsm, vm, init)
+	sqlStatement := `
+		SELECT pg_table_size($1),
+		       pg_total_relation_size($1),
+		       pg_indexes_size($1),
+		       pg_relation_size($1, 'main'),
+		       pg_relation_size($1, 'fsm'),
+		       pg_relation_size($1, 'vm'),
+		       pg_relation_size($1, 'init')
+	`
+
+	var dbNormalTableStats datamodel.DatabaseNormalTableStatistics
+	err := database.Db.QueryRow(sqlStatement, tableName).Scan(&dbNormalTableStats.PgTableSize, &dbNormalTableStats.PgTotalRelationSize, &dbNormalTableStats.PgIndexesSize, &dbNormalTableStats.PgRelationSizeMain, &dbNormalTableStats.PgRelationSizeFsm, &dbNormalTableStats.PgRelationSizeVm, &dbNormalTableStats.PgRelationSizeInit)
+	if errors.Is(err, sql.ErrNoRows) {
+		// it can happen, no need to escalate error
+		zap.S().Debugf("No Results Found")
+		return dbNormalTableStats
+	} else if err != nil {
+		database.ErrorHandling(sqlStatement, err, false)
+		return dbNormalTableStats
+	}
+	return dbNormalTableStats
+
+}
+
+func IsTableHyperTable(tableName string) (isHyerTable bool) {
+	// SELECT COUNT(*) FROM timescaledb_information.hypertables WHERE hypertable_name = 'processvaluetable';
+	sqlStatement := `-- noinspection SqlResolveForFile @ any/"timescaledb_information"
+	
+			SELECT COUNT(*) FROM timescaledb_information.hypertables WHERE hypertable_name = $1;
+		`
+
+	var count int
+	err := database.Db.QueryRow(sqlStatement, tableName).Scan(&count)
+	if errors.Is(err, sql.ErrNoRows) {
+		// it can happen, no need to escalate error
+		zap.S().Debugf("No Results Found")
+		return false
+	} else if err != nil {
+		database.ErrorHandling(sqlStatement, err, false)
+		return false
+	}
+	return count > 0
+}
+
+func GetHypertableStats(tableName string) (hypertableStats []datamodel.DatabaseHyperTableStatistics) {
+	hypertableStats = make([]datamodel.DatabaseHyperTableStatistics, 0)
+	sqlStatement := `-- noinspection SqlResolveForFile @ routine/"hypertable_detailed_size"
+	
+			 SELECT * FROM hypertable_detailed_size($1);
+		`
+	rows, err := database.Db.Query(sqlStatement, tableName)
+	if errors.Is(err, sql.ErrNoRows) {
+		// it can happen, no need to escalate error
+		zap.S().Debugf("No Results Found")
+		return hypertableStats
+	} else if err != nil {
+		database.ErrorHandling(sqlStatement, err, false)
+		return hypertableStats
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var hypertableStat datamodel.DatabaseHyperTableStatistics
+		err = rows.Scan(&hypertableStat.TableBytes, &hypertableStat.IndexBytes, &hypertableStat.ToastBytes, &hypertableStat.TotalBytes, &hypertableStat.NodeName)
+		if err != nil {
+			database.ErrorHandling(sqlStatement, err, false)
+			return hypertableStats
+		}
+		hypertableStats = append(hypertableStats, hypertableStat)
+	}
+	return hypertableStats
+}
+
+func GetHyperRetentionSettings(tableName string) (retentionSettings datamodel.DatabaseHyperTableRetention) {
+	sqlStatement := `-- noinspection SqlResolveForFile @ any/"timescaledb_information"
+	
+	SELECT schedule_interval, config FROM timescaledb_information.jobs
+	WHERE hypertable_name = $1
+	AND timescaledb_information.jobs.proc_name = 'policy_retention';
+	`
+	err := database.Db.QueryRow(sqlStatement, tableName).Scan(&retentionSettings.ScheduleInterval, &retentionSettings.Config)
+	if errors.Is(err, sql.ErrNoRows) {
+		// it can happen, no need to escalate error
+		zap.S().Debugf("No Results Found")
+		return retentionSettings
+	} else if err != nil {
+		database.ErrorHandling(sqlStatement, err, false)
+		return retentionSettings
+	}
+
+	return retentionSettings
+}
+func GetHyperCompressionSettings(tableName string) (retentionSettings datamodel.DatabaseHyperTableCompression) {
+	sqlStatement := `-- noinspection SqlResolveForFile @ any/"timescaledb_information"
+	
+	SELECT schedule_interval, config FROM timescaledb_information.jobs
+	WHERE hypertable_name = $1
+	AND timescaledb_information.jobs.proc_name = 'policy_compression';
+	`
+	err := database.Db.QueryRow(sqlStatement, tableName).Scan(&retentionSettings.ScheduleInterval, &retentionSettings.Config)
+	if errors.Is(err, sql.ErrNoRows) {
+		// it can happen, no need to escalate error
+		zap.S().Debugf("No Results Found")
+		return retentionSettings
+	} else if err != nil {
+		database.ErrorHandling(sqlStatement, err, false)
+		return retentionSettings
+	}
+
+	return retentionSettings
+}
+
+func GetAllTableNamesInPublic() (tableNames []string) {
+	tableNames = make([]string, 0)
+	sqlStatement := `-- noinspection SqlResolveForFile @ any/"information_schema"
+
+			SELECT table_name FROM information_schema.tables WHERE table_schema='public';
+		`
+	rows, err := database.Db.Query(sqlStatement)
+	if errors.Is(err, sql.ErrNoRows) {
+		// it can happen, no need to escalate error
+		zap.S().Debugf("No Results Found")
+		return tableNames
+	} else if err != nil {
+		database.ErrorHandling(sqlStatement, err, false)
+		return tableNames
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var tableName string
+		err = rows.Scan(&tableName)
+		if err != nil {
+			database.ErrorHandling(sqlStatement, err, false)
+			return tableNames
+		}
+		tableNames = append(tableNames, tableName)
+	}
+	return tableNames
+}
+
+func GetDatabaseSizeInBytes() (size int64) {
+	sqlStatement := `
+	SELECT pg_database_size('factoryinsight');`
+
+	err := database.Db.QueryRow(sqlStatement).Scan(&size)
+	if errors.Is(err, sql.ErrNoRows) {
+		// it can happen, no need to escalate error
+		zap.S().Debugf("No Results Found")
+		return 0
+	} else if err != nil {
+		database.ErrorHandling(sqlStatement, err, false)
+		return 0
+	}
+
+	return size
+}
+
+func GetVacuumAndAnalyzeStats(tableName string) (lastAutoanalyze, lastAnalyze, lastVacuum, lastAutovacuum string) {
+	sqlStatement := `-- noinspection SqlResolveForFile @ table/"pg_stat_all_tables"
+
+		SELECT schemaname, relname, last_autoanalyze, last_analyze, last_vacuum, last_autovacuum FROM pg_stat_all_tables WHERE relname = $1;`
+
+	var schemaName, relName string
+	err := database.Db.QueryRow(sqlStatement, tableName).Scan(&schemaName, &relName, &lastAutoanalyze, &lastAnalyze, &lastVacuum, &lastAutovacuum)
+	if errors.Is(err, sql.ErrNoRows) {
+		// it can happen, no need to escalate error
+		zap.S().Debugf("No Results Found")
+		return "", "", "", ""
+	} else if err != nil {
+		database.ErrorHandling(sqlStatement, err, false)
+
+		return "", "", "", ""
+	}
+
+	return lastAutoanalyze, lastAnalyze, lastVacuum, lastAutovacuum
+}

--- a/golang/cmd/factoryinsight/v2/services/service-stats.go
+++ b/golang/cmd/factoryinsight/v2/services/service-stats.go
@@ -24,6 +24,8 @@ func GetDatabaseStatistics() (datamodel.DatabaseStatistics, error) {
 			dbTableStats.HyperRetention = GetHyperRetentionSettings(tableName)
 			dbTableStats.HyperCompression = GetHyperCompressionSettings(tableName)
 			dbTableStats.ApproximateRows = GetApproximateHyperRows(tableName)
+		} else {
+			dbTableStats.ApproximateRows = GetApproximateNormalRows(tableName)
 		}
 
 		dbStats.TableStatistics[tableName] = dbTableStats
@@ -32,8 +34,10 @@ func GetDatabaseStatistics() (datamodel.DatabaseStatistics, error) {
 }
 
 func GetApproximateHyperRows(tableName string) (approximateRows int64) {
-	sqlStatement := `-- noinspection SqlResolveForFile @ routine/"hypertable_approximate_row_count"
-		SELECT hypertable_approximate_row_count($1);`
+	sqlStatement := `-- noinspection SqlResolveForFile
+	
+	-- noinspection SqlResolveForFile @ routine/"hypertable_approximate_row_count"
+			SELECT approximate_row_count FROM hypertable_approximate_row_count($1);`
 
 	err := database.Db.QueryRow(sqlStatement, tableName).Scan(&approximateRows)
 	if errors.Is(err, sql.ErrNoRows) {

--- a/golang/pkg/datamodel/structs.go
+++ b/golang/pkg/datamodel/structs.go
@@ -46,6 +46,57 @@ type EnterpriseConfiguration struct {
 	AutomaticallyIdentifyChangeovers             bool
 }
 
+type DatabaseStatistics struct {
+	DatabaseSizeInBytes int64
+	TableStatistics     map[string]DatabaseTableStatistics
+}
+
+type DatabaseTableStatistics struct {
+	ApproximateRows  int64
+	LastAutoAnalyze  string
+	LastAutoVacuum   string
+	LastAnalyze      string
+	LastVacuum       string
+	IsHyperTable     bool
+	NormalStats      DatabaseNormalTableStatistics
+	HyperStats       []DatabaseHyperTableStatistics
+	HyperRetention   DatabaseHyperTableRetention
+	HyperCompression DatabaseHyperTableCompression
+}
+
+type DatabaseNormalTableStatistics struct {
+	PgTableSize         int64
+	PgTotalRelationSize int64
+	PgIndexesSize       int64
+	PgRelationSizeMain  int64
+	PgRelationSizeFsm   int64
+	PgRelationSizeVm    int64
+	PgRelationSizeInit  int64
+}
+
+type DatabaseHyperTableStatistics struct {
+	TableBytes int64
+	IndexBytes int64
+	ToastBytes int64
+	TotalBytes int64
+	NodeName   string
+}
+
+type DatabaseHyperTableRetention struct {
+	ScheduleInterval int64
+	Config           string
+}
+
+type DatabaseHyperTableCompression struct {
+	ScheduleInterval int64
+	Config           string
+}
+
+type DatabaseHyperTableDataRetention struct {
+	ScheduleInterval int64
+	Config           string
+}
+
 // DataResponseAny is the format of the returned JSON.
 type DataResponseAny struct {
 	ColumnNames []string        `json:"columnNames"`

--- a/golang/pkg/datamodel/structs.go
+++ b/golang/pkg/datamodel/structs.go
@@ -46,11 +46,13 @@ type EnterpriseConfiguration struct {
 	AutomaticallyIdentifyChangeovers             bool
 }
 
+// DatabaseStatistics holds statistics for a database, including the size of the database in bytes and statistics for each table in the database
 type DatabaseStatistics struct {
 	DatabaseSizeInBytes int64
 	TableStatistics     map[string]DatabaseTableStatistics
 }
 
+// DatabaseTableStatistics holds statistics for a table in a database, including the number of approximate rows, the last time the table was auto-analyzed and auto-vacuumed, and whether or not the table is a hypertable
 type DatabaseTableStatistics struct {
 	ApproximateRows  int64
 	LastAutoAnalyze  string
@@ -64,6 +66,7 @@ type DatabaseTableStatistics struct {
 	HyperCompression DatabaseHyperTableCompression
 }
 
+// DatabaseNormalTableStatistics holds statistics for a normal table in a database, including the sizes of various components of the table
 type DatabaseNormalTableStatistics struct {
 	PgTableSize         int64
 	PgTotalRelationSize int64
@@ -74,6 +77,7 @@ type DatabaseNormalTableStatistics struct {
 	PgRelationSizeInit  int64
 }
 
+// DatabaseHyperTableStatistics holds statistics for a hypertable in a database, including the sizes of various components of the table and the name of the node hosting the table
 type DatabaseHyperTableStatistics struct {
 	TableBytes int64
 	IndexBytes int64
@@ -82,17 +86,14 @@ type DatabaseHyperTableStatistics struct {
 	NodeName   string
 }
 
+// DatabaseHyperTableRetention holds information about the retention policy for a hypertable
 type DatabaseHyperTableRetention struct {
 	ScheduleInterval int64
 	Config           string
 }
 
+// DatabaseHyperTableCompression holds information about the compression policy for a hypertable
 type DatabaseHyperTableCompression struct {
-	ScheduleInterval int64
-	Config           string
-}
-
-type DatabaseHyperTableDataRetention struct {
 	ScheduleInterval int64
 	Config           string
 }

--- a/golang/pkg/datamodel/structs.go
+++ b/golang/pkg/datamodel/structs.go
@@ -48,22 +48,22 @@ type EnterpriseConfiguration struct {
 
 // DatabaseStatistics holds statistics for a database, including the size of the database in bytes and statistics for each table in the database
 type DatabaseStatistics struct {
-	DatabaseSizeInBytes int64
 	TableStatistics     map[string]DatabaseTableStatistics
+	DatabaseSizeInBytes int64
 }
 
 // DatabaseTableStatistics holds statistics for a table in a database, including the number of approximate rows, the last time the table was auto-analyzed and auto-vacuumed, and whether or not the table is a hypertable
 type DatabaseTableStatistics struct {
-	ApproximateRows  int64
+	HyperRetention   DatabaseHyperTableRetention
+	HyperCompression DatabaseHyperTableCompression
 	LastAutoAnalyze  sql.NullString
 	LastAutoVacuum   sql.NullString
 	LastAnalyze      sql.NullString
 	LastVacuum       sql.NullString
-	IsHyperTable     bool
-	NormalStats      DatabaseNormalTableStatistics
 	HyperStats       []DatabaseHyperTableStatistics
-	HyperRetention   DatabaseHyperTableRetention
-	HyperCompression DatabaseHyperTableCompression
+	NormalStats      DatabaseNormalTableStatistics
+	ApproximateRows  int64
+	IsHyperTable     bool
 }
 
 // DatabaseNormalTableStatistics holds statistics for a normal table in a database, including the sizes of various components of the table
@@ -79,11 +79,11 @@ type DatabaseNormalTableStatistics struct {
 
 // DatabaseHyperTableStatistics holds statistics for a hypertable in a database, including the sizes of various components of the table and the name of the node hosting the table
 type DatabaseHyperTableStatistics struct {
+	NodeName   sql.NullString
 	TableBytes int64
 	IndexBytes int64
 	ToastBytes int64
 	TotalBytes int64
-	NodeName   sql.NullString
 }
 
 // DatabaseHyperTableRetention holds information about the retention policy for a hypertable

--- a/golang/pkg/datamodel/structs.go
+++ b/golang/pkg/datamodel/structs.go
@@ -88,13 +88,13 @@ type DatabaseHyperTableStatistics struct {
 
 // DatabaseHyperTableRetention holds information about the retention policy for a hypertable
 type DatabaseHyperTableRetention struct {
-	ScheduleInterval int64
+	ScheduleInterval string
 	Config           string
 }
 
 // DatabaseHyperTableCompression holds information about the compression policy for a hypertable
 type DatabaseHyperTableCompression struct {
-	ScheduleInterval int64
+	ScheduleInterval string
 	Config           string
 }
 

--- a/golang/pkg/datamodel/structs.go
+++ b/golang/pkg/datamodel/structs.go
@@ -55,10 +55,10 @@ type DatabaseStatistics struct {
 // DatabaseTableStatistics holds statistics for a table in a database, including the number of approximate rows, the last time the table was auto-analyzed and auto-vacuumed, and whether or not the table is a hypertable
 type DatabaseTableStatistics struct {
 	ApproximateRows  int64
-	LastAutoAnalyze  string
-	LastAutoVacuum   string
-	LastAnalyze      string
-	LastVacuum       string
+	LastAutoAnalyze  sql.NullString
+	LastAutoVacuum   sql.NullString
+	LastAnalyze      sql.NullString
+	LastVacuum       sql.NullString
 	IsHyperTable     bool
 	NormalStats      DatabaseNormalTableStatistics
 	HyperStats       []DatabaseHyperTableStatistics
@@ -83,7 +83,7 @@ type DatabaseHyperTableStatistics struct {
 	IndexBytes int64
 	ToastBytes int64
 	TotalBytes int64
-	NodeName   string
+	NodeName   sql.NullString
 }
 
 // DatabaseHyperTableRetention holds information about the retention policy for a hypertable


### PR DESCRIPTION
# Description

This pr adds an endpoint to Factoryinsight, to query the current customer configuration.
It also adds an env variable to turn off authentication, for easier testing

Fixes https://github.com/united-manufacturing-hub/united-manufacturing-hub/issues/21
Fixes https://github.com/united-manufacturing-hub/umh-datasource-v2/issues/19

## Type of change

- [X] New feature (non-breaking change which adds functionality)