### PR TITLE
fix: incorrect time formatting

### DIFF
--- a/golang/cmd/factoryinsight/v1/database.go
+++ b/golang/cmd/factoryinsight/v1/database.go
@@ -491,9 +491,7 @@ func GetProcessValue(
 			database.ErrorHandling(sqlStatement, err, false)
 			return
 		}
-		unixTimestamp := timestamp.UnixNano() / (int64(time.Millisecond) / int64(time.Nanosecond))
-		t := time.Unix(unixTimestamp, 0)
-		formatted := t.Format(time.RFC3339) //formatting the Unix time to RFC3339
+		formatted := timestamp.Format(time.RFC3339) //formatting the Unix time to RFC3339
 		fullRow := []interface{}{
 			formatted,
 			dataPoint}


### PR DESCRIPTION
This pr hotfixes a time bug for v1 api in factoryinsight.

It was already deployed to 0.9.10's docker image.