### PR TITLE
Fix: missing env variables for factoryinput

### DIFF
--- a/deployment/united-manufacturing-hub/templates/factoryinput/statefulset.yaml
+++ b/deployment/united-manufacturing-hub/templates/factoryinput/statefulset.yaml
@@ -63,10 +63,10 @@ spec:
           imagePullPolicy: {{.Values.factoryinput.image.pullPolicy}}
           env:
             - name: CERTIFICATE_NAME
-              value: NO_CERT
+              value: {{.Values.factoryinput.env.certificateName}}
 
             - name: LOGGING_LEVEL
-              value: PRODUCTION
+              value: {{.Values.factoryinput.env.loggingLevel}}
 
             - name: BROKER_URL
               {{- if .Values._000_commonConfig.infrastructure.mqtt.tls.useTLS}}
@@ -88,7 +88,7 @@ spec:
               value: {{.Values._000_commonConfig.serialNumber}}
 
             - name: VERSION
-              value: "1"
+              value: {{.Values.factoryinput.env.version}}
 
             - name: FACTORYINPUT_USER
               valueFrom:
@@ -104,6 +104,9 @@ spec:
 
             - name: MQTT_PASSWORD
               value: {{.Values.factoryinput.mqtt.password | quote}}
+
+            - name: MQTT_QUEUE_HANDLER
+              value: {{.Values.factoryinput.env.mqttQueueHandler }}
 
             {{$index := 1}}
             {{range $customerName, $password := .Values.customers | default dict}}

--- a/deployment/united-manufacturing-hub/values.yaml
+++ b/deployment/united-manufacturing-hub/values.yaml
@@ -815,6 +815,11 @@ factoryinput:
   mqtt:
     password: INSECURE_INSECURE_INSECURE
     encryptedPassword: emQ1NHEzcWN3ajVNZnRkaXphbzJDZ1V6aEFsMnlxTlU=:100:wR0Br1UBGt5i2oruSbzNXJEicUEpcSwY/RmR8igExshAuEeLeFeWy82a9AOkkiGVBP2N2IMTBFRvY0W/lvQ8gA==
+  env:
+    certificateName: "NO_CERT"
+    loggingLevel: "PRODUCTION"
+    version: "2"
+    mqttQueueHandler: "10"
 
 ### grafanaproxy ###
 grafanaproxy:

--- a/golang/cmd/factoryinput/main.go
+++ b/golang/cmd/factoryinput/main.go
@@ -43,7 +43,7 @@ func GetEnv(variableName string) (envValue string) {
 	var envValueEnvSet bool
 	envValue, envValueEnvSet = os.LookupEnv(variableName)
 	if !envValueEnvSet {
-		zap.S().Fatal("env value (ENV_VALUE) must be set")
+		zap.S().Warnf("Env variable %s not set", variableName)
 	}
 	if len(envValue) == 0 {
 		zap.S().Warnf("Env variable %s is empty", variableName)


### PR DESCRIPTION
# Description

This PR adds the possibility to change some env variables of factoryinput from values.yaml. Moreover, adds the missing env variable `MQTT_QUEUE_HANDLER`.
Merged into [fix/1453/factoryinput-not-working-if-mqtt-tls-is-enabled](https://github.com/united-manufacturing-hub/united-manufacturing-hub/tree/fix/1453/factoryinput-not-working-if-mqtt-tls-is-enabled) in order to begin working on issue #1453  

Fixes #1454 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Not tested because related to #1453 

# Checklist:

- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding changes to the changelog (if needed).
- [ ] I have made corresponding notices to the upgrade instructions (if needed)

# Changelog changes

*none*

# Upgrade instructions

*none*