### PR TITLE
Fix: factoryinput not working if mqtt tls is enabled

### DIFF
--- a/deployment/united-manufacturing-hub/templates/factoryinput/secret.yaml
+++ b/deployment/united-manufacturing-hub/templates/factoryinput/secret.yaml
@@ -30,4 +30,21 @@ stringData:
   apiKey: 'Basic {{(printf "%s:%s" .Values.factoryinput.user $password )|b64enc}}'
   password: {{$password | quote}}
 {{end}}
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{include "united-manufacturing-hub.fullname" . }}-factoryinput-mqtt-secrets
+  labels:
+    {{- include "united-manufacturing-hub.labels.factoryinput" . | nindent 4}}
+type: Opaque
+data:
+  ca.crt: |
+    {{.Values._000_commonConfig.infrastructure.mqtt.tls.caCert | nindent 4}}
+  tls.crt: |
+    {{.Values._000_commonConfig.infrastructure.mqtt.tls.factoryinput.cert | nindent 4}}
+  tls.key: |
+    {{.Values._000_commonConfig.infrastructure.mqtt.tls.factoryinput.key | nindent 4}}
+
 {{end}}

--- a/deployment/united-manufacturing-hub/templates/factoryinput/statefulset.yaml
+++ b/deployment/united-manufacturing-hub/templates/factoryinput/statefulset.yaml
@@ -63,7 +63,11 @@ spec:
           imagePullPolicy: {{.Values.factoryinput.image.pullPolicy}}
           env:
             - name: CERTIFICATE_NAME
-              value: {{.Values.factoryinput.env.certificateName}}
+              {{- if .Values._000_commonConfig.infrastructure.mqtt.tls.useTLS}}
+              value: "USE_TLS"
+              {{- else}}
+              value: "NO_CERT"
+              {{- end}}
 
             - name: LOGGING_LEVEL
               value: {{.Values.factoryinput.env.loggingLevel}}
@@ -88,7 +92,7 @@ spec:
               value: {{.Values._000_commonConfig.serialNumber}}
 
             - name: VERSION
-              value: {{.Values.factoryinput.env.version}}
+              value: {{.Values.factoryinput.env.version | quote}}
 
             - name: FACTORYINPUT_USER
               valueFrom:
@@ -106,7 +110,7 @@ spec:
               value: {{.Values.factoryinput.mqtt.password | quote}}
 
             - name: MQTT_QUEUE_HANDLER
-              value: {{.Values.factoryinput.env.mqttQueueHandler }}
+              value: {{.Values.factoryinput.env.mqttQueueHandler | quote}}
 
             {{$index := 1}}
             {{range $customerName, $password := .Values.customers | default dict}}
@@ -124,8 +128,9 @@ spec:
           volumeMounts:
             - name: {{include "united-manufacturing-hub.fullname" .}}-factoryinput-data
               mountPath: /data
-              # - name: secret-volume
-              #   mountPath: /SSL_certs/kafka
+            - name: {{include "united-manufacturing-hub.fullname" .}}-factoryinput-mqtt-certificates
+              mountPath: /SSL_certs/mqtt
+              readOnly: true
 
 
           livenessProbe:
@@ -152,6 +157,10 @@ spec:
           #- name: secret-volume
           #secret:
           #secretName: factoryinput-secret
+      volumes:
+        - name: {{include "united-manufacturing-hub.fullname" .}}-factoryinput-mqtt-certificates
+          secret:
+            secretName: {{include "united-manufacturing-hub.fullname" .}}-factoryinput-mqtt-secrets
       serviceAccountName: ""
       restartPolicy: Always
   {{end}}

--- a/deployment/united-manufacturing-hub/templates/factoryinput/statefulset.yaml
+++ b/deployment/united-manufacturing-hub/templates/factoryinput/statefulset.yaml
@@ -63,10 +63,10 @@ spec:
           imagePullPolicy: {{.Values.factoryinput.image.pullPolicy}}
           env:
             - name: CERTIFICATE_NAME
-              value: NO_CERT
+              value: {{.Values.factoryinput.env.certificateName}}
 
             - name: LOGGING_LEVEL
-              value: PRODUCTION
+              value: {{.Values.factoryinput.env.loggingLevel}}
 
             - name: BROKER_URL
               {{- if .Values._000_commonConfig.infrastructure.mqtt.tls.useTLS}}
@@ -88,7 +88,7 @@ spec:
               value: {{.Values._000_commonConfig.serialNumber}}
 
             - name: VERSION
-              value: "1"
+              value: {{.Values.factoryinput.env.version}}
 
             - name: FACTORYINPUT_USER
               valueFrom:
@@ -104,6 +104,9 @@ spec:
 
             - name: MQTT_PASSWORD
               value: {{.Values.factoryinput.mqtt.password | quote}}
+
+            - name: MQTT_QUEUE_HANDLER
+              value: {{.Values.factoryinput.env.mqttQueueHandler }}
 
             {{$index := 1}}
             {{range $customerName, $password := .Values.customers | default dict}}

--- a/deployment/united-manufacturing-hub/values.yaml
+++ b/deployment/united-manufacturing-hub/values.yaml
@@ -816,7 +816,6 @@ factoryinput:
     password: INSECURE_INSECURE_INSECURE
     encryptedPassword: emQ1NHEzcWN3ajVNZnRkaXphbzJDZ1V6aEFsMnlxTlU=:100:wR0Br1UBGt5i2oruSbzNXJEicUEpcSwY/RmR8igExshAuEeLeFeWy82a9AOkkiGVBP2N2IMTBFRvY0W/lvQ8gA==
   env:
-    certificateName: "NO_CERT"
     loggingLevel: "PRODUCTION"
     version: "2"
     mqttQueueHandler: "10"

--- a/deployment/united-manufacturing-hub/values.yaml
+++ b/deployment/united-manufacturing-hub/values.yaml
@@ -815,6 +815,11 @@ factoryinput:
   mqtt:
     password: INSECURE_INSECURE_INSECURE
     encryptedPassword: emQ1NHEzcWN3ajVNZnRkaXphbzJDZ1V6aEFsMnlxTlU=:100:wR0Br1UBGt5i2oruSbzNXJEicUEpcSwY/RmR8igExshAuEeLeFeWy82a9AOkkiGVBP2N2IMTBFRvY0W/lvQ8gA==
+  env:
+    certificateName: "NO_CERT"
+    loggingLevel: "PRODUCTION"
+    version: "2"
+    mqttQueueHandler: "10"
 
 ### grafanaproxy ###
 grafanaproxy:

--- a/golang/cmd/factoryinput/main.go
+++ b/golang/cmd/factoryinput/main.go
@@ -43,7 +43,7 @@ func GetEnv(variableName string) (envValue string) {
 	var envValueEnvSet bool
 	envValue, envValueEnvSet = os.LookupEnv(variableName)
 	if !envValueEnvSet {
-		zap.S().Fatal("env value (ENV_VALUE) must be set")
+		zap.S().Warnf("Env variable %s not set", variableName)
 	}
 	if len(envValue) == 0 {
 		zap.S().Warnf("Env variable %s is empty", variableName)


### PR DESCRIPTION
# Description

This PR fixes tls connection for factoryinput. Now if tls is enabled within mqtt, the correct certificates are used by factoryinput. Otherwise it will communicate without encryption.

Changes from #1455 are also included

Fixes #1453 
Fixes #1454 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Deployed the stack (using a factoryinput image that includes this changes)

# Checklist:

- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding changes to the changelog (if needed).
- [ ] I have made corresponding notices to the upgrade instructions (if needed)

# Changelog changes

*none*

# Upgrade instructions

*none*