### PR TITLE
Remove conflicting flags from `go build` command

### DIFF
--- a/deployment/barcodereader/Dockerfile
+++ b/deployment/barcodereader/Dockerfile
@@ -47,7 +47,7 @@ RUN CGO_ENABLED=1 GOOS=linux go build -tags musl,kafka --mod=readonly -buildvcs=
 
 FROM builder AS branch-race
 WORKDIR /build
-RUN CGO_ENABLED=1 GOOS=linux go build -race -msan -asan -tags musl,kafka --mod=readonly -buildvcs=false -trimpath -buildvcs=false -trimpath -o mainFile ./cmd/barcodereader
+RUN CGO_ENABLED=1 GOOS=linux go build -race -asan -tags musl,kafka --mod=readonly -buildvcs=false -trimpath -buildvcs=false -trimpath -o mainFile ./cmd/barcodereader
 
 FROM branch${BRANCH} AS final
 

--- a/deployment/barcodereader/Dockerfile
+++ b/deployment/barcodereader/Dockerfile
@@ -47,7 +47,7 @@ RUN CGO_ENABLED=1 GOOS=linux go build -tags musl,kafka --mod=readonly -buildvcs=
 
 FROM builder AS branch-race
 WORKDIR /build
-RUN CGO_ENABLED=1 GOOS=linux go build -race -asan -tags musl,kafka --mod=readonly -buildvcs=false -trimpath -buildvcs=false -trimpath -o mainFile ./cmd/barcodereader
+RUN CGO_ENABLED=1 GOOS=linux go build -race -tags musl,kafka --mod=readonly -buildvcs=false -trimpath -buildvcs=false -trimpath -o mainFile ./cmd/barcodereader
 
 FROM branch${BRANCH} AS final
 

--- a/deployment/custom-microservice-tester/Dockerfile
+++ b/deployment/custom-microservice-tester/Dockerfile
@@ -36,7 +36,7 @@ RUN CGO_ENABLED=1 GOOS=linux go build --mod=readonly -buildvcs=false -trimpath -
 
 FROM builder AS branch-race
 WORKDIR /build
-RUN CGO_ENABLED=1 GOOS=linux go build -race -msan -asan --mod=readonly -buildvcs=false -trimpath -o mainFile ./cmd/custom-microservice-tester
+RUN CGO_ENABLED=1 GOOS=linux go build -race -asan --mod=readonly -buildvcs=false -trimpath -o mainFile ./cmd/custom-microservice-tester
 
 FROM branch${BRANCH} AS final
 

--- a/deployment/custom-microservice-tester/Dockerfile
+++ b/deployment/custom-microservice-tester/Dockerfile
@@ -36,7 +36,7 @@ RUN CGO_ENABLED=1 GOOS=linux go build --mod=readonly -buildvcs=false -trimpath -
 
 FROM builder AS branch-race
 WORKDIR /build
-RUN CGO_ENABLED=1 GOOS=linux go build -race -asan --mod=readonly -buildvcs=false -trimpath -o mainFile ./cmd/custom-microservice-tester
+RUN CGO_ENABLED=1 GOOS=linux go build -race --mod=readonly -buildvcs=false -trimpath -o mainFile ./cmd/custom-microservice-tester
 
 FROM branch${BRANCH} AS final
 

--- a/deployment/factoryinput/Dockerfile
+++ b/deployment/factoryinput/Dockerfile
@@ -43,7 +43,7 @@ RUN CGO_ENABLED=1 GOOS=linux go build -tags musl,kafka --mod=readonly -buildvcs=
 
 FROM builder AS branch-race
 WORKDIR /build
-RUN CGO_ENABLED=1 GOOS=linux go build -race -msan -asan -tags musl,kafka --mod=readonly -buildvcs=false -trimpath -o mainFile ./cmd/factoryinput
+RUN CGO_ENABLED=1 GOOS=linux go build -race -asan -tags musl,kafka --mod=readonly -buildvcs=false -trimpath -o mainFile ./cmd/factoryinput
 
 FROM branch${BRANCH} AS final
 

--- a/deployment/factoryinput/Dockerfile
+++ b/deployment/factoryinput/Dockerfile
@@ -43,7 +43,7 @@ RUN CGO_ENABLED=1 GOOS=linux go build -tags musl,kafka --mod=readonly -buildvcs=
 
 FROM builder AS branch-race
 WORKDIR /build
-RUN CGO_ENABLED=1 GOOS=linux go build -race -asan -tags musl,kafka --mod=readonly -buildvcs=false -trimpath -o mainFile ./cmd/factoryinput
+RUN CGO_ENABLED=1 GOOS=linux go build -race -tags musl,kafka --mod=readonly -buildvcs=false -trimpath -o mainFile ./cmd/factoryinput
 
 FROM branch${BRANCH} AS final
 

--- a/deployment/factoryinsight/Dockerfile
+++ b/deployment/factoryinsight/Dockerfile
@@ -43,7 +43,7 @@ RUN CGO_ENABLED=1 GOOS=linux go build -tags musl,kafka --mod=readonly -buildvcs=
 
 FROM builder AS branch-race
 WORKDIR /build
-RUN CGO_ENABLED=1 GOOS=linux go build -race -asan -tags musl,kafka --mod=readonly -buildvcs=false -trimpath -o mainFile ./cmd/factoryinsight
+RUN CGO_ENABLED=1 GOOS=linux go build -race -tags musl,kafka --mod=readonly -buildvcs=false -trimpath -o mainFile ./cmd/factoryinsight
 
 FROM branch${BRANCH} AS final
 

--- a/deployment/factoryinsight/Dockerfile
+++ b/deployment/factoryinsight/Dockerfile
@@ -43,7 +43,7 @@ RUN CGO_ENABLED=1 GOOS=linux go build -tags musl,kafka --mod=readonly -buildvcs=
 
 FROM builder AS branch-race
 WORKDIR /build
-RUN CGO_ENABLED=1 GOOS=linux go build -race -msan -asan -tags musl,kafka --mod=readonly -buildvcs=false -trimpath -o mainFile ./cmd/factoryinsight
+RUN CGO_ENABLED=1 GOOS=linux go build -race -asan -tags musl,kafka --mod=readonly -buildvcs=false -trimpath -o mainFile ./cmd/factoryinsight
 
 FROM branch${BRANCH} AS final
 

--- a/deployment/grafana-proxy/Dockerfile
+++ b/deployment/grafana-proxy/Dockerfile
@@ -42,7 +42,7 @@ RUN CGO_ENABLED=1 GOOS=linux go build -tags musl,kafka --mod=readonly -buildvcs=
 
 FROM builder AS branch-race
 WORKDIR /build
-RUN CGO_ENABLED=1 GOOS=linux go build -race -msan -asan -tags musl,kafka --mod=readonly -buildvcs=false -trimpath -o mainFile ./cmd/grafana-proxy
+RUN CGO_ENABLED=1 GOOS=linux go build -race -asan -tags musl,kafka --mod=readonly -buildvcs=false -trimpath -o mainFile ./cmd/grafana-proxy
 
 FROM branch${BRANCH} AS final
 

--- a/deployment/grafana-proxy/Dockerfile
+++ b/deployment/grafana-proxy/Dockerfile
@@ -42,7 +42,7 @@ RUN CGO_ENABLED=1 GOOS=linux go build -tags musl,kafka --mod=readonly -buildvcs=
 
 FROM builder AS branch-race
 WORKDIR /build
-RUN CGO_ENABLED=1 GOOS=linux go build -race -asan -tags musl,kafka --mod=readonly -buildvcs=false -trimpath -o mainFile ./cmd/grafana-proxy
+RUN CGO_ENABLED=1 GOOS=linux go build -race -tags musl,kafka --mod=readonly -buildvcs=false -trimpath -o mainFile ./cmd/grafana-proxy
 
 FROM branch${BRANCH} AS final
 

--- a/deployment/kafka-bridge/Dockerfile
+++ b/deployment/kafka-bridge/Dockerfile
@@ -43,7 +43,7 @@ RUN CGO_ENABLED=1 GOOS=linux go build -tags musl,kafka --mod=readonly -buildvcs=
 
 FROM builder AS branch-race
 WORKDIR /build
-RUN CGO_ENABLED=1 GOOS=linux go build -race -msan -asan -tags musl,kafka --mod=readonly -buildvcs=false -trimpath -o mainFile ./cmd/kafka-bridge
+RUN CGO_ENABLED=1 GOOS=linux go build -race -asan -tags musl,kafka --mod=readonly -buildvcs=false -trimpath -o mainFile ./cmd/kafka-bridge
 
 FROM branch${BRANCH} AS final
 

--- a/deployment/kafka-bridge/Dockerfile
+++ b/deployment/kafka-bridge/Dockerfile
@@ -43,7 +43,7 @@ RUN CGO_ENABLED=1 GOOS=linux go build -tags musl,kafka --mod=readonly -buildvcs=
 
 FROM builder AS branch-race
 WORKDIR /build
-RUN CGO_ENABLED=1 GOOS=linux go build -race -asan -tags musl,kafka --mod=readonly -buildvcs=false -trimpath -o mainFile ./cmd/kafka-bridge
+RUN CGO_ENABLED=1 GOOS=linux go build -race -tags musl,kafka --mod=readonly -buildvcs=false -trimpath -o mainFile ./cmd/kafka-bridge
 
 FROM branch${BRANCH} AS final
 

--- a/deployment/kafka-debug/Dockerfile
+++ b/deployment/kafka-debug/Dockerfile
@@ -41,7 +41,7 @@ RUN CGO_ENABLED=1 GOOS=linux go build -tags musl,kafka --mod=readonly -buildvcs=
 
 FROM builder AS branch-race
 WORKDIR /build
-RUN CGO_ENABLED=1 GOOS=linux go build -race -msan -asan -tags musl,kafka --mod=readonly -buildvcs=false -trimpath -o mainFile ./cmd/kafka-debug
+RUN CGO_ENABLED=1 GOOS=linux go build -msan -asan -tags musl,kafka --mod=readonly -buildvcs=false -trimpath -o mainFile ./cmd/kafka-debug
 
 FROM branch${BRANCH} AS final
 

--- a/deployment/kafka-debug/Dockerfile
+++ b/deployment/kafka-debug/Dockerfile
@@ -41,7 +41,7 @@ RUN CGO_ENABLED=1 GOOS=linux go build -tags musl,kafka --mod=readonly -buildvcs=
 
 FROM builder AS branch-race
 WORKDIR /build
-RUN CGO_ENABLED=1 GOOS=linux go build -msan -asan -tags musl,kafka --mod=readonly -buildvcs=false -trimpath -o mainFile ./cmd/kafka-debug
+RUN CGO_ENABLED=1 GOOS=linux go build -race -tags musl,kafka --mod=readonly -buildvcs=false -trimpath -o mainFile ./cmd/kafka-debug
 
 FROM branch${BRANCH} AS final
 

--- a/deployment/kafka-init/Dockerfile
+++ b/deployment/kafka-init/Dockerfile
@@ -40,7 +40,7 @@ RUN CGO_ENABLED=1 GOOS=linux go build -tags musl,kafka --mod=readonly -buildvcs=
 
 FROM builder AS branch-race
 WORKDIR /build
-RUN CGO_ENABLED=1 GOOS=linux go build -race -msan -asan -tags musl,kafka --mod=readonly -buildvcs=false -trimpath -o mainFile ./cmd/kafka-init
+RUN CGO_ENABLED=1 GOOS=linux go build -race -asan -tags musl,kafka --mod=readonly -buildvcs=false -trimpath -o mainFile ./cmd/kafka-init
 
 FROM branch${BRANCH} AS final
 

--- a/deployment/kafka-init/Dockerfile
+++ b/deployment/kafka-init/Dockerfile
@@ -40,7 +40,7 @@ RUN CGO_ENABLED=1 GOOS=linux go build -tags musl,kafka --mod=readonly -buildvcs=
 
 FROM builder AS branch-race
 WORKDIR /build
-RUN CGO_ENABLED=1 GOOS=linux go build -race -asan -tags musl,kafka --mod=readonly -buildvcs=false -trimpath -o mainFile ./cmd/kafka-init
+RUN CGO_ENABLED=1 GOOS=linux go build -race -tags musl,kafka --mod=readonly -buildvcs=false -trimpath -o mainFile ./cmd/kafka-init
 
 FROM branch${BRANCH} AS final
 

--- a/deployment/kafka-state-detector/Dockerfile
+++ b/deployment/kafka-state-detector/Dockerfile
@@ -41,7 +41,7 @@ RUN CGO_ENABLED=1 GOOS=linux go build -tags musl,kafka --mod=readonly -buildvcs=
 
 FROM builder AS branch-race
 WORKDIR /build
-RUN CGO_ENABLED=1 GOOS=linux go build -race -msan -asan -tags musl,kafka --mod=readonly -buildvcs=false -trimpath -o mainFile ./cmd/kafka-state-detector
+RUN CGO_ENABLED=1 GOOS=linux go build -race -asan -tags musl,kafka --mod=readonly -buildvcs=false -trimpath -o mainFile ./cmd/kafka-state-detector
 
 
 FROM branch${BRANCH} AS final

--- a/deployment/kafka-state-detector/Dockerfile
+++ b/deployment/kafka-state-detector/Dockerfile
@@ -41,7 +41,7 @@ RUN CGO_ENABLED=1 GOOS=linux go build -tags musl,kafka --mod=readonly -buildvcs=
 
 FROM builder AS branch-race
 WORKDIR /build
-RUN CGO_ENABLED=1 GOOS=linux go build -race -asan -tags musl,kafka --mod=readonly -buildvcs=false -trimpath -o mainFile ./cmd/kafka-state-detector
+RUN CGO_ENABLED=1 GOOS=linux go build -race -tags musl,kafka --mod=readonly -buildvcs=false -trimpath -o mainFile ./cmd/kafka-state-detector
 
 
 FROM branch${BRANCH} AS final

--- a/deployment/kafka-to-postgresql/Dockerfile
+++ b/deployment/kafka-to-postgresql/Dockerfile
@@ -40,7 +40,7 @@ RUN CGO_ENABLED=1 GOOS=linux go build -tags musl,kafka --mod=readonly -buildvcs=
 
 FROM builder AS branch-race
 WORKDIR /build
-RUN CGO_ENABLED=1 GOOS=linux go build -race -asan -tags musl,kafka --mod=readonly -buildvcs=false -trimpath -o mainFile ./cmd/kafka-to-postgresql
+RUN CGO_ENABLED=1 GOOS=linux go build -race -tags musl,kafka --mod=readonly -buildvcs=false -trimpath -o mainFile ./cmd/kafka-to-postgresql
 
 
 FROM branch${BRANCH} AS final

--- a/deployment/kafka-to-postgresql/Dockerfile
+++ b/deployment/kafka-to-postgresql/Dockerfile
@@ -40,7 +40,7 @@ RUN CGO_ENABLED=1 GOOS=linux go build -tags musl,kafka --mod=readonly -buildvcs=
 
 FROM builder AS branch-race
 WORKDIR /build
-RUN CGO_ENABLED=1 GOOS=linux go build -race -msan -asan -tags musl,kafka --mod=readonly -buildvcs=false -trimpath -o mainFile ./cmd/kafka-to-postgresql
+RUN CGO_ENABLED=1 GOOS=linux go build -race -asan -tags musl,kafka --mod=readonly -buildvcs=false -trimpath -o mainFile ./cmd/kafka-to-postgresql
 
 
 FROM branch${BRANCH} AS final

--- a/deployment/mqtt-bridge/Dockerfile
+++ b/deployment/mqtt-bridge/Dockerfile
@@ -41,7 +41,7 @@ RUN CGO_ENABLED=1 GOOS=linux go build -tags musl,kafka --mod=readonly -buildvcs=
 
 FROM builder AS branch-race
 WORKDIR /build
-RUN CGO_ENABLED=1 GOOS=linux go build -race -msan -asan -tags musl,kafka --mod=readonly -buildvcs=false -trimpath -o mainFile ./cmd/mqtt-bridge
+RUN CGO_ENABLED=1 GOOS=linux go build -race -asan -tags musl,kafka --mod=readonly -buildvcs=false -trimpath -o mainFile ./cmd/mqtt-bridge
 
 FROM branch${BRANCH} AS final
 

--- a/deployment/mqtt-bridge/Dockerfile
+++ b/deployment/mqtt-bridge/Dockerfile
@@ -41,7 +41,7 @@ RUN CGO_ENABLED=1 GOOS=linux go build -tags musl,kafka --mod=readonly -buildvcs=
 
 FROM builder AS branch-race
 WORKDIR /build
-RUN CGO_ENABLED=1 GOOS=linux go build -race -asan -tags musl,kafka --mod=readonly -buildvcs=false -trimpath -o mainFile ./cmd/mqtt-bridge
+RUN CGO_ENABLED=1 GOOS=linux go build -race -tags musl,kafka --mod=readonly -buildvcs=false -trimpath -o mainFile ./cmd/mqtt-bridge
 
 FROM branch${BRANCH} AS final
 

--- a/deployment/mqtt-kafka-bridge/Dockerfile
+++ b/deployment/mqtt-kafka-bridge/Dockerfile
@@ -42,7 +42,7 @@ RUN CGO_ENABLED=1 GOOS=linux go build -tags musl,kafka --mod=readonly -buildvcs=
 
 FROM builder AS branch-race
 WORKDIR /build
-RUN CGO_ENABLED=1 GOOS=linux go build -race -asan -tags musl,kafka --mod=readonly -buildvcs=false -trimpath -o mainFile ./cmd/mqtt-kafka-bridge
+RUN CGO_ENABLED=1 GOOS=linux go build -race -tags musl,kafka --mod=readonly -buildvcs=false -trimpath -o mainFile ./cmd/mqtt-kafka-bridge
 
 FROM branch${BRANCH} AS final
 

--- a/deployment/mqtt-kafka-bridge/Dockerfile
+++ b/deployment/mqtt-kafka-bridge/Dockerfile
@@ -42,7 +42,7 @@ RUN CGO_ENABLED=1 GOOS=linux go build -tags musl,kafka --mod=readonly -buildvcs=
 
 FROM builder AS branch-race
 WORKDIR /build
-RUN CGO_ENABLED=1 GOOS=linux go build -race -msan -asan -tags musl,kafka --mod=readonly -buildvcs=false -trimpath -o mainFile ./cmd/mqtt-kafka-bridge
+RUN CGO_ENABLED=1 GOOS=linux go build -race -asan -tags musl,kafka --mod=readonly -buildvcs=false -trimpath -o mainFile ./cmd/mqtt-kafka-bridge
 
 FROM branch${BRANCH} AS final
 

--- a/deployment/sensorconnect/Dockerfile
+++ b/deployment/sensorconnect/Dockerfile
@@ -42,7 +42,7 @@ RUN CGO_ENABLED=1 GOOS=linux go build -tags musl,kafka --mod=readonly -buildvcs=
 
 FROM builder AS branch-race
 WORKDIR /build
-RUN CGO_ENABLED=1 GOOS=linux go build -race -asan -tags musl,kafka --mod=readonly -buildvcs=false -trimpath -o mainFile ./cmd/sensorconnect
+RUN CGO_ENABLED=1 GOOS=linux go build -race -tags musl,kafka --mod=readonly -buildvcs=false -trimpath -o mainFile ./cmd/sensorconnect
 
 FROM branch${BRANCH} AS final
 # Create a list of shared libraries required by the mainFile binary and copy them to the deps directory

--- a/deployment/sensorconnect/Dockerfile
+++ b/deployment/sensorconnect/Dockerfile
@@ -42,7 +42,7 @@ RUN CGO_ENABLED=1 GOOS=linux go build -tags musl,kafka --mod=readonly -buildvcs=
 
 FROM builder AS branch-race
 WORKDIR /build
-RUN CGO_ENABLED=1 GOOS=linux go build -race -msan -asan -tags musl,kafka --mod=readonly -buildvcs=false -trimpath -o mainFile ./cmd/sensorconnect
+RUN CGO_ENABLED=1 GOOS=linux go build -race -asan -tags musl,kafka --mod=readonly -buildvcs=false -trimpath -o mainFile ./cmd/sensorconnect
 
 FROM branch${BRANCH} AS final
 # Create a list of shared libraries required by the mainFile binary and copy them to the deps directory


### PR DESCRIPTION
This PR fixes the `go build` command, that doesn't allow `-msan` and `-asan` flags if `-race` is present