### PR TITLE
Remove `-race` tag from hivemq-init image

### DIFF
--- a/deployment/united-manufacturing-hub/templates/hivemq/statefulset.yaml
+++ b/deployment/united-manufacturing-hub/templates/hivemq/statefulset.yaml
@@ -56,7 +56,7 @@ spec:
         {{- end}}
       initContainers:
         - name: hivemqce-extension-init
-          image: {{.Values.mqtt_broker.initContainer.hivemqextensioninit.image.repository}}:{{.Values.mqtt_broker.initContainer.hivemqextensioninit.image.tag}}{{- if .Values._000_commonConfig.racedetector.enabled}}-race{{- end}}
+          image: {{.Values.mqtt_broker.initContainer.hivemqextensioninit.image.repository}}:{{.Values.mqtt_broker.initContainer.hivemqextensioninit.image.tag}}
           imagePullPolicy: {{.Values.mqtt_broker.initContainer.hivemqextensioninit.image.pullPolicy}}
           volumeMounts:
             - mountPath: /opt/hivemq-ce-2022.1/extensions


### PR DESCRIPTION
This PR removes the `-race` tag from the hivemq-init image, since that image does not exists