### PR TITLE
Missing go install in workflow

### DIFF
--- a/.github/workflows/golint.yml
+++ b/.github/workflows/golint.yml
@@ -23,8 +23,16 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: '1.20.*'
+      - name: Install vulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        working-directory: ./golang
+        shell: bash
       - name: Run go vulncheck and generate report
         run: go run golang.org/x/vuln/cmd/govulncheck ./...
+        working-directory: ./golang
+        shell: bash
+      - name: Install golangci-lint
+        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
         working-directory: ./golang
         shell: bash
       - name: Run golangci-lint


### PR DESCRIPTION
This pr adds go install commands to the go run, preventing some issues, where the tools can't be directly installed and run.