### PR TITLE
refactor ConsumerName fields of kafka client options to ConsumerGroupId

### DIFF
--- a/golang/cmd/barcodereader/main.go
+++ b/golang/cmd/barcodereader/main.go
@@ -3,18 +3,19 @@ package main
 import (
 	"bufio"
 	"fmt"
-	"github.com/heptiolabs/healthcheck"
-	"github.com/united-manufacturing-hub/Sarama-Kafka-Wrapper/pkg/kafka"
-	"github.com/united-manufacturing-hub/umh-utils/env"
-	"github.com/united-manufacturing-hub/umh-utils/logger"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/internal"
-	"go.uber.org/zap"
 	"net/http"
 	"os"
 	"regexp"
 	"strings"
 	"syscall"
 	"unsafe"
+
+	"github.com/heptiolabs/healthcheck"
+	"github.com/united-manufacturing-hub/Sarama-Kafka-Wrapper/pkg/kafka"
+	"github.com/united-manufacturing-hub/umh-utils/env"
+	"github.com/united-manufacturing-hub/umh-utils/logger"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/internal"
+	"go.uber.org/zap"
 )
 
 const (
@@ -113,7 +114,7 @@ func initKafka() {
 
 	client, err = kafka.NewKafkaClient(&kafka.NewClientOptions{
 		ListenTopicRegex:  nil,
-		ConsumerName:      "barcodereader",
+		ConsumerGroupId:   "barcodereader",
 		Brokers:           []string{KafkaBoostrapServer},
 		StartOffset:       0,
 		Partitions:        6,

--- a/golang/cmd/kafka-init/kafka.go
+++ b/golang/cmd/kafka-init/kafka.go
@@ -14,11 +14,12 @@
 package main
 
 import (
+	"strings"
+
 	"github.com/Shopify/sarama"
 	"github.com/united-manufacturing-hub/Sarama-Kafka-Wrapper/pkg/kafka"
 	"github.com/united-manufacturing-hub/umh-utils/env"
 	"go.uber.org/zap"
-	"strings"
 )
 
 func Init(kafkaBroker string) {
@@ -38,7 +39,7 @@ func Init(kafkaBroker string) {
 	zap.S().Debug("Creating kafka client")
 	client, err := kafka.NewKafkaClient(&kafka.NewClientOptions{
 		Brokers:           []string{kafkaBroker},
-		ConsumerName:      "kafka-init",
+		ConsumerGroupId:   "kafka-init",
 		Partitions:        6,
 		ReplicationFactor: 1,
 		EnableTLS:         useSsl,

--- a/golang/cmd/mqtt-kafka-bridge/kafka_processor/kafka.go
+++ b/golang/cmd/mqtt-kafka-bridge/kafka_processor/kafka.go
@@ -1,15 +1,16 @@
 package kafka_processor
 
 import (
+	"regexp"
+	"strings"
+	"time"
+
 	"github.com/Shopify/sarama"
 	"github.com/united-manufacturing-hub/Sarama-Kafka-Wrapper/pkg/kafka"
 	"github.com/united-manufacturing-hub/umh-utils/env"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/cmd/mqtt-kafka-bridge/message"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/internal"
 	"go.uber.org/zap"
-	"regexp"
-	"strings"
-	"time"
 )
 
 var client *kafka.Client
@@ -40,7 +41,7 @@ func Init(kafkaToMqttChan chan kafka.Message, sChan chan bool) {
 		Brokers: []string{
 			KafkaBootstrapServer,
 		},
-		ConsumerName:      "mqtt-kafka-bridge",
+		ConsumerGroupId:   "mqtt-kafka-bridge",
 		ListenTopicRegex:  compile,
 		Partitions:        6,
 		ReplicationFactor: 1,


### PR DESCRIPTION
Adjust to [Sarama-Kafka-Wrapper](https://github.com/united-manufacturing-hub/Sarama-Kafka-Wrapper) API changes introduced in this [commit](https://github.com/united-manufacturing-hub/Sarama-Kafka-Wrapper/commit/2eb80ec06c75163ec6269e631b89238410be2e58).

Should fix previous docker build errors of `barcodereader`, `kafka-init` and `mqtt-kafka-bridge`.