### PR TITLE
Add kafka handler

### DIFF
--- a/golang/cmd/data-bridge/kafka.go
+++ b/golang/cmd/data-bridge/kafka.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"encoding/hex"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/IBM/sarama"
+	"github.com/goccy/go-json"
+	"github.com/united-manufacturing-hub/Sarama-Kafka-Wrapper/pkg/kafka"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/internal"
+	"go.uber.org/zap"
+	"golang.org/x/crypto/sha3"
+)
+
+type kafkaClient struct {
+	client *kafka.Client
+}
+
+func newKafkaClient(broker, topic, serialNumber string, partitions, replicationFactor int) (kc *kafkaClient, err error) {
+	topicsRegex, err := regexp.Compile(topic)
+	if err != nil {
+		zap.S().Fatalf("Error compiling regex: %v", err)
+	}
+
+	hasher := sha3.New256()
+	hasher.Write([]byte(serialNumber))
+	consumerGroupId := "data-bridge-" + hex.EncodeToString(hasher.Sum(nil))
+
+	options := &kafka.NewClientOptions{
+		Brokers: []string{
+			broker,
+		},
+		ConsumerGroupId:   consumerGroupId,
+		ListenTopicRegex:  topicsRegex,
+		Partitions:        int32(partitions),
+		ReplicationFactor: int16(replicationFactor),
+		StartOffset:       sarama.OffsetOldest,
+	}
+
+	kc.client, err = kafka.NewKafkaClient(options)
+	return
+}
+
+func (k *kafkaClient) getProducerStats() (sent uint64) {
+	sent, _, _, _ = kafka.GetKafkaStats()
+	return
+}
+
+func (k *kafkaClient) getConsumerStats() (received uint64) {
+	_, received, _, _ = kafka.GetKafkaStats()
+	return
+}
+
+// startProducing starts to read incoming messages from msgChan, transforms them
+// into valid kafka messagges, does the splitting and sends them to kafka
+func (k *kafkaClient) startProducing(msgChan chan kafka.Message, split int) {
+	go func() {
+		for {
+			msg := <-msgChan
+
+			if strings.HasPrefix(msg.Topic, "$share") {
+				msg.Topic = string(regexp.MustCompile(`\$share\/data-bridge-(.*?)\/`).ReplaceAll([]byte(msg.Topic), []byte("")))
+			}
+
+			msg.Topic = strings.ReplaceAll(msg.Topic, "/", ".")
+			if !isValidKafkaMessage(msg) {
+				continue
+			}
+
+			msg = splitMessage(msg, split)
+
+			internal.AddSXOrigin(&msg)
+			var err error
+			err = internal.AddSXTrace(&msg)
+			if err != nil {
+				zap.S().Fatalf("Failed to marshal trace")
+				continue
+			}
+
+			err = k.client.EnqueueMessage(msg)
+			for err != nil {
+				time.Sleep(10 * time.Millisecond)
+				err = k.client.EnqueueMessage(msg)
+			}
+		}
+	}()
+}
+
+// startConsuming starts to read incoming messages from kafka and sends them to the msgChan
+func (k *kafkaClient) startConsuming(msgChan chan kafka.Message) {
+	go func() {
+		for {
+			msg := <-k.client.GetMessages()
+			msgChan <- kafka.Message{
+				Topic:  msg.Topic,
+				Value:  msg.Value,
+				Header: msg.Header,
+				Key:    msg.Key,
+			}
+		}
+	}()
+}
+
+func (k *kafkaClient) shutdown() error {
+	zap.S().Info("Shutting down kafka client")
+	return k.client.Close()
+}
+
+// splitMessage splits the topic of msg into two parts, the first part will be
+// the topic of splittedMsg, the second part will be the key of splittedMsg.
+//
+// If the topic of msg has less than split parts, splittedMsg will have the same
+// topic and key as msg.
+// The key of msg will always be appended to the end of the key of splittedMsg.
+func splitMessage(msg kafka.Message, split int) (splittedMsg kafka.Message) {
+	parts := strings.Split(msg.Topic, ".")
+
+	if len(parts) < split {
+		splittedMsg.Topic = msg.Topic
+		splittedMsg.Key = msg.Key
+	} else {
+		splittedMsg.Topic = strings.Join(parts[:split], ".")
+		// append existing key to the end of the new key, in order to account
+		// for messages that have already been split
+		splittedMsg.Key = append([]byte(strings.Join(parts[split:], ".")), msg.Key...)
+	}
+	splittedMsg.Value = msg.Value
+	splittedMsg.Header = msg.Header
+
+	return splittedMsg
+}
+
+func isValidKafkaMessage(message kafka.Message) bool {
+	if strings.HasPrefix(message.Topic, ".") {
+		zap.S().Warnf("Topic starts with a dot: %s", message.Topic)
+		return false
+	}
+
+	if strings.HasSuffix(message.Topic, ".") {
+		zap.S().Warnf("Topic ends with a dot: %s", message.Topic)
+		return false
+	}
+
+	if !json.Valid(message.Value) {
+		zap.S().Warnf("Not a valid json in message: %s", message.Topic, string(message.Value))
+		return false
+	}
+
+	if internal.IsSameOrigin(&message) {
+		zap.S().Warnf("Message from same origin: %s", message.Topic)
+		return false
+	}
+
+	if internal.IsInTrace(&message) {
+		zap.S().Warnf("Message in trace: %s", message.Topic)
+		return false
+	}
+
+	return true
+}

--- a/golang/cmd/data-bridge/main.go
+++ b/golang/cmd/data-bridge/main.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/heptiolabs/healthcheck"
+	"github.com/united-manufacturing-hub/umh-utils/env"
+	"github.com/united-manufacturing-hub/umh-utils/logger"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/internal"
+	"go.uber.org/zap"
+)
+
+func main() {
+	var err error
+	logLevel, _ := env.GetAsString("LOGGING_LEVEL", false, "PRODUCTION") //nolint:errcheck
+	log := logger.New(logLevel)
+	defer func(logger *zap.SugaredLogger) {
+		err = logger.Sync()
+		if err != nil {
+			panic(err)
+		}
+	}(log)
+
+	internal.Initfgtrace()
+
+	zap.S().Debug("Checking environment variables")
+	serialNumber, err := env.GetAsString("SERIAL_NUMBER", true, "")
+	if err != nil {
+		zap.S().Fatal(err)
+	}
+	microserviceName, err := env.GetAsString("MICROSERVICE_NAME", true, "")
+	if err != nil {
+		zap.S().Fatal(err)
+	}
+
+	mode, err := env.GetAsInt("MODE", true, -1)
+	if err != nil {
+		zap.S().Fatal(err)
+	}
+	if mode != 0 && mode != 1 {
+		zap.S().Fatal("invalid MODE")
+	}
+	bridgeMode, err := env.GetAsInt("BRIDGE_MODE", true, -1)
+	if err != nil {
+		zap.S().Fatal(err)
+	}
+	if bridgeMode != 0 && bridgeMode != 1 {
+		zap.S().Fatal("invalid BRIDGE_MODE")
+	}
+
+	brokerA, err := env.GetAsString("BROKER_A", true, "")
+	if err != nil {
+		zap.S().Fatal(err)
+	}
+	brokerB, err := env.GetAsString("BROKER_B", true, "")
+	if err != nil {
+		zap.S().Fatal(err)
+	}
+
+	topic, err := env.GetAsString("TOPIC", true, "")
+	if err != nil {
+		zap.S().Fatal(err)
+	}
+	split, err := env.GetAsInt("SPLIT", true, -1)
+	if err != nil {
+		zap.S().Fatal(err)
+	}
+
+	partitons, err := env.GetAsInt("PARTITIONS", false, 6)
+	if err != nil {
+		zap.S().Error(err)
+	}
+	if partitons < 1 {
+		zap.S().Fatal("PARTITIONS must be at least 1")
+	}
+	replicationFactor, err := env.GetAsInt("REPLICATION_FACTOR", false, 1)
+	if err != nil {
+		zap.S().Error(err)
+	}
+	if replicationFactor % 2 == 0 {
+		zap.S().Fatal("REPLICATION_FACTOR must be odd")
+	}
+
+	zap.S().Debug("Starting healthcheck")
+	health := healthcheck.NewHandler()
+	health.AddLivenessCheck("goroutine-threshold", healthcheck.GoroutineCountCheck(1000000))
+	go func() {
+		/* #nosec G114 */
+		err := http.ListenAndServe("0.0.0.0:8086", health)
+		if err != nil {
+			zap.S().Errorf("Error starting healthcheck: %s", err)
+		}
+	}()
+
+	gs := internal.NewGracefulShutdown(func() error {
+		// close the clients
+		return nil
+	})
+}

--- a/golang/cmd/data-bridge/main.go
+++ b/golang/cmd/data-bridge/main.go
@@ -31,10 +31,6 @@ func main() {
 	if err != nil {
 		zap.S().Fatal(err)
 	}
-	microserviceName, err := env.GetAsString("MICROSERVICE_NAME", true, "")
-	if err != nil {
-		zap.S().Fatal(err)
-	}
 
 	mode, err := env.GetAsInt("MODE", true, -1)
 	if err != nil {
@@ -102,11 +98,11 @@ func main() {
 	switch mode {
 	case 0: // kafka to kafka
 		zap.S().Infof("Starting kafka to kafka bridge")
-		clientA, err = newKafkaClient(brokerA, topic, partitons, replicationFactor)
+		clientA, err = newKafkaClient(brokerA, topic, serialNumber, partitons, replicationFactor)
 		if err != nil {
 			zap.S().Errorf("failed to create kafka client: %s", err)
 		}
-		clientB, err = newKafkaClient(brokerB, topic, partitons, replicationFactor)
+		clientB, err = newKafkaClient(brokerB, topic, serialNumber, partitons, replicationFactor)
 		if err != nil {
 			zap.S().Errorf("failed to create kafka client: %s", err)
 		}
@@ -125,12 +121,12 @@ func main() {
 			if err != nil {
 				zap.S().Errorf("failed to create mqtt client: %s", err)
 			}
-			clientB, err = newKafkaClient(brokerB, topic, partitons, replicationFactor)
+			clientB, err = newKafkaClient(brokerB, topic, serialNumber, partitons, replicationFactor)
 			if err != nil {
 				zap.S().Errorf("failed to create kafka client: %s", err)
 			}
 		} else {
-			clientA, err = newKafkaClient(brokerA, topic, partitons, replicationFactor)
+			clientA, err = newKafkaClient(brokerA, topic, serialNumber, partitons, replicationFactor)
 			if err != nil {
 				zap.S().Errorf("failed to create kafka client: %s", err)
 			}

--- a/golang/cmd/data-bridge/main.go
+++ b/golang/cmd/data-bridge/main.go
@@ -101,6 +101,7 @@ func main() {
 	var clientA, clientB client
 	switch mode {
 	case 0: // kafka to kafka
+		zap.S().Infof("Starting kafka to kafka bridge")
 		clientA, err = newKafkaClient(brokerA, topic, partitons, replicationFactor)
 		if err != nil {
 			zap.S().Errorf("failed to create kafka client: %s", err)
@@ -110,6 +111,7 @@ func main() {
 			zap.S().Errorf("failed to create kafka client: %s", err)
 		}
 	case 1: // kafka to mqtt
+		zap.S().Infof("Starting kafka to mqtt bridge")
 		mqttUseTls, err := env.GetAsBool("MQTT_ENABLE_TLS", false, false)
 		if err != nil {
 			zap.S().Error(err)
@@ -138,6 +140,7 @@ func main() {
 			}
 		}
 	case 2: // mqtt to mqtt
+		zap.S().Infof("Starting mqtt to mqtt bridge")
 		clientA, err = newMqttClient(brokerA, topic, false, "")
 		if err != nil {
 			zap.S().Errorf("failed to create mqtt client: %s", err)
@@ -170,6 +173,7 @@ func main() {
 
 }
 
+// reportStats logs the number of messages sent and received every 10 seconds. It also shuts down the application if no messages are sent or received for 3 minutes.
 func reportStats(msgChan chan kafka.Message, consumerClient, producerClient client, gs internal.GracefulShutdownHandler) {
 	var sent, recv uint64
 	sent = producerClient.getProducerStats()

--- a/golang/cmd/data-bridge/main.go
+++ b/golang/cmd/data-bridge/main.go
@@ -2,8 +2,11 @@ package main
 
 import (
 	"net/http"
+	"strings"
+	"time"
 
 	"github.com/heptiolabs/healthcheck"
+	"github.com/united-manufacturing-hub/Sarama-Kafka-Wrapper/pkg/kafka"
 	"github.com/united-manufacturing-hub/umh-utils/env"
 	"github.com/united-manufacturing-hub/umh-utils/logger"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/internal"
@@ -61,9 +64,12 @@ func main() {
 	if err != nil {
 		zap.S().Fatal(err)
 	}
-	split, err := env.GetAsInt("SPLIT", true, -1)
+	split, err := env.GetAsInt("SPLIT", false, -1)
 	if err != nil {
-		zap.S().Fatal(err)
+		zap.S().Error(err)
+	}
+	if split != -1 && split < 3 {
+		zap.S().Fatal("SPLIT must be at least 3")
 	}
 
 	partitons, err := env.GetAsInt("PARTITIONS", false, 6)
@@ -77,7 +83,7 @@ func main() {
 	if err != nil {
 		zap.S().Error(err)
 	}
-	if replicationFactor % 2 == 0 {
+	if replicationFactor%2 == 0 {
 		zap.S().Fatal("REPLICATION_FACTOR must be odd")
 	}
 
@@ -92,8 +98,107 @@ func main() {
 		}
 	}()
 
+	var clientA, clientB client
+	if mode == 0 {
+		// kafka to kafka
+		clientA, err = newKafkaClient(brokerA, topic, partitons, replicationFactor)
+		if err != nil {
+			zap.S().Errorf("failed to create kafka client: %s", err)
+		}
+		clientB, err = newKafkaClient(brokerB, topic, partitons, replicationFactor)
+		if err != nil {
+			zap.S().Errorf("failed to create kafka client: %s", err)
+		}
+	} else {
+		// mqtt to kafka
+		mqttUseTls, err := env.GetAsBool("MQTT_ENABLE_TLS", false, false)
+		if err != nil {
+			zap.S().Error(err)
+		}
+		mqttPsw, err := env.GetAsString("MQTT_PASSWORD", false, "")
+		if err != nil {
+			zap.S().Error(err)
+		}
+		if strings.HasSuffix(brokerA, "1883") || strings.HasSuffix(brokerA, "8883") {
+			clientA, err = newMqttClient(brokerA, topic, mqttUseTls, mqttPsw)
+			if err != nil {
+				zap.S().Errorf("failed to create mqtt client: %s", err)
+			}
+			clientB, err = newKafkaClient(brokerB, topic, partitons, replicationFactor)
+			if err != nil {
+				zap.S().Errorf("failed to create kafka client: %s", err)
+			}
+		} else {
+			clientA, err = newKafkaClient(brokerA, topic, partitons, replicationFactor)
+			if err != nil {
+				zap.S().Errorf("failed to create kafka client: %s", err)
+			}
+			clientB, err = newMqttClient(brokerB, topic, mqttUseTls, mqttPsw)
+			if err != nil {
+				zap.S().Errorf("failed to create mqtt client: %s", err)
+			}
+		}
+	}
+
 	gs := internal.NewGracefulShutdown(func() error {
-		// close the clients
+		clientA.shutdown()
+		clientB.shutdown()
 		return nil
 	})
+
+	var msgChan = make(chan kafka.Message, 100)
+
+	if bridgeMode == 0 {
+		// a to b
+		clientA.startConsuming(msgChan)
+		clientB.startProducing(msgChan, split)
+		go reportStats(msgChan, clientA, clientB, gs)
+	} else {
+		// b to a
+		clientA.startProducing(msgChan, split)
+		clientB.startConsuming(msgChan)
+		go reportStats(msgChan, clientB, clientA, gs)
+	}
+
+}
+
+func reportStats(msgChan chan kafka.Message, consumerClient, producerClient client, gs internal.GracefulShutdownHandler) {
+	var sent, recv uint64
+	sent = producerClient.getProducerStats()
+	recv = consumerClient.getConsumerStats()
+
+	ticker := time.NewTicker(10 * time.Second)
+	shutdownTimer := time.NewTimer(3 * time.Minute)
+	for {
+		select {
+		case <-ticker.C:
+			var newSent, newRecv uint64
+			newSent = producerClient.getProducerStats()
+			newRecv = consumerClient.getConsumerStats()
+
+			sentPerSecond := (newSent - sent) / 10
+			recvPerSecond := (newRecv - recv) / 10
+
+			zap.S().Infof("Recieved: %d (%d/) | Sent: %d (%d/s) | Lag: %d", newSent, sentPerSecond, newRecv, recvPerSecond, len(msgChan))
+
+			if newSent != sent && newRecv != recv {
+				shutdownTimer.Reset(3 * time.Minute)
+				return
+			}
+
+			sent, recv = newSent, newRecv
+		case <-shutdownTimer.C:
+			zap.S().Error("connection lost")
+			gs.Shutdown()
+			return
+		}
+	}
+}
+
+type client interface {
+	getProducerStats() (messages uint64)
+	getConsumerStats() (messages uint64)
+	startProducing(messageChan chan kafka.Message, split int)
+	startConsuming(messageChan chan kafka.Message)
+	shutdown() error
 }


### PR DESCRIPTION
This PR adds the kafka client that implements the `client` interface.
When using the `startConsumer` method, it starts reading the messages from the broker and sending them to the `msgChan`
When using the `startProducer` method, it reads the messages from `msgChan`, transforms them from mqtt-style to kafka-style (if necessary) and does the splitting

I would have added unit tests, but unfortunately, due to the fact that I used the sarama wrapper, I couldn't mock the kafka client in order to test the consumer and producer functionalities,

Close https://github.com/united-manufacturing-hub/MgmtIssues/issues/345