### PR TITLE
Add MQTT handler

### DIFF
--- a/golang/cmd/data-bridge/main.go
+++ b/golang/cmd/data-bridge/main.go
@@ -117,7 +117,7 @@ func main() {
 			zap.S().Error(err)
 		}
 		if strings.HasSuffix(brokerA, "1883") || strings.HasSuffix(brokerA, "8883") {
-			clientA, err = newMqttClient(brokerA, topic, mqttUseTls, mqttPsw)
+			clientA, err = newMqttClient(brokerA, topic, mqttPsw, serialNumber, mqttUseTls)
 			if err != nil {
 				zap.S().Errorf("failed to create mqtt client: %s", err)
 			}
@@ -130,18 +130,26 @@ func main() {
 			if err != nil {
 				zap.S().Errorf("failed to create kafka client: %s", err)
 			}
-			clientB, err = newMqttClient(brokerB, topic, mqttUseTls, mqttPsw)
+			clientB, err = newMqttClient(brokerB, topic, mqttPsw, serialNumber, mqttUseTls)
 			if err != nil {
 				zap.S().Errorf("failed to create mqtt client: %s", err)
 			}
 		}
 	case 2: // mqtt to mqtt
 		zap.S().Infof("Starting mqtt to mqtt bridge")
-		clientA, err = newMqttClient(brokerA, topic, false, "")
+		mqttUseTls, err := env.GetAsBool("MQTT_ENABLE_TLS", false, false)
+		if err != nil {
+			zap.S().Error(err)
+		}
+		mqttPsw, err := env.GetAsString("MQTT_PASSWORD", false, "")
+		if err != nil {
+			zap.S().Error(err)
+		}
+		clientA, err = newMqttClient(brokerA, topic, mqttPsw, serialNumber, mqttUseTls)
 		if err != nil {
 			zap.S().Errorf("failed to create mqtt client: %s", err)
 		}
-		clientB, err = newMqttClient(brokerB, topic, false, "")
+		clientB, err = newMqttClient(brokerB, topic, mqttPsw, serialNumber, mqttUseTls)
 		if err != nil {
 			zap.S().Errorf("failed to create mqtt client: %s", err)
 		}

--- a/golang/cmd/data-bridge/mqtt.go
+++ b/golang/cmd/data-bridge/mqtt.go
@@ -1,0 +1,282 @@
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/hex"
+	"fmt"
+	"net"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/eclipse/paho.golang/packets"
+	"github.com/eclipse/paho.golang/paho"
+	"github.com/goccy/go-json"
+	"github.com/united-manufacturing-hub/Sarama-Kafka-Wrapper/pkg/kafka"
+	"github.com/united-manufacturing-hub/umh-utils/env"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/internal"
+	"go.uber.org/zap"
+	"golang.org/x/crypto/sha3"
+)
+
+type mqttClient struct {
+	client *paho.Client
+	topic  string
+}
+
+func newMqttClient(broker, topic, psw, serialNumber string, enableSsl bool) (mc *mqttClient, err error) {
+	podName, err := env.GetAsString("POD_NAME", true, "")
+	if err != nil {
+		return nil, err
+	}
+
+	if !isValidMqttTopic(topic) {
+		return nil, fmt.Errorf("invalid MQTT topic: %s", topic)
+	}
+	hasher := sha3.New256()
+	hasher.Write([]byte(serialNumber))
+	mc.topic = fmt.Sprintf("$share/DATA_BRIDGE_%s/%s", hex.EncodeToString(hasher.Sum(nil)), topic)
+
+	config := paho.ClientConfig{
+		ClientID:      podName,
+		OnClientError: func(err error) { zap.S().Errorf("server requested disconnect: %s\n", err) },
+		OnServerDisconnect: func(d *paho.Disconnect) {
+			if d.Properties != nil {
+				zap.S().Errorf("server requested disconnect: %s\n", d.Properties.ReasonString)
+			} else {
+				zap.S().Errorf("server requested disconnect; reason code: %d\n", d.ReasonCode)
+			}
+		},
+	}
+
+	mc.client, err = establishBrokerConnection(context.Background(), broker, psw, enableSsl, config)
+	return mc, err
+}
+
+// newTLSConfig returns the TLS config for a given clientID and mode
+func newTLSConfig() tls.Config {
+
+	// Import trusted certificates from CAfile.pem.
+	// Alternatively, manually add CA certificates to
+	// default openssl CA bundle.
+	certpool := x509.NewCertPool()
+	pemCerts, err := os.ReadFile("/SSL_certs/mqtt/ca.crt")
+	if err == nil {
+		ok := certpool.AppendCertsFromPEM(pemCerts)
+		if !ok {
+			zap.S().Errorf("Failed to parse root certificate")
+		}
+	} else {
+		zap.S().Errorf("Error reading CA certificate: %s", err)
+	}
+
+	zap.S().Debugf("CA cert: %s", pemCerts)
+
+	// Import client certificate/key pair
+	cert, err := tls.LoadX509KeyPair("/SSL_certs/mqtt/tls.crt", "/SSL_certs/mqtt/tls.key")
+	if err != nil {
+		// Read /SSL_certs/mqtt/tls.crt
+		var file []byte
+		file, err = os.ReadFile("/SSL_certs/mqtt/tls.crt")
+		if err != nil {
+			zap.S().Errorf("Error reading client certificate: %s", err)
+		}
+		zap.S().Fatalf("Error reading client certificate: %s (File: %s)", err, file)
+	}
+
+	zap.S().Debugf("Client cert: %v", cert)
+
+	// Just to print out the client certificate..
+	cert.Leaf, err = x509.ParseCertificate(cert.Certificate[0])
+	if err != nil {
+		zap.S().Fatalf("Error parsing client certificate: %s", err)
+	}
+
+	skipVerify, err := env.GetAsBool("INSECURE_SKIP_VERIFY", false, true)
+	if err != nil {
+		zap.S().Error(err)
+	}
+
+	// Create tls.Config with desired tls properties
+	/* #nosec G402 -- Remote verification is not yet implemented*/
+	return tls.Config{
+		// RootCAs = certs used to verify server cert.
+		RootCAs: certpool,
+		// ClientAuth = whether to request cert from server.
+		// Since the server is set up for SSL, this happens
+		// anyways.
+		// ClientAuth: tls.NoClientCert,
+		// ClientCAs = certs used to validate client cert.
+		// ClientCAs: nil,
+		// InsecureSkipVerify = verify that cert contents
+		// match server. IP matches what is in cert etc.
+		/* #nosec G402 -- Remote verification is not yet implemented*/
+		InsecureSkipVerify: skipVerify,
+		// Certificates = list of certs client sends to server.
+		Certificates: []tls.Certificate{cert},
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+	}
+}
+
+// establishBrokerConnection - establishes a connection with the broker retrying until successful or the
+// context is cancelled (in which case nil will be returned).
+func establishBrokerConnection(ctx context.Context, broker, psw string, enableSsl bool, cfg paho.ClientConfig) (cli *paho.Client, err error) {
+	for {
+		connCtx, cancelConnCtx := context.WithTimeout(ctx, 1*time.Minute)
+
+		if enableSsl {
+			tlsCfg := newTLSConfig()
+			cfg.Conn, err = attemptTLSConnection(connCtx, broker, &tlsCfg)
+		} else {
+			cfg.Conn, err = attemptTCPConnection(connCtx, broker)
+		}
+
+		if err == nil {
+			cli := paho.NewClient(cfg)
+
+			cp := paho.Connect{
+				ClientID:     cfg.ClientID,
+				KeepAlive:    30,
+				CleanStart:   true,
+				Username:     "DATA_BRIDGE",
+				UsernameFlag: true,
+			}
+			if len(psw) > 0 {
+				cp.Password = []byte(psw)
+				cp.PasswordFlag = true
+			}
+
+			_, err = cli.Connect(connCtx, &cp) // will return an error if the connection is unsuccessful (checks the reason code)
+			if err == nil {                    // Successfully connected
+				cancelConnCtx()
+				return cli, nil
+			}
+		}
+		cancelConnCtx()
+
+		// Possible failure was due to outer context being cancelled
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
+		// Delay before attempting another connection
+		select {
+		case <-time.After(10 * time.Second):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+}
+
+func attemptTCPConnection(ctx context.Context, address string) (net.Conn, error) {
+	var d net.Dialer
+	conn, err := d.DialContext(ctx, "tcp", address)
+	return packets.NewThreadSafeConn(conn), err
+}
+
+func attemptTLSConnection(ctx context.Context, address string, tlsConfig *tls.Config) (net.Conn, error) {
+	d := tls.Dialer{
+		Config: tlsConfig,
+	}
+	conn, err := d.DialContext(ctx, "tcp", address)
+	return packets.NewThreadSafeConn(conn), err
+}
+
+func (m *mqttClient) getProducerStats() (sent uint64) {
+	panic("not implemented")
+}
+
+func (m *mqttClient) getConsumerStats() (received uint64) {
+	panic("not implemented")
+}
+
+func (m *mqttClient) startProducing(msgChan chan kafka.Message, split int) {
+	go func() {
+		for {
+			msg := <-msgChan
+
+			if strings.HasPrefix(msg.Topic, "$share") {
+				msg.Topic = string(regexp.MustCompile(`\$share\/data-bridge-(.*?)\/`).ReplaceAll([]byte(msg.Topic), []byte("")))
+			}
+
+			msg.Topic = strings.ReplaceAll(msg.Topic, ".", "/")
+
+		}
+	}()
+}
+
+func (m *mqttClient) startConsuming(msgChan chan kafka.Message) {
+	go func() {
+		m.client.Router = paho.NewSingleHandlerRouter(func(p *paho.Publish) {
+			msg := kafka.Message{
+				Topic: p.Topic,
+				Value: p.Payload,
+			}
+
+			msgChan <- msg
+		})
+
+		// Note: the SubscribeOptions map will become a slice in the next
+		// release of the eclipse/paho.golang library (currently 0.11)
+		if _, err := m.client.Subscribe(context.Background(), &paho.Subscribe{
+			Subscriptions: map[string]paho.SubscribeOptions{
+				m.topic: {
+					QoS: 1,
+				},
+			},
+		}); err != nil {
+			zap.S().Errorf("error subscribing to topic %s: %s", m.topic, err)
+			return
+		}
+		zap.S().Infof("subscribed to topic %s", m.topic)
+
+		// TODO: block this function somehow, so it continues to read messages
+	}()
+}
+
+func (m *mqttClient) shutdown() error {
+	zap.S().Infof("Shutting down mqtt client")
+	return m.client.Disconnect(&paho.Disconnect{ReasonCode: packets.DisconnectNormalDisconnection})
+}
+
+func isValidMqttMessage(message kafka.Message) bool {
+	if strings.HasPrefix(message.Topic, "/") {
+		zap.S().Warnf("Invalid MQTT topic: %s", message.Topic)
+		return false
+	}
+
+	if strings.HasSuffix(message.Topic, "/") {
+		zap.S().Warnf("Invalid MQTT topic: %s", message.Topic)
+		return false
+	}
+
+	if !json.Valid(message.Value) {
+		zap.S().Warnf("Not a valid json in message: %s", message.Topic)
+		return false
+	}
+
+	if internal.IsSameOrigin(&message) {
+		zap.S().Warnf("Message from same origin: %s", message.Topic)
+		return false
+	}
+
+	if internal.IsInTrace(&message) {
+		zap.S().Warnf("Message in trace: %s", message.Topic)
+		return false
+	}
+
+	return true
+}
+
+func isValidMqttTopic(topic string) bool {
+	if strings.HasPrefix(topic, "/") ||
+		strings.HasSuffix(topic, "/") ||
+		!regexp.MustCompile(`^(?!\$share)[\w/#+]+$`).MatchString(topic) {
+		fmt.Printf("Invalid MQTT topic: %s\n", topic)
+		return false
+	}
+	return true
+}

--- a/golang/go.mod
+++ b/golang/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/confluentinc/confluent-kafka-go v1.9.2
 	github.com/coocood/freecache v1.2.3
 	github.com/cristalhq/base64 v0.1.2
+	github.com/eclipse/paho.golang v0.11.0
 	github.com/eclipse/paho.mqtt.golang v1.4.3
 	github.com/felixge/fgtrace v0.2.0
 	github.com/gin-contrib/gzip v0.0.6

--- a/golang/go.sum
+++ b/golang/go.sum
@@ -60,6 +60,8 @@ github.com/eapache/go-xerial-snappy v0.0.0-20230731223053-c322873962e3 h1:Oy0F4A
 github.com/eapache/go-xerial-snappy v0.0.0-20230731223053-c322873962e3/go.mod h1:YvSRo5mw33fLEx1+DlK6L2VV43tJt5Eyel9n9XBcR+0=
 github.com/eapache/queue v1.1.0 h1:YOEu7KNc61ntiQlcEeUIoDTJ2o8mQznoNvUhiigpIqc=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
+github.com/eclipse/paho.golang v0.11.0 h1:6Avu5dkkCfcB61/y1vx+XrPQ0oAl4TPYtY0uw3HbQdM=
+github.com/eclipse/paho.golang v0.11.0/go.mod h1:rhrV37IEwauUyx8FHrvmXOKo+QRKng5ncoN1vJiJMcs=
 github.com/eclipse/paho.mqtt.golang v1.4.3 h1:2kwcUGn8seMUfWndX0hGbvH8r7crgcJguQNCyp70xik=
 github.com/eclipse/paho.mqtt.golang v1.4.3/go.mod h1:CSYvoAlsMkhYOXh/oKyxa8EcBci6dVkLCbo5tTC1RIE=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -147,6 +149,7 @@ github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
 github.com/gorilla/sessions v1.2.1/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/zI+bUmuGM=
+github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
@@ -381,6 +384,7 @@ golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.3.0 h1:ftCYgMx6zT/asHUrPw8BLLscYtGznsLAnjq5RH9P66E=


### PR DESCRIPTION
This PR adds the MQTT client that implements the `client` interface.
When using the `startConsumer` method, it starts reading the messages from the broker and sending them to the `msgChan`.
When using the `startProducer` method, it reads the messages from `msgChan`, transforms them from kafka-style to mqtt-style (if necessary) and does the splitting


Close https://github.com/united-manufacturing-hub/MgmtIssues/issues/346