### PR TITLE
Handle tag groups in k2p-v2

### DIFF
--- a/golang/cmd/kafka-to-postgresql-v2/postgresql/postgresql.go
+++ b/golang/cmd/kafka-to-postgresql-v2/postgresql/postgresql.go
@@ -336,7 +336,7 @@ func getCacheKey(topic *sharedStructs.TopicDetails) string {
 	return cacheKey.String()
 }
 
-func (c *Connection) InsertHistorianValue(value *sharedStructs.Value, timestampMs int64, origin string, topic *sharedStructs.TopicDetails) error {
+func (c *Connection) InsertHistorianValue(value []sharedStructs.Value, timestampMs int64, origin string, topic *sharedStructs.TopicDetails) error {
 	assetId, err := c.GetOrInsertAsset(topic)
 	if err != nil {
 		return err
@@ -344,23 +344,27 @@ func (c *Connection) InsertHistorianValue(value *sharedStructs.Value, timestampM
 	seconds := timestampMs / 1000
 	nanoseconds := (timestampMs % 1000) * 1000000
 	timestamp := time.Unix(seconds, nanoseconds)
-	if value.IsNumeric {
-		c.numericalValuesChannel <- DBValue{
-			Timestamp: timestamp,
-			Origin:    origin,
-			AssetId:   assetId,
-			Value:     value,
+
+	for _, v := range value {
+		if v.IsNumeric {
+			c.numericalValuesChannel <- DBValue{
+				Timestamp: timestamp,
+				Origin:    origin,
+				AssetId:   assetId,
+				Value:     &v,
+			}
+			c.numericalReceived.Add(1)
+		} else {
+			c.stringValuesChannel <- DBValue{
+				Timestamp: timestamp,
+				Origin:    origin,
+				AssetId:   assetId,
+				Value:     &v,
+			}
+			c.stringsReceived.Add(1)
 		}
-		c.numericalReceived.Add(1)
-	} else {
-		c.stringValuesChannel <- DBValue{
-			Timestamp: timestamp,
-			Origin:    origin,
-			AssetId:   assetId,
-			Value:     value,
-		}
-		c.stringsReceived.Add(1)
 	}
+
 	return nil
 }
 

--- a/golang/cmd/kafka-to-postgresql-v2/shared/structs.go
+++ b/golang/cmd/kafka-to-postgresql-v2/shared/structs.go
@@ -1,5 +1,8 @@
 package shared
 
+const (
+	DbTagSeparator = "$"
+)
 type TopicDetails struct {
 	Enterprise     string
 	Site           string

--- a/golang/cmd/kafka-to-postgresql-v2/shared/structs.go
+++ b/golang/cmd/kafka-to-postgresql-v2/shared/structs.go
@@ -7,7 +7,7 @@ type TopicDetails struct {
 	ProductionLine string
 	WorkCell       string
 	OriginId       string
-	Usecase        string
+	Schema         string
 	Tag            string
 }
 

--- a/golang/cmd/kafka-to-postgresql-v2/worker/topicProcessor.go
+++ b/golang/cmd/kafka-to-postgresql-v2/worker/topicProcessor.go
@@ -9,8 +9,8 @@ import (
 	sharedStructs "github.com/united-manufacturing-hub/united-manufacturing-hub/cmd/kafka-to-postgresql-v2/shared"
 )
 
-// Test this regex at https://regex101.com/r/VQAUvY/1
-var topicRegex = regexp.MustCompile(`^umh\.v1\.(?P<enterprise>[\w-_]+)\.((?P<site>[\w-_]+)\.)?((?P<area>[\w-_]+)\.)?((?P<productionLine>[\w-_]+)\.)?((?P<workCell>[\w-_]+)\.)?((?P<originId>[\w-_]+)\.)?_(?P<usecase>(historian)|(analytics))(\.(?P<tag>[\w-_]+))?$`)
+// Test this regex at https://regex101.com/r/VQAUvY/4
+var topicRegex = regexp.MustCompile(`^umh\.v1\.(?P<enterprise>[\w-_]+)\.((?P<site>[\w-_]+)\.)?((?P<area>[\w-_]+)\.)?((?P<productionLine>[\w-_]+)\.)?((?P<workCell>[\w-_]+)\.)?((?P<originId>[\w-_]+)\.)?_(?P<usecase>(historian)|(analytics))\.(?P<tag>(?:[\w-_.]+\w)+)$`)
 
 func recreateTopic(msg *shared.KafkaMessage) (*sharedStructs.TopicDetails, error) {
 	topic := strings.Builder{}

--- a/golang/cmd/kafka-to-postgresql-v2/worker/topicProcessor.go
+++ b/golang/cmd/kafka-to-postgresql-v2/worker/topicProcessor.go
@@ -2,10 +2,11 @@ package worker
 
 import (
 	"errors"
-	"github.com/united-manufacturing-hub/Sarama-Kafka-Wrapper-2/pkg/kafka/shared"
-	sharedStructs "github.com/united-manufacturing-hub/united-manufacturing-hub/cmd/kafka-to-postgresql-v2/shared"
 	"regexp"
 	"strings"
+
+	"github.com/united-manufacturing-hub/Sarama-Kafka-Wrapper-2/pkg/kafka/shared"
+	sharedStructs "github.com/united-manufacturing-hub/united-manufacturing-hub/cmd/kafka-to-postgresql-v2/shared"
 )
 
 // Test this regex at https://regex101.com/r/VQAUvY/1
@@ -13,21 +14,12 @@ var topicRegex = regexp.MustCompile(`^umh\.v1\.(?P<enterprise>[\w-_]+)\.((?P<sit
 
 func recreateTopic(msg *shared.KafkaMessage) (*sharedStructs.TopicDetails, error) {
 	topic := strings.Builder{}
-	topic.WriteString(msg.Topic)
+	// Trim leading and trailing dots from the topic
+	topic.WriteString(strings.Trim(msg.Topic, "."))
 	if len(msg.Key) > 0 {
-		key := string(msg.Key)
-		topicHasDot := strings.HasSuffix(msg.Topic, ".")
-		keyHasDot := strings.HasPrefix(key, ".")
-		if topicHasDot && keyHasDot {
-			// Topic ends with dot and string has dot prefix
-			topic.WriteString(key[1:])
-		} else if (topicHasDot && !keyHasDot) || (!topicHasDot && keyHasDot) {
-			// Topic ends with dot and string has no dot
-			topic.WriteString(key)
-		} else if !topicHasDot && !keyHasDot {
-			topic.WriteRune('.')
-			topic.WriteString(key)
-		}
+		topic.WriteRune('.')
+		// Trim leading and trailing dots from the key
+		topic.WriteString(strings.Trim(string(msg.Key), "."))
 	}
 
 	matches := topicRegex.FindStringSubmatch(topic.String())
@@ -43,7 +35,7 @@ func recreateTopic(msg *shared.KafkaMessage) (*sharedStructs.TopicDetails, error
 		ProductionLine: getMatch(matches, "productionLine"),
 		WorkCell:       getMatch(matches, "workCell"),
 		OriginId:       getMatch(matches, "originId"),
-		Usecase:        getMatch(matches, "usecase"),
+		Schema:         getMatch(matches, "usecase"),
 		Tag:            getMatch(matches, "tag"),
 	}, nil
 }

--- a/golang/cmd/kafka-to-postgresql-v2/worker/worker.go
+++ b/golang/cmd/kafka-to-postgresql-v2/worker/worker.go
@@ -125,9 +125,9 @@ func parseHistorianPayload(value []byte, tag string) ([]sharedStructs.Value, int
 	}
 
 	// Recursively parse the remaining fields
-	parseValue(tag, message, &values)
+	err = parseValue(tag, message, &values)
 
-	return values, timestampMs, nil
+	return values, timestampMs, err
 }
 
 func parseInt(v interface{}) (int64, error) {
@@ -138,7 +138,7 @@ func parseInt(v interface{}) (int64, error) {
 	return int64(timestamp), nil
 }
 
-func parseValue(prefix string, v interface{}, values *[]sharedStructs.Value) {
+func parseValue(prefix string, v interface{}, values *[]sharedStructs.Value) (err error) {
 	switch val := v.(type) {
 	case map[string]interface{}:
 		for k, v := range val {
@@ -150,7 +150,7 @@ func parseValue(prefix string, v interface{}, values *[]sharedStructs.Value) {
 					fullKey = prefix + "." + k
 				}
 			}
-			parseValue(fullKey, v, values)
+			err = parseValue(fullKey, v, values)
 		}
 	case float64:
 		f := float32(val)
@@ -188,6 +188,7 @@ func parseValue(prefix string, v interface{}, values *[]sharedStructs.Value) {
 			IsNumeric:    true,
 		})
 	default:
-		zap.S().Warnf("Unsupported type %T (%v) for tag %s", val, val, prefix)
+		return fmt.Errorf("unsupported type %T (%v) for tag %s", val, val, prefix)
 	}
+	return err
 }

--- a/golang/cmd/kafka-to-postgresql-v2/worker/worker.go
+++ b/golang/cmd/kafka-to-postgresql-v2/worker/worker.go
@@ -3,6 +3,7 @@ package worker
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -143,7 +144,11 @@ func parseValue(prefix string, v interface{}, values *[]sharedStructs.Value) {
 		for k, v := range val {
 			fullKey := k
 			if prefix != "" {
-				fullKey = prefix + "." + k
+				if strings.HasSuffix(prefix, k) {
+					fullKey = prefix
+				} else {
+					fullKey = prefix + "." + k
+				}
 			}
 			parseValue(fullKey, v, values)
 		}

--- a/golang/cmd/kafka-to-postgresql-v2/worker/worker.go
+++ b/golang/cmd/kafka-to-postgresql-v2/worker/worker.go
@@ -124,6 +124,9 @@ func parseHistorianPayload(value []byte, tag string) ([]sharedStructs.Value, int
 		delete(message, "timestamp_ms")
 	}
 
+	// Replace separators in the tag with $
+	tag = strings.ReplaceAll(tag, ".", sharedStructs.DbTagSeparator)
+
 	// Recursively parse the remaining fields
 	err = parseValue(tag, message, &values)
 
@@ -147,7 +150,7 @@ func parseValue(prefix string, v interface{}, values *[]sharedStructs.Value) (er
 				if strings.HasSuffix(prefix, k) {
 					fullKey = prefix
 				} else {
-					fullKey = prefix + "." + k
+					fullKey = prefix + sharedStructs.DbTagSeparator + k
 				}
 			}
 			err = parseValue(fullKey, v, values)

--- a/golang/cmd/kafka-to-postgresql-v2/worker/worker.go
+++ b/golang/cmd/kafka-to-postgresql-v2/worker/worker.go
@@ -3,6 +3,9 @@ package worker
 import (
 	"errors"
 	"fmt"
+	"sync"
+	"time"
+
 	"github.com/goccy/go-json"
 	"github.com/united-manufacturing-hub/Sarama-Kafka-Wrapper-2/pkg/kafka/shared"
 	"github.com/united-manufacturing-hub/umh-utils/env"
@@ -10,8 +13,6 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/cmd/kafka-to-postgresql-v2/postgresql"
 	sharedStructs "github.com/united-manufacturing-hub/united-manufacturing-hub/cmd/kafka-to-postgresql-v2/shared"
 	"go.uber.org/zap"
-	"sync"
-	"time"
 )
 
 type Worker struct {
@@ -69,7 +70,7 @@ func handleParsing(msgChan <-chan *shared.KafkaMessage, i int) {
 			origin = "unknown"
 		}
 
-		switch topic.Usecase {
+		switch topic.Schema {
 		case "historian":
 			payload, timestampMs, err := parseHistorianPayload(msg.Value)
 			if err != nil {
@@ -86,7 +87,7 @@ func handleParsing(msgChan <-chan *shared.KafkaMessage, i int) {
 		case "analytics":
 			zap.S().Warnf("Analytics not yet supported, ignoring")
 		default:
-			zap.S().Errorf("Unknown usecase %s", topic.Usecase)
+			zap.S().Errorf("Unknown usecase %s", topic.Schema)
 		}
 		k.MarkMessage(msg)
 		messagesHandled++
@@ -97,48 +98,40 @@ func handleParsing(msgChan <-chan *shared.KafkaMessage, i int) {
 	}
 }
 
-func parseHistorianPayload(value []byte) (*sharedStructs.Value, int64, error) {
+func parseHistorianPayload(value []byte) ([]sharedStructs.Value, int64, error) {
 	// Attempt to JSON decode the message
 	var message map[string]interface{}
 	err := json.Unmarshal(value, &message)
 	if err != nil {
 		return nil, 0, err
 	}
-	// There should only be two fields and one of them is "timestamp_ms"
-	if len(message) != 2 {
-		return nil, 0, errors.New("message contains does not have exactly 2 fields")
+	// The payload must contain at least 2 fields: timestamp_ms and a value
+	if len(message) < 2 {
+		return nil, 0, errors.New("message payload does not contain enough fields")
 	}
 	var timestampMs int64
-	var timestampFound bool
-	var v *sharedStructs.Value
+	var values = make([]sharedStructs.Value, 0)
 	var vFound bool
 
-	for key, value := range message {
-		if key == "timestamp_ms" {
-			timestampMs, err = parseInt(value)
-			if err != nil {
-				return nil, 0, err
-			}
-			zap.S().Debugf("Parsed %s:%s as timestamp_ms: %d", key, value, timestampMs)
-			timestampFound = true
-		} else {
-			v, err = parseValue(value)
-			if err != nil {
-				return nil, 0, err
-			}
-			vFound = true
-			v.Name = key
+	// Extract and remove the timestamp_ms field
+	if ts, ok := message["timestamp_ms"]; !ok {
+		return nil, 0, errors.New("message value does not contain timestamp_ms")
+	} else {
+		timestampMs, err = parseInt(ts)
+		if err != nil {
+			return nil, 0, err
 		}
+		delete(message, "timestamp_ms")
 	}
 
-	if !timestampFound {
-		return nil, 0, fmt.Errorf("message value does not contain timestamp_ms: %+v", message)
-	}
+	// Recursively parse the remaining fields
+	parseValue("", message, &values)
+
 	if !vFound {
 		return nil, 0, fmt.Errorf("message does not contain any value: %+v", message)
 	}
 
-	return v, timestampMs, nil
+	return values, timestampMs, nil
 }
 
 func parseInt(v interface{}) (int64, error) {
@@ -149,34 +142,52 @@ func parseInt(v interface{}) (int64, error) {
 	return int64(timestamp), nil
 }
 
-func parseValue(v interface{}) (*sharedStructs.Value, error) {
-	var val sharedStructs.Value
-	var numericVal float32
-
-	switch t := v.(type) {
-	case float64:
-		numericVal = float32(t)
-		val.NumericValue = &numericVal
-		val.IsNumeric = true
-	case string:
-		val.StringValue = &t
-	case float32:
-		numericVal = t
-		val.NumericValue = &numericVal
-		val.IsNumeric = true
-	case int:
-		numericVal = float32(t)
-		val.NumericValue = &numericVal
-		val.IsNumeric = true
-	case bool:
-		numericVal = 0.0
-		if t {
-			numericVal = 1.0
+func parseValue(prefix string, v interface{}, values *[]sharedStructs.Value) {
+	switch val := v.(type) {
+	case map[string]interface{}:
+		for k, v := range val {
+			fullKey := k
+			if prefix != "" {
+				fullKey = prefix + "." + k
+			}
+			parseValue(fullKey, v, values)
 		}
-		val.NumericValue = &numericVal
+	case float64:
+		f := float32(val)
+		*values = append(*values, sharedStructs.Value{
+			Name:         prefix,
+			NumericValue: &f,
+			IsNumeric:    true,
+		})
+	case float32:
+		*values = append(*values, sharedStructs.Value{
+			Name:         prefix,
+			NumericValue: &val,
+			IsNumeric:    true,
+		})
+	case int:
+		f := float32(val)
+		*values = append(*values, sharedStructs.Value{
+			Name:         prefix,
+			NumericValue: &f,
+			IsNumeric:    true,
+		})
+	case string:
+		*values = append(*values, sharedStructs.Value{
+			Name:        prefix,
+			StringValue: &val,
+		})
+	case bool:
+		f := float32(0.0)
+		if val {
+			f = 1.0
+		}
+		*values = append(*values, sharedStructs.Value{
+			Name:         prefix,
+			NumericValue: &f,
+			IsNumeric:    true,
+		})
 	default:
-		return nil, fmt.Errorf("unsupported type: %T (%v)", t, v)
+		zap.S().Warnf("Unsupported type %T (%v) for tag %s", val, val, prefix)
 	}
-
-	return &val, nil
 }

--- a/golang/cmd/kafka-to-postgresql-v2/worker/worker_test.go
+++ b/golang/cmd/kafka-to-postgresql-v2/worker/worker_test.go
@@ -123,7 +123,7 @@ func TestParseHistorianPayload(t *testing.T) {
 			tag: "tag1",
 			expected: []sharedStructs.Value{
 				{
-					Name:        "tag1.stringValue",
+					Name:        "tag1$stringValue",
 					StringValue: &sV,
 					IsNumeric:   false,
 				},
@@ -139,7 +139,7 @@ func TestParseHistorianPayload(t *testing.T) {
 			tag: "tag2",
 			expected: []sharedStructs.Value{
 				{
-					Name:         "tag2.intValue",
+					Name:         "tag2$intValue",
 					NumericValue: &iV,
 					IsNumeric:    true,
 				},
@@ -155,7 +155,7 @@ func TestParseHistorianPayload(t *testing.T) {
 			tag: "tag3",
 			expected: []sharedStructs.Value{
 				{
-					Name:         "tag3.floatValue",
+					Name:         "tag3$floatValue",
 					NumericValue: &fV,
 					IsNumeric:    true,
 				},
@@ -171,7 +171,7 @@ func TestParseHistorianPayload(t *testing.T) {
 			tag: "tag4",
 			expected: []sharedStructs.Value{
 				{
-					Name:         "tag4.boolValue",
+					Name:         "tag4$boolValue",
 					NumericValue: &bV,
 					IsNumeric:    true,
 				},
@@ -192,22 +192,22 @@ func TestParseHistorianPayload(t *testing.T) {
 			tag: "tag5",
 			expected: []sharedStructs.Value{
 				{
-					Name:        "tag5.structValue.stringValue",
+					Name:        "tag5$structValue$stringValue",
 					StringValue: &sV,
 					IsNumeric:   false,
 				},
 				{
-					Name:         "tag5.structValue.intValue",
+					Name:         "tag5$structValue$intValue",
 					NumericValue: &iV,
 					IsNumeric:    true,
 				},
 				{
-					Name:         "tag5.structValue.floatValue",
+					Name:         "tag5$structValue$floatValue",
 					NumericValue: &fV,
 					IsNumeric:    true,
 				},
 				{
-					Name:         "tag5.structValue.boolValue",
+					Name:         "tag5$structValue$boolValue",
 					NumericValue: &bV,
 					IsNumeric:    true,
 				},

--- a/golang/cmd/kafka-to-postgresql-v2/worker/worker_test.go
+++ b/golang/cmd/kafka-to-postgresql-v2/worker/worker_test.go
@@ -240,6 +240,22 @@ func TestParseHistorianPayload(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "Multiple tag groups from topic",
+			input: []byte(`{
+				"timestamp_ms": 12345,
+				"multipleTagGroups": "this is a string"
+			}`),
+			tag: "multipleTagGroups$tag1$tag2$tag3",
+			expected: []sharedStructs.Value{
+				{
+					Name:        "multipleTagGroups$tag1$tag2$tag3$multipleTagGroups",
+					StringValue: &sV,
+					IsNumeric:   false,
+				},
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/golang/cmd/kafka-to-postgresql-v2/worker/worker_test.go
+++ b/golang/cmd/kafka-to-postgresql-v2/worker/worker_test.go
@@ -110,6 +110,7 @@ func TestParseHistorianPayload(t *testing.T) {
 		input    []byte
 		tag      string
 		expected []sharedStructs.Value
+		wantErr  bool
 	}{
 		{
 			name: "String value",
@@ -125,6 +126,7 @@ func TestParseHistorianPayload(t *testing.T) {
 					IsNumeric:   false,
 				},
 			},
+			wantErr: false,
 		},
 		{
 			name: "Int value",
@@ -140,6 +142,7 @@ func TestParseHistorianPayload(t *testing.T) {
 					IsNumeric:    true,
 				},
 			},
+			wantErr: false,
 		},
 		{
 			name: "Float value",
@@ -155,6 +158,7 @@ func TestParseHistorianPayload(t *testing.T) {
 					IsNumeric:    true,
 				},
 			},
+			wantErr: false,
 		},
 		{
 			name: "Bool value",
@@ -170,6 +174,7 @@ func TestParseHistorianPayload(t *testing.T) {
 					IsNumeric:    true,
 				},
 			},
+			wantErr: false,
 		},
 		{
 			name: "Nested struct value",
@@ -205,14 +210,25 @@ func TestParseHistorianPayload(t *testing.T) {
 					IsNumeric:    true,
 				},
 			},
+			wantErr: false,
+		},
+		{
+			name: "Unsupported type",
+			input: []byte(`{
+				"timestamp_ms": 12345,
+				"unsupportedValue": ["this", "is", "an", "array"]
+			}`),
+			tag: "tag6",
+			expected: []sharedStructs.Value{},
+			wantErr:  true,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			values, timestampMs, err := parseHistorianPayload(tc.input, tc.tag)
-			assert.NoError(t, err, "unexpected error")
-			assert.Equal(t, tc.expected, values, "unexpected values. want %+v, got %+v", tc.expected, values)
+			assert.Equal(t, tc.wantErr, err != nil, "unexpected error. want %v, got %v", tc.wantErr, err)
+			assert.ElementsMatch(t, tc.expected, values, "unexpected values. want %+v, got %+v", tc.expected, values)
 			assert.Equal(t, int64(12345), timestampMs, "unexpected timestamp. want %d, got %d", 12345, timestampMs)
 		})
 	}

--- a/golang/cmd/kafka-to-postgresql-v2/worker/worker_test.go
+++ b/golang/cmd/kafka-to-postgresql-v2/worker/worker_test.go
@@ -3,6 +3,7 @@ package worker
 import (
 	"github.com/stretchr/testify/assert"
 	"github.com/united-manufacturing-hub/Sarama-Kafka-Wrapper-2/pkg/kafka/shared"
+	sharedStructs "github.com/united-manufacturing-hub/united-manufacturing-hub/cmd/kafka-to-postgresql-v2/shared"
 	"math/rand"
 	"strings"
 	"testing"
@@ -28,9 +29,10 @@ func TestRecreateTopic(t *testing.T) {
 		"umh.v1.Che-rnobyl.Auxiliary.Building2.WaterSupply.MainValve1.ValveID-1234._historian.FlowRate",
 		"umh.v1.Che_rnobyl.Auxiliary.Building2.WaterSupply.MainValve1.ValveID-1234._historian.FlowRate",
 		"umh.v1.Che_rnobyl.Auxiliary.Building2.WaterSupply.MainValve1.ValveID-1234._analytics.FlowRate",
+		"umh.v1.Che_rnobyl.Auxiliary.Building2.WaterSupply.MainValve1.ValveID-1234._analytics.FlowRate.X",
+		"umh.v1.Che_rnobyl.Auxiliary.Building2.WaterSupply.MainValve1.ValveID-1234._analytics.FlowRate.X.Y.Z",
 	}
 	invalid := []string{
-		"umh.v1.Che_rnobyl.Auxiliary.Building2.WaterSupply.MainValve1.ValveID-1234._analytics.FlowRate.X",
 		"umh.v1.Chernobyl.MainSite",
 		"umh.v1.Chernobyl.Security",
 		"umh.v1.Chernobyl.VisitorCenter",
@@ -96,5 +98,122 @@ func TestRecreateTopic(t *testing.T) {
 		}
 		_, err := recreateTopic(&msg)
 		assert.NoError(t, err, "modified topic %s with key %s failed to parse", modifiedTopic, key)
+	}
+}
+func TestParseHistorianPayload(t *testing.T) {
+	sV := "this is a string"
+	var iV float32 = 1
+	var fV float32 = 1.5
+	var bV float32 = 1.0
+	testCases := []struct {
+		name     string
+		input    []byte
+		tag      string
+		expected []sharedStructs.Value
+	}{
+		{
+			name: "String value",
+			input: []byte(`{
+				"timestamp_ms": 12345,
+				"stringValue": "this is a string"
+			}`),
+			tag: "tag1",
+			expected: []sharedStructs.Value{
+				{
+					Name:        "tag1.stringValue",
+					StringValue: &sV,
+					IsNumeric:   false,
+				},
+			},
+		},
+		{
+			name: "Int value",
+			input: []byte(`{
+				"timestamp_ms": 12345,
+				"intValue": 1
+			}`),
+			tag: "tag2",
+			expected: []sharedStructs.Value{
+				{
+					Name:         "tag2.intValue",
+					NumericValue: &iV,
+					IsNumeric:    true,
+				},
+			},
+		},
+		{
+			name: "Float value",
+			input: []byte(`{
+				"timestamp_ms": 12345,
+				"floatValue": 1.5
+			}`),
+			tag: "tag3",
+			expected: []sharedStructs.Value{
+				{
+					Name:         "tag3.floatValue",
+					NumericValue: &fV,
+					IsNumeric:    true,
+				},
+			},
+		},
+		{
+			name: "Bool value",
+			input: []byte(`{
+				"timestamp_ms": 12345,
+				"boolValue": true
+			}`),
+			tag: "tag4",
+			expected: []sharedStructs.Value{
+				{
+					Name:         "tag4.boolValue",
+					NumericValue: &bV,
+					IsNumeric:    true,
+				},
+			},
+		},
+		{
+			name: "Nested struct value",
+			input: []byte(`{
+				"timestamp_ms": 12345,
+				"structValue": {
+					"stringValue": "this is a string",
+					"intValue": 1,
+					"floatValue": 1.5,
+					"boolValue": true
+				}
+			}`),
+			tag: "tag5",
+			expected: []sharedStructs.Value{
+				{
+					Name:        "tag5.structValue.stringValue",
+					StringValue: &sV,
+					IsNumeric:   false,
+				},
+				{
+					Name:         "tag5.structValue.intValue",
+					NumericValue: &iV,
+					IsNumeric:    true,
+				},
+				{
+					Name:         "tag5.structValue.floatValue",
+					NumericValue: &fV,
+					IsNumeric:    true,
+				},
+				{
+					Name:         "tag5.structValue.boolValue",
+					NumericValue: &bV,
+					IsNumeric:    true,
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			values, timestampMs, err := parseHistorianPayload(tc.input, tc.tag)
+			assert.NoError(t, err, "unexpected error")
+			assert.Equal(t, tc.expected, values, "unexpected values. want %+v, got %+v", tc.expected, values)
+			assert.Equal(t, int64(12345), timestampMs, "unexpected timestamp. want %d, got %d", 12345, timestampMs)
+		})
 	}
 }

--- a/golang/cmd/kafka-to-postgresql-v2/worker/worker_test.go
+++ b/golang/cmd/kafka-to-postgresql-v2/worker/worker_test.go
@@ -107,7 +107,9 @@ func TestParseHistorianPayload(t *testing.T) {
 	var bV float32 = 1.0
 	testCases := []struct {
 		name     string
+		// input is the JSON payload to parse
 		input    []byte
+		// tag is the tag parsed from the topic, including eventual tag groups
 		tag      string
 		expected []sharedStructs.Value
 		wantErr  bool
@@ -218,9 +220,25 @@ func TestParseHistorianPayload(t *testing.T) {
 				"timestamp_ms": 12345,
 				"unsupportedValue": ["this", "is", "an", "array"]
 			}`),
-			tag: "tag6",
+			tag:      "tag6",
 			expected: []sharedStructs.Value{},
 			wantErr:  true,
+		},
+		{
+			name: "Duplicate tag group",
+			input: []byte(`{
+				"timestamp_ms": 12345,
+				"duplicateTag": "this is a string"
+			}`),
+			tag: "duplicateTag",
+			expected: []sharedStructs.Value{
+				{
+					Name:        "duplicateTag",
+					StringValue: &sV,
+					IsNumeric:   false,
+				},
+			},
+			wantErr: false,
 		},
 	}
 


### PR DESCRIPTION
This PR adds support for tag groups in kafka-to-postgresql-v2.
It is able to handle both tag group in the full topic name or in the payload (as defined [here](https://github.com/united-manufacturing-hub/MgmtIssues/issues/1285)). The topic tag has precedence over the payload tag.

If a payload has more than one value field, each different field will result in a specific INSERT in the database: the tag name will be composed by concatenating the topic tag and the payload tag for each field, while the asset_id will be the same for all the specific entries

Additionally, the tag group separator for the database is `$`

Close https://github.com/united-manufacturing-hub/MgmtIssues/issues/1272

## Example
The topic here is already the result of topic + key. More examples can be found in the `worker_test.go` file

- Received message:
  Topic: `umh.v1.pharma-genix.aachen.packaging.packaging_1.blister._historian.machineState`
  Payload:
  ```json
  {
    "timestamp_ms": 12345,
    "head": {
      "pos": {
        "x": 1,
        "y": 2,
        "z": 3
      }
    }
  }
  ```
- Inserts:
  asset_id = `<asset id of umh.v1.pharma-genix.aachen.packaging.packaging_1.blister>`
  | Tag name | Value |
  | --- | --- |
  | machineState$head$pos$x | 1 |
  | machineState$head$pos$y | 2 |
  | machineState$head$pos$z | 3 |
