### PR TITLE
Added overwrites for last images

### DIFF
--- a/deployment/united-manufacturing-hub/templates/nodered/statefulset.yaml
+++ b/deployment/united-manufacturing-hub/templates/nodered/statefulset.yaml
@@ -55,7 +55,7 @@ spec:
 
       containers:
       - name: {{include "united-manufacturing-hub.fullname" .}}-nodered
-        image: nodered/node-red:{{.Values.nodered.tag}}
+        image: management.umh.app/oci/nodered/node-red:{{.Values.nodered.tag}}
         ports:
         - containerPort: 1880
           name: nodered-ui

--- a/deployment/united-manufacturing-hub/values.yaml
+++ b/deployment/united-manufacturing-hub/values.yaml
@@ -701,6 +701,8 @@ timescaledb-single:
 grafana:
   image:
     repository: management.umh.app/oci/grafana/grafana
+  downloadDashboardsImage:
+    repository: management.umh.app/oci/curlimages/curl
   serviceAccount:
     create: false
 
@@ -737,7 +739,6 @@ grafana:
   persistence:
     enabled: true
     size: 5Gi
-
   initChownData:
     ## If false, data ownership will not be reset at startup
     ## This allows the prometheus-server to be run with an arbitrary user
@@ -984,6 +985,8 @@ redpanda:
   fullnameOverride: united-manufacturing-hub-kafka
   statefulset:
     replicas: 1
+    initContainerImage:
+      repository: management.umh.app/oci/library/busybox
   rbac:
     enabled: true
   storage:
@@ -1007,6 +1010,8 @@ redpanda:
   tls:
     enabled: false
   console:
+    image:
+      registry: management.umh.app/oci
     serviceAccount:
       create: false
     service:


### PR DESCRIPTION
This pr removes the last remaining images that where not on management.umh.app and are not hardcoded in external dependencies. (Our containerd overwrite takes care of those)

This is a bug fix for the existing https://github.com/united-manufacturing-hub/MgmtIssues/issues/1050 user journey