### PR TITLE
Upgrade hivemq

### DIFF
--- a/deployment/hivemq-init/Dockerfile
+++ b/deployment/hivemq-init/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM hivemq/hivemq-ce:2024.2 as hivemq
+FROM hivemq/hivemq-ce:2024.1 as hivemq
 FROM alpine as base
 
 # Download hivemq-file-rbac-extension

--- a/deployment/hivemq-init/Dockerfile
+++ b/deployment/hivemq-init/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM hivemq/hivemq-ce:2023.7 as hivemq
+FROM hivemq/hivemq-ce:2024.2 as hivemq
 FROM alpine as base
 
 # Download hivemq-file-rbac-extension

--- a/deployment/hivemq-init/runner.sh
+++ b/deployment/hivemq-init/runner.sh
@@ -17,14 +17,14 @@
 # Copy hivemq-file-rbac-extension only if RBAC_ENABLED is true
 if [ "$RBAC_ENABLED" = "true" ]; then
     echo "RBAC is enabled"
-    cp -r /hivemq-file-rbac-extension /opt/hivemq-ce-2024.2/extensions/hivemq-file-rbac-extension
+    cp -r /hivemq-file-rbac-extension /opt/hivemq-ce-2024.3/extensions/hivemq-file-rbac-extension
 else
     echo "RBAC is disabled. Skipping hivemq-file-rbac-extension"
-    cp -r /hivemq-allow-all-extension /opt/hivemq-ce-2024.2/extensions/hivemq-allow-all-extension
+    cp -r /hivemq-allow-all-extension /opt/hivemq-ce-2024.3/extensions/hivemq-allow-all-extension
 fi
-cp -r /hivemq-prometheus-extension /opt/hivemq-ce-2024.2/extensions/hivemq-prometheus-extension
-cp -r /hivemq-heartbeat-extension /opt/hivemq-ce-2024.2/extensions/hivemq-heartbeat-extension
+cp -r /hivemq-prometheus-extension /opt/hivemq-ce-2024.3/extensions/hivemq-prometheus-extension
+cp -r /hivemq-heartbeat-extension /opt/hivemq-ce-2024.3/extensions/hivemq-heartbeat-extension
 
 
 echo "Listing extensions directory"
-ls -la /opt/hivemq-ce-2024.2/extensions
+ls -la /opt/hivemq-ce-2024.3/extensions

--- a/deployment/hivemq-init/runner.sh
+++ b/deployment/hivemq-init/runner.sh
@@ -17,14 +17,14 @@
 # Copy hivemq-file-rbac-extension only if RBAC_ENABLED is true
 if [ "$RBAC_ENABLED" = "true" ]; then
     echo "RBAC is enabled"
-    cp -r /hivemq-file-rbac-extension /opt/hivemq-ce-2024.3/extensions/hivemq-file-rbac-extension
+    cp -r /hivemq-file-rbac-extension /opt/hivemq-ce-2024.1/extensions/hivemq-file-rbac-extension
 else
     echo "RBAC is disabled. Skipping hivemq-file-rbac-extension"
-    cp -r /hivemq-allow-all-extension /opt/hivemq-ce-2024.3/extensions/hivemq-allow-all-extension
+    cp -r /hivemq-allow-all-extension /opt/hivemq-ce-2024.1/extensions/hivemq-allow-all-extension
 fi
-cp -r /hivemq-prometheus-extension /opt/hivemq-ce-2024.3/extensions/hivemq-prometheus-extension
-cp -r /hivemq-heartbeat-extension /opt/hivemq-ce-2024.3/extensions/hivemq-heartbeat-extension
+cp -r /hivemq-prometheus-extension /opt/hivemq-ce-2024.1/extensions/hivemq-prometheus-extension
+cp -r /hivemq-heartbeat-extension /opt/hivemq-ce-2024.1/extensions/hivemq-heartbeat-extension
 
 
 echo "Listing extensions directory"
-ls -la /opt/hivemq-ce-2024.3/extensions
+ls -la /opt/hivemq-ce-2024.1/extensions

--- a/deployment/hivemq-init/runner.sh
+++ b/deployment/hivemq-init/runner.sh
@@ -17,14 +17,14 @@
 # Copy hivemq-file-rbac-extension only if RBAC_ENABLED is true
 if [ "$RBAC_ENABLED" = "true" ]; then
     echo "RBAC is enabled"
-    cp -r /hivemq-file-rbac-extension /opt/hivemq-ce-2023.7/extensions/hivemq-file-rbac-extension
+    cp -r /hivemq-file-rbac-extension /opt/hivemq-ce-2024.2/extensions/hivemq-file-rbac-extension
 else
     echo "RBAC is disabled. Skipping hivemq-file-rbac-extension"
-    cp -r /hivemq-allow-all-extension /opt/hivemq-ce-2023.7/extensions/hivemq-allow-all-extension
+    cp -r /hivemq-allow-all-extension /opt/hivemq-ce-2024.2/extensions/hivemq-allow-all-extension
 fi
-cp -r /hivemq-prometheus-extension /opt/hivemq-ce-2023.7/extensions/hivemq-prometheus-extension
-cp -r /hivemq-heartbeat-extension /opt/hivemq-ce-2023.7/extensions/hivemq-heartbeat-extension
+cp -r /hivemq-prometheus-extension /opt/hivemq-ce-2024.2/extensions/hivemq-prometheus-extension
+cp -r /hivemq-heartbeat-extension /opt/hivemq-ce-2024.2/extensions/hivemq-heartbeat-extension
 
 
 echo "Listing extensions directory"
-ls -la /opt/hivemq-ce-2023.7/extensions
+ls -la /opt/hivemq-ce-2024.2/extensions

--- a/deployment/united-manufacturing-hub/templates/hivemq/statefulset.yaml
+++ b/deployment/united-manufacturing-hub/templates/hivemq/statefulset.yaml
@@ -59,7 +59,7 @@ spec:
           image: {{.Values.mqtt_broker.initContainer.hivemqextensioninit.image.repository}}:{{.Values.mqtt_broker.initContainer.hivemqextensioninit.image.tag}}
           imagePullPolicy: {{.Values.mqtt_broker.initContainer.hivemqextensioninit.image.pullPolicy}}
           volumeMounts:
-            - mountPath: /opt/hivemq-ce-2023.7/extensions
+            - mountPath: /opt/hivemq-ce-2024.2/extensions
               name: {{include "united-manufacturing-hub.fullname" .}}-hivemqce-extensions
           env:
             - name: RBAC_ENABLED
@@ -73,7 +73,7 @@ spec:
           {{if .Values.mqtt_broker.image.tag}}
           image: {{.Values.mqtt_broker.image.repository}}:{{.Values.mqtt_broker.image.tag}}
           {{- else}}
-          image: {{.Values.mqtt_broker.image.repository}}:2023.7
+          image: {{.Values.mqtt_broker.image.repository}}:2024.2
           {{end}}
           imagePullPolicy: {{.Values.mqtt_broker.image.pullPolicy}}
           env:

--- a/deployment/united-manufacturing-hub/templates/hivemq/statefulset.yaml
+++ b/deployment/united-manufacturing-hub/templates/hivemq/statefulset.yaml
@@ -59,7 +59,7 @@ spec:
           image: {{.Values.mqtt_broker.initContainer.hivemqextensioninit.image.repository}}:{{.Values.mqtt_broker.initContainer.hivemqextensioninit.image.tag}}
           imagePullPolicy: {{.Values.mqtt_broker.initContainer.hivemqextensioninit.image.pullPolicy}}
           volumeMounts:
-            - mountPath: /opt/hivemq-ce-2024.2/extensions
+            - mountPath: /opt/hivemq-ce-2024.1/extensions
               name: {{include "united-manufacturing-hub.fullname" .}}-hivemqce-extensions
           env:
             - name: RBAC_ENABLED
@@ -73,7 +73,7 @@ spec:
           {{if .Values.mqtt_broker.image.tag}}
           image: {{.Values.mqtt_broker.image.repository}}:{{.Values.mqtt_broker.image.tag}}
           {{- else}}
-          image: {{.Values.mqtt_broker.image.repository}}:2024.3
+          image: {{.Values.mqtt_broker.image.repository}}:2024.1
           {{end}}
           imagePullPolicy: {{.Values.mqtt_broker.image.pullPolicy}}
           env:

--- a/deployment/united-manufacturing-hub/templates/hivemq/statefulset.yaml
+++ b/deployment/united-manufacturing-hub/templates/hivemq/statefulset.yaml
@@ -73,7 +73,7 @@ spec:
           {{if .Values.mqtt_broker.image.tag}}
           image: {{.Values.mqtt_broker.image.repository}}:{{.Values.mqtt_broker.image.tag}}
           {{- else}}
-          image: {{.Values.mqtt_broker.image.repository}}:2024.2
+          image: {{.Values.mqtt_broker.image.repository}}:2024.3
           {{end}}
           imagePullPolicy: {{.Values.mqtt_broker.image.pullPolicy}}
           env:

--- a/deployment/united-manufacturing-hub/values.yaml
+++ b/deployment/united-manufacturing-hub/values.yaml
@@ -817,11 +817,11 @@ redis:
       repository: bitnami/os-shell
 
 ##### CONFIG FOR HIVEMQ CE
-##### you can set a tag if you want a version other than 2023.7
+##### you can set a tag if you want a version other than 2024.2
 mqtt_broker:
   image:
     repository: management.umh.app/oci/hivemq/hivemq-ce
-    tag: 2023.7
+    tag: 2024.2
     pullPolicy: IfNotPresent
   rbacEnabled: false
   initContainer:

--- a/deployment/united-manufacturing-hub/values.yaml
+++ b/deployment/united-manufacturing-hub/values.yaml
@@ -817,11 +817,11 @@ redis:
       repository: bitnami/os-shell
 
 ##### CONFIG FOR HIVEMQ CE
-##### you can set a tag if you want a version other than 2024.2
+##### you can set a tag if you want a version other than 2024.3
 mqtt_broker:
   image:
     repository: management.umh.app/oci/hivemq/hivemq-ce
-    tag: 2024.2
+    tag: 2024.3
     pullPolicy: IfNotPresent
   rbacEnabled: false
   initContainer:

--- a/deployment/united-manufacturing-hub/values.yaml
+++ b/deployment/united-manufacturing-hub/values.yaml
@@ -817,7 +817,7 @@ redis:
       repository: bitnami/os-shell
 
 ##### CONFIG FOR HIVEMQ CE
-##### you can set a tag if you want a version other than 2024.3
+##### you can set a tag if you want a version other than 2024.1
 mqtt_broker:
   image:
     repository: management.umh.app/oci/hivemq/hivemq-ce

--- a/deployment/united-manufacturing-hub/values.yaml
+++ b/deployment/united-manufacturing-hub/values.yaml
@@ -821,7 +821,7 @@ redis:
 mqtt_broker:
   image:
     repository: management.umh.app/oci/hivemq/hivemq-ce
-    tag: 2024.3
+    tag: 2024.1
     pullPolicy: IfNotPresent
   rbacEnabled: false
   initContainer:


### PR DESCRIPTION
### Description
This change upgrades hivemq-ce 2023.7 to 2024.1. Deployment and basic flow (nodered, mqtt, kafka, umh-v2 db) are tested on the local cluster.

### Issues at upgrading to the latest and second latest version

- https://github.com/united-manufacturing-hub/MgmtIssues/issues/1647#issuecomment-1969430276
- https://github.com/united-manufacturing-hub/MgmtIssues/issues/1647#issuecomment-1969461151

### What will be improved by this upgrade?
- Increased broker efficiency by reducing end-to-end message latency, CPU usage, and memory footprint.
- Improved error handling in the internal executor service to facilitate debugging
- etc.

closes united-manufacturing-hub/MgmtIssues/issues/1647