### PR TITLE
[#1662 (1)] Fix names in postgresql tables and coloumns

### DIFF
--- a/.github/workflows/run_go_tests_k2pg-v2.yaml
+++ b/.github/workflows/run_go_tests_k2pg-v2.yaml
@@ -5,6 +5,11 @@ on:
       - main
       - staging
 
+    paths:
+      - deployment/united-manufacturing-hub/
+      - deployment/united-manufacturing-hub/*
+      - deployment/united-manufacturing-hub/**/*
+
 jobs:
   run-tests:
     runs-on: ubuntu-latest

--- a/deployment/united-manufacturing-hub/templates/timescaledb/configmap.yaml
+++ b/deployment/united-manufacturing-hub/templates/timescaledb/configmap.yaml
@@ -60,10 +60,10 @@ data:
         UNIQUE(timestamp, asset_id)
     );
     -- creating hypertable
-    SELECT create_hypertable('stateTable', 'timestamp');
+    SELECT create_hypertable('stateTable', 'timestamp', if_not_exists => TRUE);;
 
     -- creating an index to increase performance
-    CREATE INDEX ON stateTable (asset_id, timestamp DESC);
+    CREATE INDEX IF NOT EXISTS ON stateTable (asset_id, timestamp DESC);
 
     -------------------- TimescaleDB table for counts --------------------
     CREATE TABLE IF NOT EXISTS countTable
@@ -74,10 +74,10 @@ data:
         UNIQUE(timestamp, asset_id)
     );
     -- creating hypertable
-    SELECT create_hypertable('countTable', 'timestamp');
+    SELECT create_hypertable('countTable', 'timestamp', if_not_exists => TRUE);;
 
     -- creating an index to increase performance
-    CREATE INDEX ON countTable (asset_id, timestamp DESC);
+    CREATE INDEX IF NOT EXISTS ON countTable (asset_id, timestamp DESC);
 
     -------------------- TimescaleDB table for process values --------------------
     CREATE TABLE IF NOT EXISTS processValueTable
@@ -89,16 +89,16 @@ data:
         UNIQUE(timestamp, asset_id, valueName)
     );
     -- creating hypertable
-    SELECT create_hypertable('processValueTable', 'timestamp');
+    SELECT create_hypertable('processValueTable', 'timestamp', if_not_exists => TRUE);;
 
     -- creating an index to increase performance
-    CREATE INDEX ON processValueTable (asset_id, timestamp DESC);
+    CREATE INDEX IF NOT EXISTS ON processValueTable (asset_id, timestamp DESC);
 
     -- creating an index to increase performance
-    CREATE INDEX ON processValueTable (valuename);
+    CREATE INDEX IF NOT EXISTS ON processValueTable (valuename);
 
     -- create an index to increase performance
-    CREATE INDEX ON processvaluetable(valuename, asset_id) WITH (timescaledb.transaction_per_chunk);
+    CREATE INDEX IF NOT EXISTS ON processvaluetable(valuename, asset_id) WITH (timescaledb.transaction_per_chunk);
 
     -------------------- TimescaleDB table for uniqueProduct --------------------
     CREATE TABLE IF NOT EXISTS uniqueProductTable
@@ -116,7 +116,7 @@ data:
     );
 
     -- creating an index to increase performance
-    CREATE INDEX ON uniqueProductTable (asset_id, uid, station_id);
+    CREATE INDEX IF NOT EXISTS ON uniqueProductTable (asset_id, uid, station_id);
 
 
     -------------------- TimescaleDB table for recommendations  --------------------
@@ -247,7 +247,7 @@ data:
     UNIQUE(product_uid, valueName)
     );
     -- creating hypertable
-    SELECT create_hypertable('productTagTable', 'product_uid', chunk_time_interval => 100000);
+    SELECT create_hypertable('productTagTable', 'product_uid', chunk_time_interval => 100000, if_not_exists => TRUE);;
 
     -------------------- TimescaleDB table for product tags strings --------------------
     CREATE TABLE IF NOT EXISTS productTagStringTable
@@ -259,7 +259,7 @@ data:
     UNIQUE(product_uid, valueName)
     );
     -- creating hypertable
-    SELECT create_hypertable('productTagStringTable', 'product_uid', chunk_time_interval => 100000);
+    SELECT create_hypertable('productTagStringTable', 'product_uid', chunk_time_interval => 100000, if_not_exists => TRUE);;
 
     -------------------- TimescaleDB table for product inheritance info --------------------
     CREATE TABLE IF NOT EXISTS productInheritanceTable
@@ -270,8 +270,8 @@ data:
     UNIQUE(parent_uid, child_uid)
     );
     -- creating hypertable
-    CREATE INDEX ON productInheritanceTable (parent_uid, timestamp DESC);
-    CREATE INDEX ON productInheritanceTable (child_uid, timestamp DESC);
+    CREATE INDEX IF NOT EXISTS ON productInheritanceTable (parent_uid, timestamp DESC);
+    CREATE INDEX IF NOT EXISTS ON productInheritanceTable (child_uid, timestamp DESC);
 
     -------------------- TimescaleDB table for process values string --------------------
     CREATE TABLE IF NOT EXISTS processValueStringTable
@@ -283,12 +283,12 @@ data:
     UNIQUE(timestamp, asset_id, valueName)
     );
     -- creating hypertable
-    SELECT create_hypertable('processValueStringTable', 'timestamp');
+    SELECT create_hypertable('processValueStringTable', 'timestamp', if_not_exists => TRUE);;
     -- creating an index to increase performance
-    CREATE INDEX ON processValueStringTable (asset_id, timestamp DESC);
+    CREATE INDEX IF NOT EXISTS ON processValueStringTable (asset_id, timestamp DESC);
 
     -- creating an index to increase performance
-    CREATE INDEX ON processValueStringTable (valueName);
+    CREATE INDEX IF NOT EXISTS ON processValueStringTable (valueName);
 
 
     -------------------- TimescaleDB table for components --------------------
@@ -7595,7 +7595,7 @@ data:
     GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO {{.Values.kafkatopostgresqlv2.database.user}};
 
     -------------------- ASSET TABLE --------------------
-    CREATE TABLE asset (
+    CREATE TABLE IF NOT EXISTS asset (
       id SERIAL PRIMARY KEY,
       enterprise TEXT NOT NULL,
       site TEXT DEFAULT '' NOT NULL,
@@ -7616,7 +7616,7 @@ data:
 
     -------------------- TAG TABLE --------------------
 
-    CREATE TABLE tag (
+    CREATE TABLE IF NOT EXISTS tag (
       timestamp TIMESTAMPTZ NOT NULL,
       name TEXT NOT NULL,
       origin TEXT NOT NULL,
@@ -7624,13 +7624,13 @@ data:
       value REAL,
       UNIQUE (name, asset_id, timestamp)
     );
-    SELECT create_hypertable('tag', 'timestamp');
-    CREATE INDEX ON tag (asset_id, timestamp DESC);
-    CREATE INDEX ON tag (name);
+    SELECT create_hypertable('tag', 'timestamp', if_not_exists => TRUE);;
+    CREATE INDEX IF NOT EXISTS ON tag (asset_id, timestamp DESC);
+    CREATE INDEX IF NOT EXISTS ON tag (name);
 
     -------------------- TAG STRING TABLE --------------------
 
-    CREATE TABLE tag_string (
+    CREATE TABLE IF NOT EXISTS tag_string (
       timestamp TIMESTAMPTZ NOT NULL,
       name TEXT NOT NULL,
       origin TEXT NOT NULL,
@@ -7638,9 +7638,9 @@ data:
       value TEXT,
       UNIQUE (name, asset_id, timestamp)
     );
-    SELECT create_hypertable('tag_string', 'timestamp');
-    CREATE INDEX ON tag_string (asset_id, timestamp DESC);
-    CREATE INDEX ON tag_string (name);
+    SELECT create_hypertable('tag_string', 'timestamp', if_not_exists => TRUE);;
+    CREATE INDEX IF NOT EXISTS ON tag_string (asset_id, timestamp DESC);
+    CREATE INDEX IF NOT EXISTS ON tag_string (name);
 
     
     CREATE OR REPLACE FUNCTION get_asset_id(
@@ -7697,59 +7697,61 @@ data:
 
     -------------------- ANALYTICS --------------------
 
+    -------------------- PRODUCT TYPES TABLE --------------------
+    CREATE TABLE IF NOT EXISTS product_type (
+      product_type_id INT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+      external_product_type_id TEXT NOT NULL,
+      cycle_time_ms INTEGER NOT NULL,
+      asset_id INTEGER REFERENCES asset(id),
+      CONSTRAINT external_product_asset_uniq UNIQUE (external_product_type_id, asset_id),
+      CHECK (cycle_time_ms > 0)
+    );
+
     -------------------- WORK ORDER TABLE --------------------
+    CREATE EXTENSION IF NOT EXISTS btree_gist;
 
     -- This table stores information about manufacturing orders. The ISA-95 model defines work orders in terms of production requests.
     -- Here, each work order is linked to a specific asset and product type
-    CREATE TABLE work_orders (
-      workOrderId INT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
-      externalWorkOrderId TEXT NOT NULL,
-      assetId INTEGER NOT NULL REFERENCES assets(id),
-      productTypeId INTEGER NOT NULL REFERENCES product_types(productTypeId),
+    CREATE TABLE IF NOT EXISTS work_order (
+      work_order_id INT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+      external_work_order_id TEXT NOT NULL,
+      asset_id INTEGER NOT NULL REFERENCES asset(id),
+      product_type_id INTEGER NOT NULL REFERENCES product_type(product_type_id),
       quantity INTEGER NOT NULL,
       status INTEGER NOT NULL DEFAULT 0, -- 0: planned, 1: in progress, 2: completed
-      startTime TIMESTAMPTZ,
-      endTime TIMESTAMPTZ,
-      CONSTRAINT asset_workorder_uniq UNIQUE (assetId, externalWorkOrderId),
+      start_time TIMESTAMPTZ,
+      end_time TIMESTAMPTZ,
+      CONSTRAINT asset_workorder_uniq UNIQUE (asset_id, external_work_order_id),
       CHECK (quantity > 0),
       CHECK (status BETWEEN 0 AND 2),
-      EXCLUDE USING gist (assetId WITH =, tstzrange(startTime, endTime) WITH &&) WHERE (startTime IS NOT NULL AND endTime IS NOT NULL)
+      EXCLUDE USING gist (asset_id WITH =, tstzrange(start_time, end_time) WITH &&) WHERE (start_time IS NOT NULL AND end_time IS NOT NULL)
     );
 
-    -------------------- PRODUCT TYPES TABLE --------------------
-    CREATE TABLE product_types (
-      productTypeId INT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
-      externalProductTypeId TEXT NOT NULL,
-      cycleTime INTEGER NOT NULL,
-      assetId INTEGER REFERENCES assets(id),
-      CONSTRAINT external_product_asset_uniq UNIQUE (externalProductTypeId, assetId),
-      CHECK (cycleTime > 0)
-    )
 
     -------------------- PRODUCTS TABLE --------------------
 
-    -- -- Tracks individual products produced. This table captures production output, quality (through badQuantity), and timing
-    CREATE TABLE products (
-      productId INT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
-      externalProductTypeId INTEGER REFERENCES product_types(productTypeId),
-      productBatchId TEXT,
-      assetId INTEGER REFERENCES assets(id),
-      startTime TIMESTAMPTZ,
-      endTime TIMESTAMPTZ NOT NULL,
+    -- -- Tracks individual products produced. This table captures production output, quality (through bad_quantity), and timing
+    CREATE TABLE IF NOT EXISTS product (
+      product_id INT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+      external_product_type_id INTEGER REFERENCES product_type(product_type_id),
+      product_batch_id TEXT,
+      asset_id INTEGER REFERENCES asset(id),
+      start_time TIMESTAMPTZ,
+      end_time TIMESTAMPTZ NOT NULL,
       quantity INTEGER NOT NULL,
-      badQuantity INTEGER DEFAULT 0,
+      bad_quantity INTEGER DEFAULT 0,
       CHECK (quantity > 0),
-      CHECK (badQuantity >= 0),
-    CHECK (badQuantity <= quantity),
-      CHECK (startTime <= endTime),
-      CONSTRAINT product_endtime_asset_uniq UNIQUE (endTime, assetId)
+      CHECK (bad_quantity >= 0),
+      CHECK (bad_quantity <= quantity),
+      CHECK (start_time <= end_time),
+      CONSTRAINT product_end_time_asset_uniq UNIQUE (end_time, asset_id)
     );
 
     -- creating hypertable
-    SELECT create_hypertable('products', 'endTime');
+    SELECT create_hypertable('product', 'end_time', if_not_exists => TRUE);;
 
     -- creating an index to increase performance
-    CREATE INDEX idx_products_asset_endtime ON products(assetId, endTime DESC);
+    CREATE INDEX IF NOT EXISTS idx_products_asset_end_time ON product(asset_id, end_time DESC);
 
 
     -------------------- SHIFTS TABLE --------------------
@@ -7758,35 +7760,35 @@ data:
     -- Source: https://gist.github.com/fphilipe/0a2a3d50a9f3834683bf
 
     -- Manages work shifts for assets. Shift scheduling is a key operational aspect under ISA-95, impacting resource planning and allocation.
-    CREATE TABLE shifts (
+    CREATE TABLE IF NOT EXISTS shift (
       shiftId INT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
-      assetId INTEGER REFERENCES assets(id),
-      startTime TIMESTAMPTZ NOT NULL,
-      endTime TIMESTAMPTZ NOT NULL,
-      CONSTRAINT shift_start_asset_uniq UNIQUE (startTime, assetId),
-      CHECK (startTime < endTime),
-      EXCLUDE USING gist (assetId WITH =, tstzrange(startTime, endTime) WITH &&)
+      asset_id INTEGER REFERENCES asset(id),
+      start_time TIMESTAMPTZ NOT NULL,
+      end_time TIMESTAMPTZ NOT NULL,
+      CONSTRAINT shift_start_asset_uniq UNIQUE (start_time, asset_id),
+      CHECK (start_time < end_time),
+      EXCLUDE USING gist (asset_id WITH =, tstzrange(start_time, end_time) WITH &&)
     );
 
     -------------------- STATES TABLE --------------------
 
     -- Records the state changes of assets over time. State tracking supports ISA-95's goal of detailed monitoring and control of manufacturing operations.
     -- State Table
-    CREATE TABLE states (
+    CREATE TABLE IF NOT EXISTS state (
       stateId INT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
-      assetId INTEGER REFERENCES assets(id),
-      startTime TIMESTAMPTZ NOT NULL,
-      endTime TIMESTAMPTZ,
+      asset_id INTEGER REFERENCES asset(id),
+      start_time TIMESTAMPTZ NOT NULL,
+      end_time TIMESTAMPTZ,
       state INT NOT NULL,
       CHECK (state >= 0),
-      CHECK (startTime < endTime),
-      CONSTRAINT state_start_asset_uniq UNIQUE (startTime, assetId)
+      CHECK (start_time < end_time),
+      CONSTRAINT state_start_asset_uniq UNIQUE (start_time, asset_id)
     );
     -- creating hypertable
-    SELECT create_hypertable('states', 'startTime');
+    SELECT create_hypertable('state', 'start_time', if_not_exists => TRUE);;
 
     -- creating an index to increase performance
-    CREATE INDEX idx_states_asset_starttime ON states(assetId, startTime DESC);
+    CREATE INDEX IF NOT EXISTS idx_states_asset_start_time ON state(asset_id, start_time DESC);
 
 
       -------------------- FIX OWNERS --------------------

--- a/deployment/united-manufacturing-hub/templates/timescaledb/configmap.yaml
+++ b/deployment/united-manufacturing-hub/templates/timescaledb/configmap.yaml
@@ -7780,7 +7780,7 @@ data:
       end_time TIMESTAMPTZ,
       state INT NOT NULL,
       CHECK (state >= 0),
-      CHECK (start_time < end_time),
+      CHECK (end_time IS NULL OR start_time < end_time),
       UNIQUE (start_time, asset_id)
     );
     -- creating hypertable

--- a/deployment/united-manufacturing-hub/templates/timescaledb/configmap.yaml
+++ b/deployment/united-manufacturing-hub/templates/timescaledb/configmap.yaml
@@ -7815,5 +7815,5 @@ data:
     GRANT SELECT ON {{.Values._000_commonConfig.datamodel_v2.database.name}}.public.state TO {{.Values._000_commonConfig.datamodel_v2.grafana.dbreader}};
 
 
-    __SQL__
+  __SQL__
 {{end}}

--- a/deployment/united-manufacturing-hub/templates/timescaledb/configmap.yaml
+++ b/deployment/united-manufacturing-hub/templates/timescaledb/configmap.yaml
@@ -7697,6 +7697,7 @@ data:
 
     -------------------- ANALYTICS --------------------
 
+
     -------------------- PRODUCT TYPES TABLE --------------------
     CREATE TABLE IF NOT EXISTS product_type (
       product_type_id INT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
@@ -7732,7 +7733,6 @@ data:
 
     -- -- Tracks individual products produced. This table captures production output, quality (through bad_quantity), and timing
     CREATE TABLE IF NOT EXISTS product (
-      product_id INT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
       external_product_type_id INTEGER REFERENCES product_type(product_type_id),
       product_batch_id TEXT,
       asset_id INTEGER REFERENCES asset(id),
@@ -7744,7 +7744,7 @@ data:
       CHECK (bad_quantity >= 0),
       CHECK (bad_quantity <= quantity),
       CHECK (start_time <= end_time),
-      CONSTRAINT product_end_time_asset_uniq UNIQUE (end_time, asset_id)
+      UNIQUE (asset_id, end_time, product_batch_id)
     );
 
     -- creating hypertable
@@ -7775,14 +7775,13 @@ data:
     -- Records the state changes of assets over time. State tracking supports ISA-95's goal of detailed monitoring and control of manufacturing operations.
     -- State Table
     CREATE TABLE IF NOT EXISTS state (
-      stateId INT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
       asset_id INTEGER REFERENCES asset(id),
       start_time TIMESTAMPTZ NOT NULL,
       end_time TIMESTAMPTZ,
       state INT NOT NULL,
       CHECK (state >= 0),
       CHECK (start_time < end_time),
-      CONSTRAINT state_start_asset_uniq UNIQUE (start_time, asset_id)
+      UNIQUE (start_time, asset_id)
     );
     -- creating hypertable
     SELECT create_hypertable('state', 'start_time', if_not_exists => TRUE);;
@@ -7791,17 +7790,18 @@ data:
     CREATE INDEX IF NOT EXISTS idx_states_asset_start_time ON state(asset_id, start_time DESC);
 
 
+
       -------------------- FIX OWNERS --------------------
 
       ALTER TABLE asset OWNER TO {{.Values.kafkatopostgresqlv2.database.user}};
       ALTER TABLE tag OWNER TO {{.Values.kafkatopostgresqlv2.database.user}};
       ALTER TABLE tag_string OWNER TO {{.Values.kafkatopostgresqlv2.database.user}};
 
-      ALTER TABLE work_orders OWNER TO {{.Values.kafkatopostgresqlv2.database.user}};
-      ALTER TABLE product_types OWNER TO {{.Values.kafkatopostgresqlv2.database.user}};
-      ALTER TABLE products OWNER TO {{.Values.kafkatopostgresqlv2.database.user}};
-      ALTER TABLE shifts OWNER TO {{.Values.kafkatopostgresqlv2.database.user}};
-      ALTER TABLE states OWNER TO {{.Values.kafkatopostgresqlv2.database.user}};
+      ALTER TABLE work_order OWNER TO {{.Values.kafkatopostgresqlv2.database.user}};
+      ALTER TABLE product_type OWNER TO {{.Values.kafkatopostgresqlv2.database.user}};
+      ALTER TABLE product OWNER TO {{.Values.kafkatopostgresqlv2.database.user}};
+      ALTER TABLE shift OWNER TO {{.Values.kafkatopostgresqlv2.database.user}};
+      ALTER TABLE state OWNER TO {{.Values.kafkatopostgresqlv2.database.user}};
 
 
       GRANT SELECT ON {{.Values._000_commonConfig.datamodel_v2.database.name}}.public.asset TO {{.Values._000_commonConfig.datamodel_v2.grafana.dbreader}};
@@ -7809,11 +7809,11 @@ data:
       GRANT SELECT ON {{.Values._000_commonConfig.datamodel_v2.database.name}}.public.tag_string TO {{.Values._000_commonConfig.datamodel_v2.grafana.dbreader}};
 
 
-      GRANT SELECT ON {{.Values._000_commonConfig.datamodel_v2.database.name}}.public.work_orders TO {{.Values._000_commonConfig.datamodel_v2.grafana.dbreader}};
-      GRANT SELECT ON {{.Values._000_commonConfig.datamodel_v2.database.name}}.public.product_types TO {{.Values._000_commonConfig.datamodel_v2.grafana.dbreader}};
-      GRANT SELECT ON {{.Values._000_commonConfig.datamodel_v2.database.name}}.public.products TO {{.Values._000_commonConfig.datamodel_v2.grafana.dbreader}};
-      GRANT SELECT ON {{.Values._000_commonConfig.datamodel_v2.database.name}}.public.shifts TO {{.Values._000_commonConfig.datamodel_v2.grafana.dbreader}};
-      GRANT SELECT ON {{.Values._000_commonConfig.datamodel_v2.database.name}}.public.states TO {{.Values._000_commonConfig.datamodel_v2.grafana.dbreader}};
+      GRANT SELECT ON {{.Values._000_commonConfig.datamodel_v2.database.name}}.public.work_order TO {{.Values._000_commonConfig.datamodel_v2.grafana.dbreader}};
+      GRANT SELECT ON {{.Values._000_commonConfig.datamodel_v2.database.name}}.public.product_type TO {{.Values._000_commonConfig.datamodel_v2.grafana.dbreader}};
+      GRANT SELECT ON {{.Values._000_commonConfig.datamodel_v2.database.name}}.public.product TO {{.Values._000_commonConfig.datamodel_v2.grafana.dbreader}};
+      GRANT SELECT ON {{.Values._000_commonConfig.datamodel_v2.database.name}}.public.shift TO {{.Values._000_commonConfig.datamodel_v2.grafana.dbreader}};
+      GRANT SELECT ON {{.Values._000_commonConfig.datamodel_v2.database.name}}.public.state TO {{.Values._000_commonConfig.datamodel_v2.grafana.dbreader}};
 
 
   __SQL__

--- a/deployment/united-manufacturing-hub/templates/timescaledb/configmap.yaml
+++ b/deployment/united-manufacturing-hub/templates/timescaledb/configmap.yaml
@@ -7733,7 +7733,7 @@ data:
 
     -- -- Tracks individual products produced. This table captures production output, quality (through bad_quantity), and timing
     CREATE TABLE IF NOT EXISTS product (
-      external_product_type_id INTEGER REFERENCES product_type(product_type_id),
+      product_type_id INTEGER REFERENCES product_type(product_type_id),
       product_batch_id TEXT,
       asset_id INTEGER REFERENCES asset(id),
       start_time TIMESTAMPTZ,
@@ -7774,13 +7774,12 @@ data:
 
     -- Records the state changes of assets over time. State tracking supports ISA-95's goal of detailed monitoring and control of manufacturing operations.
     -- State Table
+      -- It assumes that a state continues until a new state is recorded.
     CREATE TABLE IF NOT EXISTS state (
       asset_id INTEGER REFERENCES asset(id),
       start_time TIMESTAMPTZ NOT NULL,
-      end_time TIMESTAMPTZ,
       state INT NOT NULL,
       CHECK (state >= 0),
-      CHECK (end_time IS NULL OR start_time < end_time),
       UNIQUE (start_time, asset_id)
     );
     -- creating hypertable

--- a/deployment/united-manufacturing-hub/templates/timescaledb/configmap.yaml
+++ b/deployment/united-manufacturing-hub/templates/timescaledb/configmap.yaml
@@ -7791,30 +7791,30 @@ data:
 
 
 
-      -------------------- FIX OWNERS --------------------
+    -------------------- FIX OWNERS --------------------
 
-      ALTER TABLE asset OWNER TO {{.Values.kafkatopostgresqlv2.database.user}};
-      ALTER TABLE tag OWNER TO {{.Values.kafkatopostgresqlv2.database.user}};
-      ALTER TABLE tag_string OWNER TO {{.Values.kafkatopostgresqlv2.database.user}};
+    ALTER TABLE asset OWNER TO {{.Values.kafkatopostgresqlv2.database.user}};
+    ALTER TABLE tag OWNER TO {{.Values.kafkatopostgresqlv2.database.user}};
+    ALTER TABLE tag_string OWNER TO {{.Values.kafkatopostgresqlv2.database.user}};
 
-      ALTER TABLE work_order OWNER TO {{.Values.kafkatopostgresqlv2.database.user}};
-      ALTER TABLE product_type OWNER TO {{.Values.kafkatopostgresqlv2.database.user}};
-      ALTER TABLE product OWNER TO {{.Values.kafkatopostgresqlv2.database.user}};
-      ALTER TABLE shift OWNER TO {{.Values.kafkatopostgresqlv2.database.user}};
-      ALTER TABLE state OWNER TO {{.Values.kafkatopostgresqlv2.database.user}};
-
-
-      GRANT SELECT ON {{.Values._000_commonConfig.datamodel_v2.database.name}}.public.asset TO {{.Values._000_commonConfig.datamodel_v2.grafana.dbreader}};
-      GRANT SELECT ON {{.Values._000_commonConfig.datamodel_v2.database.name}}.public.tag TO {{.Values._000_commonConfig.datamodel_v2.grafana.dbreader}};
-      GRANT SELECT ON {{.Values._000_commonConfig.datamodel_v2.database.name}}.public.tag_string TO {{.Values._000_commonConfig.datamodel_v2.grafana.dbreader}};
+    ALTER TABLE work_order OWNER TO {{.Values.kafkatopostgresqlv2.database.user}};
+    ALTER TABLE product_type OWNER TO {{.Values.kafkatopostgresqlv2.database.user}};
+    ALTER TABLE product OWNER TO {{.Values.kafkatopostgresqlv2.database.user}};
+    ALTER TABLE shift OWNER TO {{.Values.kafkatopostgresqlv2.database.user}};
+    ALTER TABLE state OWNER TO {{.Values.kafkatopostgresqlv2.database.user}};
 
 
-      GRANT SELECT ON {{.Values._000_commonConfig.datamodel_v2.database.name}}.public.work_order TO {{.Values._000_commonConfig.datamodel_v2.grafana.dbreader}};
-      GRANT SELECT ON {{.Values._000_commonConfig.datamodel_v2.database.name}}.public.product_type TO {{.Values._000_commonConfig.datamodel_v2.grafana.dbreader}};
-      GRANT SELECT ON {{.Values._000_commonConfig.datamodel_v2.database.name}}.public.product TO {{.Values._000_commonConfig.datamodel_v2.grafana.dbreader}};
-      GRANT SELECT ON {{.Values._000_commonConfig.datamodel_v2.database.name}}.public.shift TO {{.Values._000_commonConfig.datamodel_v2.grafana.dbreader}};
-      GRANT SELECT ON {{.Values._000_commonConfig.datamodel_v2.database.name}}.public.state TO {{.Values._000_commonConfig.datamodel_v2.grafana.dbreader}};
+    GRANT SELECT ON {{.Values._000_commonConfig.datamodel_v2.database.name}}.public.asset TO {{.Values._000_commonConfig.datamodel_v2.grafana.dbreader}};
+    GRANT SELECT ON {{.Values._000_commonConfig.datamodel_v2.database.name}}.public.tag TO {{.Values._000_commonConfig.datamodel_v2.grafana.dbreader}};
+    GRANT SELECT ON {{.Values._000_commonConfig.datamodel_v2.database.name}}.public.tag_string TO {{.Values._000_commonConfig.datamodel_v2.grafana.dbreader}};
 
 
-  __SQL__
+    GRANT SELECT ON {{.Values._000_commonConfig.datamodel_v2.database.name}}.public.work_order TO {{.Values._000_commonConfig.datamodel_v2.grafana.dbreader}};
+    GRANT SELECT ON {{.Values._000_commonConfig.datamodel_v2.database.name}}.public.product_type TO {{.Values._000_commonConfig.datamodel_v2.grafana.dbreader}};
+    GRANT SELECT ON {{.Values._000_commonConfig.datamodel_v2.database.name}}.public.product TO {{.Values._000_commonConfig.datamodel_v2.grafana.dbreader}};
+    GRANT SELECT ON {{.Values._000_commonConfig.datamodel_v2.database.name}}.public.shift TO {{.Values._000_commonConfig.datamodel_v2.grafana.dbreader}};
+    GRANT SELECT ON {{.Values._000_commonConfig.datamodel_v2.database.name}}.public.state TO {{.Values._000_commonConfig.datamodel_v2.grafana.dbreader}};
+
+
+    __SQL__
 {{end}}

--- a/golang/cmd/kafka-to-postgresql-v2/postgresql/analytics-product-type.go
+++ b/golang/cmd/kafka-to-postgresql-v2/postgresql/analytics-product-type.go
@@ -23,12 +23,12 @@ func (c *Connection) InsertProductTypeCreate(msg *sharedStructs.ProductTypeCreat
 	// Insert product_type
 	var cmdTag pgconn.CommandTag
 	cmdTag, err = tx.Exec(ctx, `
-		INSERT INTO product_types (externalProductTypeId, cycleTime, assetId)
+		INSERT INTO product_types (external_product_type_id, cycle_time_ms, asset_id)
 		VALUES ($1, $2, $3)
-		ON CONFLICT (externalProductTypeId, assetId) DO NOTHING
+		ON CONFLICT (external_product_type_id, asset_id) DO NOTHING
 	`, msg.ExternalProductTypeId, int(msg.CycleTimeMs), int(assetId))
 	if err != nil {
-		zap.S().Warnf("Error inserting product-type: %v (externalProductTypeId: %v) [%s]", err, msg.ExternalProductTypeId, cmdTag)
+		zap.S().Warnf("Error inserting product-type: %v (external_product_type_id: %v) [%s]", err, msg.ExternalProductTypeId, cmdTag)
 		zap.S().Debugf("Message: %v (Topic: %v)", msg, topic)
 		errR := tx.Rollback(ctx)
 		if errR != nil {

--- a/golang/cmd/kafka-to-postgresql-v2/postgresql/analytics-product-type.go
+++ b/golang/cmd/kafka-to-postgresql-v2/postgresql/analytics-product-type.go
@@ -23,7 +23,7 @@ func (c *Connection) InsertProductTypeCreate(msg *sharedStructs.ProductTypeCreat
 	// Insert product_type
 	var cmdTag pgconn.CommandTag
 	cmdTag, err = tx.Exec(ctx, `
-		INSERT INTO product_types (external_product_type_id, cycle_time_ms, asset_id)
+		INSERT INTO product_type(external_product_type_id, cycle_time_ms, asset_id)
 		VALUES ($1, $2, $3)
 		ON CONFLICT (external_product_type_id, asset_id) DO NOTHING
 	`, msg.ExternalProductTypeId, int(msg.CycleTimeMs), int(assetId))

--- a/golang/cmd/kafka-to-postgresql-v2/postgresql/analytics-product.go
+++ b/golang/cmd/kafka-to-postgresql-v2/postgresql/analytics-product.go
@@ -27,7 +27,7 @@ func (c *Connection) InsertProductAdd(msg *sharedStructs.ProductAddMessage, topi
 	// Insert product
 	var cmdTag pgconn.CommandTag
 	cmdTag, err = tx.Exec(ctx, `
-		INSERT INTO products (externalProductTypeId, productBatchId, assetId, startTime, endTime, quantity, badQuantity)
+		INSERT INTO products (external_product_type_id, product_batch_id, asset_id, start_time, end_time, quantity, bad_quantity)
 		VALUES ($1, $2, $3, to_timestamp($4/1000), to_timestamp($5/1000), $6, $7)
 	`, int(productTypeId), msg.ProductBatchId, int(assetId), msg.StartTimeUnixMs, msg.EndTimeUnixMs, int(msg.Quantity), int(msg.BadQuantity))
 	if err != nil {
@@ -63,11 +63,11 @@ func (c *Connection) UpdateBadQuantityForProduct(msg *sharedStructs.ProductSetBa
 	// Update bad quantity with check integrated in WHERE clause
 	cmdTag, err := tx.Exec(ctx, `
         UPDATE products
-        SET badQuantity = badQuantity + $1
-        WHERE externalProductTypeId = $2
-          AND assetId = $3
-          AND endTime = $4
-          AND (quantity - badQuantity) >= $1
+        SET bad_quantity = bad_quantity + $1
+        WHERE external_product_type_id = $2
+          AND asset_id = $3
+          AND end_time = $4
+          AND (quantity - bad_quantity) >= $1
     `, int(msg.BadQuantity), productTypeId, assetId, msg.EndTimeUnixMs)
 
 	if err != nil {

--- a/golang/cmd/kafka-to-postgresql-v2/postgresql/analytics-product.go
+++ b/golang/cmd/kafka-to-postgresql-v2/postgresql/analytics-product.go
@@ -27,7 +27,7 @@ func (c *Connection) InsertProductAdd(msg *sharedStructs.ProductAddMessage, topi
 	// Insert product
 	var cmdTag pgconn.CommandTag
 	cmdTag, err = tx.Exec(ctx, `
-		INSERT INTO products (external_product_type_id, product_batch_id, asset_id, start_time, end_time, quantity, bad_quantity)
+		INSERT INTO product(external_product_type_id, product_batch_id, asset_id, start_time, end_time, quantity, bad_quantity)
 		VALUES ($1, $2, $3, to_timestamp($4/1000), to_timestamp($5/1000), $6, $7)
 	`, int(productTypeId), msg.ProductBatchId, int(assetId), msg.StartTimeUnixMs, msg.EndTimeUnixMs, int(msg.Quantity), int(msg.BadQuantity))
 	if err != nil {
@@ -62,7 +62,7 @@ func (c *Connection) UpdateBadQuantityForProduct(msg *sharedStructs.ProductSetBa
 
 	// Update bad quantity with check integrated in WHERE clause
 	cmdTag, err := tx.Exec(ctx, `
-        UPDATE products
+        UPDATE product
         SET bad_quantity = bad_quantity + $1
         WHERE external_product_type_id = $2
           AND asset_id = $3

--- a/golang/cmd/kafka-to-postgresql-v2/postgresql/analytics-shift.go
+++ b/golang/cmd/kafka-to-postgresql-v2/postgresql/analytics-shift.go
@@ -23,7 +23,7 @@ func (c *Connection) InsertShiftAdd(msg *sharedStructs.ShiftAddMessage, topic *s
 	// Insert shift
 	var cmdTag pgconn.CommandTag
 	cmdTag, err = tx.Exec(ctx, `
-		INSERT INTO shifts (asset_id, start_time, end_time)
+		INSERT INTO shift(asset_id, start_time, end_time)
 		VALUES ($1, to_timestamp($2 / 1000), to_timestamp($3 / 1000))
 		ON CONFLICT ON CONSTRAINT shift_start_asset_uniq
 		DO NOTHING;
@@ -57,7 +57,7 @@ func (c *Connection) DeleteShiftByStartTime(msg *sharedStructs.ShiftDeleteMessag
 	// Delete shift
 	var cmdTag pgconn.CommandTag
 	cmdTag, err = tx.Exec(ctx, `
-		DELETE FROM shifts
+		DELETE FROM shift
 		WHERE asset_id = $1 AND start_time = to_timestamp($2 / 1000);
 	`, int(assetId), msg.StartTimeUnixMs)
 

--- a/golang/cmd/kafka-to-postgresql-v2/postgresql/analytics-shift.go
+++ b/golang/cmd/kafka-to-postgresql-v2/postgresql/analytics-shift.go
@@ -23,7 +23,7 @@ func (c *Connection) InsertShiftAdd(msg *sharedStructs.ShiftAddMessage, topic *s
 	// Insert shift
 	var cmdTag pgconn.CommandTag
 	cmdTag, err = tx.Exec(ctx, `
-		INSERT INTO shifts (assetId, startTime, endTime)
+		INSERT INTO shifts (asset_id, start_time, end_time)
 		VALUES ($1, to_timestamp($2 / 1000), to_timestamp($3 / 1000))
 		ON CONFLICT ON CONSTRAINT shift_start_asset_uniq
 		DO NOTHING;
@@ -58,7 +58,7 @@ func (c *Connection) DeleteShiftByStartTime(msg *sharedStructs.ShiftDeleteMessag
 	var cmdTag pgconn.CommandTag
 	cmdTag, err = tx.Exec(ctx, `
 		DELETE FROM shifts
-		WHERE assetId = $1 AND startTime = to_timestamp($2 / 1000);
+		WHERE asset_id = $1 AND start_time = to_timestamp($2 / 1000);
 	`, int(assetId), msg.StartTimeUnixMs)
 
 	if err != nil {

--- a/golang/cmd/kafka-to-postgresql-v2/postgresql/analytics-state.go
+++ b/golang/cmd/kafka-to-postgresql-v2/postgresql/analytics-state.go
@@ -24,10 +24,10 @@ func (c *Connection) InsertStateAdd(msg *sharedStructs.StateAddMessage, topic *s
 	var cmdTag pgconn.CommandTag
 	cmdTag, err = tx.Exec(ctx, `
 		UPDATE states
-		SET endTime = to_timestamp($2/1000)
-		WHERE assetId = $1
-		AND endTime IS NULL
-		AND startTime < to_timestamp($2/1000)
+		SET end_time = to_timestamp($2/1000)
+		WHERE asset_id = $1
+		AND end_time IS NULL
+		AND start_time < to_timestamp($2/1000)
 	`, int(assetId), msg.StartTimeUnixMs)
 
 	if err != nil {
@@ -42,7 +42,7 @@ func (c *Connection) InsertStateAdd(msg *sharedStructs.StateAddMessage, topic *s
 
 	// Insert state
 	cmdTag, err = tx.Exec(ctx, `
-		INSERT INTO states (assetId, startTime, state)
+		INSERT INTO states (asset_id, start_time, state)
 		VALUES ($1, to_timestamp($2/1000), $3)
 		ON CONFLICT ON CONSTRAINT state_start_asset_uniq
 		DO NOTHING
@@ -84,9 +84,9 @@ func (c *Connection) OverwriteStateByStartEndTime(msg *sharedStructs.StateOverwr
 	var cmdTag pgconn.CommandTag
 	cmdTag, err = tx.Exec(ctx, `
 		DELETE FROM states
-		WHERE assetId = $1
-		AND startTime >= to_timestamp($2/1000)
-		AND startTime <= to_timestamp($3/1000)
+		WHERE asset_id = $1
+		AND start_time >= to_timestamp($2/1000)
+		AND start_time <= to_timestamp($3/1000)
 	`, int(assetId), msg.StartTimeUnixMs, msg.EndTimeUnixMs)
 
 	if err != nil {
@@ -102,10 +102,10 @@ func (c *Connection) OverwriteStateByStartEndTime(msg *sharedStructs.StateOverwr
 	// Check for overlapping state and modify it's end time
 	cmdTag, err = tx.Exec(ctx, `
 		UPDATE states
-		SET endTime = to_timestamp($2/1000)
-		WHERE assetId = $1
-		AND endTime > to_timestamp($2/1000)
-		AND endTime <= to_timestamp($3/1000)
+		SET end_time = to_timestamp($2/1000)
+		WHERE asset_id = $1
+		AND end_time > to_timestamp($2/1000)
+		AND end_time <= to_timestamp($3/1000)
 	`, int(assetId), msg.StartTimeUnixMs, msg.EndTimeUnixMs)
 
 	if err != nil {
@@ -121,10 +121,10 @@ func (c *Connection) OverwriteStateByStartEndTime(msg *sharedStructs.StateOverwr
 	// Check for overlapping state and modify it's start time
 	cmdTag, err = tx.Exec(ctx, `
 		UPDATE states
-		SET startTime = to_timestamp($3/1000)
-		WHERE assetId = $1
-		AND startTime >= to_timestamp($2/1000)
-		AND startTime < to_timestamp($3/1000)
+		SET start_time = to_timestamp($3/1000)
+		WHERE asset_id = $1
+		AND start_time >= to_timestamp($2/1000)
+		AND start_time < to_timestamp($3/1000)
 	`, int(assetId), msg.StartTimeUnixMs, msg.EndTimeUnixMs)
 
 	if err != nil {
@@ -140,7 +140,7 @@ func (c *Connection) OverwriteStateByStartEndTime(msg *sharedStructs.StateOverwr
 	// Insert state
 
 	cmdTag, err = tx.Exec(ctx, `
-		INSERT INTO states (assetId, startTime, endTime, state)
+		INSERT INTO states (asset_id, start_time, end_time, state)
 		VALUES ($1, to_timestamp($2/1000), to_timestamp($3/1000), $4)
 	`, int(assetId), msg.StartTimeUnixMs, msg.EndTimeUnixMs, int(msg.State))
 

--- a/golang/cmd/kafka-to-postgresql-v2/postgresql/analytics-state.go
+++ b/golang/cmd/kafka-to-postgresql-v2/postgresql/analytics-state.go
@@ -23,7 +23,7 @@ func (c *Connection) InsertStateAdd(msg *sharedStructs.StateAddMessage, topic *s
 	// If there is already a previous state, set it's end time to the new state's start time
 	var cmdTag pgconn.CommandTag
 	cmdTag, err = tx.Exec(ctx, `
-		UPDATE states
+		UPDATE state
 		SET end_time = to_timestamp($2/1000)
 		WHERE asset_id = $1
 		AND end_time IS NULL
@@ -42,7 +42,7 @@ func (c *Connection) InsertStateAdd(msg *sharedStructs.StateAddMessage, topic *s
 
 	// Insert state
 	cmdTag, err = tx.Exec(ctx, `
-		INSERT INTO states (asset_id, start_time, state)
+		INSERT INTO state(asset_id, start_time, state)
 		VALUES ($1, to_timestamp($2/1000), $3)
 		ON CONFLICT ON CONSTRAINT state_start_asset_uniq
 		DO NOTHING
@@ -83,7 +83,7 @@ func (c *Connection) OverwriteStateByStartEndTime(msg *sharedStructs.StateOverwr
 	// Delete states between start and end time (inclusive) for the asset
 	var cmdTag pgconn.CommandTag
 	cmdTag, err = tx.Exec(ctx, `
-		DELETE FROM states
+		DELETE FROM state
 		WHERE asset_id = $1
 		AND start_time >= to_timestamp($2/1000)
 		AND start_time <= to_timestamp($3/1000)
@@ -101,7 +101,7 @@ func (c *Connection) OverwriteStateByStartEndTime(msg *sharedStructs.StateOverwr
 
 	// Check for overlapping state and modify it's end time
 	cmdTag, err = tx.Exec(ctx, `
-		UPDATE states
+		UPDATE state
 		SET end_time = to_timestamp($2/1000)
 		WHERE asset_id = $1
 		AND end_time > to_timestamp($2/1000)
@@ -120,7 +120,7 @@ func (c *Connection) OverwriteStateByStartEndTime(msg *sharedStructs.StateOverwr
 
 	// Check for overlapping state and modify it's start time
 	cmdTag, err = tx.Exec(ctx, `
-		UPDATE states
+		UPDATE state
 		SET start_time = to_timestamp($3/1000)
 		WHERE asset_id = $1
 		AND start_time >= to_timestamp($2/1000)
@@ -140,7 +140,7 @@ func (c *Connection) OverwriteStateByStartEndTime(msg *sharedStructs.StateOverwr
 	// Insert state
 
 	cmdTag, err = tx.Exec(ctx, `
-		INSERT INTO states (asset_id, start_time, end_time, state)
+		INSERT INTO state(asset_id, start_time, end_time, state)
 		VALUES ($1, to_timestamp($2/1000), to_timestamp($3/1000), $4)
 	`, int(assetId), msg.StartTimeUnixMs, msg.EndTimeUnixMs, int(msg.State))
 

--- a/golang/cmd/kafka-to-postgresql-v2/postgresql/analytics-work-order.go
+++ b/golang/cmd/kafka-to-postgresql-v2/postgresql/analytics-work-order.go
@@ -25,7 +25,7 @@ func (c *Connection) InsertWorkOrderCreate(msg *sharedStructs.WorkOrderCreateMes
 	// Don't forget to convert unix ms to timestamptz
 	var cmdTag pgconn.CommandTag
 	cmdTag, err = tx.Exec(ctx, `
-		INSERT INTO work_orders (externalWorkOrderId, assetId, productTypeId, quantity, status, startTime, endTime)
+		INSERT INTO work_orders (externalWorkOrderId, asset_id, productTypeId, quantity, status, start_time, end_time)
 		VALUES ($1, $2, $3, $4, $5, to_timestamp($6/1000), to_timestamp($7/1000))
 	`, msg.ExternalWorkOrderId, int(assetId), int(productTypeId), msg.Quantity, int(msg.Status), msg.StartTimeUnixMs, msg.EndTimeUnixMs)
 	if err != nil {
@@ -58,11 +58,11 @@ func (c *Connection) UpdateWorkOrderSetStart(msg *sharedStructs.WorkOrderStartMe
 	var cmdTag pgconn.CommandTag
 	cmdTag, err = tx.Exec(ctx, `
 		UPDATE work_orders
-		SET status = 1, startTime = to_timestamp($2 / 1000)
+		SET status = 1, start_time = to_timestamp($2 / 1000)
 		WHERE externalWorkOrderId = $1
 		  AND status = 0 
-		  AND startTime IS NULL
-		  AND assetId = $3
+		  AND start_time IS NULL
+		  AND asset_id = $3
 	`, msg.ExternalWorkOrderId, msg.StartTimeUnixMs, int(assetId))
 	if err != nil {
 		zap.S().Warnf("Error updating work order: %v (workOrderId: %v) [%s]", err, msg.ExternalWorkOrderId, cmdTag)
@@ -99,11 +99,11 @@ func (c *Connection) UpdateWorkOrderSetStop(msg *sharedStructs.WorkOrderStopMess
 	var cmdTag pgconn.CommandTag
 	cmdTag, err = tx.Exec(ctx, `
 		UPDATE work_orders
-		SET status = 2, endTime = to_timestamp($2 / 1000)
+		SET status = 2, end_time = to_timestamp($2 / 1000)
 		WHERE externalWorkOrderId = $1
 		  AND status = 1
-		  AND endTime IS NULL
-		  AND assetId = $3
+		  AND end_time IS NULL
+		  AND asset_id = $3
 	`, msg.ExternalWorkOrderId, msg.EndTimeUnixMs, int(assetId))
 	if err != nil {
 		zap.S().Warnf("Error updating work order: %v (workOrderId: %v) [%s]", err, msg.ExternalWorkOrderId, cmdTag)

--- a/golang/cmd/kafka-to-postgresql-v2/postgresql/analytics-work-order.go
+++ b/golang/cmd/kafka-to-postgresql-v2/postgresql/analytics-work-order.go
@@ -25,7 +25,7 @@ func (c *Connection) InsertWorkOrderCreate(msg *sharedStructs.WorkOrderCreateMes
 	// Don't forget to convert unix ms to timestamptz
 	var cmdTag pgconn.CommandTag
 	cmdTag, err = tx.Exec(ctx, `
-		INSERT INTO work_orders (externalWorkOrderId, asset_id, productTypeId, quantity, status, start_time, end_time)
+		INSERT INTO work_order(externalWorkOrderId, asset_id, productTypeId, quantity, status, start_time, end_time)
 		VALUES ($1, $2, $3, $4, $5, to_timestamp($6/1000), to_timestamp($7/1000))
 	`, msg.ExternalWorkOrderId, int(assetId), int(productTypeId), msg.Quantity, int(msg.Status), msg.StartTimeUnixMs, msg.EndTimeUnixMs)
 	if err != nil {
@@ -57,7 +57,7 @@ func (c *Connection) UpdateWorkOrderSetStart(msg *sharedStructs.WorkOrderStartMe
 
 	var cmdTag pgconn.CommandTag
 	cmdTag, err = tx.Exec(ctx, `
-		UPDATE work_orders
+		UPDATE work_order
 		SET status = 1, start_time = to_timestamp($2 / 1000)
 		WHERE externalWorkOrderId = $1
 		  AND status = 0 
@@ -98,7 +98,7 @@ func (c *Connection) UpdateWorkOrderSetStop(msg *sharedStructs.WorkOrderStopMess
 
 	var cmdTag pgconn.CommandTag
 	cmdTag, err = tx.Exec(ctx, `
-		UPDATE work_orders
+		UPDATE work_order
 		SET status = 2, end_time = to_timestamp($2 / 1000)
 		WHERE externalWorkOrderId = $1
 		  AND status = 1

--- a/golang/cmd/kafka-to-postgresql-v2/postgresql/analytics_test.go
+++ b/golang/cmd/kafka-to-postgresql-v2/postgresql/analytics_test.go
@@ -46,7 +46,7 @@ func TestWorkOrder(t *testing.T) {
 		// Expect Exec from InsertWorkOrderCreate
 		mock.ExpectBeginTx(pgx.TxOptions{})
 		mock.ExpectExec(`
-		INSERT INTO work_orders \(externalWorkOrderId, asset_id, productTypeId, quantity, status, start_time, end_time\) VALUES \(\$1, \$2, \$3, \$4, \$5, to_timestamp\(\$6\/1000\), to_timestamp\(\$7\/1000\)\)
+		INSERT INTO work_order\(externalWorkOrderId, asset_id, productTypeId, quantity, status, start_time, end_time\) VALUES \(\$1, \$2, \$3, \$4, \$5, to_timestamp\(\$6\/1000\), to_timestamp\(\$7\/1000\)\)
 	`).WithArgs("#1274", 1, 1, uint64(0), int(0), uint64(0), uint64(0)).
 			WillReturnResult(pgxmock.NewResult("INSERT", 1))
 		mock.ExpectCommit()
@@ -68,7 +68,7 @@ func TestWorkOrder(t *testing.T) {
 		// Expect Exec from UpdateWorkOrderSetStart
 		mock.ExpectBeginTx(pgx.TxOptions{})
 		mock.ExpectExec(`
-		UPDATE work_orders
+		UPDATE work_order
 		SET status = 1, start_time = to_timestamp\(\$2 \/ 1000\)
 		WHERE externalWorkOrderId = \$1 AND status = 0 AND start_time IS NULL AND asset_id = \$3
 	`).WithArgs("#1274", uint64(0), 1).
@@ -92,7 +92,7 @@ func TestWorkOrder(t *testing.T) {
 		// Expect Exec from UpdateWorkOrderSetStop
 		mock.ExpectBeginTx(pgx.TxOptions{})
 		mock.ExpectExec(`
-		UPDATE work_orders
+		UPDATE work_order
 		SET status = 2, end_time = to_timestamp\(\$2 \/ 1000\)
 		WHERE externalWorkOrderId = \$1 AND status = 1 AND end_time IS NULL AND asset_id = \$3
 		`).WithArgs("#1274", uint64(0), 1).
@@ -141,7 +141,7 @@ func TestProduct(t *testing.T) {
 
 		// Expect Exec from InsertProductAdd
 		mock.ExpectBeginTx(pgx.TxOptions{})
-		mock.ExpectExec(`INSERT INTO products \(external_product_type_id, product_batch_id, asset_id, start_time, end_time, quantity, bad_quantity\)
+		mock.ExpectExec(`INSERT INTO product\(external_product_type_id, product_batch_id, asset_id, start_time, end_time, quantity, bad_quantity\)
 		VALUES \(\$1, \$2, \$3, to_timestamp\(\$4\/1000\), to_timestamp\(\$5\/1000\), \$6, \$7\)`).
 			WithArgs(1, "0000-1234", 1, uint64(0), uint64(10), 512, 0).
 			WillReturnResult(pgxmock.NewResult("INSERT", 1))
@@ -177,7 +177,7 @@ func TestProductType(t *testing.T) {
 
 		// Expect Exec from InsertProductTypeCreate
 		mock.ExpectBeginTx(pgx.TxOptions{})
-		mock.ExpectExec(`INSERT INTO product_types \(external_product_type_id, cycle_time_ms, asset_id\)
+		mock.ExpectExec(`INSERT INTO product_type\(external_product_type_id, cycle_time_ms, asset_id\)
 		VALUES \(\$1, \$2, \$3\)
 		ON CONFLICT \(external_product_type_id, asset_id\) DO NOTHING`).
 			WithArgs("#1275", 512, 1).
@@ -216,7 +216,7 @@ func TestShift(t *testing.T) {
 
 		// Expect Exec from InsertShiftAdd
 		mock.ExpectBeginTx(pgx.TxOptions{})
-		mock.ExpectExec(`INSERT INTO shifts \(asset_id, start_time, end_time\)
+		mock.ExpectExec(`INSERT INTO shift\(asset_id, start_time, end_time\)
 		VALUES \(\$1, to_timestamp\(\$2 \/ 1000\), to_timestamp\(\$3 \/ 1000\)\)
 		ON CONFLICT ON CONSTRAINT shift_start_asset_uniq
 		DO NOTHING;`).WithArgs(1, uint64(1), uint64(2)).
@@ -239,7 +239,7 @@ func TestShift(t *testing.T) {
 		}
 
 		mock.ExpectBeginTx(pgx.TxOptions{})
-		mock.ExpectExec(`DELETE FROM shifts WHERE asset_id = \$1 AND start_time = to_timestamp\(\$2 \/ 1000\)`).
+		mock.ExpectExec(`DELETE FROM shift WHERE asset_id = \$1 AND start_time = to_timestamp\(\$2 \/ 1000\)`).
 			WithArgs(1, uint64(1)).
 			WillReturnResult(pgxmock.NewResult("DELETE", 1))
 
@@ -277,7 +277,7 @@ func TestState(t *testing.T) {
 		// Expect Exec from InsertStateAdd
 		mock.ExpectBeginTx(pgx.TxOptions{})
 
-		mock.ExpectExec(`UPDATE states
+		mock.ExpectExec(`UPDATE state
 		SET end_time \= to_timestamp\(\$2\/1000\)
 		WHERE asset_id \= \$1
 		AND end_time IS NULL
@@ -285,7 +285,7 @@ func TestState(t *testing.T) {
 		`).WithArgs(1, uint64(1)).
 			WillReturnResult(pgxmock.NewResult("UPDATE", 0))
 
-		mock.ExpectExec(`INSERT INTO states \(asset_id, start_time, state\)
+		mock.ExpectExec(`INSERT INTO state\(asset_id, start_time, state\)
 		VALUES \(\$1, to_timestamp\(\$2\/1000\), \$3\)
 		ON CONFLICT ON CONSTRAINT state_start_asset_uniq
 		DO NOTHING`).WithArgs(1, uint64(1), 10000).
@@ -304,7 +304,7 @@ func TestState(t *testing.T) {
 		}
 
 		mock.ExpectBeginTx(pgx.TxOptions{})
-		mock.ExpectExec(`UPDATE states
+		mock.ExpectExec(`UPDATE state
 		SET end_time \= to_timestamp\(\$2\/1000\)
 		WHERE asset_id \= \$1
 		AND end_time IS NULL
@@ -312,7 +312,7 @@ func TestState(t *testing.T) {
 		`).WithArgs(1, uint64(100)).
 			WillReturnResult(pgxmock.NewResult("UPDATE", 1))
 
-		mock.ExpectExec(`INSERT INTO states \(asset_id, start_time, state\)
+		mock.ExpectExec(`INSERT INTO state\(asset_id, start_time, state\)
 		VALUES \(\$1, to_timestamp\(\$2\/1000\), \$3\)
 		ON CONFLICT ON CONSTRAINT state_start_asset_uniq
 		DO NOTHING`).WithArgs(1, uint64(100), 20000).
@@ -329,7 +329,7 @@ func TestState(t *testing.T) {
 		}
 
 		mock.ExpectBeginTx(pgx.TxOptions{})
-		mock.ExpectExec(`UPDATE states
+		mock.ExpectExec(`UPDATE state
 		SET end_time \= to_timestamp\(\$2\/1000\)
 		WHERE asset_id \= \$1
 		AND end_time IS NULL
@@ -337,7 +337,7 @@ func TestState(t *testing.T) {
 		`).WithArgs(1, uint64(200)).
 			WillReturnResult(pgxmock.NewResult("UPDATE", 1))
 
-		mock.ExpectExec(`INSERT INTO states \(asset_id, start_time, state\)
+		mock.ExpectExec(`INSERT INTO state\(asset_id, start_time, state\)
 		VALUES \(\$1, to_timestamp\(\$2\/1000\), \$3\)
 		ON CONFLICT ON CONSTRAINT state_start_asset_uniq
 		DO NOTHING`).WithArgs(1, uint64(200), 30000).
@@ -367,7 +367,7 @@ func TestState(t *testing.T) {
 
 		mock.ExpectBeginTx(pgx.TxOptions{})
 		// The prev state will be cleanly deleted
-		mock.ExpectExec(`DELETE FROM states
+		mock.ExpectExec(`DELETE FROM state
 		WHERE asset_id = \$1
 		AND start_time >= to_timestamp\(\$2\/1000\)
 		AND start_time <= to_timestamp\(\$3\/1000\)
@@ -375,7 +375,7 @@ func TestState(t *testing.T) {
 			WillReturnResult(pgxmock.NewResult("DELETE", 1))
 
 		// The left update command will not change anything
-		mock.ExpectExec(`UPDATE states
+		mock.ExpectExec(`UPDATE state
 		SET end_time = to_timestamp\(\$2\/1000\)
 		WHERE asset_id = \$1
 		AND end_time > to_timestamp\(\$2\/1000\)
@@ -384,7 +384,7 @@ func TestState(t *testing.T) {
 			WillReturnResult(pgxmock.NewResult("UPDATE", 0))
 
 		// The right update command will not change anything
-		mock.ExpectExec(`UPDATE states
+		mock.ExpectExec(`UPDATE state
 		SET start_time = to_timestamp\(\$3\/1000\)
 		WHERE asset_id = \$1
 		AND start_time >= to_timestamp\(\$2\/1000\)
@@ -393,7 +393,7 @@ func TestState(t *testing.T) {
 			WillReturnResult(pgxmock.NewResult("UPDATE", 0))
 
 		// The insert command will insert the new state
-		mock.ExpectExec(`INSERT INTO states \(asset_id, start_time, end_time, state\)
+		mock.ExpectExec(`INSERT INTO state\(asset_id, start_time, end_time, state\)
 		VALUES \(\$1, to_timestamp\(\$2\/1000\), to_timestamp\(\$3\/1000\), \$4\)`).
 			WithArgs(1, uint64(0), uint64(100), 40000).
 			WillReturnResult(pgxmock.NewResult("INSERT", 1))
@@ -412,7 +412,7 @@ func TestState(t *testing.T) {
 
 		mock.ExpectBeginTx(pgx.TxOptions{})
 		// There is no state inbetween to be deleted, so we expect 0 deletes
-		mock.ExpectExec(`DELETE FROM states
+		mock.ExpectExec(`DELETE FROM state
 		WHERE asset_id = \$1
 		AND start_time >= to_timestamp\(\$2\/1000\)
 		AND start_time <= to_timestamp\(\$3\/1000\)
@@ -420,7 +420,7 @@ func TestState(t *testing.T) {
 			WillReturnResult(pgxmock.NewResult("DELETE", 0))
 
 		// The left update command will update the end time of the first state
-		mock.ExpectExec(`UPDATE states
+		mock.ExpectExec(`UPDATE state
 		SET end_time = to_timestamp\(\$2\/1000\)
 		WHERE asset_id = \$1
 		AND end_time > to_timestamp\(\$2\/1000\)
@@ -429,7 +429,7 @@ func TestState(t *testing.T) {
 			WillReturnResult(pgxmock.NewResult("UPDATE", 1))
 
 		// The right update command will update the start time of the second state
-		mock.ExpectExec(`UPDATE states
+		mock.ExpectExec(`UPDATE state
 		SET start_time = to_timestamp\(\$3\/1000\)
 		WHERE asset_id = \$1
 		AND start_time >= to_timestamp\(\$2\/1000\)
@@ -438,7 +438,7 @@ func TestState(t *testing.T) {
 			WillReturnResult(pgxmock.NewResult("UPDATE", 1))
 
 		// The insert command will insert the new state
-		mock.ExpectExec(`INSERT INTO states \(asset_id, start_time, end_time, state\)
+		mock.ExpectExec(`INSERT INTO state\(asset_id, start_time, end_time, state\)
 		VALUES \(\$1, to_timestamp\(\$2\/1000\), to_timestamp\(\$3\/1000\), \$4\)`).
 			WithArgs(1, uint64(50), uint64(150), 50000).
 			WillReturnResult(pgxmock.NewResult("INSERT", 1))

--- a/golang/cmd/kafka-to-postgresql-v2/postgresql/analytics_test.go
+++ b/golang/cmd/kafka-to-postgresql-v2/postgresql/analytics_test.go
@@ -39,14 +39,14 @@ func TestWorkOrder(t *testing.T) {
 			WillReturnRows(mock.NewRows([]string{"id"}).AddRow(1))
 
 		// Expect Query from GetOrInsertProduct
-		mock.ExpectQuery(`SELECT productTypeId FROM product_types WHERE externalProductTypeId = \$1 AND assetId = \$2`).
+		mock.ExpectQuery(`SELECT productTypeId FROM product_types WHERE external_product_type_id = \$1 AND asset_id = \$2`).
 			WithArgs("test", 1).
 			WillReturnRows(mock.NewRows([]string{"productTypeId"}).AddRow(1))
 
 		// Expect Exec from InsertWorkOrderCreate
 		mock.ExpectBeginTx(pgx.TxOptions{})
 		mock.ExpectExec(`
-		INSERT INTO work_orders \(externalWorkOrderId, assetId, productTypeId, quantity, status, startTime, endTime\) VALUES \(\$1, \$2, \$3, \$4, \$5, to_timestamp\(\$6\/1000\), to_timestamp\(\$7\/1000\)\)
+		INSERT INTO work_orders \(externalWorkOrderId, asset_id, productTypeId, quantity, status, start_time, end_time\) VALUES \(\$1, \$2, \$3, \$4, \$5, to_timestamp\(\$6\/1000\), to_timestamp\(\$7\/1000\)\)
 	`).WithArgs("#1274", 1, 1, uint64(0), int(0), uint64(0), uint64(0)).
 			WillReturnResult(pgxmock.NewResult("INSERT", 1))
 		mock.ExpectCommit()
@@ -69,8 +69,8 @@ func TestWorkOrder(t *testing.T) {
 		mock.ExpectBeginTx(pgx.TxOptions{})
 		mock.ExpectExec(`
 		UPDATE work_orders
-		SET status = 1, startTime = to_timestamp\(\$2 \/ 1000\)
-		WHERE externalWorkOrderId = \$1 AND status = 0 AND startTime IS NULL AND assetId = \$3
+		SET status = 1, start_time = to_timestamp\(\$2 \/ 1000\)
+		WHERE externalWorkOrderId = \$1 AND status = 0 AND start_time IS NULL AND asset_id = \$3
 	`).WithArgs("#1274", uint64(0), 1).
 			WillReturnResult(pgxmock.NewResult("UPDATE", 1))
 		mock.ExpectCommit()
@@ -93,8 +93,8 @@ func TestWorkOrder(t *testing.T) {
 		mock.ExpectBeginTx(pgx.TxOptions{})
 		mock.ExpectExec(`
 		UPDATE work_orders
-		SET status = 2, endTime = to_timestamp\(\$2 \/ 1000\)
-		WHERE externalWorkOrderId = \$1 AND status = 1 AND endTime IS NULL AND assetId = \$3
+		SET status = 2, end_time = to_timestamp\(\$2 \/ 1000\)
+		WHERE externalWorkOrderId = \$1 AND status = 1 AND end_time IS NULL AND asset_id = \$3
 		`).WithArgs("#1274", uint64(0), 1).
 			WillReturnResult(pgxmock.NewResult("UPDATE", 1))
 		mock.ExpectCommit()
@@ -114,7 +114,7 @@ func TestProduct(t *testing.T) {
 	assert.True(t, ok)
 
 	// Insert mock product type
-	mock.ExpectQuery(`SELECT productTypeId FROM product_types WHERE externalProductTypeId = \$1 AND assetId = \$2`).
+	mock.ExpectQuery(`SELECT productTypeId FROM product_types WHERE external_product_type_id = \$1 AND asset_id = \$2`).
 		WithArgs("#1274", 1).
 		WillReturnRows(mock.NewRows([]string{"productTypeId"}).AddRow(1))
 	_, err := c.GetOrInsertProductType(1, "#1274", 1)
@@ -141,7 +141,7 @@ func TestProduct(t *testing.T) {
 
 		// Expect Exec from InsertProductAdd
 		mock.ExpectBeginTx(pgx.TxOptions{})
-		mock.ExpectExec(`INSERT INTO products \(externalProductTypeId, productBatchId, assetId, startTime, endTime, quantity, badQuantity\)
+		mock.ExpectExec(`INSERT INTO products \(external_product_type_id, product_batch_id, asset_id, start_time, end_time, quantity, bad_quantity\)
 		VALUES \(\$1, \$2, \$3, to_timestamp\(\$4\/1000\), to_timestamp\(\$5\/1000\), \$6, \$7\)`).
 			WithArgs(1, "0000-1234", 1, uint64(0), uint64(10), 512, 0).
 			WillReturnResult(pgxmock.NewResult("INSERT", 1))
@@ -177,9 +177,9 @@ func TestProductType(t *testing.T) {
 
 		// Expect Exec from InsertProductTypeCreate
 		mock.ExpectBeginTx(pgx.TxOptions{})
-		mock.ExpectExec(`INSERT INTO product_types \(externalProductTypeId, cycleTime, assetId\)
+		mock.ExpectExec(`INSERT INTO product_types \(external_product_type_id, cycle_time_ms, asset_id\)
 		VALUES \(\$1, \$2, \$3\)
-		ON CONFLICT \(externalProductTypeId, assetId\) DO NOTHING`).
+		ON CONFLICT \(external_product_type_id, asset_id\) DO NOTHING`).
 			WithArgs("#1275", 512, 1).
 			WillReturnResult(pgxmock.NewResult("INSERT", 1))
 
@@ -216,7 +216,7 @@ func TestShift(t *testing.T) {
 
 		// Expect Exec from InsertShiftAdd
 		mock.ExpectBeginTx(pgx.TxOptions{})
-		mock.ExpectExec(`INSERT INTO shifts \(assetId, startTime, endTime\)
+		mock.ExpectExec(`INSERT INTO shifts \(asset_id, start_time, end_time\)
 		VALUES \(\$1, to_timestamp\(\$2 \/ 1000\), to_timestamp\(\$3 \/ 1000\)\)
 		ON CONFLICT ON CONSTRAINT shift_start_asset_uniq
 		DO NOTHING;`).WithArgs(1, uint64(1), uint64(2)).
@@ -239,7 +239,7 @@ func TestShift(t *testing.T) {
 		}
 
 		mock.ExpectBeginTx(pgx.TxOptions{})
-		mock.ExpectExec(`DELETE FROM shifts WHERE assetId = \$1 AND startTime = to_timestamp\(\$2 \/ 1000\)`).
+		mock.ExpectExec(`DELETE FROM shifts WHERE asset_id = \$1 AND start_time = to_timestamp\(\$2 \/ 1000\)`).
 			WithArgs(1, uint64(1)).
 			WillReturnResult(pgxmock.NewResult("DELETE", 1))
 
@@ -278,14 +278,14 @@ func TestState(t *testing.T) {
 		mock.ExpectBeginTx(pgx.TxOptions{})
 
 		mock.ExpectExec(`UPDATE states
-		SET endTime \= to_timestamp\(\$2\/1000\)
-		WHERE assetId \= \$1
-		AND endTime IS NULL
-		AND startTime \< to_timestamp\(\$2\/1000\)
+		SET end_time \= to_timestamp\(\$2\/1000\)
+		WHERE asset_id \= \$1
+		AND end_time IS NULL
+		AND start_time \< to_timestamp\(\$2\/1000\)
 		`).WithArgs(1, uint64(1)).
 			WillReturnResult(pgxmock.NewResult("UPDATE", 0))
 
-		mock.ExpectExec(`INSERT INTO states \(assetId, startTime, state\)
+		mock.ExpectExec(`INSERT INTO states \(asset_id, start_time, state\)
 		VALUES \(\$1, to_timestamp\(\$2\/1000\), \$3\)
 		ON CONFLICT ON CONSTRAINT state_start_asset_uniq
 		DO NOTHING`).WithArgs(1, uint64(1), 10000).
@@ -305,14 +305,14 @@ func TestState(t *testing.T) {
 
 		mock.ExpectBeginTx(pgx.TxOptions{})
 		mock.ExpectExec(`UPDATE states
-		SET endTime \= to_timestamp\(\$2\/1000\)
-		WHERE assetId \= \$1
-		AND endTime IS NULL
-		AND startTime \< to_timestamp\(\$2\/1000\)
+		SET end_time \= to_timestamp\(\$2\/1000\)
+		WHERE asset_id \= \$1
+		AND end_time IS NULL
+		AND start_time \< to_timestamp\(\$2\/1000\)
 		`).WithArgs(1, uint64(100)).
 			WillReturnResult(pgxmock.NewResult("UPDATE", 1))
 
-		mock.ExpectExec(`INSERT INTO states \(assetId, startTime, state\)
+		mock.ExpectExec(`INSERT INTO states \(asset_id, start_time, state\)
 		VALUES \(\$1, to_timestamp\(\$2\/1000\), \$3\)
 		ON CONFLICT ON CONSTRAINT state_start_asset_uniq
 		DO NOTHING`).WithArgs(1, uint64(100), 20000).
@@ -330,14 +330,14 @@ func TestState(t *testing.T) {
 
 		mock.ExpectBeginTx(pgx.TxOptions{})
 		mock.ExpectExec(`UPDATE states
-		SET endTime \= to_timestamp\(\$2\/1000\)
-		WHERE assetId \= \$1
-		AND endTime IS NULL
-		AND startTime \< to_timestamp\(\$2\/1000\)
+		SET end_time \= to_timestamp\(\$2\/1000\)
+		WHERE asset_id \= \$1
+		AND end_time IS NULL
+		AND start_time \< to_timestamp\(\$2\/1000\)
 		`).WithArgs(1, uint64(200)).
 			WillReturnResult(pgxmock.NewResult("UPDATE", 1))
 
-		mock.ExpectExec(`INSERT INTO states \(assetId, startTime, state\)
+		mock.ExpectExec(`INSERT INTO states \(asset_id, start_time, state\)
 		VALUES \(\$1, to_timestamp\(\$2\/1000\), \$3\)
 		ON CONFLICT ON CONSTRAINT state_start_asset_uniq
 		DO NOTHING`).WithArgs(1, uint64(200), 30000).
@@ -368,32 +368,32 @@ func TestState(t *testing.T) {
 		mock.ExpectBeginTx(pgx.TxOptions{})
 		// The prev state will be cleanly deleted
 		mock.ExpectExec(`DELETE FROM states
-		WHERE assetId = \$1
-		AND startTime >= to_timestamp\(\$2\/1000\)
-		AND startTime <= to_timestamp\(\$3\/1000\)
+		WHERE asset_id = \$1
+		AND start_time >= to_timestamp\(\$2\/1000\)
+		AND start_time <= to_timestamp\(\$3\/1000\)
 		`).WithArgs(1, uint64(0), uint64(100)).
 			WillReturnResult(pgxmock.NewResult("DELETE", 1))
 
 		// The left update command will not change anything
 		mock.ExpectExec(`UPDATE states
-		SET endTime = to_timestamp\(\$2\/1000\)
-		WHERE assetId = \$1
-		AND endTime > to_timestamp\(\$2\/1000\)
-		AND endTime <= to_timestamp\(\$3\/1000\)
+		SET end_time = to_timestamp\(\$2\/1000\)
+		WHERE asset_id = \$1
+		AND end_time > to_timestamp\(\$2\/1000\)
+		AND end_time <= to_timestamp\(\$3\/1000\)
 		`).WithArgs(1, uint64(0), uint64(100)).
 			WillReturnResult(pgxmock.NewResult("UPDATE", 0))
 
 		// The right update command will not change anything
 		mock.ExpectExec(`UPDATE states
-		SET startTime = to_timestamp\(\$3\/1000\)
-		WHERE assetId = \$1
-		AND startTime >= to_timestamp\(\$2\/1000\)
-		AND startTime < to_timestamp\(\$3\/1000\)
+		SET start_time = to_timestamp\(\$3\/1000\)
+		WHERE asset_id = \$1
+		AND start_time >= to_timestamp\(\$2\/1000\)
+		AND start_time < to_timestamp\(\$3\/1000\)
 		`).WithArgs(1, uint64(0), uint64(100)).
 			WillReturnResult(pgxmock.NewResult("UPDATE", 0))
 
 		// The insert command will insert the new state
-		mock.ExpectExec(`INSERT INTO states \(assetId, startTime, endTime, state\)
+		mock.ExpectExec(`INSERT INTO states \(asset_id, start_time, end_time, state\)
 		VALUES \(\$1, to_timestamp\(\$2\/1000\), to_timestamp\(\$3\/1000\), \$4\)`).
 			WithArgs(1, uint64(0), uint64(100), 40000).
 			WillReturnResult(pgxmock.NewResult("INSERT", 1))
@@ -413,32 +413,32 @@ func TestState(t *testing.T) {
 		mock.ExpectBeginTx(pgx.TxOptions{})
 		// There is no state inbetween to be deleted, so we expect 0 deletes
 		mock.ExpectExec(`DELETE FROM states
-		WHERE assetId = \$1
-		AND startTime >= to_timestamp\(\$2\/1000\)
-		AND startTime <= to_timestamp\(\$3\/1000\)
+		WHERE asset_id = \$1
+		AND start_time >= to_timestamp\(\$2\/1000\)
+		AND start_time <= to_timestamp\(\$3\/1000\)
 		`).WithArgs(1, uint64(50), uint64(150)).
 			WillReturnResult(pgxmock.NewResult("DELETE", 0))
 
 		// The left update command will update the end time of the first state
 		mock.ExpectExec(`UPDATE states
-		SET endTime = to_timestamp\(\$2\/1000\)
-		WHERE assetId = \$1
-		AND endTime > to_timestamp\(\$2\/1000\)
-		AND endTime <= to_timestamp\(\$3\/1000\)
+		SET end_time = to_timestamp\(\$2\/1000\)
+		WHERE asset_id = \$1
+		AND end_time > to_timestamp\(\$2\/1000\)
+		AND end_time <= to_timestamp\(\$3\/1000\)
 		`).WithArgs(1, uint64(50), uint64(150)).
 			WillReturnResult(pgxmock.NewResult("UPDATE", 1))
 
 		// The right update command will update the start time of the second state
 		mock.ExpectExec(`UPDATE states
-		SET startTime = to_timestamp\(\$3\/1000\)
-		WHERE assetId = \$1
-		AND startTime >= to_timestamp\(\$2\/1000\)
-		AND startTime < to_timestamp\(\$3\/1000\)
+		SET start_time = to_timestamp\(\$3\/1000\)
+		WHERE asset_id = \$1
+		AND start_time >= to_timestamp\(\$2\/1000\)
+		AND start_time < to_timestamp\(\$3\/1000\)
 		`).WithArgs(1, uint64(50), uint64(150)).
 			WillReturnResult(pgxmock.NewResult("UPDATE", 1))
 
 		// The insert command will insert the new state
-		mock.ExpectExec(`INSERT INTO states \(assetId, startTime, endTime, state\)
+		mock.ExpectExec(`INSERT INTO states \(asset_id, start_time, end_time, state\)
 		VALUES \(\$1, to_timestamp\(\$2\/1000\), to_timestamp\(\$3\/1000\), \$4\)`).
 			WithArgs(1, uint64(50), uint64(150), 50000).
 			WillReturnResult(pgxmock.NewResult("INSERT", 1))

--- a/golang/cmd/kafka-to-postgresql-v2/postgresql/lru.go
+++ b/golang/cmd/kafka-to-postgresql-v2/postgresql/lru.go
@@ -90,7 +90,7 @@ func (c *Connection) GetOrInsertProductType(assetId uint64, externalProductId st
 		    productTypeId INT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
 		    externalProductTypeId TEXT NOT NULL,
 		    cycleTime INTEGER NOT NULL,
-		    assetId INTEGER REFERENCES assets(id),
+		    assetId INTEGER REFERENCES asset(id),
 		    CONSTRAINT external_product_asset_uniq UNIQUE (externalProductTypeId, assetId),
 		    CHECK (cycleTime > 0)
 		);

--- a/golang/cmd/kafka-to-postgresql-v2/postgresql/lru.go
+++ b/golang/cmd/kafka-to-postgresql-v2/postgresql/lru.go
@@ -118,7 +118,7 @@ func (c *Connection) GetOrInsertProductType(assetId uint64, externalProductId st
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			// Row isn't found, need to insert
-			insertQuery := `INSERT INTO product_types (external_product_type_id, cycle_time_ms, asset_id) VALUES ($1, $2, $3) RETURNING productTypeId`
+			insertQuery := `INSERT INTO product_type(external_product_type_id, cycle_time_ms, asset_id) VALUES ($1, $2, $3) RETURNING productTypeId`
 			insertRowContext, insertRowContextCncl := get1MinuteContext()
 			defer insertRowContextCncl()
 

--- a/golang/cmd/kafka-to-postgresql-v2/worker/analytics.go
+++ b/golang/cmd/kafka-to-postgresql-v2/worker/analytics.go
@@ -100,7 +100,7 @@ func parseProductTypeCreate(value []byte) (*shared.ProductTypeCreateMessage, err
 
 	// Validate that ExternalProductTypeId & CycleTimeMs are set
 	if message.ExternalProductTypeId == "" {
-		return nil, errors.New("externalProductTypeId is required")
+		return nil, errors.New("external_product_type_id is required")
 	}
 	if message.CycleTimeMs == 0 {
 		return nil, errors.New("cycleTimeMs is required")


### PR DESCRIPTION
pg internally converts camelCase to lowercase, therefore this pr changes our names to snake_case (this is also in line with _historian).

Based on #1757