### PR TITLE
[ENG-1123] Install pg_stat_statements plugin for timescaledb

### DIFF
--- a/deployment/united-manufacturing-hub/templates/timescaledb/configmap.yaml
+++ b/deployment/united-manufacturing-hub/templates/timescaledb/configmap.yaml
@@ -41,6 +41,9 @@ data:
     -- Extend the database with TimescaleDB
     CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;
 
+    -- Enable pg_stat_statements plugin for observability;
+    CREATE EXTENSION IF NOT EXISTS pg_stat_statements CASCADE;
+
     -------------------- Table with all assets --------------------
     CREATE TABLE IF NOT EXISTS assetTable
     (


### PR DESCRIPTION
## Descripition

pg_stat_statements is an observability plugin that provides valuable metrics on TimescaleDB performance. UMH intends to integrate these metrics into the Management Console, enhancing visibility into the database’s activity and health.