### PR TITLE
Fix/289/sensorconnect always returns values as string

### DIFF
--- a/golang/cmd/sensorconnect/processSensorData.go
+++ b/golang/cmd/sensorconnect/processSensorData.go
@@ -398,10 +398,9 @@ func isEmpty(object interface{}) bool {
 }
 
 // getUnixTimestampMs returns the current unix timestamp as string in milliseconds
-func getUnixTimestampMs() (timestampMs string) {
+func getUnixTimestampMs() (timestampMs int64) {
 	t := time.Now()
-	timestampMsInt := int(t.UnixNano() / 1000000)
-	timestampMs = strconv.Itoa(timestampMsInt)
+	timestampMs = t.UnixNano() / 1000000
 	return
 }
 
@@ -572,7 +571,7 @@ func convertBinaryValueToString(binaryValue string, datatype string) (output str
 }
 
 // createDigitalInputPayload creates a json output body from a DigitalInput to send via mqtt or kafka to the server
-func createDigitalInputPayload(timestampMs string, dataPin2In []byte, payload *map[string]interface{}) {
+func createDigitalInputPayload(timestampMs int64, dataPin2In []byte, payload *map[string]interface{}) {
 	(*payload)["timestamp_ms"] = timestampMs
 	(*payload)["type"] = "DI"
 	(*payload)["connected"] = "connected"

--- a/golang/cmd/sensorconnect/processSensorData_test.go
+++ b/golang/cmd/sensorconnect/processSensorData_test.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"fmt"
+	"math"
 	"testing"
 )
 
@@ -132,5 +133,133 @@ func TestBitConversions(t *testing.T) {
 	fmt.Println(longHexString)
 	if endHexStringPadded != "0000fc000001ff000000ff000161ff000025ff03" {
 		t.Error("Problem with BitConversions")
+	}
+}
+
+// IO-Link Interface and System Specification V1.1.4 F.2.2
+func TestBooleanTTConversions(t *testing.T) {
+	tests := []struct {
+		binary   string
+		expected bool
+	}{
+		{
+			binary:   "1",
+			expected: true,
+		},
+		{
+			binary:   "0",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("When binary is: %s, Then convertBinaryValue returns: %t", tt.binary, tt.expected), func(t *testing.T) {
+			result := convertBinaryValue(tt.binary, "BooleanT")
+			if result != tt.expected {
+				t.Errorf("Expected %t, got %t", tt.expected, result)
+			}
+		})
+	}
+}
+
+// IO-Link Interface and System Specification V1.1.4 F.2.5
+func TestFloat32TConversions(t *testing.T) {
+	tests := []struct {
+		binary   string
+		expected float32
+	}{
+		{
+			binary:   "01000000010000000000000000000000",
+			expected: 3.0,
+		},
+		{
+			binary:   "11000000010000000000000000000000",
+			expected: -3.0,
+		},
+		{
+			binary:   "00000000000000000000000000000000",
+			expected: 0.0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("When binary is: %s, Then convertBinaryValue returns: %f", tt.binary, tt.expected), func(t *testing.T) {
+			result := convertBinaryValue(tt.binary, "Float32T")
+			if result != tt.expected {
+				t.Errorf("Expected %f, got %f", tt.expected, result)
+			}
+		})
+	}
+}
+
+// IO-Link Interface and System Specification V1.1.4 F.2.3
+func TestUIntegerTConversions(t *testing.T) {
+	tests := []struct {
+		binary   string
+		expected uint64
+	}{
+		{
+			binary:   "0001101",
+			expected: 13,
+		},
+		{
+			binary:   "10110111001011010",
+			expected: 93786,
+		},
+		{
+			binary:   "11111111111111111111111111111111",
+			expected: math.MaxUint32,
+		},
+		{
+			binary:   "1111111111111111111111111111111111111111111111111111111111111111",
+			expected: math.MaxUint64,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("When binary is: %s, Then convertBinaryValue returns: %v", tt.binary, tt.expected), func(t *testing.T) {
+			result := convertBinaryValue(tt.binary, "UIntegerT")
+			if result != tt.expected {
+				t.Errorf("Expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}
+
+// IO-Link Interface and System Specification V1.1.4 F.2.4
+func TestIntegerTConversions(t *testing.T) {
+	tests := []struct {
+		binary   string
+		expected int
+	}{
+		{
+			binary:   "10000000",
+			expected: math.MinInt8,
+		},
+		{
+			binary:   "01111111",
+			expected: math.MaxInt8,
+		},
+		{
+			binary:   "1000000000000000",
+			expected: math.MinInt16,
+		},
+		{
+			binary:   "10000000000000000000000000000000",
+			expected: math.MinInt32,
+		},
+		{
+			binary:   "1000000000000000000000000000000000000000000000000000000000000000",
+			expected: math.MinInt64,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("When binary is: %s, Then convertBinaryValue returns: %v", tt.binary, tt.expected), func(t *testing.T) {
+			result := convertBinaryValue(tt.binary, "IntegerT")
+			if result != tt.expected {
+				t.Errorf("Expected %v, got %v", tt.expected, result)
+			}
+		})
 	}
 }


### PR DESCRIPTION
fixes: https://github.com/united-manufacturing-hub/united-manufacturing-hub/issues/289


Sensorconnect should return values according to the in the [IODD spec.](https://io-link.com/share/Downloads/Package-2024-released/IOL-Interface-Spec_10002_V114_Jun24.pdf) specified type instead of string


```json
{
   "Distance":"47",
   "Switch state [OUT1]":"1",
   "connected":"connected",
   "timestamp_ms":"1728629682975",
   "type":"Io-Link"
}

```

=>

```json
{
   "Distance":47,
   "Switch state [OUT1]":true,
   "connected":"connected",
   "timestamp_ms":1728631520855,
   "type":"Io-Link"
}
```
Implemented Types:

  ✅  `BoolenT`IOLINK Spec. V1.1.4 F.2.2
  ✅  `UIntegerT`IOLINK Spec. V1.1.4 F.2.3
  ✅  `IntegerT` IOLINK Spec. V1.1.4 F.2.4
  ✅  `Float32T` IOLINK Spec. V1.1.4 F.2.5
  ✅  `OctetStringT` IOLINK Spec.  V1.1.4 F.2.7


Not Implemented Types:

  ❌   `StringT` IOLINK Spec.  V1.1.4 F.2.6
  ❌   `TimeT` IOLINK Spec.  V1.1.4 F.2.8
  ❌   `TimeSpanT` IOLINK Spec.  V1.1.4 F.2.9
  ❌   `ArrayT` IOLINK Spec.  V1.1.4 F.3.2
  ❌   `RecordT` IOLINK Spec.  V1.1.4 F.3.2








