### PR TITLE
[ENG-1708] Fix typo in Port number for Modbus simulator

### DIFF
--- a/deployment/united-manufacturing-hub/templates/modbussimulator/config.yaml
+++ b/deployment/united-manufacturing-hub/templates/modbussimulator/config.yaml
@@ -27,7 +27,7 @@ data:
     {
       "server": {
         "listenerAddress": "0.0.0.0",
-        "listenerPort": 502,
+        "listenerPort": 5020,
         "tlsParams": {
           "description": "path to certificate and private key to enable tls",
           "privateKey": null,

--- a/deployment/united-manufacturing-hub/templates/modbussimulator/deployment.yaml
+++ b/deployment/united-manufacturing-hub/templates/modbussimulator/deployment.yaml
@@ -51,7 +51,7 @@ spec:
               cpu: "100m"
               memory: "500Mi"
           ports:
-            - containerPort: 502
+            - containerPort: 5020
           command:
             [
               "-f /server_config.json",

--- a/deployment/united-manufacturing-hub/templates/modbussimulator/service.yaml
+++ b/deployment/united-manufacturing-hub/templates/modbussimulator/service.yaml
@@ -25,7 +25,7 @@ spec:
   type: LoadBalancer
   ports:
     - port: 50502
-      targetPort: 502
+      targetPort: 5020
       protocol: TCP
       name: modbus
   selector:


### PR DESCRIPTION
## Description 

The default port number of the Modbus simulator that we use is( https://github.com/cybcon/modbus-server) is 5020 but the helm template had it as 502. PR changes the port 502 to 5020