### PR TITLE
[ENG-1691] Fix modbus simulator command

### DIFF
--- a/deployment/united-manufacturing-hub/templates/modbussimulator/deployment.yaml
+++ b/deployment/united-manufacturing-hub/templates/modbussimulator/deployment.yaml
@@ -54,7 +54,7 @@ spec:
             - containerPort: 5020
           command:
             [
-              "-f /server_config.json",
+              "python","-u","/app/modbus_server.py","-f","/server_config.json",
             ]
           volumeMounts:
           - name: modbussimulator-config

--- a/deployment/united-manufacturing-hub/templates/modbussimulator/deployment.yaml
+++ b/deployment/united-manufacturing-hub/templates/modbussimulator/deployment.yaml
@@ -54,7 +54,11 @@ spec:
             - containerPort: 5020
           command:
             [
-              "python","-u","/app/modbus_server.py","-f","/server_config.json",
+              "python",
+              "-u",
+              "/app/modbus_server.py",
+              "-f",
+              "/server_config.json"
             ]
           volumeMounts:
           - name: modbussimulator-config

--- a/deployment/united-manufacturing-hub/templates/opcuasimulatorv2/deployment.yaml
+++ b/deployment/united-manufacturing-hub/templates/opcuasimulatorv2/deployment.yaml
@@ -42,7 +42,7 @@ spec:
             name: {{include "united-manufacturing-hub.fullname" .}}-opcsimv2-config
       containers:
         - name: {{include "united-manufacturing-hub.fullname" .}}-opcsimv2
-          image: management.umh.app/oci/iotedge/opc-plc:1.3.2
+          image: management.umh.app/oci/iotedge/opc-plc:2.9.11
           resources:
             requests:
               cpu: "50m"


### PR DESCRIPTION
## Description 

- The command for modbus simulator is fixed according to the source repo https://github.com/cybcon/modbus-server/blob/main/Dockerfile#L23
- The opc plc image tag is fixed