### PR TITLE
ENG-2091 trim & limit topic

### DIFF
--- a/deployment/united-manufacturing-hub/templates/bridges/mqtt-to-kafka/historian/configmap.yaml
+++ b/deployment/united-manufacturing-hub/templates/bridges/mqtt-to-kafka/historian/configmap.yaml
@@ -26,9 +26,9 @@ metadata:
     # This does not change over time
     data-flow-component-uuid: 1db88f9f-789d-45fa-b095-cf579cc9074d
     # This is the random UUID of the version of the component
-    data-flow-component-version-uuid: fb8c6d0c-d544-41c0-93e3-bac4a48d7f17
+    data-flow-component-version-uuid: d798380b-f9f8-41a3-847c-051ef16c8692
     # Timestamp of last change to the component in unix milliseconds since epoch
-    data-flow-version: '1730983044602'
+    data-flow-version: '1734365174785'
     # Generic label to indicate that this is a data flow component
     is-data-flow-component: 'true'
     # Required for mgmtcompanion to manage the component
@@ -107,6 +107,12 @@ data:
               _ => deleted()
             }
             let converted_topic = $topic.replace("/", ".")
+
+            # Ensure that no characters outside "[a-zA-Z0-9\\._\\-]" are in the topic
+            # If found replace then with an underscore
+            # https://regex101.com/r/1pEvIK/1
+            let converted_topic = $converted_topic.re_replace_all("[^a-zA-Z0-9\._\-]", "_")
+
             let trimmed_topic = $converted_topic.trim(".")
             # Step 2
             if ($merge_point > 0) {
@@ -118,6 +124,9 @@ data:
               meta "kafka_topic" = $kafka_topic
               meta "kafka_key" = $kafka_key
             } else {
+              # Ensure max topic length of 249 characters
+              let kafka_topic = $trimmed_topic.slice(0, 249)
+
               meta "kafka_topic" = $trimmed_topic
               meta "kafka_key" = ""
             }

--- a/deployment/united-manufacturing-hub/templates/bridges/mqtt-to-kafka/historian/configmap.yaml
+++ b/deployment/united-manufacturing-hub/templates/bridges/mqtt-to-kafka/historian/configmap.yaml
@@ -125,7 +125,7 @@ data:
               meta "kafka_key" = $kafka_key
             } else {
               # Ensure max topic length of 249 characters
-              let kafka_topic = $trimmed_topic.slice(0, 249)
+              let trimmed_topic = $trimmed_topic.slice(0, 249)
 
               meta "kafka_topic" = $trimmed_topic
               meta "kafka_key" = ""

--- a/deployment/united-manufacturing-hub/templates/bridges/mqtt-to-kafka/historian/deployment.yaml
+++ b/deployment/united-manufacturing-hub/templates/bridges/mqtt-to-kafka/historian/deployment.yaml
@@ -26,9 +26,9 @@ metadata:
     # This does not change over time
     data-flow-component-uuid: 1db88f9f-789d-45fa-b095-cf579cc9074d
     # This is the random UUID of the version of the component
-    data-flow-component-version-uuid: fb8c6d0c-d544-41c0-93e3-bac4a48d7f17
+    data-flow-component-version-uuid: d798380b-f9f8-41a3-847c-051ef16c8692
     # Timestamp of last change to the component in unix milliseconds since epoch
-    data-flow-version: '1730983044602'
+    data-flow-version: '1734365174785'
     # Generic label to indicate that this is a data flow component
     is-data-flow-component: 'true'
     # Required for mgmtcompanion to manage the component
@@ -48,9 +48,9 @@ spec:
         # This does not change over time
         data-flow-component-uuid: 1db88f9f-789d-45fa-b095-cf579cc9074d
         # This is the random UUID of the version of the component
-        data-flow-component-version-uuid: fb8c6d0c-d544-41c0-93e3-bac4a48d7f17
+        data-flow-component-version-uuid: d798380b-f9f8-41a3-847c-051ef16c8692
         # Timestamp of last change to the component in unix milliseconds since epoch
-        data-flow-version: '1730983044602'
+        data-flow-version: '1734365174785'
         # Generic label to indicate that this is a data flow component
         is-data-flow-component: 'true'
         # Required for mgmtcompanion to manage the component

--- a/go.work.sum
+++ b/go.work.sum
@@ -117,6 +117,7 @@ golang.org/x/image v0.6.0/go.mod h1:MXLdDR43H7cDJq5GEGXEVeeNhPgi+YYEQ2pC1byI1x0=
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de h1:5hukYrvBGR8/eNkX5mdUezrA6JiaEZDtJb9Ei+1LlBs=
 golang.org/x/mod v0.12.0 h1:rmsUpXtvNzj340zd98LZ4KntptpfRHwpFOHG188oHXc=
 golang.org/x/mod v0.12.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
+golang.org/x/mod v0.17.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 h1:H2TDz8ibqkAF6YGhCdN3jS9O0/s90v0rJh3X/OLHEUk=
 golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
 gonum.org/v1/plot v0.10.1 h1:dnifSs43YJuNMDzB7v8wV64O4ABBHReuAVAoBxqBqS4=


### PR DESCRIPTION
This pr trims the len to 249 (when no merge point).
It also replaces all weird characters with underscores.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced topic name handling for MQTT to Kafka bridge, including character replacement and length restrictions.
  
- **Bug Fixes**
	- Updated metadata labels to reflect new versioning for the MQTT to Kafka historian component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->