### PR TITLE
ENG-2448 Stricter validation logic for incoming payloads

### DIFF
--- a/deployment/united-manufacturing-hub/templates/bridges/kafka-to-mqtt/historian/configmap.yaml
+++ b/deployment/united-manufacturing-hub/templates/bridges/kafka-to-mqtt/historian/configmap.yaml
@@ -26,9 +26,9 @@ metadata:
     # This does not change over time
     data-flow-component-uuid: fcdec4de-a930-4229-befc-d318c9964a2e
     # This is the random UUID of the version of the component
-    data-flow-component-version-uuid: 148530e8-c79a-4f45-9c76-9cc9d859b1c8
+    data-flow-component-version-uuid: 5b12b552-2b76-43dd-91f7-50d746e654bf
     # Timestamp of last change to the component in unix milliseconds since epoch
-    data-flow-version: '1730983044602'
+    data-flow-version: '1738848631531'
     # Generic label to indicate that this is a data flow component
     is-data-flow-component: 'true'
     # Required for mgmtcompanion to manage the component
@@ -116,7 +116,7 @@ data:
             type: counter_by
             name: invalid_json
             value: ${! meta("invalid_json_count") }
-            
+
         - label: delete_if_invalid_json
           bloblang: |
             let invalid_json = meta("invalid_json_count")

--- a/deployment/united-manufacturing-hub/templates/bridges/kafka-to-mqtt/historian/configmap.yaml
+++ b/deployment/united-manufacturing-hub/templates/bridges/kafka-to-mqtt/historian/configmap.yaml
@@ -116,6 +116,7 @@ data:
             type: counter_by
             name: invalid_json
             value: ${! meta("invalid_json_count") }
+            
         - label: delete_if_invalid_json
           bloblang: |
             let invalid_json = meta("invalid_json_count")

--- a/deployment/united-manufacturing-hub/templates/bridges/kafka-to-mqtt/historian/deployment.yaml
+++ b/deployment/united-manufacturing-hub/templates/bridges/kafka-to-mqtt/historian/deployment.yaml
@@ -26,9 +26,9 @@ metadata:
     # This does not change over time
     data-flow-component-uuid: fcdec4de-a930-4229-befc-d318c9964a2e
     # This is the random UUID of the version of the component
-    data-flow-component-version-uuid: 148530e8-c79a-4f45-9c76-9cc9d859b1c8
+    data-flow-component-version-uuid: 5b12b552-2b76-43dd-91f7-50d746e654bf
     # Timestamp of last change to the component in unix milliseconds since epoch
-    data-flow-version: '1730983044602'
+    data-flow-version: '1738848631531'
     # Generic label to indicate that this is a data flow component
     is-data-flow-component: 'true'
     # Required for mgmtcompanion to manage the component
@@ -48,9 +48,9 @@ spec:
         # This does not change over time
         data-flow-component-uuid: fcdec4de-a930-4229-befc-d318c9964a2e
         # This is the random UUID of the version of the component
-        data-flow-component-version-uuid: 148530e8-c79a-4f45-9c76-9cc9d859b1c8
+        data-flow-component-version-uuid: 5b12b552-2b76-43dd-91f7-50d746e654bf
         # Timestamp of last change to the component in unix milliseconds since epoch
-        data-flow-version: '1730983044602'
+        data-flow-version: '1738848631531'
         # Generic label to indicate that this is a data flow component
         is-data-flow-component: 'true'
         # Required for mgmtcompanion to manage the component

--- a/deployment/united-manufacturing-hub/templates/bridges/kafka_to_postgres/historian/configmap.yaml
+++ b/deployment/united-manufacturing-hub/templates/bridges/kafka_to_postgres/historian/configmap.yaml
@@ -28,7 +28,7 @@ metadata:
     # This is the random UUID of the version of the component
     data-flow-component-version-uuid: 0edc0bc1-7df2-4fb8-ad90-955ad1aacc04
     # Timestamp of last change to the component in unix milliseconds since epoch
-    data-flow-version: '1730983044602'
+    data-flow-version: '1738848631531'
     # Generic label to indicate that this is a data flow component
     is-data-flow-component: 'true'
     # Required for mgmtcompanion to manage the component

--- a/deployment/united-manufacturing-hub/templates/bridges/kafka_to_postgres/historian/deployment.yaml
+++ b/deployment/united-manufacturing-hub/templates/bridges/kafka_to_postgres/historian/deployment.yaml
@@ -28,7 +28,7 @@ metadata:
     # This is the random UUID of the version of the component
     data-flow-component-version-uuid: 0edc0bc1-7df2-4fb8-ad90-955ad1aacc04
     # Timestamp of last change to the component in unix milliseconds since epoch
-    data-flow-version: '1730983044602'
+    data-flow-version: '1738848631531'
     # Generic label to indicate that this is a data flow component
     is-data-flow-component: 'true'
     # Required for mgmtcompanion to manage the component
@@ -50,7 +50,7 @@ spec:
         # This is the random UUID of the version of the component
         data-flow-component-version-uuid: 0edc0bc1-7df2-4fb8-ad90-955ad1aacc04
         # Timestamp of last change to the component in unix milliseconds since epoch
-        data-flow-version: '1730983044602'
+        data-flow-version: '1738848631531'
         # Generic label to indicate that this is a data flow component
         is-data-flow-component: 'true'
         # Required for mgmtcompanion to manage the component

--- a/deployment/united-manufacturing-hub/templates/bridges/mqtt-to-kafka/historian/configmap.yaml
+++ b/deployment/united-manufacturing-hub/templates/bridges/mqtt-to-kafka/historian/configmap.yaml
@@ -26,9 +26,9 @@ metadata:
     # This does not change over time
     data-flow-component-uuid: 1db88f9f-789d-45fa-b095-cf579cc9074d
     # This is the random UUID of the version of the component
-    data-flow-component-version-uuid: 8c5ffaf0-356f-48bc-bcd5-645306e27b91
+    data-flow-component-version-uuid: 8c1f7abf-db4f-4ed7-990f-c2ca8c2ef5e6
     # Timestamp of last change to the component in unix milliseconds since epoch
-    data-flow-version: '1734512405848'
+    data-flow-version: '1738848631531'
     # Generic label to indicate that this is a data flow component
     is-data-flow-component: 'true'
     # Required for mgmtcompanion to manage the component

--- a/deployment/united-manufacturing-hub/templates/bridges/mqtt-to-kafka/historian/configmap.yaml
+++ b/deployment/united-manufacturing-hub/templates/bridges/mqtt-to-kafka/historian/configmap.yaml
@@ -132,20 +132,17 @@ data:
             }
             # Step 3
             let invalid_json = this.catch(true)
-            # Step 4
-            root = if $invalid_json == true {
-              {
-                "parsing_failure": "invalid-json",
-                "payload": content().encode("base64")
-              }
-            } else {
-              this
-            }
             # Step 4 (report metric if invalid)
             if $invalid_json == true {
               meta "invalid_json_count" = 1
             } else {
               meta "invalid_json_count" = 0
+            }
+            # Step 4
+            root = if $invalid_json == true {
+              deleted()
+            } else {
+              this
             }
 
         - label: increment_invalid_json_metric
@@ -180,7 +177,25 @@ data:
                   }
                 },
                 "minProperties": 2,
-                "additionalProperties": true
+                "additionalProperties": {
+                  "$ref": "#/definitions/non_array_value"
+                },
+                "definitions": {
+                  "non_array_value": {
+                    "oneOf": [
+                      { "type": "string" },
+                      { "type": "number" },
+                      { "type": "boolean" },
+                      { "type": "null" },
+                      {
+                        "type": "object",
+                        "additionalProperties": {
+                          "$ref": "#/definitions/non_array_value"
+                        }
+                      }
+                    ]
+                  }
+                }
               }
               """).catch(false)
             } else {
@@ -201,6 +216,15 @@ data:
             type: counter_by
             name: invalid_schema
             value: ${! meta("invalid_schema_count") }
+
+        - label: delete_if_invalid_schema
+          bloblang: |
+            let invalid_schema = meta("invalid_schema_count")
+            root = if $invalid_schema.string() == "0" {
+              root
+            } else {
+              deleted()
+            }
 
     output:
       broker:

--- a/deployment/united-manufacturing-hub/templates/bridges/mqtt-to-kafka/historian/deployment.yaml
+++ b/deployment/united-manufacturing-hub/templates/bridges/mqtt-to-kafka/historian/deployment.yaml
@@ -26,9 +26,9 @@ metadata:
     # This does not change over time
     data-flow-component-uuid: 1db88f9f-789d-45fa-b095-cf579cc9074d
     # This is the random UUID of the version of the component
-    data-flow-component-version-uuid: 8c5ffaf0-356f-48bc-bcd5-645306e27b91
+    data-flow-component-version-uuid: 8c1f7abf-db4f-4ed7-990f-c2ca8c2ef5e6
     # Timestamp of last change to the component in unix milliseconds since epoch
-    data-flow-version: '1734512405848'
+    data-flow-version: '1738848631531'
     # Generic label to indicate that this is a data flow component
     is-data-flow-component: 'true'
     # Required for mgmtcompanion to manage the component
@@ -48,9 +48,9 @@ spec:
         # This does not change over time
         data-flow-component-uuid: 1db88f9f-789d-45fa-b095-cf579cc9074d
         # This is the random UUID of the version of the component
-        data-flow-component-version-uuid: 8c5ffaf0-356f-48bc-bcd5-645306e27b91
+        data-flow-component-version-uuid: 8c1f7abf-db4f-4ed7-990f-c2ca8c2ef5e6
         # Timestamp of last change to the component in unix milliseconds since epoch
-        data-flow-version: '1734512405848'
+        data-flow-version: '1738848631531'
         # Generic label to indicate that this is a data flow component
         is-data-flow-component: 'true'
         # Required for mgmtcompanion to manage the component


### PR DESCRIPTION
Previously the bridge allowed some invalid payloads to pass like these:
```json
[1,2,3]

{
  "timestamp_ms": 1234567890,
  "value": [1, 2, 3], 
  "nested": {
    "also_value": [4, 5, 6]
  }
}
```

The new validation logic now prevents arrays recursivly, while allowing our previously allowed good values like:
```json
{
  "timestamp_ms": 1234567890,
  "value": 42,
  "nested": {
    "string": "hello",
    "number": 123,
    "boolean": true,
    "null_value": null,
    "deep_nested": {
      "also_ok": "value"
    }
  }
}
```


Simple test:
https://www.jsonschemavalidator.net/s/BQHUwvd8

Array:
https://www.jsonschemavalidator.net/s/judAChlm

Nested array:
https://www.jsonschemavalidator.net/s/Qo0MmqUb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced additional validation steps in message processing that automatically drop records failing JSON or schema checks, ensuring cleaner data streams.
  
- **Chores**
  - Updated internal versioning information across integration components to enhance overall consistency and system stability.

These improvements streamline data handling by filtering out invalid messages and reinforce the reliability of the integration bridges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->