### PR TITLE
ENG-2225: update iotedge/opc-plc to newest release + update runners

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -187,7 +187,7 @@ jobs:
       contents: read
       packages: write
     runs-on:
-      group: arc-runners
+      group: arc-runners-tests
     defaults:
       run:
         shell: bash

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -21,7 +21,7 @@ on:
       - main
       - staging
     tags:
-      - '*'
+      - "*"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -35,19 +35,27 @@ jobs:
       contents: read
     strategy:
       matrix:
-        component: [ 'factoryinsight', 'grafana-umh', 'hivemq-init', 'kafka-init','kafka-to-postgresql','kafka-to-postgresql-v2']
-        architecture: [ 'amd64', 'arm64' ]
+        component:
+          [
+            "factoryinsight",
+            "grafana-umh",
+            "hivemq-init",
+            "kafka-init",
+            "kafka-to-postgresql",
+            "kafka-to-postgresql-v2",
+          ]
+        architecture: ["amd64", "arm64"]
         exclude:
-          - component: 'factoryinsight'
-            architecture: 'arm64'
-          - component: 'kafka-init'
-            architecture: 'arm64'
-          - component: 'kafka-to-postgresql'
-            architecture: 'arm64'
-          - component: 'kafka-to-postgresql-v2'
-            architecture: 'arm64'
+          - component: "factoryinsight"
+            architecture: "arm64"
+          - component: "kafka-init"
+            architecture: "arm64"
+          - component: "kafka-to-postgresql"
+            architecture: "arm64"
+          - component: "kafka-to-postgresql-v2"
+            architecture: "arm64"
     runs-on:
-      group: ${{ matrix.architecture == 'arm64' && 'arc-runners-small' || 'arc-runners' }}
+      group: ${{ matrix.architecture == 'arm64' && 'arc-runners-small' || 'arc-runners-tests' }}
     env:
       PR_ID: ${{ github.event.pull_request.number }}
     outputs:
@@ -62,7 +70,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request && github.head_ref || github.ref_name }}
-          fetch-depth: '1'
+          fetch-depth: "1"
 
       - name: Check if Docker daemon is running
         id: check_docker
@@ -185,7 +193,15 @@ jobs:
         shell: bash
     strategy:
       matrix:
-        component: [ 'factoryinsight', 'grafana-umh', 'hivemq-init', 'kafka-init','kafka-to-postgresql','kafka-to-postgresql-v2']
+        component:
+          [
+            "factoryinsight",
+            "grafana-umh",
+            "hivemq-init",
+            "kafka-init",
+            "kafka-to-postgresql",
+            "kafka-to-postgresql-v2",
+          ]
     steps:
       - name: Login to GitHub Container registry
         uses: docker/login-action@v3

--- a/deployment/united-manufacturing-hub/templates/opcuasimulatorv2/deployment.yaml
+++ b/deployment/united-manufacturing-hub/templates/opcuasimulatorv2/deployment.yaml
@@ -42,7 +42,7 @@ spec:
             name: {{include "united-manufacturing-hub.fullname" .}}-opcsimv2-config
       containers:
         - name: {{include "united-manufacturing-hub.fullname" .}}-opcsimv2
-          image: management.umh.app/oci/iotedge/opc-plc:2.9.11
+          image: management.umh.app/oci/iotedge/opc-plc:2.12.29
           resources:
             requests:
               cpu: "50m"


### PR DESCRIPTION
- update to the latest release of iotedge/opc-plc
- tested on my instance

We will still need some fixes in benthos, since the image-upgrade works fine, but `benthos-umh`-subscriptions don't seem to work just as before the image-update. Only works reliable if you pick specific nodes and not subscribe to `i=84`

References:
- ENG-2506 -> seems to be solved by connecting via:
    - `securityPolicy: Basic256Sha256`
    - `securityMode: SignAndEncrypt`
    - `username: sysadmin`
    - `password: demo`
- ENG-1544 (rare error)
- ENG-2165

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Chores**
	- Upgraded the OPC simulator to a newer release, incorporating the latest performance improvements and bug fixes.
	- Improved formatting and readability of the Docker build workflow configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->