### PR TITLE
More timeouts for integration tests

### DIFF
--- a/.github/workflows/build-umh-core.yml
+++ b/.github/workflows/build-umh-core.yml
@@ -85,6 +85,20 @@ jobs:
           PLATFORM_SHORT="${PLATFORM_SHORT//\//-}"
           echo "PLATFORM_SHORT=${PLATFORM_SHORT}" >> $GITHUB_OUTPUT
 
+      - name: Determine app version
+        id: set_version
+        run: |
+          # Check if this is a tag build
+          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+            # If it's a tag, use the tag name as version
+            VERSION="${{ github.ref_name }}"
+          else
+            # For branch builds, use a dev version with the SHA
+            VERSION="0.0.0-dev-${{ github.sha }}"
+          fi
+          echo "APP_VERSION=${VERSION}" >> $GITHUB_OUTPUT
+          echo "Setting APP_VERSION to ${VERSION}"
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
@@ -126,6 +140,8 @@ jobs:
           platforms: linux/${{ matrix.architecture }}
           tags: ${{ steps.prepare_tags.outputs.NEW_TAGS }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            APP_VERSION=${{ steps.set_version.outputs.APP_VERSION }}
           provenance: false
 
       - name: Set Output Tags

--- a/.github/workflows/test-umh-core.yml
+++ b/.github/workflows/test-umh-core.yml
@@ -67,4 +67,6 @@ jobs:
         run: make install
 
       - name: Run integration tests
+        env:
+          CI: true
         run: make integration-test

--- a/umh-core/Dockerfile
+++ b/umh-core/Dockerfile
@@ -16,6 +16,9 @@ FROM golang:1.24-alpine as build
 
 WORKDIR /go/src/github.com/united-manufacturing-hub/united-manufacturing-hub
 
+# Set app version with a default value - can be overridden at build time
+ARG APP_VERSION=0.0.0-dev
+
 # Install build dependencies
 RUN apk add --no-cache \
     gcc \
@@ -29,7 +32,7 @@ RUN go mod download
 # Copy and build umh-core
 COPY . .
 RUN CGO_ENABLED=0 go build \
-    -ldflags "-s -w" \
+    -ldflags "-s -w -X main.appVersion=${APP_VERSION}" \
     -o /go/bin/umh-core \
     cmd/main.go
 

--- a/umh-core/Makefile
+++ b/umh-core/Makefile
@@ -34,6 +34,9 @@ TAG = latest
 GINKGO_VERSION = v2.23.3
 NILWAY_VERSION = latest
 
+# Determine version based on git
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "0.0.0-dev")
+
 install:
 	go install go.uber.org/nilaway/cmd/nilaway@$(NILWAY_VERSION)
 	go install github.com/onsi/ginkgo/v2/ginkgo@$(GINKGO_VERSION)
@@ -41,6 +44,7 @@ install:
 build:
 	docker build --platform=$$(if [ "$$(uname -m)" = "arm64" ]; then echo "linux/arm64"; else echo "linux/amd64"; fi) \
 		--build-arg TARGETARCH=$$(if [ "$$(uname -m)" = "arm64" ]; then echo "arm64"; else echo "amd64"; fi) \
+		--build-arg APP_VERSION=$(VERSION) \
 		-t $(IMAGE_NAME):$(TAG) -f Dockerfile .
 	
 clean:

--- a/umh-core/Makefile
+++ b/umh-core/Makefile
@@ -48,6 +48,11 @@ clean:
 	docker rm $(IMAGE_NAME) || true
 	docker rmi $(IMAGE_NAME):$(TAG) || true
 
+# Clean up Docker build cache and unused objects for CI environments
+cleanup-ci: clean
+	docker builder prune -f
+	docker system prune -f --volumes
+
 vet:
 	go vet -tags=test ./...
 

--- a/umh-core/cmd/main.go
+++ b/umh-core/cmd/main.go
@@ -33,7 +33,7 @@ import (
 	"go.uber.org/zap"
 )
 
-var appVersion string // set by the build system
+var appVersion = "0.0.0-dev" // set by the build system
 
 func main() {
 	// Initialize the global logger first thing

--- a/umh-core/integration/docker_test_helpers.go
+++ b/umh-core/integration/docker_test_helpers.go
@@ -373,6 +373,9 @@ func StopContainer() {
 	// Clean up config file
 	cleanupConfigFile()
 
+}
+
+func CleanupDockerBuildCache() {
 	// If running in CI environment, also clean up Docker build cache
 	if os.Getenv("CI") == "true" {
 		fmt.Println("Running in CI environment, cleaning up Docker build cache...")

--- a/umh-core/integration/docker_test_helpers.go
+++ b/umh-core/integration/docker_test_helpers.go
@@ -372,6 +372,14 @@ func StopContainer() {
 
 	// Clean up config file
 	cleanupConfigFile()
+
+	// If running in CI environment, also clean up Docker build cache
+	if os.Getenv("CI") == "true" {
+		fmt.Println("Running in CI environment, cleaning up Docker build cache...")
+		runDockerCommand("builder", "prune", "-f")
+		// Only prune non-running containers/images to avoid conflicts with other tests
+		runDockerCommand("system", "prune", "-f")
+	}
 }
 
 // printContainerDebugInfo prints detailed information about the container

--- a/umh-core/integration/integration_test.go
+++ b/umh-core/integration/integration_test.go
@@ -56,6 +56,7 @@ var _ = Describe("UMH Container Integration", Ordered, Label("integration"), fun
 	AfterAll(func() {
 		// Always stop container after the entire suite
 		StopContainer()
+		CleanupDockerBuildCache()
 	})
 
 	Context("with an empty config", func() {

--- a/umh-core/pkg/constants/benthos.go
+++ b/umh-core/pkg/constants/benthos.go
@@ -27,3 +27,10 @@ const (
 const (
 	BenthosUpdateObservedStateTimeout = time.Millisecond * 5
 )
+
+const (
+	// BenthosExpectedMaxP95ExecutionTimePerInstance means that an instance will not reconcile if not 30ms are left
+	// Note: in the intergation test, we defined an alerting threshold of 80% of the max ticker time, which is 100ms
+	// So by setting this to 30 ms, we can ensure that an instance will never start if it triggers the alerting threshold
+	BenthosExpectedMaxP95ExecutionTimePerInstance = time.Millisecond * 30
+)

--- a/umh-core/pkg/constants/s6basedir.go
+++ b/umh-core/pkg/constants/s6basedir.go
@@ -25,3 +25,10 @@ const (
 const (
 	S6UpdateObservedStateTimeout = time.Millisecond * 3
 )
+
+const (
+	// S6ExpectedMaxP95ExecutionTimePerInstance means that an instance will not reconcile if not 30ms are left
+	// Note: in the intergation test, we defined an alerting threshold of 80% of the max ticker time, which is 100ms
+	// So by setting this to 30 ms, we can ensure that an instance will never start if it triggers the alerting threshold
+	S6ExpectedMaxP95ExecutionTimePerInstance = time.Millisecond * 30
+)

--- a/umh-core/pkg/fsm/benthos/machine.go
+++ b/umh-core/pkg/fsm/benthos/machine.go
@@ -17,11 +17,13 @@ package benthos
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/looplab/fsm"
 
 	internal_fsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/internal/fsm"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/logger"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/metrics"
 	benthos_service "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/benthos"
@@ -154,8 +156,7 @@ func (b *BenthosInstance) PrintState() {
 	b.baseFSMInstance.GetLogger().Debugf("Observed state: %+v", b.ObservedState)
 }
 
-// TODO: Add Benthos-specific health check methods
-// Examples:
-// - IsProcessingData() - Checks if Benthos is actively processing data
-// - HasWarnings() - Checks if Benthos is reporting warnings
-// - HasErrors() - Checks if Benthos is reporting errors
+// GetExpectedMaxP95ExecutionTimePerInstance returns the expected max p95 execution time of the instance
+func (b *BenthosInstance) GetExpectedMaxP95ExecutionTimePerInstance() time.Duration {
+	return constants.BenthosExpectedMaxP95ExecutionTimePerInstance
+}

--- a/umh-core/pkg/fsm/benthos/manager.go
+++ b/umh-core/pkg/fsm/benthos/manager.go
@@ -86,8 +86,15 @@ func NewBenthosManager(name string) *BenthosManager {
 			benthosInstance.config = cfg.BenthosServiceConfig
 			return nil
 		},
+		// Get expected max p95 execution time per instance
+		func(instance public_fsm.FSMInstance) (time.Duration, error) {
+			benthosInstance, ok := instance.(*BenthosInstance)
+			if !ok {
+				return 0, fmt.Errorf("instance is not a BenthosInstance")
+			}
+			return benthosInstance.GetExpectedMaxP95ExecutionTimePerInstance(), nil
+		},
 	)
-
 	metrics.InitErrorCounter(metrics.ComponentBenthosManager, name)
 
 	// Initialize port manager with default range (9000-9999)

--- a/umh-core/pkg/fsm/benthos/manager_mock.go
+++ b/umh-core/pkg/fsm/benthos/manager_mock.go
@@ -16,8 +16,10 @@ package benthos
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants"
 	public_fsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/logger"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/metrics"
@@ -122,6 +124,10 @@ func NewBenthosManagerWithMockedServices(name string) (*BenthosManager, *benthos
 			}
 
 			return nil
+		},
+		// Get expected max p95 execution time per instance - same as original
+		func(instance public_fsm.FSMInstance) (time.Duration, error) {
+			return constants.BenthosExpectedMaxP95ExecutionTimePerInstance, nil
 		},
 	)
 

--- a/umh-core/pkg/fsm/s6/manager.go
+++ b/umh-core/pkg/fsm/s6/manager.go
@@ -16,6 +16,7 @@ package s6
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants"
@@ -74,6 +75,14 @@ func NewS6Manager(name string) *S6Manager {
 			}
 			s6Instance.config.S6ServiceConfig = cfg.S6ServiceConfig
 			return nil
+		},
+		// Get expected max p95 execution time per instance
+		func(instance public_fsm.FSMInstance) (time.Duration, error) {
+			s6Instance, ok := instance.(*S6Instance)
+			if !ok {
+				return 0, fmt.Errorf("instance is not an S6Instance")
+			}
+			return s6Instance.GetExpectedMaxP95ExecutionTimePerInstance(), nil
 		},
 	)
 

--- a/umh-core/pkg/fsm/s6/manager_mock.go
+++ b/umh-core/pkg/fsm/s6/manager_mock.go
@@ -16,8 +16,10 @@ package s6
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants"
 	public_fsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/logger"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/metrics"
@@ -107,6 +109,10 @@ func NewS6ManagerWithMockedServices(name string) *S6Manager {
 			}
 
 			return nil
+		},
+		// Get expected max p95 execution time per instance - same as original
+		func(instance public_fsm.FSMInstance) (time.Duration, error) {
+			return constants.S6ExpectedMaxP95ExecutionTimePerInstance, nil
 		},
 	)
 

--- a/umh-core/pkg/fsm/s6/models.go
+++ b/umh-core/pkg/fsm/s6/models.go
@@ -15,9 +15,12 @@
 package s6
 
 import (
+	"time"
+
 	internalfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/internal/fsm"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/s6serviceconfig"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants"
 	publicfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
 	s6svc "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/s6"
 )
@@ -138,4 +141,9 @@ func (s *S6Instance) SetService(service s6svc.Service) {
 // This is a testing-only utility to access the private field
 func (s *S6Instance) GetConfig() config.S6FSMConfig {
 	return s.config
+}
+
+// GetExpectedMaxP95ExecutionTimePerInstance returns the expected max p95 execution time of the instance
+func (s *S6Instance) GetExpectedMaxP95ExecutionTimePerInstance() time.Duration {
+	return constants.S6ExpectedMaxP95ExecutionTimePerInstance
 }

--- a/umh-core/pkg/sentry/SENTRY_TEST_README.md
+++ b/umh-core/pkg/sentry/SENTRY_TEST_README.md
@@ -1,0 +1,38 @@
+# Sentry Test
+
+This directory contains a test to verify Sentry integration and troubleshoot why reports may not be showing up in Sentry.
+
+## Running the Test
+
+To run the test:
+
+```bash
+cd umh-core
+go test -v -ginkgo.focus "Manually sends a test message to Sentry" ./pkg/sentry
+```
+
+## What the Test Does
+
+The test:
+
+1. Initializes Sentry with a test version ("0.0.0-test")
+2. Sends several test messages to Sentry with a timestamp for identification:
+   - A warning message via `ReportIssue`
+   - An error message via `ReportIssue`
+   - A formatted warning message via `ReportIssuef`
+3. Waits 5 seconds for messages to be sent to Sentry
+4. Outputs information about what messages to look for in the Sentry dashboard
+
+## Troubleshooting
+
+If messages don't appear in Sentry, check:
+
+1. Network connectivity to Sentry servers
+2. DSN configuration in `sentry.go`
+3. Authentication issues
+4. Rate limiting or filtering in Sentry
+5. Firewall or proxy settings
+
+## Modifying the Test
+
+You can modify the test in `sentry_test.go` to try different types of messages or error scenarios. 

--- a/umh-core/pkg/sentry/sentry.go
+++ b/umh-core/pkg/sentry/sentry.go
@@ -15,9 +15,6 @@
 package sentry
 
 import (
-	"os"
-	"strconv"
-
 	"github.com/Masterminds/semver/v3"
 	"github.com/getsentry/sentry-go"
 	"go.uber.org/zap"
@@ -30,7 +27,6 @@ func InitSentry(appVersion string) {
 	}
 
 	environment := "development"
-	sampleRate := 0.3
 
 	version, err := semver.NewVersion(appVersion)
 	if err != nil {
@@ -38,33 +34,15 @@ func InitSentry(appVersion string) {
 	} else {
 		if version.Prerelease() == "" {
 			environment = "production"
-			sampleRate = 0.1
-		}
-	}
-
-	if rate := os.Getenv("SENTRY_SAMPLE_RATE"); rate != "" {
-		if parsedRate, err := strconv.ParseFloat(rate, 64); err == nil {
-			sampleRate = parsedRate
 		}
 	}
 
 	err = sentry.Init(sentry.ClientOptions{
-		Dsn:              "https://abc@staging.management.umh.app/sentry",
-		Environment:      environment,
-		Release:          "umhcore@" + appVersion,
-		EnableTracing:    true,
-		TracesSampleRate: sampleRate,
-		TracesSampler: func(ctx sentry.SamplingContext) float64 {
-			// If this transaction has a parent, we should respect the parent's sampling decision
-			if ctx.Parent != nil && ctx.Parent.Sampled != sentry.SampledUndefined {
-				if ctx.Parent.Sampled == sentry.SampledTrue {
-					return 1.0
-				}
-				return 0.0
-			}
-			// Otherwise, use our configured sample rate
-			return sampleRate
-		},
+		// management.umh.app is not working anymore, so we use the direct DSN
+		Dsn:           "https://1e1f51c30e576ff39d2445e76dc89da7@o4507265932394496.ingest.de.sentry.io/4509039283798097",
+		Environment:   environment,
+		Release:       "umhcore@" + appVersion,
+		EnableTracing: false, // no need for tracing, it doesnt work anyway
 	})
 	if err != nil {
 		zap.S().Error("Failed to initialize Sentry: %s", err)

--- a/umh-core/pkg/sentry/sentry_test.go
+++ b/umh-core/pkg/sentry/sentry_test.go
@@ -1,0 +1,75 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sentry_test
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/sentry"
+)
+
+var _ = Describe("Sentry Integration", func() {
+	var logger *zap.SugaredLogger
+
+	BeforeEach(func() {
+		// Create a test logger
+		testLogger := zaptest.NewLogger(GinkgoT())
+		logger = testLogger.Sugar()
+	})
+
+	// This test is focused (F) so it can be run manually
+	// Use: go test -v -ginkgo.focus "FManually sends a test message to Sentry" ./pkg/sentry
+	It("Manually sends a test message to Sentry", func() {
+		Skip("Skipping Sentry test")
+		// Initialize Sentry with a test version
+		sentry.InitSentry("0.0.0-test")
+
+		// Generate a unique test message with timestamp
+		testMessage := fmt.Sprintf("Sentry test message at %s", time.Now().Format(time.RFC3339))
+		testError := errors.New(testMessage)
+
+		By("Sending a warning via ReportIssue")
+		sentry.ReportIssue(testError, sentry.IssueTypeWarning, logger)
+
+		By("Sending an error via ReportIssue")
+		sentry.ReportIssue(testError, sentry.IssueTypeError, logger)
+
+		By("Sending a formatted message via ReportIssuef")
+		sentry.ReportIssuef(sentry.IssueTypeWarning, logger, "Formatted test message: %s", testMessage)
+
+		// Flush to ensure messages are sent before test completes
+		// Sleep to allow Sentry to process the messages
+		time.Sleep(5 * time.Second)
+
+		// This test doesn't actually assert anything as we're just checking
+		// if messages appear in the Sentry dashboard
+		Expect(true).To(BeTrue(), "Test completed - check Sentry dashboard for messages")
+
+		// Print instructions for the user
+		fmt.Println("\n==================================================")
+		fmt.Println("Check your Sentry dashboard for these test messages:")
+		fmt.Println("- Warning issue:", testError.Error())
+		fmt.Println("- Error issue:", testError.Error())
+		fmt.Println("- Formatted warning:", "Formatted test message: "+testMessage)
+		fmt.Println("==================================================")
+	})
+})

--- a/umh-core/pkg/sentry/sentry_test_suite_test.go
+++ b/umh-core/pkg/sentry/sentry_test_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sentry_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestSentry(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Sentry Suite")
+}

--- a/umh-core/test/fsm/benthos/manager_test.go
+++ b/umh-core/test/fsm/benthos/manager_test.go
@@ -20,6 +20,7 @@ package benthos_test
 import (
 	"context"
 	"fmt"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -41,10 +42,15 @@ var _ = Describe("BenthosManager", func() {
 		mockService *benthossvc.MockBenthosService
 		ctx         context.Context
 		tick        uint64
+		cancel      context.CancelFunc
 	)
 
+	AfterEach(func() {
+		cancel()
+	})
+
 	BeforeEach(func() {
-		ctx = context.Background()
+		ctx, cancel = context.WithTimeout(context.Background(), 10*time.Second) // we need to have a deadline as the reconcile logic in the base fsm manager requires it
 		tick = 0
 
 		// Create a new BenthosManager with the mock service

--- a/umh-core/test/fsm/s6/manager_test.go
+++ b/umh-core/test/fsm/s6/manager_test.go
@@ -20,6 +20,7 @@ package s6_test
 import (
 	"context"
 	"fmt"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -37,12 +38,18 @@ var _ = Describe("S6Manager", func() {
 		manager *s6fsm.S6Manager
 		ctx     context.Context
 		tick    uint64
+		cancel  context.CancelFunc
 	)
 
+	AfterEach(func() {
+		cancel()
+	})
+
 	BeforeEach(func() {
-		ctx = context.Background()
+		ctx, cancel = context.WithTimeout(context.Background(), 10*time.Second) // we need to have a deadline as the reconcile logic in the base fsm manager requires it
+		tick = 0
+
 		manager = s6fsm.NewS6ManagerWithMockedServices("")
-		tick = uint64(0)
 	})
 
 	Context("Initialization", func() {


### PR DESCRIPTION
based on https://github.com/united-manufacturing-hub/united-manufacturing-hub/pull/1878

includes a sentry fix and a logic that doesn't make a manager reconcile an instance if the expected p95Time does not fit anymore into the remaining tick time

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the system’s integration process with improved cleanup routines and performance metric checks to ensure smooth and reliable operations.
  - Added environment awareness for integration tests and a dedicated cleanup process for CI environments.
  - Introduced versioning for Docker images and application binaries to reflect the current build version.

- **Documentation**
  - Introduced a new Sentry integration guide outlining testing steps and troubleshooting tips for verifying message reporting.

- **Tests**
  - Upgraded test suites with refined timeout and resource management to bolster overall system stability and accuracy during execution.
  - Added tests for Sentry integration to verify message reporting functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->