### PR TITLE
Eng 2764 move internal configuration to internal

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -43,7 +43,7 @@
     // Use 'forwardPorts' to make a list of ports inside the container available locally.
     // "forwardPorts": [],
     // Use 'postCreateCommand' to run commands after the container is created.
-    "postCreateCommand": "go install github.com/onsi/ginkgo/v2/ginkgo@v2.23.3",
+    "postCreateCommand": "make install",
     // Set `remoteUser` to `root` to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
     "remoteUser": "vscode",
     "containerUser": "vscode",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,8 +21,7 @@
     "runArgs": [
         "--cap-add=SYS_PTRACE",
         "--security-opt",
-        "seccomp=unconfined",
-        "--userns=keep-id"
+        "seccomp=unconfined"
     ],
     // Configure tool-specific properties.
     "customizations": {

--- a/umh-core/examples/example-config-100.yaml
+++ b/umh-core/examples/example-config-100.yaml
@@ -15,1404 +15,1405 @@
 agent:
   metricsPort: 8080
 
-services:
-  - desiredState: running
-    name: hello-world-1
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-1/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"1\"\n   \
-          \ interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-2
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-2/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"2\"\n   \
-          \ interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-3
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-3/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"3\"\n   \
-          \ interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-4
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-4/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"4\"\n   \
-          \ interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-5
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-5/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"5\"\n   \
-          \ interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-6
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-6/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"6\"\n   \
-          \ interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-7
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-7/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"7\"\n   \
-          \ interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-8
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-8/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"8\"\n   \
-          \ interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-9
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-9/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"9\"\n   \
-          \ interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-10
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-10/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"10\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-11
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-11/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"11\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-12
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-12/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"12\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-13
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-13/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"13\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-14
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-14/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"14\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-15
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-15/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"15\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-16
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-16/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"16\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-17
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-17/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"17\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-18
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-18/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"18\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-19
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-19/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"19\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-20
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-20/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"20\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-21
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-21/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"21\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-22
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-22/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"22\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-23
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-23/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"23\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-24
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-24/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"24\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-25
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-25/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"25\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-26
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-26/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"26\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-27
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-27/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"27\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-28
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-28/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"28\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-29
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-29/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"29\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-30
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-30/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"30\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-31
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-31/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"31\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-32
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-32/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"32\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-33
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-33/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"33\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-34
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-34/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"34\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-35
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-35/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"35\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-36
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-36/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"36\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-37
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-37/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"37\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-38
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-38/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"38\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-39
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-39/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"39\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-40
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-40/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"40\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-41
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-41/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"41\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-42
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-42/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"42\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-43
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-43/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"43\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-44
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-44/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"44\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-45
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-45/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"45\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-46
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-46/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"46\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-47
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-47/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"47\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-48
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-48/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"48\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-49
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-49/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"49\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-50
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-50/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"50\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-51
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-51/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"51\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-52
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-52/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"52\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-53
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-53/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"53\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-54
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-54/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"54\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-55
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-55/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"55\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-56
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-56/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"56\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-57
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-57/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"57\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-58
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-58/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"58\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-59
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-59/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"59\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-60
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-60/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"60\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-61
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-61/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"61\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-62
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-62/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"62\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-63
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-63/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"63\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-64
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-64/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"64\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-65
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-65/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"65\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-66
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-66/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"66\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-67
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-67/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"67\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-68
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-68/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"68\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-69
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-69/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"69\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-70
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-70/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"70\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-71
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-71/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"71\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-72
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-72/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"72\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-73
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-73/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"73\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-74
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-74/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"74\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-75
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-75/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"75\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-76
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-76/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"76\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-77
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-77/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"77\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-78
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-78/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"78\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-79
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-79/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"79\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-80
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-80/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"80\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-81
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-81/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"81\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-82
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-82/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"82\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-83
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-83/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"83\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-84
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-84/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"84\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-85
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-85/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"85\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-86
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-86/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"86\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-87
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-87/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"87\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-88
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-88/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"88\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-89
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-89/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"89\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-90
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-90/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"90\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-91
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-91/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"91\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-92
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-92/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"92\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-93
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-93/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"93\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-94
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-94/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"94\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-95
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-95/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"95\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-96
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-96/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"96\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-97
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-97/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"97\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-98
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-98/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"98\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-99
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-99/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"99\"\n  \
-          \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
-  - desiredState: running
-    name: hello-world-100
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world-100/config/hello-world.yaml
-      configFiles:
-        hello-world.yaml:
-          "---\ninput:\n  generate:\n    mapping: root = \"100\"\n \
-          \   interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
-          \ messages\noutput:\n  stdout: {}\n"
-      env:
-        LOG_LEVEL: DEBUG
+internal:
+  services:
+    - desiredState: running
+      name: hello-world-1
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-1/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"1\"\n   \
+            \ interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-2
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-2/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"2\"\n   \
+            \ interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-3
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-3/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"3\"\n   \
+            \ interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-4
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-4/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"4\"\n   \
+            \ interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-5
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-5/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"5\"\n   \
+            \ interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-6
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-6/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"6\"\n   \
+            \ interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-7
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-7/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"7\"\n   \
+            \ interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-8
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-8/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"8\"\n   \
+            \ interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-9
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-9/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"9\"\n   \
+            \ interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-10
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-10/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"10\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-11
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-11/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"11\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-12
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-12/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"12\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-13
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-13/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"13\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-14
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-14/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"14\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-15
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-15/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"15\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-16
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-16/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"16\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-17
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-17/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"17\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-18
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-18/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"18\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-19
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-19/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"19\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-20
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-20/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"20\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-21
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-21/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"21\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-22
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-22/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"22\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-23
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-23/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"23\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-24
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-24/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"24\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-25
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-25/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"25\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-26
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-26/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"26\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-27
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-27/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"27\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-28
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-28/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"28\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-29
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-29/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"29\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-30
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-30/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"30\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-31
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-31/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"31\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-32
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-32/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"32\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-33
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-33/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"33\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-34
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-34/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"34\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-35
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-35/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"35\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-36
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-36/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"36\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-37
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-37/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"37\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-38
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-38/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"38\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-39
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-39/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"39\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-40
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-40/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"40\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-41
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-41/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"41\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-42
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-42/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"42\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-43
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-43/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"43\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-44
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-44/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"44\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-45
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-45/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"45\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-46
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-46/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"46\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-47
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-47/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"47\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-48
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-48/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"48\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-49
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-49/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"49\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-50
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-50/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"50\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-51
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-51/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"51\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-52
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-52/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"52\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-53
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-53/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"53\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-54
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-54/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"54\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-55
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-55/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"55\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-56
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-56/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"56\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-57
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-57/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"57\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-58
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-58/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"58\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-59
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-59/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"59\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-60
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-60/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"60\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-61
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-61/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"61\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-62
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-62/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"62\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-63
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-63/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"63\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-64
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-64/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"64\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-65
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-65/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"65\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-66
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-66/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"66\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-67
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-67/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"67\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-68
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-68/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"68\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-69
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-69/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"69\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-70
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-70/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"70\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-71
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-71/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"71\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-72
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-72/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"72\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-73
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-73/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"73\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-74
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-74/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"74\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-75
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-75/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"75\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-76
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-76/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"76\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-77
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-77/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"77\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-78
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-78/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"78\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-79
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-79/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"79\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-80
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-80/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"80\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-81
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-81/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"81\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-82
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-82/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"82\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-83
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-83/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"83\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-84
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-84/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"84\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-85
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-85/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"85\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-86
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-86/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"86\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-87
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-87/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"87\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-88
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-88/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"88\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-89
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-89/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"89\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-90
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-90/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"90\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-91
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-91/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"91\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-92
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-92/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"92\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-93
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-93/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"93\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-94
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-94/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"94\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-95
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-95/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"95\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-96
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-96/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"96\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-97
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-97/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"97\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-98
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-98/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"98\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-99
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-99/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"99\"\n  \
+            \  interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG
+    - desiredState: running
+      name: hello-world-100
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world-100/config/hello-world.yaml
+        configFiles:
+          hello-world.yaml:
+            "---\ninput:\n  generate:\n    mapping: root = \"100\"\n \
+            \   interval: 2s # Output every 2 seconds\n    count: 0 # Set to 0 for unlimited\
+            \ messages\noutput:\n  stdout: {}\n"
+        env:
+          LOG_LEVEL: DEBUG

--- a/umh-core/examples/example-config-benthos.yaml
+++ b/umh-core/examples/example-config-benthos.yaml
@@ -15,24 +15,25 @@
 agent:
   metricsPort: 8080
 
-benthos:
-  - name: hello-world
-    desiredState: active
-    benthosServiceConfig:
-      input:
-        generate:
-          mapping: root = "hello world from Benthos!"
-          interval: 1s # Output every 2 seconds
-          count: 0 # Set to 0 for unlimited messages
-      output:
-        stdout: {}
-  - name: hello-world-2
-    desiredState: active
-    benthosServiceConfig:
-      input:
-        generate:
-          mapping: root = "hello world from Benthos 2!"
-          interval: 1s # Output every 2 seconds
-          count: 0 # Set to 0 for unlimited messages
-      output:
-        stdout: {}
+internal:
+  benthos:
+    - name: hello-world
+      desiredState: active
+      benthosServiceConfig:
+        input:
+          generate:
+            mapping: root = "hello world from Benthos!"
+            interval: 1s # Output every 2 seconds
+            count: 0 # Set to 0 for unlimited messages
+        output:
+          stdout: {}
+    - name: hello-world-2
+      desiredState: active
+      benthosServiceConfig:
+        input:
+          generate:
+            mapping: root = "hello world from Benthos 2!"
+            interval: 1s # Output every 2 seconds
+            count: 0 # Set to 0 for unlimited messages
+        output:
+          stdout: {}

--- a/umh-core/examples/example-config-broken.yaml
+++ b/umh-core/examples/example-config-broken.yaml
@@ -15,23 +15,24 @@
 agent:
   metricsPort: 8080
 
-services:
-  - name: hello-world
-    desiredState: running
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world/config/hello-world.yaml
-      env:
-        LOG_LEVEL: DEBUG
-      configFiles:
-        hello-world2.yaml: |
-          ---
-          input:
-            generate:
-              mapping: root = "hello world from Benthos!" 
-              interval: 2s # Output every 2 seconds
-              count: 0 # Set to 0 for unlimited messages
-          output:
-            stdout: {}
+internal:
+  services:
+    - name: hello-world
+      desiredState: running
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world/config/hello-world.yaml
+        env:
+          LOG_LEVEL: DEBUG
+        configFiles:
+          hello-world2.yaml: |
+            ---
+            input:
+              generate:
+                mapping: root = "hello world from Benthos!" 
+                interval: 2s # Output every 2 seconds
+                count: 0 # Set to 0 for unlimited messages
+            output:
+              stdout: {}

--- a/umh-core/examples/example-config-comm.yaml
+++ b/umh-core/examples/example-config-comm.yaml
@@ -18,14 +18,16 @@ agent:
     apiUrl: https://management.umh.app/api
     authToken: a7caf5d82dacb972c300baf72d76326a3168141975f9e31f077aa28beced1ab7
   releaseChannel: stable
-benthos:
-  - name: hello-world
-    desiredState: active
-    benthosServiceConfig:
-      input:
-        generate:
-          mapping: root = "hello world from Benthos!"
-          interval: 1s # Output every 2 seconds
-          count: 0 # Set to 0 for unlimited messages
-      output:
-        stdout: {}
+
+internal:
+  benthos:
+    - name: hello-world
+      desiredState: active
+      benthosServiceConfig:
+        input:
+          generate:
+            mapping: root = "hello world from Benthos!"
+            interval: 1s # Output every 2 seconds
+            count: 0 # Set to 0 for unlimited messages
+        output:
+          stdout: {}

--- a/umh-core/examples/example-config-empty.yaml
+++ b/umh-core/examples/example-config-empty.yaml
@@ -15,4 +15,5 @@
 agent:
   metricsPort: 8080
 
-services: []
+internal:
+  services: []

--- a/umh-core/examples/example-config.yaml
+++ b/umh-core/examples/example-config.yaml
@@ -15,23 +15,24 @@
 agent:
   metricsPort: 8080
 
-services:
-  - name: hello-world
-    desiredState: running
-    s6ServiceConfig:
-      command:
-        - /usr/local/bin/benthos
-        - -c
-        - /run/service/hello-world/config/hello-world.yaml
-      env:
-        LOG_LEVEL: DEBUG
-      configFiles:
-        hello-world.yaml: |
-          ---
-          input:
-            generate:
-              mapping: root = "hello world from Benthos!" 
-              interval: 2s # Output every 2 seconds
-              count: 0 # Set to 0 for unlimited messages
-          output:
-            stdout: {}
+internal:
+  services:
+    - name: hello-world
+      desiredState: running
+      s6ServiceConfig:
+        command:
+          - /usr/local/bin/benthos
+          - -c
+          - /run/service/hello-world/config/hello-world.yaml
+        env:
+          LOG_LEVEL: DEBUG
+        configFiles:
+          hello-world.yaml: |
+            ---
+            input:
+              generate:
+                mapping: root = "hello world from Benthos!" 
+                interval: 2s # Output every 2 seconds
+                count: 0 # Set to 0 for unlimited messages
+            output:
+              stdout: {}

--- a/umh-core/integration/benthos_builder.go
+++ b/umh-core/integration/benthos_builder.go
@@ -34,8 +34,10 @@ func NewBenthosBuilder() *BenthosBuilder {
 			Agent: config.AgentConfig{
 				MetricsPort: 8080,
 			},
-			Services: []config.S6FSMConfig{},
-			Benthos:  []config.BenthosConfig{},
+			Internal: config.InternalConfig{
+				Services: []config.S6FSMConfig{},
+				Benthos:  []config.BenthosConfig{},
+			},
 		},
 		activeBenthos: make(map[string]bool),
 	}
@@ -65,7 +67,7 @@ func (b *BenthosBuilder) AddGoldenBenthos() *BenthosBuilder {
 	}
 
 	// Add to configuration
-	b.full.Benthos = append(b.full.Benthos, benthosConfig)
+	b.full.Internal.Benthos = append(b.full.Internal.Benthos, benthosConfig)
 	b.activeBenthos["golden-benthos"] = true
 	return b
 }
@@ -95,7 +97,7 @@ func (b *BenthosBuilder) AddGeneratorBenthos(name string, interval string) *Bent
 	}
 
 	// Add to configuration
-	b.full.Benthos = append(b.full.Benthos, benthosConfig)
+	b.full.Internal.Benthos = append(b.full.Internal.Benthos, benthosConfig)
 	b.activeBenthos[name] = true
 	return b
 }
@@ -103,12 +105,12 @@ func (b *BenthosBuilder) AddGeneratorBenthos(name string, interval string) *Bent
 // UpdateGeneratorBenthos updates the interval of an existing generator Benthos service
 func (b *BenthosBuilder) UpdateGeneratorBenthos(name string, newInterval string) *BenthosBuilder {
 	// Find and update the service
-	for i, benthos := range b.full.Benthos {
+	for i, benthos := range b.full.Internal.Benthos {
 		if benthos.FSMInstanceConfig.Name == name {
 			// Create updated input config with new interval
 			if input, ok := benthos.BenthosServiceConfig.Input["generate"].(map[string]interface{}); ok {
 				input["interval"] = newInterval
-				b.full.Benthos[i].BenthosServiceConfig.Input["generate"] = input
+				b.full.Internal.Benthos[i].BenthosServiceConfig.Input["generate"] = input
 			}
 			break
 		}
@@ -118,9 +120,9 @@ func (b *BenthosBuilder) UpdateGeneratorBenthos(name string, newInterval string)
 
 // StartBenthos sets a Benthos service to active state
 func (b *BenthosBuilder) StartBenthos(name string) *BenthosBuilder {
-	for i, benthos := range b.full.Benthos {
+	for i, benthos := range b.full.Internal.Benthos {
 		if benthos.FSMInstanceConfig.Name == name {
-			b.full.Benthos[i].FSMInstanceConfig.DesiredFSMState = "active"
+			b.full.Internal.Benthos[i].FSMInstanceConfig.DesiredFSMState = "active"
 			b.activeBenthos[name] = true
 			break
 		}
@@ -130,9 +132,9 @@ func (b *BenthosBuilder) StartBenthos(name string) *BenthosBuilder {
 
 // StopBenthos sets a Benthos service to inactive state
 func (b *BenthosBuilder) StopBenthos(name string) *BenthosBuilder {
-	for i, benthos := range b.full.Benthos {
+	for i, benthos := range b.full.Internal.Benthos {
 		if benthos.FSMInstanceConfig.Name == name {
-			b.full.Benthos[i].FSMInstanceConfig.DesiredFSMState = "stopped"
+			b.full.Internal.Benthos[i].FSMInstanceConfig.DesiredFSMState = "stopped"
 			b.activeBenthos[name] = false
 			break
 		}

--- a/umh-core/integration/config_builder.go
+++ b/umh-core/integration/config_builder.go
@@ -31,8 +31,10 @@ func NewBuilder() *Builder {
 			Agent: config.AgentConfig{
 				MetricsPort: 8080, // Default port inside container
 			},
-			Services: []config.S6FSMConfig{},
-			Benthos:  []config.BenthosConfig{},
+			Internal: config.InternalConfig{
+				Services: []config.S6FSMConfig{},
+				Benthos:  []config.BenthosConfig{},
+			},
 		},
 	}
 }
@@ -44,7 +46,7 @@ func (b *Builder) SetMetricsPort(port int) *Builder {
 }
 
 func (b *Builder) AddGoldenService() *Builder {
-	b.full.Services = append(b.full.Services, config.S6FSMConfig{
+	b.full.Internal.Services = append(b.full.Internal.Services, config.S6FSMConfig{
 		FSMInstanceConfig: config.FSMInstanceConfig{
 			Name:            "golden-service",
 			DesiredFSMState: "running",
@@ -74,7 +76,7 @@ output:
 }
 
 func (b *Builder) AddService(s config.S6FSMConfig) *Builder {
-	b.full.Services = append(b.full.Services, s)
+	b.full.Internal.Services = append(b.full.Internal.Services, s)
 	return b
 }
 
@@ -84,7 +86,7 @@ func (b *Builder) BuildYAML() string {
 }
 
 func (b *Builder) AddSleepService(name string, duration string) *Builder {
-	b.full.Services = append(b.full.Services, config.S6FSMConfig{
+	b.full.Internal.Services = append(b.full.Internal.Services, config.S6FSMConfig{
 		FSMInstanceConfig: config.FSMInstanceConfig{
 			Name:            name,
 			DesiredFSMState: "running",
@@ -98,9 +100,9 @@ func (b *Builder) AddSleepService(name string, duration string) *Builder {
 
 // StopService stops a service by name
 func (b *Builder) StopService(name string) *Builder {
-	for i, s := range b.full.Services {
+	for i, s := range b.full.Internal.Services {
 		if s.FSMInstanceConfig.Name == name {
-			b.full.Services[i].FSMInstanceConfig.DesiredFSMState = "stopped"
+			b.full.Internal.Services[i].FSMInstanceConfig.DesiredFSMState = "stopped"
 			break
 		}
 	}
@@ -109,9 +111,9 @@ func (b *Builder) StopService(name string) *Builder {
 
 // StartService starts a service by name
 func (b *Builder) StartService(name string) *Builder {
-	for i, s := range b.full.Services {
+	for i, s := range b.full.Internal.Services {
 		if s.FSMInstanceConfig.Name == name {
-			b.full.Services[i].FSMInstanceConfig.DesiredFSMState = "running"
+			b.full.Internal.Services[i].FSMInstanceConfig.DesiredFSMState = "running"
 			break
 		}
 	}

--- a/umh-core/pkg/communicator/actions/edit_instance_test.go
+++ b/umh-core/pkg/communicator/actions/edit_instance_test.go
@@ -54,9 +54,11 @@ func NewMockConfigManager() *MockConfigManager {
 					1: "Old Site",
 				},
 			},
-			Services: []config.S6FSMConfig{},
-			Benthos:  []config.BenthosConfig{},
-			Nmap:     []config.NmapConfig{},
+			Internal: config.InternalConfig{
+				Services: []config.S6FSMConfig{},
+				Benthos:  []config.BenthosConfig{},
+				Nmap:     []config.NmapConfig{},
+			},
 		},
 	}
 }

--- a/umh-core/pkg/config/config.go
+++ b/umh-core/pkg/config/config.go
@@ -24,7 +24,11 @@ import (
 )
 
 type FullConfig struct {
-	Agent    AgentConfig     `yaml:"agent"`    // Agent config, requires restart to take effect
+	Agent    AgentConfig    `yaml:"agent"`    // Agent config, requires restart to take effect
+	Internal InternalConfig `yaml:"internal"` // Internal config, not to be used by the user, only to be used for testing internal components
+}
+
+type InternalConfig struct {
 	Services []S6FSMConfig   `yaml:"services"` // Services to manage, can be updated while running
 	Benthos  []BenthosConfig `yaml:"benthos"`  // Benthos services to manage, can be updated while running
 	Nmap     []NmapConfig    `yaml:"nmap"`     // Nmap services to manage, can be updated while running
@@ -97,21 +101,8 @@ func (c NmapServiceConfig) Equal(other NmapServiceConfig) bool {
 
 // Clone creates a deep copy of FullConfig
 func (c FullConfig) Clone() FullConfig {
-	clone := FullConfig{
-		Agent:    c.Agent,
-		Services: make([]S6FSMConfig, len(c.Services)),
-		Benthos:  make([]BenthosConfig, len(c.Benthos)),
-		Nmap:     make([]NmapConfig, len(c.Nmap)),
-	}
-	// deep copy the location map if it exists
-	if c.Agent.Location != nil {
-		clone.Agent.Location = make(map[int]string)
-		for k, v := range c.Agent.Location {
-			clone.Agent.Location[k] = v
-		}
-	}
-	deepcopy.Copy(&clone.Services, &c.Services)
-	deepcopy.Copy(&clone.Benthos, &c.Benthos)
-	deepcopy.Copy(&clone.Nmap, &c.Nmap)
+	var clone FullConfig
+	deepcopy.Copy(&clone.Agent, &c.Agent)
+	deepcopy.Copy(&clone.Internal, &c.Internal)
 	return clone
 }

--- a/umh-core/pkg/config/manager_test.go
+++ b/umh-core/pkg/config/manager_test.go
@@ -57,15 +57,17 @@ var _ = Describe("ConfigManager", func() {
 
 	Describe("GetConfig", func() {
 		var (
-			validYAML = `services:
-- name: service1
-  desiredState: running
-  s6ServiceConfig:
-    command: ["/bin/echo", "hello world"]
-    env:
-      KEY: value
-    configFiles:
-      file.txt: content
+			validYAML = `
+internal:
+  services:
+    - name: service1
+      desiredState: running
+      s6ServiceConfig:
+        command: ["/bin/echo", "hello world"]
+        env:
+          KEY: value
+        configFiles:
+          file.txt: content
 `
 			invalidYAML = `services: - invalid: yaml: content`
 		)

--- a/umh-core/pkg/config/manager_test.go
+++ b/umh-core/pkg/config/manager_test.go
@@ -92,12 +92,12 @@ var _ = Describe("ConfigManager", func() {
 				config, err := configManager.GetConfig(ctx, tick)
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(config.Services).To(HaveLen(1))
-				Expect(config.Services[0].Name).To(Equal("service1"))
-				Expect(config.Services[0].FSMInstanceConfig.DesiredFSMState).To(Equal("running"))
-				Expect(config.Services[0].S6ServiceConfig.Command).To(Equal([]string{"/bin/echo", "hello world"}))
-				Expect(config.Services[0].S6ServiceConfig.Env).To(HaveKeyWithValue("KEY", "value"))
-				Expect(config.Services[0].S6ServiceConfig.ConfigFiles).To(HaveKeyWithValue("file.txt", "content"))
+				Expect(config.Internal.Services).To(HaveLen(1))
+				Expect(config.Internal.Services[0].Name).To(Equal("service1"))
+				Expect(config.Internal.Services[0].FSMInstanceConfig.DesiredFSMState).To(Equal("running"))
+				Expect(config.Internal.Services[0].S6ServiceConfig.Command).To(Equal([]string{"/bin/echo", "hello world"}))
+				Expect(config.Internal.Services[0].S6ServiceConfig.Env).To(HaveKeyWithValue("KEY", "value"))
+				Expect(config.Internal.Services[0].S6ServiceConfig.ConfigFiles).To(HaveKeyWithValue("file.txt", "content"))
 			})
 		})
 
@@ -116,7 +116,7 @@ var _ = Describe("ConfigManager", func() {
 				config, err := configManager.GetConfig(ctx, tick)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("config file does not exist"))
-				Expect(config.Services).To(BeEmpty())
+				Expect(config.Internal.Services).To(BeEmpty())
 			})
 		})
 

--- a/umh-core/pkg/control/loop_test.go
+++ b/umh-core/pkg/control/loop_test.go
@@ -41,12 +41,12 @@ func generateDefectiveConfig() config.FullConfig {
 	defects := []func(config.FullConfig) config.FullConfig{
 		// Empty services
 		func(cfg config.FullConfig) config.FullConfig {
-			cfg.Services = []config.S6FSMConfig{}
+			cfg.Internal.Services = []config.S6FSMConfig{}
 			return cfg
 		},
 		// Service with empty name
 		func(cfg config.FullConfig) config.FullConfig {
-			cfg.Services = []config.S6FSMConfig{{
+			cfg.Internal.Services = []config.S6FSMConfig{{
 				FSMInstanceConfig: config.FSMInstanceConfig{
 					Name:            "",
 					DesiredFSMState: "running",
@@ -56,7 +56,7 @@ func generateDefectiveConfig() config.FullConfig {
 		},
 		// Service with invalid desired state
 		func(cfg config.FullConfig) config.FullConfig {
-			cfg.Services = []config.S6FSMConfig{{
+			cfg.Internal.Services = []config.S6FSMConfig{{
 				FSMInstanceConfig: config.FSMInstanceConfig{
 					Name:            "test-service",
 					DesiredFSMState: "invalid-state",
@@ -66,7 +66,7 @@ func generateDefectiveConfig() config.FullConfig {
 		},
 		// Multiple services with same name
 		func(cfg config.FullConfig) config.FullConfig {
-			cfg.Services = []config.S6FSMConfig{
+			cfg.Internal.Services = []config.S6FSMConfig{
 				{
 					FSMInstanceConfig: config.FSMInstanceConfig{
 						Name:            "duplicate-service",
@@ -136,11 +136,13 @@ var _ = Describe("ControlLoop", func() {
 	Describe("Reconcile", func() {
 		It("should fetch config and call manager's reconcile", func() {
 			expectedConfig := config.FullConfig{
-				Services: []config.S6FSMConfig{
-					{
-						FSMInstanceConfig: config.FSMInstanceConfig{
-							Name:            "test-service",
-							DesiredFSMState: "running",
+				Internal: config.InternalConfig{
+					Services: []config.S6FSMConfig{
+						{
+							FSMInstanceConfig: config.FSMInstanceConfig{
+								Name:            "test-service",
+								DesiredFSMState: "running",
+							},
 						},
 					},
 				},

--- a/umh-core/pkg/fsm/benthos/manager.go
+++ b/umh-core/pkg/fsm/benthos/manager.go
@@ -55,7 +55,7 @@ func NewBenthosManager(name string) *BenthosManager {
 		baseBenthosDir,
 		// Extract Benthos configs from full config
 		func(fullConfig config.FullConfig) ([]config.BenthosConfig, error) {
-			return fullConfig.Benthos, nil
+			return fullConfig.Internal.Benthos, nil
 		},
 		// Get name from Benthos config
 		func(cfg config.BenthosConfig) (string, error) {
@@ -180,7 +180,7 @@ func (m *BenthosManager) Reconcile(ctx context.Context, cfg config.FullConfig, t
 		metrics.ObserveReconcileTime(logger.ComponentBenthosManager, m.BaseFSMManager.GetManagerName(), duration)
 	}()
 	// Phase 1: Port Management Pre-reconciliation
-	benthosConfigs := cfg.Benthos
+	benthosConfigs := cfg.Internal.Benthos
 	instanceNames := make([]string, len(benthosConfigs))
 	for i, cfg := range benthosConfigs {
 		instanceNames[i] = cfg.Name
@@ -195,10 +195,10 @@ func (m *BenthosManager) Reconcile(ctx context.Context, cfg config.FullConfig, t
 
 	// Create a new config with allocated ports
 	cfgWithPorts := cfg.Clone() // Ensure you have a proper Clone method in config.FullConfig
-	for i, bc := range cfgWithPorts.Benthos {
+	for i, bc := range cfgWithPorts.Internal.Benthos {
 		if port, exists := m.portManager.GetPort(bc.Name); exists {
 			// Update the BenthosServiceConfig with the allocated port
-			cfgWithPorts.Benthos[i].BenthosServiceConfig.MetricsPort = port
+			cfgWithPorts.Internal.Benthos[i].BenthosServiceConfig.MetricsPort = port
 		}
 	}
 

--- a/umh-core/pkg/fsm/benthos/manager_mock.go
+++ b/umh-core/pkg/fsm/benthos/manager_mock.go
@@ -50,7 +50,7 @@ func NewBenthosManagerWithMockedServices(name string) (*BenthosManager, *benthos
 		"/dev/null", // Prevent any real filesystem writes
 		// Extract Benthos configs from full config - same as original
 		func(fullConfig config.FullConfig) ([]config.BenthosConfig, error) {
-			return fullConfig.Benthos, nil
+			return fullConfig.Internal.Benthos, nil
 		},
 		// Get name from Benthos config - same as original
 		func(cfg config.BenthosConfig) (string, error) {

--- a/umh-core/pkg/fsm/s6/manager.go
+++ b/umh-core/pkg/fsm/s6/manager.go
@@ -45,7 +45,7 @@ func NewS6Manager(name string) *S6Manager {
 		baseS6Dir,
 		// Extract S6 configs from full config
 		func(fullConfig config.FullConfig) ([]config.S6FSMConfig, error) {
-			return fullConfig.Services, nil
+			return fullConfig.Internal.Services, nil
 		},
 		// Get name from S6 config
 		func(cfg config.S6FSMConfig) (string, error) {

--- a/umh-core/pkg/fsm/s6/manager_mock.go
+++ b/umh-core/pkg/fsm/s6/manager_mock.go
@@ -37,7 +37,7 @@ func NewS6ManagerWithMockedServices(name string) *S6Manager {
 		"/dev/null", // Prevent any real filesystem writes
 		// Extract S6 configs from full config - same as original
 		func(fullConfig config.FullConfig) ([]config.S6FSMConfig, error) {
-			return fullConfig.Services, nil
+			return fullConfig.Internal.Services, nil
 		},
 		// Get name from S6 config - same as original
 		func(cfg config.S6FSMConfig) (string, error) {

--- a/umh-core/pkg/service/benthos/benthos.go
+++ b/umh-core/pkg/service/benthos/benthos.go
@@ -1032,7 +1032,7 @@ func (s *BenthosService) ReconcileManager(ctx context.Context, tick uint64) (err
 		return ctx.Err(), false
 	}
 
-	return s.s6Manager.Reconcile(ctx, config.FullConfig{Services: s.s6ServiceConfigs}, tick)
+	return s.s6Manager.Reconcile(ctx, config.FullConfig{Internal: config.InternalConfig{Services: s.s6ServiceConfigs}}, tick)
 }
 
 // IsLogsFine analyzes Benthos logs to determine if there are any critical issues

--- a/umh-core/pkg/service/nmap/nmap.go
+++ b/umh-core/pkg/service/nmap/nmap.go
@@ -517,7 +517,7 @@ func (s *NmapService) ReconcileManager(ctx context.Context, tick uint64) (err er
 		return ctx.Err(), false
 	}
 
-	return s.s6Manager.Reconcile(ctx, config.FullConfig{Services: s.s6ServiceConfigs}, tick)
+	return s.s6Manager.Reconcile(ctx, config.FullConfig{Internal: config.InternalConfig{Services: s.s6ServiceConfigs}}, tick)
 }
 
 // ServiceExists checks if a nmap service exists

--- a/umh-core/test/fsm/benthos/manager_test.go
+++ b/umh-core/test/fsm/benthos/manager_test.go
@@ -66,7 +66,7 @@ var _ = Describe("BenthosManager", func() {
 	// -------------------------------------------------------------------------
 	Context("Initialization", func() {
 		It("should handle empty config without errors", func() {
-			emptyConfig := config.FullConfig{Benthos: []config.BenthosConfig{}}
+			emptyConfig := config.FullConfig{Internal: config.InternalConfig{Benthos: []config.BenthosConfig{}}}
 
 			// Single call to a helper that wraps Reconcile
 			newTick, err := fsmtest.WaitForBenthosManagerStable(
@@ -80,8 +80,10 @@ var _ = Describe("BenthosManager", func() {
 		It("should create a service in stopped state and remain stable", func() {
 			serviceName := "test-stopped-service"
 			cfg := config.FullConfig{
-				Benthos: []config.BenthosConfig{
-					fsmtest.CreateBenthosTestConfig(serviceName, benthosfsm.OperationalStateStopped),
+				Internal: config.InternalConfig{
+					Benthos: []config.BenthosConfig{
+						fsmtest.CreateBenthosTestConfig(serviceName, benthosfsm.OperationalStateStopped),
+					},
 				},
 			}
 
@@ -110,8 +112,10 @@ var _ = Describe("BenthosManager", func() {
 		It("should create a service in active state and reach idle or active", func() {
 			serviceName := "test-active-service"
 			cfg := config.FullConfig{
-				Benthos: []config.BenthosConfig{
-					fsmtest.CreateBenthosTestConfig(serviceName, benthosfsm.OperationalStateActive),
+				Internal: config.InternalConfig{
+					Benthos: []config.BenthosConfig{
+						fsmtest.CreateBenthosTestConfig(serviceName, benthosfsm.OperationalStateActive),
+					},
 				},
 			}
 
@@ -143,8 +147,10 @@ var _ = Describe("BenthosManager", func() {
 			serviceName := "test-lifecycle"
 			// Start from active config
 			fullCfg := config.FullConfig{
-				Benthos: []config.BenthosConfig{
-					fsmtest.CreateBenthosTestConfig(serviceName, benthosfsm.OperationalStateActive),
+				Internal: config.InternalConfig{
+					Benthos: []config.BenthosConfig{
+						fsmtest.CreateBenthosTestConfig(serviceName, benthosfsm.OperationalStateActive),
+					},
 				},
 			}
 
@@ -170,7 +176,7 @@ var _ = Describe("BenthosManager", func() {
 			fsmtest.ConfigureBenthosManagerForState(mockService, serviceName, benthosfsm.OperationalStateStopped)
 
 			// 4) Remove from config => instance eventually stops & is removed
-			emptyConfig := config.FullConfig{Benthos: []config.BenthosConfig{}}
+			emptyConfig := config.FullConfig{Internal: config.InternalConfig{Benthos: []config.BenthosConfig{}}}
 			newTick, err = fsmtest.WaitForBenthosManagerInstanceRemoval(
 				ctx,
 				manager,
@@ -189,8 +195,10 @@ var _ = Describe("BenthosManager", func() {
 			serviceName := "test-toggle"
 			// Start from active config
 			activeCfg := config.FullConfig{
-				Benthos: []config.BenthosConfig{
-					fsmtest.CreateBenthosTestConfig(serviceName, benthosfsm.OperationalStateActive),
+				Internal: config.InternalConfig{
+					Benthos: []config.BenthosConfig{
+						fsmtest.CreateBenthosTestConfig(serviceName, benthosfsm.OperationalStateActive),
+					},
 				},
 			}
 
@@ -208,8 +216,10 @@ var _ = Describe("BenthosManager", func() {
 
 			// Switch config to stopped
 			stoppedCfg := config.FullConfig{
-				Benthos: []config.BenthosConfig{
-					fsmtest.CreateBenthosTestConfig(serviceName, benthosfsm.OperationalStateStopped),
+				Internal: config.InternalConfig{
+					Benthos: []config.BenthosConfig{
+						fsmtest.CreateBenthosTestConfig(serviceName, benthosfsm.OperationalStateStopped),
+					},
 				},
 			}
 
@@ -240,7 +250,9 @@ var _ = Describe("BenthosManager", func() {
 			config1 := fsmtest.CreateBenthosTestConfig(svc1, benthosfsm.OperationalStateActive)
 			config2 := fsmtest.CreateBenthosTestConfig(svc2, benthosfsm.OperationalStateActive)
 			fullCfg := config.FullConfig{
-				Benthos: []config.BenthosConfig{config1, config2},
+				Internal: config.InternalConfig{
+					Benthos: []config.BenthosConfig{config1, config2},
+				},
 			}
 
 			// Configure both services for transition to Idle
@@ -282,8 +294,10 @@ var _ = Describe("BenthosManager", func() {
 		It("should recover from transient startup failures", func() {
 			serviceName := "transient-error"
 			fullCfg := config.FullConfig{
-				Benthos: []config.BenthosConfig{
-					fsmtest.CreateBenthosTestConfig(serviceName, benthosfsm.OperationalStateActive),
+				Internal: config.InternalConfig{
+					Benthos: []config.BenthosConfig{
+						fsmtest.CreateBenthosTestConfig(serviceName, benthosfsm.OperationalStateActive),
+					},
 				},
 			}
 
@@ -308,8 +322,10 @@ var _ = Describe("BenthosManager", func() {
 		It("should remove an instance if it hits a permanent error in stopped state", func() {
 			serviceName := "perm-error-test"
 			fullCfg := config.FullConfig{
-				Benthos: []config.BenthosConfig{
-					fsmtest.CreateBenthosTestConfig(serviceName, benthosfsm.OperationalStateActive),
+				Internal: config.InternalConfig{
+					Benthos: []config.BenthosConfig{
+						fsmtest.CreateBenthosTestConfig(serviceName, benthosfsm.OperationalStateActive),
+					},
 				},
 			}
 
@@ -327,8 +343,10 @@ var _ = Describe("BenthosManager", func() {
 
 			// Set desired state to stopped
 			stoppedCfg := config.FullConfig{
-				Benthos: []config.BenthosConfig{
-					fsmtest.CreateBenthosTestConfig(serviceName, benthosfsm.OperationalStateStopped),
+				Internal: config.InternalConfig{
+					Benthos: []config.BenthosConfig{
+						fsmtest.CreateBenthosTestConfig(serviceName, benthosfsm.OperationalStateStopped),
+					},
 				},
 			}
 
@@ -344,7 +362,7 @@ var _ = Describe("BenthosManager", func() {
 			// Wait for manager to remove instance due to permanent error
 			newTick, err = fsmtest.WaitForBenthosManagerInstanceRemoval(
 				ctx, manager,
-				config.FullConfig{Benthos: []config.BenthosConfig{}},
+				config.FullConfig{Internal: config.InternalConfig{Benthos: []config.BenthosConfig{}}},
 				serviceName,
 				15,
 				tick,
@@ -363,8 +381,10 @@ var _ = Describe("BenthosManager", func() {
 		It("should handle 'service not found' gracefully", func() {
 			serviceName := "ghost-service"
 			fullCfg := config.FullConfig{
-				Benthos: []config.BenthosConfig{
-					fsmtest.CreateBenthosTestConfig(serviceName, benthosfsm.OperationalStateActive),
+				Internal: config.InternalConfig{
+					Benthos: []config.BenthosConfig{
+						fsmtest.CreateBenthosTestConfig(serviceName, benthosfsm.OperationalStateActive),
+					},
 				},
 			}
 
@@ -401,7 +421,9 @@ var _ = Describe("BenthosManager", func() {
 			// Create a BenthosConfig that desires an Active state
 			benthosCfg := fsmtest.CreateBenthosTestConfig(serviceName, benthosfsm.OperationalStateActive)
 			fullCfg := config.FullConfig{
-				Benthos: []config.BenthosConfig{benthosCfg},
+				Internal: config.InternalConfig{
+					Benthos: []config.BenthosConfig{benthosCfg},
+				},
 			}
 
 			// Initialize a mock port manager that tracks Pre/Post calls
@@ -440,7 +462,9 @@ var _ = Describe("BenthosManager", func() {
 			// Create config for the service
 			benthosCfg := fsmtest.CreateBenthosTestConfig(serviceName, benthosfsm.OperationalStateActive)
 			fullCfg := config.FullConfig{
-				Benthos: []config.BenthosConfig{benthosCfg},
+				Internal: config.InternalConfig{
+					Benthos: []config.BenthosConfig{benthosCfg},
+				},
 			}
 
 			// Create a mock port manager that returns an error on PreReconcile
@@ -469,7 +493,11 @@ var _ = Describe("BenthosManager", func() {
 		It("should call post-reconciliation after base reconciliation", func() {
 			serviceName := "test-service-port-post"
 			benthosCfg := fsmtest.CreateBenthosTestConfig(serviceName, benthosfsm.OperationalStateActive)
-			fullCfg := config.FullConfig{Benthos: []config.BenthosConfig{benthosCfg}}
+			fullCfg := config.FullConfig{
+				Internal: config.InternalConfig{
+					Benthos: []config.BenthosConfig{benthosCfg},
+				},
+			}
 
 			// Set up a mock port manager
 			mockPortMgr := portmanager.NewMockPortManager()

--- a/umh-core/test/fsm/s6/manager_test.go
+++ b/umh-core/test/fsm/s6/manager_test.go
@@ -58,7 +58,7 @@ var _ = Describe("S6Manager", func() {
 			emptyConfig := []config.S6FSMConfig{}
 
 			// Reconcile with empty config using a single reconciliation
-			err, _ := manager.Reconcile(ctx, config.FullConfig{Services: emptyConfig}, tick)
+			err, _ := manager.Reconcile(ctx, config.FullConfig{Internal: config.InternalConfig{Services: emptyConfig}}, tick)
 			tick++
 			Expect(err).NotTo(HaveOccurred())
 
@@ -69,7 +69,7 @@ var _ = Describe("S6Manager", func() {
 		It("should initialize service in stopped state and maintain it", func() {
 			// First setup with empty config to ensure no instances exist
 			emptyConfig := []config.S6FSMConfig{}
-			err, _ := manager.Reconcile(ctx, config.FullConfig{Services: emptyConfig}, tick)
+			err, _ := manager.Reconcile(ctx, config.FullConfig{Internal: config.InternalConfig{Services: emptyConfig}}, tick)
 			tick++
 			Expect(err).NotTo(HaveOccurred())
 			Expect(manager.GetInstances()).To(BeEmpty())
@@ -94,7 +94,7 @@ var _ = Describe("S6Manager", func() {
 
 			// Reconcile to create service and ensure it reaches stopped state
 			var nextTick uint64
-			nextTick, err = fsmtest.WaitForMockedManagerInstanceState(ctx, manager, config.FullConfig{Services: configWithStoppedService},
+			nextTick, err = fsmtest.WaitForMockedManagerInstanceState(ctx, manager, config.FullConfig{Internal: config.InternalConfig{Services: configWithStoppedService}},
 				serviceName, s6fsm.OperationalStateStopped, 10, tick)
 			tick = nextTick
 			Expect(err).NotTo(HaveOccurred())
@@ -111,7 +111,7 @@ var _ = Describe("S6Manager", func() {
 			Expect(service.GetDesiredFSMState()).To(Equal(s6fsm.OperationalStateStopped))
 
 			// Verify state remains stable over multiple reconciliation cycles
-			nextTick, err = fsmtest.WaitForMockedManagerInstanceState(ctx, manager, config.FullConfig{Services: configWithStoppedService},
+			nextTick, err = fsmtest.WaitForMockedManagerInstanceState(ctx, manager, config.FullConfig{Internal: config.InternalConfig{Services: configWithStoppedService}},
 				serviceName, s6fsm.OperationalStateStopped, 3, tick)
 			tick = nextTick
 			Expect(err).NotTo(HaveOccurred())
@@ -124,7 +124,7 @@ var _ = Describe("S6Manager", func() {
 		It("should initialize service in running state when config requests it", func() {
 			// First setup with empty config to ensure no instances exist
 			emptyConfig := []config.S6FSMConfig{}
-			err, _ := manager.Reconcile(ctx, config.FullConfig{Services: emptyConfig}, tick)
+			err, _ := manager.Reconcile(ctx, config.FullConfig{Internal: config.InternalConfig{Services: emptyConfig}}, tick)
 			tick++
 			Expect(err).NotTo(HaveOccurred())
 			Expect(manager.GetInstances()).To(BeEmpty())
@@ -149,7 +149,7 @@ var _ = Describe("S6Manager", func() {
 
 			// Reconcile to create service and wait for it to reach running state
 			var nextTick uint64
-			nextTick, err = fsmtest.WaitForMockedManagerInstanceState(ctx, manager, config.FullConfig{Services: configWithRunningService},
+			nextTick, err = fsmtest.WaitForMockedManagerInstanceState(ctx, manager, config.FullConfig{Internal: config.InternalConfig{Services: configWithRunningService}},
 				serviceName, s6fsm.OperationalStateRunning, 10, tick)
 			tick = nextTick
 			Expect(err).NotTo(HaveOccurred())
@@ -188,12 +188,12 @@ var _ = Describe("S6Manager", func() {
 			// Create and wait for the service to reach stopped state
 			var err error
 			var nextTick uint64
-			nextTick, err = fsmtest.WaitForManagerInstanceCreation(ctx, manager, config.FullConfig{Services: initialConfig},
+			nextTick, err = fsmtest.WaitForManagerInstanceCreation(ctx, manager, config.FullConfig{Internal: config.InternalConfig{Services: initialConfig}},
 				serviceName, 10, tick)
 			tick = nextTick
 			Expect(err).NotTo(HaveOccurred(), "Failed to create instance")
 
-			nextTick, err = fsmtest.WaitForMockedManagerInstanceState(ctx, manager, config.FullConfig{Services: initialConfig},
+			nextTick, err = fsmtest.WaitForMockedManagerInstanceState(ctx, manager, config.FullConfig{Internal: config.InternalConfig{Services: initialConfig}},
 				serviceName, s6fsm.OperationalStateStopped, 10, tick)
 			tick = nextTick
 			Expect(err).NotTo(HaveOccurred(), "Failed to reach stopped state")
@@ -220,7 +220,7 @@ var _ = Describe("S6Manager", func() {
 			}
 
 			// Wait for service to transition to running state
-			nextTick, err = fsmtest.WaitForMockedManagerInstanceState(ctx, manager, config.FullConfig{Services: updatedConfig},
+			nextTick, err = fsmtest.WaitForMockedManagerInstanceState(ctx, manager, config.FullConfig{Internal: config.InternalConfig{Services: updatedConfig}},
 				serviceName, s6fsm.OperationalStateRunning, 10, tick)
 			tick = nextTick
 			Expect(err).NotTo(HaveOccurred(), "Failed to transition to running state")
@@ -247,7 +247,7 @@ var _ = Describe("S6Manager", func() {
 			}
 
 			// Wait for service to transition back to stopped state
-			nextTick, err = fsmtest.WaitForMockedManagerInstanceState(ctx, manager, config.FullConfig{Services: stoppedConfig},
+			nextTick, err = fsmtest.WaitForMockedManagerInstanceState(ctx, manager, config.FullConfig{Internal: config.InternalConfig{Services: stoppedConfig}},
 				serviceName, s6fsm.OperationalStateStopped, 10, tick)
 			tick = nextTick
 			Expect(err).NotTo(HaveOccurred(), "Failed to transition back to stopped state")
@@ -281,13 +281,13 @@ var _ = Describe("S6Manager", func() {
 			// Wait for instance to be created
 			var err error
 			var nextTick uint64
-			nextTick, err = fsmtest.WaitForManagerInstanceCreation(ctx, manager, config.FullConfig{Services: runningConfig},
+			nextTick, err = fsmtest.WaitForManagerInstanceCreation(ctx, manager, config.FullConfig{Internal: config.InternalConfig{Services: runningConfig}},
 				serviceName, 10, tick)
 			tick = nextTick
 			Expect(err).NotTo(HaveOccurred(), "Failed to create instance")
 
 			// Wait for service to reach running state
-			nextTick, err = fsmtest.WaitForMockedManagerInstanceState(ctx, manager, config.FullConfig{Services: runningConfig},
+			nextTick, err = fsmtest.WaitForMockedManagerInstanceState(ctx, manager, config.FullConfig{Internal: config.InternalConfig{Services: runningConfig}},
 				serviceName, s6fsm.OperationalStateRunning, 10, tick)
 			tick = nextTick
 			Expect(err).NotTo(HaveOccurred(), "Failed to reach running state")
@@ -313,7 +313,7 @@ var _ = Describe("S6Manager", func() {
 			}
 
 			// Wait for service to reach stopped state
-			nextTick, err = fsmtest.WaitForMockedManagerInstanceState(ctx, manager, config.FullConfig{Services: stoppedConfig},
+			nextTick, err = fsmtest.WaitForMockedManagerInstanceState(ctx, manager, config.FullConfig{Internal: config.InternalConfig{Services: stoppedConfig}},
 				serviceName, s6fsm.OperationalStateStopped, 10, tick)
 			tick = nextTick
 			Expect(err).NotTo(HaveOccurred(), "Failed to transition to stopped state")
@@ -323,7 +323,7 @@ var _ = Describe("S6Manager", func() {
 
 			// Reconcile with empty config and wait for the service to be removed
 			// Using more attempts since removal might take longer
-			nextTick, err = fsmtest.WaitForManagerInstanceRemoval(ctx, manager, config.FullConfig{Services: emptyConfig},
+			nextTick, err = fsmtest.WaitForManagerInstanceRemoval(ctx, manager, config.FullConfig{Internal: config.InternalConfig{Services: emptyConfig}},
 				serviceName, 25, tick)
 			tick = nextTick
 			Expect(err).NotTo(HaveOccurred(), "Failed to remove instance")
@@ -356,7 +356,7 @@ var _ = Describe("S6Manager", func() {
 			// Wait for initial service to be created and reach stopped state
 			var err error
 			var nextTick uint64
-			nextTick, err = fsmtest.WaitForMockedManagerInstanceState(ctx, manager, config.FullConfig{Services: initialConfig},
+			nextTick, err = fsmtest.WaitForMockedManagerInstanceState(ctx, manager, config.FullConfig{Internal: config.InternalConfig{Services: initialConfig}},
 				initialServiceName, s6fsm.OperationalStateStopped, 10, tick)
 			tick = nextTick
 			Expect(err).NotTo(HaveOccurred())
@@ -377,13 +377,13 @@ var _ = Describe("S6Manager", func() {
 			})
 
 			// Wait for the new instance to be created
-			nextTick, err = fsmtest.WaitForManagerInstanceCreation(ctx, manager, config.FullConfig{Services: updatedConfig},
+			nextTick, err = fsmtest.WaitForManagerInstanceCreation(ctx, manager, config.FullConfig{Internal: config.InternalConfig{Services: updatedConfig}},
 				newServiceName, 10, tick)
 			tick = nextTick
 			Expect(err).NotTo(HaveOccurred(), "Failed to create new instance")
 
 			// Now wait for the new service to reach stopped state
-			nextTick, err = fsmtest.WaitForMockedManagerInstanceState(ctx, manager, config.FullConfig{Services: updatedConfig},
+			nextTick, err = fsmtest.WaitForMockedManagerInstanceState(ctx, manager, config.FullConfig{Internal: config.InternalConfig{Services: updatedConfig}},
 				newServiceName, s6fsm.OperationalStateStopped, 10, tick)
 			tick = nextTick
 			Expect(err).NotTo(HaveOccurred())
@@ -436,25 +436,25 @@ var _ = Describe("S6Manager", func() {
 			var nextTick uint64
 
 			// Wait for first service to be created
-			nextTick, err = fsmtest.WaitForManagerInstanceCreation(ctx, manager, config.FullConfig{Services: initialConfig},
+			nextTick, err = fsmtest.WaitForManagerInstanceCreation(ctx, manager, config.FullConfig{Internal: config.InternalConfig{Services: initialConfig}},
 				service1Name, 10, tick)
 			tick = nextTick
 			Expect(err).NotTo(HaveOccurred(), "Failed to create first instance")
 
 			// Wait for second service to be created
-			nextTick, err = fsmtest.WaitForManagerInstanceCreation(ctx, manager, config.FullConfig{Services: initialConfig},
+			nextTick, err = fsmtest.WaitForManagerInstanceCreation(ctx, manager, config.FullConfig{Internal: config.InternalConfig{Services: initialConfig}},
 				service2Name, 10, tick)
 			tick = nextTick
 			Expect(err).NotTo(HaveOccurred(), "Failed to create second instance")
 
 			// Wait for first service to reach stopped state
-			nextTick, err = fsmtest.WaitForMockedManagerInstanceState(ctx, manager, config.FullConfig{Services: initialConfig},
+			nextTick, err = fsmtest.WaitForMockedManagerInstanceState(ctx, manager, config.FullConfig{Internal: config.InternalConfig{Services: initialConfig}},
 				service1Name, s6fsm.OperationalStateStopped, 10, tick)
 			tick = nextTick
 			Expect(err).NotTo(HaveOccurred())
 
 			// Wait for second service to reach stopped state
-			nextTick, err = fsmtest.WaitForMockedManagerInstanceState(ctx, manager, config.FullConfig{Services: initialConfig},
+			nextTick, err = fsmtest.WaitForMockedManagerInstanceState(ctx, manager, config.FullConfig{Internal: config.InternalConfig{Services: initialConfig}},
 				service2Name, s6fsm.OperationalStateStopped, 10, tick)
 			tick = nextTick
 			Expect(err).NotTo(HaveOccurred())
@@ -480,7 +480,7 @@ var _ = Describe("S6Manager", func() {
 			}
 
 			// Wait for the service to be completely removed from the manager
-			nextTick, err = fsmtest.WaitForManagerInstanceRemoval(ctx, manager, config.FullConfig{Services: updatedConfig},
+			nextTick, err = fsmtest.WaitForManagerInstanceRemoval(ctx, manager, config.FullConfig{Internal: config.InternalConfig{Services: updatedConfig}},
 				service2Name, 15, tick)
 			tick = nextTick
 			Expect(err).NotTo(HaveOccurred(), "Failed waiting for instance removal")
@@ -518,12 +518,12 @@ var _ = Describe("S6Manager", func() {
 			// Create and wait for the service to reach stopped state
 			var err error
 			var nextTick uint64
-			nextTick, err = fsmtest.WaitForManagerInstanceCreation(ctx, manager, config.FullConfig{Services: serviceConfig},
+			nextTick, err = fsmtest.WaitForManagerInstanceCreation(ctx, manager, config.FullConfig{Internal: config.InternalConfig{Services: serviceConfig}},
 				serviceName, 10, tick)
 			tick = nextTick
 			Expect(err).NotTo(HaveOccurred(), "Failed to create instance")
 
-			nextTick, err = fsmtest.WaitForMockedManagerInstanceState(ctx, manager, config.FullConfig{Services: serviceConfig},
+			nextTick, err = fsmtest.WaitForMockedManagerInstanceState(ctx, manager, config.FullConfig{Internal: config.InternalConfig{Services: serviceConfig}},
 				serviceName, s6fsm.OperationalStateStopped, 10, tick)
 			tick = nextTick
 			Expect(err).NotTo(HaveOccurred(), "Failed to reach stopped state")
@@ -541,7 +541,7 @@ var _ = Describe("S6Manager", func() {
 			mockService.StatusError = fmt.Errorf("temporary error fetching service state")
 
 			// Run reconciliation a few times with the error active
-			nextTick, err = fsmtest.RunMultipleReconciliations(ctx, manager, config.FullConfig{Services: serviceConfig}, 15, tick)
+			nextTick, err = fsmtest.RunMultipleReconciliations(ctx, manager, config.FullConfig{Internal: config.InternalConfig{Services: serviceConfig}}, 15, tick)
 			tick = nextTick
 
 			// Verify the instance still exists despite errors
@@ -552,7 +552,7 @@ var _ = Describe("S6Manager", func() {
 			mockService.StatusError = nil
 
 			// Wait for the instance to recover to stopped state
-			nextTick, err = fsmtest.WaitForMockedManagerInstanceState(ctx, manager, config.FullConfig{Services: serviceConfig},
+			nextTick, err = fsmtest.WaitForMockedManagerInstanceState(ctx, manager, config.FullConfig{Internal: config.InternalConfig{Services: serviceConfig}},
 				serviceName, s6fsm.OperationalStateStopped, 10, tick)
 			tick = nextTick
 			Expect(err).NotTo(HaveOccurred(), "Failed to recover to stopped state")
@@ -583,12 +583,12 @@ var _ = Describe("S6Manager", func() {
 			// Create and wait for the service to reach stopped state
 			var err error
 			var nextTick uint64
-			nextTick, err = fsmtest.WaitForManagerInstanceCreation(ctx, manager, config.FullConfig{Services: serviceConfig},
+			nextTick, err = fsmtest.WaitForManagerInstanceCreation(ctx, manager, config.FullConfig{Internal: config.InternalConfig{Services: serviceConfig}},
 				serviceName, 10, tick)
 			tick = nextTick
 			Expect(err).NotTo(HaveOccurred(), "Failed to create instance")
 
-			nextTick, err = fsmtest.WaitForMockedManagerInstanceState(ctx, manager, config.FullConfig{Services: serviceConfig},
+			nextTick, err = fsmtest.WaitForMockedManagerInstanceState(ctx, manager, config.FullConfig{Internal: config.InternalConfig{Services: serviceConfig}},
 				serviceName, s6fsm.OperationalStateStopped, 10, tick)
 			tick = nextTick
 			Expect(err).NotTo(HaveOccurred(), "Failed to reach stopped state")
@@ -607,7 +607,7 @@ var _ = Describe("S6Manager", func() {
 			mockService.GetConfigError = fmt.Errorf("%s", permanentErrorMsg)
 
 			// Run several reconciliations to allow the error to be detected and handled
-			nextTick, err = fsmtest.RunMultipleReconciliations(ctx, manager, config.FullConfig{Services: serviceConfig}, 5, tick)
+			nextTick, err = fsmtest.RunMultipleReconciliations(ctx, manager, config.FullConfig{Internal: config.InternalConfig{Services: serviceConfig}}, 5, tick)
 			tick = nextTick
 
 			// Verify the instance has been removed due to permanent error
@@ -652,23 +652,23 @@ var _ = Describe("S6Manager", func() {
 			var nextTick uint64
 
 			// Wait for both services to be created
-			nextTick, err = fsmtest.WaitForManagerInstanceCreation(ctx, manager, config.FullConfig{Services: multiServiceConfig},
+			nextTick, err = fsmtest.WaitForManagerInstanceCreation(ctx, manager, config.FullConfig{Internal: config.InternalConfig{Services: multiServiceConfig}},
 				service1Name, 10, tick)
 			tick = nextTick
 			Expect(err).NotTo(HaveOccurred(), "Failed to create first service")
 
-			nextTick, err = fsmtest.WaitForManagerInstanceCreation(ctx, manager, config.FullConfig{Services: multiServiceConfig},
+			nextTick, err = fsmtest.WaitForManagerInstanceCreation(ctx, manager, config.FullConfig{Internal: config.InternalConfig{Services: multiServiceConfig}},
 				service2Name, 10, tick)
 			tick = nextTick
 			Expect(err).NotTo(HaveOccurred(), "Failed to create second service")
 
 			// Wait for both services to reach stopped state
-			nextTick, err = fsmtest.WaitForMockedManagerInstanceState(ctx, manager, config.FullConfig{Services: multiServiceConfig},
+			nextTick, err = fsmtest.WaitForMockedManagerInstanceState(ctx, manager, config.FullConfig{Internal: config.InternalConfig{Services: multiServiceConfig}},
 				service1Name, s6fsm.OperationalStateStopped, 10, tick)
 			tick = nextTick
 			Expect(err).NotTo(HaveOccurred(), "First service failed to reach stopped state")
 
-			nextTick, err = fsmtest.WaitForMockedManagerInstanceState(ctx, manager, config.FullConfig{Services: multiServiceConfig},
+			nextTick, err = fsmtest.WaitForMockedManagerInstanceState(ctx, manager, config.FullConfig{Internal: config.InternalConfig{Services: multiServiceConfig}},
 				service2Name, s6fsm.OperationalStateStopped, 10, tick)
 			tick = nextTick
 			Expect(err).NotTo(HaveOccurred(), "Second service failed to reach stopped state")
@@ -722,23 +722,23 @@ var _ = Describe("S6Manager", func() {
 			var nextTick uint64
 
 			// Wait for both instances to be created
-			nextTick, err = fsmtest.WaitForManagerInstanceCreation(ctx, manager, config.FullConfig{Services: multiServiceConfig},
+			nextTick, err = fsmtest.WaitForManagerInstanceCreation(ctx, manager, config.FullConfig{Internal: config.InternalConfig{Services: multiServiceConfig}},
 				stableServiceName, 10, tick)
 			tick = nextTick
 			Expect(err).NotTo(HaveOccurred(), "Failed to create stable service")
 
-			nextTick, err = fsmtest.WaitForManagerInstanceCreation(ctx, manager, config.FullConfig{Services: multiServiceConfig},
+			nextTick, err = fsmtest.WaitForManagerInstanceCreation(ctx, manager, config.FullConfig{Internal: config.InternalConfig{Services: multiServiceConfig}},
 				failingServiceName, 10, tick)
 			tick = nextTick
 			Expect(err).NotTo(HaveOccurred(), "Failed to create failing service")
 
 			// Wait for both to reach stopped state
-			nextTick, err = fsmtest.WaitForMockedManagerInstanceState(ctx, manager, config.FullConfig{Services: multiServiceConfig},
+			nextTick, err = fsmtest.WaitForMockedManagerInstanceState(ctx, manager, config.FullConfig{Internal: config.InternalConfig{Services: multiServiceConfig}},
 				stableServiceName, s6fsm.OperationalStateStopped, 10, tick)
 			tick = nextTick
 			Expect(err).NotTo(HaveOccurred(), "Stable service failed to reach stopped state")
 
-			nextTick, err = fsmtest.WaitForMockedManagerInstanceState(ctx, manager, config.FullConfig{Services: multiServiceConfig},
+			nextTick, err = fsmtest.WaitForMockedManagerInstanceState(ctx, manager, config.FullConfig{Internal: config.InternalConfig{Services: multiServiceConfig}},
 				failingServiceName, s6fsm.OperationalStateStopped, 10, tick)
 			tick = nextTick
 			Expect(err).NotTo(HaveOccurred(), "Failing service failed to reach stopped state")
@@ -762,7 +762,7 @@ var _ = Describe("S6Manager", func() {
 			mockService.GetConfigError = fmt.Errorf("%s", permanentErrorMsg)
 
 			// Run reconciliation multiple times to allow error handling
-			nextTick, err = fsmtest.RunMultipleReconciliations(ctx, manager, config.FullConfig{Services: multiServiceConfig},
+			nextTick, err = fsmtest.RunMultipleReconciliations(ctx, manager, config.FullConfig{Internal: config.InternalConfig{Services: multiServiceConfig}},
 				5, tick)
 			tick = nextTick
 


### PR DESCRIPTION
Fixes ENG-2764

I moved it to internal to prevent confusion and accidental usage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Restructured configuration examples to use a nested, encapsulated format while preserving existing functionality.
	- Updated internal configuration management across service modules for improved organization and clarity.
- **Chores**
	- Streamlined the development environment setup by refining post-creation commands and container options for a more consistent installation process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->