### PR TITLE
[ENG-2801] Configure Statemachine Transitions for Dataflowcomponent FSM

### DIFF
--- a/umh-core/pkg/fsm/dataflowcomponent/fsm_callbacks.go
+++ b/umh-core/pkg/fsm/dataflowcomponent/fsm_callbacks.go
@@ -1,0 +1,51 @@
+package dataflowcomponent
+
+import (
+	"context"
+
+	"github.com/looplab/fsm"
+)
+
+// registerCallbacks registers common callbacks for state transitions
+// These callbacks are executed synchronously and should not have any network calls or other operations that could fail
+func (instance *DataflowComponentInstance) registerCallbacks() {
+	// Basic operational state callbacks
+	instance.baseFSMInstance.AddCallback("enter_"+OperationalStateStarting, func(ctx context.Context, e *fsm.Event) {
+		instance.baseFSMInstance.GetLogger().Infof("Entering starting state for %s", instance.baseFSMInstance.GetID())
+	})
+
+	instance.baseFSMInstance.AddCallback("enter_"+OperationalStateStopping, func(ctx context.Context, e *fsm.Event) {
+		instance.baseFSMInstance.GetLogger().Infof("Entering stopping state for %s", instance.baseFSMInstance.GetID())
+	})
+
+	instance.baseFSMInstance.AddCallback("enter_"+OperationalStateStopped, func(ctx context.Context, e *fsm.Event) {
+		instance.baseFSMInstance.GetLogger().Infof("Entering stopped state for %s", instance.baseFSMInstance.GetID())
+	})
+
+	instance.baseFSMInstance.AddCallback("enter_"+OperationalStateActive, func(ctx context.Context, e *fsm.Event) {
+		instance.baseFSMInstance.GetLogger().Infof("Entering active state for %s", instance.baseFSMInstance.GetID())
+	})
+
+	// Starting phase state callbacks
+	instance.baseFSMInstance.AddCallback("enter_"+OperationalStateStartingConfigLoading, func(ctx context.Context, e *fsm.Event) {
+		instance.baseFSMInstance.GetLogger().Infof("Entering config loading state for %s", instance.baseFSMInstance.GetID())
+	})
+
+	instance.baseFSMInstance.AddCallback("enter_"+OperationalStateStartingWaitingForHealthchecks, func(ctx context.Context, e *fsm.Event) {
+		instance.baseFSMInstance.GetLogger().Infof("Entering waiting for healthchecks state for %s", instance.baseFSMInstance.GetID())
+	})
+
+	instance.baseFSMInstance.AddCallback("enter_"+OperationalStateStartingWaitingForServiceToRemainRunning, func(ctx context.Context, e *fsm.Event) {
+		instance.baseFSMInstance.GetLogger().Infof("Entering waiting for service to remain running state for %s", instance.baseFSMInstance.GetID())
+	})
+
+	// Running phase state callbacks
+	instance.baseFSMInstance.AddCallback("enter_"+OperationalStateIdle, func(ctx context.Context, e *fsm.Event) {
+		instance.baseFSMInstance.GetLogger().Infof("Entering idle state for %s", instance.baseFSMInstance.GetID())
+	})
+
+	instance.baseFSMInstance.AddCallback("enter_"+OperationalStateDegraded, func(ctx context.Context, e *fsm.Event) {
+		instance.baseFSMInstance.GetLogger().Warnf("Entering degraded state for %s", instance.baseFSMInstance.GetID())
+		// Additional logic for handling degraded state could be added here
+	})
+}

--- a/umh-core/pkg/fsm/dataflowcomponent/models.go
+++ b/umh-core/pkg/fsm/dataflowcomponent/models.go
@@ -21,6 +21,58 @@ import (
 	dataflowcomponentsvc "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/dataflowcomponent"
 )
 
+// Operational state constants (using internal_fsm compatible naming)
+const (
+	// OperationalStateStopped is the initial state and also the state when the service is stopped
+	OperationalStateStopped = "stopped"
+
+	// Starting phase states
+	// OperationalStateStarting is the state when s6 is starting the service
+	OperationalStateStarting = "starting"
+	// OperationalStateStartingConfigLoading is the state when the process itself is running but is waiting for the config to be loaded
+	OperationalStateStartingConfigLoading = "starting_config_loading"
+	// OperationalStateStartingWaitingForHealthchecks is the state when there was no fatal config error but is waiting for the healthchecks to pass
+	OperationalStateStartingWaitingForHealthchecks = "starting_waiting_for_healthchecks"
+	// OperationalStateStartingWaitingForServiceToRemainRunning is the state when the service is running but is waiting for the service to remain running
+	OperationalStateStartingWaitingForServiceToRemainRunning = "starting_waiting_for_service_to_remain_running"
+
+	// Running phase states
+	// OperationalStateIdle is the state when the service is running but not actively processing data
+	OperationalStateIdle = "idle"
+	// OperationalStateActive is the state when the service is running and actively processing data
+	OperationalStateActive = "active"
+	// OperationalStateDegraded is the state when the service is running but has encountered issues
+	OperationalStateDegraded = "degraded"
+
+	// OperationalStateStopping is the state when the service is in the process of stopping
+	OperationalStateStopping = "stopping"
+)
+
+// Operational event constants
+const (
+	// Basic lifecycle events
+	EventStart     = "start"
+	EventStartDone = "start_done"
+	EventStop      = "stop"
+	EventStopDone  = "stop_done"
+
+	// Starting phase events
+	EventBenthosCreated = "benthos_created"
+	// TODO: Probably we might need to add more events like BenthosConfigValidated
+	// This needs some discussion as the config validation can be part of ConfigLoaded too.
+	EventBenthosConfigLoaded = "benthos_config_loaded"
+	EventBenthosRestarting   = "benthos_restarting"
+	EventBenthosStarted      = "benthos_started"
+	EventHealthchecksPassed  = "healthchecks_passed"
+	EventStartFailed         = "start_failed"
+
+	// Running phase events
+	EventDataReceived  = "data_received"
+	EventNoDataTimeout = "no_data_timeout"
+	EventDegraded      = "degraded"
+	EventRecovered     = "recovered"
+)
+
 // DataflowComponentObservedState contains the observed runtime state of a DataflowComponent instance
 type DataflowComponentObservedState struct {
 	// ServiceInfo contains information about the S6 service

--- a/umh-core/pkg/metrics/metrics.go
+++ b/umh-core/pkg/metrics/metrics.go
@@ -25,15 +25,16 @@ import (
 
 const (
 	// Component Labels
-	ComponentControlLoop      = "control_loop"
-	ComponentBaseFSMManager   = "base_fsm_manager"
-	ComponentS6Manager        = "s6_manager"
-	ComponentBenthosManager   = "benthos_manager"
-	ComponentS6Instance       = "s6_instance"
-	ComponentBenthosInstance  = "benthos_instance"
-	ComponentS6Service        = "s6_service"
-	ComponentFilesystem       = "filesystem"
-	ComponentContainerMonitor = "container_monitor"
+	ComponentControlLoop               = "control_loop"
+	ComponentBaseFSMManager            = "base_fsm_manager"
+	ComponentS6Manager                 = "s6_manager"
+	ComponentBenthosManager            = "benthos_manager"
+	ComponentS6Instance                = "s6_instance"
+	ComponentBenthosInstance           = "benthos_instance"
+	ComponentS6Service                 = "s6_service"
+	ComponentFilesystem                = "filesystem"
+	ComponentContainerMonitor          = "container_monitor"
+	ComponentDataflowComponentInstance = "dataflow_component_instance"
 )
 
 var (


### PR DESCRIPTION
## Description 

The PR configures the state machine transitions for the Dataflowcomponent FSM and adds the necessary call back functions. 