### PR TITLE
ENG-2807 fix redpanda having unconfigured state

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,15 @@
     "version": "0.2.0",
     "configurations": [
         {
+            // This connects to delve inside the umh-core container
+            "name": "Connect to umh-core",
+            "type": "go",
+            "request": "attach",
+            "mode": "remote",
+            "host": "localhost",
+            "port": 40000
+        },
+        {
             "name": "Debug Ginkgo Tests (test-fsm-benthos)",
             "type": "go",
             "request": "launch",

--- a/umh-core/Dockerfile
+++ b/umh-core/Dockerfile
@@ -22,10 +22,6 @@ WORKDIR /go/src/github.com/united-manufacturing-hub/united-manufacturing-hub
 # Set app version with a default value - can be overridden at build time
 ARG APP_VERSION=0.0.0-dev
 RUN apk add --no-cache gcc musl-dev
-# Install delve if DEBUG is true
-RUN if [ "$DEBUG" = "true" ]; then \
-    go install github.com/go-delve/delve/cmd/dlv@latest; \
-    fi
 # Copy go.mod first for better caching
 COPY ./go.mod ./umh-core/
 WORKDIR /go/src/github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core
@@ -100,13 +96,6 @@ RUN chmod +x /opt/redpanda/bin/redpanda
 # Cleanup all the files we don't need
 RUN rm -rf /s6-overlay /benthos /redpanda 
 
-# --- Debug Stage ---
-FROM build as debug-tools
-RUN if [ -f "$GOPATH/bin/dlv" ]; then \
-    mkdir -p /debug-tools && \
-    cp $GOPATH/bin/dlv /debug-tools/; \
-    fi
-
 # --- Final Stage ---
 FROM alpine:3.21 as runner
 # Copy everything from the downloader stage
@@ -118,9 +107,9 @@ COPY --from=build /go/bin/umh-core /usr/local/bin/umh-core
 # Handle DEBUG mode - install Go and Delve when DEBUG=true
 ARG DEBUG=false
 RUN if [ "$DEBUG" = "true" ]; then \
-    apk add --no-cache go && \
+    apk add --no-cache go && \ 
     go install github.com/go-delve/delve/cmd/dlv@latest && \
-    mv $GOPATH/bin/dlv /usr/local/bin/; \
+    find / -name "dlv"; \
     fi
 
 RUN chmod +x /usr/local/bin/umh-core && \
@@ -135,9 +124,11 @@ ARG DEBUG=false
 RUN if [ "$DEBUG" = "true" ]; then \
     # Use debug service instead of regular service
     cp -f /etc/s6-overlay/s6-rc.d/umh-core-debug/run /etc/s6-overlay/s6-rc.d/umh-core/run && \
+    rm -rf /etc/s6-overlay/s6-rc.d/umh-core-debug; \
     chmod +x /etc/s6-overlay/s6-rc.d/umh-core/run; \
     else \
     # Use regular service
+    rm -rf /etc/s6-overlay/s6-rc.d/umh-core-debug; \
     chmod +x /etc/s6-overlay/s6-rc.d/umh-core/run; \
     fi
 

--- a/umh-core/Dockerfile
+++ b/umh-core/Dockerfile
@@ -16,23 +16,38 @@ FROM golang:1.24-alpine as build
 ARG S6_OVERLAY_VERSION=3.2.0.2
 ARG BENTHOS_UMH_VERSION=0.6.2
 ARG REDPANDA_VERSION=24.3.8
+ARG DEBUG=false
 WORKDIR /go/src/github.com/united-manufacturing-hub/united-manufacturing-hub
 
 # Set app version with a default value - can be overridden at build time
 ARG APP_VERSION=0.0.0-dev
 RUN apk add --no-cache gcc musl-dev
+# Install delve if DEBUG is true
+RUN if [ "$DEBUG" = "true" ]; then \
+    go install github.com/go-delve/delve/cmd/dlv@latest; \
+    fi
 # Copy go.mod first for better caching
 COPY ./go.mod ./umh-core/
 WORKDIR /go/src/github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core
 RUN go mod download
 COPY . .
-RUN CGO_ENABLED=0 go build \
+RUN if [ "$DEBUG" = "true" ]; then \
+    CGO_ENABLED=0 go build \
+    -gcflags="all=-N -l" \
+    -ldflags "-X github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants.S6OverlayVersion=${S6_OVERLAY_VERSION} \
+    -X github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants.BenthosVersion=${BENTHOS_UMH_VERSION} \
+    -X github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants.RedpandaVersion=${REDPANDA_VERSION} \
+    -X main.appVersion=${APP_VERSION}" \
+    -o /go/bin/umh-core cmd/main.go; \
+    else \
+    CGO_ENABLED=0 go build \
     -ldflags "-s -w \
     -X github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants.S6OverlayVersion=${S6_OVERLAY_VERSION} \
     -X github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants.BenthosVersion=${BENTHOS_UMH_VERSION} \
     -X github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants.RedpandaVersion=${REDPANDA_VERSION} \
     -X main.appVersion=${APP_VERSION}" \
-    -o /go/bin/umh-core cmd/main.go
+    -o /go/bin/umh-core cmd/main.go; \
+    fi
 
 # --- Cache Stage ---
 FROM scratch as cache
@@ -85,18 +100,47 @@ RUN chmod +x /opt/redpanda/bin/redpanda
 # Cleanup all the files we don't need
 RUN rm -rf /s6-overlay /benthos /redpanda 
 
+# --- Debug Stage ---
+FROM build as debug-tools
+RUN if [ -f "$GOPATH/bin/dlv" ]; then \
+    mkdir -p /debug-tools && \
+    cp $GOPATH/bin/dlv /debug-tools/; \
+    fi
+
 # --- Final Stage ---
 FROM alpine:3.21 as runner
 # Copy everything from the downloader stage
 COPY --from=downloader / /
+
 # Copy built application
 COPY --from=build /go/bin/umh-core /usr/local/bin/umh-core
+
+# Handle DEBUG mode - install Go and Delve when DEBUG=true
+ARG DEBUG=false
+RUN if [ "$DEBUG" = "true" ]; then \
+    apk add --no-cache go && \
+    go install github.com/go-delve/delve/cmd/dlv@latest && \
+    mv $GOPATH/bin/dlv /usr/local/bin/; \
+    fi
+
 RUN chmod +x /usr/local/bin/umh-core && \
     ls -la /usr/local/bin/umh-core && \
     test -x /usr/local/bin/umh-core || (echo "Binary not executable" && exit 1)
+
 # Copy s6 service configuration
 COPY ./s6-base/s6-rc.d /etc/s6-overlay/s6-rc.d/
-RUN chmod +x /etc/s6-overlay/s6-rc.d/umh-core/run
+
+# Use either standard or debug service based on DEBUG flag
+ARG DEBUG=false
+RUN if [ "$DEBUG" = "true" ]; then \
+    # Use debug service instead of regular service
+    cp -f /etc/s6-overlay/s6-rc.d/umh-core-debug/run /etc/s6-overlay/s6-rc.d/umh-core/run && \
+    chmod +x /etc/s6-overlay/s6-rc.d/umh-core/run; \
+    else \
+    # Use regular service
+    chmod +x /etc/s6-overlay/s6-rc.d/umh-core/run; \
+    fi
+
 # Set environment variables and volume
 # S6_SYNC_DISKS=1: Sync the disks to ensure that the data is persisted, this is needed for the redpanda service
 ENV S6_KEEP_ENV=1 \
@@ -106,5 +150,9 @@ ENV S6_KEEP_ENV=1 \
     S6_SYNC_DISKS=1 \
     S6_LOGGING_SCRIPT="n20 s1000000 T"
 VOLUME ["/data"]
+
+# Expose Delve port
+EXPOSE 40000
+
 ENTRYPOINT ["/init"]
 CMD []

--- a/umh-core/Makefile
+++ b/umh-core/Makefile
@@ -138,7 +138,18 @@ build: download-docker-binaries
 		--build-arg APP_VERSION=$(VERSION) \
 		-t $(IMAGE_NAME):$(TAG) \
 		-f Dockerfile .
-	
+
+build-debug: download-docker-binaries
+	docker buildx build \
+		--platform linux/$(TARGETARCH) \
+		--build-arg S6_OVERLAY_VERSION=$(S6_OVERLAY_VERSION) \
+		--build-arg BENTHOS_UMH_VERSION=$(BENTHOS_UMH_VERSION) \
+		--build-arg REDPANDA_VERSION=$(REDPANDA_VERSION) \
+		--build-arg APP_VERSION=$(VERSION) \
+		--build-arg DEBUG=true \
+		-t $(IMAGE_NAME):$(TAG)-debug \
+		-f Dockerfile .
+
 clean:
 	docker stop $(IMAGE_NAME) || true
 	docker rm $(IMAGE_NAME) || true
@@ -281,6 +292,20 @@ test-dfc: clean build
 		--memory $(MEMORY) \
 		--cpus $(CPUS) \
 		$(IMAGE_NAME):$(TAG)
+
+test-debug: clean build-debug
+	@mkdir -p $(PWD)/data
+	@cp $(PWD)/examples/example-config-benthos.yaml $(PWD)/data/config.yaml
+	docker run \
+		--name $(IMAGE_NAME) \
+		-v $(PWD)/data:/data \
+		-p 8081:8080 \
+		-p 4195:4195 \
+		-p 40000:40000 \
+		--memory $(MEMORY) \
+		--cpus $(CPUS) \
+		-e LOGGING_LEVEL=DEBUG \
+		$(IMAGE_NAME):$(TAG)-debug
 
 pod-shell:
 	docker exec -it $(IMAGE_NAME) /bin/bash

--- a/umh-core/Makefile
+++ b/umh-core/Makefile
@@ -139,6 +139,9 @@ build: download-docker-binaries
 		-t $(IMAGE_NAME):$(TAG) \
 		-f Dockerfile .
 
+# build-debug: launches delve inside the container.
+# This allows you to use vscode's "Connect to umh-core" feature and use breakpoints, etc inside the container.
+# To use this, modify one of the build-<type> targets to use this target instead of build.
 build-debug: download-docker-binaries
 	docker buildx build \
 		--platform linux/$(TARGETARCH) \
@@ -147,6 +150,7 @@ build-debug: download-docker-binaries
 		--build-arg REDPANDA_VERSION=$(REDPANDA_VERSION) \
 		--build-arg APP_VERSION=$(VERSION) \
 		--build-arg DEBUG=true \
+		--progress=plain \
 		-t $(IMAGE_NAME):$(TAG)-debug \
 		-f Dockerfile .
 
@@ -247,7 +251,7 @@ test-broken: clean build
 
 test-benthos: clean build
 	@mkdir -p $(PWD)/data
-	@cp $(PWD)/examples/example-config-benthos.yaml $(PWD)/data/config.yaml
+	@cp $(PWD)/examples/example-config-benthos-broken.yaml $(PWD)/data/config.yaml
 	docker run \
 		--name $(IMAGE_NAME) \
 		-v $(PWD)/data:/data \
@@ -295,7 +299,7 @@ test-dfc: clean build
 
 test-debug: clean build-debug
 	@mkdir -p $(PWD)/data
-	@cp $(PWD)/examples/example-config-benthos.yaml $(PWD)/data/config.yaml
+	@cp $(PWD)/examples/example-config-benthos-broken.yaml $(PWD)/data/config.yaml
 	docker run \
 		--name $(IMAGE_NAME) \
 		-v $(PWD)/data:/data \

--- a/umh-core/examples/example-config-benthos-broken.yaml
+++ b/umh-core/examples/example-config-benthos-broken.yaml
@@ -1,0 +1,39 @@
+# Copyright 2025 UMH Systems GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+agent:
+  metricsPort: 8080
+
+internal:
+  benthos:
+    - name: hello-world
+      desiredState: active
+      benthosServiceConfig:
+        input:
+          generate:
+            mapping: root = "hello world from Benthos!"
+            interval: 1s # Output every 2 seconds
+            count: 0 # Set to 0 for unlimited messages
+        output:
+          stdout: {}
+    - name: hello-world-2
+      desiredState: active
+      benthosServiceConfig:
+        input:
+          generate:
+            mapping: root = "hello world from Benthos 2!"
+            interval: 1s # Output every 2 seconds
+            count: 0 # Set to 0 for unlimited messages
+        output:
+          stdout: {}

--- a/umh-core/pkg/config/manager.go
+++ b/umh-core/pkg/config/manager.go
@@ -152,6 +152,11 @@ func (m *FileConfigManager) GetConfigWithOverwritesOrCreateNew(ctx context.Conte
 		config.Agent.Location = configOverride.Agent.Location
 	}
 
+	// Enforce that redpanda has a desired state
+	if config.Internal.Redpanda.DesiredFSMState == "" {
+		config.Internal.Redpanda.DesiredFSMState = configOverride.Internal.Redpanda.DesiredFSMState
+	}
+
 	// Persist the updated config
 	if err := m.writeConfig(ctx, config); err != nil {
 		return FullConfig{}, fmt.Errorf("failed to write new config: %w", err)

--- a/umh-core/s6-base/s6-rc.d/umh-core-debug/run
+++ b/umh-core/s6-base/s6-rc.d/umh-core-debug/run
@@ -1,4 +1,4 @@
 #!/command/execlineb -P
 cd /
 fdmove -c 2 1
-/usr/local/bin/dlv --headless --listen=:40000 --api-version=2 --accept-multiclient exec /usr/local/bin/umh-core 
+/root/go/bin/dlv --headless --listen=:40000 --api-version=2 --accept-multiclient exec /usr/local/bin/umh-core 

--- a/umh-core/s6-base/s6-rc.d/umh-core-debug/run
+++ b/umh-core/s6-base/s6-rc.d/umh-core-debug/run
@@ -1,0 +1,4 @@
+#!/command/execlineb -P
+cd /
+fdmove -c 2 1
+/usr/local/bin/dlv --headless --listen=:40000 --api-version=2 --accept-multiclient exec /usr/local/bin/umh-core 


### PR DESCRIPTION
This pr ensures that redpanda always has a good state.
Also adds a build-debug target that can be used together with the "Connect to umh-core" vscode action for manual debugging of the container