### PR TITLE
added docker on macos overwrite for disk

### DIFF
--- a/umh-core/Makefile
+++ b/umh-core/Makefile
@@ -244,6 +244,8 @@ test-comm: clean build
 		-p 8081:8080 \
 		--memory $(MEMORY) \
 		--cpus $(CPUS) \
+		-e AUTH_TOKEN=$(AUTH_TOKEN) \
+		-e LOGGING_LEVEL=DEBUG \
 		$(IMAGE_NAME):$(TAG)
 
 test-broken: clean build

--- a/umh-core/pkg/communicator/pkg/tools/watchdog/watchdog.go
+++ b/umh-core/pkg/communicator/pkg/tools/watchdog/watchdog.go
@@ -348,29 +348,32 @@ func (s *Watchdog) SetHasSubscribers(has bool) {
 func (s *Watchdog) reportStateToNiceFail() {
 	// We collect the state of all registered subscribers (name, lastReportedStatus, timeSinceLastReport, warningCount)
 	// This is useful for debugging, as it allows us to see the state of all registered subscribers at the time of the panic
-	s.registeredHeartbeatsMutex.Lock()
-	defer s.registeredHeartbeatsMutex.Unlock()
-	for name, hb := range s.registeredHeartbeats {
-		if hb == nil {
-			// Skip nil heartbeats
-			continue
+	// Disabled it, as it is quite spammy
+	/*
+		s.registeredHeartbeatsMutex.Lock()
+		defer s.registeredHeartbeatsMutex.Unlock()
+		for name, hb := range s.registeredHeartbeats {
+			if hb == nil {
+				// Skip nil heartbeats
+				continue
+			}
+
+			lastReportedStatus := hb.lastReportedStatus.Load()
+			lastHeartbeat := hb.lastHeatbeatTime.Load()
+			warningCount := hb.warningCount.Load()
+
+			var status string
+			switch lastReportedStatus {
+			case int32(HEARTBEAT_STATUS_OK):
+				status = "OK"
+			case int32(HEARTBEAT_STATUS_WARNING):
+				status = "WARNING"
+			case int32(HEARTBEAT_STATUS_ERROR):
+				status = "ERROR"
+			}
+
+			// Log to the console instead of reporting to Sentry
+			s.logger.Tracef("WatchdogReport: %s, %s, %d, %d", name, status, lastHeartbeat, warningCount)
 		}
-
-		lastReportedStatus := hb.lastReportedStatus.Load()
-		lastHeartbeat := hb.lastHeatbeatTime.Load()
-		warningCount := hb.warningCount.Load()
-
-		var status string
-		switch lastReportedStatus {
-		case int32(HEARTBEAT_STATUS_OK):
-			status = "OK"
-		case int32(HEARTBEAT_STATUS_WARNING):
-			status = "WARNING"
-		case int32(HEARTBEAT_STATUS_ERROR):
-			status = "ERROR"
-		}
-
-		// Log to the console instead of reporting to Sentry
-		//s.logger.Debugf("WatchdogReport: %s, %s, %d, %d", name, status, lastHeartbeat, warningCount)
-	}
+	*/
 }

--- a/umh-core/pkg/communicator/pkg/tools/watchdog/watchdog.go
+++ b/umh-core/pkg/communicator/pkg/tools/watchdog/watchdog.go
@@ -371,6 +371,6 @@ func (s *Watchdog) reportStateToNiceFail() {
 		}
 
 		// Log to the console instead of reporting to Sentry
-		s.logger.Debugf("WatchdogReport: %s, %s, %d, %d", name, status, lastHeartbeat, warningCount)
+		//s.logger.Debugf("WatchdogReport: %s, %s, %d, %d", name, status, lastHeartbeat, warningCount)
 	}
 }

--- a/umh-core/pkg/service/container_monitor/container_monitor.go
+++ b/umh-core/pkg/service/container_monitor/container_monitor.go
@@ -31,6 +31,8 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/logger"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/models"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/filesystem"
+
+	"golang.org/x/sys/unix"
 )
 
 // ServiceInfo contains both raw metrics and health assessments
@@ -60,7 +62,7 @@ type Service interface {
 // ContainerMonitorService implements the Service interface
 type ContainerMonitorService struct {
 	fs              filesystem.Service
-	logger          *zap.Logger
+	logger          *zap.SugaredLogger
 	instanceName    string
 	lastCollectedAt time.Time
 	hwid            string
@@ -75,7 +77,7 @@ func NewContainerMonitorService(fs filesystem.Service) *ContainerMonitorService 
 
 // NewContainerMonitorServiceWithPath creates a new container monitor service with a custom data path
 func NewContainerMonitorServiceWithPath(fs filesystem.Service, dataPath string) *ContainerMonitorService {
-	log := logger.New(logger.ComponentContainerMonService, logger.FormatJSON)
+	log := logger.For(logger.ComponentContainerMonService)
 
 	return &ContainerMonitorService{
 		fs:           fs,
@@ -88,6 +90,11 @@ func NewContainerMonitorServiceWithPath(fs filesystem.Service, dataPath string) 
 // GetFilesystemService returns the filesystem service - used for testing only
 func (c *ContainerMonitorService) GetFilesystemService() filesystem.Service {
 	return c.fs
+}
+
+// SetDataPath changes the data path - used for testing only
+func (c *ContainerMonitorService) SetDataPath(path string) {
+	c.dataPath = path
 }
 
 // GetStatus collects and returns the current container metrics
@@ -305,9 +312,15 @@ func (c *ContainerMonitorService) getMemoryMetrics(ctx context.Context) (*models
 	return memStat, nil
 }
 
+// oneTB represents one terabyte in bytes.
+const oneTB uint64 = 1024 * 1024 * 1024 * 1024
+
 // getDiskMetrics collects disk usage metrics using gopsutil for the data path.
-// This will reflect the usage of the filesystem mounted at the data path.
+// It applies a special handling for Docker Desktop on macOS, where the underlying
+// Linux VM (using LinuxKit) may report an unrealistic disk size (e.g. > 10TB) due to
+// block size translation issues.
 func (c *ContainerMonitorService) getDiskMetrics(ctx context.Context) (*models.Disk, error) {
+	// Start with gopsutil as the default approach for consistency.
 	usageStat, err := disk.UsageWithContext(ctx, c.dataPath)
 	if err != nil {
 		return nil, err
@@ -316,7 +329,22 @@ func (c *ContainerMonitorService) getDiskMetrics(ctx context.Context) (*models.D
 	usedBytes := usageStat.Used
 	totalBytes := usageStat.Total
 
-	// Default to Active health
+	// If the total reported size is greater than 10TB and we are on Docker Desktop on macOS,
+	// then it is likely we are observing the known block-size inflation issue.
+	if IsDockerDesktopMac() && totalBytes > 10*oneTB {
+
+		// Use the macOS-adjusted approach as a fallback.
+		correctedUsed, correctedTotal, err := c.getMacOSAdjustedDiskMetrics()
+		if err == nil {
+			usedBytes = correctedUsed
+			totalBytes = correctedTotal
+		} else {
+			c.logger.Warnf("Failed to get macOS-adjusted disk metrics: %v", err)
+			return nil, err
+		}
+	}
+
+	// Determine health status based on disk usage thresholds.
 	category := models.Active
 	message := "Disk utilization normal"
 
@@ -325,7 +353,7 @@ func (c *ContainerMonitorService) getDiskMetrics(ctx context.Context) (*models.D
 		category = models.Degraded
 		message = "Disk utilization critical"
 	} else if diskPercent >= constants.DiskMediumThresholdPercent {
-		// Still Active but with a warning message
+		// Still Active but with a warning message.
 		message = "Disk utilization warning"
 	}
 
@@ -341,6 +369,29 @@ func (c *ContainerMonitorService) getDiskMetrics(ctx context.Context) (*models.D
 	}
 
 	return diskStat, nil
+}
+
+// getMacOSAdjustedDiskMetrics retrieves adjusted disk metrics using unix.Statfs.
+// It uses stat.Frsize when available, since on Docker Desktop for macOS the reported
+// Bsize is often 1024× larger than the actual block size.
+func (c *ContainerMonitorService) getMacOSAdjustedDiskMetrics() (usedBytes, totalBytes uint64, err error) {
+	var stat unix.Statfs_t
+	err = unix.Statfs(c.dataPath, &stat)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	// Use Frsize if available; it represents the fundamental block size for macOS.
+	bSize := uint64(stat.Bsize)
+	if stat.Frsize > 0 {
+		bSize = uint64(stat.Frsize)
+	}
+
+	// Compute total and used bytes based on the corrected block size.
+	totalBytes = stat.Blocks * bSize
+	usedBytes = (stat.Blocks - stat.Bfree) * bSize
+
+	return usedBytes, totalBytes, nil
 }
 
 // getHWID gets the hardware ID from system

--- a/umh-core/pkg/service/container_monitor/container_monitor_test.go
+++ b/umh-core/pkg/service/container_monitor/container_monitor_test.go
@@ -244,6 +244,7 @@ var _ = Describe("Container Monitor Service", func() {
 			// Use the real filesystem implementation instead of mocks
 			realFS := filesystem.NewDefaultService()
 			realService := container_monitor.NewContainerMonitorService(realFS)
+			realService.SetDataPath("/workspaces/united-manufacturing-hub")
 
 			container, err := realService.GetStatus(ctx)
 			Expect(err).ToNot(HaveOccurred())

--- a/umh-core/pkg/service/container_monitor/platform_detect.go
+++ b/umh-core/pkg/service/container_monitor/platform_detect.go
@@ -1,0 +1,51 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package container_monitor
+
+import (
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/logger"
+)
+
+var (
+	isDockerDesktopMacOnce sync.Once
+	isDockerDesktopMacVal  bool
+)
+
+// IsDockerDesktopMac determines whether the current environment is likely
+// Docker Desktop running on macOS by inspecting /proc/version for the signature "linuxkit".
+// Docker Desktop on macOS runs containers inside a Linux VM built with LinuxKit.
+// The result is cached after the first call to avoid repeated reads of /proc/version.
+func IsDockerDesktopMac() bool {
+	isDockerDesktopMacOnce.Do(func() {
+		// Read the contents of /proc/version.
+		data, err := os.ReadFile("/proc/version")
+		if err != nil {
+			// If we cannot read /proc/version, fall back to false.
+			isDockerDesktopMacVal = false
+			return
+		}
+		// Check for "linuxkit" which is indicative of Docker Desktop on macOS.
+		isDockerDesktopMacVal = strings.Contains(string(data), "linuxkit")
+		logger := logger.For("platform_detect")
+		if isDockerDesktopMacVal {
+			logger.Infof("Detected Docker Desktop on macOS! Using macOS-adjusted disk metrics.")
+		}
+	})
+	return isDockerDesktopMacVal
+}


### PR DESCRIPTION
Fixes the high amount of disk usage. The actual reason for it is using Docker on top of Mac. It is a well known problem and a lot of docker containers have it as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added detection for Docker Desktop on macOS, enabling automatic adjustments for accurate disk metrics.
  - Introduced configurable data paths to support flexible testing scenarios.

- **Enhancements**
  - Improved monitoring accuracy by refining disk metric calculations for high-capacity storage systems.
  - Streamlined logging behavior to reduce unnecessary console output during operations.

- **Tests**
  - Updated test configurations to leverage the new data path settings for enhanced service validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->