### PR TITLE
fix: ENG-2832 context expiration prevention

### DIFF
--- a/umh-core/pkg/constants/baseFSM.go
+++ b/umh-core/pkg/constants/baseFSM.go
@@ -1,3 +1,17 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package constants
 
 import "time"

--- a/umh-core/pkg/constants/baseFSM.go
+++ b/umh-core/pkg/constants/baseFSM.go
@@ -1,0 +1,7 @@
+package constants
+
+import "time"
+
+const (
+	ExpectedMaxP95ExecutionTimePerEvent = 1 * time.Millisecond
+)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved event handling to prevent deadlocks and failures when context expires during transitions.  
- **New Features**
  - Added a safeguard to skip transitions if the remaining context time is insufficient.  
- **Chores**
  - Introduced a new constant defining the expected maximum execution time per event.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->