### PR TITLE
Feat: Add nmap & connection-serviceconfig 

### DIFF
--- a/umh-core/pkg/config/config.go
+++ b/umh-core/pkg/config/config.go
@@ -15,10 +15,9 @@
 package config
 
 import (
-	"reflect"
-
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/benthosserviceconfig"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/dataflowcomponentconfig"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/nmapserviceconfig"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/redpandaserviceconfig"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/s6serviceconfig"
 
@@ -102,20 +101,7 @@ type NmapConfig struct {
 	FSMInstanceConfig `yaml:",inline"`
 
 	// For the Nmap service
-	NmapServiceConfig NmapServiceConfig `yaml:"nmapServiceConfig"`
-}
-
-// NmapServiceConfig represents the configuration for a Nmap service
-type NmapServiceConfig struct {
-	// Target to scan (hostname or IP)
-	Target string `yaml:"target"`
-	// Port to scan (single port number)
-	Port int `yaml:"port"`
-}
-
-// Equal checks if two NmapServiceConfigs are equal
-func (c NmapServiceConfig) Equal(other NmapServiceConfig) bool {
-	return reflect.DeepEqual(c, other)
+	NmapServiceConfig nmapserviceconfig.NmapServiceConfig `yaml:"nmapServiceConfig"`
 }
 
 // RedpandaConfig contains configuration for a Redpanda service

--- a/umh-core/pkg/config/connectionserviceconfig/comparator.go
+++ b/umh-core/pkg/config/connectionserviceconfig/comparator.go
@@ -1,0 +1,50 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connectionserviceconfig
+
+import (
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/nmapserviceconfig"
+)
+
+// Comparator handles the comparison of Connection configurations
+type Comparator struct {
+	normalizer *Normalizer
+}
+
+// NewComparator creates a new configuration comparator for Connection
+func NewComparator() *Comparator {
+	return &Comparator{
+		normalizer: NewNormalizer(),
+	}
+}
+
+// ConfigsEqual compares two ConnectionServiceConfigs by converting to NmapServiceConfig
+// and using the existing comparison utilization
+func (c *Comparator) ConfigsEqual(desired, observed ConnectionServiceConfig) (isEqual bool) {
+	nmapD := desired.GetNmapServiceConfig()
+	nmapO := observed.GetNmapServiceConfig()
+
+	comparator := nmapserviceconfig.NewComparator()
+	return comparator.ConfigsEqual(nmapD, nmapO)
+}
+
+// ConfigDiff returns a human-readable string describing differences between configs
+func (c *Comparator) ConfigDiff(desired, observed ConnectionServiceConfig) string {
+	nmapD := desired.GetNmapServiceConfig()
+	nmapO := observed.GetNmapServiceConfig()
+
+	comparator := nmapserviceconfig.NewComparator()
+	return comparator.ConfigDiff(nmapD, nmapO)
+}

--- a/umh-core/pkg/config/connectionserviceconfig/comparator_test.go
+++ b/umh-core/pkg/config/connectionserviceconfig/comparator_test.go
@@ -12,23 +12,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package nmapserviceconfig
+package connectionserviceconfig
 
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/nmapserviceconfig"
 )
 
-var _ = Describe("Nmap YAML Comparator", func() {
+var _ = Describe("Connection YAML Comparator", func() {
 	Describe("ConfigsEqual", func() {
 		It("should consider identical configs equal", func() {
-			config1 := NmapServiceConfig{
-				Target: "127.0.0.1",
-				Port:   443,
+
+			config1 := ConnectionServiceConfig{
+				NmapServiceConfig: nmapserviceconfig.NmapServiceConfig{
+					Target: "127.0.0.1",
+					Port:   443,
+				},
 			}
-			config2 := NmapServiceConfig{
-				Target: "127.0.0.1",
-				Port:   443,
+			config2 := ConnectionServiceConfig{
+				NmapServiceConfig: nmapserviceconfig.NmapServiceConfig{
+					Target: "127.0.0.1",
+					Port:   443,
+				},
 			}
 
 			comparator := NewComparator()
@@ -38,13 +44,17 @@ var _ = Describe("Nmap YAML Comparator", func() {
 		})
 
 		It("should consider configs with different targets not equal", func() {
-			config1 := NmapServiceConfig{
-				Target: "127.0.0.1",
-				Port:   443,
+			config1 := ConnectionServiceConfig{
+				NmapServiceConfig: nmapserviceconfig.NmapServiceConfig{
+					Target: "127.0.0.1",
+					Port:   443,
+				},
 			}
-			config2 := NmapServiceConfig{
-				Target: "127.0.0.2",
-				Port:   443,
+			config2 := ConnectionServiceConfig{
+				NmapServiceConfig: nmapserviceconfig.NmapServiceConfig{
+					Target: "127.0.0.2",
+					Port:   443,
+				},
 			}
 
 			comparator := NewComparator()
@@ -58,14 +68,17 @@ var _ = Describe("Nmap YAML Comparator", func() {
 		})
 
 		It("should consider configs with different ports not equal", func() {
-
-			config1 := NmapServiceConfig{
-				Target: "127.0.0.1",
-				Port:   443,
+			config1 := ConnectionServiceConfig{
+				NmapServiceConfig: nmapserviceconfig.NmapServiceConfig{
+					Target: "127.0.0.1",
+					Port:   443,
+				},
 			}
-			config2 := NmapServiceConfig{
-				Target: "127.0.0.1",
-				Port:   444,
+			config2 := ConnectionServiceConfig{
+				NmapServiceConfig: nmapserviceconfig.NmapServiceConfig{
+					Target: "127.0.0.1",
+					Port:   444,
+				},
 			}
 
 			comparator := NewComparator()
@@ -82,14 +95,17 @@ var _ = Describe("Nmap YAML Comparator", func() {
 	// Test package-level functions
 	Describe("Package-level functions", func() {
 		It("ConfigsEqual should use default comparator", func() {
-
-			config1 := NmapServiceConfig{
-				Target: "127.0.0.1",
-				Port:   443,
+			config1 := ConnectionServiceConfig{
+				NmapServiceConfig: nmapserviceconfig.NmapServiceConfig{
+					Target: "127.0.0.1",
+					Port:   443,
+				},
 			}
-			config2 := NmapServiceConfig{
-				Target: "127.0.0.1",
-				Port:   443,
+			config2 := ConnectionServiceConfig{
+				NmapServiceConfig: nmapserviceconfig.NmapServiceConfig{
+					Target: "127.0.0.1",
+					Port:   443,
+				},
 			}
 
 			// Use package-level function
@@ -103,16 +119,18 @@ var _ = Describe("Nmap YAML Comparator", func() {
 		})
 
 		It("ConfigDiff should use default comparator", func() {
-
-			config1 := NmapServiceConfig{
-				Target: "127.0.0.1",
-				Port:   443,
+			config1 := ConnectionServiceConfig{
+				NmapServiceConfig: nmapserviceconfig.NmapServiceConfig{
+					Target: "127.0.0.1",
+					Port:   443,
+				},
 			}
-			config2 := NmapServiceConfig{
-				Target: "127.0.0.1",
-				Port:   444,
+			config2 := ConnectionServiceConfig{
+				NmapServiceConfig: nmapserviceconfig.NmapServiceConfig{
+					Target: "127.0.0.1",
+					Port:   443,
+				},
 			}
-
 			// Use package-level function
 			diff1 := ConfigDiff(config1, config2)
 

--- a/umh-core/pkg/config/connectionserviceconfig/generator.go
+++ b/umh-core/pkg/config/connectionserviceconfig/generator.go
@@ -44,7 +44,7 @@ func (g *Generator) RenderConfig(cfg ConnectionServiceConfig) (string, error) {
 	// Marshal to YAML
 	yamlBytes, err := yaml.Marshal(normalizedMap)
 	if err != nil {
-		return "", fmt.Errorf("failed to marshal Benthos config: %w", err)
+		return "", fmt.Errorf("failed to marshal Connection config: %w", err)
 	}
 
 	yamlStr := string(yamlBytes)
@@ -90,5 +90,5 @@ type templateData struct {
 var simplifiedTemplate = `
 nmap:
   target: {{.Target}}
-	port: {{.Port}}
+  port: {{.Port}}
 `

--- a/umh-core/pkg/config/connectionserviceconfig/generator.go
+++ b/umh-core/pkg/config/connectionserviceconfig/generator.go
@@ -1,0 +1,94 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connectionserviceconfig
+
+import (
+	"fmt"
+	"text/template"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/nmapserviceconfig"
+	"gopkg.in/yaml.v3"
+)
+
+// Generator handles the generation of Nmap YAML configurations
+type Generator struct {
+	tmpl *template.Template
+}
+
+// NewGenerator creates a new YAML generator for Benthos configurations
+func NewGenerator() *Generator {
+	return &Generator{
+		tmpl: template.Must(template.New("connection").Parse(simplifiedTemplate)),
+	}
+}
+
+// RenderConfig generates a Connection YAML configuration from a ConnectionServiceConfig
+func (g *Generator) RenderConfig(cfg ConnectionServiceConfig) (string, error) {
+
+	// Convert the config to a normalized map
+	configMap := g.configToMap(cfg)
+	normalizedMap := normalizeConfig(configMap)
+
+	// Marshal to YAML
+	yamlBytes, err := yaml.Marshal(normalizedMap)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal Benthos config: %w", err)
+	}
+
+	yamlStr := string(yamlBytes)
+
+	return yamlStr, nil
+}
+
+// configToMap converts a ConnectionServiceConfig to a raw map for YAML generation
+func (g *Generator) configToMap(cfg ConnectionServiceConfig) map[string]any {
+	configMap := make(map[string]any)
+
+	// Add all sections
+	if cfg.NmapServiceConfig.Target != "" && len(cfg.NmapServiceConfig.Target) > 0 {
+		configMap["target"] = cfg.NmapServiceConfig.Target
+	}
+
+	if cfg.NmapServiceConfig.Port != 0 {
+		configMap["port"] = cfg.NmapServiceConfig.Port
+	}
+
+	// We need indent this since it should look like this:
+	// connection:
+	//    nmap:
+	//      target: "127.0.0.1"
+	//      port: 443
+	connectionConfigMap := make(map[string]any)
+	connectionConfigMap["nmap"] = configMap
+
+	return connectionConfigMap
+}
+
+// normalizeConfig does not need to adjust anything here
+func normalizeConfig(raw map[string]any) map[string]any {
+	return raw
+}
+
+// templateData represents the data structure expected by the simplified Connection YAML template
+type templateData struct {
+	NmapServiceConfig *nmapserviceconfig.NmapServiceConfig
+}
+
+// simplifiedTemplate is a much simpler template that just places pre-rendered YAML blocks
+var simplifiedTemplate = `
+nmap:
+  target: {{.Target}}
+	port: {{.Port}}
+`

--- a/umh-core/pkg/config/connectionserviceconfig/generator_test.go
+++ b/umh-core/pkg/config/connectionserviceconfig/generator_test.go
@@ -1,0 +1,110 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connectionserviceconfig
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/nmapserviceconfig"
+)
+
+var _ = Describe("Nmap YAML Generator", func() {
+	type testCase struct {
+		config      *ConnectionServiceConfig
+		expected    []string
+		notExpected []string
+	}
+
+	DescribeTable("generator rendering",
+		func(tc testCase) {
+			generator := NewGenerator()
+			yamlStr, err := generator.RenderConfig(*tc.config)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Check for expected strings
+			for _, exp := range tc.expected {
+				Expect(yamlStr).To(ContainSubstring(exp))
+			}
+
+			// Check for strings that should not be present
+			for _, notExp := range tc.notExpected {
+				Expect(yamlStr).NotTo(ContainSubstring(notExp))
+			}
+		},
+		Entry("should render empty port correctly",
+			testCase{
+				config: &ConnectionServiceConfig{
+					NmapServiceConfig: nmapserviceconfig.NmapServiceConfig{
+						Target: "127.0.0.1",
+					},
+				},
+				expected: []string{
+					"nmap:",
+					"  target:",
+				},
+				notExpected: []string{
+					"  port",
+				},
+			}),
+		Entry("should render empty target correctly",
+			testCase{
+				config: &ConnectionServiceConfig{
+					NmapServiceConfig: nmapserviceconfig.NmapServiceConfig{
+						Port: 443,
+					},
+				},
+				expected: []string{
+					"nmap:",
+					"  port: 443",
+				},
+				notExpected: []string{
+					"  target:",
+				},
+			}),
+	)
+
+	// Add package-level function test
+	Describe("RenderNmapYAML package function", func() {
+		It("should produce the same output as the Generator", func() {
+			// Setup test config
+			target := "127.0.0.1"
+			port := 443
+			nmapConfig := nmapserviceconfig.NmapServiceConfig{
+				Target: target,
+				Port:   port,
+			}
+
+			// Use package-level function
+			yamlStr1, err := RenderConnectionYAML(
+				nmapConfig,
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Use Generator directly
+			cfg := ConnectionServiceConfig{
+				NmapServiceConfig: nmapserviceconfig.NmapServiceConfig{
+					Target: target,
+					Port:   port,
+				},
+			}
+			generator := NewGenerator()
+			yamlStr2, err := generator.RenderConfig(cfg)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Both should produce the same result
+			Expect(yamlStr1).To(Equal(yamlStr2))
+		})
+	})
+})

--- a/umh-core/pkg/config/connectionserviceconfig/normalizer.go
+++ b/umh-core/pkg/config/connectionserviceconfig/normalizer.go
@@ -1,0 +1,35 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connectionserviceconfig
+
+import "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/nmapserviceconfig"
+
+// Normalizer handles the normalization of Connection configurations
+type Normalizer struct{}
+
+// NewNormalizer creates a new configuration normalizer for Connection
+func NewNormalizer() *Normalizer {
+	return &Normalizer{}
+}
+
+// NormalizeConfig applies normalization to a ConnectionServiceConfig
+// by leveraging the existing normalizer for NmapServiceConfig
+func (n *Normalizer) NormalizeConfig(cfg ConnectionServiceConfig) ConnectionServiceConfig {
+
+	normalizer := nmapserviceconfig.NewNormalizer()
+	normalized := normalizer.NormalizeConfig(cfg.NmapServiceConfig)
+
+	return FromNmapServiceConfig(normalized)
+}

--- a/umh-core/pkg/config/connectionserviceconfig/normalizer_test.go
+++ b/umh-core/pkg/config/connectionserviceconfig/normalizer_test.go
@@ -1,0 +1,61 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connectionserviceconfig
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/nmapserviceconfig"
+)
+
+var _ = Describe("Connection YAML Normalizer", func() {
+	Describe("NormalizeConfig", func() {
+
+		It("should preserve existing values", func() {
+			config := ConnectionServiceConfig{
+				NmapServiceConfig: nmapserviceconfig.NmapServiceConfig{
+					Target: "127.0.0.1",
+					Port:   443,
+				},
+			}
+
+			normalizer := NewNormalizer()
+			normalizedConfig := normalizer.NormalizeConfig(config)
+			normalizedTarget := normalizedConfig.NmapServiceConfig.Target
+			normalizedPort := normalizedConfig.NmapServiceConfig.Port
+
+			Expect(normalizedTarget).To(Equal("127.0.0.1"))
+			Expect(normalizedPort).To(Equal(443))
+		})
+	})
+
+	// Test the package-level function
+	Describe("NormalizeConnectionConfig package function", func() {
+		It("should use the default normalizer", func() {
+			config := ConnectionServiceConfig{}
+
+			// Use package-level function
+			normalizedConfig1 := NormalizeConnectionConfig(config)
+
+			// Use normalizer directly
+			normalizer := NewNormalizer()
+			normalizedConfig2 := normalizer.NormalizeConfig(config)
+
+			// Results should be the same
+			Expect(normalizedConfig1.NmapServiceConfig.Target).To(Equal(normalizedConfig2.NmapServiceConfig.Target))
+			Expect(normalizedConfig1.NmapServiceConfig.Port).To(Equal(normalizedConfig2.NmapServiceConfig.Port))
+		})
+	})
+})

--- a/umh-core/pkg/config/connectionserviceconfig/package.go
+++ b/umh-core/pkg/config/connectionserviceconfig/package.go
@@ -1,0 +1,65 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connectionserviceconfig
+
+import "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/nmapserviceconfig"
+
+var (
+	defaultGenerator  = NewGenerator()
+	defaultNormalizer = NewNormalizer()
+	defaultComparator = NewComparator()
+)
+
+// ConnectionServiceConfig represents the configuration for a DataFlowComponent
+type ConnectionServiceConfig struct {
+	NmapServiceConfig nmapserviceconfig.NmapServiceConfig `yaml:"nmap"`
+}
+
+// Equal checks if two ConnectionServiceConfigs are equal
+func (c ConnectionServiceConfig) Equal(other ConnectionServiceConfig) bool {
+	return NewComparator().ConfigsEqual(c, other)
+}
+
+// RenderConnectionYAML is a package-level function for easy YAML generation
+func RenderConnectionYAML(nmap any) (string, error) {
+	// Create a config object from the individual components
+	cfg := ConnectionServiceConfig{
+		NmapServiceConfig: nmapserviceconfig.NmapServiceConfig{},
+	}
+
+	if nmap != nil {
+		if nmapMap, ok := nmap.(nmapserviceconfig.NmapServiceConfig); ok {
+			cfg.NmapServiceConfig = nmapMap
+		}
+	}
+
+	// Use the generator to render the YAML
+	return defaultGenerator.RenderConfig(cfg)
+}
+
+// NormalizeConnectionConfig is a package-level function for easy config normalization
+func NormalizeConnectionConfig(cfg ConnectionServiceConfig) ConnectionServiceConfig {
+	return defaultNormalizer.NormalizeConfig(cfg)
+}
+
+// ConfigsEqual is a package-level function for easy config comparison
+func ConfigsEqual(desired, observed ConnectionServiceConfig) bool {
+	return defaultComparator.ConfigsEqual(desired, observed)
+}
+
+// ConfigDiff is a package-level function for easy config diff generation
+func ConfigDiff(desired, observed ConnectionServiceConfig) string {
+	return defaultComparator.ConfigDiff(desired, observed)
+}

--- a/umh-core/pkg/config/connectionserviceconfig/package.go
+++ b/umh-core/pkg/config/connectionserviceconfig/package.go
@@ -33,16 +33,10 @@ func (c ConnectionServiceConfig) Equal(other ConnectionServiceConfig) bool {
 }
 
 // RenderConnectionYAML is a package-level function for easy YAML generation
-func RenderConnectionYAML(nmap any) (string, error) {
+func RenderConnectionYAML(nmap nmapserviceconfig.NmapServiceConfig) (string, error) {
 	// Create a config object from the individual components
 	cfg := ConnectionServiceConfig{
-		NmapServiceConfig: nmapserviceconfig.NmapServiceConfig{},
-	}
-
-	if nmap != nil {
-		if nmapMap, ok := nmap.(nmapserviceconfig.NmapServiceConfig); ok {
-			cfg.NmapServiceConfig = nmapMap
-		}
+		NmapServiceConfig: nmap,
 	}
 
 	// Use the generator to render the YAML

--- a/umh-core/pkg/config/connectionserviceconfig/utils.go
+++ b/umh-core/pkg/config/connectionserviceconfig/utils.go
@@ -1,0 +1,31 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connectionserviceconfig
+
+import (
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/nmapserviceconfig"
+)
+
+// GetNmapServiceConfig converts the component config to a full NmapServiceConfig
+func (c *ConnectionServiceConfig) GetNmapServiceConfig() nmapserviceconfig.NmapServiceConfig {
+	return c.NmapServiceConfig
+}
+
+// FromNmapServiceConfig creates a ConnectionServiceConfig from a NmapServiceConfig,
+func FromNmapServiceConfig(nmap nmapserviceconfig.NmapServiceConfig) ConnectionServiceConfig {
+	return ConnectionServiceConfig{
+		NmapServiceConfig: nmap,
+	}
+}

--- a/umh-core/pkg/config/connectionserviceconfig/yaml_suite_test.go
+++ b/umh-core/pkg/config/connectionserviceconfig/yaml_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connectionserviceconfig
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestYAML(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Connection YAML Suite")
+}

--- a/umh-core/pkg/config/nmapserviceconfig/comparator.go
+++ b/umh-core/pkg/config/nmapserviceconfig/comparator.go
@@ -1,0 +1,82 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nmapserviceconfig
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Comparator handles the comparison of Nmap configurations
+type Comparator struct {
+	normalizer *Normalizer
+}
+
+// NewComparator creates a new configuration comparator for Nmap
+func NewComparator() *Comparator {
+	return &Comparator{
+		normalizer: NewNormalizer(),
+	}
+}
+
+// ConfigsEqual compares two NmapServiceConfigs after normalization
+func (c *Comparator) ConfigsEqual(desired, observed NmapServiceConfig) (isEqual bool) {
+	// First normalize both configs
+	normDesired := c.normalizer.NormalizeConfig(desired)
+	normObserved := c.normalizer.NormalizeConfig(observed)
+	defer func() {
+		if !isEqual {
+			fmt.Printf("Normalized desired: %+v\n", normDesired)
+			fmt.Printf("Normalized observed: %+v\n", normObserved)
+		}
+	}()
+
+	// Compare essential fields that must match exactly
+	if normDesired.Target != normObserved.Target {
+		return false
+	}
+
+	if normDesired.Port != normObserved.Port {
+		return false
+	}
+
+	return true
+}
+
+// ConfigDiff returns a human-readable string describing differences between configs
+func (c *Comparator) ConfigDiff(desired, observed NmapServiceConfig) string {
+	var diff strings.Builder
+
+	// First normalize both configs
+	normDesired := c.normalizer.NormalizeConfig(desired)
+	normObserved := c.normalizer.NormalizeConfig(observed)
+
+	// Check basic fields
+	if normDesired.Target != normObserved.Target {
+		diff.WriteString(fmt.Sprintf("Target: Want: %s, Have: %s\n",
+			normDesired.Target, normObserved.Target))
+	}
+
+	if normDesired.Port != normObserved.Port {
+		diff.WriteString(fmt.Sprintf("Port: Want: %d, Have: %d\n",
+			normDesired.Port, normObserved.Port))
+	}
+
+	if diff.Len() == 0 {
+		return "No significant differences"
+	}
+
+	return diff.String()
+}

--- a/umh-core/pkg/config/nmapserviceconfig/comparator_test.go
+++ b/umh-core/pkg/config/nmapserviceconfig/comparator_test.go
@@ -1,0 +1,126 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nmapserviceconfig
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Benthos YAML Comparator", func() {
+	Describe("ConfigsEqual", func() {
+		It("should consider identical configs equal", func() {
+			config1 := NmapServiceConfig{
+				Target: "127.0.0.1",
+				Port:   443,
+			}
+			config2 := NmapServiceConfig{
+				Target: "127.0.0.1",
+				Port:   443,
+			}
+
+			comparator := NewComparator()
+			equal := comparator.ConfigsEqual(config1, config2)
+
+			Expect(equal).To(BeTrue())
+		})
+
+		It("should consider configs with different targets not equal", func() {
+			config1 := NmapServiceConfig{
+				Target: "127.0.0.1",
+				Port:   443,
+			}
+			config2 := NmapServiceConfig{
+				Target: "127.0.0.2",
+				Port:   443,
+			}
+
+			comparator := NewComparator()
+			equal := comparator.ConfigsEqual(config1, config2)
+			Expect(equal).To(BeFalse())
+
+			diff := comparator.ConfigDiff(config1, config2)
+			Expect(diff).To(ContainSubstring("Target:"))
+			Expect(diff).To(ContainSubstring("Want: 127.0.0.1"))
+			Expect(diff).To(ContainSubstring("Have: 127.0.0.2"))
+		})
+
+		It("should consider configs with different outputs not equal", func() {
+
+			config1 := NmapServiceConfig{
+				Target: "127.0.0.1",
+				Port:   443,
+			}
+			config2 := NmapServiceConfig{
+				Target: "127.0.0.1",
+				Port:   444,
+			}
+
+			comparator := NewComparator()
+			equal := comparator.ConfigsEqual(config1, config2)
+			Expect(equal).To(BeFalse())
+
+			diff := comparator.ConfigDiff(config1, config2)
+			Expect(diff).To(ContainSubstring("Port:"))
+			Expect(diff).To(ContainSubstring("Want: 443"))
+			Expect(diff).To(ContainSubstring("Have: 444"))
+		})
+	})
+
+	// Test package-level functions
+	Describe("Package-level functions", func() {
+		It("ConfigsEqual should use default comparator", func() {
+
+			config1 := NmapServiceConfig{
+				Target: "127.0.0.1",
+				Port:   443,
+			}
+			config2 := NmapServiceConfig{
+				Target: "127.0.0.1",
+				Port:   443,
+			}
+
+			// Use package-level function
+			equal1 := ConfigsEqual(config1, config2)
+
+			// Use comparator directly
+			comparator := NewComparator()
+			equal2 := comparator.ConfigsEqual(config1, config2)
+
+			Expect(equal1).To(Equal(equal2))
+		})
+
+		It("ConfigDiff should use default comparator", func() {
+
+			config1 := NmapServiceConfig{
+				Target: "127.0.0.1",
+				Port:   443,
+			}
+			config2 := NmapServiceConfig{
+				Target: "127.0.0.1",
+				Port:   444,
+			}
+
+			// Use package-level function
+			diff1 := ConfigDiff(config1, config2)
+
+			// Use comparator directly
+			comparator := NewComparator()
+			diff2 := comparator.ConfigDiff(config1, config2)
+
+			Expect(diff1).To(Equal(diff2))
+		})
+	})
+})

--- a/umh-core/pkg/config/nmapserviceconfig/generator.go
+++ b/umh-core/pkg/config/nmapserviceconfig/generator.go
@@ -16,21 +16,20 @@ package nmapserviceconfig
 
 import (
 	"fmt"
-	"text/template"
 
 	"gopkg.in/yaml.v3"
 )
 
 // Generator handles the generation of Nmap YAML configurations
+// Currently BoilerPlate-Code
 type Generator struct {
-	tmpl *template.Template
 }
 
 // NewGenerator creates a new YAML generator for Nmap configurations
+// Currently BoilerPlate-Code
+
 func NewGenerator() *Generator {
-	return &Generator{
-		tmpl: template.Must(template.New("benthos").Parse(simplifiedTemplate)),
-	}
+	return &Generator{}
 }
 
 // RenderConfig generates a Nmap YAML configuration from a NmapServiceConfig

--- a/umh-core/pkg/config/nmapserviceconfig/generator.go
+++ b/umh-core/pkg/config/nmapserviceconfig/generator.go
@@ -46,7 +46,6 @@ func (g *Generator) RenderConfig(cfg NmapServiceConfig) (string, error) {
 		return "", fmt.Errorf("failed to marshal Nmap config: %w", err)
 	}
 
-	// Fix the indentation for http and logger sections to match the expected format
 	yamlStr := string(yamlBytes)
 
 	return yamlStr, nil

--- a/umh-core/pkg/config/nmapserviceconfig/generator.go
+++ b/umh-core/pkg/config/nmapserviceconfig/generator.go
@@ -1,0 +1,86 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nmapserviceconfig
+
+import (
+	"fmt"
+	"text/template"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Generator handles the generation of Nmap YAML configurations
+type Generator struct {
+	tmpl *template.Template
+}
+
+// NewGenerator creates a new YAML generator for Nmap configurations
+func NewGenerator() *Generator {
+	return &Generator{
+		tmpl: template.Must(template.New("benthos").Parse(simplifiedTemplate)),
+	}
+}
+
+// RenderConfig generates a Nmap YAML configuration from a NmapServiceConfig
+func (g *Generator) RenderConfig(cfg NmapServiceConfig) (string, error) {
+
+	// Convert the config to a normalized map
+	configMap := g.configToMap(cfg)
+	normalizedMap := normalizeConfig(configMap)
+
+	// Marshal to YAML
+	yamlBytes, err := yaml.Marshal(normalizedMap)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal Nmap config: %w", err)
+	}
+
+	// Fix the indentation for http and logger sections to match the expected format
+	yamlStr := string(yamlBytes)
+
+	return yamlStr, nil
+}
+
+// configToMap converts a NmapServiceConfig to a raw map for YAML generation
+func (g *Generator) configToMap(cfg NmapServiceConfig) map[string]any {
+	configMap := make(map[string]any)
+
+	// Add all sections
+	if cfg.Target != "" && len(cfg.Target) > 0 {
+		configMap["target"] = cfg.Target
+	}
+
+	if cfg.Port != 0 {
+		configMap["port"] = cfg.Port
+	}
+
+	return configMap
+}
+
+// normalizeConfig applies nothing since Nmap has no default settings
+func normalizeConfig(raw map[string]any) map[string]any {
+	return raw
+}
+
+// templateData represents the data structure expected by the simplified Nmap YAML template
+type templateData struct {
+	Target string
+	Port   int
+}
+
+// simplifiedTemplate is a much simpler template that just places pre-rendered YAML blocks
+var simplifiedTemplate = `target:{{.Target}}
+
+port:{{.Port}}
+`

--- a/umh-core/pkg/config/nmapserviceconfig/generator_test.go
+++ b/umh-core/pkg/config/nmapserviceconfig/generator_test.go
@@ -1,0 +1,98 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nmapserviceconfig
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Nmap YAML Generator", func() {
+	type testCase struct {
+		config      *NmapServiceConfig
+		expected    []string
+		notExpected []string
+	}
+
+	DescribeTable("generator rendering",
+		func(tc testCase) {
+			generator := NewGenerator()
+			yamlStr, err := generator.RenderConfig(*tc.config)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Check for expected strings
+			for _, exp := range tc.expected {
+				Expect(yamlStr).To(ContainSubstring(exp))
+			}
+
+			// Check for strings that should not be present
+			for _, notExp := range tc.notExpected {
+				Expect(yamlStr).NotTo(ContainSubstring(notExp))
+			}
+		},
+		Entry("should render empty port correctly",
+			testCase{
+				config: &NmapServiceConfig{
+					Target: "127.0.0.1",
+				},
+				expected: []string{
+					"target:",
+				},
+				notExpected: []string{
+					"port",
+				},
+			}),
+		Entry("should render empty target correctly",
+			testCase{
+				config: &NmapServiceConfig{
+					Port: 443,
+				},
+				expected: []string{
+					"port: 443",
+				},
+				notExpected: []string{
+					"target:",
+				},
+			}),
+	)
+
+	// Add package-level function test
+	Describe("RenderNmapYAML package function", func() {
+		It("should produce the same output as the Generator", func() {
+			// Setup test config
+			target := "127.0.0.1"
+			port := 443
+
+			// Use package-level function
+			yamlStr1, err := RenderNmapYAML(
+				target,
+				port,
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Use Generator directly
+			cfg := NmapServiceConfig{
+				Target: target,
+				Port:   port,
+			}
+			generator := NewGenerator()
+			yamlStr2, err := generator.RenderConfig(cfg)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Both should produce the same result
+			Expect(yamlStr1).To(Equal(yamlStr2))
+		})
+	})
+})

--- a/umh-core/pkg/config/nmapserviceconfig/normalizer.go
+++ b/umh-core/pkg/config/nmapserviceconfig/normalizer.go
@@ -1,0 +1,28 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nmapserviceconfig
+
+// Normalizer handles the normalization of Nmap configurations
+type Normalizer struct{}
+
+// NewNormalizer creates a new configuration normalizer for Nmap
+func NewNormalizer() *Normalizer {
+	return &Normalizer{}
+}
+
+// NormalizeConfig doesn't do anything, there is no normalization needed here
+func (n *Normalizer) NormalizeConfig(cfg NmapServiceConfig) NmapServiceConfig {
+	return cfg
+}

--- a/umh-core/pkg/config/nmapserviceconfig/normalizer_test.go
+++ b/umh-core/pkg/config/nmapserviceconfig/normalizer_test.go
@@ -1,0 +1,58 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nmapserviceconfig
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Nmap YAML Normalizer", func() {
+	Describe("NormalizeConfig", func() {
+
+		It("should preserve existing values", func() {
+			config := NmapServiceConfig{
+				Target: "127.0.0.1",
+				Port:   443,
+			}
+
+			normalizer := NewNormalizer()
+			normalizedConfig := normalizer.NormalizeConfig(config)
+			normalizedTarget := normalizedConfig.Target
+			normalizedPort := normalizedConfig.Port
+
+			Expect(normalizedTarget).To(Equal("127.0.0.1"))
+			Expect(normalizedPort).To(Equal(443))
+		})
+	})
+
+	// Test the package-level function
+	Describe("NormalizeNmapConfig package function", func() {
+		It("should use the default normalizer", func() {
+			config := NmapServiceConfig{}
+
+			// Use package-level function
+			normalizedConfig1 := NormalizeBenthosConfig(config)
+
+			// Use normalizer directly
+			normalizer := NewNormalizer()
+			normalizedConfig2 := normalizer.NormalizeConfig(config)
+
+			// Results should be the same
+			Expect(normalizedConfig1.Target).To(Equal(normalizedConfig2.Target))
+			Expect(normalizedConfig1.Port).To(Equal(normalizedConfig2.Port))
+		})
+	})
+})

--- a/umh-core/pkg/config/nmapserviceconfig/normalizer_test.go
+++ b/umh-core/pkg/config/nmapserviceconfig/normalizer_test.go
@@ -44,7 +44,7 @@ var _ = Describe("Nmap YAML Normalizer", func() {
 			config := NmapServiceConfig{}
 
 			// Use package-level function
-			normalizedConfig1 := NormalizeBenthosConfig(config)
+			normalizedConfig1 := NormalizeNmapConfig(config)
 
 			// Use normalizer directly
 			normalizer := NewNormalizer()

--- a/umh-core/pkg/config/nmapserviceconfig/package.go
+++ b/umh-core/pkg/config/nmapserviceconfig/package.go
@@ -46,7 +46,7 @@ func RenderNmapYAML(target string, port int) (string, error) {
 }
 
 // NormalizeNmapConfig is a package-level function for easy config normalization
-func NormalizeBenthosConfig(cfg NmapServiceConfig) NmapServiceConfig {
+func NormalizeNmapConfig(cfg NmapServiceConfig) NmapServiceConfig {
 	return defaultNormalizer.NormalizeConfig(cfg)
 }
 

--- a/umh-core/pkg/config/nmapserviceconfig/package.go
+++ b/umh-core/pkg/config/nmapserviceconfig/package.go
@@ -1,0 +1,61 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nmapserviceconfig
+
+var (
+	defaultGenerator  = NewGenerator()
+	defaultNormalizer = NewNormalizer()
+	defaultComparator = NewComparator()
+)
+
+// NmapServiceConfig represents the configuration for a Nmap service
+type NmapServiceConfig struct {
+	// Target to scan (hostname or IP)
+	Target string `yaml:"target"`
+	// Port to scan (single port number)
+	Port int `yaml:"port"`
+}
+
+// Equal checks if two BenthosServiceConfigs are equal
+func (c NmapServiceConfig) Equal(other NmapServiceConfig) bool {
+	return NewComparator().ConfigsEqual(c, other)
+}
+
+// RenderNmapYAML is a package-level function for easy YAML generation
+func RenderNmapYAML(target string, port int) (string, error) {
+	// Create a config object from the individual components
+	cfg := NmapServiceConfig{
+		Target: target,
+		Port:   port,
+	}
+
+	// Use the generator to render the YAML
+	return defaultGenerator.RenderConfig(cfg)
+}
+
+// NormalizeNmapConfig is a package-level function for easy config normalization
+func NormalizeBenthosConfig(cfg NmapServiceConfig) NmapServiceConfig {
+	return defaultNormalizer.NormalizeConfig(cfg)
+}
+
+// ConfigsEqual is a package-level function for easy config comparison
+func ConfigsEqual(desired, observed NmapServiceConfig) bool {
+	return defaultComparator.ConfigsEqual(desired, observed)
+}
+
+// ConfigDiff is a package-level function for easy config diff generation
+func ConfigDiff(desired, observed NmapServiceConfig) string {
+	return defaultComparator.ConfigDiff(desired, observed)
+}

--- a/umh-core/pkg/config/nmapserviceconfig/yaml_suite_test.go
+++ b/umh-core/pkg/config/nmapserviceconfig/yaml_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nmapserviceconfig
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestYAML(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Nmap YAML Suite")
+}

--- a/umh-core/pkg/service/nmap/mock.go
+++ b/umh-core/pkg/service/nmap/mock.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/nmapserviceconfig"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/s6serviceconfig"
 	s6fsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/s6"
 )
@@ -26,7 +27,7 @@ import (
 // MockNmapService is a mock implementation of the INmapService interface for testing
 type MockNmapService struct {
 	// Configs keeps track of registered services
-	Configs map[string]*config.NmapServiceConfig
+	Configs map[string]*nmapserviceconfig.NmapServiceConfig
 
 	// StateMap keeps track of desired states
 	StateMap map[string]string
@@ -35,7 +36,7 @@ type MockNmapService struct {
 	StatusResult ServiceInfo
 
 	// GetConfig response to return
-	GetConfigResult config.NmapServiceConfig
+	GetConfigResult nmapserviceconfig.NmapServiceConfig
 
 	// Error to return for various operations
 	GenerateConfigError error
@@ -61,7 +62,7 @@ var _ INmapService = (*MockNmapService)(nil)
 // NewMockNmapService creates a new mock nmap service
 func NewMockNmapService() *MockNmapService {
 	return &MockNmapService{
-		Configs:          make(map[string]*config.NmapServiceConfig),
+		Configs:          make(map[string]*nmapserviceconfig.NmapServiceConfig),
 		StateMap:         make(map[string]string),
 		ServiceStates:    make(map[string]*ServiceInfo),
 		ExistingServices: make(map[string]bool),
@@ -69,7 +70,7 @@ func NewMockNmapService() *MockNmapService {
 }
 
 // GenerateS6ConfigForNmap generates a mock S6 config
-func (m *MockNmapService) GenerateS6ConfigForNmap(nmapConfig *config.NmapServiceConfig, s6ServiceName string) (s6serviceconfig.S6ServiceConfig, error) {
+func (m *MockNmapService) GenerateS6ConfigForNmap(nmapConfig *nmapserviceconfig.NmapServiceConfig, s6ServiceName string) (s6serviceconfig.S6ServiceConfig, error) {
 	if m.GenerateConfigError != nil {
 		return s6serviceconfig.S6ServiceConfig{}, m.GenerateConfigError
 	}
@@ -83,13 +84,13 @@ func (m *MockNmapService) GenerateS6ConfigForNmap(nmapConfig *config.NmapService
 }
 
 // GetConfig returns the mock config
-func (m *MockNmapService) GetConfig(ctx context.Context, nmapName string) (config.NmapServiceConfig, error) {
+func (m *MockNmapService) GetConfig(ctx context.Context, nmapName string) (nmapserviceconfig.NmapServiceConfig, error) {
 	if ctx.Err() != nil {
-		return config.NmapServiceConfig{}, ctx.Err()
+		return nmapserviceconfig.NmapServiceConfig{}, ctx.Err()
 	}
 
 	if m.GetConfigError != nil {
-		return config.NmapServiceConfig{}, m.GetConfigError
+		return nmapserviceconfig.NmapServiceConfig{}, m.GetConfigError
 	}
 
 	if cfg, exists := m.Configs[nmapName]; exists {
@@ -117,7 +118,7 @@ func (m *MockNmapService) Status(ctx context.Context, nmapName string, tick uint
 }
 
 // AddNmapToS6Manager mocks adding a service
-func (m *MockNmapService) AddNmapToS6Manager(ctx context.Context, cfg *config.NmapServiceConfig, nmapName string) error {
+func (m *MockNmapService) AddNmapToS6Manager(ctx context.Context, cfg *nmapserviceconfig.NmapServiceConfig, nmapName string) error {
 	if ctx.Err() != nil {
 		return ctx.Err()
 	}
@@ -152,7 +153,7 @@ func (m *MockNmapService) AddNmapToS6Manager(ctx context.Context, cfg *config.Nm
 }
 
 // UpdateNmapInS6Manager mocks updating a service
-func (m *MockNmapService) UpdateNmapInS6Manager(ctx context.Context, cfg *config.NmapServiceConfig, nmapName string) error {
+func (m *MockNmapService) UpdateNmapInS6Manager(ctx context.Context, cfg *nmapserviceconfig.NmapServiceConfig, nmapName string) error {
 	if ctx.Err() != nil {
 		return ctx.Err()
 	}

--- a/umh-core/pkg/service/nmap/nmap_test.go
+++ b/umh-core/pkg/service/nmap/nmap_test.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/nmapserviceconfig"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/filesystem"
 	s6service "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/s6"
 
@@ -48,7 +48,7 @@ var _ = Describe("Nmap Service", func() {
 	Describe("Script Generation", func() {
 		Context("with valid config", func() {
 			It("should generate a valid shell script", func() {
-				config := &config.NmapServiceConfig{
+				config := &nmapserviceconfig.NmapServiceConfig{
 					Target: "localhost",
 					Port:   80,
 				}
@@ -79,7 +79,7 @@ var _ = Describe("Nmap Service", func() {
 		Context("when adding a new service", func() {
 			It("should add the service to S6 manager", func() {
 				ctx := context.Background()
-				cfg := &config.NmapServiceConfig{
+				cfg := &nmapserviceconfig.NmapServiceConfig{
 					Target: "example.com",
 					Port:   443,
 				}
@@ -94,7 +94,7 @@ var _ = Describe("Nmap Service", func() {
 
 			It("should return error when service already exists", func() {
 				ctx := context.Background()
-				cfg := &config.NmapServiceConfig{
+				cfg := &nmapserviceconfig.NmapServiceConfig{
 					Target: "example.com",
 					Port:   443,
 				}
@@ -112,7 +112,7 @@ var _ = Describe("Nmap Service", func() {
 		Context("when updating a service", func() {
 			BeforeEach(func() {
 				ctx := context.Background()
-				cfg := &config.NmapServiceConfig{
+				cfg := &nmapserviceconfig.NmapServiceConfig{
 					Target: "example.com",
 					Port:   443,
 				}
@@ -123,7 +123,7 @@ var _ = Describe("Nmap Service", func() {
 
 			It("should update the service config", func() {
 				ctx := context.Background()
-				updatedCfg := &config.NmapServiceConfig{
+				updatedCfg := &nmapserviceconfig.NmapServiceConfig{
 					Target: "example.com",
 					Port:   8080, // Changed port
 				}
@@ -139,7 +139,7 @@ var _ = Describe("Nmap Service", func() {
 
 			It("should return error when service doesn't exist", func() {
 				ctx := context.Background()
-				updatedCfg := &config.NmapServiceConfig{
+				updatedCfg := &nmapserviceconfig.NmapServiceConfig{
 					Target: "example.com",
 					Port:   8080,
 				}
@@ -152,7 +152,7 @@ var _ = Describe("Nmap Service", func() {
 		Context("when removing a service", func() {
 			BeforeEach(func() {
 				ctx := context.Background()
-				cfg := &config.NmapServiceConfig{
+				cfg := &nmapserviceconfig.NmapServiceConfig{
 					Target: "example.com",
 					Port:   443,
 				}
@@ -371,7 +371,7 @@ done`
 	Describe("Service Status", func() {
 		BeforeEach(func() {
 			ctx := context.Background()
-			cfg := &config.NmapServiceConfig{
+			cfg := &nmapserviceconfig.NmapServiceConfig{
 				Target: "example.com",
 				Port:   443,
 			}
@@ -397,7 +397,7 @@ done`
 	Describe("Service Control", func() {
 		BeforeEach(func() {
 			ctx := context.Background()
-			cfg := &config.NmapServiceConfig{
+			cfg := &nmapserviceconfig.NmapServiceConfig{
 				Target: "example.com",
 				Port:   443,
 			}

--- a/umh-core/pkg/service/nmap/types.go
+++ b/umh-core/pkg/service/nmap/types.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/nmapserviceconfig"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/s6serviceconfig"
 	s6fsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/s6"
 	s6service "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/s6"
@@ -32,15 +32,15 @@ const (
 // INmapService defines the interface for managing nmap scan services
 type INmapService interface {
 	// GenerateS6ConfigForNmap generates a S6 config for a given nmap instance
-	GenerateS6ConfigForNmap(nmapConfig *config.NmapServiceConfig, s6ServiceName string) (s6serviceconfig.S6ServiceConfig, error)
+	GenerateS6ConfigForNmap(nmapConfig *nmapserviceconfig.NmapServiceConfig, s6ServiceName string) (s6serviceconfig.S6ServiceConfig, error)
 	// GetConfig returns the actual nmap config from the S6 service
-	GetConfig(ctx context.Context, nmapName string) (config.NmapServiceConfig, error)
+	GetConfig(ctx context.Context, nmapName string) (nmapserviceconfig.NmapServiceConfig, error)
 	// Status checks the status of a nmap service
 	Status(ctx context.Context, nmapName string, tick uint64) (ServiceInfo, error)
 	// AddNmapToS6Manager adds a nmap instance to the S6 manager
-	AddNmapToS6Manager(ctx context.Context, cfg *config.NmapServiceConfig, nmapName string) error
+	AddNmapToS6Manager(ctx context.Context, cfg *nmapserviceconfig.NmapServiceConfig, nmapName string) error
 	// UpdateNmapInS6Manager updates an existing nmap instance in the S6 manager
-	UpdateNmapInS6Manager(ctx context.Context, cfg *config.NmapServiceConfig, nmapName string) error
+	UpdateNmapInS6Manager(ctx context.Context, cfg *nmapserviceconfig.NmapServiceConfig, nmapName string) error
 	// RemoveNmapFromS6Manager removes a nmap instance from the S6 manager
 	RemoveNmapFromS6Manager(ctx context.Context, nmapName string) error
 	// StartNmap starts a nmap instance


### PR DESCRIPTION
### Description:
- added `nmapserviceconfig` accordingly to existing ones
- added tests for `nmapserviceconfig`
- moved and adjustet the previous `nmapserviceconfig` 
- added `connectionserviceconfig` , which is based on `nmapserviceconfig` 
- added tests for `connectionserviceconfig`

this should be the base for the connection-service

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced dedicated configuration management for Nmap services, including YAML rendering, normalization, and comparison utilities.
  - Added APIs for generating, normalizing, and comparing connection service configurations.

- **Refactor**
  - Updated Nmap service components to use a specialized configuration type, improving clarity and modularity.
  - Centralized Nmap configuration logic into a dedicated package for better maintainability.

- **Tests**
  - Added comprehensive unit tests for configuration comparison, normalization, and YAML generation to ensure correctness and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->