### PR TITLE
fix(s6): handle already removed services gracefully in RemoveInstance

### DIFF
--- a/umh-core/pkg/fsm/s6/actions.go
+++ b/umh-core/pkg/fsm/s6/actions.go
@@ -16,6 +16,7 @@ package s6
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"time"
@@ -86,6 +87,11 @@ func (s *S6Instance) RemoveInstance(ctx context.Context, filesystemService files
 	// Remove the service directory
 	err := s.service.Remove(ctx, s.servicePath, filesystemService)
 	if err != nil {
+		// If the service doesn't exist, consider removal successful
+		if errors.Is(err, s6service.ErrServiceNotExist) {
+			s.baseFSMInstance.GetLogger().Debugf("S6 service %s already removed", s.baseFSMInstance.GetID())
+			return nil
+		}
 		return fmt.Errorf("failed to remove service directory for %s: %w", s.baseFSMInstance.GetID(), err)
 	}
 


### PR DESCRIPTION
Encountered an integration test failure in https://github.com/united-manufacturing-hub/united-manufacturing-hub/pull/1946, so I fixed the issue here.

When an S6 service was physically removed but its FSM state hadn't been updated, the system would get stuck in an error loop trying to remove a non-existent service. This caused recurring "service does not exist" errors in the logs and eventually triggered a ForceRemove fallback, which could still fail.

Modified RemoveInstance() to treat ErrServiceNotExist as a successful removal instead of an error, allowing the FSM to transition properly to the removed state. This change makes the FSM reconciliation loop more resilient to race conditions between filesystem state and FSM state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling when removing a service that does not exist, ensuring the process completes successfully without raising unnecessary errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->