### PR TITLE
Early exit if desired & current state are stopped

### DIFF
--- a/umh-core/pkg/fsm/benthos/actions.go
+++ b/umh-core/pkg/fsm/benthos/actions.go
@@ -155,6 +155,13 @@ func (b *BenthosInstance) UpdateObservedStateOfInstance(ctx context.Context, fil
 		return ctx.Err()
 	}
 
+	currentState := b.baseFSMInstance.GetCurrentFSMState()
+	desiredState := b.baseFSMInstance.GetDesiredFSMState()
+
+	if currentState == OperationalStateStopped && desiredState == OperationalStateStopped {
+		return nil
+	}
+
 	start := time.Now()
 	info, err := b.getServiceStatus(ctx, filesystemService, tick)
 	if err != nil {

--- a/umh-core/pkg/fsm/container/actions.go
+++ b/umh-core/pkg/fsm/container/actions.go
@@ -62,6 +62,19 @@ func (c *ContainerInstance) StopInstance(ctx context.Context, filesystemService 
 // UpdateObservedStateOfInstance is called when the FSM transitions to updating.
 // For container monitoring, this is a no-op as we don't need to update any resources.
 func (c *ContainerInstance) UpdateObservedStateOfInstance(ctx context.Context, filesystemService filesystem.Service, tick uint64, loopStartTime time.Time) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
+	// Skip health checks if the desired state or current state indicates stopped/stopping
+	currentState := c.baseFSMInstance.GetCurrentFSMState()
+	desiredState := c.baseFSMInstance.GetDesiredFSMState()
+	// If both desired and current state are stopped, we can return immediately
+	// There wont be any logs, metrics, etc. to check
+	if desiredState == OperationalStateStopped && currentState == OperationalStateStopped {
+		return nil
+	}
+
 	c.baseFSMInstance.GetLogger().Debugf("Updating observed state for %s (no-op)", c.baseFSMInstance.GetID())
 	return nil
 }

--- a/umh-core/pkg/fsm/container/actions.go
+++ b/umh-core/pkg/fsm/container/actions.go
@@ -66,7 +66,6 @@ func (c *ContainerInstance) UpdateObservedStateOfInstance(ctx context.Context, f
 		return ctx.Err()
 	}
 
-	// Skip health checks if the desired state or current state indicates stopped/stopping
 	currentState := c.baseFSMInstance.GetCurrentFSMState()
 	desiredState := c.baseFSMInstance.GetDesiredFSMState()
 	// If both desired and current state are stopped, we can return immediately

--- a/umh-core/pkg/fsm/dataflowcomponent/actions.go
+++ b/umh-core/pkg/fsm/dataflowcomponent/actions.go
@@ -61,7 +61,6 @@ func (d *DataflowComponentInstance) UpdateObservedStateOfInstance(ctx context.Co
 		return ctx.Err()
 	}
 
-	// Skip health checks if the desired state or current state indicates stopped/stopping
 	currentState := d.baseFSMInstance.GetCurrentFSMState()
 	desiredState := d.baseFSMInstance.GetDesiredFSMState()
 	// If both desired and current state are stopped, we can return immediately

--- a/umh-core/pkg/fsm/redpanda/actions.go
+++ b/umh-core/pkg/fsm/redpanda/actions.go
@@ -183,6 +183,11 @@ func (r *RedpandaInstance) UpdateObservedStateOfInstance(ctx context.Context, fi
 			return nil
 		}
 	}
+	// If both desired and current state are stopped, we can return immediately
+	// There wont be any logs, metrics, etc. to check
+	if desiredState == OperationalStateStopped && currentState == OperationalStateStopped {
+		return nil
+	}
 
 	// Start an errgroup with the **same context** so if one sub-task
 	// fails or the context is canceled, all sub-tasks are signaled to stop.

--- a/umh-core/pkg/fsm/redpanda/actions.go
+++ b/umh-core/pkg/fsm/redpanda/actions.go
@@ -173,6 +173,12 @@ func (r *RedpandaInstance) UpdateObservedStateOfInstance(ctx context.Context, fi
 	// Skip health checks if the desired state or current state indicates stopped/stopping
 	currentState := r.baseFSMInstance.GetCurrentFSMState()
 	desiredState := r.baseFSMInstance.GetDesiredFSMState()
+	// If both desired and current state are stopped, we can return immediately
+	// There wont be any logs, metrics, etc. to check
+	if desiredState == OperationalStateStopped && currentState == OperationalStateStopped {
+		return nil
+	}
+
 	if desiredState == OperationalStateStopped || currentState == OperationalStateStopped || currentState == OperationalStateStopping {
 		// For stopped instances, just check if the S6 service exists but don't do health checks
 		// This minimal information is sufficient for reconciliation
@@ -182,11 +188,6 @@ func (r *RedpandaInstance) UpdateObservedStateOfInstance(ctx context.Context, fi
 			r.ObservedState = RedpandaObservedState{}
 			return nil
 		}
-	}
-	// If both desired and current state are stopped, we can return immediately
-	// There wont be any logs, metrics, etc. to check
-	if desiredState == OperationalStateStopped && currentState == OperationalStateStopped {
-		return nil
 	}
 
 	// Start an errgroup with the **same context** so if one sub-task

--- a/umh-core/pkg/fsm/redpanda/actions.go
+++ b/umh-core/pkg/fsm/redpanda/actions.go
@@ -170,15 +170,10 @@ func (r *RedpandaInstance) UpdateObservedStateOfInstance(ctx context.Context, fi
 		return ctx.Err()
 	}
 
-	// Skip health checks if the desired state or current state indicates stopped/stopping
 	currentState := r.baseFSMInstance.GetCurrentFSMState()
 	desiredState := r.baseFSMInstance.GetDesiredFSMState()
-	// If both desired and current state are stopped, we can return immediately
-	// There wont be any logs, metrics, etc. to check
-	if desiredState == OperationalStateStopped && currentState == OperationalStateStopped {
-		return nil
-	}
 
+	// Skip health checks if the desired state or current state indicates stopped/stopping
 	if desiredState == OperationalStateStopped || currentState == OperationalStateStopped || currentState == OperationalStateStopping {
 		// For stopped instances, just check if the S6 service exists but don't do health checks
 		// This minimal information is sufficient for reconciliation
@@ -188,6 +183,12 @@ func (r *RedpandaInstance) UpdateObservedStateOfInstance(ctx context.Context, fi
 			r.ObservedState = RedpandaObservedState{}
 			return nil
 		}
+	}
+
+	// If both desired and current state are stopped, we can return immediately
+	// There wont be any logs, metrics, etc. to check
+	if desiredState == OperationalStateStopped && currentState == OperationalStateStopped {
+		return nil
 	}
 
 	// Start an errgroup with the **same context** so if one sub-task

--- a/umh-core/pkg/fsm/s6/actions.go
+++ b/umh-core/pkg/fsm/s6/actions.go
@@ -135,14 +135,7 @@ func (s *S6Instance) UpdateObservedStateOfInstance(ctx context.Context, filesyst
 		return ctx.Err()
 	}
 
-	// Skip health checks if the desired state or current state indicates stopped/stopping
-	currentState := s.baseFSMInstance.GetCurrentFSMState()
-	desiredState := s.baseFSMInstance.GetDesiredFSMState()
-	// If both desired and current state are stopped, we can return immediately
-	// There wont be any logs, metrics, etc. to check
-	if desiredState == OperationalStateStopped && currentState == OperationalStateStopped {
-		return nil
-	}
+	// If both desired and current state are stopped, we do not return immediately, as we still need to check for permanent errors
 
 	// Measure status time
 	info, err := s.service.Status(ctx, s.servicePath, filesystemService)

--- a/umh-core/pkg/fsm/s6/actions.go
+++ b/umh-core/pkg/fsm/s6/actions.go
@@ -131,6 +131,18 @@ func (s *S6Instance) StopInstance(ctx context.Context, filesystemService filesys
 
 // UpdateObservedStateOfInstance updates the observed state of the service
 func (s *S6Instance) UpdateObservedStateOfInstance(ctx context.Context, filesystemService filesystem.Service, tick uint64, loopStartTime time.Time) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
+	// Skip health checks if the desired state or current state indicates stopped/stopping
+	currentState := s.baseFSMInstance.GetCurrentFSMState()
+	desiredState := s.baseFSMInstance.GetDesiredFSMState()
+	// If both desired and current state are stopped, we can return immediately
+	// There wont be any logs, metrics, etc. to check
+	if desiredState == OperationalStateStopped && currentState == OperationalStateStopped {
+		return nil
+	}
 
 	// Measure status time
 	info, err := s.service.Status(ctx, s.servicePath, filesystemService)

--- a/umh-core/pkg/service/redpanda/redpanda.go
+++ b/umh-core/pkg/service/redpanda/redpanda.go
@@ -300,7 +300,6 @@ func (s *RedpandaService) Status(ctx context.Context, filesystemService filesyst
 		}
 		return ServiceInfo{}, fmt.Errorf("failed to get current FSM state: %w", err)
 	}
-
 	// Let's get the logs of the Redpanda service
 	s6ServicePath := filepath.Join(constants.S6BaseDir, constants.RedpandaServiceName)
 	logs, err := s.s6Service.GetLogs(ctx, s6ServicePath, filesystemService)

--- a/umh-core/test/fsm/redpanda/state_transition_test.go
+++ b/umh-core/test/fsm/redpanda/state_transition_test.go
@@ -328,34 +328,96 @@ var _ = Describe("RedpandaService State Transitions", func() {
 			var err error
 			tick := uint64(0)
 
-			By("Adding Redpanda to S6 manager with initial config")
+			By("Adding and starting Redpanda")
 			err = redpandaService.AddRedpandaToS6Manager(ctx, redpandaConfig, mockFileSystem)
 			Expect(err).NotTo(HaveOccurred())
 
+			tick = reconcileRedpandaUntilState(ctx, redpandaService, mockFileSystem, tick, s6.LifecycleStateCreating)
 			tick = reconcileRedpandaUntilState(ctx, redpandaService, mockFileSystem, tick, s6fsm.OperationalStateStopped)
 
-			By("Updating the Redpanda configuration")
-			updatedConfig := &redpandaserviceconfig.RedpandaServiceConfig{
-				Topic: redpandaserviceconfig.TopicConfig{
-					DefaultTopicRetentionMs:    2000000,    // Changed value
-					DefaultTopicRetentionBytes: 2000000000, // Changed value
+			err = redpandaService.StartRedpanda(ctx)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Update mock services to simulate running state
+			mockS6Service.StatusResult = s6service.ServiceInfo{
+				Status: s6service.ServiceUp,
+			}
+
+			// Update monitor service to indicate running state
+			metricsState := redpanda_monitor.NewRedpandaMetricsState()
+			metricsState.IsActive = true
+
+			monitorMetrics := &redpanda_monitor.RedpandaMetrics{
+				Metrics: redpanda_monitor.Metrics{
+					Infrastructure: redpanda_monitor.InfrastructureMetrics{
+						Storage: redpanda_monitor.StorageMetrics{
+							FreeBytes:      10000000000,
+							TotalBytes:     20000000000,
+							FreeSpaceAlert: false,
+						},
+					},
+					Cluster: redpanda_monitor.ClusterMetrics{
+						Topics:            5,
+						UnavailableTopics: 0,
+					},
+					Throughput: redpanda_monitor.ThroughputMetrics{
+						BytesIn:  1000,
+						BytesOut: 2000,
+					},
 				},
-				Resources: redpandaserviceconfig.ResourcesConfig{
-					MaxCores:             2,                  // Changed value
-					MemoryPerCoreInBytes: 4096 * 1024 * 1024, // Changed value
+				MetricsState: metricsState,
+			}
+
+			mockMonitorService.StatusResult = redpanda_monitor.ServiceInfo{
+				S6FSMState: s6fsm.OperationalStateRunning,
+				RedpandaStatus: redpanda_monitor.RedpandaMonitorStatus{
+					IsRunning: true,
+					LastScan: &redpanda_monitor.RedpandaMetricsAndClusterConfig{
+						Metrics: monitorMetrics,
+						ClusterConfig: &redpanda_monitor.ClusterConfig{
+							Topic: redpanda_monitor.TopicConfig{
+								DefaultTopicRetentionMs:    1000000,
+								DefaultTopicRetentionBytes: 1000000000,
+							},
+						},
+						LastUpdatedAt: time.Now(),
+					},
 				},
 			}
 
+			tick = reconcileRedpandaUntilState(ctx, redpandaService, mockFileSystem, tick, s6fsm.OperationalStateRunning)
+
+			By("Updating the Redpanda configuration")
+			// Create a new config with different retention values
+			updatedConfig := &redpandaserviceconfig.RedpandaServiceConfig{
+				Topic: redpandaserviceconfig.TopicConfig{
+					DefaultTopicRetentionMs:    2000000,    // Changed from 1000000
+					DefaultTopicRetentionBytes: 2000000000, // Changed from 1000000000
+				},
+				Resources: redpandaserviceconfig.ResourcesConfig{
+					MaxCores:             2,                  // Changed from 1
+					MemoryPerCoreInBytes: 3072 * 1024 * 1024, // Changed from 2048 MB
+				},
+			}
+
+			// Update the redpanda configuration
 			err = redpandaService.UpdateRedpandaInS6Manager(ctx, updatedConfig)
 			Expect(err).NotTo(HaveOccurred())
 
-			By("Reconciling with updated configuration")
-			err, reconciled := redpandaService.ReconcileManager(ctx, mockFileSystem, tick)
+			By("Stopping the service to apply configuration changes")
+			// Stop the service
+			err = redpandaService.StopRedpanda(ctx)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(reconciled).To(BeTrue())
-			tick++
 
-			// Set up mock so GetConfig returns the updated config
+			// Update mock services to simulate stopped state
+			mockS6Service.StatusResult = s6service.ServiceInfo{
+				Status: s6service.ServiceDown,
+			}
+
+			// Update monitor service to indicate stopped state
+			stoppedMetricsState := redpanda_monitor.NewRedpandaMetricsState()
+			stoppedMetricsState.IsActive = false
+
 			mockMonitorService.StatusResult = redpanda_monitor.ServiceInfo{
 				S6FSMState: s6fsm.OperationalStateStopped,
 				RedpandaStatus: redpanda_monitor.RedpandaMonitorStatus{
@@ -371,10 +433,64 @@ var _ = Describe("RedpandaService State Transitions", func() {
 									},
 								},
 							},
-							MetricsState: redpanda_monitor.NewRedpandaMetricsState(),
+							MetricsState: stoppedMetricsState,
 						},
 						ClusterConfig: &redpanda_monitor.ClusterConfig{
 							Topic: redpanda_monitor.TopicConfig{
+								// Keep the old values in the monitor's view until redpanda restarts
+								DefaultTopicRetentionMs:    1000000,
+								DefaultTopicRetentionBytes: 1000000000,
+							},
+						},
+						LastUpdatedAt: time.Now(),
+					},
+				},
+			}
+
+			tick = reconcileRedpandaUntilState(ctx, redpandaService, mockFileSystem, tick, s6fsm.OperationalStateStopped)
+
+			By("Starting the service with the new configuration")
+			// Start the service again
+			err = redpandaService.StartRedpanda(ctx)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Update mock services to simulate running state with new configuration
+			mockS6Service.StatusResult = s6service.ServiceInfo{
+				Status: s6service.ServiceUp,
+			}
+
+			// Update monitor service to indicate running state with the new config
+			runningMetricsState := redpanda_monitor.NewRedpandaMetricsState()
+			runningMetricsState.IsActive = true
+
+			mockMonitorService.StatusResult = redpanda_monitor.ServiceInfo{
+				S6FSMState: s6fsm.OperationalStateRunning,
+				RedpandaStatus: redpanda_monitor.RedpandaMonitorStatus{
+					IsRunning: true,
+					LastScan: &redpanda_monitor.RedpandaMetricsAndClusterConfig{
+						Metrics: &redpanda_monitor.RedpandaMetrics{
+							Metrics: redpanda_monitor.Metrics{
+								Infrastructure: redpanda_monitor.InfrastructureMetrics{
+									Storage: redpanda_monitor.StorageMetrics{
+										FreeBytes:      10000000000,
+										TotalBytes:     20000000000,
+										FreeSpaceAlert: false,
+									},
+								},
+								Cluster: redpanda_monitor.ClusterMetrics{
+									Topics:            5,
+									UnavailableTopics: 0,
+								},
+								Throughput: redpanda_monitor.ThroughputMetrics{
+									BytesIn:  1000,
+									BytesOut: 2000,
+								},
+							},
+							MetricsState: runningMetricsState,
+						},
+						ClusterConfig: &redpanda_monitor.ClusterConfig{
+							Topic: redpanda_monitor.TopicConfig{
+								// Update the configuration to reflect the new values
 								DefaultTopicRetentionMs:    2000000,
 								DefaultTopicRetentionBytes: 2000000000,
 							},
@@ -384,10 +500,17 @@ var _ = Describe("RedpandaService State Transitions", func() {
 				},
 			}
 
-			// Check updated config was applied
+			tick = reconcileRedpandaUntilState(ctx, redpandaService, mockFileSystem, tick, s6fsm.OperationalStateRunning)
+
+			By("Verifying the new configuration was applied")
+			// Get the current config and verify it matches our updated values
 			config, err := redpandaService.GetConfig(ctx, mockFileSystem, tick, time.Now())
 			Expect(err).NotTo(HaveOccurred())
 			Expect(config.Topic.DefaultTopicRetentionMs).To(Equal(int64(2000000)))
+			Expect(config.Topic.DefaultTopicRetentionBytes).To(Equal(int64(2000000000)))
+
+			// Ensure the service stays running with the new configuration
+			ensureRedpandaState(ctx, redpandaService, mockFileSystem, tick, s6fsm.OperationalStateRunning, 5)
 		})
 
 		It("should handle service removal gracefully", func() {
@@ -482,19 +605,21 @@ func createRedpandaMockLogs() []s6service.LogEntry {
 
 // Reconcile until a specific state is reached
 func reconcileRedpandaUntilState(ctx context.Context, redpandaService *redpanda.RedpandaService, mockFileSystem *filesystem.MockFileSystem, tick uint64, expectedState string) uint64 {
-	for i := 0; i < 10; i++ {
+	var serviceInfo redpanda.ServiceInfo
+	for i := 0; i < 20; i++ {
 		err, _ := redpandaService.ReconcileManager(ctx, mockFileSystem, tick)
 		Expect(err).NotTo(HaveOccurred())
 		tick++
 
 		// Check state
-		serviceInfo, err := redpandaService.Status(ctx, mockFileSystem, tick, time.Now())
+		serviceInfo, err = redpandaService.Status(ctx, mockFileSystem, tick, time.Now())
+		GinkgoWriter.Printf("current state: %s, expected state: %s\n", serviceInfo.S6FSMState, expectedState)
 		if err == nil && serviceInfo.S6FSMState == expectedState {
 			return tick
 		}
 	}
 
-	Fail(fmt.Sprintf("Expected state %s not reached after 10 reconciliations", expectedState))
+	Fail(fmt.Sprintf("Expected state '%s' not reached after 20 reconciliations (current state: %s)", expectedState, serviceInfo.S6FSMState))
 	return 0
 }
 


### PR DESCRIPTION
This pr provides an early exit from the fs, reconcile->reconcileExternalChanges->UpdateObservedStateOfInstance function if desired state & current state are both stopped.
This saves some time, and is correct, as in this situation there will not be any changes to logs, metrics, etc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved efficiency by preventing unnecessary processing when services or instances are fully stopped.
  - Added early exit conditions to avoid redundant status checks and updates.
  - Enhanced test coverage for service lifecycle and configuration updates, including explicit start/stop sequences and improved reconciliation observability.
  - Minor code cleanup for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->