### PR TITLE
Fix: added forceRemoval and permError for reconciliation

### DIFF
--- a/umh-core/pkg/fsm/base_manager.go
+++ b/umh-core/pkg/fsm/base_manager.go
@@ -465,7 +465,10 @@ func (m *BaseFSMManager[C]) Reconcile(
 
 			// Otherwise, we need to remove the instance
 			m.logger.Debugf("instance %s is in state %s, starting the removing process", instanceName, instance.GetCurrentFSMState())
-			instance.Remove(ctx)
+			err := instance.Remove(ctx)
+			if err != nil {
+				return err, false
+			}
 
 			// Update last remove tick using manager-specific tick
 			m.lastRemoveTick = m.managerTick

--- a/umh-core/pkg/fsm/nmap/reconcile.go
+++ b/umh-core/pkg/fsm/nmap/reconcile.go
@@ -64,10 +64,10 @@ func (n *NmapInstance) Reconcile(ctx context.Context, snapshot fsm.SystemSnapsho
 			// For now, let's just remove it from the manager:
 			if n.IsRemoved() || n.IsRemoving() || n.IsStopped() || n.IsStopping() {
 				n.baseFSMInstance.GetLogger().Errorf("Permanent error on nmap monitor %s but it is already in a terminal/removing state", instanceName)
-				err := n.monitorService.ForceRemoveNmap(ctx, filesystemService, instanceName)
-				if err != nil {
+				forceErr := n.monitorService.ForceRemoveNmap(ctx, filesystemService, instanceName)
+				if forceErr != nil {
 					n.baseFSMInstance.GetLogger().Debugf("Remove from Manager failed: %v", err)
-					return err, false
+					return fmt.Errorf("failed to force remove the nmap instance: %s : %w", backoff.PermanentFailureError, forceErr), false
 				}
 				return backErr, false
 			} else {

--- a/umh-core/pkg/fsm/redpanda/reconcile.go
+++ b/umh-core/pkg/fsm/redpanda/reconcile.go
@@ -68,7 +68,13 @@ func (r *RedpandaInstance) Reconcile(ctx context.Context, snapshot fsm.SystemSna
 			if r.IsRemoved() || r.IsRemoving() || r.IsStopping() || r.IsStopped() {
 				r.baseFSMInstance.GetLogger().Errorf("Redpanda instance %s is already in a terminal state, force removing it", redpandaInstanceName)
 				// force delete everything from the s6 file directory
-				r.service.ForceRemoveRedpanda(ctx, filesystemService)
+				forceErr := r.service.ForceRemoveRedpanda(ctx, filesystemService)
+				if forceErr != nil {
+					// If even the force removing doesn't work the base-manager should delete the instance
+					// due to a permanent error.
+					r.baseFSMInstance.GetLogger().Errorf("error force removing Redpanda instance %s: %v", redpandaInstanceName, forceErr)
+					return fmt.Errorf("failed to force remove the redpanda instance: %s : %w", backoff.PermanentFailureError, forceErr), false
+				}
 				return err, false
 			} else {
 				r.baseFSMInstance.GetLogger().Errorf("Redpanda instance %s is not in a terminal state, resetting state and removing it", redpandaInstanceName)

--- a/umh-core/pkg/fsm/s6/actions.go
+++ b/umh-core/pkg/fsm/s6/actions.go
@@ -184,7 +184,12 @@ func (s *S6Instance) UpdateObservedStateOfInstance(ctx context.Context, filesyst
 	if !reflect.DeepEqual(s.ObservedState.ObservedS6ServiceConfig, s.config.S6ServiceConfig) {
 		s.baseFSMInstance.GetLogger().Debugf("Observed config is different from desired config, triggering a re-create")
 		s.logConfigDifferences(s.config.S6ServiceConfig, s.ObservedState.ObservedS6ServiceConfig)
-		s.baseFSMInstance.Remove(ctx)
+		err := s.baseFSMInstance.Remove(ctx)
+		if err != nil {
+			// this shouldn't need a forceRemove since this should then be handled by
+			// reconcile-loop
+			return err
+		}
 	}
 
 	return nil

--- a/umh-core/pkg/fsm/s6/reconcile.go
+++ b/umh-core/pkg/fsm/s6/reconcile.go
@@ -70,7 +70,10 @@ func (s *S6Instance) Reconcile(ctx context.Context, snapshot fsm.SystemSnapshot,
 				// force delete everything from the s6 file directory
 				forceErr := s.service.ForceRemove(ctx, s.servicePath, filesystemService)
 				if forceErr != nil {
-					s.baseFSMInstance.GetLogger().Errorf("ForceRemove failed: %v", forceErr)
+					// If even the force removing doesn't work the base-manager should delete the instance
+					// due to a permanent error.
+					s.baseFSMInstance.GetLogger().Errorf("error force removing S6 instance %s: %v", s6InstanceName, forceErr)
+					return fmt.Errorf("failed to force remove the S6 instance: %s : %w", backoff.PermanentFailureError, forceErr), false
 				}
 				return err, false
 			} else {

--- a/umh-core/test/fsm/benthos/benthos_test.go
+++ b/umh-core/test/fsm/benthos/benthos_test.go
@@ -1228,6 +1228,79 @@ var _ = Describe("BenthosInstance FSM", func() {
 			// Clear error for other tests
 			mockService.RemoveBenthosFromS6ManagerError = nil
 		})
+		It("should attempt forced removal when not in a terminal state with a permanent error", func() {
+			// 1) Get to stopped state using proper transitions
+			var err error
+
+			// First progress to creating state
+			tick, err = fsmtest.TestBenthosStateTransition(
+				ctx, instance, mockService, mockFS, serviceName,
+				internalfsm.LifecycleStateToBeCreated,
+				internalfsm.LifecycleStateCreating,
+				5,
+				tick,
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Setup service in stopped state
+			mockService.ServiceStates[serviceName] = &benthossvc.ServiceInfo{S6FSMState: s6fsm.OperationalStateStopped}
+			mockService.ExistingServices[serviceName] = true
+
+			// Progress to stopped state
+			tick, err = fsmtest.TestBenthosStateTransition(
+				ctx, instance, mockService, mockFS, serviceName,
+				internalfsm.LifecycleStateCreating,
+				benthosfsm.OperationalStateStopped,
+				5,
+				tick,
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			instance.SetDesiredFSMState(benthosfsm.OperationalStateActive)
+
+			// Progress to starting state
+			tick, err = fsmtest.TestBenthosStateTransition(
+				ctx, instance, mockService, mockFS, serviceName,
+				benthosfsm.OperationalStateStopped,
+				benthosfsm.OperationalStateStarting,
+				5,
+				tick,
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Progress to config loading state
+			tick, err = fsmtest.TestBenthosStateTransition(
+				ctx, instance, mockService, mockFS, serviceName,
+				benthosfsm.OperationalStateStarting,
+				benthosfsm.OperationalStateStartingConfigLoading,
+				5,
+				tick,
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Create a permanent error that will be encountered during reconcile
+			mockService.StatusError = fmt.Errorf("%s: test permanent error", backoff.PermanentFailureError)
+
+			// Use the helper function to reconcile until error
+			var recErr error
+			var reconciled bool
+			tick, recErr, reconciled = fsmtest.ReconcileBenthosUntilError(
+				ctx, fsm.SystemSnapshot{Tick: tick}, instance, mockService, mockFS, serviceName, 5,
+			)
+
+			// Verify force removal was attempted
+			Expect(mockService.ForceRemoveBenthosCalled).To(BeTrue())
+
+			// Now we should get the error
+			Expect(recErr).NotTo(HaveOccurred())
+			// This is true because of the handling of ReconcileBenthosUntilError
+			// When calling forceRemove and it succeeds, it returns nil (err)
+			// Therefore we get true here
+			Expect(reconciled).To(BeTrue())
+
+			// Clear error for other tests
+			mockService.RemoveBenthosFromS6ManagerError = nil
+		})
 	})
 
 })

--- a/umh-core/test/fsm/s6/instance_test.go
+++ b/umh-core/test/fsm/s6/instance_test.go
@@ -26,6 +26,7 @@ import (
 
 	internal_fsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/internal/fsm"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/internal/fsmtest"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/backoff"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
 	s6fsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/s6"
@@ -478,6 +479,54 @@ var _ = Describe("S6Instance FSM", func() {
 			)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(mockService.StartCalled).To(BeTrue())
+
+		})
+
+		It("should call forceRemoval when not in a terminal state", func() {
+			instance, mockService, _ := fsmtest.SetupS6Instance(testBaseDir, "backoff-notTerminal", s6fsm.OperationalStateStopped)
+
+			// from to_be_created => stopped
+			snapshot := fsm.SystemSnapshot{Tick: tick}
+			tick, err := fsmtest.TestS6StateTransition(ctx, snapshot, instance, mockFS,
+				internal_fsm.LifecycleStateToBeCreated,
+				s6fsm.OperationalStateStopped,
+				5,
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Force start error
+			//mockService.StartError = fmt.Errorf("failing start")
+			err = instance.SetDesiredFSMState(s6fsm.OperationalStateRunning)
+			Expect(err).NotTo(HaveOccurred())
+
+			snapshot = fsm.SystemSnapshot{Tick: tick}
+			tick, err = fsmtest.TestS6StateTransition(ctx, snapshot, instance, mockFS,
+				s6fsm.OperationalStateStopped,
+				s6fsm.OperationalStateStarting,
+				5,
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			snapshot = fsm.SystemSnapshot{Tick: tick}
+			tick, err = fsmtest.TestS6StateTransition(ctx, snapshot, instance, mockFS,
+				s6fsm.OperationalStateStarting,
+				s6fsm.OperationalStateRunning,
+				5,
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Create a permanent error that will be encountered during reconcile
+			mockService.StatusError = fmt.Errorf("%s: test permanent error", backoff.PermanentFailureError)
+
+			recErr, reconciled := instance.Reconcile(ctx, snapshot, mockFS)
+			Expect(recErr).To(BeNil())
+			Expect(reconciled).To(BeFalse())
+
+			recErr, reconciled = instance.Reconcile(ctx, snapshot, mockFS)
+			Expect(recErr).To(BeNil())
+			Expect(reconciled).To(BeFalse())
+
+			Expect(mockService.ForceRemoveCalled).To(BeTrue())
 
 		})
 	})


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced error handling and logging during instance removal after permanent failures, ensuring fallback forced removal attempts and proper error propagation.
  - Added explicit error handling for removal operations triggered by configuration mismatches and during reconciliation aborts.

- **Tests**
  - Added test cases verifying forced removal behavior and error handling when permanent errors occur in non-terminal states across multiple managed services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->