### PR TITLE
Adde stricter rate limiting to prevent failing integration test

### DIFF
--- a/umh-core/pkg/constants/baseFSM.go
+++ b/umh-core/pkg/constants/baseFSM.go
@@ -19,3 +19,48 @@ import "time"
 const (
 	ExpectedMaxP95ExecutionTimePerEvent = 1 * time.Millisecond
 )
+
+const (
+	// ─────────────────────────────────────────────────────────────────────────────
+	// Rate‑limiting parameters for a single‑threaded control loop
+	//
+	// After an *expensive* operation (add / update / remove / state‑change) the
+	// manager schedules the next time it is allowed to perform the *same* kind of
+	// operation.  The cooldown is expressed in control‑loop *ticks* – a tick
+	// corresponds to **one pass** through `BaseFSMManager.Reconcile`.
+	//
+	// The raw cooldown is `TicksBeforeNext*`, but a small amount of *jitter*
+	// (see `JitterFraction` below) is added so that, when many instances are
+	// created at once, their subsequent updates are spread out instead of all
+	// happening on the same future tick.
+	//
+	// Example (with the defaults below):
+	//   • create “A” on tick 100  →  next add allowed earliest at tick 100+15±25%
+	//   • update “B” on tick 105  →  next update allowed earliest at tick 105+15±25%
+	//   • normal per‑tick reconciliation is **not** affected – only the *rate‑limited*
+	//     operations below respect the barrier.
+	//
+	// If you lengthen these values you reduce peak load but also slow down
+	// convergence; if you shorten them the system reacts faster but risks
+	// starving later managers in the loop.
+	// ─────────────────────────────────────────────────────────────────────────────
+	TicksBeforeNextAdd    = 15 // base cooldown (in ticks) after adding an instance
+	TicksBeforeNextUpdate = 15 // base cooldown after changing an instance configuration
+	TicksBeforeNextRemove = 15 // base cooldown after starting a removal
+	TicksBeforeNextState  = 15 // base cooldown after changing desired FSM state
+
+	// JitterFraction defines how much randomness we mix into the cooldown.
+	//
+	// The effective delay δ is picked *uniformly* from
+	//     [ base * (1‑j) , base * (1+j) ]
+	// where j == JitterFraction.
+	//
+	//   j = 0    →  no jitter, always exactly `base` ticks
+	//   j = 0.25 →  ±25 % spread (default): base * 0.75  …  base * 1.25
+	//   j = 1    →  full 0 … 2*base range (rarely useful)
+	//
+	// A small jitter is enough to avoid “thundering herd” effects while keeping
+	// the expected delay equal to `base`.  Make sure `math/rand.Seed` is called
+	// once at program start so runs do not share the same pseudo‑random sequence.
+	JitterFraction = 0.25
+)

--- a/umh-core/pkg/fsm/snapshot.go
+++ b/umh-core/pkg/fsm/snapshot.go
@@ -54,14 +54,14 @@ type ManagerSnapshot interface {
 
 // BaseManagerSnapshot contains the basic immutable state common to all manager types
 type BaseManagerSnapshot struct {
-	Name            string
-	Instances       map[string]FSMInstanceSnapshot
-	ManagerTick     uint64
-	LastAddTick     uint64
-	LastUpdateTick  uint64
-	LastRemoveTick  uint64
-	LastStateChange uint64
-	SnapshotTime    time.Time
+	Name           string
+	Instances      map[string]FSMInstanceSnapshot
+	ManagerTick    uint64
+	NextAddTick    uint64
+	NextUpdateTick uint64
+	NextRemoveTick uint64
+	NextStateTick  uint64
+	SnapshotTime   time.Time
 }
 
 // GetName returns the name of the manager
@@ -196,10 +196,10 @@ func getManagerSnapshot(manager FSMManager[any]) ManagerSnapshot {
 	baseManager, ok := manager.(*BaseFSMManager[any])
 	if ok {
 		snapshot.ManagerTick = baseManager.GetManagerTick()
-		snapshot.LastAddTick = baseManager.GetLastAddTick()
-		snapshot.LastUpdateTick = baseManager.GetLastUpdateTick()
-		snapshot.LastRemoveTick = baseManager.GetLastRemoveTick()
-		snapshot.LastStateChange = baseManager.GetLastStateChange()
+		snapshot.NextAddTick = baseManager.GetNextAddTick()
+		snapshot.NextUpdateTick = baseManager.GetNextUpdateTick()
+		snapshot.NextRemoveTick = baseManager.GetNextRemoveTick()
+		snapshot.NextStateTick = baseManager.GetNextStateTick()
 	}
 
 	// Get instances and their states


### PR DESCRIPTION
Integration tests were sometimes failing as there was too much to do for the S6 manager that it kept starving the remaining managers.

The new approach tries to prevent that it has too much to do on the same tick by adding a jitter with the hope that this causes the WIP to not rise too much.

