### PR TITLE
remove too verbose logging

### DIFF
--- a/umh-core/cmd/main.go
+++ b/umh-core/cmd/main.go
@@ -27,7 +27,6 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/control"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/agent_monitor"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/logger"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/metrics"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/models"
@@ -159,11 +158,6 @@ func SystemSnapshotLogger(ctx context.Context, controlLoop *control.ControlLoop,
 				for instanceName, instance := range instances {
 					snap_logger.Infof("Instance: %s, current state: %s, desired state: %s",
 						instanceName, instance.CurrentState, instance.DesiredState)
-					// Log observed state if available
-					if instance.LastObservedState != nil {
-						sanitizedState := sanitizeObservedState(instance.LastObservedState)
-						snap_logger.Debugf("Observed state: %v", sanitizedState)
-					}
 				}
 			}
 		}
@@ -201,16 +195,4 @@ func enableBackendConnection(config *config.FullConfig, state *fsm.SystemSnapsho
 	}
 
 	logger.Info("Backend connection enabled")
-}
-
-func sanitizeObservedState(state interface{}) interface{} {
-	switch v := state.(type) {
-	case *agent_monitor.AgentObservedStateSnapshot:
-		// Create a sanitized log-friendly copy of the observed state
-		sanitizedState := *v
-		sanitizedState.ServiceInfoSnapshot.AgentLogs = nil
-		return sanitizedState
-	default:
-		return state
-	}
 }


### PR DESCRIPTION
I introduced the logging of the observed state before with another PR but now with the upcoming dfcs, this will print the dfc logs to the umh-core logs and thereby bloat the logs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed logging of sanitized agent observed state from system snapshot logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->