### PR TITLE
ENG-2860 fix panic when calling metricsstate

### DIFF
--- a/umh-core/pkg/communicator/pkg/generator/generator.go
+++ b/umh-core/pkg/communicator/pkg/generator/generator.go
@@ -319,7 +319,7 @@ func buildDataFlowComponentDataFromSnapshot(instance fsm.FSMInstanceSnapshot, lo
 		}
 		serviceInfo := observed.ServiceInfo
 		inputThroughput := int64(0)
-		if serviceInfo.BenthosObservedState.ServiceInfo.BenthosStatus.MetricsState.Input.LastCount > 0 {
+		if serviceInfo.BenthosObservedState.ServiceInfo.BenthosStatus.MetricsState != nil && serviceInfo.BenthosObservedState.ServiceInfo.BenthosStatus.MetricsState.Input.LastCount > 0 {
 			inputThroughput = int64(serviceInfo.BenthosObservedState.ServiceInfo.BenthosStatus.MetricsState.Input.MessagesPerTick / constants.DefaultTickerTime.Seconds())
 		}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed a potential issue that could cause errors when certain system metrics are unavailable, improving overall app stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->