### PR TITLE
ENG-2861 skip check when attempting to start

### DIFF
--- a/umh-core/pkg/fsm/redpanda/actions.go
+++ b/umh-core/pkg/fsm/redpanda/actions.go
@@ -154,6 +154,11 @@ func (r *RedpandaInstance) GetServiceStatus(ctx context.Context, filesystemServi
 				infoWithFailedHealthChecks.RedpandaStatus.HealthCheck.IsReady = false
 				return infoWithFailedHealthChecks, nil
 			}
+		} else if errors.Is(err, redpanda_service.ErrRedpandaMonitorNotRunning) {
+			// If the metrics service is not running, we are unable to get the logs/metrics, therefore we must return an empty status
+			if !IsRunningState(r.baseFSMInstance.GetCurrentFSMState()) {
+				return info, nil
+			}
 		}
 
 		// For other errors, log them and return

--- a/umh-core/pkg/fsm/redpanda/actions.go
+++ b/umh-core/pkg/fsm/redpanda/actions.go
@@ -191,14 +191,6 @@ func (r *RedpandaInstance) UpdateObservedStateOfInstance(ctx context.Context, fi
 		return nil
 	}
 
-	// ADDED: Special case for transitioning from stopped to active
-	// When we're trying to start Redpanda, we don't need fresh metrics
-	// because the service hasn't started yet to produce them
-	if currentState == OperationalStateStopped && desiredState == OperationalStateActive {
-		// We only need minimal state info to start the service
-		return nil
-	}
-
 	// Start an errgroup with the **same context** so if one sub-task
 	// fails or the context is canceled, all sub-tasks are signaled to stop.
 	g, gctx := errgroup.WithContext(ctx)

--- a/umh-core/pkg/fsm/redpanda/actions.go
+++ b/umh-core/pkg/fsm/redpanda/actions.go
@@ -191,6 +191,14 @@ func (r *RedpandaInstance) UpdateObservedStateOfInstance(ctx context.Context, fi
 		return nil
 	}
 
+	// ADDED: Special case for transitioning from stopped to active
+	// When we're trying to start Redpanda, we don't need fresh metrics
+	// because the service hasn't started yet to produce them
+	if currentState == OperationalStateStopped && desiredState == OperationalStateActive {
+		// We only need minimal state info to start the service
+		return nil
+	}
+
 	// Start an errgroup with the **same context** so if one sub-task
 	// fails or the context is canceled, all sub-tasks are signaled to stop.
 	g, gctx := errgroup.WithContext(ctx)

--- a/umh-core/pkg/service/redpanda/errors.go
+++ b/umh-core/pkg/service/redpanda/errors.go
@@ -25,4 +25,7 @@ var (
 
 	// ErrServiceNoLogFile indicates the health check had no logs to process
 	ErrServiceNoLogFile = errors.New("log file not found")
+
+	// ErrRedpandaMonitorNotRunning indicates the redpanda monitor service is not running
+	ErrRedpandaMonitorNotRunning = errors.New("redpanda monitor service is not running")
 )

--- a/umh-core/pkg/service/redpanda/redpanda.go
+++ b/umh-core/pkg/service/redpanda/redpanda.go
@@ -300,6 +300,15 @@ func (s *RedpandaService) Status(ctx context.Context, filesystemService filesyst
 		}
 		return ServiceInfo{}, fmt.Errorf("failed to get current FSM state: %w", err)
 	}
+
+	// If the current state is stopped, we are unable to get the logs/metrics, therefore we must return an empty status
+	if s6FSMState == s6fsm.OperationalStateStopped {
+		return ServiceInfo{
+			S6ObservedState: s6ServiceObservedState,
+			S6FSMState:      s6FSMState,
+			RedpandaStatus:  RedpandaStatus{},
+		}, nil
+	}
 	// Let's get the logs of the Redpanda service
 	s6ServicePath := filepath.Join(constants.S6BaseDir, constants.RedpandaServiceName)
 	logs, err := s.s6Service.GetLogs(ctx, s6ServicePath, filesystemService)

--- a/umh-core/pkg/service/redpanda/redpanda.go
+++ b/umh-core/pkg/service/redpanda/redpanda.go
@@ -300,27 +300,6 @@ func (s *RedpandaService) Status(ctx context.Context, filesystemService filesyst
 		}
 		return ServiceInfo{}, fmt.Errorf("failed to get current FSM state: %w", err)
 	}
-
-	// If the current state is stopped, we are unable to get the logs/metrics, therefore we must return an empty status
-	if s6FSMState == s6fsm.OperationalStateStopped {
-		s.logger.Debugf("Service %s is stopped, returning empty status", constants.RedpandaServiceName)
-		return ServiceInfo{
-			S6ObservedState: s6ServiceObservedState,
-			S6FSMState:      s6FSMState,
-			RedpandaStatus:  RedpandaStatus{},
-		}, nil
-	}
-
-	// Check if the metrics service is already running
-	if !s.metricsService.ServiceExists(ctx, filesystemService) {
-		s.logger.Debugf("Metrics service for service %s does not exist, returning empty status", constants.RedpandaServiceName)
-		return ServiceInfo{
-			S6ObservedState: s6ServiceObservedState,
-			S6FSMState:      s6FSMState,
-			RedpandaStatus:  RedpandaStatus{},
-		}, nil
-	}
-
 	// Let's get the logs of the Redpanda service
 	s6ServicePath := filepath.Join(constants.S6BaseDir, constants.RedpandaServiceName)
 	logs, err := s.s6Service.GetLogs(ctx, s6ServicePath, filesystemService)

--- a/umh-core/pkg/service/redpanda/redpanda.go
+++ b/umh-core/pkg/service/redpanda/redpanda.go
@@ -606,6 +606,11 @@ func (s *RedpandaService) StartRedpanda(ctx context.Context) error {
 		return ErrServiceNotExist
 	}
 
+	// This also needs to start the redpanda monitor service
+	if err := s.metricsService.StartRedpandaMonitor(ctx); err != nil {
+		return fmt.Errorf("failed to start redpanda monitor: %w", err)
+	}
+
 	return nil
 }
 
@@ -634,6 +639,11 @@ func (s *RedpandaService) StopRedpanda(ctx context.Context) error {
 
 	if !found {
 		return ErrServiceNotExist
+	}
+
+	// This also needs to stop the redpanda monitor service
+	if err := s.metricsService.StopRedpandaMonitor(ctx); err != nil {
+		return fmt.Errorf("failed to stop redpanda monitor: %w", err)
 	}
 
 	return nil

--- a/umh-core/pkg/service/redpanda/redpanda.go
+++ b/umh-core/pkg/service/redpanda/redpanda.go
@@ -303,12 +303,24 @@ func (s *RedpandaService) Status(ctx context.Context, filesystemService filesyst
 
 	// If the current state is stopped, we are unable to get the logs/metrics, therefore we must return an empty status
 	if s6FSMState == s6fsm.OperationalStateStopped {
+		s.logger.Debugf("Service %s is stopped, returning empty status", constants.RedpandaServiceName)
 		return ServiceInfo{
 			S6ObservedState: s6ServiceObservedState,
 			S6FSMState:      s6FSMState,
 			RedpandaStatus:  RedpandaStatus{},
 		}, nil
 	}
+
+	// Check if the metrics service is already running
+	if !s.metricsService.ServiceExists(ctx, filesystemService) {
+		s.logger.Debugf("Metrics service for service %s does not exist, returning empty status", constants.RedpandaServiceName)
+		return ServiceInfo{
+			S6ObservedState: s6ServiceObservedState,
+			S6FSMState:      s6FSMState,
+			RedpandaStatus:  RedpandaStatus{},
+		}, nil
+	}
+
 	// Let's get the logs of the Redpanda service
 	s6ServicePath := filepath.Join(constants.S6BaseDir, constants.RedpandaServiceName)
 	logs, err := s.s6Service.GetLogs(ctx, s6ServicePath, filesystemService)

--- a/umh-core/pkg/service/redpanda/redpanda.go
+++ b/umh-core/pkg/service/redpanda/redpanda.go
@@ -336,6 +336,14 @@ func (s *RedpandaService) Status(ctx context.Context, filesystemService filesyst
 			}, redpanda_monitor.ErrServiceConnectionRefused
 		}
 
+		if strings.Contains(err.Error(), ErrRedpandaMonitorNotRunning.Error()) {
+			return ServiceInfo{
+				S6ObservedState: s6ServiceObservedState,
+				S6FSMState:      s6FSMState,
+				RedpandaStatus:  redpandaStatus,
+			}, ErrRedpandaMonitorNotRunning
+		}
+
 		return ServiceInfo{}, fmt.Errorf("failed to get health check: %w", err)
 	}
 
@@ -386,6 +394,10 @@ func (s *RedpandaService) GetHealthCheckAndMetrics(ctx context.Context, tick uin
 	redpandaStatus, err := s.metricsService.Status(ctx, filesystemService, tick)
 	if err != nil {
 		return RedpandaStatus{}, fmt.Errorf("failed to get redpanda status: %w", err)
+	}
+
+	if redpandaStatus.S6FSMState != s6fsm.OperationalStateRunning {
+		return RedpandaStatus{}, ErrRedpandaMonitorNotRunning
 	}
 
 	// If this is nil, we have not yet tried to scan for metrics and config, or there has been an error (but that one will be cached in the above Status() return)

--- a/umh-core/test/fsm/redpanda/state_transition_test.go
+++ b/umh-core/test/fsm/redpanda/state_transition_test.go
@@ -737,6 +737,7 @@ func ensureRedpandaState(ctx context.Context, redpandaService *redpanda.Redpanda
 
 		// Check state
 		serviceInfo, err := redpandaService.Status(ctx, mockFileSystem, tick, time.Now())
+
 		Expect(err).NotTo(HaveOccurred())
 		Expect(serviceInfo.S6FSMState).To(Equal(expectedState))
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced error handling for the Redpanda monitor service during status checks and lifecycle operations.
  - Improved handling of Redpanda monitor service during start and stop operations to ensure proper error reporting.

- **Tests**
  - Added a test to verify that the service can transition from stopped to running state even when stale metrics are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->