### PR TITLE
ENG-2869 Integration test for restart behaviour.

### DIFF
--- a/umh-core/Makefile
+++ b/umh-core/Makefile
@@ -224,12 +224,17 @@ benchmark-s6-parse-log:
 	@echo "Running S6 parseLogLine benchmarks..."
 	cd pkg/service/s6 && go test -bench=ParseLogLine -benchmem
 
-integration-test: stop-all-pods vet nilaway lint
+# Meta target to setup the environment for the tests
+pre-test: stop-all-pods vet nilaway lint
+
+integration-test: pre-test dfc-restart-test
 	ginkgo -r -v --tags=test --label-filter='integration' --fail-fast ./...
 
-redpanda-extended-test: stop-all-pods vet nilaway
+redpanda-extended-test: pre-test
 	ginkgo -r -v --tags=test --label-filter='redpanda-extended' --fail-fast --timeout=1.5h ./...
 
+dfc-restart-test: pre-test
+	ginkgo -r -v --tags=test --label-filter='dfc-restart' --fail-fast ./...
 
 # integration-test-ci: Runs integration tests in CI environments with proper version tagging
 # - Injects VERSION via ldflags into AppVersion for proper error identification in Sentry
@@ -414,6 +419,3 @@ push-platform:
 
 # Build and push in one command (for CI)
 build-push: build push-platform
-
-dfc-restart-test: stop-all-pods vet nilaway lint
-	ginkgo -r -v --tags=test --label-filter='dfc-restart' --fail-fast ./...

--- a/umh-core/Makefile
+++ b/umh-core/Makefile
@@ -414,3 +414,6 @@ push-platform:
 
 # Build and push in one command (for CI)
 build-push: build push-platform
+
+dfc-restart-test: stop-all-pods vet nilaway lint
+	ginkgo -r -v --tags=test --label-filter='dfc-restart' --fail-fast ./...

--- a/umh-core/Makefile
+++ b/umh-core/Makefile
@@ -227,20 +227,21 @@ benchmark-s6-parse-log:
 # Meta target to setup the environment for the tests
 pre-test: stop-all-pods vet nilaway lint
 
-integration-test: pre-test dfc-restart-test
+# Meta target to setup the environment for the tests in CI environments
+pre-test-ci: vet nilaway lint
+
+integration-test: pre-test
 	ginkgo -r -v --tags=test --label-filter='integration' --fail-fast ./...
 
 redpanda-extended-test: pre-test
 	ginkgo -r -v --tags=test --label-filter='redpanda-extended' --fail-fast --timeout=1.5h ./...
 
-dfc-restart-test: pre-test
-	ginkgo -r -v --tags=test --label-filter='dfc-restart' --fail-fast ./...
 
 # integration-test-ci: Runs integration tests in CI environments with proper version tagging
 # - Injects VERSION via ldflags into AppVersion for proper error identification in Sentry
 # - CI test failures SHOULD be reported to Sentry (unlike local dev failures)
 # - Helps identify flaky tests by consistently tracking failures in CI pipelines
-integration-test-ci: vet nilaway lint
+integration-test-ci: pre-test-ci
 	VERSION=$(VERSION) ginkgo -r -v --tags=test --label-filter='integration' --fail-fast -ldflags="-X 'github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/version.AppVersion=$(VERSION)'" ./...
 
 update-go-dependencies:

--- a/umh-core/integration/dataflowcomponent_restart_test.go
+++ b/umh-core/integration/dataflowcomponent_restart_test.go
@@ -1,0 +1,141 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration_test
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("DataFlowComponent Restart Integration Test", Ordered, Label("dfc-restart"), func() {
+	const (
+		topicName         = "dfc-restart-test-topic"
+		messagesPerSecond = 5
+		testDuration      = 30 * time.Second
+		postRestartWait   = 5 * time.Second
+		containerDownWait = 30 * time.Second
+		lossTolerance     = 0.10 // 10% message loss allowed
+	)
+
+	var lastOffset = -1
+	var lastTimestamp time.Time
+
+	BeforeAll(func() {
+		By("Starting umh-core with Redpanda and a DFC that outputs to Kafka")
+		builder := NewDataFlowComponentBuilder()
+		builder.full.Internal.Redpanda.DesiredFSMState = "active"
+		builder.full.Internal.Redpanda.Name = "redpanda"
+		builder.AddGeneratorDataFlowComponentToKafka("dfc-restart", fmt.Sprintf("%dms", 1000/messagesPerSecond), topicName)
+		cfg := builder.BuildYAML()
+		Expect(writeConfigFile(cfg)).To(Succeed())
+		Expect(BuildAndRunContainer(cfg, DEFAULT_MEMORY, DEFAULT_CPUS)).To(Succeed())
+		Expect(waitForMetrics()).To(Succeed(), "Metrics endpoint should be available after startup")
+	})
+
+	AfterAll(func() {
+		By("Stopping and cleaning up the container after the test")
+		PrintLogsAndStopContainer()
+		CleanupDockerBuildCache()
+		if !CurrentSpecReport().Failed() {
+			cleanupTmpDirs(getContainerName())
+		}
+	})
+
+	It("should produce messages, survive a restart, and produce messages again", func() {
+		By("Waiting for services to stabilize")
+		// Allow time for redpanda and benthos services to start
+		time.Sleep(30 * time.Second)
+
+		By("Waiting for messages to be produced before restart")
+		startTime := time.Now()
+		lastTimestamp = time.Now()
+		for time.Since(startTime) < testDuration {
+			newOffset, err := checkRPK(topicName, lastOffset, lastTimestamp, lossTolerance, messagesPerSecond)
+			Expect(err).ToNot(HaveOccurred())
+			lastOffset = newOffset
+			lastTimestamp = time.Now()
+			time.Sleep(2 * time.Second)
+		}
+
+		By("Stopping the container")
+		out, err := runDockerCommand("stop", getContainerName())
+		GinkgoWriter.Printf("Stopped container: %s\n", out)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Validating that the container is stopped (via docker ps)")
+		out, err = runDockerCommand("ps", "-a", "--format", "{{.Names}} {{.ID}} {{.Status}}")
+		GinkgoWriter.Printf("Docker ps: %s\n", out)
+		Expect(err).ToNot(HaveOccurred())
+		// Extract line with our container name, and check for "Exited" in the status column
+		lines := strings.Split(out, "\n")
+		var containerLine string
+		for _, line := range lines {
+			if strings.Contains(line, getContainerName()) {
+				containerLine = line
+				break
+			}
+		}
+		Expect(containerLine).To(ContainSubstring("Exited"))
+
+		By(fmt.Sprintf("Waiting %s before restart", containerDownWait))
+		for i := 0; i < int(containerDownWait/time.Second); i++ {
+			time.Sleep(time.Second)
+			GinkgoWriter.Printf("Waiting until we can restart: %d seconds\n", i)
+		}
+
+		By("Starting the container again")
+		out, err = runDockerCommand("start", getContainerName())
+		GinkgoWriter.Printf("Started container: %s\n", out)
+		Expect(err).ToNot(HaveOccurred())
+
+		By(fmt.Sprintf("Waiting %s for container to become healthy", postRestartWait))
+		time.Sleep(postRestartWait)
+		// Optionally, wait for metrics endpoint
+		Eventually(func() bool {
+			resp, err := httpGetWithTimeout(GetMetricsURL(), 1*time.Second)
+			return err == nil && resp == 200
+		}, 20*time.Second, 1*time.Second).Should(BeTrue(), "Metrics endpoint should be healthy after restart")
+
+		By("Validating messages are being produced again after restart")
+		// Reset lastTimestamp to now, but keep lastOffset
+		lastTimestamp = time.Now()
+		for i := 0; i < 5; i++ {
+			newOffset, err := checkRPK(topicName, lastOffset, lastTimestamp, lossTolerance, messagesPerSecond)
+			Expect(err).ToNot(HaveOccurred())
+			lastOffset = newOffset
+			lastTimestamp = time.Now()
+			time.Sleep(2 * time.Second)
+		}
+	})
+})
+
+// httpGetWithTimeout is a helper for Eventually to check endpoint health
+func httpGetWithTimeout(url string, timeout time.Duration) (int, error) {
+	client := &http.Client{Timeout: timeout}
+	resp, err := client.Get(url)
+	if err != nil {
+		return 0, err
+	}
+	err = resp.Body.Close()
+	if err != nil {
+		return 0, err
+	}
+	return resp.StatusCode, nil
+}

--- a/umh-core/integration/dataflowcomponent_restart_test.go
+++ b/umh-core/integration/dataflowcomponent_restart_test.go
@@ -24,7 +24,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("DataFlowComponent Restart Integration Test", Ordered, Label("dfc-restart"), func() {
+var _ = Describe("DataFlowComponent Restart Integration Test", Ordered, Label("integration"), func() {
 	const (
 		topicName         = "dfc-restart-test-topic"
 		messagesPerSecond = 5

--- a/umh-core/integration/redpanda_extended_test.go
+++ b/umh-core/integration/redpanda_extended_test.go
@@ -196,7 +196,7 @@ func checkRPK(topic string, lastLoopOffset int, lastLoopTimestamp time.Time, los
 		Fail("❌ Msg per sec is not positive")
 	}
 	if msgPerSec < float64(messagesPerSecond)*0.9 {
-		Fail(fmt.Sprintf("❌ Msg per sec is too low: %f\n", msgPerSec))
+		Fail(fmt.Sprintf("❌ Msg per sec is too low: %f (expected %d)\n", msgPerSec, messagesPerSecond))
 	} else {
 		// Let's warn (but not fail) if we are below the loss tolerance (use a nice warning signal)
 		if msgPerSec < float64(messagesPerSecond)*(1-lossToleranceWarning) {


### PR DESCRIPTION
This pr adds a test for 2 different restart behaviors of a umh-core container (graceful via `stop` and instant via `kill`).

It does the following steps:
 - setup umh-core with a dataflow component that outputs messages to kafka
 - waits for it to come up
 - check if the messages appear in kafka (via rpk)
 - stops/kills the container
 - wait for 15s (this will ensure that the old redpanda-monitor service's data is considered stale by the restarted container)
 - wait for the container to be back online
 - check that messages are coming in again