### PR TITLE
ENG-2873 Fix CPU health reporting

### DIFF
--- a/umh-core/pkg/service/container_monitor/container_monitor_test.go
+++ b/umh-core/pkg/service/container_monitor/container_monitor_test.go
@@ -260,7 +260,7 @@ var _ = Describe("Container Monitor Service", func() {
 			if container.CPU != nil {
 				GinkgoWriter.Printf("Core Count: %d\n", container.CPU.CoreCount)
 				GinkgoWriter.Printf("Total Usage (mCPU): %.2f\n", container.CPU.TotalUsageMCpu)
-				GinkgoWriter.Printf("Usage Per Core: %.2f%%\n", container.CPU.TotalUsageMCpu/float64(container.CPU.CoreCount)/10.0)
+				GinkgoWriter.Printf("Usage Per Core: %.2f%%\n", (container.CPU.TotalUsageMCpu/1000.0)/float64(container.CPU.CoreCount)*100.0)
 			} else {
 				GinkgoWriter.Printf("CPU metrics unavailable\n")
 			}


### PR DESCRIPTION
## Changes
- Modified `getRawCPUMetrics` to return the original CPU percentage directly
- Updated `getCPUMetrics` to use this percentage value rather than recalculating it (source of the bug)
- Eliminates redundant conversions and reduces potential for calculation errors while maintaining precision

Using the previous calculation, if a system has 4 cores and is using 2000 millicores (2 cores), it would calculate:
(2000 / 4) * 100 = 50000%, which is clearly wrong (should be 50%) and causes a degraded state pretty much all the time except when usage is close to 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved calculation and handling of CPU usage metrics for more accurate and consistent reporting.
- **Tests**
  - Updated test output to display CPU usage per core percentage with clearer and more accurate formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->