### PR TITLE
Cleanup makefile & add pprof flag

### DIFF
--- a/umh-core/Dockerfile
+++ b/umh-core/Dockerfile
@@ -17,6 +17,7 @@ ARG S6_OVERLAY_VERSION=3.2.0.2
 ARG BENTHOS_UMH_VERSION=0.6.2
 ARG REDPANDA_VERSION=24.3.8
 ARG DEBUG=false
+ARG PPROF=false
 WORKDIR /go/src/github.com/united-manufacturing-hub/united-manufacturing-hub
 
 # Set app version with a default value - can be overridden at build time
@@ -32,6 +33,14 @@ RUN if [ "$DEBUG" = "true" ]; then \
     CGO_ENABLED=0 go build \
     -gcflags="all=-N -l" \
     -ldflags "-X github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants.S6OverlayVersion=${S6_OVERLAY_VERSION} \
+    -X github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants.BenthosVersion=${BENTHOS_UMH_VERSION} \
+    -X github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants.RedpandaVersion=${REDPANDA_VERSION} \
+    -X github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/version.AppVersion=${APP_VERSION}" \
+    -o /go/bin/umh-core cmd/main.go; \
+    elif [ "$PPROF" = "true" ]; then \
+    CGO_ENABLED=0 go build -mod=vendor -tags pprof \
+    -ldflags "-s -w \
+    -X github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants.S6OverlayVersion=${S6_OVERLAY_VERSION} \
     -X github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants.BenthosVersion=${BENTHOS_UMH_VERSION} \
     -X github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants.RedpandaVersion=${REDPANDA_VERSION} \
     -X github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/version.AppVersion=${APP_VERSION}" \
@@ -110,6 +119,7 @@ COPY --from=build /go/bin/umh-core /usr/local/bin/umh-core
 # Delve is a debugger for Go (https://github.com/go-delve/delve/)
 # We can use it for remote debugging of the UMH Core
 ARG DEBUG=false
+ARG DLV_VERSION=1.24.2
 RUN if [ "$DEBUG" = "true" ]; then \
     apk add --no-cache go && \ 
     go install github.com/go-delve/delve/cmd/dlv@${DLV_VERSION} && \

--- a/umh-core/Makefile
+++ b/umh-core/Makefile
@@ -135,37 +135,31 @@ download-docker-binaries:
 
 	@echo "All required files are present and up to date"
 
-build: download-docker-binaries
-	docker buildx build \
-		--platform linux/$(TARGETARCH) \
-		--build-arg S6_OVERLAY_VERSION=$(S6_OVERLAY_VERSION) \
-		--build-arg BENTHOS_UMH_VERSION=$(BENTHOS_UMH_VERSION) \
-		--build-arg REDPANDA_VERSION=$(REDPANDA_VERSION) \
-		--build-arg APP_VERSION=$(VERSION) \
-		--build-arg TARGETARCH=$(TARGETARCH) \
-		-t $(IMAGE_NAME):$(TAG) \
-		--progress=plain \
-		--load \
-		-f Dockerfile .
-    
-# build-debug: launches delve inside the container.
-# This allows you to use vscode's "Connect to umh-core" feature and use breakpoints, etc inside the container.
-# To use this, modify one of the build-<type> targets to use this target instead of build.
-# You also need to add -p 40000:40000 to the docker run command to expose the Delve port.
-build-debug: download-docker-binaries
-	docker buildx build \
-		--platform linux/$(TARGETARCH) \
-		--build-arg S6_OVERLAY_VERSION=$(S6_OVERLAY_VERSION) \
-		--build-arg BENTHOS_UMH_VERSION=$(BENTHOS_UMH_VERSION) \
-		--build-arg REDPANDA_VERSION=$(REDPANDA_VERSION) \
-		--build-arg APP_VERSION=$(VERSION) \
-		--build-arg TARGETARCH=$(TARGETARCH) \
-		--build-arg DLV_VERSION=$(DLV_VERSION) \
-		--build-arg DEBUG=true \
-		--progress=plain \
-		-t $(IMAGE_NAME):$(TAG)-debug \
-		-f Dockerfile .
-    
+.PHONY: build build-pprof build-debug
+COMMON_ARGS = \
+	--platform linux/$(TARGETARCH) \
+	--build-arg S6_OVERLAY_VERSION=$(S6_OVERLAY_VERSION) \
+	--build-arg BENTHOS_UMH_VERSION=$(BENTHOS_UMH_VERSION) \
+	--build-arg REDPANDA_VERSION=$(REDPANDA_VERSION) \
+	--build-arg APP_VERSION=$(VERSION) \
+	--build-arg TARGETARCH=$(TARGETARCH)
+
+define DOCKER_BUILD
+	docker buildx build $(COMMON_ARGS) $(EXTRA_ARGS) \
+		--progress=plain --load -f Dockerfile \
+		-t $(IMAGE_NAME):$(TAG) .
+endef
+
+build:
+build-pprof:       EXTRA_ARGS := --build-arg PPROF=true
+build-debug:       EXTRA_ARGS := --build-arg DLV_VERSION=$(DLV_VERSION) --build-arg DEBUG=true
+
+build build-pprof build-debug:
+	$(call DOCKER_BUILD)
+
+FLAVOR ?=                         # empty → normal build
+BUILD_TARGET = $(if $(FLAVOR),build-$(FLAVOR),build)
+
 stop-and-remove-umh-core-latest:
 	docker stop $(IMAGE_NAME) || true
 	docker rm $(IMAGE_NAME) || true
@@ -243,28 +237,47 @@ update-go-dependencies:
 	go mod tidy
 	go mod vendor
 
-test-empty: stop-and-remove-umh-core-latest build
+
+
+###############################################################################
+# choose build flavour                                                        #
+#   make test-dfc              → uses normal  image (build)                  #
+#   make test-dfc FLAVOR=pprof → uses pprof   image (build-pprof)            #
+#   make test-dfc FLAVOR=debug → uses delve   image (build-debug)            #
+###############################################################################
+# To extract pprof data use:
+# http://localhost:6060/debug/pprof/profile?seconds=20
+# And open it with flamegraph.com
+
+test-empty: stop-and-remove-umh-core-latest $(BUILD_TARGET)
 	@mkdir -p $(PWD)/data
 	@cp $(PWD)/examples/example-config-empty.yaml $(PWD)/data/config.yaml
 	docker run \
 		--name $(IMAGE_NAME) \
 		-v $(PWD)/data:/data \
 		-p 8081:8080 \
+		-p 4195:4195 \
+		-p 6060:6060 \
+		-p 40000:40000 \
 		--memory $(MEMORY) \
 		--cpus $(CPUS) \
 		$(IMAGE_NAME):$(TAG)
 
-test-clean-install: stop-and-remove-umh-core-latest build
+test-clean-install: stop-and-remove-umh-core-latest $(BUILD_TARGET)
 	docker run \
 		--name $(IMAGE_NAME) \
 		-v $(PWD)/data:/data \
 		-e API_URL=https://management.umh.app/api \
 		-e RELEASE_CHANNEL=enterprise \
+		-p 8081:8080 \
+		-p 4195:4195 \
+		-p 6060:6060 \
+		-p 40000:40000 \
 		--memory $(MEMORY) \
 		--cpus $(CPUS) \
 		$(IMAGE_NAME):$(TAG)
 
-test-hello: stop-and-remove-umh-core-latest build
+test-hello: stop-and-remove-umh-core-latest $(BUILD_TARGET)
 	@mkdir -p $(PWD)/data
 	@cp $(PWD)/examples/example-config.yaml $(PWD)/data/config.yaml
 	docker run \
@@ -272,12 +285,14 @@ test-hello: stop-and-remove-umh-core-latest build
 		-v $(PWD)/data:/data \
 		-p 8081:8080 \
 		-p 4195:4195 \
+		-p 6060:6060 \
+		-p 40000:40000 \
 		--memory $(MEMORY) \
 		--cpus $(CPUS) \
 		-e LOGGING_LEVEL=DEBUG \
 		$(IMAGE_NAME):$(TAG)
 
-test-comm: stop-and-remove-umh-core-latest build
+test-comm: stop-and-remove-umh-core-latest $(BUILD_TARGET)
 	@mkdir -p $(PWD)/data
 	@cp $(PWD)/examples/example-config-comm.yaml $(PWD)/data/config.yaml
 	docker run \
@@ -285,13 +300,15 @@ test-comm: stop-and-remove-umh-core-latest build
 		-v $(PWD)/data:/data \
 		-p 8081:8080 \
 		-p 4195:4195 \
+		-p 6060:6060 \
+		-p 40000:40000 \
 		--memory $(MEMORY) \
 		--cpus $(CPUS) \
 		-e AUTH_TOKEN=$(AUTH_TOKEN) \
 		-e LOGGING_LEVEL=DEBUG \
 		$(IMAGE_NAME):$(TAG)
 
-test-broken: stop-and-remove-umh-core-latest build
+test-broken: stop-and-remove-umh-core-latest $(BUILD_TARGET)
 	@mkdir -p $(PWD)/data
 	@cp $(PWD)/examples/example-config-broken.yaml $(PWD)/data/config.yaml
 	docker run \
@@ -299,11 +316,13 @@ test-broken: stop-and-remove-umh-core-latest build
 		-v $(PWD)/data:/data \
 		-p 8081:8080 \
 		-p 4195:4195 \
+		-p 6060:6060 \
+		-p 40000:40000 \
 		--memory $(MEMORY) \
 		--cpus $(CPUS) \
 		$(IMAGE_NAME):$(TAG)
 
-test-benthos: stop-and-remove-umh-core-latest build
+test-benthos: stop-and-remove-umh-core-latest $(BUILD_TARGET)
 	@mkdir -p $(PWD)/data
 	@cp $(PWD)/examples/example-config-benthos.yaml $(PWD)/data/config.yaml
 	docker run \
@@ -312,11 +331,13 @@ test-benthos: stop-and-remove-umh-core-latest build
 		-e LOGGING_LEVEL=DEBUG \
 		-p 8081:8080 \
 		-p 4195:4195 \
+		-p 6060:6060 \
+		-p 40000:40000 \
 		--memory $(MEMORY) \
 		--cpus $(CPUS) \
 		$(IMAGE_NAME):$(TAG)
 
-test-benthos-single: stop-and-remove-umh-core-latest build
+test-benthos-single: stop-and-remove-umh-core-latest $(BUILD_TARGET)
 	@mkdir -p $(PWD)/data
 	@cp $(PWD)/examples/example-config-benthos-single.yaml $(PWD)/data/config.yaml
 	docker run \
@@ -325,11 +346,13 @@ test-benthos-single: stop-and-remove-umh-core-latest build
 		-e LOGGING_LEVEL=DEBUG \
 		-p 8081:8080 \
 		-p 4195:4195 \
+		-p 6060:6060 \
+		-p 40000:40000 \
 		--memory $(MEMORY) \
 		--cpus $(CPUS) \
 		$(IMAGE_NAME):$(TAG)
 
-test-redpanda: stop-and-remove-umh-core-latest build
+test-redpanda: stop-and-remove-umh-core-latest $(BUILD_TARGET)
 	@mkdir -p $(PWD)/data
 	@cp $(PWD)/examples/example-config-redpanda.yaml $(PWD)/data/config.yaml
 	docker run \
@@ -337,32 +360,43 @@ test-redpanda: stop-and-remove-umh-core-latest build
 		-v $(PWD)/data:/data \
 		-e LOGGING_LEVEL=DEBUG \
 		-p 8081:8080 \
+		-p 4195:4195 \
+		-p 6060:6060 \
+		-p 40000:40000 \
 		--memory $(MEMORY) \
 		--cpus $(CPUS) \
 		$(IMAGE_NAME):$(TAG)
 
-test-dfc: stop-and-remove-umh-core-latest build
+test-dfc: stop-and-remove-umh-core-latest $(BUILD_TARGET)
 	@mkdir -p $(PWD)/data
 	@cp $(PWD)/examples/example-config-dataflow.yaml $(PWD)/data/config.yaml
 	docker run \
 		--name $(IMAGE_NAME) \
 		-v $(PWD)/data:/data \
-		-e LOGGING_LEVEL=DEBUG \
+		-p 8081:8080 \
+		-p 4195:4195 \
+		-p 6060:6060 \
+		-p 40000:40000 \
 		--memory $(MEMORY) \
 		--cpus $(CPUS) \
+		-e LOGGING_LEVEL=DEBUG \
 		$(IMAGE_NAME):$(TAG)
 
-test-benthos-monitor: 
+test-benthos-monitor: stop-and-remove-umh-core-latest $(BUILD_TARGET)
 	@mkdir -p $(PWD)/data
 	@cp $(PWD)/examples/example-config-benthos-monitor.yaml $(PWD)/data/config.yaml
 	docker run \
 		--name umh-core-staging \
 		-v $(PWD)/data:/data \
+		-p 8081:8080 \
+		-p 4195:4195 \
+		-p 6060:6060 \
+		-p 40000:40000 \
 		--memory $(MEMORY) \
 		--cpus $(CPUS) \
 		ghcr.io/united-manufacturing-hub/united-manufacturing-hub/umh-core:staging
 
-test-debug: stop-and-remove-umh-core-latest build-debug
+test-debug: stop-and-remove-umh-core-latest $(BUILD_TARGET)
 	@mkdir -p $(PWD)/data
 	@cp $(PWD)/examples/example-config-benthos-broken.yaml $(PWD)/data/config.yaml
 	docker run \
@@ -370,11 +404,12 @@ test-debug: stop-and-remove-umh-core-latest build-debug
 		-v $(PWD)/data:/data \
 		-p 8081:8080 \
 		-p 4195:4195 \
+		-p 6060:6060 \
 		-p 40000:40000 \
 		--memory $(MEMORY) \
 		--cpus $(CPUS) \
 		-e LOGGING_LEVEL=DEBUG \
-		$(IMAGE_NAME):$(TAG)-debug
+		$(IMAGE_NAME):$(TAG)
 
 pod-shell:
 	docker exec -it $(IMAGE_NAME) /bin/bash

--- a/umh-core/cmd/main.go
+++ b/umh-core/cmd/main.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/internal/pprof"
 	v2 "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/communicator/api/v2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/communicator/communication_state"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/communicator/pkg/tools/watchdog"
@@ -47,6 +48,9 @@ func main() {
 
 	// Log using the component logger with structured fields
 	log.Info("Starting umh-core...")
+
+	// Start the pprof server (if enabled)
+	pprof.StartPprofServer()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/umh-core/internal/pprof/no_pprof.go
+++ b/umh-core/internal/pprof/no_pprof.go
@@ -1,0 +1,24 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !pprof
+// +build !pprof
+
+package pprof
+
+import "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/logger"
+
+func StartPprofServer() {
+	logger.For(logger.ComponentCore).Info("Pprof is disabled")
+}

--- a/umh-core/internal/pprof/pprof.go
+++ b/umh-core/internal/pprof/pprof.go
@@ -1,0 +1,34 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build pprof
+// +build pprof
+
+package pprof
+
+// Registers the pprof handlers on the default ServeMux when the tag is set.
+import (
+	"net/http"
+	_ "net/http/pprof"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/logger"
+)
+
+// Open webserver for pprof
+func StartPprofServer() {
+	logger.For(logger.ComponentCore).Info("Starting pprof server on port 6060")
+	go func() {
+		http.ListenAndServe(":6060", nil)
+	}()
+}


### PR DESCRIPTION
This pr cleanup the makefile a bit, by combining the build targets.
It now also allows you to do:
`make test-X` (normal build)
`make test-X FLAVOR=pprof` (enables pprof on port 6060)
`make test-X FLAVOR=debug` (enables delve on port 40000)