### PR TITLE
ENG-2884 finetune metrics parse timeouts

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -54,5 +54,6 @@ header:
     - "umh-core/pkg/service/redpanda_monitor/test_metrics.txt"
     - "umh-core/pkg/service/benthos_monitor/test_metrics.txt"
     - "umh-core/pkg/service/s6/s6_test_data.txt"
+    - "umh-core/pkg/service/s6/s6_test_log_data.txt"
 
   comment: on-failure

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -60,6 +60,13 @@
             "program": "${workspaceFolder}/umh-core/pkg/service/benthos"
         },
         {
+            "name": "Debug Ginkgo Tests (service-s6)",
+            "type": "go",
+            "request": "launch",
+            "mode": "test",
+            "program": "${workspaceFolder}/umh-core/pkg/service/s6"
+        },
+        {
             "name": "Debug Ginkgo Tests (service-benthos_monitor)",
             "type": "go",
             "request": "launch",

--- a/umh-core/Dockerfile
+++ b/umh-core/Dockerfile
@@ -17,6 +17,7 @@ ARG S6_OVERLAY_VERSION=3.2.0.2
 ARG BENTHOS_UMH_VERSION=0.6.2
 ARG REDPANDA_VERSION=24.3.8
 ARG DEBUG=false
+ARG PPROF=false
 WORKDIR /go/src/github.com/united-manufacturing-hub/united-manufacturing-hub
 
 # Set app version with a default value - can be overridden at build time
@@ -32,6 +33,14 @@ RUN if [ "$DEBUG" = "true" ]; then \
     CGO_ENABLED=0 go build \
     -gcflags="all=-N -l" \
     -ldflags "-X github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants.S6OverlayVersion=${S6_OVERLAY_VERSION} \
+    -X github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants.BenthosVersion=${BENTHOS_UMH_VERSION} \
+    -X github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants.RedpandaVersion=${REDPANDA_VERSION} \
+    -X github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/version.AppVersion=${APP_VERSION}" \
+    -o /go/bin/umh-core cmd/main.go; \
+    elif [ "$PPROF" = "true" ]; then \
+    CGO_ENABLED=0 go build -mod=vendor -tags pprof \
+    -ldflags "-s -w \
+    -X github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants.S6OverlayVersion=${S6_OVERLAY_VERSION} \
     -X github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants.BenthosVersion=${BENTHOS_UMH_VERSION} \
     -X github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants.RedpandaVersion=${REDPANDA_VERSION} \
     -X github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/version.AppVersion=${APP_VERSION}" \
@@ -110,6 +119,7 @@ COPY --from=build /go/bin/umh-core /usr/local/bin/umh-core
 # Delve is a debugger for Go (https://github.com/go-delve/delve/)
 # We can use it for remote debugging of the UMH Core
 ARG DEBUG=false
+ARG DLV_VERSION=1.24.2
 RUN if [ "$DEBUG" = "true" ]; then \
     apk add --no-cache go && \ 
     go install github.com/go-delve/delve/cmd/dlv@${DLV_VERSION} && \

--- a/umh-core/Makefile
+++ b/umh-core/Makefile
@@ -218,6 +218,10 @@ benchmark-s6-parse-log:
 	@echo "Running S6 parseLogLine benchmarks..."
 	cd pkg/service/s6 && go test -bench=ParseLogLine -benchmem
 
+benchmark-benthos-metrics:
+	@echo "Running Benthos metrics benchmarks..."
+	cd pkg/service/benthos_monitor && go test -bench=. -benchmem
+
 integration-test: stop-all-pods vet nilaway lint
 	ginkgo -r -v --tags=test --label-filter='integration' --fail-fast ./...
 

--- a/umh-core/Makefile
+++ b/umh-core/Makefile
@@ -135,37 +135,31 @@ download-docker-binaries:
 
 	@echo "All required files are present and up to date"
 
-build: download-docker-binaries
-	docker buildx build \
-		--platform linux/$(TARGETARCH) \
-		--build-arg S6_OVERLAY_VERSION=$(S6_OVERLAY_VERSION) \
-		--build-arg BENTHOS_UMH_VERSION=$(BENTHOS_UMH_VERSION) \
-		--build-arg REDPANDA_VERSION=$(REDPANDA_VERSION) \
-		--build-arg APP_VERSION=$(VERSION) \
-		--build-arg TARGETARCH=$(TARGETARCH) \
-		-t $(IMAGE_NAME):$(TAG) \
-		--progress=plain \
-		--load \
-		-f Dockerfile .
-    
-# build-debug: launches delve inside the container.
-# This allows you to use vscode's "Connect to umh-core" feature and use breakpoints, etc inside the container.
-# To use this, modify one of the build-<type> targets to use this target instead of build.
-# You also need to add -p 40000:40000 to the docker run command to expose the Delve port.
-build-debug: download-docker-binaries
-	docker buildx build \
-		--platform linux/$(TARGETARCH) \
-		--build-arg S6_OVERLAY_VERSION=$(S6_OVERLAY_VERSION) \
-		--build-arg BENTHOS_UMH_VERSION=$(BENTHOS_UMH_VERSION) \
-		--build-arg REDPANDA_VERSION=$(REDPANDA_VERSION) \
-		--build-arg APP_VERSION=$(VERSION) \
-		--build-arg TARGETARCH=$(TARGETARCH) \
-		--build-arg DLV_VERSION=$(DLV_VERSION) \
-		--build-arg DEBUG=true \
-		--progress=plain \
-		-t $(IMAGE_NAME):$(TAG)-debug \
-		-f Dockerfile .
-    
+.PHONY: build build-pprof build-debug
+COMMON_ARGS = \
+	--platform linux/$(TARGETARCH) \
+	--build-arg S6_OVERLAY_VERSION=$(S6_OVERLAY_VERSION) \
+	--build-arg BENTHOS_UMH_VERSION=$(BENTHOS_UMH_VERSION) \
+	--build-arg REDPANDA_VERSION=$(REDPANDA_VERSION) \
+	--build-arg APP_VERSION=$(VERSION) \
+	--build-arg TARGETARCH=$(TARGETARCH)
+
+define DOCKER_BUILD
+	docker buildx build $(COMMON_ARGS) $(EXTRA_ARGS) \
+		--progress=plain --load -f Dockerfile \
+		-t $(IMAGE_NAME):$(TAG) .
+endef
+
+build:
+build-pprof:       EXTRA_ARGS := --build-arg PPROF=true
+build-debug:       EXTRA_ARGS := --build-arg DLV_VERSION=$(DLV_VERSION) --build-arg DEBUG=true
+
+build build-pprof build-debug:
+	$(call DOCKER_BUILD)
+
+FLAVOR ?=                         # empty → normal build
+BUILD_TARGET = $(if $(FLAVOR),build-$(FLAVOR),build)
+
 stop-and-remove-umh-core-latest:
 	docker stop $(IMAGE_NAME) || true
 	docker rm $(IMAGE_NAME) || true
@@ -243,28 +237,47 @@ update-go-dependencies:
 	go mod tidy
 	go mod vendor
 
-test-empty: stop-and-remove-umh-core-latest build
+
+
+###############################################################################
+# choose build flavour                                                        #
+#   make test-dfc              → uses normal  image (build)                  #
+#   make test-dfc FLAVOR=pprof → uses pprof   image (build-pprof)            #
+#   make test-dfc FLAVOR=debug → uses delve   image (build-debug)            #
+###############################################################################
+# To extract pprof data use:
+# http://localhost:6060/debug/pprof/profile?seconds=20
+# And open it with flamegraph.com
+
+test-empty: stop-and-remove-umh-core-latest $(BUILD_TARGET)
 	@mkdir -p $(PWD)/data
 	@cp $(PWD)/examples/example-config-empty.yaml $(PWD)/data/config.yaml
 	docker run \
 		--name $(IMAGE_NAME) \
 		-v $(PWD)/data:/data \
 		-p 8081:8080 \
+		-p 4195:4195 \
+		-p 6060:6060 \
+		-p 40000:40000 \
 		--memory $(MEMORY) \
 		--cpus $(CPUS) \
 		$(IMAGE_NAME):$(TAG)
 
-test-clean-install: stop-and-remove-umh-core-latest build
+test-clean-install: stop-and-remove-umh-core-latest $(BUILD_TARGET)
 	docker run \
 		--name $(IMAGE_NAME) \
 		-v $(PWD)/data:/data \
 		-e API_URL=https://management.umh.app/api \
 		-e RELEASE_CHANNEL=enterprise \
+		-p 8081:8080 \
+		-p 4195:4195 \
+		-p 6060:6060 \
+		-p 40000:40000 \
 		--memory $(MEMORY) \
 		--cpus $(CPUS) \
 		$(IMAGE_NAME):$(TAG)
 
-test-hello: stop-and-remove-umh-core-latest build
+test-hello: stop-and-remove-umh-core-latest $(BUILD_TARGET)
 	@mkdir -p $(PWD)/data
 	@cp $(PWD)/examples/example-config.yaml $(PWD)/data/config.yaml
 	docker run \
@@ -272,12 +285,14 @@ test-hello: stop-and-remove-umh-core-latest build
 		-v $(PWD)/data:/data \
 		-p 8081:8080 \
 		-p 4195:4195 \
+		-p 6060:6060 \
+		-p 40000:40000 \
 		--memory $(MEMORY) \
 		--cpus $(CPUS) \
 		-e LOGGING_LEVEL=DEBUG \
 		$(IMAGE_NAME):$(TAG)
 
-test-comm: stop-and-remove-umh-core-latest build
+test-comm: stop-and-remove-umh-core-latest $(BUILD_TARGET)
 	@mkdir -p $(PWD)/data
 	@cp $(PWD)/examples/example-config-comm.yaml $(PWD)/data/config.yaml
 	docker run \
@@ -285,13 +300,15 @@ test-comm: stop-and-remove-umh-core-latest build
 		-v $(PWD)/data:/data \
 		-p 8081:8080 \
 		-p 4195:4195 \
+		-p 6060:6060 \
+		-p 40000:40000 \
 		--memory $(MEMORY) \
 		--cpus $(CPUS) \
 		-e AUTH_TOKEN=$(AUTH_TOKEN) \
 		-e LOGGING_LEVEL=DEBUG \
 		$(IMAGE_NAME):$(TAG)
 
-test-broken: stop-and-remove-umh-core-latest build
+test-broken: stop-and-remove-umh-core-latest $(BUILD_TARGET)
 	@mkdir -p $(PWD)/data
 	@cp $(PWD)/examples/example-config-broken.yaml $(PWD)/data/config.yaml
 	docker run \
@@ -299,11 +316,13 @@ test-broken: stop-and-remove-umh-core-latest build
 		-v $(PWD)/data:/data \
 		-p 8081:8080 \
 		-p 4195:4195 \
+		-p 6060:6060 \
+		-p 40000:40000 \
 		--memory $(MEMORY) \
 		--cpus $(CPUS) \
 		$(IMAGE_NAME):$(TAG)
 
-test-benthos: stop-and-remove-umh-core-latest build
+test-benthos: stop-and-remove-umh-core-latest $(BUILD_TARGET)
 	@mkdir -p $(PWD)/data
 	@cp $(PWD)/examples/example-config-benthos.yaml $(PWD)/data/config.yaml
 	docker run \
@@ -312,11 +331,13 @@ test-benthos: stop-and-remove-umh-core-latest build
 		-e LOGGING_LEVEL=DEBUG \
 		-p 8081:8080 \
 		-p 4195:4195 \
+		-p 6060:6060 \
+		-p 40000:40000 \
 		--memory $(MEMORY) \
 		--cpus $(CPUS) \
 		$(IMAGE_NAME):$(TAG)
 
-test-benthos-single: stop-and-remove-umh-core-latest build
+test-benthos-single: stop-and-remove-umh-core-latest $(BUILD_TARGET)
 	@mkdir -p $(PWD)/data
 	@cp $(PWD)/examples/example-config-benthos-single.yaml $(PWD)/data/config.yaml
 	docker run \
@@ -325,11 +346,13 @@ test-benthos-single: stop-and-remove-umh-core-latest build
 		-e LOGGING_LEVEL=DEBUG \
 		-p 8081:8080 \
 		-p 4195:4195 \
+		-p 6060:6060 \
+		-p 40000:40000 \
 		--memory $(MEMORY) \
 		--cpus $(CPUS) \
 		$(IMAGE_NAME):$(TAG)
 
-test-redpanda: stop-and-remove-umh-core-latest build
+test-redpanda: stop-and-remove-umh-core-latest $(BUILD_TARGET)
 	@mkdir -p $(PWD)/data
 	@cp $(PWD)/examples/example-config-redpanda.yaml $(PWD)/data/config.yaml
 	docker run \
@@ -337,32 +360,43 @@ test-redpanda: stop-and-remove-umh-core-latest build
 		-v $(PWD)/data:/data \
 		-e LOGGING_LEVEL=DEBUG \
 		-p 8081:8080 \
+		-p 4195:4195 \
+		-p 6060:6060 \
+		-p 40000:40000 \
 		--memory $(MEMORY) \
 		--cpus $(CPUS) \
 		$(IMAGE_NAME):$(TAG)
 
-test-dfc: stop-and-remove-umh-core-latest build
+test-dfc: stop-and-remove-umh-core-latest $(BUILD_TARGET)
 	@mkdir -p $(PWD)/data
 	@cp $(PWD)/examples/example-config-dataflow.yaml $(PWD)/data/config.yaml
 	docker run \
 		--name $(IMAGE_NAME) \
 		-v $(PWD)/data:/data \
-		-e LOGGING_LEVEL=DEBUG \
+		-p 8081:8080 \
+		-p 4195:4195 \
+		-p 6060:6060 \
+		-p 40000:40000 \
 		--memory $(MEMORY) \
 		--cpus $(CPUS) \
+		-e LOGGING_LEVEL=DEBUG \
 		$(IMAGE_NAME):$(TAG)
 
-test-benthos-monitor: 
+test-benthos-monitor: stop-and-remove-umh-core-latest $(BUILD_TARGET)
 	@mkdir -p $(PWD)/data
 	@cp $(PWD)/examples/example-config-benthos-monitor.yaml $(PWD)/data/config.yaml
 	docker run \
 		--name umh-core-staging \
 		-v $(PWD)/data:/data \
+		-p 8081:8080 \
+		-p 4195:4195 \
+		-p 6060:6060 \
+		-p 40000:40000 \
 		--memory $(MEMORY) \
 		--cpus $(CPUS) \
 		ghcr.io/united-manufacturing-hub/united-manufacturing-hub/umh-core:staging
 
-test-debug: stop-and-remove-umh-core-latest build-debug
+test-debug: stop-and-remove-umh-core-latest $(BUILD_TARGET)
 	@mkdir -p $(PWD)/data
 	@cp $(PWD)/examples/example-config-benthos-broken.yaml $(PWD)/data/config.yaml
 	docker run \
@@ -370,11 +404,12 @@ test-debug: stop-and-remove-umh-core-latest build-debug
 		-v $(PWD)/data:/data \
 		-p 8081:8080 \
 		-p 4195:4195 \
+		-p 6060:6060 \
 		-p 40000:40000 \
 		--memory $(MEMORY) \
 		--cpus $(CPUS) \
 		-e LOGGING_LEVEL=DEBUG \
-		$(IMAGE_NAME):$(TAG)-debug
+		$(IMAGE_NAME):$(TAG)
 
 pod-shell:
 	docker exec -it $(IMAGE_NAME) /bin/bash

--- a/umh-core/Makefile
+++ b/umh-core/Makefile
@@ -222,6 +222,10 @@ benchmark-benthos-metrics:
 	@echo "Running Benthos metrics benchmarks..."
 	cd pkg/service/benthos_monitor && go test -bench=. -benchmem
 
+benchmark-redpanda-metrics:
+	@echo "Running Redpanda metrics benchmarks..."
+	cd pkg/service/redpanda_monitor && go test -bench=. -benchmem
+
 integration-test: stop-all-pods vet nilaway lint
 	ginkgo -r -v --tags=test --label-filter='integration' --fail-fast ./...
 

--- a/umh-core/cmd/main.go
+++ b/umh-core/cmd/main.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/internal/pprof"
 	v2 "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/communicator/api/v2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/communicator/communication_state"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/communicator/pkg/tools/watchdog"
@@ -47,6 +48,9 @@ func main() {
 
 	// Log using the component logger with structured fields
 	log.Info("Starting umh-core...")
+
+	// Start the pprof server (if enabled)
+	pprof.StartPprofServer()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/umh-core/integration/monitoring_helpers.go
+++ b/umh-core/integration/monitoring_helpers.go
@@ -82,6 +82,14 @@ func printSystemInformation() {
 			vmStat.Used/1024/1024,
 			vmStat.Total/1024/1024)
 	}
+
+	// Get starvation from cat /sys/fs/cgroup/cpu.stat within the container
+	cpuStat, err := runDockerCommand("exec", "-it", getContainerName(), "cat", "/sys/fs/cgroup/cpu.stat")
+	if err != nil {
+		GinkgoWriter.Printf("Failed to get cpu.stat: %v\n", err)
+	} else {
+		GinkgoWriter.Printf("cpu.stat: %s\n", cpuStat)
+	}
 }
 
 // failOnMetricsHealthIssue expects the metrics to be healthy, otherwise it fails the test

--- a/umh-core/internal/pprof/no_pprof.go
+++ b/umh-core/internal/pprof/no_pprof.go
@@ -1,0 +1,24 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !pprof
+// +build !pprof
+
+package pprof
+
+import "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/logger"
+
+func StartPprofServer() {
+	logger.For(logger.ComponentCore).Info("Pprof is disabled")
+}

--- a/umh-core/internal/pprof/pprof.go
+++ b/umh-core/internal/pprof/pprof.go
@@ -1,0 +1,34 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build pprof
+// +build pprof
+
+package pprof
+
+// Registers the pprof handlers on the default ServeMux when the tag is set.
+import (
+	"net/http"
+	_ "net/http/pprof"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/logger"
+)
+
+// Open webserver for pprof
+func StartPprofServer() {
+	logger.For(logger.ComponentCore).Info("Starting pprof server on port 6060")
+	go func() {
+		http.ListenAndServe(":6060", nil)
+	}()
+}

--- a/umh-core/pkg/constants/baseFSM.go
+++ b/umh-core/pkg/constants/baseFSM.go
@@ -17,7 +17,8 @@ package constants
 import "time"
 
 const (
-	ExpectedMaxP95ExecutionTimePerEvent = 1 * time.Millisecond
+	ExpectedMaxP95ExecutionTimePerEvent     = 1 * time.Millisecond
+	DefaultMaxTicksToRemainInTransientState = 600 // If a FSM remains in a transient state for more than this number of ticks, it will be considered stuck and will trigger a remove / force remove
 )
 
 const (

--- a/umh-core/pkg/constants/benthos.go
+++ b/umh-core/pkg/constants/benthos.go
@@ -32,7 +32,7 @@ const (
 	// BenthosExpectedMaxP95ExecutionTimePerInstance means that an instance will not reconcile if not 30ms are left
 	// Note: in the intergation test, we defined an alerting threshold of 80% of the max ticker time, which is 100ms
 	// So by setting this to 30 ms, we can ensure that an instance will never start if it triggers the alerting threshold
-	BenthosExpectedMaxP95ExecutionTimePerInstance = time.Millisecond * 40 // needs to be higher than S6ExpectedMaxP95ExecutionTimePerInstance
+	BenthosExpectedMaxP95ExecutionTimePerInstance = time.Millisecond * 40 // needs to be higher than S6ExpectedMaxP95ExecutionTimePerInstance and also higher than benthos monitor
 )
 
 const (

--- a/umh-core/pkg/constants/benthos_monitor.go
+++ b/umh-core/pkg/constants/benthos_monitor.go
@@ -19,7 +19,7 @@ import "time"
 // BenthosMonitorUpdateObservedStateTimeout is the timeout for updating the observed state
 const BenthosMonitorUpdateObservedStateTimeout = 5 * time.Millisecond
 
-const BenthosMonitorProcessMetricsTimeout = 1 * time.Millisecond // needs to be smaller than BenthosMonitorUpdateObservedStateTimeout
+const BenthosMonitorProcessMetricsTimeout = 2 * time.Millisecond // needs to be smaller than BenthosMonitorUpdateObservedStateTimeout
 
 // BenthosMonitorExpectedMaxP95ExecutionTimePerInstance means that an instance will not reconcile if not 30ms are left
 // Note: in the intergation test, we defined an alerting threshold of 80% of the max ticker time, which is 100ms

--- a/umh-core/pkg/constants/benthos_monitor.go
+++ b/umh-core/pkg/constants/benthos_monitor.go
@@ -17,7 +17,9 @@ package constants
 import "time"
 
 // BenthosMonitorUpdateObservedStateTimeout is the timeout for updating the observed state
-const BenthosMonitorUpdateObservedStateTimeout = 2 * time.Millisecond
+const BenthosMonitorUpdateObservedStateTimeout = 5 * time.Millisecond
+
+const BenthosMonitorProcessMetricsTimeout = 1 * time.Millisecond // needs to be smaller than BenthosMonitorUpdateObservedStateTimeout
 
 // BenthosMonitorExpectedMaxP95ExecutionTimePerInstance means that an instance will not reconcile if not 30ms are left
 // Note: in the intergation test, we defined an alerting threshold of 80% of the max ticker time, which is 100ms

--- a/umh-core/pkg/constants/redpanda.go
+++ b/umh-core/pkg/constants/redpanda.go
@@ -27,7 +27,7 @@ const (
 
 const (
 	RedpandaUpdateObservedStateTimeout = 20 * time.Millisecond
-	RedpandaProcessMetricsTimeout      = 15 * time.Millisecond // needs to be smaller than RedpandaUpdateObservedStateTimeout
+	RedpandaProcessMetricsTimeout      = 8 * time.Millisecond // needs to be smaller than RedpandaUpdateObservedStateTimeout
 )
 const (
 	// RedpandaExpectedMaxP95ExecutionTimePerInstance represents the maximum expected time for a Redpanda instance

--- a/umh-core/pkg/constants/redpanda.go
+++ b/umh-core/pkg/constants/redpanda.go
@@ -26,13 +26,14 @@ const (
 )
 
 const (
-	RedpandaUpdateObservedStateTimeout = 15 * time.Millisecond
+	RedpandaUpdateObservedStateTimeout = 20 * time.Millisecond
+	RedpandaProcessMetricsTimeout      = 15 * time.Millisecond // needs to be smaller than RedpandaUpdateObservedStateTimeout
 )
 const (
 	// RedpandaExpectedMaxP95ExecutionTimePerInstance represents the maximum expected time for a Redpanda instance
 	// to update its observed state. We reserve 50ms of buffer time to ensure the total execution time stays
 	// under the alerting threshold. The system has a 100ms max ticker time with an 80% (80ms) alerting threshold.
-	// By setting this to RedpandaUpdateObservedStateTimeout (15ms) + 35ms, we ensure that Redpanda operations
+	// By setting this to RedpandaUpdateObservedStateTimeout + 35ms, we ensure that Redpanda operations
 	// complete with enough margin to avoid triggering alerts during normal operation.
 	RedpandaExpectedMaxP95ExecutionTimePerInstance = RedpandaUpdateObservedStateTimeout + time.Millisecond*35 // needs to be higher than S6ExpectedMaxP95ExecutionTimePerInstance
 )

--- a/umh-core/pkg/constants/s6.go
+++ b/umh-core/pkg/constants/s6.go
@@ -30,6 +30,7 @@ var (
 
 const (
 	S6UpdateObservedStateTimeout = time.Millisecond * 3
+	S6RemoveTimeout              = time.Millisecond * 3
 )
 
 const (

--- a/umh-core/pkg/control/loop.go
+++ b/umh-core/pkg/control/loop.go
@@ -58,7 +58,6 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/metrics"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/sentry"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/filesystem"
-	s6svc "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/s6"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/serviceregistry"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/starvationchecker"
 	"go.uber.org/zap"
@@ -128,16 +127,6 @@ func NewControlLoop(configManager config.ConfigManager) *ControlLoop {
 	snapshotManager := fsm.NewSnapshotManager()
 
 	metrics.InitErrorCounter(metrics.ComponentControlLoop, "main")
-
-	// Now clean the S6 service directory except for the known services
-	s6Service := s6svc.NewDefaultService()
-	log.Debugf("Cleaning S6 service directory: %s", constants.S6BaseDir)
-	err = s6Service.CleanS6ServiceDirectory(context.Background(), constants.S6BaseDir, servicesRegistry.GetFileSystem()) // we do not use the buffered service here, because we want to clean the real filesystem
-	if err != nil {
-		sentry.ReportIssuef(sentry.IssueTypeError, log, "Failed to clean S6 service directory: %s", err)
-
-	}
-	log.Debugf("S6 service directory cleaned: %s", constants.S6BaseDir)
 
 	return &ControlLoop{
 		managers:          managers,

--- a/umh-core/pkg/fsm/agent_monitor/actions.go
+++ b/umh-core/pkg/fsm/agent_monitor/actions.go
@@ -60,6 +60,12 @@ func (a *AgentInstance) StopInstance(ctx context.Context, filesystemService file
 	return nil
 }
 
+// CheckForCreation is called when the FSM transitions to creating.
+// For agent monitoring, this is a no-op as we don't need to check anything
+func (a *AgentInstance) CheckForCreation(ctx context.Context, filesystemService filesystem.Service) bool {
+	return true
+}
+
 // UpdateObservedStateOfInstance is called when the FSM transitions to updating.
 // For agent monitoring, this is a no-op as we don't need to update any resources.
 func (a *AgentInstance) UpdateObservedStateOfInstance(ctx context.Context, services serviceregistry.Provider, tick uint64, loopStartTime time.Time) error {

--- a/umh-core/pkg/fsm/agent_monitor/models.go
+++ b/umh-core/pkg/fsm/agent_monitor/models.go
@@ -120,3 +120,10 @@ type AgentInstance struct {
 func (a *AgentInstance) GetLastObservedState() publicfsm.ObservedState {
 	return a.ObservedState
 }
+
+// IsTransientStreakCounterMaxed returns whether the transient streak counter
+// has reached the maximum number of ticks, which means that the FSM is stuck in a state
+// and should be removed
+func (a *AgentInstance) IsTransientStreakCounterMaxed() bool {
+	return a.baseFSMInstance.IsTransientStreakCounterMaxed()
+}

--- a/umh-core/pkg/fsm/base_manager.go
+++ b/umh-core/pkg/fsm/base_manager.go
@@ -29,6 +29,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/logger"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/metrics"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/sentry"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/filesystem"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/serviceregistry"
 	"go.uber.org/zap"
 )
@@ -53,6 +54,10 @@ type FSMInstance interface {
 	GetDesiredFSMState() string
 	// SetDesiredFSMState sets the desired state of the instance
 	SetDesiredFSMState(desiredState string) error
+	// IsTransientStreakCounterMaxed returns whether the transient streak counter
+	// has reached the maximum number of ticks, which means that the FSM is stuck in a state
+	// and should be removed
+	IsTransientStreakCounterMaxed() bool
 	// Reconcile moves the instance toward its desired state
 	// Returns an error if reconciliation fails, and a boolean indicating
 	// whether a change was made to the instance's state
@@ -548,6 +553,9 @@ func (m *BaseFSMManager[C]) Reconcile(
 			return fmt.Errorf("error reconciling instance: %w", err), false
 		}
 
+		// Check if the instance has been stuck in a transient state for too long
+		m.maybeEscalateRemoval(ctx, instance, services)
+
 		if reconciled {
 			return nil, true
 		}
@@ -655,4 +663,123 @@ func (m *BaseFSMManager[C]) schedule(base uint64) uint64 {
 
 	// Round to nearest integer tick and add to the current manager tick
 	return m.managerTick + uint64(delta+0.5)
+}
+
+// maybeEscalateRemoval is the **watch-dog** that prevents an FSM from being
+// stuck forever in one of the *transient* lifecycle states.
+//
+// It is invoked by the manager **once per tick** *after* an
+// `inst.Reconcile(…)` call has completed.
+// It checks if an instance has been in a transient state for too long
+// and takes action to prevent it from remaining stuck.
+//
+// # Inputs
+//
+//   - inst  – any FSMInstance that was just reconciled.
+//   - filesystemService - service used for file operations if a force remove is needed
+//
+// # Logic
+//
+//  1. **Check if the instance has been in a transient state too long**
+//     by using GetTransientStreakCounter() and comparing to a threshold
+//
+//  2. **Escalate** depending on the *current* state:
+//
+//     * **creating / to_be_created**
+//     → initiate normal removal. This asks the normal "graceful remove"
+//     path to start.
+//
+//     * **removing**
+//     → attempt a hard, unconditional teardown.
+//     If the concrete instance implements the ForceRemover interface,
+//     the manager calls the method in a detached goroutine.
+//
+// # Side effects
+//
+//   - May initiate instance removal
+//   - May launch a goroutine that calls `ForceRemove`
+//   - No error is returned from this function
+//
+// # Errors
+//
+// This helper never returns an error. All failures in operations
+// are handled through the normal FSM reconciliation mechanisms.
+func (m *BaseFSMManager[C]) maybeEscalateRemoval(ctx context.Context, inst FSMInstance, services serviceregistry.Provider) {
+	// Check if the instance has been in a transient state for too long
+	if !inst.IsTransientStreakCounterMaxed() {
+		return // Not stuck yet
+	}
+
+	currentState := inst.GetCurrentFSMState()
+
+	// Find the instance name from the instances map
+	var instanceName string
+	for name, i := range m.instances {
+		if i == inst {
+			instanceName = name
+			break
+		}
+	}
+
+	switch currentState {
+	case internalfsm.LifecycleStateRemoving:
+		// Instance is stuck in removing state - try force removal if possible
+		if forceRemover, ok := inst.(interface {
+			ForceRemove(context.Context, filesystem.Service) error
+		}); ok {
+			// Run force removal in a detached goroutine to avoid blocking the main reconciliation loop
+			go func() {
+				err := forceRemover.ForceRemove(ctx, services.GetFileSystem())
+				if err != nil {
+					sentry.ReportFSMErrorf(
+						m.logger,
+						instanceName,
+						m.managerName,
+						"force_remove_error",
+						"Error force removing instance: %v",
+						err,
+					)
+				}
+				sentry.ReportIssuef(sentry.IssueTypeWarning, m.logger, "force removing instance %s: %v", instanceName, err)
+			}()
+		} else {
+			sentry.ReportIssuef(sentry.IssueTypeWarning, m.logger, "no force remover for instance %s, cannot force remove", instanceName)
+		}
+		return
+	default:
+		// Instance is stuck in creating or to_be_created state - try normal removal
+		err := inst.Remove(ctx)
+		if err != nil {
+			sentry.ReportFSMErrorf(
+				m.logger,
+				instanceName,
+				m.managerName,
+				"remove_error",
+				"Error removing instance: %v",
+				err,
+			)
+			if forceRemover, ok := inst.(interface {
+				ForceRemove(context.Context, filesystem.Service) error
+			}); ok {
+				// Run force removal in a detached goroutine to avoid blocking the main reconciliation loop
+				go func() {
+					err := forceRemover.ForceRemove(ctx, services.GetFileSystem())
+					if err != nil {
+						sentry.ReportFSMErrorf(
+							m.logger,
+							instanceName,
+							m.managerName,
+							"force_remove_error",
+							"Error force removing instance after normal removal failed: %v",
+							err,
+						)
+					}
+					sentry.ReportIssuef(sentry.IssueTypeWarning, m.logger, "force removing instance %s after normal removal failed: %v", instanceName, err)
+				}()
+			} else {
+				sentry.ReportIssuef(sentry.IssueTypeWarning, m.logger, "no force remover for instance %s, cannot force remove", instanceName)
+			}
+		}
+		return
+	}
 }

--- a/umh-core/pkg/fsm/benthos/machine.go
+++ b/umh-core/pkg/fsm/benthos/machine.go
@@ -31,8 +31,10 @@ import (
 )
 
 // NewBenthosInstance creates a new BenthosInstance with the given ID and service path
-func NewBenthosInstance(
-	config config.BenthosConfig) *BenthosInstance {
+func NewBenthosInstanceWithService(
+	config config.BenthosConfig,
+	service *benthos_service.BenthosService,
+) *BenthosInstance {
 
 	cfg := internal_fsm.BaseFSMInstanceConfig{
 		ID:                           config.Name,
@@ -82,7 +84,7 @@ func NewBenthosInstance(
 
 	instance := &BenthosInstance{
 		baseFSMInstance: internal_fsm.NewBaseFSMInstance(cfg, backoffConfig, logger),
-		service:         benthos_service.NewDefaultBenthosService(config.Name),
+		service:         service,
 		config:          config.BenthosServiceConfig,
 		ObservedState:   BenthosObservedState{},
 	}
@@ -97,6 +99,12 @@ func NewBenthosInstance(
 	metrics.InitErrorCounter(metrics.ComponentBenthosInstance, config.Name)
 
 	return instance
+}
+
+func NewBenthosInstance(
+	config config.BenthosConfig,
+) *BenthosInstance {
+	return NewBenthosInstanceWithService(config, benthos_service.NewDefaultBenthosService(config.Name))
 }
 
 // SetDesiredFSMState safely updates the desired state

--- a/umh-core/pkg/fsm/benthos/models.go
+++ b/umh-core/pkg/fsm/benthos/models.go
@@ -160,3 +160,10 @@ func (b *BenthosInstance) SetService(service benthossvc.IBenthosService) {
 func (b *BenthosInstance) GetConfig() benthosserviceconfig.BenthosServiceConfig {
 	return b.config
 }
+
+// IsTransientStreakCounterMaxed returns whether the transient streak counter
+// has reached the maximum number of ticks, which means that the FSM is stuck in a state
+// and should be removed
+func (b *BenthosInstance) IsTransientStreakCounterMaxed() bool {
+	return b.baseFSMInstance.IsTransientStreakCounterMaxed()
+}

--- a/umh-core/pkg/fsm/benthos_monitor/actions.go
+++ b/umh-core/pkg/fsm/benthos_monitor/actions.go
@@ -16,6 +16,7 @@ package benthos_monitor
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -25,6 +26,7 @@ import (
 	benthos_monitor_service "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/benthos_monitor"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/filesystem"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/serviceregistry"
+	standarderrors "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/standarderrors"
 )
 
 // CreateInstance is called when the FSM transitions from to_be_created -> creating.
@@ -53,16 +55,43 @@ func (b *BenthosMonitorInstance) RemoveInstance(ctx context.Context, filesystemS
 
 	// Remove the Benthos from the S6 manager
 	err := b.monitorService.RemoveBenthosMonitorFromS6Manager(ctx)
-	if err != nil {
-		if err == benthos_monitor_service.ErrServiceNotExist {
-			b.baseFSMInstance.GetLogger().Debugf("Benthos Monitor service %s not found in S6 manager", b.baseFSMInstance.GetID())
-			return nil // do not throw an error, as each action is expected to be idempotent
-		}
-		return fmt.Errorf("failed to remove Benthos Monitor service %s from S6 manager: %w", b.baseFSMInstance.GetID(), err)
-	}
+	switch {
+	// ---------------------------------------------------------------
+	// happy paths
+	// ---------------------------------------------------------------
+	case err == nil: // fully removed
+		b.baseFSMInstance.GetLogger().
+			Infof("Benthos monitor service %s removed from S6 manager",
+				b.baseFSMInstance.GetID())
+		return nil
 
-	b.baseFSMInstance.GetLogger().Debugf("Benthos Monitor service %s removed from S6 manager", b.baseFSMInstance.GetID())
-	return nil
+	case errors.Is(err, benthos_monitor_service.ErrServiceNotExist):
+		b.baseFSMInstance.GetLogger().
+			Infof("Benthos monitor service %s already removed from S6 manager",
+				b.baseFSMInstance.GetID())
+		// idempotent: was already gone
+		return nil
+
+	// ---------------------------------------------------------------
+	// transient path – keep retrying
+	// ---------------------------------------------------------------
+	case errors.Is(err, standarderrors.ErrRemovalPending):
+		b.baseFSMInstance.GetLogger().
+			Infof("Benthos monitor service %s removal still in progress",
+				b.baseFSMInstance.GetID())
+		// not an error from the FSM’s perspective – just means “try again”
+		return err
+
+	// ---------------------------------------------------------------
+	// real error – escalate
+	// ---------------------------------------------------------------
+	default:
+		b.baseFSMInstance.GetLogger().
+			Errorf("failed to remove Benthos Monitor service %s: %s",
+				b.baseFSMInstance.GetID(), err)
+		return fmt.Errorf("failed to remove Benthos Monitor service %s: %w",
+			b.baseFSMInstance.GetID(), err)
+	}
 }
 
 // StartInstance is called when the agent monitoring should be enabled.
@@ -96,6 +125,11 @@ func (b *BenthosMonitorInstance) StopInstance(ctx context.Context, filesystemSer
 
 	b.baseFSMInstance.GetLogger().Debugf("Benthos Monitor service %s stop command executed", b.baseFSMInstance.GetID())
 	return nil
+}
+
+// CheckForCreation checks if the Benthos Monitor service should be created
+func (b *BenthosMonitorInstance) CheckForCreation(ctx context.Context, filesystemService filesystem.Service) bool {
+	return true
 }
 
 // UpdateObservedStateOfInstance is called when the FSM transitions to updating.

--- a/umh-core/pkg/fsm/benthos_monitor/models.go
+++ b/umh-core/pkg/fsm/benthos_monitor/models.go
@@ -119,3 +119,10 @@ type BenthosMonitorInstance struct {
 func (b *BenthosMonitorInstance) GetLastObservedState() publicfsm.ObservedState {
 	return b.ObservedState
 }
+
+// IsTransientStreakCounterMaxed returns whether the transient streak counter
+// has reached the maximum number of ticks, which means that the FSM is stuck in a state
+// and should be removed
+func (b *BenthosMonitorInstance) IsTransientStreakCounterMaxed() bool {
+	return b.baseFSMInstance.IsTransientStreakCounterMaxed()
+}

--- a/umh-core/pkg/fsm/connection/TODO.md
+++ b/umh-core/pkg/fsm/connection/TODO.md
@@ -1,0 +1,3 @@
+Please note that the actions.go needs to be adjusted to the new error handling, specifically the ignoring of connectionservice.ErrRemovalPending. See also benthos/actions.go for the same issue.
+
+The same goes for the reconcile.go file, where the same error is ignored.

--- a/umh-core/pkg/fsm/container/actions.go
+++ b/umh-core/pkg/fsm/container/actions.go
@@ -60,6 +60,12 @@ func (c *ContainerInstance) StopInstance(ctx context.Context, filesystemService 
 	return nil
 }
 
+// CheckForCreation checks whether the creation was successful
+// For container monitoring, this is a no-op as we don't need to check anything
+func (c *ContainerInstance) CheckForCreation(ctx context.Context, filesystemService filesystem.Service) bool {
+	return true
+}
+
 // UpdateObservedStateOfInstance is called when the FSM transitions to updating.
 // For container monitoring, this is a no-op as we don't need to update any resources.
 func (c *ContainerInstance) UpdateObservedStateOfInstance(ctx context.Context, services serviceregistry.Provider, tick uint64, loopStartTime time.Time) error {

--- a/umh-core/pkg/fsm/container/models.go
+++ b/umh-core/pkg/fsm/container/models.go
@@ -120,3 +120,10 @@ type ContainerInstance struct {
 func (c *ContainerInstance) GetLastObservedState() publicfsm.ObservedState {
 	return c.ObservedState
 }
+
+// IsTransientStreakCounterMaxed returns whether the transient streak counter
+// has reached the maximum number of ticks, which means that the FSM is stuck in a state
+// and should be removed
+func (c *ContainerInstance) IsTransientStreakCounterMaxed() bool {
+	return c.baseFSMInstance.IsTransientStreakCounterMaxed()
+}

--- a/umh-core/pkg/fsm/container/reconcile.go
+++ b/umh-core/pkg/fsm/container/reconcile.go
@@ -26,8 +26,8 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/metrics"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/models"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/filesystem"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/serviceregistry"
+	standarderrors "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/standarderrors"
 )
 
 // Reconcile periodically checks if the FSM needs state transitions based on metrics
@@ -108,11 +108,11 @@ func (c *ContainerInstance) Reconcile(ctx context.Context, snapshot fsm.SystemSn
 	}
 
 	// Step 3: Attempt to reconcile the state.
-	err, reconciled = c.reconcileStateTransition(ctx, services.GetFileSystem())
+	err, reconciled = c.reconcileStateTransition(ctx, services)
 	if err != nil {
 		// If the instance is removed, we don't want to return an error here, because we want to continue reconciling
 		// Also this should not
-		if errors.Is(err, fsm.ErrInstanceRemoved) {
+		if errors.Is(err, standarderrors.ErrInstanceRemoved) {
 			return nil, false
 		}
 
@@ -201,7 +201,7 @@ func healthCategoryToString(category models.HealthCategory) string {
 // Any functions that fetch information are disallowed here and must be called in reconcileExternalChanges
 // and exist in ExternalState.
 // This is to ensure full testability of the FSM.
-func (c *ContainerInstance) reconcileStateTransition(ctx context.Context, filesystemService filesystem.Service) (err error, reconciled bool) {
+func (c *ContainerInstance) reconcileStateTransition(ctx context.Context, services serviceregistry.Provider) (err error, reconciled bool) {
 	start := time.Now()
 	defer func() {
 		metrics.ObserveReconcileTime(metrics.ComponentContainerMonitor, c.baseFSMInstance.GetID()+".reconcileStateTransition", time.Since(start))
@@ -217,7 +217,7 @@ func (c *ContainerInstance) reconcileStateTransition(ctx context.Context, filesy
 
 	// Handle lifecycle states first - these take precedence over operational states
 	if internal_fsm.IsLifecycleState(currentState) {
-		err, reconciled := c.reconcileLifecycleStates(ctx, filesystemService, currentState)
+		err, reconciled := c.baseFSMInstance.ReconcileLifecycleStates(ctx, services, currentState, c.CreateInstance, c.RemoveInstance, c.CheckForCreation)
 		if err != nil {
 			return err, false
 		}
@@ -230,7 +230,7 @@ func (c *ContainerInstance) reconcileStateTransition(ctx context.Context, filesy
 
 	// Handle operational states
 	if IsOperationalState(currentState) {
-		err, reconciled := c.reconcileOperationalStates(ctx, filesystemService, currentState, desiredState, time.Now())
+		err, reconciled := c.reconcileOperationalStates(ctx, services, currentState, desiredState, time.Now())
 		if err != nil {
 			return err, false
 		}
@@ -255,37 +255,8 @@ func (c *ContainerInstance) updateObservedState(ctx context.Context) error {
 	return nil
 }
 
-// reconcileLifecycleStates handles to_be_created, creating, removing, removed
-func (c *ContainerInstance) reconcileLifecycleStates(ctx context.Context, filesystemService filesystem.Service, currentState string) (error, bool) {
-	switch currentState {
-	case internal_fsm.LifecycleStateToBeCreated:
-		// do creation
-		if err := c.CreateInstance(ctx, filesystemService); err != nil {
-			return err, false
-		}
-		return c.baseFSMInstance.SendEvent(ctx, internal_fsm.LifecycleEventCreate), true
-
-	case internal_fsm.LifecycleStateCreating:
-		// We can assume creation is done immediately (no real action)
-		return c.baseFSMInstance.SendEvent(ctx, internal_fsm.LifecycleEventCreateDone), true
-
-	case internal_fsm.LifecycleStateRemoving:
-		if err := c.RemoveInstance(ctx, filesystemService); err != nil {
-			return err, false
-		}
-		return c.baseFSMInstance.SendEvent(ctx, internal_fsm.LifecycleEventRemoveDone), true
-
-	case internal_fsm.LifecycleStateRemoved:
-		// The manager will clean this up eventually
-		return fsm.ErrInstanceRemoved, true
-
-	default:
-		return nil, false
-	}
-}
-
 // reconcileOperationalStates handles states related to instance operations (starting/stopping)
-func (c *ContainerInstance) reconcileOperationalStates(ctx context.Context, filesystemService filesystem.Service, currentState string, desiredState string, currentTime time.Time) (err error, reconciled bool) {
+func (c *ContainerInstance) reconcileOperationalStates(ctx context.Context, services serviceregistry.Provider, currentState string, desiredState string, currentTime time.Time) (err error, reconciled bool) {
 	start := time.Now()
 	defer func() {
 		metrics.ObserveReconcileTime(metrics.ComponentContainerMonitor, c.baseFSMInstance.GetID()+".reconcileOperationalStates", time.Since(start))
@@ -293,9 +264,9 @@ func (c *ContainerInstance) reconcileOperationalStates(ctx context.Context, file
 
 	switch desiredState {
 	case OperationalStateActive:
-		return c.reconcileTransitionToActive(ctx, filesystemService, currentState, currentTime)
+		return c.reconcileTransitionToActive(ctx, services, currentState, currentTime)
 	case OperationalStateStopped:
-		return c.reconcileTransitionToStopped(ctx, filesystemService, currentState)
+		return c.reconcileTransitionToStopped(ctx, services, currentState)
 	default:
 		return fmt.Errorf("invalid desired state: %s", desiredState), false
 	}
@@ -303,7 +274,7 @@ func (c *ContainerInstance) reconcileOperationalStates(ctx context.Context, file
 
 // reconcileTransitionToActive handles transitions when the desired state is Active.
 // It deals with moving from various states to the Active state.
-func (c *ContainerInstance) reconcileTransitionToActive(ctx context.Context, filesystemService filesystem.Service, currentState string, currentTime time.Time) (err error, reconciled bool) {
+func (c *ContainerInstance) reconcileTransitionToActive(ctx context.Context, services serviceregistry.Provider, currentState string, currentTime time.Time) (err error, reconciled bool) {
 	start := time.Now()
 	defer func() {
 		metrics.ObserveReconcileTime(metrics.ComponentContainerMonitor, c.baseFSMInstance.GetID()+".reconcileTransitionToActive", time.Since(start))
@@ -313,16 +284,16 @@ func (c *ContainerInstance) reconcileTransitionToActive(ctx context.Context, fil
 	// If we're stopped, we need to start first
 	case currentState == OperationalStateStopped:
 		// nothing to start here, just for consistency with other fsms
-		err := c.StartInstance(ctx, filesystemService)
+		err := c.StartInstance(ctx, services.GetFileSystem())
 		if err != nil {
 			return err, false
 		}
 		// Send event to transition from Stopped to Starting
 		return c.baseFSMInstance.SendEvent(ctx, EventStart), true
 	case IsStartingState(currentState):
-		return c.reconcileStartingStates(ctx, filesystemService, currentState, currentTime)
+		return c.reconcileStartingStates(ctx, services, currentState, currentTime)
 	case IsRunningState(currentState):
-		return c.reconcileRunningStates(ctx, filesystemService, currentState, currentTime)
+		return c.reconcileRunningStates(ctx, services, currentState, currentTime)
 	default:
 		return fmt.Errorf("invalid current state: %s", currentState), false
 	}
@@ -330,7 +301,7 @@ func (c *ContainerInstance) reconcileTransitionToActive(ctx context.Context, fil
 
 // reconcileStartingStates handles the various starting phase states when transitioning to a running state
 // no big startup process here
-func (c *ContainerInstance) reconcileStartingStates(ctx context.Context, filesystemService filesystem.Service, currentState string, currentTime time.Time) (err error, reconciled bool) {
+func (c *ContainerInstance) reconcileStartingStates(ctx context.Context, services serviceregistry.Provider, currentState string, currentTime time.Time) (err error, reconciled bool) {
 	start := time.Now()
 	defer func() {
 		metrics.ObserveReconcileTime(metrics.ComponentContainerMonitor, c.baseFSMInstance.GetID()+".reconcileStartingStates", time.Since(start))
@@ -347,7 +318,7 @@ func (c *ContainerInstance) reconcileStartingStates(ctx context.Context, filesys
 }
 
 // reconcileRunningStates handles the various running states when transitioning to Active.
-func (c *ContainerInstance) reconcileRunningStates(ctx context.Context, filesystemService filesystem.Service, currentState string, currentTime time.Time) (err error, reconciled bool) {
+func (c *ContainerInstance) reconcileRunningStates(ctx context.Context, services serviceregistry.Provider, currentState string, currentTime time.Time) (err error, reconciled bool) {
 	start := time.Now()
 	defer func() {
 		metrics.ObserveReconcileTime(metrics.ComponentContainerMonitor, c.baseFSMInstance.GetID()+".reconcileRunningStates", time.Since(start))
@@ -373,7 +344,7 @@ func (c *ContainerInstance) reconcileRunningStates(ctx context.Context, filesyst
 
 // reconcileTransitionToStopped handles transitions when the desired state is Stopped.
 // It deals with moving from any operational state to Stopping and then to Stopped.
-func (c *ContainerInstance) reconcileTransitionToStopped(ctx context.Context, filesystemService filesystem.Service, currentState string) (err error, reconciled bool) {
+func (c *ContainerInstance) reconcileTransitionToStopped(ctx context.Context, services serviceregistry.Provider, currentState string) (err error, reconciled bool) {
 	start := time.Now()
 	defer func() {
 		metrics.ObserveReconcileTime(metrics.ComponentContainerMonitor, c.baseFSMInstance.GetID()+".reconcileTransitionToStopped", time.Since(start))
@@ -392,7 +363,7 @@ func (c *ContainerInstance) reconcileTransitionToStopped(ctx context.Context, fi
 		return c.baseFSMInstance.SendEvent(ctx, EventStopDone), true
 	default:
 		// For any other state, initiate stop
-		err := c.StopInstance(ctx, filesystemService)
+		err := c.StopInstance(ctx, services.GetFileSystem())
 		if err != nil {
 			return err, false
 		}

--- a/umh-core/pkg/fsm/dataflowcomponent/models.go
+++ b/umh-core/pkg/fsm/dataflowcomponent/models.go
@@ -152,3 +152,10 @@ func (d *DataflowComponentInstance) GetConfig() dataflowcomponentconfig.Dataflow
 func (d *DataflowComponentInstance) GetLastError() error {
 	return d.baseFSMInstance.GetLastError()
 }
+
+// IsTransientStreakCounterMaxed returns whether the transient streak counter
+// has reached the maximum number of ticks, which means that the FSM is stuck in a state
+// and should be removed
+func (d *DataflowComponentInstance) IsTransientStreakCounterMaxed() bool {
+	return d.baseFSMInstance.IsTransientStreakCounterMaxed()
+}

--- a/umh-core/pkg/fsm/dataflowcomponent/reconcile.go
+++ b/umh-core/pkg/fsm/dataflowcomponent/reconcile.go
@@ -23,12 +23,12 @@ import (
 	internal_fsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/internal/fsm"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/backoff"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/metrics"
 	dataflowcomponentservice "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/dataflowcomponent"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/s6"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/serviceregistry"
-
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
+	standarderrors "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/standarderrors"
 )
 
 // Reconcile examines the DataflowComponentInstance and, in three steps:
@@ -123,7 +123,7 @@ func (d *DataflowComponentInstance) Reconcile(ctx context.Context, snapshot fsm.
 	err, reconciled = d.reconcileStateTransition(ctx, services, currentTime)
 	if err != nil {
 		// If the instance is removed, we don't want to return an error here, because we want to continue reconciling
-		if errors.Is(err, fsm.ErrInstanceRemoved) {
+		if errors.Is(err, standarderrors.ErrInstanceRemoved) {
 			return nil, false
 		}
 
@@ -187,7 +187,7 @@ func (d *DataflowComponentInstance) reconcileStateTransition(ctx context.Context
 
 	// Handle lifecycle states first - these take precedence over operational states
 	if internal_fsm.IsLifecycleState(currentState) {
-		err, reconciled := d.reconcileLifecycleStates(ctx, services, currentState)
+		err, reconciled := d.baseFSMInstance.ReconcileLifecycleStates(ctx, services, currentState, d.CreateInstance, d.RemoveInstance, d.CheckForCreation)
 		if err != nil {
 			return err, false
 		}
@@ -204,37 +204,6 @@ func (d *DataflowComponentInstance) reconcileStateTransition(ctx context.Context
 	}
 
 	return fmt.Errorf("invalid state: %s", currentState), false
-}
-
-// reconcileLifecycleStates handles states related to instance lifecycle (creating/removing)
-func (d *DataflowComponentInstance) reconcileLifecycleStates(ctx context.Context, services serviceregistry.Provider, currentState string) (err error, reconciled bool) {
-	start := time.Now()
-	defer func() {
-		metrics.ObserveReconcileTime(metrics.ComponentDataflowComponentInstance, d.baseFSMInstance.GetID()+".reconcileLifecycleStates", time.Since(start))
-	}()
-
-	// Independent what the desired state is, we always need to reconcile the lifecycle states first
-	switch currentState {
-	case internal_fsm.LifecycleStateToBeCreated:
-		if err := d.CreateInstance(ctx, services.GetFileSystem()); err != nil {
-			return err, false
-		}
-		return d.baseFSMInstance.SendEvent(ctx, internal_fsm.LifecycleEventCreate), true
-	case internal_fsm.LifecycleStateCreating:
-		// Check if the service is created
-		// For now, we'll assume it's created immediately after initiating creation
-		return d.baseFSMInstance.SendEvent(ctx, internal_fsm.LifecycleEventCreateDone), true
-	case internal_fsm.LifecycleStateRemoving:
-		if err := d.RemoveInstance(ctx, services.GetFileSystem()); err != nil {
-			return err, false
-		}
-		return d.baseFSMInstance.SendEvent(ctx, internal_fsm.LifecycleEventRemoveDone), true
-	case internal_fsm.LifecycleStateRemoved:
-		return fsm.ErrInstanceRemoved, true
-	default:
-		// If we are not in a lifecycle state, just continue
-		return nil, false
-	}
 }
 
 // reconcileOperationalStates handles states related to instance operations (starting/stopping)

--- a/umh-core/pkg/fsm/interfaces.go
+++ b/umh-core/pkg/fsm/interfaces.go
@@ -38,4 +38,7 @@ type FSMInstanceActions interface {
 
 	// UpdateObservedStateOfInstance updates the observed state of the instance
 	UpdateObservedStateOfInstance(ctx context.Context, services serviceregistry.Provider, tick uint64, loopStartTime time.Time) error
+
+	// CheckForCreation checks if the instance should be created
+	CheckForCreation(ctx context.Context, filesystemService filesystem.Service) bool
 }

--- a/umh-core/pkg/fsm/nmap/models.go
+++ b/umh-core/pkg/fsm/nmap/models.go
@@ -170,3 +170,10 @@ func (n *NmapInstance) GetLastObservedState() publicfsm.ObservedState {
 func (n *NmapInstance) SetService(service nmap.INmapService) {
 	n.monitorService = service
 }
+
+// IsTransientStreakCounterMaxed returns whether the transient streak counter
+// has reached the maximum number of ticks, which means that the FSM is stuck in a state
+// and should be removed
+func (n *NmapInstance) IsTransientStreakCounterMaxed() bool {
+	return n.baseFSMInstance.IsTransientStreakCounterMaxed()
+}

--- a/umh-core/pkg/fsm/redpanda/actions.go
+++ b/umh-core/pkg/fsm/redpanda/actions.go
@@ -113,6 +113,12 @@ func (r *RedpandaInstance) StopInstance(ctx context.Context, filesystemService f
 	return nil
 }
 
+// CheckForCreation checks whether the creation was successful
+// For Redpanda, this is a no-op as we don't need to check anything
+func (r *RedpandaInstance) CheckForCreation(ctx context.Context, filesystemService filesystem.Service) bool {
+	return true
+}
+
 // getServiceStatus gets the status of the Redpanda service
 // its main purpose is to habdle the edge cases where the service is not yet created or not yet running
 func (r *RedpandaInstance) GetServiceStatus(ctx context.Context, filesystemService filesystem.Service, tick uint64, loopStartTime time.Time) (redpanda_service.ServiceInfo, error) {

--- a/umh-core/pkg/fsm/redpanda/models.go
+++ b/umh-core/pkg/fsm/redpanda/models.go
@@ -142,3 +142,10 @@ func (r *RedpandaInstance) SetService(service redpandasvc.IRedpandaService) {
 func (r *RedpandaInstance) GetConfig() redpandaserviceconfig.RedpandaServiceConfig {
 	return r.config
 }
+
+// IsTransientStreakCounterMaxed returns whether the transient streak counter
+// has reached the maximum number of ticks, which means that the FSM is stuck in a state
+// and should be removed
+func (r *RedpandaInstance) IsTransientStreakCounterMaxed() bool {
+	return r.baseFSMInstance.IsTransientStreakCounterMaxed()
+}

--- a/umh-core/pkg/fsm/redpanda/reconcile.go
+++ b/umh-core/pkg/fsm/redpanda/reconcile.go
@@ -26,9 +26,9 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/metrics"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/filesystem"
 	redpanda_service "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/redpanda"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/serviceregistry"
+	standarderrors "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/standarderrors"
 )
 
 // Reconcile examines the RedpandaInstance and, in three steps:
@@ -118,10 +118,10 @@ func (r *RedpandaInstance) Reconcile(ctx context.Context, snapshot fsm.SystemSna
 
 	// Step 3: Attempt to reconcile the state.
 	currentTime := time.Now() // this is used to check if the instance is degraded and for the log check
-	err, reconciled = r.reconcileStateTransition(ctx, services.GetFileSystem(), currentTime)
+	err, reconciled = r.reconcileStateTransition(ctx, services, currentTime)
 	if err != nil {
 		// If the instance is removed, we don't want to return an error here, because we want to continue reconciling
-		if errors.Is(err, fsm.ErrInstanceRemoved) {
+		if errors.Is(err, standarderrors.ErrInstanceRemoved) {
 			return nil, false
 		}
 
@@ -174,7 +174,7 @@ func (r *RedpandaInstance) reconcileExternalChanges(ctx context.Context, service
 // Any functions that fetch information are disallowed here and must be called in reconcileExternalChanges
 // and exist in ObservedState.
 // This is to ensure full testability of the FSM.
-func (r *RedpandaInstance) reconcileStateTransition(ctx context.Context, filesystemService filesystem.Service, currentTime time.Time) (err error, reconciled bool) {
+func (r *RedpandaInstance) reconcileStateTransition(ctx context.Context, services serviceregistry.Provider, currentTime time.Time) (err error, reconciled bool) {
 	start := time.Now()
 	defer func() {
 		metrics.ObserveReconcileTime(metrics.ComponentRedpandaInstance, r.baseFSMInstance.GetID()+".reconcileStateTransition", time.Since(start))
@@ -185,7 +185,7 @@ func (r *RedpandaInstance) reconcileStateTransition(ctx context.Context, filesys
 
 	// Handle lifecycle states first - these take precedence over operational states
 	if internal_fsm.IsLifecycleState(currentState) {
-		err, reconciled := r.reconcileLifecycleStates(ctx, filesystemService, currentState)
+		err, reconciled := r.baseFSMInstance.ReconcileLifecycleStates(ctx, services, currentState, r.CreateInstance, r.RemoveInstance, r.CheckForCreation)
 		if err != nil {
 			return err, false
 		}
@@ -199,7 +199,7 @@ func (r *RedpandaInstance) reconcileStateTransition(ctx context.Context, filesys
 
 	// Handle operational states
 	if IsOperationalState(currentState) {
-		err, reconciled := r.reconcileOperationalStates(ctx, filesystemService, currentState, desiredState, currentTime)
+		err, reconciled := r.reconcileOperationalStates(ctx, services, currentState, desiredState, currentTime)
 		if err != nil {
 			return err, false
 		}
@@ -209,39 +209,8 @@ func (r *RedpandaInstance) reconcileStateTransition(ctx context.Context, filesys
 	return fmt.Errorf("invalid state: %s", currentState), false
 }
 
-// reconcileLifecycleStates handles states related to instance lifecycle (creating/removing)
-func (r *RedpandaInstance) reconcileLifecycleStates(ctx context.Context, filesystemService filesystem.Service, currentState string) (err error, reconciled bool) {
-	start := time.Now()
-	defer func() {
-		metrics.ObserveReconcileTime(metrics.ComponentRedpandaInstance, r.baseFSMInstance.GetID()+".reconcileLifecycleStates", time.Since(start))
-	}()
-
-	// Independent what the desired state is, we always need to reconcile the lifecycle states first
-	switch currentState {
-	case internal_fsm.LifecycleStateToBeCreated:
-		if err := r.CreateInstance(ctx, filesystemService); err != nil {
-			return err, false
-		}
-		return r.baseFSMInstance.SendEvent(ctx, internal_fsm.LifecycleEventCreate), true
-	case internal_fsm.LifecycleStateCreating:
-		// Check if the service is created
-		// For now, we'll assume it's created immediately after initiating creation
-		return r.baseFSMInstance.SendEvent(ctx, internal_fsm.LifecycleEventCreateDone), true
-	case internal_fsm.LifecycleStateRemoving:
-		if err := r.RemoveInstance(ctx, filesystemService); err != nil {
-			return err, false
-		}
-		return r.baseFSMInstance.SendEvent(ctx, internal_fsm.LifecycleEventRemoveDone), true
-	case internal_fsm.LifecycleStateRemoved:
-		return fsm.ErrInstanceRemoved, true
-	default:
-		// If we are not in a lifecycle state, just continue
-		return nil, false
-	}
-}
-
 // reconcileOperationalStates handles states related to instance operations (starting/stopping)
-func (r *RedpandaInstance) reconcileOperationalStates(ctx context.Context, filesystemService filesystem.Service, currentState string, desiredState string, currentTime time.Time) (err error, reconciled bool) {
+func (r *RedpandaInstance) reconcileOperationalStates(ctx context.Context, services serviceregistry.Provider, currentState string, desiredState string, currentTime time.Time) (err error, reconciled bool) {
 	start := time.Now()
 	defer func() {
 		metrics.ObserveReconcileTime(metrics.ComponentRedpandaInstance, r.baseFSMInstance.GetID()+".reconcileOperationalStates", time.Since(start))
@@ -249,9 +218,9 @@ func (r *RedpandaInstance) reconcileOperationalStates(ctx context.Context, files
 
 	switch desiredState {
 	case OperationalStateActive:
-		return r.reconcileTransitionToActive(ctx, filesystemService, currentState, currentTime)
+		return r.reconcileTransitionToActive(ctx, services, currentState, currentTime)
 	case OperationalStateStopped:
-		return r.reconcileTransitionToStopped(ctx, filesystemService, currentState)
+		return r.reconcileTransitionToStopped(ctx, services, currentState)
 	default:
 		return fmt.Errorf("invalid desired state: %s", desiredState), false
 	}
@@ -259,7 +228,7 @@ func (r *RedpandaInstance) reconcileOperationalStates(ctx context.Context, files
 
 // reconcileTransitionToActive handles transitions when the desired state is Active.
 // It deals with moving from various states to the Active state.
-func (r *RedpandaInstance) reconcileTransitionToActive(ctx context.Context, filesystemService filesystem.Service, currentState string, currentTime time.Time) (err error, reconciled bool) {
+func (r *RedpandaInstance) reconcileTransitionToActive(ctx context.Context, services serviceregistry.Provider, currentState string, currentTime time.Time) (err error, reconciled bool) {
 	start := time.Now()
 	defer func() {
 		metrics.ObserveReconcileTime(metrics.ComponentRedpandaInstance, r.baseFSMInstance.GetID()+".reconcileTransitionToActive", time.Since(start))
@@ -268,7 +237,7 @@ func (r *RedpandaInstance) reconcileTransitionToActive(ctx context.Context, file
 	// If we're stopped, we need to start first
 	if currentState == OperationalStateStopped {
 		// Attempt to initiate start
-		if err := r.StartInstance(ctx, filesystemService); err != nil {
+		if err := r.StartInstance(ctx, services.GetFileSystem()); err != nil {
 			return err, false
 		}
 		// Send event to transition from Stopped to Starting
@@ -277,16 +246,16 @@ func (r *RedpandaInstance) reconcileTransitionToActive(ctx context.Context, file
 
 	// Handle starting phase states
 	if IsStartingState(currentState) {
-		return r.reconcileStartingStates(ctx, filesystemService, currentState, currentTime)
+		return r.reconcileStartingStates(ctx, services, currentState, currentTime)
 	} else if IsRunningState(currentState) {
-		return r.reconcileRunningStates(ctx, filesystemService, currentState, currentTime)
+		return r.reconcileRunningStates(ctx, services, currentState, currentTime)
 	}
 
 	return nil, false
 }
 
 // reconcileStartingStates handles the various starting phase states when transitioning to Active.
-func (r *RedpandaInstance) reconcileStartingStates(ctx context.Context, filesystemService filesystem.Service, currentState string, currentTime time.Time) (err error, reconciled bool) {
+func (r *RedpandaInstance) reconcileStartingStates(ctx context.Context, services serviceregistry.Provider, currentState string, currentTime time.Time) (err error, reconciled bool) {
 	start := time.Now()
 	defer func() {
 		metrics.ObserveReconcileTime(metrics.ComponentRedpandaInstance, r.baseFSMInstance.GetID()+".reconcileStartingState", time.Since(start))
@@ -311,7 +280,7 @@ func (r *RedpandaInstance) reconcileStartingStates(ctx context.Context, filesyst
 }
 
 // reconcileRunningStates handles the various running states when transitioning to Active.
-func (r *RedpandaInstance) reconcileRunningStates(ctx context.Context, filesystemService filesystem.Service, currentState string, currentTime time.Time) (err error, reconciled bool) {
+func (r *RedpandaInstance) reconcileRunningStates(ctx context.Context, services serviceregistry.Provider, currentState string, currentTime time.Time) (err error, reconciled bool) {
 	start := time.Now()
 	defer func() {
 		metrics.ObserveReconcileTime(metrics.ComponentRedpandaInstance, r.baseFSMInstance.GetID()+".reconcileRunningState", time.Since(start))
@@ -347,7 +316,7 @@ func (r *RedpandaInstance) reconcileRunningStates(ctx context.Context, filesyste
 
 // reconcileTransitionToStopped handles transitions when the desired state is Stopped.
 // It deals with moving from any operational state to Stopping and then to Stopped.
-func (r *RedpandaInstance) reconcileTransitionToStopped(ctx context.Context, filesystemService filesystem.Service, currentState string) (err error, reconciled bool) {
+func (r *RedpandaInstance) reconcileTransitionToStopped(ctx context.Context, services serviceregistry.Provider, currentState string) (err error, reconciled bool) {
 	start := time.Now()
 	defer func() {
 		metrics.ObserveReconcileTime(metrics.ComponentRedpandaInstance, r.baseFSMInstance.GetID()+".reconcileTransitionToStopped", time.Since(start))
@@ -356,7 +325,7 @@ func (r *RedpandaInstance) reconcileTransitionToStopped(ctx context.Context, fil
 	// If we're in any operational state except Stopped or Stopping, initiate stop
 	if currentState != OperationalStateStopped && currentState != OperationalStateStopping {
 		// Attempt to initiate a stop
-		if err := r.StopInstance(ctx, filesystemService); err != nil {
+		if err := r.StopInstance(ctx, services.GetFileSystem()); err != nil {
 			return err, false
 		}
 		// Send event to transition to Stopping

--- a/umh-core/pkg/fsm/s6/models.go
+++ b/umh-core/pkg/fsm/s6/models.go
@@ -147,3 +147,10 @@ func (s *S6Instance) GetConfig() config.S6FSMConfig {
 func (s *S6Instance) GetExpectedMaxP95ExecutionTimePerInstance() time.Duration {
 	return constants.S6ExpectedMaxP95ExecutionTimePerInstance
 }
+
+// IsTransientStreakCounterMaxed returns whether the transient streak counter
+// has reached the maximum number of ticks, which means that the FSM is stuck in a state
+// and should be removed
+func (s *S6Instance) IsTransientStreakCounterMaxed() bool {
+	return s.baseFSMInstance.IsTransientStreakCounterMaxed()
+}

--- a/umh-core/pkg/metrics/metrics.go
+++ b/umh-core/pkg/metrics/metrics.go
@@ -37,6 +37,7 @@ const (
 	ComponentNmapManager           = "nmap_manager"
 	ComponentDataFlowCompManager   = "dataflow_component_manager"
 	// Instances
+	ComponentBaseFSMInstance           = "base_fsm_instance"
 	ComponentS6Instance                = "s6_instance"
 	ComponentBenthosInstance           = "benthos_instance"
 	ComponentRedpandaInstance          = "redpanda_instance"

--- a/umh-core/pkg/service/benthos/benthos_test.go
+++ b/umh-core/pkg/service/benthos/benthos_test.go
@@ -533,7 +533,7 @@ var _ = Describe("Benthos Service", func() {
 				WithS6Manager(mockS6Manager),
 			)
 
-			s6ServiceName = service.getS6ServiceName(benthosName)
+			s6ServiceName = service.GetS6ServiceName(benthosName)
 
 			mockS6Service.ExistingServices[s6ServiceName] = true
 			mockS6Service.ServiceExistsResult = true
@@ -755,7 +755,7 @@ logger:
 				WithS6Manager(mockS6Manager),
 			)
 
-			s6ServiceName = service.getS6ServiceName(benthosName)
+			s6ServiceName = service.GetS6ServiceName(benthosName)
 
 			mockS6Service.ExistingServices[s6ServiceName] = true
 			mockS6Service.ServiceExistsResult = true
@@ -993,7 +993,7 @@ logger:
 			Expect(mockS6Service.ForceRemoveCalled).To(BeTrue())
 
 			// Verify the path is correct
-			expectedS6ServiceName := service.getS6ServiceName(benthosName)
+			expectedS6ServiceName := service.GetS6ServiceName(benthosName)
 			expectedS6ServicePath := filepath.Join(constants.S6BaseDir, expectedS6ServiceName)
 			Expect(mockS6Service.ForceRemovePath).To(Equal(expectedS6ServicePath))
 		})

--- a/umh-core/pkg/service/benthos_monitor/benthos_monitor_benchmark_test.go
+++ b/umh-core/pkg/service/benthos_monitor/benthos_monitor_benchmark_test.go
@@ -147,6 +147,9 @@ func BenchmarkCompleteProcessing(b *testing.B) {
 			b.Fatal(err)
 		}
 		err = gzipReader.Close()
+		if err != nil {
+			b.Fatal(err)
+		}
 
 		// Step 3: Parse metrics
 		_, err = ParseMetricsFromBytes(decompressedData)

--- a/umh-core/pkg/service/benthos_monitor/benthos_monitor_benchmark_test.go
+++ b/umh-core/pkg/service/benthos_monitor/benthos_monitor_benchmark_test.go
@@ -18,11 +18,11 @@
 // ────────────────────────────────────────────────────────────────────────────────
 //
 // Benchmarks (Go 1.22, Ryzen 9-5900X, pkg/service/benthos_monitor):
-//   BenchmarkGzipDecode-24            104 859 ops   11.4 µs/op   49 169 B   11 allocs
-//   BenchmarkHexDecode-24           3 027 370 ops    0.39 µs/op      416 B   1 alloc
-//   BenchmarkMetricsParsing-24         28 386 ops   42.2 µs/op   28 392 B  781 allocs
-//   BenchmarkCompleteProcessing-24     20 557 ops   58.0 µs/op   75 673 B  792 allocs
-//   BenchmarkParseBenthosLogsWithPercentiles-24        10000            111753 ns/op            112572 p50ns            345167 p95ns            484639 p99ns          217350 B/op        911 allocs/op
+//	BenchmarkGzipDecode-24                             98608             11983 ns/op           49169 B/op         11 allocs/op
+// 	BenchmarkHexDecode-24                            3110442             388.6 ns/op             416 B/op          1 allocs/op
+// 	BenchmarkMetricsParsing-24                         27571             42960 ns/op           28392 B/op        781 allocs/op
+// 	BenchmarkCompleteProcessing-24                     20348             59672 ns/op           75673 B/op        792 allocs/op
+// 	BenchmarkParseBenthosLogsWithPercentiles-24        10000            111753 ns/op            112572 p50ns            345167 p95ns            484639 p99ns          217350 B/op        911 allocs/op
 //
 // Findings
 // --------

--- a/umh-core/pkg/service/benthos_monitor/benthos_monitor_benchmark_test.go
+++ b/umh-core/pkg/service/benthos_monitor/benthos_monitor_benchmark_test.go
@@ -1,0 +1,145 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package benthos_monitor
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/hex"
+	"io"
+	"testing"
+)
+
+var sampleMetrics = `# HELP input_connection_failed Benthos Counter metric
+# TYPE input_connection_failed counter
+input_connection_failed{label="",path="root.input"} 0
+# HELP input_connection_lost Benthos Counter metric
+# TYPE input_connection_lost counter
+input_connection_lost{label="",path="root.input"} 0
+# HELP input_connection_up Benthos Counter metric
+# TYPE input_connection_up counter
+input_connection_up{label="",path="root.input"} 1
+# HELP input_latency_ns Benthos Timing metric
+# TYPE input_latency_ns summary
+input_latency_ns{label="",path="root.input",quantile="0.5"} 127167
+input_latency_ns{label="",path="root.input",quantile="0.9"} 378375
+input_latency_ns{label="",path="root.input",quantile="0.99"} 858666
+input_latency_ns_sum{label="",path="root.input"} 3.629208e+06
+input_latency_ns_count{label="",path="root.input"} 18
+# HELP input_received Benthos Counter metric
+# TYPE input_received counter
+input_received{label="",path="root.input"} 18
+# HELP output_batch_sent Benthos Counter metric
+# TYPE output_batch_sent counter
+output_batch_sent{label="",path="root.output"} 18
+# HELP output_connection_failed Benthos Counter metric
+# TYPE output_connection_failed counter
+output_connection_failed{label="",path="root.output"} 0
+# HELP output_connection_lost Benthos Counter metric
+# TYPE output_connection_lost counter
+output_connection_lost{label="",path="root.output"} 0
+# HELP output_connection_up Benthos Counter metric
+# TYPE output_connection_up counter
+output_connection_up{label="",path="root.output"} 1
+# HELP output_error Benthos Counter metric
+# TYPE output_error counter
+output_error{label="",path="root.output"} 0
+# HELP output_latency_ns Benthos Timing metric
+# TYPE output_latency_ns summary
+output_latency_ns{label="",path="root.output",quantile="0.5"} 33250
+output_latency_ns{label="",path="root.output",quantile="0.9"} 94709
+output_latency_ns{label="",path="root.output",quantile="0.99"} 138250
+output_latency_ns_sum{label="",path="root.output"} 816919
+output_latency_ns_count{label="",path="root.output"} 18
+# HELP output_sent Benthos Counter metric
+# TYPE output_sent counter
+output_sent{label="",path="root.output"} 18
+`
+
+// Returns a gzip compressed string of the sample metrics
+// Also returns the same data but hex encoded
+func prepareDataForBenchmark() ([]byte, string) {
+	var buf bytes.Buffer
+	gzipWriter := gzip.NewWriter(&buf)
+	_, _ = gzipWriter.Write([]byte(sampleMetrics))
+	gzipWriter.Close()
+
+	hexData := hex.EncodeToString(buf.Bytes())
+	return buf.Bytes(), hexData
+}
+
+// BenchmarkGzipDecode benchmarks just the gzip decoding operation
+func BenchmarkGzipDecode(b *testing.B) {
+	encodedData, _ := prepareDataForBenchmark()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		reader, err := gzip.NewReader(bytes.NewReader(encodedData))
+		if err != nil {
+			b.Fatal(err)
+		}
+		_, err = io.ReadAll(reader)
+		if err != nil {
+			b.Fatal(err)
+		}
+		reader.Close()
+	}
+}
+
+// BenchmarkHexDecode benchmarks just the hex decoding operation
+func BenchmarkHexDecode(b *testing.B) {
+	_, encodedAndHexedData := prepareDataForBenchmark()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := hex.DecodeString(encodedAndHexedData)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkMetricsParsing benchmarks the metrics parsing operation
+func BenchmarkMetricsParsing(b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := ParseMetricsFromBytes([]byte(sampleMetrics))
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkCompleteProcessing benchmarks the entire pipeline: hex decode -> gzip decode -> parse metrics
+func BenchmarkCompleteProcessing(b *testing.B) {
+	_, encodedAndHexedData := prepareDataForBenchmark()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// Step 1: Hex decode
+		decodedMetricsDataBytes, _ := hex.DecodeString(encodedAndHexedData)
+
+		// Step 2: Gzip decompress
+		gzipReader, _ := gzip.NewReader(bytes.NewReader(decodedMetricsDataBytes))
+		decompressedData, _ := io.ReadAll(gzipReader)
+		gzipReader.Close()
+
+		// Step 3: Parse metrics
+		_, err := ParseMetricsFromBytes(decompressedData)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/umh-core/pkg/service/connection/connection_test.go
+++ b/umh-core/pkg/service/connection/connection_test.go
@@ -405,13 +405,8 @@ var _ = Describe("ConnectionService", func() {
 			}
 		})
 
-		It("should return error when removing non-existent component", func() {
-			// Act - try to remove a non-existent component
-			err := service.RemoveConnectionFromNmapManager(ctx, mockServices, "non-existent")
-
-			// Assert
-			Expect(err).To(MatchError(ErrServiceNotExist))
-		})
+		// Note: removing a non-existent component should not result in an error
+		// the remove action will be called multiple times until the component is gone it returns nil
 	})
 
 	Describe("ReconcileManager", func() {

--- a/umh-core/pkg/service/dataflowcomponent/dataflowcomponent_test.go
+++ b/umh-core/pkg/service/dataflowcomponent/dataflowcomponent_test.go
@@ -437,13 +437,8 @@ var _ = Describe("DataFlowComponentService", func() {
 			}
 		})
 
-		It("should return error when removing non-existent component", func() {
-			// Act - try to remove a non-existent component
-			err := service.RemoveDataFlowComponentFromBenthosManager(ctx, mockSvcRegistry.GetFileSystem(), "non-existent")
-
-			// Assert
-			Expect(err).To(MatchError(ErrServiceNotExists))
-		})
+		// Note: removing a non-existent component should not result in an error
+		// the remove action will be called multiple times until the component is gone it returns nil
 	})
 
 	Describe("ReconcileManager", func() {

--- a/umh-core/pkg/service/nmap/nmap.go
+++ b/umh-core/pkg/service/nmap/nmap.go
@@ -34,6 +34,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/filesystem"
 	s6service "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/s6"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/serviceregistry"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/standarderrors"
 	"go.uber.org/zap"
 )
 
@@ -439,21 +440,29 @@ func (s *NmapService) RemoveNmapFromS6Manager(ctx context.Context, nmapName stri
 		return ctx.Err()
 	}
 
-	s6ServiceName := s.getS6ServiceName(nmapName)
+	// ------------------------------------------------------------------
+	// 1) Delete the *desired* config entry so the S6-manager will stop it
+	// ------------------------------------------------------------------
+	s6Name := s.getS6ServiceName(nmapName)
 
-	found := false
-
-	// Remove the S6 FSM config from the list
-	for i, s6Config := range s.s6ServiceConfigs {
-		if s6Config.Name == s6ServiceName {
-			s.s6ServiceConfigs = append(s.s6ServiceConfigs[:i], s.s6ServiceConfigs[i+1:]...)
-			found = true
-			break
+	// Helper that deletes exactly one element *without* reallocating when the
+	// element is already missing – keeps the call idempotent and allocation-free.
+	sliceRemoveByName := func(arr []config.S6FSMConfig, name string) []config.S6FSMConfig {
+		for i, cfg := range arr {
+			if cfg.Name == name {
+				return append(arr[:i], arr[i+1:]...)
+			}
 		}
+		return arr
 	}
 
-	if !found {
-		return ErrServiceNotExist
+	s.s6ServiceConfigs = sliceRemoveByName(s.s6ServiceConfigs, s6Name)
+
+	// ------------------------------------------------------------------
+	// 2) is the child FSM still alive?
+	// ------------------------------------------------------------------
+	if inst, ok := s.s6Manager.GetInstance(s6Name); ok {
+		return fmt.Errorf("%w: S6 instance state=%s", standarderrors.ErrRemovalPending, inst.GetCurrentFSMState())
 	}
 
 	// Clean up the cached scan results

--- a/umh-core/pkg/service/nmap/nmap_test.go
+++ b/umh-core/pkg/service/nmap/nmap_test.go
@@ -171,11 +171,8 @@ var _ = Describe("Nmap Service", func() {
 				Expect(service.s6ServiceConfigs).To(BeEmpty())
 			})
 
-			It("should return error when service doesn't exist", func() {
-				ctx := context.Background()
-				err := service.RemoveNmapFromS6Manager(ctx, "nonexistent")
-				Expect(err).To(Equal(ErrServiceNotExist))
-			})
+			// Note: removing a non-existent component should not result in an error
+			// the remove action will be called multiple times until the component is gone it returns nil
 		})
 	})
 

--- a/umh-core/pkg/service/redpanda/redpanda.go
+++ b/umh-core/pkg/service/redpanda/redpanda.go
@@ -364,8 +364,6 @@ func (s *RedpandaService) Status(ctx context.Context, filesystemService filesyst
 
 // GetHealthCheckAndMetrics returns the health check and metrics of a Redpanda service
 func (s *RedpandaService) GetHealthCheckAndMetrics(ctx context.Context, tick uint64, logs []s6service.LogEntry, filesystemService filesystem.Service, loopStartTime time.Time) (RedpandaStatus, error) {
-
-	s.logger.Debugf("Getting health check and metrics for tick %d", tick)
 	start := time.Now()
 	defer func() {
 		metrics.ObserveReconcileTime(logger.ComponentRedpandaService, constants.RedpandaServiceName, time.Since(start))

--- a/umh-core/pkg/service/redpanda_monitor/redpanda_monitor.go
+++ b/umh-core/pkg/service/redpanda_monitor/redpanda_monitor.go
@@ -228,9 +228,9 @@ func (s *RedpandaMonitorService) generateRedpandaScript() (string, error) {
 	scriptContent := fmt.Sprintf(`#!/bin/sh
 while true; do
   echo "%s"
-  curl -sSL --max-time 1 http://localhost:9644/public_metrics | gzip -c | xxd -p
+  curl -sSL --max-time 1 http://localhost:9644/public_metrics 2>&1 | gzip -c | xxd -p
   echo "%s"
-  curl -sSL --max-time 1 http://localhost:9644/v1/cluster_config | gzip -c | xxd -p
+  curl -sSL --max-time 1 http://localhost:9644/v1/cluster_config 2>&1 | gzip -c | xxd -p
   echo "%s"
   date +%%s%%9N
   echo "%s"
@@ -385,11 +385,11 @@ func (s *RedpandaMonitorService) ParseRedpandaLogs(ctx context.Context, logs []s
 
 	var metrics *RedpandaMetrics
 	var clusterConfig *ClusterConfig
-	// Processing the Metrics & cluster config takes ~5ms (especially the metrics parsing) each, therefore process them in parallel
+	// Processing the Metrics & cluster config takes time (especially the metrics parsing) each, therefore process them in parallel
 
-	ctx8, cancel8 := context.WithTimeout(ctx, 8*time.Millisecond)
-	defer cancel8()
-	g, _ := errgroup.WithContext(ctx8)
+	ctxProcessMetrics, cancelProcessMetrics := context.WithTimeout(ctx, constants.RedpandaProcessMetricsTimeout)
+	defer cancelProcessMetrics()
+	g, _ := errgroup.WithContext(ctxProcessMetrics)
 
 	g.Go(func() error {
 		var err error
@@ -424,11 +424,11 @@ func (s *RedpandaMonitorService) ParseRedpandaLogs(ctx context.Context, logs []s
 			return nil, err
 		}
 		// If err is nil, all goroutines completed successfully.
-	case <-ctx.Done():
+	case <-ctxProcessMetrics.Done():
 		// The context was canceled or its deadline was exceeded before all goroutines finished.
 		// Although some goroutines might still be running in the background,
 		// they use a context (gctx) that should cause them to terminate promptly.
-		return nil, ctx.Err()
+		return nil, ctxProcessMetrics.Err()
 	}
 
 	timestampDataString := strings.TrimSpace(string(timestampDataBytes))
@@ -474,11 +474,6 @@ func parseCurlError(errorString string) error {
 
 func (s *RedpandaMonitorService) processMetricsDataBytes(metricsDataBytes []byte, tick uint64) (*RedpandaMetrics, error) {
 
-	curlError := parseCurlError(string(metricsDataBytes))
-	if curlError != nil {
-		return nil, curlError
-	}
-
 	metricsDataString := string(metricsDataBytes)
 	// Strip any newlines
 	metricsDataString = strings.ReplaceAll(metricsDataString, "\n", "")
@@ -518,11 +513,6 @@ func (s *RedpandaMonitorService) processMetricsDataBytes(metricsDataBytes []byte
 
 func (s *RedpandaMonitorService) processClusterConfigDataBytes(clusterConfigDataBytes []byte, tick uint64) (*ClusterConfig, error) {
 
-	curlError := parseCurlError(string(clusterConfigDataBytes))
-	if curlError != nil {
-		return nil, curlError
-	}
-
 	clusterConfigDataString := string(clusterConfigDataBytes)
 	// Strip any newlines
 	clusterConfigDataString = strings.ReplaceAll(clusterConfigDataString, "\n", "")
@@ -545,9 +535,19 @@ func (s *RedpandaMonitorService) processClusterConfigDataBytes(clusterConfigData
 		}
 	}()
 
+	data, err := io.ReadAll(gzipReader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read cluster config data: %w", err)
+	}
+
+	curlError := parseCurlError(string(data))
+	if curlError != nil {
+		return nil, curlError
+	}
+
 	// Parse the JSON response
 	var redpandaConfig map[string]interface{}
-	if err := json.NewDecoder(gzipReader).Decode(&redpandaConfig); err != nil {
+	if err := json.NewDecoder(bytes.NewReader(data)).Decode(&redpandaConfig); err != nil {
 		return nil, fmt.Errorf("failed to parse cluster config data: %w", err)
 	}
 
@@ -586,9 +586,18 @@ func ParseMetrics(dataReader io.Reader) (Metrics, error) {
 			TopicPartitionMap: make(map[string]int64), // Pre-allocate map to avoid nil check later
 		},
 	}
+	data, err := io.ReadAll(dataReader)
+	if err != nil {
+		return Metrics{}, fmt.Errorf("failed to read metrics data: %w", err)
+	}
+
+	curlError := parseCurlError(string(data))
+	if curlError != nil {
+		return Metrics{}, curlError
+	}
 
 	// Parse the metrics text into prometheus format
-	mf, err := parser.TextToMetricFamilies(dataReader)
+	mf, err := parser.TextToMetricFamilies(bytes.NewReader(data))
 	if err != nil {
 		return metrics, fmt.Errorf("failed to parse metrics: %w", err)
 	}

--- a/umh-core/pkg/service/redpanda_monitor/redpanda_monitor_benchmark_test.go
+++ b/umh-core/pkg/service/redpanda_monitor/redpanda_monitor_benchmark_test.go
@@ -1,0 +1,1491 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// ────────────────────────────────────────────────────────────────────────────────
+// ENG-2893  Faster metric parsing for Redpanda/Redpanda
+// Context: Slack thread 2025-04-30 (this file ↔ ENG-2893, ENG-2884)
+// ────────────────────────────────────────────────────────────────────────────────
+//
+// Benchmarks (Go 1.22, Ryzen 9-5900X, pkg/service/redpanda_monitor):
+//	BenchmarkGzipDecode-24                             98608             11983 ns/op           49169 B/op         11 allocs/op
+// 	BenchmarkHexDecode-24                            3110442             388.6 ns/op             416 B/op          1 allocs/op
+// 	BenchmarkMetricsParsing-24                         27571             42960 ns/op           28392 B/op        781 allocs/op
+// 	BenchmarkCompleteProcessing-24                     20348             59672 ns/op           75673 B/op        792 allocs/op
+// 	BenchmarkParseRedpandaLogsWithPercentiles-24        10000            111753 ns/op            112572 p50ns            345167 p95ns            484639 p99ns          217350 B/op        911 allocs/op
+//
+// Findings
+// --------
+// • ParseMetricsFromBytes ≈ 73 % of end-to-end time (42 µs of 58 µs).
+// • Total cost to handle one Redpanda metrics payload (gzip→hex→parse) ≈ 0.05 ms.
+// • Hex decode is negligible; gzip decompression is minor; Prometheus text parse
+//   is the clear hotspot.
+//
+// Options under evaluation
+// ------------------------
+// 1. Avoid parsing every tick for every Redpanda instance (parse only when needed).
+// 2. Replace Prometheus text parser with minimal hand-rolled parser.
+//
+// Related tickets
+//  • ENG-2893 – performance work.
+//  • ENG-2884 – parsing errors / observed-state update.
+//
+// Sample metrics used for the benchmark are below (taken from test_metrics.txt).
+// ────────────────────────────────────────────────────────────────────────────────
+
+package redpanda_monitor
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"sort"
+	"testing"
+	"time"
+
+	s6service "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/s6"
+)
+
+var sampleMetrics = `# HELP redpanda_application_build Redpanda build information
+# TYPE redpanda_application_build gauge
+redpanda_application_build{redpanda_revision="b1dd9f54ab1fcd31110608ff214d0937bf30fdb1",redpanda_version="v24.3.8"} 1.000000
+# HELP redpanda_application_fips_mode Identifies whether or not Redpanda is running in FIPS mode.
+# TYPE redpanda_application_fips_mode gauge
+redpanda_application_fips_mode{} 0.000000
+# HELP redpanda_application_uptime_seconds_total Redpanda uptime in seconds
+# TYPE redpanda_application_uptime_seconds_total gauge
+redpanda_application_uptime_seconds_total{} 27.203389
+# HELP redpanda_authorization_result Total number of authorization results by type
+# TYPE redpanda_authorization_result counter
+redpanda_authorization_result{type="empty"} 0
+redpanda_authorization_result{type="deny"} 0
+redpanda_authorization_result{type="allow"} 0
+# HELP redpanda_cluster_brokers Number of configured brokers in the cluster
+# TYPE redpanda_cluster_brokers gauge
+redpanda_cluster_brokers{} 1.000000
+# HELP redpanda_cluster_controller_log_limit_requests_available_rps Controller log rate limiting. Available rps for group
+# TYPE redpanda_cluster_controller_log_limit_requests_available_rps gauge
+redpanda_cluster_controller_log_limit_requests_available_rps{redpanda_cmd_group="node_management_operations"} 1000.000000
+redpanda_cluster_controller_log_limit_requests_available_rps{redpanda_cmd_group="move_operations"} 1000.000000
+redpanda_cluster_controller_log_limit_requests_available_rps{redpanda_cmd_group="configuration_operations"} 1000.000000
+redpanda_cluster_controller_log_limit_requests_available_rps{redpanda_cmd_group="topic_operations"} 1000.000000
+redpanda_cluster_controller_log_limit_requests_available_rps{redpanda_cmd_group="acls_and_users_operations"} 1000.000000
+# HELP redpanda_cluster_controller_log_limit_requests_dropped Controller log rate limiting. Amount of requests that are dropped due to exceeding limit in group
+# TYPE redpanda_cluster_controller_log_limit_requests_dropped counter
+redpanda_cluster_controller_log_limit_requests_dropped{redpanda_cmd_group="node_management_operations"} 0
+redpanda_cluster_controller_log_limit_requests_dropped{redpanda_cmd_group="move_operations"} 0
+redpanda_cluster_controller_log_limit_requests_dropped{redpanda_cmd_group="configuration_operations"} 0
+redpanda_cluster_controller_log_limit_requests_dropped{redpanda_cmd_group="topic_operations"} 0
+redpanda_cluster_controller_log_limit_requests_dropped{redpanda_cmd_group="acls_and_users_operations"} 0
+# HELP redpanda_cluster_features_enterprise_license_expiry_sec Number of seconds remaining until the Enterprise license expires
+# TYPE redpanda_cluster_features_enterprise_license_expiry_sec gauge
+redpanda_cluster_features_enterprise_license_expiry_sec{} 2591973.000000
+# HELP redpanda_cluster_members_backend_queued_node_operations Number of queued node operations
+# TYPE redpanda_cluster_members_backend_queued_node_operations gauge
+redpanda_cluster_members_backend_queued_node_operations{shard="0"} 0.000000
+# HELP redpanda_cluster_non_homogenous_fips_mode Number of nodes that have a non-homogenous FIPS mode value
+# TYPE redpanda_cluster_non_homogenous_fips_mode gauge
+redpanda_cluster_non_homogenous_fips_mode{} 0.000000
+# HELP redpanda_cluster_partition_moving_from_node Amount of partitions that are moving from node
+# TYPE redpanda_cluster_partition_moving_from_node gauge
+redpanda_cluster_partition_moving_from_node{} 0.000000
+# HELP redpanda_cluster_partition_moving_to_node Amount of partitions that are moving to node
+# TYPE redpanda_cluster_partition_moving_to_node gauge
+redpanda_cluster_partition_moving_to_node{} 0.000000
+# HELP redpanda_cluster_partition_node_cancelling_movements Amount of cancelling partition movements for node
+# TYPE redpanda_cluster_partition_node_cancelling_movements gauge
+redpanda_cluster_partition_node_cancelling_movements{} 0.000000
+# HELP redpanda_cluster_partition_num_with_broken_rack_constraint Number of partitions that don't satisfy the rack awareness constraint
+# TYPE redpanda_cluster_partition_num_with_broken_rack_constraint gauge
+redpanda_cluster_partition_num_with_broken_rack_constraint{} 0.000000
+# HELP redpanda_cluster_partitions Number of partitions in the cluster (replicas not included)
+# TYPE redpanda_cluster_partitions gauge
+redpanda_cluster_partitions{} 0.000000
+# HELP redpanda_cluster_topics Number of topics in the cluster
+# TYPE redpanda_cluster_topics gauge
+redpanda_cluster_topics{} 0.000000
+# HELP redpanda_cluster_unavailable_partitions Number of partitions that lack quorum among replicants
+# TYPE redpanda_cluster_unavailable_partitions gauge
+redpanda_cluster_unavailable_partitions{} 0.000000
+# HELP redpanda_cpu_busy_seconds_total Total CPU busy time in seconds
+# TYPE redpanda_cpu_busy_seconds_total gauge
+redpanda_cpu_busy_seconds_total{shard="0"} 1.939297
+# HELP redpanda_debug_bundle_failed_generation_count Running count of failed debug bundle generations
+# TYPE redpanda_debug_bundle_failed_generation_count counter
+redpanda_debug_bundle_failed_generation_count{shard="0"} 0
+# HELP redpanda_debug_bundle_last_failed_bundle_timestamp_seconds Timestamp of last failed debug bundle generation (seconds since epoch)
+# TYPE redpanda_debug_bundle_last_failed_bundle_timestamp_seconds gauge
+redpanda_debug_bundle_last_failed_bundle_timestamp_seconds{shard="0"} 0.000000
+# HELP redpanda_debug_bundle_last_successful_bundle_timestamp_seconds Timestamp of last successful debug bundle generation (seconds since epoch)
+# TYPE redpanda_debug_bundle_last_successful_bundle_timestamp_seconds gauge
+redpanda_debug_bundle_last_successful_bundle_timestamp_seconds{shard="0"} 0.000000
+# HELP redpanda_debug_bundle_successful_generation_count Running count of successful debug bundle generations
+# TYPE redpanda_debug_bundle_successful_generation_count counter
+redpanda_debug_bundle_successful_generation_count{shard="0"} 0
+# HELP redpanda_io_queue_total_read_ops Total read operations passed in the queue
+# TYPE redpanda_io_queue_total_read_ops counter
+redpanda_io_queue_total_read_ops{class="",iogroup="0",mountpoint="none",shard="0"} 1
+# HELP redpanda_io_queue_total_write_ops Total write operations passed in the queue
+# TYPE redpanda_io_queue_total_write_ops counter
+redpanda_io_queue_total_write_ops{class="",iogroup="0",mountpoint="none",shard="0"} 31
+# HELP redpanda_kafka_handler_latency_seconds Latency histogram of kafka requests
+# TYPE redpanda_kafka_handler_latency_seconds histogram
+redpanda_kafka_handler_latency_seconds_sum{handler="produce"} 0
+redpanda_kafka_handler_latency_seconds_count{handler="produce"} 0
+redpanda_kafka_handler_latency_seconds_bucket{handler="produce",le="0.000255"} 0
+redpanda_kafka_handler_latency_seconds_bucket{handler="produce",le="0.000511"} 0
+redpanda_kafka_handler_latency_seconds_bucket{handler="produce",le="0.001023"} 0
+redpanda_kafka_handler_latency_seconds_bucket{handler="produce",le="0.002047"} 0
+redpanda_kafka_handler_latency_seconds_bucket{handler="produce",le="0.004095"} 0
+redpanda_kafka_handler_latency_seconds_bucket{handler="produce",le="0.008191"} 0
+redpanda_kafka_handler_latency_seconds_bucket{handler="produce",le="0.016383"} 0
+redpanda_kafka_handler_latency_seconds_bucket{handler="produce",le="0.032767"} 0
+redpanda_kafka_handler_latency_seconds_bucket{handler="produce",le="0.065535"} 0
+redpanda_kafka_handler_latency_seconds_bucket{handler="produce",le="0.131071"} 0
+redpanda_kafka_handler_latency_seconds_bucket{handler="produce",le="0.262143"} 0
+redpanda_kafka_handler_latency_seconds_bucket{handler="produce",le="0.524287"} 0
+redpanda_kafka_handler_latency_seconds_bucket{handler="produce",le="1.048575"} 0
+redpanda_kafka_handler_latency_seconds_bucket{handler="produce",le="2.097151"} 0
+redpanda_kafka_handler_latency_seconds_bucket{handler="produce",le="4.194303"} 0
+redpanda_kafka_handler_latency_seconds_bucket{handler="produce",le="8.388607"} 0
+redpanda_kafka_handler_latency_seconds_bucket{handler="produce",le="16.777215"} 0
+redpanda_kafka_handler_latency_seconds_bucket{handler="produce",le="33.554431"} 0
+redpanda_kafka_handler_latency_seconds_bucket{handler="produce",le="+Inf"} 0
+redpanda_kafka_handler_latency_seconds_sum{handler="fetch"} 0
+redpanda_kafka_handler_latency_seconds_count{handler="fetch"} 0
+redpanda_kafka_handler_latency_seconds_bucket{handler="fetch",le="0.000255"} 0
+redpanda_kafka_handler_latency_seconds_bucket{handler="fetch",le="0.000511"} 0
+redpanda_kafka_handler_latency_seconds_bucket{handler="fetch",le="0.001023"} 0
+redpanda_kafka_handler_latency_seconds_bucket{handler="fetch",le="0.002047"} 0
+redpanda_kafka_handler_latency_seconds_bucket{handler="fetch",le="0.004095"} 0
+redpanda_kafka_handler_latency_seconds_bucket{handler="fetch",le="0.008191"} 0
+redpanda_kafka_handler_latency_seconds_bucket{handler="fetch",le="0.016383"} 0
+redpanda_kafka_handler_latency_seconds_bucket{handler="fetch",le="0.032767"} 0
+redpanda_kafka_handler_latency_seconds_bucket{handler="fetch",le="0.065535"} 0
+redpanda_kafka_handler_latency_seconds_bucket{handler="fetch",le="0.131071"} 0
+redpanda_kafka_handler_latency_seconds_bucket{handler="fetch",le="0.262143"} 0
+redpanda_kafka_handler_latency_seconds_bucket{handler="fetch",le="0.524287"} 0
+redpanda_kafka_handler_latency_seconds_bucket{handler="fetch",le="1.048575"} 0
+redpanda_kafka_handler_latency_seconds_bucket{handler="fetch",le="2.097151"} 0
+redpanda_kafka_handler_latency_seconds_bucket{handler="fetch",le="4.194303"} 0
+redpanda_kafka_handler_latency_seconds_bucket{handler="fetch",le="8.388607"} 0
+redpanda_kafka_handler_latency_seconds_bucket{handler="fetch",le="16.777215"} 0
+redpanda_kafka_handler_latency_seconds_bucket{handler="fetch",le="33.554431"} 0
+redpanda_kafka_handler_latency_seconds_bucket{handler="fetch",le="+Inf"} 0
+# HELP redpanda_kafka_max_offset Latest readable offset of the partition (i.e. high watermark)
+# TYPE redpanda_kafka_max_offset gauge
+redpanda_kafka_max_offset{redpanda_namespace="redpanda",redpanda_partition="0",redpanda_topic="controller"} 7.000000
+# HELP redpanda_kafka_quotas_client_quota_throttle_time Client quota throttling delay per rule and quota type (in seconds)
+# TYPE redpanda_kafka_quotas_client_quota_throttle_time histogram
+redpanda_kafka_quotas_client_quota_throttle_time_sum{redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_count{redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.001000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.003000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.007000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.015000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.031000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.063000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.127000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.255000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.511000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="1.023000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="2.047000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="4.095000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="8.191000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="16.383000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="+Inf",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_sum{redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_count{redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.001000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.003000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.007000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.015000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.031000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.063000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.127000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.255000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.511000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="1.023000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="2.047000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="4.095000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="8.191000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="16.383000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="+Inf",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_sum{redpanda_quota_rule="not_applicable",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_count{redpanda_quota_rule="not_applicable",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.001000",redpanda_quota_rule="not_applicable",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.003000",redpanda_quota_rule="not_applicable",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.007000",redpanda_quota_rule="not_applicable",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.015000",redpanda_quota_rule="not_applicable",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.031000",redpanda_quota_rule="not_applicable",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.063000",redpanda_quota_rule="not_applicable",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.127000",redpanda_quota_rule="not_applicable",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.255000",redpanda_quota_rule="not_applicable",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.511000",redpanda_quota_rule="not_applicable",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="1.023000",redpanda_quota_rule="not_applicable",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="2.047000",redpanda_quota_rule="not_applicable",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="4.095000",redpanda_quota_rule="not_applicable",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="8.191000",redpanda_quota_rule="not_applicable",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="16.383000",redpanda_quota_rule="not_applicable",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="+Inf",redpanda_quota_rule="not_applicable",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_sum{redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_count{redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.001000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.003000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.007000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.015000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.031000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.063000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.127000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.255000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.511000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="1.023000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="2.047000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="4.095000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="8.191000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="16.383000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="+Inf",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_sum{redpanda_quota_rule="kafka_client_id",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_count{redpanda_quota_rule="kafka_client_id",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.001000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.003000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.007000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.015000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.031000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.063000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.127000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.255000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.511000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="1.023000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="2.047000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="4.095000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="8.191000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="16.383000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="+Inf",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_sum{redpanda_quota_rule="kafka_client_id",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_count{redpanda_quota_rule="kafka_client_id",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.001000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.003000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.007000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.015000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.031000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.063000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.127000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.255000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.511000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="1.023000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="2.047000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="4.095000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="8.191000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="16.383000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="+Inf",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_sum{redpanda_quota_rule="not_applicable",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_count{redpanda_quota_rule="not_applicable",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.001000",redpanda_quota_rule="not_applicable",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.003000",redpanda_quota_rule="not_applicable",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.007000",redpanda_quota_rule="not_applicable",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.015000",redpanda_quota_rule="not_applicable",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.031000",redpanda_quota_rule="not_applicable",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.063000",redpanda_quota_rule="not_applicable",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.127000",redpanda_quota_rule="not_applicable",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.255000",redpanda_quota_rule="not_applicable",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.511000",redpanda_quota_rule="not_applicable",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="1.023000",redpanda_quota_rule="not_applicable",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="2.047000",redpanda_quota_rule="not_applicable",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="4.095000",redpanda_quota_rule="not_applicable",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="8.191000",redpanda_quota_rule="not_applicable",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="16.383000",redpanda_quota_rule="not_applicable",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="+Inf",redpanda_quota_rule="not_applicable",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_sum{redpanda_quota_rule="kafka_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_count{redpanda_quota_rule="kafka_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.001000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.003000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.007000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.015000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.031000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.063000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.127000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.255000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.511000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="1.023000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="2.047000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="4.095000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="8.191000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="16.383000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="+Inf",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_sum{redpanda_quota_rule="not_applicable",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_count{redpanda_quota_rule="not_applicable",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.001000",redpanda_quota_rule="not_applicable",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.003000",redpanda_quota_rule="not_applicable",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.007000",redpanda_quota_rule="not_applicable",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.015000",redpanda_quota_rule="not_applicable",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.031000",redpanda_quota_rule="not_applicable",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.063000",redpanda_quota_rule="not_applicable",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.127000",redpanda_quota_rule="not_applicable",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.255000",redpanda_quota_rule="not_applicable",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.511000",redpanda_quota_rule="not_applicable",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="1.023000",redpanda_quota_rule="not_applicable",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="2.047000",redpanda_quota_rule="not_applicable",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="4.095000",redpanda_quota_rule="not_applicable",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="8.191000",redpanda_quota_rule="not_applicable",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="16.383000",redpanda_quota_rule="not_applicable",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="+Inf",redpanda_quota_rule="not_applicable",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_sum{redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_count{redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.001000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.003000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.007000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.015000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.031000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.063000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.127000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.255000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.511000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="1.023000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="2.047000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="4.095000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="8.191000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="16.383000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="+Inf",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_sum{redpanda_quota_rule="kafka_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_count{redpanda_quota_rule="kafka_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.001000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.003000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.007000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.015000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.031000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.063000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.127000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.255000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.511000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="1.023000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="2.047000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="4.095000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="8.191000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="16.383000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="+Inf",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_sum{redpanda_quota_rule="kafka_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_count{redpanda_quota_rule="kafka_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.001000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.003000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.007000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.015000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.031000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.063000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.127000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.255000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.511000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="1.023000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="2.047000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="4.095000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="8.191000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="16.383000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="+Inf",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_sum{redpanda_quota_rule="cluster_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_count{redpanda_quota_rule="cluster_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.001000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.003000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.007000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.015000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.031000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.063000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.127000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.255000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.511000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="1.023000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="2.047000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="4.095000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="8.191000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="16.383000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="+Inf",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_sum{redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_count{redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.001000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.003000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.007000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.015000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.031000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.063000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.127000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.255000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.511000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="1.023000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="2.047000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="4.095000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="8.191000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="16.383000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="+Inf",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_sum{redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_count{redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.001000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.003000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.007000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.015000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.031000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.063000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.127000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.255000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.511000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="1.023000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="2.047000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="4.095000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="8.191000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="16.383000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="+Inf",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_sum{redpanda_quota_rule="kafka_client_id",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_count{redpanda_quota_rule="kafka_client_id",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.001000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.003000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.007000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.015000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.031000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.063000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.127000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.255000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.511000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="1.023000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="2.047000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="4.095000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="8.191000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="16.383000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="+Inf",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_sum{redpanda_quota_rule="cluster_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_count{redpanda_quota_rule="cluster_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.001000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.003000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.007000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.015000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.031000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.063000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.127000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.255000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.511000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="1.023000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="2.047000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="4.095000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="8.191000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="16.383000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="+Inf",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_sum{redpanda_quota_rule="cluster_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_count{redpanda_quota_rule="cluster_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.001000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.003000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.007000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.015000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.031000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.063000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.127000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.255000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="0.511000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="1.023000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="2.047000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="4.095000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="8.191000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="16.383000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throttle_time_bucket{le="+Inf",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="fetch_quota"} 0
+# HELP redpanda_kafka_quotas_client_quota_throughput Client quota throughput per rule and quota type
+# TYPE redpanda_kafka_quotas_client_quota_throughput histogram
+redpanda_kafka_quotas_client_quota_throughput_sum{redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_count{redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="7.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="15.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="31.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="63.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="127.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="255.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="511.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="1023.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="2047.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="4095.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="8191.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="16383.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="32767.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="65535.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="131071.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="262143.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="524287.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="1048575.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="2097151.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="4194303.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="8388607.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="16777215.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="33554431.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="67108863.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="134217727.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="268435455.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="+Inf",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_sum{redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_count{redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="7.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="15.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="31.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="63.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="127.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="255.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="511.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="1023.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="2047.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="4095.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="8191.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="16383.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="32767.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="65535.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="131071.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="262143.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="524287.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="1048575.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="2097151.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="4194303.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="8388607.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="16777215.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="33554431.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="67108863.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="134217727.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="268435455.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="+Inf",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_sum{redpanda_quota_rule="not_applicable",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_count{redpanda_quota_rule="not_applicable",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="7.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="15.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="31.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="63.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="127.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="255.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="511.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="1023.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="2047.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="4095.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="8191.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="16383.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="32767.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="65535.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="131071.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="262143.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="524287.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="1048575.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="2097151.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="4194303.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="8388607.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="16777215.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="33554431.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="67108863.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="134217727.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="268435455.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="+Inf",redpanda_quota_rule="not_applicable",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_sum{redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_count{redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="7.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="15.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="31.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="63.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="127.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="255.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="511.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="1023.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="2047.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="4095.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="8191.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="16383.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="32767.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="65535.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="131071.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="262143.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="524287.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="1048575.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="2097151.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="4194303.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="8388607.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="16777215.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="33554431.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="67108863.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="134217727.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="268435455.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="+Inf",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_sum{redpanda_quota_rule="kafka_client_id",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_count{redpanda_quota_rule="kafka_client_id",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="7.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="15.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="31.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="63.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="127.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="255.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="511.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="1023.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="2047.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="4095.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="8191.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="16383.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="32767.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="65535.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="131071.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="262143.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="524287.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="1048575.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="2097151.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="4194303.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="8388607.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="16777215.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="33554431.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="67108863.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="134217727.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="268435455.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="+Inf",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_sum{redpanda_quota_rule="kafka_client_id",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_count{redpanda_quota_rule="kafka_client_id",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="7.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="15.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="31.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="63.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="127.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="255.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="511.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="1023.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="2047.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="4095.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="8191.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="16383.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="32767.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="65535.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="131071.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="262143.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="524287.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="1048575.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="2097151.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="4194303.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="8388607.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="16777215.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="33554431.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="67108863.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="134217727.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="268435455.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="+Inf",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_sum{redpanda_quota_rule="not_applicable",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_count{redpanda_quota_rule="not_applicable",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="7.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="15.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="31.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="63.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="127.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="255.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="511.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="1023.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="2047.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="4095.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="8191.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="16383.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="32767.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="65535.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="131071.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="262143.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="524287.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="1048575.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="2097151.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="4194303.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="8388607.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="16777215.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="33554431.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="67108863.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="134217727.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="268435455.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="+Inf",redpanda_quota_rule="not_applicable",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_sum{redpanda_quota_rule="kafka_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_count{redpanda_quota_rule="kafka_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="7.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="15.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="31.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="63.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="127.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="255.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="511.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="1023.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="2047.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="4095.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="8191.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="16383.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="32767.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="65535.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="131071.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="262143.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="524287.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="1048575.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="2097151.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="4194303.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="8388607.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="16777215.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="33554431.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="67108863.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="134217727.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="268435455.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="+Inf",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_sum{redpanda_quota_rule="not_applicable",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_count{redpanda_quota_rule="not_applicable",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="7.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="15.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="31.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="63.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="127.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="255.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="511.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="1023.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="2047.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="4095.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="8191.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="16383.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="32767.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="65535.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="131071.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="262143.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="524287.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="1048575.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="2097151.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="4194303.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="8388607.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="16777215.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="33554431.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="67108863.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="134217727.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="268435455.000000",redpanda_quota_rule="not_applicable",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="+Inf",redpanda_quota_rule="not_applicable",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_sum{redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_count{redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="7.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="15.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="31.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="63.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="127.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="255.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="511.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="1023.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="2047.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="4095.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="8191.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="16383.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="32767.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="65535.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="131071.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="262143.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="524287.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="1048575.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="2097151.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="4194303.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="8388607.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="16777215.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="33554431.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="67108863.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="134217727.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="268435455.000000",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="+Inf",redpanda_quota_rule="kafka_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_sum{redpanda_quota_rule="kafka_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_count{redpanda_quota_rule="kafka_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="7.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="15.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="31.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="63.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="127.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="255.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="511.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="1023.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="2047.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="4095.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="8191.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="16383.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="32767.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="65535.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="131071.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="262143.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="524287.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="1048575.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="2097151.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="4194303.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="8388607.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="16777215.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="33554431.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="67108863.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="134217727.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="268435455.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="+Inf",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_sum{redpanda_quota_rule="kafka_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_count{redpanda_quota_rule="kafka_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="7.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="15.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="31.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="63.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="127.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="255.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="511.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="1023.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="2047.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="4095.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="8191.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="16383.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="32767.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="65535.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="131071.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="262143.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="524287.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="1048575.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="2097151.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="4194303.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="8388607.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="16777215.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="33554431.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="67108863.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="134217727.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="268435455.000000",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="+Inf",redpanda_quota_rule="kafka_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_sum{redpanda_quota_rule="cluster_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_count{redpanda_quota_rule="cluster_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="7.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="15.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="31.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="63.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="127.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="255.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="511.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="1023.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="2047.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="4095.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="8191.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="16383.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="32767.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="65535.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="131071.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="262143.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="524287.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="1048575.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="2097151.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="4194303.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="8388607.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="16777215.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="33554431.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="67108863.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="134217727.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="268435455.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="+Inf",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_sum{redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_count{redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="7.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="15.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="31.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="63.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="127.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="255.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="511.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="1023.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="2047.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="4095.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="8191.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="16383.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="32767.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="65535.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="131071.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="262143.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="524287.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="1048575.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="2097151.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="4194303.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="8388607.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="16777215.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="33554431.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="67108863.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="134217727.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="268435455.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="+Inf",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_sum{redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_count{redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="7.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="15.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="31.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="63.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="127.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="255.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="511.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="1023.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="2047.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="4095.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="8191.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="16383.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="32767.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="65535.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="131071.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="262143.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="524287.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="1048575.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="2097151.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="4194303.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="8388607.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="16777215.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="33554431.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="67108863.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="134217727.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="268435455.000000",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="+Inf",redpanda_quota_rule="cluster_client_prefix",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_sum{redpanda_quota_rule="kafka_client_id",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_count{redpanda_quota_rule="kafka_client_id",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="7.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="15.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="31.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="63.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="127.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="255.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="511.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="1023.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="2047.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="4095.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="8191.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="16383.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="32767.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="65535.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="131071.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="262143.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="524287.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="1048575.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="2097151.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="4194303.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="8388607.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="16777215.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="33554431.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="67108863.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="134217727.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="268435455.000000",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="+Inf",redpanda_quota_rule="kafka_client_id",redpanda_quota_type="produce_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_sum{redpanda_quota_rule="cluster_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_count{redpanda_quota_rule="cluster_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="7.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="15.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="31.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="63.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="127.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="255.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="511.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="1023.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="2047.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="4095.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="8191.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="16383.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="32767.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="65535.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="131071.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="262143.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="524287.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="1048575.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="2097151.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="4194303.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="8388607.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="16777215.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="33554431.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="67108863.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="134217727.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="268435455.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="+Inf",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="partition_mutation_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_sum{redpanda_quota_rule="cluster_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_count{redpanda_quota_rule="cluster_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="7.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="15.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="31.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="63.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="127.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="255.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="511.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="1023.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="2047.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="4095.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="8191.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="16383.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="32767.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="65535.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="131071.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="262143.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="524287.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="1048575.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="2097151.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="4194303.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="8388607.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="16777215.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="33554431.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="67108863.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="134217727.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="268435455.000000",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="fetch_quota"} 0
+redpanda_kafka_quotas_client_quota_throughput_bucket{le="+Inf",redpanda_quota_rule="cluster_client_default",redpanda_quota_type="fetch_quota"} 0
+# HELP redpanda_kafka_records_fetched_total Total number of records fetched
+# TYPE redpanda_kafka_records_fetched_total counter
+redpanda_kafka_records_fetched_total{redpanda_namespace="redpanda",redpanda_topic="controller"} 0
+# HELP redpanda_kafka_records_produced_total Total number of records produced
+# TYPE redpanda_kafka_records_produced_total counter
+redpanda_kafka_records_produced_total{redpanda_namespace="redpanda",redpanda_topic="controller"} 0
+# HELP redpanda_kafka_request_bytes_total Total number of bytes produced per topic
+# TYPE redpanda_kafka_request_bytes_total counter
+redpanda_kafka_request_bytes_total{redpanda_namespace="redpanda",redpanda_request="produce",redpanda_topic="controller"} 0
+redpanda_kafka_request_bytes_total{redpanda_namespace="redpanda",redpanda_request="follower_consume",redpanda_topic="controller"} 0
+redpanda_kafka_request_bytes_total{redpanda_namespace="redpanda",redpanda_request="consume",redpanda_topic="controller"} 0
+# HELP redpanda_kafka_request_latency_seconds Internal latency of kafka produce requests
+# TYPE redpanda_kafka_request_latency_seconds histogram
+redpanda_kafka_request_latency_seconds_sum{redpanda_request="produce"} 0
+redpanda_kafka_request_latency_seconds_count{redpanda_request="produce"} 0
+redpanda_kafka_request_latency_seconds_bucket{le="0.000255",redpanda_request="produce"} 0
+redpanda_kafka_request_latency_seconds_bucket{le="0.000511",redpanda_request="produce"} 0
+redpanda_kafka_request_latency_seconds_bucket{le="0.001023",redpanda_request="produce"} 0
+redpanda_kafka_request_latency_seconds_bucket{le="0.002047",redpanda_request="produce"} 0
+redpanda_kafka_request_latency_seconds_bucket{le="0.004095",redpanda_request="produce"} 0
+redpanda_kafka_request_latency_seconds_bucket{le="0.008191",redpanda_request="produce"} 0
+redpanda_kafka_request_latency_seconds_bucket{le="0.016383",redpanda_request="produce"} 0
+redpanda_kafka_request_latency_seconds_bucket{le="0.032767",redpanda_request="produce"} 0
+redpanda_kafka_request_latency_seconds_bucket{le="0.065535",redpanda_request="produce"} 0
+redpanda_kafka_request_latency_seconds_bucket{le="0.131071",redpanda_request="produce"} 0
+redpanda_kafka_request_latency_seconds_bucket{le="0.262143",redpanda_request="produce"} 0
+redpanda_kafka_request_latency_seconds_bucket{le="0.524287",redpanda_request="produce"} 0
+redpanda_kafka_request_latency_seconds_bucket{le="1.048575",redpanda_request="produce"} 0
+redpanda_kafka_request_latency_seconds_bucket{le="2.097151",redpanda_request="produce"} 0
+redpanda_kafka_request_latency_seconds_bucket{le="4.194303",redpanda_request="produce"} 0
+redpanda_kafka_request_latency_seconds_bucket{le="8.388607",redpanda_request="produce"} 0
+redpanda_kafka_request_latency_seconds_bucket{le="16.777215",redpanda_request="produce"} 0
+redpanda_kafka_request_latency_seconds_bucket{le="33.554431",redpanda_request="produce"} 0
+redpanda_kafka_request_latency_seconds_bucket{le="+Inf",redpanda_request="produce"} 0
+redpanda_kafka_request_latency_seconds_sum{redpanda_request="consume"} 0
+redpanda_kafka_request_latency_seconds_count{redpanda_request="consume"} 0
+redpanda_kafka_request_latency_seconds_bucket{le="0.000255",redpanda_request="consume"} 0
+redpanda_kafka_request_latency_seconds_bucket{le="0.000511",redpanda_request="consume"} 0
+redpanda_kafka_request_latency_seconds_bucket{le="0.001023",redpanda_request="consume"} 0
+redpanda_kafka_request_latency_seconds_bucket{le="0.002047",redpanda_request="consume"} 0
+redpanda_kafka_request_latency_seconds_bucket{le="0.004095",redpanda_request="consume"} 0
+redpanda_kafka_request_latency_seconds_bucket{le="0.008191",redpanda_request="consume"} 0
+redpanda_kafka_request_latency_seconds_bucket{le="0.016383",redpanda_request="consume"} 0
+redpanda_kafka_request_latency_seconds_bucket{le="0.032767",redpanda_request="consume"} 0
+redpanda_kafka_request_latency_seconds_bucket{le="0.065535",redpanda_request="consume"} 0
+redpanda_kafka_request_latency_seconds_bucket{le="0.131071",redpanda_request="consume"} 0
+redpanda_kafka_request_latency_seconds_bucket{le="0.262143",redpanda_request="consume"} 0
+redpanda_kafka_request_latency_seconds_bucket{le="0.524287",redpanda_request="consume"} 0
+redpanda_kafka_request_latency_seconds_bucket{le="1.048575",redpanda_request="consume"} 0
+redpanda_kafka_request_latency_seconds_bucket{le="2.097151",redpanda_request="consume"} 0
+redpanda_kafka_request_latency_seconds_bucket{le="4.194303",redpanda_request="consume"} 0
+redpanda_kafka_request_latency_seconds_bucket{le="8.388607",redpanda_request="consume"} 0
+redpanda_kafka_request_latency_seconds_bucket{le="16.777215",redpanda_request="consume"} 0
+redpanda_kafka_request_latency_seconds_bucket{le="33.554431",redpanda_request="consume"} 0
+redpanda_kafka_request_latency_seconds_bucket{le="+Inf",redpanda_request="consume"} 0
+# HELP redpanda_kafka_rpc_sasl_session_expiration_total Total number of SASL session expirations
+# TYPE redpanda_kafka_rpc_sasl_session_expiration_total counter
+redpanda_kafka_rpc_sasl_session_expiration_total{} 0
+# HELP redpanda_kafka_rpc_sasl_session_reauth_attempts_total Total number of SASL reauthentication attempts
+# TYPE redpanda_kafka_rpc_sasl_session_reauth_attempts_total counter
+redpanda_kafka_rpc_sasl_session_reauth_attempts_total{} 0
+# HELP redpanda_kafka_rpc_sasl_session_revoked_total Total number of SASL sessions revoked
+# TYPE redpanda_kafka_rpc_sasl_session_revoked_total counter
+redpanda_kafka_rpc_sasl_session_revoked_total{} 0
+# HELP redpanda_kafka_under_replicated_replicas Number of under replicated replicas (i.e. replicas that are live, but not at the latest offest)
+# TYPE redpanda_kafka_under_replicated_replicas gauge
+redpanda_kafka_under_replicated_replicas{redpanda_namespace="redpanda",redpanda_partition="0",redpanda_topic="controller"} 0.000000
+# HELP redpanda_memory_allocated_memory Allocated memory size in bytes
+# TYPE redpanda_memory_allocated_memory gauge
+redpanda_memory_allocated_memory{shard="0"} 545533952.000000
+# HELP redpanda_memory_available_memory Total shard memory potentially available in bytes (free_memory plus reclaimable)
+# TYPE redpanda_memory_available_memory gauge
+redpanda_memory_available_memory{shard="0"} 1601982464.000000
+# HELP redpanda_memory_available_memory_low_water_mark The low-water mark for available_memory from process start
+# TYPE redpanda_memory_available_memory_low_water_mark gauge
+redpanda_memory_available_memory_low_water_mark{shard="0"} 1601982464.000000
+# HELP redpanda_memory_free_memory Free memory size in bytes
+# TYPE redpanda_memory_free_memory gauge
+redpanda_memory_free_memory{shard="0"} 1601949696.000000
+# HELP redpanda_node_status_rpcs_received Number of node status RPCs received by this node
+# TYPE redpanda_node_status_rpcs_received gauge
+redpanda_node_status_rpcs_received{} 0.000000
+# HELP redpanda_node_status_rpcs_sent Number of node status RPCs sent by this node
+# TYPE redpanda_node_status_rpcs_sent gauge
+redpanda_node_status_rpcs_sent{} 0.000000
+# HELP redpanda_node_status_rpcs_timed_out Number of timed out node status RPCs from this node
+# TYPE redpanda_node_status_rpcs_timed_out gauge
+redpanda_node_status_rpcs_timed_out{} 0.000000
+# HELP redpanda_raft_leadership_changes Number of won leader elections across all partitions in given topic
+# TYPE redpanda_raft_leadership_changes counter
+redpanda_raft_leadership_changes{redpanda_namespace="redpanda",redpanda_topic="controller"} 1
+# HELP redpanda_raft_learners_gap_bytes Total numbers of bytes that must be delivered to learners
+# TYPE redpanda_raft_learners_gap_bytes gauge
+redpanda_raft_learners_gap_bytes{shard="0"} 0.000000
+# HELP redpanda_raft_recovery_offsets_pending Sum of offsets that partitions on this node need to recover.
+# TYPE redpanda_raft_recovery_offsets_pending gauge
+redpanda_raft_recovery_offsets_pending{} 0.000000
+# HELP redpanda_raft_recovery_partition_movement_available_bandwidth Bandwidth available for partition movement. bytes/sec
+# TYPE redpanda_raft_recovery_partition_movement_available_bandwidth gauge
+redpanda_raft_recovery_partition_movement_available_bandwidth{shard="0"} 104857600.000000
+# HELP redpanda_raft_recovery_partition_movement_consumed_bandwidth Bandwidth consumed for partition movement. bytes/sec
+# TYPE redpanda_raft_recovery_partition_movement_consumed_bandwidth gauge
+redpanda_raft_recovery_partition_movement_consumed_bandwidth{shard="0"} 0.000000
+# HELP redpanda_raft_recovery_partitions_active Number of partition replicas are currently recovering on this node.
+# TYPE redpanda_raft_recovery_partitions_active gauge
+redpanda_raft_recovery_partitions_active{} 0.000000
+# HELP redpanda_raft_recovery_partitions_to_recover Number of partition replicas that have to recover for this node.
+# TYPE redpanda_raft_recovery_partitions_to_recover gauge
+redpanda_raft_recovery_partitions_to_recover{} 0.000000
+# HELP redpanda_rest_proxy_inflight_requests_memory_usage_ratio Memory usage ratio of in-flight requests in the rest_proxy
+# TYPE redpanda_rest_proxy_inflight_requests_memory_usage_ratio gauge
+redpanda_rest_proxy_inflight_requests_memory_usage_ratio{shard="0"} 0.000000
+# HELP redpanda_rest_proxy_inflight_requests_usage_ratio Usage ratio of in-flight requests in the rest_proxy
+# TYPE redpanda_rest_proxy_inflight_requests_usage_ratio gauge
+redpanda_rest_proxy_inflight_requests_usage_ratio{shard="0"} 0.000000
+# HELP redpanda_rest_proxy_queued_requests_memory_blocked Number of requests queued in rest_proxy, due to memory limitations
+# TYPE redpanda_rest_proxy_queued_requests_memory_blocked gauge
+redpanda_rest_proxy_queued_requests_memory_blocked{shard="0"} 0.000000
+# HELP redpanda_rest_proxy_request_errors_total Total number of rest_proxy server errors
+# TYPE redpanda_rest_proxy_request_errors_total counter
+redpanda_rest_proxy_request_errors_total{redpanda_status="5xx"} 0
+redpanda_rest_proxy_request_errors_total{redpanda_status="4xx"} 0
+redpanda_rest_proxy_request_errors_total{redpanda_status="3xx"} 0
+# HELP redpanda_rest_proxy_request_latency_seconds Internal latency of request for rest_proxy
+# TYPE redpanda_rest_proxy_request_latency_seconds histogram
+redpanda_rest_proxy_request_latency_seconds_sum{} 0
+redpanda_rest_proxy_request_latency_seconds_count{} 0
+redpanda_rest_proxy_request_latency_seconds_bucket{le="0.000255"} 0
+redpanda_rest_proxy_request_latency_seconds_bucket{le="0.000511"} 0
+redpanda_rest_proxy_request_latency_seconds_bucket{le="0.001023"} 0
+redpanda_rest_proxy_request_latency_seconds_bucket{le="0.002047"} 0
+redpanda_rest_proxy_request_latency_seconds_bucket{le="0.004095"} 0
+redpanda_rest_proxy_request_latency_seconds_bucket{le="0.008191"} 0
+redpanda_rest_proxy_request_latency_seconds_bucket{le="0.016383"} 0
+redpanda_rest_proxy_request_latency_seconds_bucket{le="0.032767"} 0
+redpanda_rest_proxy_request_latency_seconds_bucket{le="0.065535"} 0
+redpanda_rest_proxy_request_latency_seconds_bucket{le="0.131071"} 0
+redpanda_rest_proxy_request_latency_seconds_bucket{le="0.262143"} 0
+redpanda_rest_proxy_request_latency_seconds_bucket{le="0.524287"} 0
+redpanda_rest_proxy_request_latency_seconds_bucket{le="1.048575"} 0
+redpanda_rest_proxy_request_latency_seconds_bucket{le="2.097151"} 0
+redpanda_rest_proxy_request_latency_seconds_bucket{le="4.194303"} 0
+redpanda_rest_proxy_request_latency_seconds_bucket{le="8.388607"} 0
+redpanda_rest_proxy_request_latency_seconds_bucket{le="16.777215"} 0
+redpanda_rest_proxy_request_latency_seconds_bucket{le="33.554431"} 0
+redpanda_rest_proxy_request_latency_seconds_bucket{le="+Inf"} 0
+# HELP redpanda_rpc_active_connections Count of currently active connections
+# TYPE redpanda_rpc_active_connections gauge
+redpanda_rpc_active_connections{redpanda_server="kafka"} 0.000000
+redpanda_rpc_active_connections{redpanda_server="internal"} 0.000000
+# HELP redpanda_rpc_received_bytes internal: Number of bytes received from the clients in valid requests
+# TYPE redpanda_rpc_received_bytes counter
+redpanda_rpc_received_bytes{redpanda_server="kafka"} 0
+redpanda_rpc_received_bytes{redpanda_server="internal"} 0
+# HELP redpanda_rpc_request_errors_total Number of rpc errors
+# TYPE redpanda_rpc_request_errors_total counter
+redpanda_rpc_request_errors_total{redpanda_server="kafka"} 0
+redpanda_rpc_request_errors_total{redpanda_server="internal"} 0
+# HELP redpanda_rpc_request_latency_seconds RPC latency
+# TYPE redpanda_rpc_request_latency_seconds histogram
+redpanda_rpc_request_latency_seconds_sum{redpanda_server="kafka"} 0
+redpanda_rpc_request_latency_seconds_count{redpanda_server="kafka"} 0
+redpanda_rpc_request_latency_seconds_bucket{le="0.000255",redpanda_server="kafka"} 0
+redpanda_rpc_request_latency_seconds_bucket{le="0.000511",redpanda_server="kafka"} 0
+redpanda_rpc_request_latency_seconds_bucket{le="0.001023",redpanda_server="kafka"} 0
+redpanda_rpc_request_latency_seconds_bucket{le="0.002047",redpanda_server="kafka"} 0
+redpanda_rpc_request_latency_seconds_bucket{le="0.004095",redpanda_server="kafka"} 0
+redpanda_rpc_request_latency_seconds_bucket{le="0.008191",redpanda_server="kafka"} 0
+redpanda_rpc_request_latency_seconds_bucket{le="0.016383",redpanda_server="kafka"} 0
+redpanda_rpc_request_latency_seconds_bucket{le="0.032767",redpanda_server="kafka"} 0
+redpanda_rpc_request_latency_seconds_bucket{le="0.065535",redpanda_server="kafka"} 0
+redpanda_rpc_request_latency_seconds_bucket{le="0.131071",redpanda_server="kafka"} 0
+redpanda_rpc_request_latency_seconds_bucket{le="0.262143",redpanda_server="kafka"} 0
+redpanda_rpc_request_latency_seconds_bucket{le="0.524287",redpanda_server="kafka"} 0
+redpanda_rpc_request_latency_seconds_bucket{le="1.048575",redpanda_server="kafka"} 0
+redpanda_rpc_request_latency_seconds_bucket{le="2.097151",redpanda_server="kafka"} 0
+redpanda_rpc_request_latency_seconds_bucket{le="4.194303",redpanda_server="kafka"} 0
+redpanda_rpc_request_latency_seconds_bucket{le="8.388607",redpanda_server="kafka"} 0
+redpanda_rpc_request_latency_seconds_bucket{le="16.777215",redpanda_server="kafka"} 0
+redpanda_rpc_request_latency_seconds_bucket{le="33.554431",redpanda_server="kafka"} 0
+redpanda_rpc_request_latency_seconds_bucket{le="+Inf",redpanda_server="kafka"} 0
+redpanda_rpc_request_latency_seconds_sum{redpanda_server="internal"} 0
+redpanda_rpc_request_latency_seconds_count{redpanda_server="internal"} 0
+redpanda_rpc_request_latency_seconds_bucket{le="0.000255",redpanda_server="internal"} 0
+redpanda_rpc_request_latency_seconds_bucket{le="0.000511",redpanda_server="internal"} 0
+redpanda_rpc_request_latency_seconds_bucket{le="0.001023",redpanda_server="internal"} 0
+redpanda_rpc_request_latency_seconds_bucket{le="0.002047",redpanda_server="internal"} 0
+redpanda_rpc_request_latency_seconds_bucket{le="0.004095",redpanda_server="internal"} 0
+redpanda_rpc_request_latency_seconds_bucket{le="0.008191",redpanda_server="internal"} 0
+redpanda_rpc_request_latency_seconds_bucket{le="0.016383",redpanda_server="internal"} 0
+redpanda_rpc_request_latency_seconds_bucket{le="0.032767",redpanda_server="internal"} 0
+redpanda_rpc_request_latency_seconds_bucket{le="0.065535",redpanda_server="internal"} 0
+redpanda_rpc_request_latency_seconds_bucket{le="0.131071",redpanda_server="internal"} 0
+redpanda_rpc_request_latency_seconds_bucket{le="0.262143",redpanda_server="internal"} 0
+redpanda_rpc_request_latency_seconds_bucket{le="0.524287",redpanda_server="internal"} 0
+redpanda_rpc_request_latency_seconds_bucket{le="1.048575",redpanda_server="internal"} 0
+redpanda_rpc_request_latency_seconds_bucket{le="2.097151",redpanda_server="internal"} 0
+redpanda_rpc_request_latency_seconds_bucket{le="4.194303",redpanda_server="internal"} 0
+redpanda_rpc_request_latency_seconds_bucket{le="8.388607",redpanda_server="internal"} 0
+redpanda_rpc_request_latency_seconds_bucket{le="16.777215",redpanda_server="internal"} 0
+redpanda_rpc_request_latency_seconds_bucket{le="33.554431",redpanda_server="internal"} 0
+redpanda_rpc_request_latency_seconds_bucket{le="+Inf",redpanda_server="internal"} 0
+# HELP redpanda_rpc_sent_bytes internal: Number of bytes sent to clients
+# TYPE redpanda_rpc_sent_bytes counter
+redpanda_rpc_sent_bytes{redpanda_server="kafka"} 0
+redpanda_rpc_sent_bytes{redpanda_server="internal"} 0
+# HELP redpanda_scheduler_runtime_seconds_total Accumulated runtime of task queue associated with this scheduling group
+# TYPE redpanda_scheduler_runtime_seconds_total counter
+redpanda_scheduler_runtime_seconds_total{redpanda_scheduling_group="admin",shard="0"} 0.174560
+redpanda_scheduler_runtime_seconds_total{redpanda_scheduling_group="archival_upload",shard="0"} 0.000000
+redpanda_scheduler_runtime_seconds_total{redpanda_scheduling_group="cache_background_reclaim",shard="0"} 0.000644
+redpanda_scheduler_runtime_seconds_total{redpanda_scheduling_group="cluster",shard="0"} 0.000000
+redpanda_scheduler_runtime_seconds_total{redpanda_scheduling_group="datalake",shard="0"} 0.000000
+redpanda_scheduler_runtime_seconds_total{redpanda_scheduling_group="fetch",shard="0"} 0.000000
+redpanda_scheduler_runtime_seconds_total{redpanda_scheduling_group="kafka",shard="0"} 0.000000
+redpanda_scheduler_runtime_seconds_total{redpanda_scheduling_group="log_compaction",shard="0"} 0.216092
+redpanda_scheduler_runtime_seconds_total{redpanda_scheduling_group="main",shard="0"} 1.467145
+redpanda_scheduler_runtime_seconds_total{redpanda_scheduling_group="node_status",shard="0"} 0.000000
+redpanda_scheduler_runtime_seconds_total{redpanda_scheduling_group="raft",shard="0"} 0.000000
+redpanda_scheduler_runtime_seconds_total{redpanda_scheduling_group="raft_learner_recovery",shard="0"} 0.000000
+redpanda_scheduler_runtime_seconds_total{redpanda_scheduling_group="self_test",shard="0"} 0.000000
+redpanda_scheduler_runtime_seconds_total{redpanda_scheduling_group="transforms",shard="0"} 0.000000
+# HELP redpanda_schema_registry_cache_schema_count The number of schemas in the store
+# TYPE redpanda_schema_registry_cache_schema_count gauge
+redpanda_schema_registry_cache_schema_count{} 0.000000
+# HELP redpanda_schema_registry_cache_schema_memory_bytes The memory usage of schemas in the store
+# TYPE redpanda_schema_registry_cache_schema_memory_bytes gauge
+redpanda_schema_registry_cache_schema_memory_bytes{} 0.000000
+# HELP redpanda_schema_registry_cache_subject_count The number of subjects in the store
+# TYPE redpanda_schema_registry_cache_subject_count gauge
+redpanda_schema_registry_cache_subject_count{deleted="true"} 0.000000
+redpanda_schema_registry_cache_subject_count{deleted="false"} 0.000000
+# HELP redpanda_schema_registry_inflight_requests_memory_usage_ratio Memory usage ratio of in-flight requests in the schema_registry
+# TYPE redpanda_schema_registry_inflight_requests_memory_usage_ratio gauge
+redpanda_schema_registry_inflight_requests_memory_usage_ratio{shard="0"} 0.000000
+# HELP redpanda_schema_registry_inflight_requests_usage_ratio Usage ratio of in-flight requests in the schema_registry
+# TYPE redpanda_schema_registry_inflight_requests_usage_ratio gauge
+redpanda_schema_registry_inflight_requests_usage_ratio{shard="0"} 0.000000
+# HELP redpanda_schema_registry_queued_requests_memory_blocked Number of requests queued in schema_registry, due to memory limitations
+# TYPE redpanda_schema_registry_queued_requests_memory_blocked gauge
+redpanda_schema_registry_queued_requests_memory_blocked{shard="0"} 0.000000
+# HELP redpanda_schema_registry_request_errors_total Total number of schema_registry server errors
+# TYPE redpanda_schema_registry_request_errors_total counter
+redpanda_schema_registry_request_errors_total{redpanda_status="5xx"} 0
+redpanda_schema_registry_request_errors_total{redpanda_status="4xx"} 0
+redpanda_schema_registry_request_errors_total{redpanda_status="3xx"} 0
+# HELP redpanda_schema_registry_request_latency_seconds Internal latency of request for schema_registry
+# TYPE redpanda_schema_registry_request_latency_seconds histogram
+redpanda_schema_registry_request_latency_seconds_sum{} 0
+redpanda_schema_registry_request_latency_seconds_count{} 0
+redpanda_schema_registry_request_latency_seconds_bucket{le="0.000255"} 0
+redpanda_schema_registry_request_latency_seconds_bucket{le="0.000511"} 0
+redpanda_schema_registry_request_latency_seconds_bucket{le="0.001023"} 0
+redpanda_schema_registry_request_latency_seconds_bucket{le="0.002047"} 0
+redpanda_schema_registry_request_latency_seconds_bucket{le="0.004095"} 0
+redpanda_schema_registry_request_latency_seconds_bucket{le="0.008191"} 0
+redpanda_schema_registry_request_latency_seconds_bucket{le="0.016383"} 0
+redpanda_schema_registry_request_latency_seconds_bucket{le="0.032767"} 0
+redpanda_schema_registry_request_latency_seconds_bucket{le="0.065535"} 0
+redpanda_schema_registry_request_latency_seconds_bucket{le="0.131071"} 0
+redpanda_schema_registry_request_latency_seconds_bucket{le="0.262143"} 0
+redpanda_schema_registry_request_latency_seconds_bucket{le="0.524287"} 0
+redpanda_schema_registry_request_latency_seconds_bucket{le="1.048575"} 0
+redpanda_schema_registry_request_latency_seconds_bucket{le="2.097151"} 0
+redpanda_schema_registry_request_latency_seconds_bucket{le="4.194303"} 0
+redpanda_schema_registry_request_latency_seconds_bucket{le="8.388607"} 0
+redpanda_schema_registry_request_latency_seconds_bucket{le="16.777215"} 0
+redpanda_schema_registry_request_latency_seconds_bucket{le="33.554431"} 0
+redpanda_schema_registry_request_latency_seconds_bucket{le="+Inf"} 0
+# HELP redpanda_security_audit_errors_total Running count of errors in creating/publishing audit event log entries
+# TYPE redpanda_security_audit_errors_total counter
+redpanda_security_audit_errors_total{} 0
+# HELP redpanda_security_audit_last_event_timestamp_seconds Timestamp of last successful publish on the audit log (seconds since epoch)
+# TYPE redpanda_security_audit_last_event_timestamp_seconds counter
+redpanda_security_audit_last_event_timestamp_seconds{} 0
+# HELP redpanda_storage_cache_disk_free_bytes Disk storage bytes free.
+# TYPE redpanda_storage_cache_disk_free_bytes gauge
+redpanda_storage_cache_disk_free_bytes{} 258907324416.000000
+# HELP redpanda_storage_cache_disk_free_space_alert Status of low storage space alert. 0-OK, 1-Low Space 2-Degraded
+# TYPE redpanda_storage_cache_disk_free_space_alert gauge
+redpanda_storage_cache_disk_free_space_alert{} 0.000000
+# HELP redpanda_storage_cache_disk_total_bytes Total size of attached storage, in bytes.
+# TYPE redpanda_storage_cache_disk_total_bytes gauge
+redpanda_storage_cache_disk_total_bytes{} 494384795648.000000
+# HELP redpanda_storage_disk_free_bytes Disk storage bytes free.
+# TYPE redpanda_storage_disk_free_bytes gauge
+redpanda_storage_disk_free_bytes{} 258907324416.000000
+# HELP redpanda_storage_disk_free_space_alert Status of low storage space alert. 0-OK, 1-Low Space 2-Degraded
+# TYPE redpanda_storage_disk_free_space_alert gauge
+redpanda_storage_disk_free_space_alert{} 0.000000
+# HELP redpanda_storage_disk_total_bytes Total size of attached storage, in bytes.
+# TYPE redpanda_storage_disk_total_bytes gauge
+redpanda_storage_disk_total_bytes{} 494384795648.000000
+`
+
+var clusterConfig = `{"iceberg_rest_catalog_crl_file":null,"iceberg_rest_catalog_request_timeout_ms":10000,"iceberg_rest_catalog_token":null,"iceberg_rest_catalog_client_secret":null,"iceberg_rest_catalog_client_id":null,"iceberg_rest_catalog_endpoint":null,"iceberg_catalog_type":"object_storage","datalake_coordinator_snapshot_max_delay_secs":900,"iceberg_catalog_commit_interval_ms":60000,"iceberg_delete":true,"iceberg_enabled":false,"tls_min_version":"v1.2","unsafe_enable_consumer_offsets_delete_retention":false,"virtual_cluster_min_producer_ids":18446744073709551615,"http_authentication":["BASIC"],"oidc_keys_refresh_interval":3600,"oidc_principal_mapping":"$.sub","oidc_discovery_url":"https://auth.prd.cloud.redpanda.com/.well-known/openid-configuration","debug_bundle_auto_removal_seconds":null,"rpk_path":"/usr/bin/rpk","debug_bundle_storage_dir":null,"cpu_profiler_sample_period_ms":100,"cpu_profiler_enabled":false,"kafka_memory_share_for_fetch":0.5,"max_in_flight_schema_registry_requests_per_shard":500,"schema_registry_protobuf_renderer_v2":false,"enable_schema_id_validation":"none","legacy_unsafe_log_warning_interval_sec":300,"legacy_permit_unsafe_log_operation":true,"node_isolation_heartbeat_timeout":3000,"kafka_throughput_controlled_api_keys":["produce","fetch"],"kafka_quota_balancer_min_shard_throughput_ratio":0.01,"kafka_quota_balancer_window_ms":5000,"kafka_throughput_limit_node_out_bps":null,"kafka_throughput_limit_node_in_bps":null,"controller_log_accummulation_rps_capacity_move_operations":null,"rps_limit_move_operations":1000,"controller_log_accummulation_rps_capacity_node_management_operations":null,"controller_log_accummulation_rps_capacity_acls_and_users_operations":null,"enable_controller_log_rate_limiting":false,"cloud_storage_upload_ctrl_d_coeff":0.0,"metrics_reporter_report_interval":86400000,"enable_transactions":true,"enable_metrics_reporter":true,"storage_strict_data_init":false,"cloud_storage_disable_tls":false,"health_monitor_max_metadata_age":10000,"health_manager_tick_interval":180000,"internal_topic_replication_factor":3,"cloud_storage_crl_file":null,"kafka_qdc_latency_alpha":0.002,"core_balancing_continuous":false,"fetch_max_bytes":57671680,"core_balancing_on_core_count_change":true,"alive_timeout_ms":5000,"default_leaders_preference":"none","leader_balancer_mute_timeout":300000,"log_cleanup_policy":"delete","cloud_storage_upload_ctrl_min_shares":100,"partition_autobalancing_topic_aware":true,"cloud_storage_cluster_metadata_num_consumer_groups_per_upload":1000,"partition_autobalancing_node_availability_timeout_sec":900,"lz4_decompress_reusable_buffers_disabled":false,"auto_create_topics_enabled":true,"partition_autobalancing_min_size_threshold":null,"zstd_decompress_workspace_bytes":8388608,"kafka_qdc_depth_update_ms":7000,"cloud_storage_bucket":null,"kafka_qdc_max_depth":100,"kafka_qdc_idle_depth":10,"topic_partitions_per_shard":1000,"kafka_qdc_enable":false,"cloud_storage_inventory_self_managed_report_config":false,"controller_log_accummulation_rps_capacity_configuration_operations":null,"cloud_storage_inventory_reports_prefix":"redpanda_scrubber_inventory","cloud_storage_cache_trim_threshold_percent_size":null,"rps_limit_topic_operations":1000,"cloud_storage_cache_num_buckets":0,"tls_enable_renegotiation":false,"cloud_storage_cache_size":0,"cloud_storage_chunk_eviction_strategy":"eager","cloud_storage_disable_chunk_reads":false,"kafka_schema_id_validation_cache_capacity":128,"cloud_storage_min_chunks_per_segment_threshold":5,"cloud_storage_cache_chunk_size":16777216,"join_retry_timeout_ms":5000,"cloud_storage_throughput_limit_percent":50,"metrics_reporter_tick_interval":60000,"kafka_max_bytes_per_fetch":67108864,"cloud_storage_disable_upload_consistency_checks":false,"cloud_storage_max_segment_readers_per_shard":null,"controller_snapshot_max_age_sec":60,"cloud_storage_cache_max_objects":100000,"cloud_storage_cache_trim_threshold_percent_objects":null,"cloud_storage_cache_size_percent":20.0,"initial_retention_local_target_ms_default":null,"space_management_enable_override":false,"retention_local_trim_overage_coeff":2.0,"sasl_kerberos_principal":"redpanda","retention_local_strict_override":true,"retention_local_target_ms_default":86400000,"cloud_storage_upload_ctrl_p_coeff":-2.0,"cloud_storage_azure_adls_port":null,"cloud_storage_azure_shared_key":null,"topic_fds_per_partition":5,"cloud_storage_cache_check_interval":5000,"log_compaction_use_sliding_window":true,"retention_local_trim_interval":30000,"cloud_storage_partial_scrub_interval_ms":3600000,"cloud_storage_azure_container":null,"raft_recovery_throttle_disable_dynamic_mode":false,"cloud_storage_hydration_timeout_ms":600000,"raft_replica_max_flush_delay_ms":100,"cloud_storage_segment_upload_timeout_ms":30000,"cloud_storage_disable_metadata_consistency_checks":true,"iceberg_rest_catalog_prefix":null,"cloud_storage_enable_segment_merging":true,"cloud_storage_topic_purge_grace_period_ms":30000,"raft_recovery_default_read_size":524288,"cloud_storage_materialized_manifest_ttl_ms":10000,"raft_enable_lw_heartbeat":true,"cloud_storage_manifest_cache_size":1048576,"cloud_storage_spillover_manifest_size":65536,"append_chunk_size":16384,"cloud_storage_credentials_host":null,"cloud_storage_spillover_manifest_max_segments":null,"cloud_storage_max_concurrent_hydrations_per_shard":null,"cloud_storage_backend":"unknown","initial_retention_local_target_bytes_default":null,"cloud_storage_max_throughput_per_shard":1073741824,"cloud_storage_segment_size_target":null,"cloud_storage_recovery_topic_validation_mode":"check_manifest_existence","cloud_storage_recovery_temporary_retention_bytes_default":1073741824,"disable_batch_cache":false,"enable_rack_awareness":false,"cloud_storage_enable_compacted_topic_reupload":true,"enable_cluster_metadata_upload_loop":true,"raft_io_timeout_ms":10000,"disable_cluster_recovery_loop_for_tests":false,"cloud_storage_disable_upload_loop_for_tests":false,"partition_autobalancing_concurrent_moves":50,"cloud_storage_scrubbing_interval_jitter_ms":600000,"cloud_storage_enable_scrubbing":false,"cloud_storage_background_jobs_quota":5000,"storage_min_free_bytes":5368709120,"rps_limit_configuration_operations":1000,"cloud_storage_idle_threshold_rps":10.0,"transaction_coordinator_cleanup_policy":"delete","cloud_storage_idle_timeout_ms":10000,"leader_balancer_transfer_limit_per_shard":512,"node_management_operation_timeout_ms":5000,"cloud_storage_housekeeping_interval_ms":300000,"cloud_storage_metadata_sync_timeout_ms":10000,"cloud_storage_inventory_based_scrub_enabled":false,"cloud_storage_credentials_source":"config_file","cloud_storage_readreplica_manifest_sync_timeout_ms":30000,"cloud_storage_garbage_collect_timeout_ms":30000,"cloud_storage_initial_backoff_ms":100,"cloud_storage_upload_loop_initial_backoff_ms":100,"use_fetch_scheduler_group":true,"cloud_storage_roles_operation_timeout_ms":30000,"node_status_interval":100,"cloud_storage_azure_managed_identity_id":null,"group_max_session_timeout_ms":300000,"cloud_storage_url_style":null,"schema_registry_normalize_on_startup":false,"cloud_storage_api_endpoint":null,"cloud_storage_region":null,"fetch_session_eviction_timeout_ms":60000,"cloud_storage_secret_key":null,"cloud_storage_access_key":null,"topic_memory_per_partition":4194304,"cloud_storage_disable_archiver_manager":true,"cloud_storage_enable_remote_write":false,"kafka_connections_max_per_ip":null,"cloud_storage_chunk_prefetch":0,"raft_heartbeat_interval_ms":150,"audit_excluded_principals":[],"kafka_qdc_window_size_ms":1500,"retention_local_target_capacity_percent":80.0,"audit_excluded_topics":[],"audit_client_max_buffer_size":16777216,"audit_log_replication_factor":null,"controller_log_accummulation_rps_capacity_topic_operations":null,"log_message_timestamp_type":"CreateTime","audit_log_num_partitions":12,"audit_enabled":false,"kafka_enable_describe_log_dirs_remote_storage":true,"cloud_storage_azure_hierarchical_namespace_enabled":null,"kafka_rpc_server_tcp_send_buf":null,"kafka_rpc_server_tcp_recv_buf":null,"aggregate_metrics":false,"kafka_client_group_byte_rate_quota":[],"kafka_connections_max_overrides":[],"cloud_storage_full_scrub_interval_ms":43200000,"legacy_group_offset_retention_enabled":false,"kafka_connections_max":null,"rpc_server_listen_backlog":null,"compaction_ctrl_backlog_size":null,"compaction_ctrl_max_shares":1000,"cloud_storage_cluster_metadata_retries":5,"compaction_ctrl_i_coeff":0.0,"topic_partitions_reserve_shard0":0,"kafka_batch_max_bytes":1048576,"kafka_quota_balancer_node_period_ms":0,"cloud_storage_segment_size_min":null,"rpc_server_tcp_send_buf":null,"kafka_enable_partition_reassignment":true,"enable_mpx_extensions":false,"tx_timeout_delay_ms":1000,"raft_heartbeat_disconnect_failures":3,"sasl_mechanisms":["SCRAM"],"compaction_ctrl_p_coeff":-12.5,"cloud_storage_enabled":false,"kafka_mtls_principal_mapping_rules":null,"cloud_storage_inventory_id":"redpanda_scrubber_inventory","cloud_storage_azure_storage_account":null,"sasl_kerberos_keytab":"/var/lib/redpanda/redpanda.keytab","group_offset_retention_sec":604800,"cloud_storage_upload_loop_max_backoff_ms":10000,"kafka_nodelete_topics":["_redpanda.audit_log","__consumer_offsets","_schemas"],"oidc_clock_skew_tolerance":0,"node_status_reconnect_max_backoff_ms":15000,"memory_enable_memory_sampling":true,"sasl_kerberos_config":"/etc/krb5.conf","data_transforms_per_core_memory_reservation":20971520,"log_retention_ms":604800000,"id_allocator_log_capacity":100,"debug_load_slice_warning_depth":null,"storage_ignore_cstore_hints":false,"group_initial_rebalance_delay":3000,"storage_compaction_index_memory":134217728,"cloud_storage_recovery_topic_validation_depth":10,"disk_reservation_percent":25.0,"storage_max_concurrent_replay":1024,"reclaim_batch_cache_min_free":67108864,"cloud_storage_upload_ctrl_update_interval_ms":60000,"alter_topic_cfg_timeout_ms":5000,"max_in_flight_pandaproxy_requests_per_shard":500,"kafka_tcp_keepalive_probes":3,"data_transforms_enabled":false,"default_window_sec":1000,"segment_fallocation_step":33554432,"partition_autobalancing_mode":"node_add","storage_reserve_min_segments":2,"storage_read_readahead_count":10,"cloud_storage_disable_read_replica_loop_for_tests":false,"enable_sasl":false,"kvstore_max_segment_size":16777216,"retention_bytes":null,"release_cache_on_segment_roll":false,"memory_abort_on_alloc_failure":true,"cloud_storage_disable_remote_labels_for_tests":false,"kvstore_flush_interval":10,"raft_enable_longest_log_detection":true,"minimum_topic_replications":1,"enable_pid_file":true,"reclaim_stable_window":10000,"metrics_reporter_url":"https://m.rp.vectorized.io/v2","reclaim_min_size":131072,"cloud_storage_trust_file":null,"storage_target_replay_bytes":10737418240,"id_allocator_batch_size":1000,"raft_replicate_batch_window_size":1048576,"cloud_storage_api_endpoint_port":443,"recovery_append_timeout_ms":5000,"compaction_ctrl_d_coeff":0.2,"replicate_append_timeout_ms":3000,"reclaim_growth_window":3000,"cloud_storage_max_segments_pending_deletion_per_partition":5000,"partition_autobalancing_max_disk_usage_percent":80,"kafka_group_recovery_timeout_ms":30000,"partition_autobalancing_tick_moves_drop_threshold":0.2,"default_topic_partitions":1,"max_compacted_log_segment_size":5368709120,"iceberg_rest_catalog_trust_file":null,"create_topic_timeout_ms":2000,"max_kafka_throttle_delay_ms":30000,"kafka_throughput_control":[],"raft_smp_max_non_local_requests":null,"cloud_storage_manifest_max_upload_interval_sec":60,"transaction_max_timeout_ms":900000,"write_caching_default":"false","abort_timed_out_transactions_interval_ms":10000,"transaction_coordinator_log_segment_size":1073741824,"storage_read_buffer_size":131072,"cloud_storage_hydrated_chunks_per_segment_ratio":0.7,"tombstone_retention_ms":null,"cloud_storage_inventory_report_check_interval_ms":21600000,"compaction_ctrl_update_interval_ms":30000,"kafka_request_max_bytes":104857600,"default_topic_replications":1,"retention_local_strict":false,"tm_sync_timeout_ms":10000,"log_disable_housekeeping_for_tests":false,"cloud_storage_attempt_cluster_restore_on_bootstrap":false,"data_transforms_write_buffer_memory_percentage":45,"abort_index_segment_size":50000,"kafka_memory_batch_size_estimate_for_fetch":1048576,"kafka_client_group_fetch_byte_rate_quota":[],"storage_compaction_key_map_memory":134217728,"enable_idempotence":true,"oidc_token_audience":"redpanda","audit_queue_drain_interval_ms":500,"raft_max_concurrent_append_requests_per_follower":16,"kafka_connection_rate_limit_overrides":[],"log_compaction_interval_ms":10000,"kafka_connection_rate_limit":null,"partition_autobalancing_tick_interval_ms":30000,"group_min_session_timeout_ms":6000,"space_management_max_segment_concurrency":10,"metadata_status_wait_timeout_ms":2000,"kafka_qdc_max_latency_ms":80,"cloud_storage_max_connection_idle_time_ms":5000,"kafka_qdc_window_count":12,"usage_disk_persistance_interval_sec":300,"storage_compaction_key_map_memory_limit_percent":12.0,"kafka_tcp_keepalive_timeout":120,"segment_appender_flush_timeout_ms":1000,"data_transforms_binary_max_size":10485760,"log_message_timestamp_alert_after_ms":7200000,"superusers":[],"raft_learner_recovery_rate":104857600,"log_message_timestamp_alert_before_ms":null,"storage_space_alert_free_threshold_percent":5,"fetch_pid_target_utilization_fraction":0.2,"rpc_server_compress_replies":false,"iceberg_catalog_base_location":"redpanda-iceberg-catalog","target_quota_byte_rate":0,"fetch_pid_p_coeff":100.0,"fetch_pid_d_coeff":0.0,"fetch_read_strategy":"non_polling","rm_sync_timeout_ms":10000,"kafka_quota_balancer_min_shard_throughput_bps":256,"fetch_pid_i_coeff":0.01,"controller_backend_housekeeping_interval_ms":1000,"data_transforms_commit_interval_ms":3000,"metadata_dissemination_retries":30,"default_num_windows":10,"target_fetch_quota_byte_rate":null,"metadata_dissemination_retry_delay_ms":320,"cloud_storage_cache_trim_walk_concurrency":1,"group_offset_retention_check_ms":600000,"readers_cache_target_max_size":200,"log_segment_size_min":1048576,"cloud_storage_upload_ctrl_max_shares":1000,"cluster_id":"e5c27f6a-45dc-4427-a0fc-5b9183b6b28d","log_segment_size_max":null,"group_new_member_join_timeout":30000,"transaction_coordinator_partitions":50,"members_backend_retry_ms":5000,"core_balancing_debounce_timeout":10000,"cloud_storage_cluster_metadata_upload_timeout_ms":60000,"kafka_rpc_server_stream_recv_buf":null,"rps_limit_node_management_operations":1000,"readers_cache_eviction_timeout_ms":30000,"fetch_pid_max_debounce_ms":100,"usage_window_width_interval_sec":3600,"max_concurrent_producer_ids":18446744073709551615,"cloud_storage_enable_remote_read":false,"raft_timeout_now_timeout_ms":1000,"usage_num_windows":24,"quota_manager_gc_sec":30000,"storage_ignore_timestamps_in_future_sec":null,"raft_recovery_concurrency_per_shard":64,"kafka_qdc_depth_alpha":0.8,"kafka_admin_topic_api_rate":null,"cloud_storage_segment_max_upload_interval_sec":3600,"kafka_throughput_throttling_v2":true,"kafka_sasl_max_reauth_ms":null,"log_compression_type":"producer","fetch_reads_debounce_timeout":1,"storage_space_alert_free_threshold_bytes":0,"log_segment_ms":1209600000,"features_auto_enable":true,"rpc_server_tcp_recv_buf":null,"wait_for_leader_timeout_ms":5000,"cloud_storage_cluster_metadata_upload_interval_ms":3600000,"transactional_id_expiration_ms":604800000,"data_transforms_logging_line_max_bytes":1024,"data_transforms_per_function_memory_limit":2097152,"data_transforms_logging_flush_interval_ms":500,"sasl_kerberos_principal_mapping":["DEFAULT"],"raft_heartbeat_timeout_ms":3000,"retention_local_target_capacity_bytes":null,"partition_manager_shutdown_watchdog_timeout":30000,"cloud_storage_graceful_transfer_timeout_ms":5000,"cloud_storage_manifest_upload_timeout_ms":10000,"leader_balancer_idle_timeout":120000,"kafka_enable_authorization":null,"data_transforms_logging_buffer_capacity_bytes":512000,"raft_replica_max_pending_flush_bytes":262144,"audit_enabled_event_types":["management","authenticate","admin"],"disable_public_metrics":false,"data_transforms_read_buffer_memory_percentage":45,"kafka_throughput_replenish_threshold":null,"transaction_coordinator_delete_retention_ms":604800000,"compaction_ctrl_min_shares":10,"election_timeout_ms":1500,"data_transforms_runtime_limit_ms":3000,"pp_sr_smp_max_non_local_requests":null,"enable_leader_balancer":true,"raft_transfer_leader_recovery_timeout_ms":10000,"reclaim_max_size":4194304,"cloud_storage_inventory_max_hash_size_during_parse":67108864,"raft_max_recovery_memory":null,"space_management_max_log_concurrency":20,"rps_limit_acls_and_users_operations":1000,"kafka_noproduce_topics":[],"space_management_enable":true,"group_topic_partitions":16,"log_segment_size":134217728,"max_transactions_per_coordinator":18446744073709551615,"audit_queue_max_buffer_size_per_shard":1048576,"log_segment_size_jitter_percent":5,"rpc_client_connections_per_peer":128,"cloud_storage_max_connections":20,"log_segment_ms_max":31536000000,"admin_api_require_auth":false,"log_segment_ms_min":600000,"metadata_dissemination_interval_ms":3000,"enable_usage":false,"kafka_qdc_min_depth":1,"compacted_log_segment_size":268435456,"cloud_storage_azure_adls_endpoint":null,"disable_metrics":false,"kafka_tcp_keepalive_probe_interval_seconds":60,"retention_local_target_bytes_default":null}`
+
+// Returns a gzip compressed string of the sample metrics
+// Also returns the same data but hex encoded
+func prepareDataForBenchmark(rawData string) (string, []byte) {
+	var buf bytes.Buffer
+	gzipWriter := gzip.NewWriter(&buf)
+	_, _ = gzipWriter.Write([]byte(rawData))
+	err := gzipWriter.Close()
+	if err != nil {
+		panic(err)
+	}
+	bufBytes := buf.Bytes()
+
+	return hex.EncodeToString(bufBytes), bufBytes
+}
+
+// Prepare sample log entries for ParseRedpandaLogs benchmark
+func prepareSampleLogEntries() []s6service.LogEntry {
+	entries := []s6service.LogEntry{}
+
+	// Add BLOCK_START_MARKER
+	entries = append(entries, s6service.LogEntry{Content: BLOCK_START_MARKER})
+
+	// Add metrics data
+	metricsGZIPHex, _ := prepareDataForBenchmark(sampleMetrics)
+	entries = append(entries, s6service.LogEntry{Content: metricsGZIPHex})
+
+	// Add METRICS_END_MARKER
+	entries = append(entries, s6service.LogEntry{Content: METRICS_END_MARKER})
+
+	// Add cluster config data
+	clusterConfigGZIPHex, _ := prepareDataForBenchmark(clusterConfig)
+	entries = append(entries, s6service.LogEntry{Content: clusterConfigGZIPHex})
+
+	// Add CLUSTERCONFIG_END_MARKER
+	entries = append(entries, s6service.LogEntry{Content: CLUSTERCONFIG_END_MARKER})
+
+	// Add timestamp (unix timestamp in nanoseconds)
+	timestamp := fmt.Sprintf("%d", time.Now().UnixNano())
+	entries = append(entries, s6service.LogEntry{Content: timestamp})
+
+	// Add BLOCK_END_MARKER
+	entries = append(entries, s6service.LogEntry{Content: BLOCK_END_MARKER})
+
+	return entries
+}
+
+// BenchmarkGzipDecode benchmarks just the gzip decoding operation
+func BenchmarkGzipDecode(b *testing.B) {
+	encodedData, _ := prepareDataForBenchmark(sampleMetrics)
+
+	// Hex decode
+	decodedData, _ := hex.DecodeString(encodedData)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		reader, err := gzip.NewReader(bytes.NewReader([]byte(decodedData)))
+		if err != nil {
+			b.Fatal(err)
+		}
+		_, err = io.ReadAll(reader)
+		if err != nil {
+			b.Fatal(err)
+		}
+		err = reader.Close()
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkHexDecode benchmarks just the hex decoding operation
+func BenchmarkHexDecode(b *testing.B) {
+	encodedAndHexedData, _ := prepareDataForBenchmark(sampleMetrics)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := hex.DecodeString(string(encodedAndHexedData))
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkMetricsParsing benchmarks the metrics parsing operation
+func BenchmarkMetricsParsing(b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := ParseMetrics(bytes.NewReader([]byte(sampleMetrics)))
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkCompleteProcessing benchmarks the entire pipeline: hex decode -> gzip decode -> parse metrics
+func BenchmarkCompleteProcessing(b *testing.B) {
+	encodedAndHexedData, _ := prepareDataForBenchmark(sampleMetrics)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// Step 1: Hex decode
+		decodedMetricsDataBytes, _ := hex.DecodeString(string(encodedAndHexedData))
+
+		// Step 2: Gzip decompress
+		gzipReader, err := gzip.NewReader(bytes.NewReader(decodedMetricsDataBytes))
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		// Step 3: Parse metrics
+		_, err = ParseMetrics(gzipReader)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkParseRedpandaLogs benchmarks the ParseRedpandaLogs function
+func BenchmarkParseRedpandaLogsWithPercentiles(b *testing.B) {
+	// Create service and test data
+	service := NewRedpandaMonitorService()
+	logs := prepareSampleLogEntries()
+	ctx := context.Background()
+
+	// Collect execution times
+	times := make([]time.Duration, b.N)
+
+	b.ResetTimer()
+	b.StopTimer()
+	for i := 0; i < b.N; i++ {
+		start := time.Now()
+		b.StartTimer()
+		_, err := service.ParseRedpandaLogs(ctx, logs, uint64(i))
+		b.StopTimer()
+		if err != nil {
+			b.Fatal(err)
+		}
+		times[i] = time.Since(start)
+	}
+
+	// Sort times for percentile calculation
+	sort.Slice(times, func(i, j int) bool {
+		return times[i] < times[j]
+	})
+
+	// Calculate and report percentiles
+	p50 := times[int(float64(len(times))*0.50)]
+	p95 := times[int(float64(len(times))*0.95)]
+	p99 := times[int(float64(len(times))*0.99)]
+
+	b.ReportMetric(float64(p50.Nanoseconds()), "p50ns")
+	b.ReportMetric(float64(p95.Nanoseconds()), "p95ns")
+	b.ReportMetric(float64(p99.Nanoseconds()), "p99ns")
+}

--- a/umh-core/pkg/service/s6/s6.go
+++ b/umh-core/pkg/service/s6/s6.go
@@ -39,6 +39,8 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/metrics"
+
+	"golang.org/x/sync/errgroup"
 )
 
 // ServiceStatus represents the status of an S6 service
@@ -315,52 +317,133 @@ func (s *DefaultService) createS6ConfigFiles(ctx context.Context, servicePath st
 	return nil
 }
 
-// Remove removes the S6 service directory structure
+// Remove deletes every artefact that `Create` produced:
+//
+//   - <servicePath>             (the long-run service directory)
+//   - <servicePath>/log         (nested logger service)
+//   - <logBase>/<name>          (rotated log directory)
+//
+// The method is called once per reconcile *tick* while the S6-FSM is in the
+// *removing* state, therefore it must:
+//
+//  1. **Return quickly** – never wait or poll.
+//  2. **Be idempotent**  – safe to call when directories are half-gone.
+//  3. **Return nil only when nothing is left.**
+//
+// Any remaining file or I/O error leads to a non-nil return so the FSM keeps
+// trying (or escalates after the back-off threshold).
 func (s *DefaultService) Remove(ctx context.Context, servicePath string, fsService filesystem.Service) error {
 	start := time.Now()
 	defer func() {
-		metrics.ObserveReconcileTime(metrics.ComponentS6Service, servicePath+".remove", time.Since(start))
+		metrics.ObserveReconcileTime(metrics.ComponentS6Service,
+			servicePath+".remove", time.Since(start))
 	}()
 
-	if s.logger != nil {
-		s.logger.Debugf("Removing S6 service %s", servicePath)
+	if ctx.Err() != nil {
+		return ctx.Err() // context already cancelled / deadline exceeded
 	}
 
-	exists, err := s.ServiceExists(ctx, servicePath, fsService)
-	if err != nil {
-		return fmt.Errorf("failed to check if service exists: %w", err)
-	}
-	if !exists {
-		return ErrServiceNotExist
+	srvName := filepath.Base(servicePath)
+	logDir := filepath.Join(constants.S6LogBaseDir, srvName)
+
+	// ──────────────────────── fast-path ────────────────────────────
+	// If both paths are already gone we are done – lets the FSM fire
+	// "remove_done" immediately and exit the reconcile loop.
+	if gone, _ := fsService.PathExists(ctx, servicePath); !gone {
+		if gone2, _ := fsService.PathExists(ctx, logDir); !gone2 {
+			return nil
+		}
 	}
 
-	// Remove the service from contents.d first
-	serviceName := filepath.Base(servicePath)
-	//contentsFile := filepath.Join(filepath.Dir(servicePath), "user", "contents.d", serviceName)
-	//fsService.Remove(ctx, contentsFile) // Ignore errors - file might not exist
+	//----------------------------------------------------------------
+	// Two independent best-effort deletions.  We *always* call them,
+	// even if the directory is missing, because RemoveAll on a non-
+	// existent path is cheap and returns nil – keeps the code simple.
+	// We start it in a separate goroutine and wait for constants.S6RemoveTimeout
+	// so that we keep the main reconcile loop fast. If this requires a couple
+	// of retries, it is fine as long as we do not block the main reconcile loop.
+	//----------------------------------------------------------------
+	ctxRemoveTimeout, cancel := context.WithTimeout(ctx, constants.S6RemoveTimeout)
+	defer cancel()
 
-	// Remove the service directory
-	err = fsService.RemoveAll(ctx, servicePath)
-	if err != nil {
-		return fmt.Errorf("failed to remove S6 service %s: %w", servicePath, err)
+	g, gctx := errgroup.WithContext(ctxRemoveTimeout)
+
+	var srvErr, logErr error
+
+	g.Go(func() error {
+		srvErr = fsService.RemoveAll(gctx, servicePath)
+		return srvErr
+	})
+
+	g.Go(func() error {
+		logErr = fsService.RemoveAll(gctx, logDir)
+		return logErr
+	})
+
+	// Create a buffered channel to receive the result from g.Wait().
+	// The channel is buffered so that the goroutine sending on it doesn't block.
+	errc := make(chan error, 1)
+
+	// Run g.Wait() in a separate goroutine.
+	// This allows us to use a select statement to return early if the context is canceled.
+	go func() {
+		// g.Wait() blocks until all goroutines launched with g.Go() have returned.
+		// It returns the first non-nil error, if any.
+		errc <- g.Wait()
+	}()
+
+	// Use a select statement to wait for either the g.Wait() result or the context's cancellation.
+	select {
+	case err := <-errc:
+		// g.Wait() has finished, so check if any goroutine returned an error.
+		if err != nil {
+			// If there was an error in any sub-call, return that error.
+			return fmt.Errorf("s6.Remove incomplete for %q: %s",
+				servicePath, err.Error())
+		}
+		// If err is nil, all goroutines completed successfully.
+	case <-ctxRemoveTimeout.Done():
+		// The context was canceled or its deadline was exceeded before all goroutines finished.
+		// Although some goroutines might still be running in the background,
+		// they use a context (gctx) that should cause them to terminate promptly.
+		return ctxRemoveTimeout.Err()
 	}
 
-	// Clean up logs directory (best effort - don't block removal if this fails)
-	logDir := filepath.Join(constants.S6LogBaseDir, serviceName)
-	if logErr := fsService.RemoveAll(ctx, logDir); logErr != nil && s.logger != nil {
-		sentry.ReportServiceErrorf(
-			s.logger,
-			serviceName,
-			"s6",
-			"cleanup_logs",
-			"Failed to clean up log directory: %v",
-			logErr,
-		)
+	//----------------------------------------------------------------
+	// Double-check: report success only when both paths are gone *and*
+	// no I/O error occurred.
+	//----------------------------------------------------------------
+	srvLeft, srvLeftErr := fsService.PathExists(ctx, servicePath)
+	logLeft, logLeftErr := fsService.PathExists(ctx, logDir)
+
+	if srvErr != nil || logErr != nil || srvLeft || logLeft {
+		// build a helpful composite error message
+		var parts []string
+		if srvErr != nil {
+			parts = append(parts, fmt.Sprintf("serviceDir: %v", srvErr))
+		}
+		if logErr != nil {
+			parts = append(parts, fmt.Sprintf("logDir: %v", logErr))
+		}
+		if srvLeft {
+			parts = append(parts, "serviceDir still exists")
+		}
+		if logLeft {
+			parts = append(parts, "logDir still exists")
+		}
+
+		if srvLeftErr != nil {
+			parts = append(parts, fmt.Sprintf("serviceDir: %v", srvLeftErr))
+		}
+		if logLeftErr != nil {
+			parts = append(parts, fmt.Sprintf("logDir: %v", logLeftErr))
+		}
+
+		return fmt.Errorf("s6.Remove incomplete for %q: %s",
+			servicePath, strings.Join(parts, "; "))
 	}
 
-	if s.logger != nil {
-		s.logger.Debugf("Removed S6 service %s and its logs", servicePath)
-	}
+	s.logger.Debugf("Removed S6 service %s and its logs", servicePath)
 	return nil
 }
 
@@ -1101,31 +1184,136 @@ func (s *DefaultService) GetS6ConfigFile(ctx context.Context, servicePath string
 	return content, nil
 }
 
-// ForceRemove removes a service from the S6 manager
-func (s *DefaultService) ForceRemove(ctx context.Context, servicePath string, fsService filesystem.Service) error {
+// ForceRemove tears down an S6 long-run service **unconditionally**.
+//
+// It is the “nuclear option” the manager calls after several failed
+// graceful removals.  The function must therefore:
+//
+//   - **Be idempotent & non-blocking** – safe to invoke every 100 ms;
+//     never waits or polls.
+//   - **Erase every artefact** the service could have left behind.
+//   - **Return nil only when nothing remains.**
+//
+// Removal sequence
+// ----------------
+//  1. Best-effort **stop** the daemon *and* its logger with `s6-svc -d`.
+//     This is fast and harmless even if they are already down.
+//  2. **SIGTERM any lingering `s6-supervise` processes** (main + logger)
+//     by reading `<servicedir>/supervise/pid`.  Without this step a still-
+//     running supervisor could re-create the `supervise/` directory after
+//     we delete the tree.
+//  3. **Delete the two artefact trees**
+//     <servicePath>                       (includes …/log subdir)
+//     <logsBase>/<serviceName>            (rotated log files)
+//  4. **Double-check** that both paths are truly gone and that no I/O
+//     errors occurred; otherwise return an error so the caller retries.
+func (s *DefaultService) ForceRemove(
+	ctx context.Context,
+	servicePath string,
+	fsService filesystem.Service,
+) error {
+	start := time.Now()
+	defer func() {
+		metrics.IncErrorCount(metrics.ComponentS6Service, servicePath+".forceRemove") // a force remove is an error
+		metrics.ObserveReconcileTime(
+			metrics.ComponentS6Service,
+			servicePath+".forceRemove",
+			time.Since(start))
+	}()
+
 	if ctx.Err() != nil {
 		return ctx.Err()
 	}
 
-	err := fsService.RemoveAll(ctx, servicePath)
-	if err != nil {
-		return fmt.Errorf("failed to remove service: %w", err)
+	//--------------------------------------------------------------------
+	// 1. Best-effort graceful stop (idempotent, non-blocking)
+	//--------------------------------------------------------------------
+	mainErr := s.Stop(ctx, servicePath, fsService)                         // main
+	loggerErr := s.Stop(ctx, filepath.Join(servicePath, "log"), fsService) // logger
+
+	//--------------------------------------------------------------------
+	// 2. SIGTERM lingering s6-supervise processes to avoid resurrection
+	//--------------------------------------------------------------------
+	killSupervise := func(dir string) error {
+		pidFile := filepath.Join(dir, "supervise", "pid")
+		data, err := fsService.ReadFile(ctx, pidFile)
+		if err != nil || len(data) == 0 {
+			return nil // no supervisor ⇒ nothing to kill
+		}
+		if pid, err := strconv.Atoi(strings.TrimSpace(string(data))); err == nil && pid > 0 {
+			err = syscall.Kill(pid, syscall.SIGTERM)
+			if err != nil {
+				return fmt.Errorf("failed to kill supervisor for service %s: %w", dir, err)
+			}
+		}
+		return nil
+	}
+	killSuperviseMainErr := killSupervise(servicePath)
+	killSuperviseLoggerErr := killSupervise(filepath.Join(servicePath, "log"))
+
+	//--------------------------------------------------------------------
+	// 3. Delete artefact trees
+	//--------------------------------------------------------------------
+	srvErr := fsService.RemoveAll(ctx, servicePath)
+
+	svcName := filepath.Base(servicePath)
+	logDir := filepath.Join(constants.S6LogBaseDir, svcName)
+	logErr := fsService.RemoveAll(ctx, logDir)
+
+	//--------------------------------------------------------------------
+	// 4. Verification – declare success *only* if nothing is left
+	//--------------------------------------------------------------------
+	svcLeft, pathExistsMainErr := fsService.PathExists(ctx, servicePath)
+	logLeft, pathExistsLoggerErr := fsService.PathExists(ctx, logDir)
+
+	if srvErr != nil || logErr != nil || svcLeft || logLeft {
+		var parts []string
+		if srvErr != nil {
+			parts = append(parts, fmt.Sprintf("serviceDir: %v", srvErr))
+		}
+		if logErr != nil {
+			parts = append(parts, fmt.Sprintf("logDir: %v", logErr))
+		}
+		if svcLeft || pathExistsMainErr != nil {
+			parts = append(parts, "serviceDir still exists")
+		}
+		if logLeft || pathExistsLoggerErr != nil {
+			parts = append(parts, "logDir still exists")
+		}
+
+		if mainErr != nil {
+			parts = append(parts, fmt.Sprintf("stopping service: %v", mainErr))
+		}
+
+		if loggerErr != nil {
+			parts = append(parts, fmt.Sprintf("stopping logger for service: %v", loggerErr))
+		}
+
+		if killSuperviseMainErr != nil {
+			parts = append(parts, fmt.Sprintf("killing supervisor for service: %v", killSuperviseMainErr))
+		}
+
+		if killSuperviseLoggerErr != nil {
+			parts = append(parts, fmt.Sprintf("killing supervisor for logger: %v", killSuperviseLoggerErr))
+		}
+
+		if pathExistsMainErr != nil {
+			parts = append(parts, fmt.Sprintf("checking if service exists: %v", pathExistsMainErr))
+		}
+
+		if pathExistsLoggerErr != nil {
+			parts = append(parts, fmt.Sprintf("checking if logger exists: %v", pathExistsLoggerErr))
+		}
+
+		aggregatedErr := fmt.Errorf("s6.ForceRemove incomplete for %q: %s",
+			servicePath, strings.Join(parts, "; "))
+
+		sentry.ReportIssuef(sentry.IssueTypeWarning, s.logger, "%s", aggregatedErr.Error())
+
+		return aggregatedErr
 	}
 
-	// Clean up logs directory (best effort - don't block removal if this fails)
-	serviceName := filepath.Base(servicePath)
-	logDir := filepath.Join(constants.S6LogBaseDir, serviceName)
-	if logErr := fsService.RemoveAll(ctx, logDir); logErr != nil && s.logger != nil {
-		sentry.ReportServiceErrorf(
-			s.logger,
-			serviceName,
-			"s6",
-			"cleanup_logs",
-			"Failed to clean up log directory: %v",
-			logErr,
-		)
-	}
-
+	s.logger.Infof("Force-removed S6 service %s and its logs", servicePath)
 	return nil
 }
 
@@ -1164,6 +1352,15 @@ func (s *DefaultService) GetLogs(ctx context.Context, servicePath string, fsServ
 		return nil, fmt.Errorf("failed to read log file: %w", err)
 	}
 
+	entries, err := ParseLogsFromBytes(content)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse logs: %w", err)
+	}
+
+	return entries, nil
+}
+
+func ParseLogsFromBytes(content []byte) ([]LogEntry, error) {
 	// Split logs by newline
 	logs := strings.Split(strings.TrimSpace(string(content)), "\n")
 
@@ -1179,13 +1376,14 @@ func (s *DefaultService) GetLogs(ctx context.Context, servicePath string, fsServ
 			entries = append(entries, entry)
 		}
 	}
+
 	return entries, nil
 }
 
 // parseLogLine parses a log line from S6 format and returns a LogEntry
 func parseLogLine(line string) LogEntry {
 	// Quick check for empty strings or too short lines
-	if len(line) < 29 { // Minimum length for "YYYY-MM-DD HH:MM:SS  content"
+	if len(line) < 29 { // Minimum length for "YYYY-MM-DD HH:MM:SS.<9 digit nanoseconds>  content"
 		return LogEntry{Content: line}
 	}
 

--- a/umh-core/pkg/service/s6/s6_test.go
+++ b/umh-core/pkg/service/s6/s6_test.go
@@ -16,13 +16,16 @@ package s6
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/s6serviceconfig"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/logger"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/filesystem"
 )
 
@@ -382,4 +385,93 @@ var _ = Describe("S6 Service", func() {
 			})
 		})
 	})
+
+	// --- NEW TESTS FOR DefaultService.Remove ------------------------------------
+	Describe("DefaultService Remove()", func() {
+		var (
+			ctx     context.Context
+			mockFS  *filesystem.MockFileSystem
+			svc     *DefaultService
+			svcPath string
+			logDir  string
+
+			exists sync.Map // key:string → bool, simple in-memory "filesystem"
+		)
+
+		// helper – PathExists reads from our map
+		pathExists := func(p string) bool {
+			exists, ok := exists.Load(p)
+			return ok && exists.(bool)
+		}
+
+		BeforeEach(func() {
+			ctx = context.Background()
+			mockFS = filesystem.NewMockFileSystem()
+			svc = &DefaultService{
+				logger: logger.For("test"),
+			}
+			svcPath = filepath.Join(constants.S6BaseDir, "my-service")
+			logDir = filepath.Join(constants.S6LogBaseDir, "my-service")
+
+			// default: both paths exist
+			exists.Store(svcPath, true)
+			exists.Store(logDir, true)
+
+			// --- mock functions --------------------------------------------------
+
+			mockFS.WithPathExistsFunc(func(ctx context.Context, p string) (bool, error) {
+				return pathExists(p), nil
+			})
+
+			mockFS.WithRemoveAllFunc(func(ctx context.Context, p string) error {
+				// simulate deletion
+				exists.Delete(p)
+				return nil
+			})
+		})
+
+		It("removes both service and log directory (normal case)", func() {
+			err := svc.Remove(ctx, svcPath, mockFS)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pathExists(svcPath)).To(BeFalse())
+			Expect(pathExists(logDir)).To(BeFalse())
+		})
+
+		It("is successful when only the log dir had to be removed", func() {
+			exists.Delete(svcPath) // service dir already gone
+
+			err := svc.Remove(ctx, svcPath, mockFS)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pathExists(logDir)).To(BeFalse())
+		})
+
+		It("is idempotent (everything already gone)", func() {
+			exists = sync.Map{} // nothing exists
+
+			removeCalls := 0
+			mockFS.WithRemoveAllFunc(func(ctx context.Context, p string) error {
+				removeCalls++
+				return nil
+			})
+
+			err := svc.Remove(ctx, svcPath, mockFS)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(removeCalls).To(Equal(0), "RemoveAll should not be called when nothing exists")
+		})
+
+		It("returns an error when deletion fails", func() {
+			boom := fmt.Errorf("IO error")
+			mockFS.WithRemoveAllFunc(func(ctx context.Context, p string) error {
+				if p == svcPath {
+					return boom // fail removing service dir
+				}
+				exists.Delete(p)
+				return nil
+			})
+
+			err := svc.Remove(ctx, svcPath, mockFS)
+			Expect(err).To(MatchError(ContainSubstring("IO error")))
+		})
+	})
+
 })

--- a/umh-core/pkg/standarderrors/fsm.go
+++ b/umh-core/pkg/standarderrors/fsm.go
@@ -12,4 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package fsm
+package standarderrors
+
+import "errors"
+
+var (
+	// ErrInstanceRemoved is returned when an instance has been successfully removed
+	ErrInstanceRemoved = errors.New("instance removed")
+
+	// ErrRemovalPending is returned by RemoveBenthosFromS6Manager while the
+	// S6 manager is still busy shutting the service down.  Callers should
+	// treat it as a *retryable* error.
+	ErrRemovalPending = errors.New("service removal still in progress")
+)

--- a/umh-core/test/fsm/benthos/manager_test.go
+++ b/umh-core/test/fsm/benthos/manager_test.go
@@ -30,8 +30,12 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
 	benthosfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/benthos"
+	benthos_monitor_fsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/benthos_monitor"
+	s6fsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/s6"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/portmanager"
 	benthossvc "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/benthos"
+	benthos_monitor_service "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/benthos_monitor"
+	s6service "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/s6"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/serviceregistry"
 )
 
@@ -547,6 +551,119 @@ var _ = Describe("BenthosManager", func() {
 
 			// Verify post was called
 			Expect(mockPortMgr.PostReconcileCalled).To(BeTrue())
+		})
+	})
+
+	Context("Benthos-to-S6 remove hook", func() {
+		It("calls the S6 mock’s Remove() when a Benthos instance disappears from config", func() {
+
+			//----------------------------------------------------------------------
+			// 0. plumbing & constants
+			//----------------------------------------------------------------------
+			const benthosName = "remove-me"
+
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			var tick uint64
+
+			// Get the config and the resulting S6 config
+			benthosCfg := fsmtest.CreateBenthosTestConfig(benthosName, benthosfsm.OperationalStateStopped)
+			realBenthosService := benthossvc.NewDefaultBenthosService(benthosName)
+			s6Config, err := realBenthosService.GenerateS6ConfigForBenthos(&benthosCfg.BenthosServiceConfig, benthosName)
+			Expect(err).NotTo(HaveOccurred())
+
+			//----------------------------------------------------------------------
+			// 1. Build the dependency graph
+			// ---------------------------------------------------------------------
+			//    – real BenthosManager
+			//    – BUT:  mock S6Manager  (so FSMs are mocks)
+			//      AND:  mock S6Service  (so ad-hoc calls are mocks)
+			//----------------------------------------------------------------------
+			benthosMgr := benthosfsm.NewBenthosManager("rm-test-mgr")
+			mockS6Mgr := s6fsm.NewS6ManagerWithMockedServices("rm-test-mgr")
+
+			// ---------- mock S6 *service* injected into BenthosService ----------
+			myMockS6Svc := s6service.NewMockService()
+			// a minimal, valid YAML so Unmarshal succeeds
+			myMockS6Svc.GetS6ConfigFileResult = []byte("logger:\n  level: info\n")
+			// we also return a stub S6ServiceConfig for GetConfig()
+			myMockS6Svc.GetConfigResult = s6Config
+
+			mockBenthosMonitorSvc := benthos_monitor_service.NewMockBenthosMonitorService()
+			mockBenthosMonitorMgr := benthos_monitor_fsm.NewBenthosMonitorManagerWithMockedService("rm-test-mgr", *mockBenthosMonitorSvc)
+
+			// ---------- assemble BenthosService with both injections -----------
+
+			benthosSvc := benthossvc.NewDefaultBenthosService(
+				benthosName,
+				benthossvc.WithS6Manager(mockS6Mgr),   // << manager mock
+				benthossvc.WithS6Service(myMockS6Svc), // << service mock
+				benthossvc.WithMonitorManager(mockBenthosMonitorMgr),
+			)
+
+			// ---------- craft the BenthosInstance & register it -----------------
+			benthosInst := benthosfsm.NewBenthosInstanceWithService(benthosCfg, benthosSvc)
+			benthosMgr.AddInstanceForTest(benthosName, benthosInst)
+
+			//----------------------------------------------------------------------
+			// 2. Reconcile until the Benthos FSM settles in “Stopped”.
+			//----------------------------------------------------------------------
+			startCfg := config.FullConfig{
+				Internal: config.InternalConfig{
+					Benthos: []config.BenthosConfig{benthosCfg},
+				},
+			}
+
+			tick, err = fsmtest.WaitForBenthosManagerInstanceState(
+				ctx,
+				fsm.SystemSnapshot{CurrentConfig: startCfg, Tick: tick},
+				benthosMgr,
+				mockSvcRegistry,
+				benthosName,
+				benthosfsm.OperationalStateStopped,
+				10,
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			//----------------------------------------------------------------------
+			// 3. Grab the *mock* S6Service nested inside the S6Instance
+			//    (we’ll check its RemoveCalled flag at the end).
+			//----------------------------------------------------------------------
+
+			s6Name := benthosSvc.GetS6ServiceName(benthosName)
+			s6InstIfc, ok := mockS6Mgr.GetInstance(s6Name)
+			Expect(ok).To(BeTrue(), "S6 instance should exist after first reconcile")
+
+			s6Inst, ok := s6InstIfc.(*s6fsm.S6Instance)
+			Expect(ok).To(BeTrue())
+
+			innerMockS6Svc, ok := s6Inst.GetService().(*s6service.MockService)
+			Expect(ok).To(BeTrue(), "internal service is not a MockService")
+
+			//----------------------------------------------------------------------
+			// 4. Hand the manager an *empty* Benthos section → instance must vanish
+			//----------------------------------------------------------------------
+			emptyCfg := config.FullConfig{
+				Internal: config.InternalConfig{Benthos: []config.BenthosConfig{}},
+			}
+
+			tick, err = fsmtest.WaitForBenthosManagerInstanceRemoval(
+				ctx,
+				fsm.SystemSnapshot{CurrentConfig: emptyCfg, Tick: tick},
+				benthosMgr,
+				mockSvcRegistry,
+				benthosName,
+				15,
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			//----------------------------------------------------------------------
+			// 5. Assertion – did the S6 FSM actually invoke Remove() ?
+			//----------------------------------------------------------------------
+			Expect(innerMockS6Svc.RemoveCalled).To(BeTrue(),
+				"S6Instance.Remove() was never called")
+
 		})
 	})
 

--- a/umh-core/test/fsm/s6/manager_test.go
+++ b/umh-core/test/fsm/s6/manager_test.go
@@ -545,7 +545,7 @@ var _ = Describe("S6Manager", func() {
 			mockService.StatusError = fmt.Errorf("temporary error fetching service state")
 
 			// Run reconciliation a few times with the error active
-			nextTick, err = fsmtest.RunMultipleReconciliations(ctx, manager, fsm.SystemSnapshot{CurrentConfig: config.FullConfig{Internal: config.InternalConfig{Services: serviceConfig}}, Tick: tick}, mockSvcRegistry, 15)
+			nextTick, err = fsmtest.RunMultipleReconciliations(ctx, manager, fsm.SystemSnapshot{CurrentConfig: config.FullConfig{Internal: config.InternalConfig{Services: serviceConfig}}, Tick: tick}, mockSvcRegistry, 10)
 			tick = nextTick
 
 			// Verify the instance still exists despite errors


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added detailed performance benchmarks for Benthos metrics parsing, including decompression, decoding, and end-to-end processing.

- **Chores**
  - Introduced Makefile targets to run benchmarks for Benthos and Redpanda metrics components.

- **Refactor**
  - Updated timeout settings for Benthos and Redpanda metrics processing to improve performance tuning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->