### PR TITLE
remove-auth-token-from-example

### DIFF
--- a/umh-core/examples/example-config-comm.yaml
+++ b/umh-core/examples/example-config-comm.yaml
@@ -16,7 +16,7 @@ agent:
   metricsPort: 8080
   communicator:
     apiUrl: https://management.umh.app/api
-    authToken: a7caf5d82dacb972c300baf72d76326a3168141975f9e31f077aa28beced1ab7
+    # authToken is provided via AUTH_TOKEN environment variable
   releaseChannel: stable
   location:
       0: Example Location 0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated configuration to require the authentication token to be set via the AUTH_TOKEN environment variable instead of being hardcoded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->