### PR TITLE
ENG-2908 fix config diff 

### DIFF
--- a/umh-core/integration/redpanda_extended_test.go
+++ b/umh-core/integration/redpanda_extended_test.go
@@ -226,6 +226,8 @@ func getRPKSample(topic string) ([]Message, error) {
 	defer cncl()
 	out, err := runDockerCommandWithCtx(ctx, "exec", getContainerName(), "/opt/redpanda/bin/rpk", "topic", "consume", topic, "--offset", "-10", "-n", "10", "--format", "%d:%t:%o\n")
 	if err != nil {
+		GinkgoWriter.Printf("❌ Error getting RPK sample: %v\n", err)
+		GinkgoWriter.Printf("❌ Output: %s\n", out)
 		return nil, err
 	}
 	/*

--- a/umh-core/pkg/config/config.go
+++ b/umh-core/pkg/config/config.go
@@ -134,7 +134,7 @@ type RedpandaConfig struct {
 	FSMInstanceConfig `yaml:",inline"`
 
 	// For the Redpanda service
-	RedpandaServiceConfig redpandaserviceconfig.RedpandaServiceConfig `yaml:"redpandaServiceConfig"`
+	RedpandaServiceConfig redpandaserviceconfig.RedpandaServiceConfig `yaml:"redpandaServiceConfig,omitempty"`
 }
 
 // ConnectionConfig contains configuration for creating a Connection service

--- a/umh-core/pkg/config/redpandaserviceconfig/generator.go
+++ b/umh-core/pkg/config/redpandaserviceconfig/generator.go
@@ -35,12 +35,12 @@ func NewGenerator() *Generator {
 
 // RenderConfig generates a Redpanda YAML configuration from a RedpandaServiceConfig
 func (g *Generator) RenderConfig(cfg RedpandaServiceConfig) (string, error) {
-	if cfg.Topic.DefaultTopicRetentionMs == 0 {
-		cfg.Topic.DefaultTopicRetentionMs = 0
-	}
-
 	if cfg.Topic.DefaultTopicRetentionBytes == 0 {
 		cfg.Topic.DefaultTopicRetentionBytes = 0
+	}
+
+	if cfg.Topic.DefaultTopicRetentionMs == 0 {
+		cfg.Topic.DefaultTopicRetentionMs = 604800000 // Redpanda by default sets this to 7 days when set to 0, therefore we just set it to 7 days to keep the code a bit cleaner
 	}
 
 	if cfg.BaseDir == "" {

--- a/umh-core/pkg/config/redpandaserviceconfig/generator_test.go
+++ b/umh-core/pkg/config/redpandaserviceconfig/generator_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Redpanda YAML Generator", func() {
 					return cfg
 				}(),
 				expected: []string{
-					"retention_ms: -1",
+					"retention_ms: 604800000",
 					"retention_bytes: null",
 				},
 			}),

--- a/umh-core/pkg/config/redpandaserviceconfig/normalizer.go
+++ b/umh-core/pkg/config/redpandaserviceconfig/normalizer.go
@@ -28,7 +28,7 @@ func (n *Normalizer) NormalizeConfig(cfg RedpandaServiceConfig) RedpandaServiceC
 	normalized := cfg
 
 	if normalized.Topic.DefaultTopicRetentionMs == 0 {
-		normalized.Topic.DefaultTopicRetentionMs = 0
+		normalized.Topic.DefaultTopicRetentionMs = 604800000 // Redpanda by default sets this to 7 days when set to 0
 	}
 
 	if normalized.Topic.DefaultTopicRetentionBytes == 0 {

--- a/umh-core/pkg/config/redpandaserviceconfig/normalizer_test.go
+++ b/umh-core/pkg/config/redpandaserviceconfig/normalizer_test.go
@@ -26,7 +26,7 @@ var _ = Describe("Redpanda YAML Normalizer", func() {
 			normalizer := NewNormalizer()
 
 			normalizedConfig := normalizer.NormalizeConfig(config)
-			Expect(normalizedConfig.Topic.DefaultTopicRetentionMs).To(Equal(int64(0)))
+			Expect(normalizedConfig.Topic.DefaultTopicRetentionMs).To(Equal(int64(604800000)))
 			Expect(normalizedConfig.Topic.DefaultTopicRetentionBytes).To(Equal(int64(0)))
 		})
 	})

--- a/umh-core/pkg/config/redpandaserviceconfig/package.go
+++ b/umh-core/pkg/config/redpandaserviceconfig/package.go
@@ -23,22 +23,22 @@ var (
 // RedpandaServiceConfig represents the configuration for a Redpanda service
 // TopicConfig represents the topic-related configuration for Redpanda
 type TopicConfig struct {
-	DefaultTopicRetentionMs    int64 `yaml:"defaultTopicRetentionMs"`
-	DefaultTopicRetentionBytes int64 `yaml:"defaultTopicRetentionBytes"`
+	DefaultTopicRetentionMs    int64 `yaml:"defaultTopicRetentionMs,omitempty"`
+	DefaultTopicRetentionBytes int64 `yaml:"defaultTopicRetentionBytes,omitempty"`
 }
 
 // ResourcesConfig represents the resource-related configuration for Redpanda
 type ResourcesConfig struct {
-	MaxCores             int `yaml:"maxCores"`
-	MemoryPerCoreInBytes int `yaml:"memoryPerCoreInBytes"`
+	MaxCores             int `yaml:"maxCores,omitempty"`
+	MemoryPerCoreInBytes int `yaml:"memoryPerCoreInBytes,omitempty"`
 }
 
 // RedpandaServiceConfig represents the configuration for a Redpanda service
 type RedpandaServiceConfig struct {
 	// Redpanda-specific configuration
-	Topic     TopicConfig     `yaml:"topic"`
-	Resources ResourcesConfig `yaml:"resources"`
-	BaseDir   string          `yaml:"baseDir"`
+	Topic     TopicConfig     `yaml:"topic,omitempty"`
+	Resources ResourcesConfig `yaml:"resources,omitempty"`
+	BaseDir   string          `yaml:"baseDir,omitempty"`
 }
 
 // Equal checks if two RedpandaServiceConfigs are equal


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected default topic retention time handling to explicitly set it to 7 days (604800000 ms) when not specified, aligning with Redpanda's default behavior.
	- Updated related tests to reflect the new default retention time.
- **Chores**
	- Enhanced test logging for better error visibility during integration tests.
- **Style**
	- Updated YAML serialization to omit fields with zero values in configuration outputs for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->