### PR TITLE
Update Benthos log regex to use 'warning' instead of 'warn'

### DIFF
--- a/umh-core/pkg/service/benthos/benthos.go
+++ b/umh-core/pkg/service/benthos/benthos.go
@@ -203,7 +203,7 @@ type configCacheEntry struct {
 func hash(buf []byte) uint64 { return xxhash.Sum64(buf) }
 
 // benthosLogRe is a helper function for BenthosService.IsLogsFine
-var benthosLogRe = regexp.MustCompile(`^level=(error|warn)\s+msg="(.+)"`)
+var benthosLogRe = regexp.MustCompile(`^level=(error|warning)\s+msg="(.+)"`)
 
 // BenthosServiceOption is a function that modifies a BenthosService
 type BenthosServiceOption func(*BenthosService)
@@ -939,7 +939,7 @@ func (s *BenthosService) IsLogsFine(
 			if level == "error" {
 				return false
 			}
-			if level == "warn" {
+			if level == "warning" {
 				for _, sub := range critWarnSubstrings {
 					if strings.Contains(msg, sub) {
 						return false

--- a/umh-core/pkg/service/benthos/benthos_test.go
+++ b/umh-core/pkg/service/benthos/benthos_test.go
@@ -213,15 +213,15 @@ var _ = Describe("Benthos Service", func() {
 				logs := []s6service.LogEntry{
 					{
 						Timestamp: currentTime.Add(-1 * time.Minute),
-						Content:   `level=warn msg="failed to process message"`,
+						Content:   `level=warning msg="failed to process message"`,
 					},
 					{
 						Timestamp: currentTime.Add(-2 * time.Minute),
-						Content:   `level=warn msg="connection lost to server"`,
+						Content:   `level=warning msg="connection lost to server"`,
 					},
 					{
 						Timestamp: currentTime.Add(-3 * time.Minute),
-						Content:   `level=warn msg="unable to reach endpoint"`,
+						Content:   `level=warning msg="unable to reach endpoint"`,
 					},
 				}
 				Expect(service.IsLogsFine(logs, currentTime, logWindow)).To(BeFalse())
@@ -231,11 +231,11 @@ var _ = Describe("Benthos Service", func() {
 				logs := []s6service.LogEntry{
 					{
 						Timestamp: currentTime.Add(-1 * time.Minute),
-						Content:   `level=warn msg="rate limit applied"`,
+						Content:   `level=warning msg="rate limit applied"`,
 					},
 					{
 						Timestamp: currentTime.Add(-2 * time.Minute),
-						Content:   `level=warn msg="message batch partially processed"`,
+						Content:   `level=warning msg="message batch partially processed"`,
 					},
 				}
 				Expect(service.IsLogsFine(logs, currentTime, logWindow)).To(BeTrue())
@@ -863,7 +863,7 @@ logger:
 					logs: []s6service.LogEntry{
 						{
 							Timestamp: currentTime.Add(-1 * time.Minute),
-							Content:   `level=warn msg="failed to process message batch"`,
+							Content:   `level=warning msg="failed to process message batch"`,
 						},
 					},
 					expectBad: true,
@@ -873,7 +873,7 @@ logger:
 					logs: []s6service.LogEntry{
 						{
 							Timestamp: currentTime.Add(-1 * time.Minute),
-							Content:   `level=warn msg="rate limit applied"`,
+							Content:   `level=warning msg="rate limit applied"`,
 						},
 					},
 					expectBad: false,
@@ -887,7 +887,7 @@ logger:
 						},
 						{
 							Timestamp: currentTime.Add(-2 * time.Minute),
-							Content:   `level=warn msg="rate limit applied"`,
+							Content:   `level=warning msg="rate limit applied"`,
 						},
 						{
 							Timestamp: currentTime.Add(-3 * time.Minute),


### PR DESCRIPTION
Fixes ENG-2936

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of warning messages in logs by updating the criteria to match "warning" instead of "warn". This enhances the accuracy of log classification for warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->