### PR TITLE
Fallback to stable if Release is nil

### DIFF
--- a/umh-core/pkg/communicator/pkg/generator/generator.go
+++ b/umh-core/pkg/communicator/pkg/generator/generator.go
@@ -411,7 +411,13 @@ func buildAgentDataFromSnapshot(instance fsm.FSMInstanceSnapshot, log *zap.Sugar
 				DesiredState:  instance.DesiredState,
 				Category:      snapshot.ServiceInfoSnapshot.OverallHealth,
 			}
-			releaseChannel = snapshot.ServiceInfoSnapshot.Release.Channel
+			// Check if Release is nil before accessing its properties
+			if snapshot.ServiceInfoSnapshot.Release != nil {
+				releaseChannel = snapshot.ServiceInfoSnapshot.Release.Channel
+			} else {
+				log.Warn("Agent release data is nil, defaulting to stable")
+				releaseChannel = "stable"
+			}
 		} else {
 			log.Warn("Agent observed state is not of expected type")
 			sentry.ReportIssuef(sentry.IssueTypeError, log, "[buildAgentDataFromSnapshot] Agent observed state is not of expected type")

--- a/umh-core/pkg/communicator/pkg/generator/generator.go
+++ b/umh-core/pkg/communicator/pkg/generator/generator.go
@@ -416,7 +416,7 @@ func buildAgentDataFromSnapshot(instance fsm.FSMInstanceSnapshot, log *zap.Sugar
 				releaseChannel = snapshot.ServiceInfoSnapshot.Release.Channel
 			} else {
 				log.Warn("Agent release data is nil, defaulting to stable")
-				releaseChannel = "stable"
+				releaseChannel = "n/a"
 			}
 		} else {
 			log.Warn("Agent observed state is not of expected type")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stability by handling missing release information more gracefully, preventing potential crashes and ensuring a default release channel is used when necessary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->