### PR TITLE
fix: parsing of scientific notation when getting large numbers

### DIFF
--- a/umh-core/pkg/service/benthos_monitor/benthos_monitor_test.go
+++ b/umh-core/pkg/service/benthos_monitor/benthos_monitor_test.go
@@ -439,7 +439,7 @@ var _ = Describe("Benthos Monitor Service", func() {
 			Expect(val).To(Equal(int64(50000)))
 		})
 
-		It("should fail to parse a float in scientific notation", func() {
+		It("should parse a float in scientific notation", func() {
 			line := []byte(`input_received{label="",path="root.input"} 1.074682e+06`)
 			val, err := benthos_monitor.TailInt(line)
 			Expect(err).NotTo(HaveOccurred())

--- a/umh-core/pkg/service/benthos_monitor/benthos_monitor_test.go
+++ b/umh-core/pkg/service/benthos_monitor/benthos_monitor_test.go
@@ -431,4 +431,19 @@ var _ = Describe("Benthos Monitor Service", func() {
 		// Here we simply check that it took the last element in the log entries
 		Expect(benthosMetricsConfig.LastUpdatedAt.Unix()).To(Equal(int64(1745502180)))
 	})
+
+	Describe("TailInt", func() {
+		It("should parse a simple integer at the end of the line", func() {
+			val, err := benthos_monitor.TailInt([]byte("foo 50000"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(val).To(Equal(int64(50000)))
+		})
+
+		It("should fail to parse a float in scientific notation", func() {
+			line := []byte(`input_received{label="",path="root.input"} 1.074682e+06`)
+			val, err := benthos_monitor.TailInt(line)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(val).To(Equal(int64(1074682)))
+		})
+	})
 })


### PR DESCRIPTION
found the issue. the parsing did not work properly for scientific notation, therefore you were then also getting the low throughput (as it was reading 1mn = 1.0e+06 as 1)

also removed float parsing as we are never actually getting floats, only int

Fixes https://linear.app/united-manufacturing-hub/issue/ENG-2944/dfc-status-shows-idle-despite-high-message-production

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved metric parsing to correctly handle both integer and floating-point values, including scientific notation, ensuring accurate monitoring data.

- **Tests**
  - Added tests to verify correct parsing of integers and scientific notation numbers.
  - Enhanced metrics state tests to confirm accurate handling of high message throughput scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->