### PR TITLE
Eng 2950 configuration changes should not panic but throw an error

### DIFF
--- a/umh-core/pkg/config/manager.go
+++ b/umh-core/pkg/config/manager.go
@@ -345,6 +345,7 @@ func NewFileConfigManagerWithBackoff() (*FileConfigManagerWithBackoff, error) {
 
 		// Create backoff manager with default settings
 		backoffConfig := backoff.DefaultConfig("ConfigManager", logger)
+		backoffConfig.MaxRetries = uint64((time.Minute * 10) / constants.DefaultTickerTime) //10 minutes
 		backoffManager := backoff.NewBackoffManager(backoffConfig)
 
 		instance = &FileConfigManagerWithBackoff{

--- a/umh-core/pkg/fsm/base_manager.go
+++ b/umh-core/pkg/fsm/base_manager.go
@@ -337,8 +337,8 @@ func (m *BaseFSMManager[C]) Reconcile(
 			err = instance.SetDesiredFSMState(desiredState)
 			if err != nil {
 				metrics.IncErrorCount(metrics.ComponentBaseFSMManager, m.managerName)
-				m.logger.Errorf("failed to set desired state: %v for instance %s", err, name)
-				return fmt.Errorf("failed to set desired state: %w", err), false
+				m.logger.Errorf("failed to set desired state: %v for newly to be created instance %s", err, name)
+				continue // Skip this instance for now, we should not create it
 			}
 			m.instances[name] = instance
 
@@ -402,7 +402,7 @@ func (m *BaseFSMManager[C]) Reconcile(
 			if err != nil {
 				metrics.IncErrorCount(metrics.ComponentBaseFSMManager, m.managerName)
 				m.logger.Errorf("failed to set desired state: %w for instance %s", err, name)
-				return fmt.Errorf("failed to set desired state: %w", err), false
+				continue // Skip this state change for now, it is broken, we should not update it
 			}
 
 			// Update last state change tick using manager-specific tick


### PR DESCRIPTION
Fixes ENG-2950
Fixes ENG-2949

Increased the backoff to 10 minutes for config (parsing) errors, so that it doesn't restart immediately. Also changed the hebaviour of a bad desired state to not throw an error (and therefore cancel), but instead log the error and not create the instance / not update the desired state of an instance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling during state reconciliation, allowing the process to continue even if setting the desired state fails for individual instances.
- **Chores**
  - Adjusted configuration to limit the maximum number of backoff retries to a duration of 10 minutes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->