### PR TITLE
fix: removal of input_received printing

### DIFF
--- a/umh-core/pkg/service/benthos_monitor/benthos_monitor.go
+++ b/umh-core/pkg/service/benthos_monitor/benthos_monitor.go
@@ -922,7 +922,6 @@ func ParseMetricsFromBytes(raw []byte) (Metrics, error) {
 			}
 			m.Input.ConnectionUp = count
 		case "input_received":
-			fmt.Printf("input received: %s\n", string(line))
 			count, err := TailInt(line)
 			if err != nil {
 				return Metrics{}, fmt.Errorf("failed to parse input received: %w", err)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed a debug print statement from the metrics monitoring process to clean up console output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->