### PR TITLE
Eng 2955 provide redpanda status in status message

### DIFF
--- a/umh-core/examples/example-config-comm.yaml
+++ b/umh-core/examples/example-config-comm.yaml
@@ -35,14 +35,13 @@ dataFlow:
         input:
           generate:
             mapping: root = "hello world from DFC!"
-            interval: 1s # Output every 2 seconds
+            interval: 1s # Output every 1 seconds
             count: 0 # Set to 0 for unlimited messages
         pipeline:
           processors:
             - bloblang: root = content()
         output:
-            stdout: {}
-  
-internal:
-  redpanda:
-    desiredState: stopped
+            kafka:
+                addresses:
+                  - localhost:9092
+                topic: messages

--- a/umh-core/pkg/communicator/pkg/generator/generator.go
+++ b/umh-core/pkg/communicator/pkg/generator/generator.go
@@ -37,10 +37,11 @@ const (
 	containerManagerName = logger.ComponentContainerManager + "_" + constants.DefaultManagerName
 	benthosManagerName   = logger.ComponentBenthosManager + "_" + constants.DefaultManagerName
 	agentManagerName     = logger.ComponentAgentManager + "_" + constants.DefaultManagerName
-	redpandaManagerName  = logger.ComponentRedpandaManager + "_" + constants.DefaultManagerName
+	redpandaManagerName  = logger.ComponentRedpandaManager + constants.DefaultManagerName
 	// Instance name constants
-	coreInstanceName  = "Core"
-	agentInstanceName = "agent"
+	coreInstanceName     = "Core"
+	agentInstanceName    = "agent"
+	redpandaInstanceName = "redpanda"
 )
 
 type StatusCollectorType struct {
@@ -156,14 +157,14 @@ func (s *StatusCollectorType) GenerateStatusMessage() *models.StatusMessage {
 	if redpandaManager, exists := snapshot.Managers[redpandaManagerName]; exists {
 		instances := redpandaManager.GetInstances()
 
-		if instance, ok := instances[coreInstanceName]; ok {
+		if instance, ok := instances[redpandaInstanceName]; ok {
 			redpandaData, err = buildRedpandaDataFromSnapshot(*instance, s.logger)
 			if err != nil {
 				s.logger.Error("Error building redpanda data", zap.Error(err))
 			}
 		} else {
 			s.logger.Warn("Redpanda instance not found in redpanda manager",
-				zap.String("instanceName", coreInstanceName))
+				zap.String("instanceName", redpandaInstanceName))
 			sentry.ReportIssuef(sentry.IssueTypeError, s.logger, "[GenerateStatusMessage] Redpanda instance not found in redpanda manager")
 			redpandaData = models.Redpanda{}
 		}

--- a/umh-core/pkg/fsm/redpanda/observed_state_snapshot.go
+++ b/umh-core/pkg/fsm/redpanda/observed_state_snapshot.go
@@ -1,0 +1,56 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package redpanda
+
+import (
+	"github.com/tiendc/go-deepcopy"
+	redpandaserviceconfig "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/redpandaserviceconfig"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/sentry"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/redpanda"
+)
+
+// RedpandaObservedStateSnapshot is a deep-copyable snapshot of BenthosObservedState
+type RedpandaObservedStateSnapshot struct {
+	Config              redpandaserviceconfig.RedpandaServiceConfig
+	ServiceInfoSnapshot redpanda.ServiceInfo
+}
+
+// IsObservedStateSnapshot implements the fsm.ObservedStateSnapshot interface
+func (s *RedpandaObservedStateSnapshot) IsObservedStateSnapshot() {
+	// Marker method implementation
+}
+
+// CreateObservedStateSnapshot implements the fsm.ObservedStateConverter interface for RedpandaInstance
+func (d *RedpandaInstance) CreateObservedStateSnapshot() fsm.ObservedStateSnapshot {
+	// Create a deep copy of the observed state
+	snapshot := &RedpandaObservedStateSnapshot{}
+
+	// Deep copy config
+	err := deepcopy.Copy(&snapshot.Config, &d.config)
+	if err != nil {
+		sentry.ReportIssuef(sentry.IssueTypeError, d.baseFSMInstance.GetLogger(), "failed to deep copy config: %v", err)
+		return nil
+	}
+
+	// Deep copy service info
+	err = deepcopy.Copy(&snapshot.ServiceInfoSnapshot, &d.ObservedState.ServiceInfo)
+	if err != nil {
+		sentry.ReportIssuef(sentry.IssueTypeError, d.baseFSMInstance.GetLogger(), "failed to deep copy service info: %v", err)
+		return nil
+	}
+
+	return snapshot
+}

--- a/umh-core/pkg/models/status_message.go
+++ b/umh-core/pkg/models/status_message.go
@@ -164,8 +164,8 @@ type DfcBridgeInfo struct {
 
 type Redpanda struct {
 	Health                                 *Health `json:"health"`
-	AvgIncomingThroughputPerMinuteInMsgSec float64 `json:"avgIncomingThroughputPerMinuteInMsgSec"` // Incoming messages per second, averaged over a minute
-	AvgOutgoingThroughputPerMinuteInMsgSec float64 `json:"avgOutgoingThroughputPerMinuteInMsgSec"` // Outgoing messages per second, averaged over a minute
+	AvgIncomingThroughputPerMinuteInMsgSec float64 `json:"avgIncomingThroughputPerMinuteInMsgSec"` // Incoming bytes per second, averaged over a minute
+	AvgOutgoingThroughputPerMinuteInMsgSec float64 `json:"avgOutgoingThroughputPerMinuteInMsgSec"` // Outgoing bytes per second, averaged over a minute
 }
 
 type UnifiedNamespace struct {

--- a/umh-core/pkg/service/benthos_monitor/benthos_monitor.go
+++ b/umh-core/pkg/service/benthos_monitor/benthos_monitor.go
@@ -922,7 +922,6 @@ func ParseMetricsFromBytes(raw []byte) (Metrics, error) {
 			}
 			m.Input.ConnectionUp = count
 		case "input_received":
-			fmt.Printf("input received: %s\n", string(line))
 			count, err := TailInt(line)
 			if err != nil {
 				return Metrics{}, fmt.Errorf("failed to parse input received: %w", err)

--- a/umh-core/pkg/service/redpanda_monitor/metrics_state.go
+++ b/umh-core/pkg/service/redpanda_monitor/metrics_state.go
@@ -14,6 +14,8 @@
 
 package redpanda_monitor
 
+import "fmt"
+
 // ComponentThroughput tracks throughput metrics for a single component
 type ComponentThroughput struct {
 	// LastTick is the last tick when metrics were updated
@@ -69,6 +71,8 @@ func (s *RedpandaMetricsState) UpdateFromMetrics(metrics Metrics, tick uint64) {
 
 	// Update activity status based on input throughput
 	s.IsActive = s.Input.BytesPerTick > 0 || s.Output.BytesPerTick > 0
+	fmt.Println("Input:", s.Input.BytesPerTick, "Output:", s.Output.BytesPerTick)
+	fmt.Println("Input:", s.Input.LastCount, "Output:", s.Output.LastCount)
 
 	// Update last tick
 	s.LastTick = tick

--- a/umh-core/pkg/service/redpanda_monitor/redpanda_monitor.go
+++ b/umh-core/pkg/service/redpanda_monitor/redpanda_monitor.go
@@ -140,7 +140,7 @@ type TopicConfig struct {
 type RedpandaMetrics struct {
 	// Metrics contains the metrics of the Redpanda service
 	Metrics Metrics
-	// LastUpdatedAt contains the last time the metrics were updated
+	// MetricsState contains the last observed state of the metrics
 	MetricsState *RedpandaMetricsState
 }
 

--- a/umh-core/pkg/service/redpanda_monitor/redpanda_monitor.go
+++ b/umh-core/pkg/service/redpanda_monitor/redpanda_monitor.go
@@ -752,15 +752,30 @@ func ParseMetricsFast(b []byte) (Metrics, error) {
 
 		// ── throughput  (needs a label) ───────────────────────────────────
 		case "redpanda_kafka_request_bytes_total":
+			/*
+				We need to sum up the values over all topics
+
+					# HELP redpanda_kafka_request_bytes_total Total number of bytes produced per topic
+					# TYPE redpanda_kafka_request_bytes_total counter
+					redpanda_kafka_request_bytes_total{redpanda_namespace="kafka",redpanda_request="produce",redpanda_topic="test"} 27768
+					redpanda_kafka_request_bytes_total{redpanda_namespace="kafka",redpanda_request="follower_consume",redpanda_topic="test"} 0
+					redpanda_kafka_request_bytes_total{redpanda_namespace="kafka",redpanda_request="follower_consume",redpanda_topic="messages"} 0
+					redpanda_kafka_request_bytes_total{redpanda_namespace="kafka",redpanda_request="consume",redpanda_topic="test"} 24564
+					redpanda_kafka_request_bytes_total{redpanda_namespace="redpanda",redpanda_request="produce",redpanda_topic="controller"} 0
+					redpanda_kafka_request_bytes_total{redpanda_namespace="redpanda",redpanda_request="follower_consume",redpanda_topic="controller"} 0
+					redpanda_kafka_request_bytes_total{redpanda_namespace="kafka",redpanda_request="produce",redpanda_topic="messages"} 0
+					redpanda_kafka_request_bytes_total{redpanda_namespace="redpanda",redpanda_request="consume",redpanda_topic="controller"} 0
+					redpanda_kafka_request_bytes_total{redpanda_namespace="kafka",redpanda_request="consume",redpanda_topic="messages"} 0
+			*/
 			if lbls == nil {
 				return m, fmt.Errorf("metric redpanda_kafka_request_bytes_total has no labels")
 			}
 			switch lbls.Get("redpanda_request") {
 			case "produce":
-				m.Throughput.BytesIn = int64(val)
+				m.Throughput.BytesIn += int64(val)
 				foundProduce = true
 			case "consume":
-				m.Throughput.BytesOut = int64(val)
+				m.Throughput.BytesOut += int64(val)
 				foundConsume = true
 			}
 


### PR DESCRIPTION
Now one can see the redpanda status in the console. What can still happen is that redpanda remains degraded in the UI. We would need to address that

@ricci2511 will take care of changing msg/sec to bytes/sec in the frontend