### PR TITLE
eng 2965 limit logs in deploy and edit action to not crash polling

### DIFF
--- a/umh-core/pkg/communicator/actions/deploy-dataflowcomponent.go
+++ b/umh-core/pkg/communicator/actions/deploy-dataflowcomponent.go
@@ -606,31 +606,7 @@ func (a *DeployDataflowComponentAction) waitForComponentToBeActive() error {
 						logs = dfcSnapshot.ServiceInfo.BenthosObservedState.ServiceInfo.BenthosStatus.BenthosLogs
 						// only send the logs that have not been sent yet
 						if len(logs) > len(lastLogs) {
-							maxLogsToSend := 10
-							logsToSend := logs[len(lastLogs):]
-							remainingLogs := len(logsToSend) - maxLogsToSend
-
-							// Send at most 10 logs
-							end := len(logsToSend)
-							if end > maxLogsToSend {
-								end = maxLogsToSend
-							}
-
-							for _, log := range logsToSend[:end] {
-								SendActionReply(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionExecuting,
-									fmt.Sprintf("[Benthos Log] %s", log.Content),
-									a.outboundChannel, models.DeployDataFlowComponent)
-							}
-
-							// Send message about remaining logs if any
-							if remainingLogs > 0 {
-								SendActionReply(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionExecuting,
-									fmt.Sprintf("[Benthos Log] %d remaining logs not displayed", remainingLogs),
-									a.outboundChannel, models.DeployDataFlowComponent)
-							}
-
-							// Update lastLogs to include all logs we've seen, even if not all were sent
-							lastLogs = logs
+							lastLogs = SendLimitedLogs(logs, lastLogs, a.instanceUUID, a.userEmail, a.actionUUID, a.outboundChannel, models.DeployDataFlowComponent)
 						}
 					}
 				}

--- a/umh-core/pkg/communicator/actions/edit-dataflowcomponent.go
+++ b/umh-core/pkg/communicator/actions/edit-dataflowcomponent.go
@@ -565,11 +565,30 @@ func (a *EditDataflowComponentAction) waitForComponentToBeActive() error {
 							logs = dfcSnapshot.ServiceInfo.BenthosObservedState.ServiceInfo.BenthosStatus.BenthosLogs
 							// only send the logs that have not been sent yet
 							if len(logs) > len(lastLogs) {
-								for _, log := range logs[len(lastLogs):] {
+								maxLogsToSend := 10
+								logsToSend := logs[len(lastLogs):]
+								remainingLogs := len(logsToSend) - maxLogsToSend
+
+								// Send at most 10 logs
+								end := len(logsToSend)
+								if end > maxLogsToSend {
+									end = maxLogsToSend
+								}
+
+								for _, log := range logsToSend[:end] {
 									SendActionReply(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionExecuting,
 										fmt.Sprintf("[Benthos Log] %s", log.Content),
 										a.outboundChannel, models.EditDataFlowComponent)
 								}
+
+								// Send message about remaining logs if any
+								if remainingLogs > 0 {
+									SendActionReply(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionExecuting,
+										fmt.Sprintf("[Benthos Log] %d remaining logs not displayed", remainingLogs),
+										a.outboundChannel, models.EditDataFlowComponent)
+								}
+
+								// Update lastLogs to include all logs we've seen, even if not all were sent
 								lastLogs = logs
 							}
 

--- a/umh-core/pkg/communicator/actions/edit-dataflowcomponent.go
+++ b/umh-core/pkg/communicator/actions/edit-dataflowcomponent.go
@@ -565,31 +565,7 @@ func (a *EditDataflowComponentAction) waitForComponentToBeActive() error {
 							logs = dfcSnapshot.ServiceInfo.BenthosObservedState.ServiceInfo.BenthosStatus.BenthosLogs
 							// only send the logs that have not been sent yet
 							if len(logs) > len(lastLogs) {
-								maxLogsToSend := 10
-								logsToSend := logs[len(lastLogs):]
-								remainingLogs := len(logsToSend) - maxLogsToSend
-
-								// Send at most 10 logs
-								end := len(logsToSend)
-								if end > maxLogsToSend {
-									end = maxLogsToSend
-								}
-
-								for _, log := range logsToSend[:end] {
-									SendActionReply(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionExecuting,
-										fmt.Sprintf("[Benthos Log] %s", log.Content),
-										a.outboundChannel, models.EditDataFlowComponent)
-								}
-
-								// Send message about remaining logs if any
-								if remainingLogs > 0 {
-									SendActionReply(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionExecuting,
-										fmt.Sprintf("[Benthos Log] %d remaining logs not displayed", remainingLogs),
-										a.outboundChannel, models.EditDataFlowComponent)
-								}
-
-								// Update lastLogs to include all logs we've seen, even if not all were sent
-								lastLogs = logs
+								lastLogs = SendLimitedLogs(logs, lastLogs, a.instanceUUID, a.userEmail, a.actionUUID, a.outboundChannel, models.EditDataFlowComponent)
 							}
 
 							continue


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Limited the number of logs displayed to users during dataflow component activation and editing to a maximum of 10 logs per update, with a summary message indicating if additional logs were omitted. This helps reduce log volume and improves readability during status updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->