### PR TITLE
ENG-2970 Only stalls longer then 500ms are log failures

### DIFF
--- a/umh-core/pkg/service/redpanda/redpanda.go
+++ b/umh-core/pkg/service/redpanda/redpanda.go
@@ -838,11 +838,6 @@ func (s *RedpandaService) ReconcileManager(ctx context.Context, services service
 
 // IsLogsFine analyzes Redpanda logs to determine if there are any critical issues
 func (s *RedpandaService) IsLogsFine(logs []s6service.LogEntry, currentTime time.Time, logWindow time.Duration) bool {
-	failures := []string{
-		"Address already in use", // https://github.com/redpanda-data/redpanda/issues/3763
-		"Reactor stalled for",    // Multiple sources
-	}
-
 	// Check logs within the time window
 	windowStart := currentTime.Add(-logWindow)
 
@@ -854,9 +849,8 @@ func (s *RedpandaService) IsLogsFine(logs []s6service.LogEntry, currentTime time
 			continue
 		}
 
-		for _, failure := range failures {
-			if strings.Contains(log.Content, failure) {
-
+		for _, failure := range RedpandaFailures {
+			if failure.IsFailure(log.Content) {
 				return false
 			}
 		}

--- a/umh-core/pkg/service/redpanda/redpanda.go
+++ b/umh-core/pkg/service/redpanda/redpanda.go
@@ -849,8 +849,8 @@ func (s *RedpandaService) IsLogsFine(logs []s6service.LogEntry, currentTime time
 			continue
 		}
 
-		for _, failure := range RedpandaFailures {
-			if failure.IsFailure(log.Content) {
+		for _, failureDetector := range RedpandaFailures {
+			if failureDetector.IsFailure(log.Content) {
 				return false
 			}
 		}

--- a/umh-core/pkg/service/redpanda/redpanda.go
+++ b/umh-core/pkg/service/redpanda/redpanda.go
@@ -849,6 +849,7 @@ func (s *RedpandaService) IsLogsFine(logs []s6service.LogEntry, currentTime time
 			continue
 		}
 
+		// Check if the log contains failure, by applying all failure detectors (see redpanda_log_failures.go)
 		for _, failureDetector := range RedpandaFailures {
 			if failureDetector.IsFailure(log.Content) {
 				return false

--- a/umh-core/pkg/service/redpanda/redpanda_log_failures.go
+++ b/umh-core/pkg/service/redpanda/redpanda_log_failures.go
@@ -24,19 +24,24 @@ type RedpandaFailure interface {
 	IsFailure(logLine string) bool
 }
 
+// RedpandaFailures is a list of failure detectors (implements RedpandaFailure), each checking for a specific condition inside the log line
 var RedpandaFailures = []RedpandaFailure{
 	&AddressAlreadyInUseFailure{},
 	&ReactorStalledFailure{},
 }
 
+// AddressAlreadyInUseFailure is a failure that occurs when the address is already in use
 type AddressAlreadyInUseFailure struct{}
 
+// IsFailure checks if the log line contains "Address already in use"
 func (a *AddressAlreadyInUseFailure) IsFailure(logLine string) bool {
 	return strings.Contains(logLine, "Address already in use")
 }
 
+// ReactorStalledFailure is a failure that occurs when the reactor is stalled
 type ReactorStalledFailure struct{}
 
+// IsFailure checks if the log line contains "Reactor stalled for", and if so, if the number of milliseconds is greater than 500
 var reactorStallRegex = regexp.MustCompile(`Reactor stalled for (\d+) ms`)
 
 func (r *ReactorStalledFailure) IsFailure(logLine string) bool {
@@ -80,5 +85,6 @@ func (r *ReactorStalledFailure) IsFailure(logLine string) bool {
 	}
 
 	// Return failure if the reactor stalled for more than 500ms
+	// 500ms was choosen, as it is very unlikely to happen during normal operation
 	return ms > 500
 }

--- a/umh-core/pkg/service/redpanda/redpanda_log_failures.go
+++ b/umh-core/pkg/service/redpanda/redpanda_log_failures.go
@@ -47,6 +47,24 @@ func (r *ReactorStalledFailure) IsFailure(logLine string) bool {
 
 	// Reactor stalls are always printed as milliseconds
 	// https://github.com/scylladb/seastar/blob/e06b9092f921da1bcf7240f16adb9e6d2e227ae5/src/core/reactor.cc#L1456C17-L1456C28
+	/*
+		void cpu_stall_detector::generate_trace() {
+		    auto delta = reactor::now() - _run_started_at;
+
+		    _total_reported++;
+		    if (_config.report) {
+		        _config.report();
+		        return;
+		    }
+
+		    backtrace_buffer buf;
+		    buf.append("Reactor stalled for ");
+		    buf.append_decimal(uint64_t(delta / 1ms));
+		    buf.append(" ms");
+		    print_with_backtrace(buf, _config.oneline);
+		    maybe_report_kernel_trace(buf);
+		}
+	*/
 	// Example line: Reactor stalled for 32 ms
 
 	// Extract the number of milliseconds from the log line

--- a/umh-core/pkg/service/redpanda/redpanda_log_failures.go
+++ b/umh-core/pkg/service/redpanda/redpanda_log_failures.go
@@ -1,0 +1,66 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package redpanda
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+type RedpandaFailure interface {
+	IsFailure(logLine string) bool
+}
+
+var RedpandaFailures = []RedpandaFailure{
+	&AddressAlreadyInUseFailure{},
+	&ReactorStalledFailure{},
+}
+
+type AddressAlreadyInUseFailure struct{}
+
+func (a *AddressAlreadyInUseFailure) IsFailure(logLine string) bool {
+	return strings.Contains(logLine, "Address already in use")
+}
+
+type ReactorStalledFailure struct{}
+
+var reactorStallRegex = regexp.MustCompile(`Reactor stalled for (\d+) ms`)
+
+func (r *ReactorStalledFailure) IsFailure(logLine string) bool {
+	// Early return if the log line does not contain "Reactor stalled for"
+	if !strings.Contains(logLine, "Reactor stalled for") {
+		return false
+	}
+
+	// Reactor stalls are always printed as milliseconds
+	// https://github.com/scylladb/seastar/blob/e06b9092f921da1bcf7240f16adb9e6d2e227ae5/src/core/reactor.cc#L1456C17-L1456C28
+	// Example line: Reactor stalled for 32 ms
+
+	// Extract the number of milliseconds from the log line
+	matches := reactorStallRegex.FindStringSubmatch(logLine)
+	if len(matches) < 2 {
+		return false
+	}
+
+	// Convert the number of milliseconds to an integer
+	ms, err := strconv.Atoi(matches[1])
+	if err != nil {
+		return false
+	}
+
+	// Return failure if the reactor stalled for more than 500ms
+	return ms > 500
+}

--- a/umh-core/pkg/service/redpanda/redpanda_log_failures_test.go
+++ b/umh-core/pkg/service/redpanda/redpanda_log_failures_test.go
@@ -15,17 +15,10 @@
 package redpanda_test
 
 import (
-	"testing"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/redpanda"
 )
-
-func TestRedpandaLogFailures(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "Redpanda Log Failures Suite")
-}
 
 var _ = Describe("Redpanda Log Failures", func() {
 	Describe("AddressAlreadyInUseFailure", func() {

--- a/umh-core/pkg/service/redpanda/redpanda_log_failures_test.go
+++ b/umh-core/pkg/service/redpanda/redpanda_log_failures_test.go
@@ -1,0 +1,87 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package redpanda_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/redpanda"
+)
+
+func TestRedpandaLogFailures(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Redpanda Log Failures Suite")
+}
+
+var _ = Describe("Redpanda Log Failures", func() {
+	Describe("AddressAlreadyInUseFailure", func() {
+		var failure *redpanda.AddressAlreadyInUseFailure
+
+		BeforeEach(func() {
+			failure = &redpanda.AddressAlreadyInUseFailure{}
+		})
+
+		It("should detect address already in use failure", func() {
+			Expect(failure.IsFailure("Address already in use")).To(BeTrue())
+		})
+
+		It("should not detect failure in normal log line", func() {
+			Expect(failure.IsFailure("Normal log line")).To(BeFalse())
+		})
+
+		It("should be case sensitive", func() {
+			Expect(failure.IsFailure("address already in use")).To(BeFalse())
+		})
+	})
+
+	Describe("ReactorStalledFailure", func() {
+		var failure *redpanda.ReactorStalledFailure
+
+		BeforeEach(func() {
+			failure = &redpanda.ReactorStalledFailure{}
+		})
+
+		It("should detect reactor stall over 500ms", func() {
+			Expect(failure.IsFailure("Reactor stalled for 501 ms")).To(BeTrue())
+		})
+
+		It("should not detect reactor stall under 500ms", func() {
+			Expect(failure.IsFailure("Reactor stalled for 499 ms")).To(BeFalse())
+		})
+
+		It("should not detect failure in normal log line", func() {
+			Expect(failure.IsFailure("Normal log line")).To(BeFalse())
+		})
+
+		It("should handle malformed log lines", func() {
+			Expect(failure.IsFailure("Reactor stalled for ms")).To(BeFalse())
+			Expect(failure.IsFailure("Reactor stalled for abc ms")).To(BeFalse())
+		})
+
+		It("should be case sensitive", func() {
+			Expect(failure.IsFailure("reactor stalled for 501 ms")).To(BeFalse())
+		})
+	})
+
+	Describe("RedpandaFailures", func() {
+		It("should contain all failure types", func() {
+			Expect(redpanda.RedpandaFailures).To(HaveLen(2))
+			Expect(redpanda.RedpandaFailures[0]).To(BeAssignableToTypeOf(&redpanda.AddressAlreadyInUseFailure{}))
+			Expect(redpanda.RedpandaFailures[1]).To(BeAssignableToTypeOf(&redpanda.ReactorStalledFailure{}))
+		})
+	})
+})

--- a/umh-core/pkg/service/redpanda/redpanda_test.go
+++ b/umh-core/pkg/service/redpanda/redpanda_test.go
@@ -472,7 +472,8 @@ var _ = Describe("Redpanda Service", func() {
 					// Inside window with error - should trigger failure
 					{
 						Timestamp: currentTime.Add(-3 * time.Minute),
-						Content:   "ERROR Reactor stalled for 10s",
+						// Stalls are always printed in milliseconds (See redpanda_log_failures.go for more details)
+						Content: "ERROR Reactor stalled for 10000 ms",
 					},
 					// Latest log, normal - should not affect result
 					{

--- a/umh-core/pkg/service/redpanda/redpanda_test.go
+++ b/umh-core/pkg/service/redpanda/redpanda_test.go
@@ -362,7 +362,8 @@ var _ = Describe("Redpanda Service", func() {
 					},
 					{
 						Timestamp: currentTime.Add(-30 * time.Second),
-						Content:   "WARN Reactor stalled for 2s",
+						// Stalls are always printed in milliseconds (See redpanda_log_failures.go for more details)
+						Content: "WARN Reactor stalled for 2 ms",
 					},
 				}
 				Expect(service.IsLogsFine(logs, currentTime, logWindow)).To(BeFalse())

--- a/umh-core/pkg/service/redpanda/redpanda_test.go
+++ b/umh-core/pkg/service/redpanda/redpanda_test.go
@@ -363,7 +363,7 @@ var _ = Describe("Redpanda Service", func() {
 					{
 						Timestamp: currentTime.Add(-30 * time.Second),
 						// Stalls are always printed in milliseconds (See redpanda_log_failures.go for more details)
-						Content: "WARN Reactor stalled for 2 ms",
+						Content: "WARN Reactor stalled for 2000 ms",
 					},
 				}
 				Expect(service.IsLogsFine(logs, currentTime, logWindow)).To(BeFalse())


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced log failure detection with a more extensible system for identifying Redpanda failures, including detection for "Address already in use" and reactor stalls exceeding 500 ms.

- **Tests**
  - Added comprehensive tests for new failure detection logic, covering various scenarios and edge cases.
  - Updated existing tests to match the revised log message formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->