### PR TITLE
[ENG-2971] Set the Protocolconverter output to uns plugin

### DIFF
--- a/umh-core/pkg/config/protocolconverterserviceconfig/normalizer.go
+++ b/umh-core/pkg/config/protocolconverterserviceconfig/normalizer.go
@@ -31,8 +31,8 @@ func NewNormalizer() *Normalizer {
 func (n *Normalizer) NormalizeConfig(cfg *ProtocolConverterServiceConfig) {
 
 	// Before normalizing, set the output config for the ProtocolConverter
-	// For the ProtocolConverter, the output is always kafka processor
-	// It is preferred to use the uns plugin that is developed in benthos-umh
+	// For the ProtocolConverter, the messages are published to a kafka sink
+	// It is preferred to use the uns benthos plugin to publish to kafka
 	cfg.DataflowComponentServiceConfig.BenthosConfig.Output = map[string]any{
 		"uns": map[string]any{},
 	}

--- a/umh-core/pkg/config/protocolconverterserviceconfig/normalizer.go
+++ b/umh-core/pkg/config/protocolconverterserviceconfig/normalizer.go
@@ -30,6 +30,13 @@ func NewNormalizer() *Normalizer {
 // NormalizeConfig applies ProtocolConverter defaults to a structured config
 func (n *Normalizer) NormalizeConfig(cfg *ProtocolConverterServiceConfig) {
 
+	// Before normalizing, set the output config for the ProtocolConverter
+	// For the ProtocolConverter, the output is always kafka processor
+	// It is preferred to use the uns plugin that is developed in benthos-umh
+	cfg.DataflowComponentServiceConfig.BenthosConfig.Output = map[string]any{
+		"uns": map[string]any{},
+	}
+
 	// We need to first normalize the underlying DFCServiceConfig
 	dfcNormalizer := dataflowcomponentserviceconfig.NewNormalizer()
 	dfcNormalizer.NormalizeConfig(cfg.GetDFCServiceConfig())

--- a/umh-core/pkg/config/protocolconverterserviceconfig/normalizer_test.go
+++ b/umh-core/pkg/config/protocolconverterserviceconfig/normalizer_test.go
@@ -50,11 +50,6 @@ var _ = Describe("ProtocolConverter YAML Normalizer", func() {
 								"topic": "test/topic",
 							},
 						},
-						Output: map[string]any{
-							"kafka": map[string]any{
-								"topic": "test-output",
-							},
-						},
 						Pipeline: map[string]any{
 							"processors": []any{
 								map[string]any{
@@ -75,9 +70,12 @@ var _ = Describe("ProtocolConverter YAML Normalizer", func() {
 			inputMqtt := config.DataflowComponentServiceConfig.BenthosConfig.Input["mqtt"].(map[string]any)
 			Expect(inputMqtt["topic"]).To(Equal("test/topic"))
 
-			// Check output preserved
-			outputKafka := config.DataflowComponentServiceConfig.BenthosConfig.Output["kafka"].(map[string]any)
-			Expect(outputKafka["topic"]).To(Equal("test-output"))
+			// The output should be automatically set to uns
+			outputKafka := config.DataflowComponentServiceConfig.BenthosConfig.Output
+			// Check that "uns" is a map[string]any{}
+			unsValue, ok := outputKafka["uns"].(map[string]any)
+			Expect(ok).To(BeTrue(), "uns value should be a map[string]any")
+			Expect(unsValue).To(BeEmpty(), "uns map should be empty")
 
 			// Check pipeline processors preserved
 			processors := config.DataflowComponentServiceConfig.BenthosConfig.Pipeline["processors"].([]any)
@@ -105,7 +103,7 @@ var _ = Describe("ProtocolConverter YAML Normalizer", func() {
 			normalizer.NormalizeConfig(config)
 
 			Expect(config.DataflowComponentServiceConfig.BenthosConfig.Input).NotTo(BeNil())
-			Expect(config.DataflowComponentServiceConfig.BenthosConfig.Output).NotTo(BeNil())
+			Expect(config.DataflowComponentServiceConfig.BenthosConfig.Output).NotTo(BeNil()) // this should be set to `uns` plugin automatically
 			Expect(config.DataflowComponentServiceConfig.BenthosConfig.Pipeline).NotTo(BeNil())
 
 			// Buffer should have the none buffer set


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - The output configuration for the ProtocolConverter now defaults to using the "uns" plugin for consistent message processing.
- **Tests**
  - Test cases were updated to confirm the automatic setting of the "uns" plugin as the default output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->