### PR TITLE
ENG-3002 Ignore reactor stalls before redpanda has started up

### DIFF
--- a/umh-core/pkg/fsm/redpanda/actions.go
+++ b/umh-core/pkg/fsm/redpanda/actions.go
@@ -363,22 +363,6 @@ func (r *RedpandaInstance) IsRedpandaS6Stopped() (bool, string) {
 	return false, fmt.Sprintf("s6 is not stopped, current state: %s", r.ObservedState.ServiceInfo.S6FSMState)
 }
 
-// IsRedpandaConfigLoaded reports true once Redpanda has been up for at least
-// five seconds, implying the configuration parsed without a crash.
-//
-// It returns:
-//
-//	ok     – true when the config is considered loaded, false otherwise.
-//	reason – empty when ok is true; otherwise the current uptime versus the
-//	         5‑second threshold.
-func (r *RedpandaInstance) IsRedpandaConfigLoaded() (bool, string) {
-	currentUptime := r.ObservedState.ServiceInfo.S6ObservedState.ServiceInfo.Uptime
-	if currentUptime >= 5 {
-		return true, ""
-	}
-	return false, fmt.Sprintf("uptime %d s (< 5 s threshold)", currentUptime)
-}
-
 // IsRedpandaHealthchecksPassed reports true when both liveness and readiness
 // probes pass.
 //
@@ -470,15 +454,11 @@ func (r *RedpandaInstance) IsRedpandaMetricsErrorFree() (bool, string) {
 //	reason   – empty when degraded is false; otherwise the first failure cause.
 func (r *RedpandaInstance) IsRedpandaDegraded(currentTime time.Time, logWindow time.Duration) (bool, string) {
 	s6Running, reasonS6Running := r.IsRedpandaS6Running()
-	configLoaded, reasonConfigLoaded := r.IsRedpandaConfigLoaded()
 	healthchecksPassed, reasonHealthchecksPassed := r.IsRedpandaHealthchecksPassed()
 	runningForSomeTimeWithoutErrors, reasonRunningForSomeTimeWithoutErrors := r.IsRedpandaRunningWithoutErrors(currentTime, logWindow)
 
 	if !s6Running {
 		return true, reasonS6Running
-	}
-	if !configLoaded {
-		return true, reasonConfigLoaded
 	}
 	if !healthchecksPassed {
 		return true, reasonHealthchecksPassed

--- a/umh-core/pkg/fsm/redpanda/actions.go
+++ b/umh-core/pkg/fsm/redpanda/actions.go
@@ -412,7 +412,7 @@ func (r *RedpandaInstance) AnyRestartsSinceCreation() (bool, string) {
 	return true, fmt.Sprintf("restarted %d times", len(r.ObservedState.ServiceInfo.S6ObservedState.ServiceInfo.ExitHistory))
 }
 
-// IsRedpandaRunningForSomeTimeWithoutErrors reports true when Redpanda has
+// IsRedpandaRunningWithoutErrors reports true when Redpanda has
 // been up for at least ten seconds, recent logs are clean, and metrics show no
 // errors.
 //
@@ -420,7 +420,7 @@ func (r *RedpandaInstance) AnyRestartsSinceCreation() (bool, string) {
 //
 //	ok     – true when all conditions pass, false otherwise.
 //	reason – empty when ok is true; otherwise the first detected failure.
-func (r *RedpandaInstance) IsRedpandaRunningForSomeTimeWithoutErrors(currentTime time.Time, logWindow time.Duration) (bool, string) {
+func (r *RedpandaInstance) IsRedpandaRunningWithoutErrors(currentTime time.Time, logWindow time.Duration) (bool, string) {
 	// Check if there are any issues in the Redpanda logs
 	logsFine, reason := r.IsRedpandaLogsFine(currentTime, logWindow)
 	if !logsFine {
@@ -472,7 +472,7 @@ func (r *RedpandaInstance) IsRedpandaDegraded(currentTime time.Time, logWindow t
 	s6Running, reasonS6Running := r.IsRedpandaS6Running()
 	configLoaded, reasonConfigLoaded := r.IsRedpandaConfigLoaded()
 	healthchecksPassed, reasonHealthchecksPassed := r.IsRedpandaHealthchecksPassed()
-	runningForSomeTimeWithoutErrors, reasonRunningForSomeTimeWithoutErrors := r.IsRedpandaRunningForSomeTimeWithoutErrors(currentTime, logWindow)
+	runningForSomeTimeWithoutErrors, reasonRunningForSomeTimeWithoutErrors := r.IsRedpandaRunningWithoutErrors(currentTime, logWindow)
 
 	if !s6Running {
 		return true, reasonS6Running

--- a/umh-core/pkg/fsm/redpanda/actions.go
+++ b/umh-core/pkg/fsm/redpanda/actions.go
@@ -421,11 +421,6 @@ func (r *RedpandaInstance) AnyRestartsSinceCreation() (bool, string) {
 //	ok     – true when all conditions pass, false otherwise.
 //	reason – empty when ok is true; otherwise the first detected failure.
 func (r *RedpandaInstance) IsRedpandaRunningForSomeTimeWithoutErrors(currentTime time.Time, logWindow time.Duration) (bool, string) {
-	currentUptime := r.ObservedState.ServiceInfo.S6ObservedState.ServiceInfo.Uptime
-	if currentUptime < 10 {
-		return false, fmt.Sprintf("uptime %d s (< %d s threshold)", currentUptime, 10)
-	}
-
 	// Check if there are any issues in the Redpanda logs
 	logsFine, reason := r.IsRedpandaLogsFine(currentTime, logWindow)
 	if !logsFine {

--- a/umh-core/pkg/fsm/redpanda/actions.go
+++ b/umh-core/pkg/fsm/redpanda/actions.go
@@ -428,7 +428,7 @@ func (r *RedpandaInstance) IsRedpandaRunningWithoutErrors(currentTime time.Time,
 //	ok     – true when logs look clean, false otherwise.
 //	reason – empty when ok is true; otherwise the first offending log line.
 func (r *RedpandaInstance) IsRedpandaLogsFine(currentTime time.Time, logWindow time.Duration) (bool, string) {
-	logsFine, logEntry := r.service.IsLogsFine(r.ObservedState.ServiceInfo.RedpandaStatus.Logs, currentTime, logWindow)
+	logsFine, logEntry := r.service.IsLogsFine(r.ObservedState.ServiceInfo.RedpandaStatus.Logs, currentTime, logWindow, r.transitionToRunningTime)
 	if !logsFine {
 		return false, fmt.Sprintf("log issue: [%s] %s", logEntry.Timestamp.Format(time.RFC3339), logEntry.Content)
 	}

--- a/umh-core/pkg/fsm/redpanda/models.go
+++ b/umh-core/pkg/fsm/redpanda/models.go
@@ -19,6 +19,8 @@ import (
 	redpandaserviceconfig "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/redpandaserviceconfig"
 	publicfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
 
+	"time"
+
 	redpandasvc "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/redpanda"
 )
 
@@ -124,6 +126,10 @@ type RedpandaInstance struct {
 
 	// config contains all the configuration for this service
 	config redpandaserviceconfig.RedpandaServiceConfig
+
+	// transitionToRunningTime tracks when we first transitioned to a running state
+	// This is used to ignore errors that occurred before we were fully running
+	transitionToRunningTime time.Time
 }
 
 // GetLastObservedState returns the last known state of the instance

--- a/umh-core/pkg/fsm/redpanda/reconcile.go
+++ b/umh-core/pkg/fsm/redpanda/reconcile.go
@@ -284,6 +284,9 @@ func (r *RedpandaInstance) reconcileStartingStates(ctx context.Context, services
 			return nil, false
 		}
 
+		// Set the transition time when we detect successful start
+		r.transitionToRunningTime = currentTime
+
 		r.ObservedState.ServiceInfo.StatusReason = ""
 		return r.baseFSMInstance.SendEvent(ctx, EventStartDone), true
 	default:

--- a/umh-core/pkg/service/redpanda/mock.go
+++ b/umh-core/pkg/service/redpanda/mock.go
@@ -329,7 +329,7 @@ func (m *MockRedpandaService) ReconcileManager(ctx context.Context, services ser
 }
 
 // IsLogsFine mocks checking if the logs are fine
-func (m *MockRedpandaService) IsLogsFine(logs []s6service.LogEntry, currentTime time.Time, logWindow time.Duration) (bool, s6service.LogEntry) {
+func (m *MockRedpandaService) IsLogsFine(logs []s6service.LogEntry, currentTime time.Time, logWindow time.Duration, transitionToRunningTime time.Time) (bool, s6service.LogEntry) {
 	m.IsLogsFineCalled = true
 	// For testing purposes, we'll consider logs fine if they're empty or nil
 	return len(logs) == 0, s6service.LogEntry{}

--- a/umh-core/pkg/service/redpanda/redpanda_log_failures.go
+++ b/umh-core/pkg/service/redpanda/redpanda_log_failures.go
@@ -18,10 +18,16 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
+
+	s6service "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/s6"
 )
 
 type RedpandaFailure interface {
-	IsFailure(logLine string) bool
+	// IsFailure checks if the log line contains a failure
+	// transitionToRunningTime is the time when the service was transitioned to running
+	// This can be used to ignore certain failures, which might occur during the startup phase
+	IsFailure(log s6service.LogEntry, transitionToRunningTime time.Time) bool
 }
 
 // RedpandaFailures is a list of failure detectors (implements RedpandaFailure), each checking for a specific condition inside the log line
@@ -34,8 +40,8 @@ var RedpandaFailures = []RedpandaFailure{
 type AddressAlreadyInUseFailure struct{}
 
 // IsFailure checks if the log line contains "Address already in use"
-func (a *AddressAlreadyInUseFailure) IsFailure(logLine string) bool {
-	return strings.Contains(logLine, "Address already in use")
+func (a *AddressAlreadyInUseFailure) IsFailure(log s6service.LogEntry, _ time.Time) bool {
+	return strings.Contains(log.Content, "Address already in use")
 }
 
 // ReactorStalledFailure is a failure that occurs when the reactor is stalled
@@ -44,9 +50,14 @@ type ReactorStalledFailure struct{}
 // IsFailure checks if the log line contains "Reactor stalled for", and if so, if the number of milliseconds is greater than 500
 var reactorStallRegex = regexp.MustCompile(`Reactor stalled for (\d+) ms`)
 
-func (r *ReactorStalledFailure) IsFailure(logLine string) bool {
+func (r *ReactorStalledFailure) IsFailure(log s6service.LogEntry, transitionToRunningTime time.Time) bool {
 	// Early return if the log line does not contain "Reactor stalled for"
-	if !strings.Contains(logLine, "Reactor stalled for") {
+	if !strings.Contains(log.Content, "Reactor stalled for") {
+		return false
+	}
+
+	// If the stall is before the time that redpanda reported to be running, we can ignore it
+	if log.Timestamp.Before(transitionToRunningTime) {
 		return false
 	}
 
@@ -73,7 +84,7 @@ func (r *ReactorStalledFailure) IsFailure(logLine string) bool {
 	// Example line: Reactor stalled for 32 ms
 
 	// Extract the number of milliseconds from the log line
-	matches := reactorStallRegex.FindStringSubmatch(logLine)
+	matches := reactorStallRegex.FindStringSubmatch(log.Content)
 	if len(matches) < 2 {
 		return false
 	}


### PR DESCRIPTION
We can ignore reactor stalls that occured before redpanda reported itself as started.
Otherwise we might start straight into degraded, even if the issue was before redpanda was running.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced error detection for Redpanda logs by considering only errors that occur after the service has fully started, improving reliability and reducing false positives.

- **Bug Fixes**
  - Improved accuracy of log failure detection by ignoring errors that happen before the service transitions to a running state.

- **Tests**
  - Updated and expanded tests to verify time-based filtering of log failures, ensuring correct behavior for logs before and after service startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->