### PR TITLE
standardized reporting

### DIFF
--- a/umh-core/Makefile
+++ b/umh-core/Makefile
@@ -12,20 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Copyright 2025 UMH Systems GmbH
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 .PHONY: build run clean test
 
 IMAGE_NAME = umh-core
@@ -64,7 +50,7 @@ install:
 download-docker-binaries:
 	@mkdir -p .docker-cache/s6-overlay .docker-cache/benthos .docker-cache/redpanda
 	@echo "Downloading binaries with caching..."
-	
+
 	@# Check and update s6-overlay version
 	@if [ ! -f .docker-cache/s6-overlay/version ] || [ "$$(cat .docker-cache/s6-overlay/version)" != "$(S6_OVERLAY_VERSION)" ]; then \
 		rm -f .docker-cache/s6-overlay/*.tar.xz; \
@@ -74,7 +60,7 @@ download-docker-binaries:
 		wget -O .docker-cache/s6-overlay/s6-overlay-x86_64.tar.xz "https://github.com/just-containers/s6-overlay/releases/download/v$(S6_OVERLAY_VERSION)/s6-overlay-x86_64.tar.xz"; \
 		wget -O .docker-cache/s6-overlay/s6-overlay-aarch64.tar.xz "https://github.com/just-containers/s6-overlay/releases/download/v$(S6_OVERLAY_VERSION)/s6-overlay-aarch64.tar.xz"; \
 	fi
-	
+
 	@# Check and update Benthos version
 	@if [ ! -f .docker-cache/benthos/version ] || [ "$$(cat .docker-cache/benthos/version)" != "$(BENTHOS_UMH_VERSION)" ]; then \
 		rm -f .docker-cache/benthos/benthos-linux-*; \
@@ -82,7 +68,7 @@ download-docker-binaries:
 		wget -O .docker-cache/benthos/benthos-linux-amd64 "https://github.com/united-manufacturing-hub/benthos-umh/releases/download/v$(BENTHOS_UMH_VERSION)/benthos-linux-amd64"; \
 		wget -O .docker-cache/benthos/benthos-linux-arm64 "https://github.com/united-manufacturing-hub/benthos-umh/releases/download/v$(BENTHOS_UMH_VERSION)/benthos-linux-arm64"; \
 	fi
-	
+
 	@# Check and update Redpanda version
 	@if [ ! -f .docker-cache/redpanda/version ] || [ "$$(cat .docker-cache/redpanda/version)" != "$(REDPANDA_VERSION)" ]; then \
 		rm -rf .docker-cache/redpanda/redpanda-*.tar.gz .docker-cache/redpanda/amd64 .docker-cache/redpanda/arm64; \
@@ -99,7 +85,7 @@ download-docker-binaries:
 		docker cp $$CONTAINER_ARM64:/opt/redpanda .docker-cache/redpanda/arm64/; \
 		docker rm -v $$CONTAINER_ARM64; \
 	fi
-	
+
 	@# Verify all required files exist
 	@echo "Verifying downloaded files..."
 	@for f in \
@@ -118,7 +104,7 @@ download-docker-binaries:
 			exit 1; \
 		fi; \
 	done
-	
+
 	@# Verify redpanda directories exist
 	@if [ ! -d .docker-cache/redpanda/amd64/redpanda ] || [ ! -d .docker-cache/redpanda/arm64/redpanda ]; then \
 		echo "Missing required Redpanda directories"; \
@@ -200,7 +186,7 @@ test: vet nilaway lint
 unit-test: vet nilaway lint
 	ginkgo -r -v --tags=test --label-filter='!integration && !redpanda-extended' --fail-fast ./...
 
-benchmark: 
+benchmark:
 	@echo "Running benchmarks..."
 	go test -bench=. -benchmem ./...
 

--- a/umh-core/pkg/communicator/actions/action_helper.go
+++ b/umh-core/pkg/communicator/actions/action_helper.go
@@ -50,7 +50,8 @@ func SendLimitedLogs(
 	userEmail string,
 	actionUUID uuid.UUID,
 	outboundChannel chan *models.UMHMessage,
-	actionType models.ActionType) []s6.LogEntry {
+	actionType models.ActionType,
+	remainingSeconds int) []s6.LogEntry {
 
 	if len(logs) <= len(lastLogs) {
 		return lastLogs
@@ -67,18 +68,35 @@ func SendLimitedLogs(
 	}
 
 	for _, log := range logsToSend[:end] {
+		stateMessage := RemainingPrefixSec(remainingSeconds) + "received log line: " + log.Content
 		SendActionReply(instanceUUID, userEmail, actionUUID, models.ActionExecuting,
-			fmt.Sprintf("[Benthos Log] %s", log.Content),
+			stateMessage,
 			outboundChannel, actionType)
 	}
 
 	// Send message about remaining logs if any
 	if remainingLogs > 0 {
+		stateMessage := RemainingPrefixSec(remainingSeconds) + fmt.Sprintf("%d remaining logs not displayed", remainingLogs)
 		SendActionReply(instanceUUID, userEmail, actionUUID, models.ActionExecuting,
-			fmt.Sprintf("[Benthos Log] %d remaining logs not displayed", remainingLogs),
+			stateMessage,
 			outboundChannel, actionType)
 	}
 
 	// Return updated lastLogs to include all logs we've seen, even if not all were sent
 	return logs
+}
+
+// RemainingPrefixSec formats d (assumed ≤20 s) as "[left: NN s] ".
+func RemainingPrefixSec(dSeconds int) string {
+	return fmt.Sprintf("[left: %02d s] ", dSeconds) // fixed 15-rune prefix
+}
+
+// High-level label for one-off (non-polling) messages.
+//
+//	action = "deploy", "edit" …
+//	name   = human name of the component
+//
+// → "deploy(foo): "
+func Label(action, name string) string {
+	return fmt.Sprintf("%s(%s): ", action, name)
 }

--- a/umh-core/pkg/communicator/actions/deploy-dataflowcomponent_test.go
+++ b/umh-core/pkg/communicator/actions/deploy-dataflowcomponent_test.go
@@ -486,7 +486,7 @@ var _ = Describe("DeployDataflowComponent", func() {
 			// Execute the action
 			result, metadata, err := action.Execute()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(ContainSubstring("Successfully deployed dataflow component"))
+			Expect(result).To(ContainSubstring("success"))
 			Expect(metadata).To(BeNil())
 
 			// Stop the state mocker
@@ -544,7 +544,7 @@ var _ = Describe("DeployDataflowComponent", func() {
 			// Execute the action - should fail
 			result, metadata, err := action.Execute()
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("Failed to add dataflow component: mock add dataflow component failure"))
+			Expect(err.Error()).To(ContainSubstring("failed to add dataflow component: mock add dataflow component failure"))
 			Expect(result).To(BeNil())
 			Expect(metadata).To(BeNil())
 
@@ -557,11 +557,11 @@ var _ = Describe("DeployDataflowComponent", func() {
 
 			// Extract the ActionReplyPayload from the decoded message
 			actionReplyPayload, ok := decodedMessage.Payload.(map[string]interface{})
-			Expect(ok).To(BeTrue(), "Failed to cast Payload to map[string]interface{}")
+			Expect(ok).To(BeTrue(), "failed to cast Payload to map[string]interface{}")
 
 			actionReplyPayloadStr, ok := actionReplyPayload["actionReplyPayload"].(string)
-			Expect(ok).To(BeTrue(), "Failed to extract actionReplyPayload as string")
-			Expect(actionReplyPayloadStr).To(ContainSubstring("Adding dataflow component 'test-component' to configuration.."))
+			Expect(ok).To(BeTrue(), "failed to extract actionReplyPayload as string")
+			Expect(actionReplyPayloadStr).To(ContainSubstring("adding to configuration"))
 		})
 
 		It("should process inject data with cache resources, rate limit resources, and buffer", func() {
@@ -618,7 +618,7 @@ buffer:
 			// Execute the action
 			result, metadata, err := action.Execute()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(ContainSubstring("Successfully deployed dataflow component: test-component-with-inject"))
+			Expect(result).To(ContainSubstring("success"))
 			Expect(metadata).To(BeNil())
 
 			// Stop the state mocker

--- a/umh-core/pkg/communicator/actions/edit-dataflowcomponent_test.go
+++ b/umh-core/pkg/communicator/actions/edit-dataflowcomponent_test.go
@@ -443,7 +443,7 @@ var _ = Describe("EditDataflowComponent", func() {
 			// Execute the action
 			result, metadata, err := action.Execute()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(ContainSubstring("Successfully edited dataflow component: test-component-updated"))
+			Expect(result).To(ContainSubstring("success"))
 			Expect(metadata).To(BeNil())
 
 			// Stop the state mocker
@@ -522,7 +522,7 @@ buffer:
 			// Execute the action
 			result, metadata, err := action.Execute()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(ContainSubstring("Successfully edited dataflow component"))
+			Expect(result).To(ContainSubstring("success"))
 			Expect(metadata).To(BeNil())
 
 			// Stop the state mocker
@@ -579,7 +579,7 @@ buffer:
 			// Execute the action - should fail
 			result, metadata, err := action.Execute()
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("Failed to edit dataflow component: mock edit dataflow component failure"))
+			Expect(err.Error()).To(ContainSubstring("failed to edit dataflow component: mock edit dataflow component failure"))
 			Expect(result).To(BeNil())
 			Expect(metadata).To(BeNil())
 
@@ -593,7 +593,7 @@ buffer:
 
 			actionReplyPayloadStr, ok := actionReplyPayload["actionReplyPayload"].(string)
 			Expect(ok).To(BeTrue(), "Failed to extract actionReplyPayload as string")
-			Expect(actionReplyPayloadStr).To(ContainSubstring("Updating dataflow component 'test-component-updated' configuration.."))
+			Expect(actionReplyPayloadStr).To(ContainSubstring("updating configuration"))
 		})
 
 		It("should handle failure when component not found", func() {

--- a/umh-core/pkg/service/container_monitor/macos_adjusted_metrics.go
+++ b/umh-core/pkg/service/container_monitor/macos_adjusted_metrics.go
@@ -1,0 +1,50 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !darwin
+// +build !darwin
+
+package container_monitor
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/unix"
+)
+
+// getMacOSAdjustedDiskMetrics retrieves adjusted disk metrics using unix.Statfs.
+// It uses stat.Frsize when available, since on Docker Desktop for macOS the reported
+// Bsize is often 1024× larger than the actual block size.
+// We use unix.Statfs directly instead of relying on gopsutil's disk.Usage because:
+// 1. It gives us direct access to the Frsize field which is crucial for proper block size calculation
+// 2. gopsutil doesn't handle the Docker Desktop for macOS edge case correctly
+func (c *ContainerMonitorService) getMacOSAdjustedDiskMetrics() (usedBytes, totalBytes uint64, err error) {
+	var stat unix.Statfs_t
+	err = unix.Statfs(c.dataPath, &stat)
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to stat filesystem at %s: %w", c.dataPath, err)
+	}
+
+	// Use Frsize if available; it represents the fundamental block size for macOS.
+	bSize := uint64(stat.Bsize)
+	if stat.Frsize > 0 {
+		bSize = uint64(stat.Frsize)
+	}
+
+	// Compute total and used bytes based on the corrected block size.
+	totalBytes = stat.Blocks * bSize
+	usedBytes = (stat.Blocks - stat.Bfree) * bSize
+
+	return usedBytes, totalBytes, nil
+}

--- a/umh-core/pkg/service/container_monitor/macos_adjusted_metrics_darwin.go
+++ b/umh-core/pkg/service/container_monitor/macos_adjusted_metrics_darwin.go
@@ -1,0 +1,23 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build darwin
+// +build darwin
+
+package container_monitor
+
+// getMacOSAdjustedDiskMetrics is not implemented for Darwin / MacOS
+func (c *ContainerMonitorService) getMacOSAdjustedDiskMetrics() (usedBytes, totalBytes uint64, err error) {
+	return 0, 0, nil
+}


### PR DESCRIPTION
Fixes ENG-3000

I standardized the reporting for editing and deploying a DFC to provide more information and also more consistent log output (same length of the prefix, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Standardized and shortened status and error messages for deployment and editing actions, providing clearer and more uniform updates with concise labels and remaining time indicators.
  - Updated test assertions to reflect new message formats with simplified, lowercase, and generic substrings for success and error validations.

- **New Features**
  - Status updates now include a countdown of remaining seconds during certain actions, enhancing user awareness of ongoing processes.

- **Chores**
  - Removed duplicated license headers and cleaned up formatting in the Makefile.

- **Bug Fixes**
  - Improved disk usage metrics calculation for macOS environments by adjusting block size handling, ensuring more accurate container monitoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->