### PR TITLE
[ENG-3005] Add Time to Logs

### DIFF
--- a/umh-core/pkg/communicator/actions/get-logs.go
+++ b/umh-core/pkg/communicator/actions/get-logs.go
@@ -121,7 +121,9 @@ func mapS6LogsToSlice(s6Logs []s6.LogEntry, startTimeUTC time.Time) []string {
 			continue
 		}
 
-		logs = append(logs, log.Content)
+		logline := fmt.Sprintf("[%s] %s", log.Timestamp.Format(time.RFC3339), log.Content)
+
+		logs = append(logs, logline)
 	}
 
 	return logs


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Log entries now display timestamps in RFC3339 format, making it easier to track when each log event occurred.

- **Tests**
  - Updated tests to verify that log outputs include timestamps formatted in RFC3339.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->