### PR TITLE
[ENG-3007] [ENG-3014] Better Errors for DFC deploy and edit

### DIFF
--- a/umh-core/pkg/communicator/actions/actions.go
+++ b/umh-core/pkg/communicator/actions/actions.go
@@ -149,6 +149,8 @@ func HandleActionMessage(instanceUUID uuid.UUID, payload models.ActionMessagePay
 	// Parse the action payload
 	err := action.Parse(payload.ActionPayload)
 	if err != nil {
+		// If parsing fails, send a structured error reply using SendActionReplyV2 with ErrRetryParseFailed
+		SendActionReplyV2(instanceUUID, sender, payload.ActionUUID, models.ActionFinishedWithFailure, "Failed to parse action payload: "+err.Error(), models.ErrRetryParseFailed, nil, outboundChannel, payload.ActionType, nil)
 		log.Errorf("Error parsing action payload: %s", err)
 		return
 	}
@@ -157,6 +159,8 @@ func HandleActionMessage(instanceUUID uuid.UUID, payload models.ActionMessagePay
 	// Validate the action payload
 	err = action.Validate()
 	if err != nil {
+		// If validation fails, send a structured error reply using SendActionReplyV2 with ErrEditValidationFailed
+		SendActionReplyV2(instanceUUID, sender, payload.ActionUUID, models.ActionFinishedWithFailure, "Failed to validate action payload: "+err.Error(), models.ErrEditValidationFailed, nil, outboundChannel, payload.ActionType, nil)
 		log.Errorf("Error validating action payload: %s", err)
 		return
 	}
@@ -282,4 +286,110 @@ func ParseActionPayload[T any](actionPayload interface{}) (T, error) {
 	}
 
 	return payload, nil
+}
+
+// SendActionReplyV2 sends an action reply with the given state and payload which is a map[string]interface{}
+// SendActionReplyV2 should be used only for ActionFailure messages for backwards compatibility. This will be changed in the future.
+// This function is preferred over SendActionReply as it is more flexible and allows for more complex payloads
+// The return type is a bool and returns false if an error occurred
+func SendActionReplyV2(
+	instanceUUID uuid.UUID,
+	userEmail string,
+	actionUUID uuid.UUID,
+	arstate models.ActionReplyState,
+	message string,
+	errorCode string,
+	payloadV2 map[string]interface{},
+	outboundChannel chan *models.UMHMessage,
+	action models.ActionType,
+	actionContext map[string]interface{},
+) bool {
+
+	return sendActionReplyWithAdditionalContextV2(instanceUUID, userEmail, actionUUID, arstate, message, errorCode, payloadV2, outboundChannel, action, actionContext)
+}
+
+func sendActionReplyWithAdditionalContextV2(
+	instanceUUID uuid.UUID,
+	userEmail string,
+	actionUUID uuid.UUID,
+	arstate models.ActionReplyState,
+	message string,
+	errorCode string,
+	payloadV2 map[string]interface{},
+	outboundChannel chan *models.UMHMessage,
+	action models.ActionType,
+	actionContext map[string]interface{},
+) bool {
+
+	err := sendActionReplyInternalV2(instanceUUID, userEmail, actionUUID, arstate, message, errorCode, payloadV2, outboundChannel, actionContext)
+	if err != nil {
+		sentry.ReportIssuef(sentry.IssueTypeError, logger.For(logger.ComponentCommunicator), "Error generating action reply: %w", err)
+		return false
+	}
+	return true
+}
+
+func sendActionReplyInternalV2(
+	instanceUUID uuid.UUID,
+	userEmail string,
+	actionUUID uuid.UUID,
+	arstate models.ActionReplyState,
+	message string,
+	errorCode string,
+	payloadV2 map[string]interface{},
+	outboundChannel chan *models.UMHMessage,
+	actionContext map[string]interface{},
+) error {
+	payloadResponse := ConstructActionReplyV2Response(message, errorCode, arstate, actionUUID.String(), payloadV2, actionContext)
+
+	umhMessageV2, err := generateUMHMessage(instanceUUID, userEmail, models.ActionReply, payloadResponse)
+	if err != nil {
+		sentry.ReportIssuef(sentry.IssueTypeError, logger.For(logger.ComponentCommunicator), "Error generating umh message: %w", err)
+		return err
+	}
+	outboundChannel <- &umhMessageV2
+
+	return nil
+}
+
+// ConstructActionReplyV2Response creates a new ActionReplyResponseSchemaJson
+func ConstructActionReplyV2Response(
+	message string,
+	errorCode string,
+	actionReplyState models.ActionReplyState,
+	actionUUID string,
+	payloadV2 map[string]interface{},
+	actionContext models.ActionReplyResponseSchemaJsonActionContext,
+) models.ActionReplyResponseSchemaJson {
+	//  For backwards compatibility, we need to support the old payload format
+	//  This will be removed in the future
+	var payload interface{}
+	if message != "" {
+		payload = message
+	}
+
+	// if payload is still nil, we use the first message from payloadV2
+	if payload == nil {
+		// Get first message from map regardless of key
+		payload = GetFirstMessageFromMap(payloadV2)
+	}
+
+	return models.ActionReplyResponseSchemaJson{
+		ActionContext:      actionContext,
+		ActionReplyPayload: payload,
+		ActionReplyPayloadV2: &models.ActionReplyResponseSchemaJsonActionReplyPayloadV2{
+			Message:   message,
+			ErrorCode: &errorCode,
+			Payload:   payloadV2,
+		},
+		ActionReplyState: models.ActionReplyResponseSchemaJsonActionReplyState(actionReplyState),
+		ActionUUID:       actionUUID,
+	}
+}
+
+func GetFirstMessageFromMap(msg map[string]interface{}) interface{} {
+	for _, v := range msg {
+		return v
+	}
+	return nil
 }

--- a/umh-core/pkg/communicator/actions/actions.go
+++ b/umh-core/pkg/communicator/actions/actions.go
@@ -183,6 +183,9 @@ func HandleActionMessage(instanceUUID uuid.UUID, payload models.ActionMessagePay
 // It is a convenience wrapper around SendActionReplyWithAdditionalContext that doesn't include additional context.
 // It returns false if an error occurred during message generation or sending.
 func SendActionReply(instanceUUID uuid.UUID, userEmail string, actionUUID uuid.UUID, arstate models.ActionReplyState, payload interface{}, outboundChannel chan *models.UMHMessage, action models.ActionType) bool {
+	// TODO: The 'action' parameter will be used in the future for action-specific logic or logging
+	_ = action
+
 	return SendActionReplyWithAdditionalContext(instanceUUID, userEmail, actionUUID, arstate, payload, outboundChannel, action, nil)
 }
 
@@ -193,6 +196,9 @@ func SendActionReply(instanceUUID uuid.UUID, userEmail string, actionUUID uuid.U
 // This is the primary method for sending action status messages to users, and is
 // used for confirmation, progress updates, success, and failure notifications.
 func SendActionReplyWithAdditionalContext(instanceUUID uuid.UUID, userEmail string, actionUUID uuid.UUID, arstate models.ActionReplyState, payload interface{}, outboundChannel chan *models.UMHMessage, action models.ActionType, actionContext map[string]interface{}) bool {
+	// TODO: The 'action' parameter will be used in the future for action-specific logic or logging
+	_ = action
+
 	err := sendActionReplyInternal(instanceUUID, userEmail, actionUUID, arstate, payload, outboundChannel, actionContext)
 	if err != nil {
 		sentry.ReportIssuef(sentry.IssueTypeError, logger.For(logger.ComponentCommunicator), "Error generating action reply: %w", err)
@@ -305,6 +311,8 @@ func SendActionReplyV2(
 	action models.ActionType,
 	actionContext map[string]interface{},
 ) bool {
+	// TODO: The 'action' parameter will be used in the future for action-specific logic or logging
+	_ = action
 
 	return sendActionReplyWithAdditionalContextV2(instanceUUID, userEmail, actionUUID, arstate, message, errorCode, payloadV2, outboundChannel, action, actionContext)
 }
@@ -321,6 +329,8 @@ func sendActionReplyWithAdditionalContextV2(
 	action models.ActionType,
 	actionContext map[string]interface{},
 ) bool {
+	// TODO: The 'action' parameter will be used in the future for action-specific logic or logging
+	_ = action
 
 	err := sendActionReplyInternalV2(instanceUUID, userEmail, actionUUID, arstate, message, errorCode, payloadV2, outboundChannel, actionContext)
 	if err != nil {

--- a/umh-core/pkg/communicator/actions/actions.go
+++ b/umh-core/pkg/communicator/actions/actions.go
@@ -151,7 +151,7 @@ func HandleActionMessage(instanceUUID uuid.UUID, payload models.ActionMessagePay
 	if err != nil {
 		// If parsing fails, send a structured error reply using SendActionReplyV2 with ErrRetryParseFailed
 		// this will allow the UI to retry the action
-		SendActionReplyV2(instanceUUID, sender, payload.ActionUUID, models.ActionFinishedWithFailure, "Failed to parse action payload: "+err.Error(), models.ErrRetryParseFailed, nil, outboundChannel, payload.ActionType, nil)
+		SendActionReplyV2(instanceUUID, sender, payload.ActionUUID, models.ActionFinishedWithFailure, "Failed to parse action payload: "+err.Error(), models.ErrParseFailed, nil, outboundChannel, payload.ActionType, nil)
 		log.Errorf("Error parsing action payload: %s", err)
 		return
 	}
@@ -161,7 +161,7 @@ func HandleActionMessage(instanceUUID uuid.UUID, payload models.ActionMessagePay
 	err = action.Validate()
 	if err != nil {
 		// If validation fails, send a structured error reply using SendActionReplyV2 with ErrEditValidationFailed
-		SendActionReplyV2(instanceUUID, sender, payload.ActionUUID, models.ActionFinishedWithFailure, "Failed to validate action payload: "+err.Error(), models.ErrEditValidationFailed, nil, outboundChannel, payload.ActionType, nil)
+		SendActionReplyV2(instanceUUID, sender, payload.ActionUUID, models.ActionFinishedWithFailure, "Failed to validate action payload: "+err.Error(), models.ErrValidationFailed, nil, outboundChannel, payload.ActionType, nil)
 		log.Errorf("Error validating action payload: %s", err)
 		return
 	}

--- a/umh-core/pkg/communicator/actions/actions.go
+++ b/umh-core/pkg/communicator/actions/actions.go
@@ -150,6 +150,7 @@ func HandleActionMessage(instanceUUID uuid.UUID, payload models.ActionMessagePay
 	err := action.Parse(payload.ActionPayload)
 	if err != nil {
 		// If parsing fails, send a structured error reply using SendActionReplyV2 with ErrRetryParseFailed
+		// this will allow the UI to retry the action
 		SendActionReplyV2(instanceUUID, sender, payload.ActionUUID, models.ActionFinishedWithFailure, "Failed to parse action payload: "+err.Error(), models.ErrRetryParseFailed, nil, outboundChannel, payload.ActionType, nil)
 		log.Errorf("Error parsing action payload: %s", err)
 		return

--- a/umh-core/pkg/communicator/actions/benthos-log-checker.go
+++ b/umh-core/pkg/communicator/actions/benthos-log-checker.go
@@ -29,6 +29,10 @@ var ErrBenthosLogLines = []string{
 // Benthos configuration errors. It performs case-insensitive checks for known
 // error patterns combined with the word "error". Returns true if any errors
 // are detected, false otherwise.
+// This function is used to detect fatal configuration errors that would cause
+// Benthos to enter a CrashLoop. When such errors are detected, we can immediately
+// abort the startup process rather than waiting for the full timeout period,
+// as these errors require configuration changes to resolve.
 func CheckBenthosLogLinesForConfigErrors(logs []s6.LogEntry) bool {
 	for _, log := range logs {
 		logContent := strings.ToLower(log.Content)

--- a/umh-core/pkg/communicator/actions/benthos-log-checker.go
+++ b/umh-core/pkg/communicator/actions/benthos-log-checker.go
@@ -1,0 +1,37 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package actions
+
+import (
+	"strings"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/s6"
+)
+
+var ErrBenthosLogLines = []string{
+	"unable to infer",
+	"Config lint error",
+}
+
+func CheckBenthosLogLinesForConfigErrors(logs []s6.LogEntry) bool {
+	for _, log := range logs {
+		for _, errLine := range ErrBenthosLogLines {
+			if strings.Contains(log.Content, errLine) && strings.Contains(log.Content, "error") {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/umh-core/pkg/communicator/actions/benthos-log-checker.go
+++ b/umh-core/pkg/communicator/actions/benthos-log-checker.go
@@ -25,10 +25,19 @@ var ErrBenthosLogLines = []string{
 	"Config lint error",
 }
 
+// CheckBenthosLogLinesForConfigErrors examines a slice of S6 log entries for
+// Benthos configuration errors. It performs case-insensitive checks for known
+// error patterns combined with the word "error". Returns true if any errors
+// are detected, false otherwise.
 func CheckBenthosLogLinesForConfigErrors(logs []s6.LogEntry) bool {
 	for _, log := range logs {
+		logContent := strings.ToLower(log.Content)
+		if !strings.Contains(logContent, "error") {
+			continue
+		}
+
 		for _, errLine := range ErrBenthosLogLines {
-			if strings.Contains(log.Content, errLine) && strings.Contains(log.Content, "error") {
+			if strings.Contains(logContent, strings.ToLower(errLine)) {
 				return true
 			}
 		}

--- a/umh-core/pkg/communicator/actions/deploy-dataflowcomponent.go
+++ b/umh-core/pkg/communicator/actions/deploy-dataflowcomponent.go
@@ -638,9 +638,10 @@ func (a *DeployDataflowComponentAction) waitForComponentToBeActive() (string, er
 						err := a.configManager.AtomicDeleteDataflowcomponent(ctx, dataflowcomponentserviceconfig.GenerateUUIDFromName(a.name))
 						if err != nil {
 							a.actionLogger.Errorf("failed to remove dataflowcomponent %s: %v", a.name, err)
-							SendActionReplyV2(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedWithFailure, "DFC not removed. Please check your configuration and consider, removing the component manually..", "ERR_CONFIG_ERROR", nil, a.outboundChannel, models.DeployDataFlowComponent, nil)
+							SendActionReplyV2(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedWithFailure, "DFC not removed. Please check your configuration and consider removing the component manually.", "ERR_CONFIG_ERROR", nil, a.outboundChannel, models.DeployDataFlowComponent, nil)
+						} else {
+							SendActionReplyV2(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedWithFailure, "DFC removed", "ERR_CONFIG_ERROR", nil, a.outboundChannel, models.DeployDataFlowComponent, nil)
 						}
-						SendActionReplyV2(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedWithFailure, "DFC removed", "ERR_CONFIG_ERROR", nil, a.outboundChannel, models.DeployDataFlowComponent, nil)
 						return models.ErrConfigFileInvalid, fmt.Errorf("dataflow component '%s' was removed because of a config error", a.name)
 					}
 

--- a/umh-core/pkg/communicator/actions/deploy-dataflowcomponent.go
+++ b/umh-core/pkg/communicator/actions/deploy-dataflowcomponent.go
@@ -628,6 +628,10 @@ func (a *DeployDataflowComponentAction) waitForComponentToBeActive() (string, er
 
 					// only send the logs that have not been sent yet
 					if len(logs) > len(lastLogs) {
+						// SendLimitedLogs is used to detect fatal configuration errors that would cause
+						// Benthos to enter a CrashLoop. When such errors are detected, we can immediately
+						// abort the startup process rather than waiting for the full timeout period,
+						// as these errors require configuration changes to resolve.
 						lastLogs = SendLimitedLogs(logs, lastLogs, a.instanceUUID, a.userEmail, a.actionUUID, a.outboundChannel, models.DeployDataFlowComponent, remainingSeconds)
 					}
 					// check if the logs contain any of the error lines and if so, cancel the action with rolling back

--- a/umh-core/pkg/communicator/actions/deploy-dataflowcomponent.go
+++ b/umh-core/pkg/communicator/actions/deploy-dataflowcomponent.go
@@ -628,13 +628,13 @@ func (a *DeployDataflowComponentAction) waitForComponentToBeActive() (string, er
 
 					// only send the logs that have not been sent yet
 					if len(logs) > len(lastLogs) {
-						// SendLimitedLogs is used to detect fatal configuration errors that would cause
-						// Benthos to enter a CrashLoop. When such errors are detected, we can immediately
-						// abort the startup process rather than waiting for the full timeout period,
-						// as these errors require configuration changes to resolve.
+
 						lastLogs = SendLimitedLogs(logs, lastLogs, a.instanceUUID, a.userEmail, a.actionUUID, a.outboundChannel, models.DeployDataFlowComponent, remainingSeconds)
 					}
-					// check if the logs contain any of the error lines and if so, cancel the action with rolling back
+					// CheckBenthosLogLinesForConfigErrors is used to detect fatal configuration errors that would cause
+					// Benthos to enter a CrashLoop. When such errors are detected, we can immediately
+					// abort the startup process rather than waiting for the full timeout period,
+					// as these errors require configuration changes to resolve.
 					if CheckBenthosLogLinesForConfigErrors(logs) {
 						SendActionReply(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionExecuting, "Failed to parse config. Removing the component.", a.outboundChannel, models.DeployDataFlowComponent)
 						ctx, cancel := context.WithTimeout(context.Background(), constants.ActionTimeout)

--- a/umh-core/pkg/communicator/actions/deploy-dataflowcomponent.go
+++ b/umh-core/pkg/communicator/actions/deploy-dataflowcomponent.go
@@ -587,7 +587,7 @@ func (a *DeployDataflowComponentAction) waitForComponentToBeActive() (string, er
 			if err != nil {
 				a.actionLogger.Errorf("failed to remove dataflowcomponent %s: %v", a.name, err)
 			}
-			return "ERR_RETRY_ROLLBACK_TIMEOUT", fmt.Errorf("dataflow component '%s' was removed because it did not become active within the timeout period", a.name)
+			return models.ErrRetryRollbackTimeout, fmt.Errorf("dataflow component '%s' was removed because it did not become active within the timeout period", a.name)
 
 		case <-ticker.C:
 
@@ -641,7 +641,7 @@ func (a *DeployDataflowComponentAction) waitForComponentToBeActive() (string, er
 							SendActionReplyV2(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedWithFailure, "DFC not removed. Please check your configuration and consider, removing the component manually..", "ERR_CONFIG_ERROR", nil, a.outboundChannel, models.DeployDataFlowComponent, nil)
 						}
 						SendActionReplyV2(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedWithFailure, "DFC removed", "ERR_CONFIG_ERROR", nil, a.outboundChannel, models.DeployDataFlowComponent, nil)
-						return "ERR_CONFIG_ERROR", fmt.Errorf("dataflow component '%s' was removed because of a config error", a.name)
+						return models.ErrConfigFileInvalid, fmt.Errorf("dataflow component '%s' was removed because of a config error", a.name)
 					}
 
 				}

--- a/umh-core/pkg/communicator/actions/deploy-dataflowcomponent.go
+++ b/umh-core/pkg/communicator/actions/deploy-dataflowcomponent.go
@@ -524,7 +524,7 @@ func (a *DeployDataflowComponentAction) Execute() (interface{}, map[string]inter
 				errorMsg := Label("deploy", a.name) + fmt.Sprintf("failed to wait for dataflow component to be active: %v", err)
 				// waitForComponentToBeActive gives us the error code, which we then forward to the frontend using the SendActionReplyV2 function
 				// the error code is a string that can be used to identify the error reason
-				// the main reason for this is to allow the frontend to determine weather it should offer a retry option or not
+				// the main reason for this is to allow the frontend to determine whether it should offer a retry option or not
 				SendActionReplyV2(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedWithFailure, errorMsg, errCode, nil, a.outboundChannel, models.DeployDataFlowComponent, nil)
 				return nil, nil, fmt.Errorf("%s", errorMsg)
 			}

--- a/umh-core/pkg/communicator/actions/deploy-dataflowcomponent.go
+++ b/umh-core/pkg/communicator/actions/deploy-dataflowcomponent.go
@@ -554,6 +554,9 @@ func (a *DeployDataflowComponentAction) GetParsedPayload() models.CDFCPayload {
 
 // waitForComponentToBeActive polls live FSM state until the new component
 // becomes active or the timeout hits (→ delete unless ignoreHealthCheck).
+// the function returns the error code and and the error message via an error object
+// the error code is a string that is sent to the frontend to allow it to determine if the action can be retried or not
+// the error message is sent to the frontend to allow the user to see the error message
 func (a *DeployDataflowComponentAction) waitForComponentToBeActive(ctx context.Context) (string, error) {
 	// checks the system snapshot
 	// 1. waits for the instance to appear in the system snapshot

--- a/umh-core/pkg/communicator/actions/edit-dataflowcomponent.go
+++ b/umh-core/pkg/communicator/actions/edit-dataflowcomponent.go
@@ -482,7 +482,7 @@ func (a *EditDataflowComponentAction) Execute() (interface{}, map[string]interfa
 				errorMsg := Label("edit", a.name) + fmt.Sprintf("failed to wait for dataflow component to be active: %v", err)
 				// waitForComponentToBeActive gives us the error code, which we then forward to the frontend using the SendActionReplyV2 function
 				// the error code is a string that can be used to identify the error reason
-				// the main reason for this is to allow the frontend to determine weather it should offer a retry option or not
+				// the main reason for this is to allow the frontend to determine whether it should offer a retry option or not
 				SendActionReplyV2(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedWithFailure, errorMsg, errCode, nil, a.outboundChannel, models.EditDataFlowComponent, nil)
 				return nil, nil, fmt.Errorf("%s", errorMsg)
 			}

--- a/umh-core/pkg/communicator/actions/edit-dataflowcomponent.go
+++ b/umh-core/pkg/communicator/actions/edit-dataflowcomponent.go
@@ -545,7 +545,7 @@ func (a *EditDataflowComponentAction) waitForComponentToBeActive() (string, erro
 
 				a.actionLogger.Errorf("failed to roll back dataflow component %s: %v", a.name, err)
 			}
-			return "ERR_RETRY_ROLLBACK_TIMEOUT", fmt.Errorf("dataflow component %s was not active in time and was rolled back to the old config", a.name)
+			return models.ErrRetryRollbackTimeout, fmt.Errorf("dataflow component %s was not active in time and was rolled back to the old config", a.name)
 
 		case <-ticker.C:
 			elapsed := time.Since(startTime)
@@ -620,7 +620,7 @@ func (a *EditDataflowComponentAction) waitForComponentToBeActive() (string, erro
 								SendActionReplyV2(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedWithFailure, "DFC not rolled back. Please check your configuration and consider, removing the component manually..", "ERR_CONFIG_ERROR", nil, a.outboundChannel, models.DeployDataFlowComponent, nil)
 								a.actionLogger.Errorf("failed to roll back dataflow component %s: %v", a.name, err)
 							}
-							return "ERR_CONFIG_ERROR", fmt.Errorf("dataflow component '%s' was rolled back because of a config error", a.name)
+							return models.ErrConfigFileInvalid, fmt.Errorf("dataflow component '%s' was rolled back because of a config error", a.name)
 						}
 
 						continue

--- a/umh-core/pkg/communicator/actions/edit-dataflowcomponent.go
+++ b/umh-core/pkg/communicator/actions/edit-dataflowcomponent.go
@@ -407,7 +407,7 @@ func (a *EditDataflowComponentAction) Execute() (interface{}, map[string]interfa
 				err := yaml.Unmarshal([]byte(processor.Data), &procConfig)
 				if err != nil {
 					errMsg := Label("edit", a.name) + fmt.Sprintf("failed to parse pipeline processor %s: %s", processorName, err.Error())
-					SendActionReplyV2(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedWithFailure, errMsg, "ERR_RETRY_DFC_TIMEOUT", nil, a.outboundChannel, models.EditDataFlowComponent, nil)
+					SendActionReplyV2(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedWithFailure, errMsg, models.ErrRetryRollbackTimeout, nil, a.outboundChannel, models.EditDataFlowComponent, nil)
 					return nil, nil, fmt.Errorf("%s", errMsg)
 				}
 

--- a/umh-core/pkg/communicator/actions/edit-dataflowcomponent.go
+++ b/umh-core/pkg/communicator/actions/edit-dataflowcomponent.go
@@ -608,13 +608,13 @@ func (a *EditDataflowComponentAction) waitForComponentToBeActive() (string, erro
 
 						// only send the logs that have not been sent yet
 						if len(logs) > len(lastLogs) {
-							// SendLimitedLogs is used to detect fatal configuration errors that would cause
-							// Benthos to enter a CrashLoop. When such errors are detected, we can immediately
-							// abort the startup process rather than waiting for the full timeout period,
-							// as these errors require configuration changes to resolve.
+
 							lastLogs = SendLimitedLogs(logs, lastLogs, a.instanceUUID, a.userEmail, a.actionUUID, a.outboundChannel, models.EditDataFlowComponent, remainingSeconds)
 						}
-						// check if the logs contain any of the error lines and if so, cancel the action with rolling back
+						// CheckBenthosLogLinesForConfigErrors is used to detect fatal configuration errors that would cause
+						// Benthos to enter a CrashLoop. When such errors are detected, we can immediately
+						// abort the startup process rather than waiting for the full timeout period,
+						// as these errors require configuration changes to resolve.
 						if CheckBenthosLogLinesForConfigErrors(logs) {
 							SendActionReply(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionExecuting, "Failed to parse config. Rolling back...", a.outboundChannel, models.EditDataFlowComponent)
 							ctx, cancel := context.WithTimeout(context.Background(), constants.ActionTimeout)

--- a/umh-core/pkg/communicator/actions/edit-dataflowcomponent.go
+++ b/umh-core/pkg/communicator/actions/edit-dataflowcomponent.go
@@ -608,6 +608,10 @@ func (a *EditDataflowComponentAction) waitForComponentToBeActive() (string, erro
 
 						// only send the logs that have not been sent yet
 						if len(logs) > len(lastLogs) {
+							// SendLimitedLogs is used to detect fatal configuration errors that would cause
+							// Benthos to enter a CrashLoop. When such errors are detected, we can immediately
+							// abort the startup process rather than waiting for the full timeout period,
+							// as these errors require configuration changes to resolve.
 							lastLogs = SendLimitedLogs(logs, lastLogs, a.instanceUUID, a.userEmail, a.actionUUID, a.outboundChannel, models.EditDataFlowComponent, remainingSeconds)
 						}
 						// check if the logs contain any of the error lines and if so, cancel the action with rolling back

--- a/umh-core/pkg/communicator/actions/edit-dataflowcomponent.go
+++ b/umh-core/pkg/communicator/actions/edit-dataflowcomponent.go
@@ -522,6 +522,9 @@ func (a *EditDataflowComponentAction) GetComponentUUID() uuid.UUID {
 // Concurrency note: The method never writes to `systemSnapshot`; the FSM runtime
 // is the single writer.  We only take read‑locks while **copying** the full
 // snapshot to avoid holding the lock during YAML comparisons.
+// the function returns the error code and and the error message via an error object
+// the error code is a string that is sent to the frontend to allow it to determine if the action can be retried or not
+// the error message is sent to the frontend to allow the user to see the error message
 func (a *EditDataflowComponentAction) waitForComponentToBeActive(ctx context.Context) (string, error) {
 	// checks the system snapshot
 	// 1. waits for the component to appear in the system snapshot (relevant for changed name)

--- a/umh-core/pkg/models/action_models.go
+++ b/umh-core/pkg/models/action_models.go
@@ -588,5 +588,6 @@ const (
 	ErrRetryDFCConfigError  = "ERR_RETRY_DFC_CONFIG_ERROR"
 	ErrSendingActionReply   = "ERR_SENDING_REPLY"
 	ErrAbortRollbackFailed  = "ERR_ABORT_ROLLBACK_FAILED"
-	ErrEditPayload          = "ERR_EDIT_PAYLOAD"
+	ErrRetryRollbackTimeout = "ERR_RETRY_ROLLBACK_TIMEOUT"
+	ErrConfigFileInvalid    = "ERR_CONFIG_FILE_INVALID"
 )

--- a/umh-core/pkg/models/action_models.go
+++ b/umh-core/pkg/models/action_models.go
@@ -532,3 +532,62 @@ type GetLogsResponse struct {
 type GetDataflowcomponentMetricsRequest struct {
 	UUID string `json:"uuid" binding:"required"`
 }
+
+type ActionReplyResponseSchemaJson struct {
+	// Additional contextual data for the action, allows arbitrary key-value pairs.
+	ActionContext ActionReplyResponseSchemaJsonActionContext `json:"actionContext,omitempty" yaml:"actionContext,omitempty" mapstructure:"actionContext,omitempty"`
+
+	// Legacy action reply payload, can be a string or an object for backward
+	// compatibility.
+	ActionReplyPayload interface{} `json:"actionReplyPayload" yaml:"actionReplyPayload" mapstructure:"actionReplyPayload"`
+
+	// Structured response payload for any action reply.
+	ActionReplyPayloadV2 *ActionReplyResponseSchemaJsonActionReplyPayloadV2 `json:"actionReplyPayloadV2,omitempty" yaml:"actionReplyPayloadV2,omitempty" mapstructure:"actionReplyPayloadV2,omitempty"`
+
+	// State of the action reply.
+	ActionReplyState ActionReplyResponseSchemaJsonActionReplyState `json:"actionReplyState" yaml:"actionReplyState" mapstructure:"actionReplyState"`
+
+	// Unique identifier for the action.
+	ActionUUID string `json:"actionUUID" yaml:"actionUUID" mapstructure:"actionUUID"`
+}
+
+// Additional contextual data for the action, allows arbitrary key-value pairs.
+type ActionReplyResponseSchemaJsonActionContext map[string]interface{}
+
+type ActionReplyResponseSchemaJsonActionReplyPayloadV2 struct {
+	// Machine-readable error code (e.g., 'ERR_CONFIG_CHANGED').
+	ErrorCode *string `json:"errorCode,omitempty" yaml:"errorCode,omitempty" mapstructure:"errorCode,omitempty"`
+
+	// Human-readable error message.
+	Message string `json:"message" yaml:"message" mapstructure:"message"`
+
+	// Additional payload for the action reply.
+	Payload ActionReplyResponseSchemaJsonActionReplyPayloadV2Payload `json:"payload,omitempty" yaml:"payload,omitempty" mapstructure:"payload,omitempty"`
+}
+
+type ActionReplyResponseSchemaJsonActionReplyState string
+
+const ActionReplyResponseSchemaJsonActionReplyStateActionConfirmed ActionReplyResponseSchemaJsonActionReplyState = "action-confirmed"
+const ActionReplyResponseSchemaJsonActionReplyStateActionExecuting ActionReplyResponseSchemaJsonActionReplyState = "action-executing"
+const ActionReplyResponseSchemaJsonActionReplyStateActionFailure ActionReplyResponseSchemaJsonActionReplyState = "action-failure"
+const ActionReplyResponseSchemaJsonActionReplyStateActionSuccess ActionReplyResponseSchemaJsonActionReplyState = "action-success"
+
+// var enumValues_ActionReplyResponseSchemaJsonActionReplyState = []interface{}{
+// 	"action-confirmed",
+// 	"action-executing",
+// 	"action-success",
+// 	"action-failure",
+// }
+
+type ActionReplyResponseSchemaJsonActionReplyPayloadV2Payload map[string]interface{}
+
+const (
+	ErrRetryParseFailed     = "ERR_RETRY_ACTION_PARSE_FAILED"
+	ErrEditValidationFailed = "ERR_EDIT_VALIDATION_FAILED"
+	ErrAbortExecutionFailed = "ERR_ABORT_EXECUTION_FAILED"
+	ErrRetryDFCTimeout      = "ERR_RETRY_DFC_TIMEOUT"
+	ErrRetryDFCConfigError  = "ERR_RETRY_DFC_CONFIG_ERROR"
+	ErrSendingActionReply   = "ERR_SENDING_REPLY"
+	ErrAbortRollbackFailed  = "ERR_ABORT_ROLLBACK_FAILED"
+	ErrEditPayload          = "ERR_EDIT_PAYLOAD"
+)

--- a/umh-core/pkg/models/action_models.go
+++ b/umh-core/pkg/models/action_models.go
@@ -580,14 +580,21 @@ const ActionReplyResponseSchemaJsonActionReplyStateActionSuccess ActionReplyResp
 
 type ActionReplyResponseSchemaJsonActionReplyPayloadV2Payload map[string]interface{}
 
+// Error codes for the action reply payload.
+// The error codes have two purposes:
+// 1. To allow the frontend to determine if the action can be retried or not
+// 2. To display them to the user
+// if an error code starts with "ERR_RETRY_" the action can be retried (see fetcher.js in the frontend)
 const (
-	ErrRetryParseFailed     = "ERR_RETRY_ACTION_PARSE_FAILED"
-	ErrEditValidationFailed = "ERR_EDIT_VALIDATION_FAILED"
-	ErrAbortExecutionFailed = "ERR_ABORT_EXECUTION_FAILED"
-	ErrRetryDFCTimeout      = "ERR_RETRY_DFC_TIMEOUT"
-	ErrRetryDFCConfigError  = "ERR_RETRY_DFC_CONFIG_ERROR"
-	ErrSendingActionReply   = "ERR_SENDING_REPLY"
-	ErrAbortRollbackFailed  = "ERR_ABORT_ROLLBACK_FAILED"
+	// ErrParseFailed is the error code for a failed parse of the action payload.
+	// the error is not retryable because the parsing is deterministic
+	ErrParseFailed = "ERR_ACTION_PARSE_FAILED"
+	// ErrValidationFailed is the error code for a failed validation of the action payload.
+	// the error is not retryable because the validation is deterministic
+	ErrValidationFailed = "ERR_VALIDATION_FAILED"
+	// ErrRetryRollbackTimeout is the error code for a timeout during the dfc deployment.
+	// It is retryable because the timeout might be caused by a busy system.
 	ErrRetryRollbackTimeout = "ERR_RETRY_ROLLBACK_TIMEOUT"
-	ErrConfigFileInvalid    = "ERR_CONFIG_FILE_INVALID"
+	// ErrConfigFileInvalid is sent when the deployment of a dfc fails because the config file is invalid.
+	ErrConfigFileInvalid = "ERR_CONFIG_FILE_INVALID"
 )


### PR DESCRIPTION
This PR introduces early aborts on benthos config errors and provides the frontend with better error info (i.e. error code) so that it can determine weather to offer the user the retry-option or not. Therefore, we include the SendActionReplyV2 which already existed in UMH Classic. In the frontend, the fetcher checks the action reply error code for the prefix `ERR_RETRY_`  . If it finds the prefix in the error code or no error code at all, the retry option is displayed. 