### PR TITLE
ENG-3037 Fix unbound variable error in notify mc job

### DIFF
--- a/.github/workflows/build-umh-core.yml
+++ b/.github/workflows/build-umh-core.yml
@@ -284,6 +284,7 @@ jobs:
         run: |
           set -euo pipefail
           VERSION="${{ github.ref_name }}"
+          SECRET="${{ secrets.UMH_MC_WEBHOOK_SECRET }}"
 
           notify_mc() {
             local base_url=$1
@@ -299,7 +300,7 @@ jobs:
             if [[ "$CHANNEL" == "nightly" ]]; then
               # Pre-release, simply update the channel
               curl --fail --silent --show-error --max-time 30 --retry 3 -X POST "$base_url/api/v2/webhook/versions/umh-core/update" \
-              -H "X-Webhook-Secret: ${{ secrets.UMH_MC_WEBHOOK_SECRET }}" \
+              -H "X-Webhook-Secret: $SECRET" \
               -H "Content-Type: application/json" \
               -d "{\"channel\":\"${CHANNEL}\",\"version\":\"${VERSION}\"}"
             else
@@ -313,13 +314,13 @@ jobs:
               if [[ "$VERSION" == "$NIGHTLY_BASE_VERSION" ]]; then
                 # Promote nightly to stable
                 curl --fail --silent --show-error --max-time 30 --retry 3 -X POST "$base_url/api/v2/webhook/versions/umh-core/update" \
-                -H "X-Webhook-Secret: ${{ secrets.UMH_MC_WEBHOOK_SECRET }}" \
+                -H "X-Webhook-Secret: $SECRET" \
                 -H "Content-Type: application/json" \
                 -d "{\"channel\":\"stable\",\"version\":\"${VERSION}\",\"isPromotion\":true,\"promotedFrom\":\"nightly\"}"
               else
                 # New stable release without promotion
                 curl --fail --silent --show-error --max-time 30 --retry 3 -X POST "$base_url/api/v2/webhook/versions/umh-core/update" \
-                -H "X-Webhook-Secret: ${{ secrets.UMH_MC_WEBHOOK_SECRET }}" \
+                -H "X-Webhook-Secret: $SECRET" \
                 -H "Content-Type: application/json" \
                 -d "{\"channel\":\"stable\",\"version\":\"${VERSION}\"}"
               fi


### PR DESCRIPTION
Fixed the "unbound variable" error that happened during release by changing how we handle the webhook secret in bash scripts.

- Problem: The secret likely contains special bash characters like `$something` that bash tries to interpret as variables.
- Fix: Store the secret in a variable at the script level before using it in curl commands, preventing bash from trying to expand stuff inside the secret value.

While this should fix the issue, GitHub Actions environments can be unpredictable sometimes...