### PR TITLE
ENG-2986: bump benthos-umh version for uns-plugin

### DIFF
--- a/umh-core/Dockerfile
+++ b/umh-core/Dockerfile
@@ -14,7 +14,7 @@
 # --- Build Stage ---
 FROM golang:1.24.2-alpine as build
 ARG S6_OVERLAY_VERSION=3.2.0.2
-ARG BENTHOS_UMH_VERSION=0.9.2
+ARG BENTHOS_UMH_VERSION=0.9.3-alpha.2
 ARG REDPANDA_VERSION=24.3.8
 ARG DEBUG=false
 ARG PPROF=false
@@ -67,7 +67,7 @@ FROM alpine:3.21 as downloader
 RUN apk add --no-cache bash curl jq tzdata ca-certificates xz bc
 
 ARG S6_OVERLAY_VERSION=3.2.0.2
-ARG BENTHOS_UMH_VERSION=0.9.2
+ARG BENTHOS_UMH_VERSION=0.9.3-alpha.2
 ARG REDPANDA_VERSION=24.3.8
 ARG DLV_VERSION=1.24.2
 ARG TARGETARCH=amd64

--- a/umh-core/Makefile
+++ b/umh-core/Makefile
@@ -24,7 +24,7 @@ TARGETARCH := $(shell go env GOARCH)
 
 # Default values for build arguments
 S6_OVERLAY_VERSION = 3.2.0.2
-BENTHOS_UMH_VERSION = 0.9.2
+BENTHOS_UMH_VERSION = 0.9.3-alpha.2
 REDPANDA_VERSION = 24.3.8
 
 # Debug values


### PR DESCRIPTION
- bump `benthos-umh-version` to `v0.9.3-alpha.2` to include uns-input topic renaming and other minor things