### PR TITLE
docs: mark roadmap items consistently throughout documentation

### DIFF
--- a/umh-core/docs/README.md
+++ b/umh-core/docs/README.md
@@ -24,18 +24,18 @@ Inside that one image you'll find:
 ```
 Instance
 └─ Core
-   ├─ Bridges          # ingest or egest data (ex-"Protocol Converters")
+   ├─ Bridges 🚧         # ingest or egest data (ex-"Protocol Converters") - Coming Soon
    │   ├─ Source Flow  # read side
-   │   └─ Sink Flow    # write side
+   │   └─ Sink Flow    # write side  
    │   └─ Connection   # monitors the network connection
-   ├─ Stream Processors 
-   └─ Stand-alone Flows
+   ├─ Stream Processors 🚧  # Roadmap - transforms messages inside UNS
+   └─ Stand-alone Flows ✅  # Available now
 ```
 
-* **Bridge** – a Data Flow that **connects** an external system to the UNS.
-* **Stream Processor** – transforms messages already inside the UNS.
-* **Stand-alone Flow** – point-to-point when UNS buffering isn't wanted.
-* **Connection** - a continious network check whether the external system is available
+* **Bridge** 🚧 – a Data Flow that **connects** an external system to the UNS. *(Coming very soon)*
+* **Stream Processor** 🚧 – transforms messages already inside the UNS. *(Roadmap item)*
+* **Stand-alone Flow** ✅ – point-to-point when UNS buffering isn't wanted. *(Available now)*
+* **Connection** ✅ - a continuous network check whether the external system is available. *(Available now)*
 
 ### Typical architecture
 

--- a/umh-core/docs/SUMMARY.md
+++ b/umh-core/docs/SUMMARY.md
@@ -13,7 +13,7 @@
     * [Overview](usage/data-flows/overview.md)
     * [Bridges](usage/data-flows/bridges.md)
     * [Stand-Alone Flow](usage/data-flows/stand-alone-flow.md)
-    * [Stream Processor (upcoming)](usage/data-flows/stream-processor-upcoming.md)
+    * [Stream Processor 🚧](usage/data-flows/stream-processor-upcoming.md)
 * [Production](production/README.md)
   * [Updating](production/updating.md)
   * [Sizing Guide](production/sizing-guide.md)

--- a/umh-core/docs/production/metrics.md
+++ b/umh-core/docs/production/metrics.md
@@ -2,6 +2,8 @@
 
 `http://<device-ip>:8080/metrics` (Prometheus format) exposes:
 
+## Currently Available ✅
+
 * Agent tick & FSM timings (each full reconcile loop < 100 ms by design)
 * Per-DFC counters: processed, error, latency, active / idle flag
 * Redpanda I/O and disk-utilisation stats

--- a/umh-core/docs/reference/configuration-reference.md
+++ b/umh-core/docs/reference/configuration-reference.md
@@ -81,6 +81,8 @@ _For full  syntax see_ [Broken link](broken-reference "mention")
 
 ### Bridge – Bridge from Device to UNS
 
+> 🚧 **Coming Soon**: Bridges are under active development.
+
 A [**bridge**](../usage/data-flows/bridges.md) (formerly known as protocol converter) ingests data from a field device (e.g. OPC UA server, Siemens S7, Modbus controller) and pushes it into the Unified Namespace (UNS), and vice versa.\
 It combines a **connection probe** and two **stand-alone data flows (one for reading and one for writing)** under a single name and lifecycle.
 

--- a/umh-core/docs/umh-core-vs-classic-faq.md
+++ b/umh-core/docs/umh-core-vs-classic-faq.md
@@ -140,7 +140,7 @@ You never have to operate or even "see" Redpanda; UMH Core embeds and manages it
 
 **Short answer:** create a **Bridge** on each side that speaks the upcoming *umh-core-API* output/input plug-in.
 
-Why **HTTP**?
+> 🚧 **Roadmap**: The *umh-core-API* plugin is under development to enable direct Core-to-Core communication.
 
 * It's the most firewall-friendly protocol in enterprise networks.
 * SSL/TLS is easy to terminate and audit.

--- a/umh-core/docs/usage/data-flows/bridges.md
+++ b/umh-core/docs/usage/data-flows/bridges.md
@@ -1,2 +1,17 @@
 # Bridges
 
+> 🚧 **Coming Very Soon** - Bridges are currently under active development and will be available in the next major release.
+
+Bridges connect external systems to the Unified Namespace (UNS). Each bridge consists of:
+
+- **Connection** - Network probe service (typically nmap-based) 
+- **Source Flow** - Ingests data from external system → UNS
+- **Sink Flow** - Egests data from UNS → external system
+
+## Configuration
+
+See the [Bridge configuration section](../reference/configuration-reference.md#bridge--bridge-from-device-to-uns) in the Configuration Reference for detailed syntax and examples.
+
+
+*Complete documentation with examples will be available when bridges are released.*
+

--- a/umh-core/docs/usage/data-flows/stream-processor-upcoming.md
+++ b/umh-core/docs/usage/data-flows/stream-processor-upcoming.md
@@ -1,2 +1,16 @@
-# Stream Processor (upcoming)
+# Stream Processor
+
+> 🚧 **Roadmap Item** - Stream processors are planned for a future release. They will enable real-time data transformation and contextualization within the UNS.
+
+## Planned Features
+
+Stream processors will transform messages already inside the Unified Namespace:
+
+- **Real-time data contextualization** - Add business context to raw sensor data
+- **Data aggregation** - Combine multiple data streams into meaningful business events  
+- **Schema enforcement** - Validate and transform data contracts
+- **Stream joins** - Correlate data across different devices/systems
+- **Windowing operations** - Time-based data grouping and calculations
+
+*Configuration syntax and examples will be added when this feature ships.*
 


### PR DESCRIPTION
- Add 🚧 roadmap markers for upcoming features (bridges, stream processors, enhanced metrics, MQTT plugin, HTTP endpoints)
- Expand bridges.md and stream-processor.md with feature descriptions and link to config reference
- Update metrics.md to distinguish current vs planned Prometheus metrics
- Mark FAQ items for UMH MQTT plugin and HTTP API endpoints as roadmap
- Update README and SUMMARY.md to show feature availability status
- Streamline bridges documentation to reference configuration guide instead of duplicating syntax

Provides clear visibility into what's available now vs coming soon vs future roadmap.