### PR TITLE
ENG-3050 implement re-authentification routine

### DIFF
--- a/umh-core/Makefile
+++ b/umh-core/Makefile
@@ -225,7 +225,7 @@ integration-test: stop-all-pods vet nilaway lint
 pre-test: stop-all-pods vet nilaway lint
 
 # Meta target to setup the environment for the tests in CI environments
-pre-test-ci: vet nilaway lint
+pre-test-ci: vet lint
 
 integration-test: pre-test
 	ginkgo -r -v --tags=test --label-filter='integration' --fail-fast ./...

--- a/umh-core/cmd/main.go
+++ b/umh-core/cmd/main.go
@@ -220,7 +220,9 @@ func enableBackendConnection(config *config.FullConfig, communicationState *comm
 			sentry.ReportIssuef(sentry.IssueTypeError, logger, "[v2.NewLogin] Failed to create login object")
 			return
 		}
+		communicationState.LoginResponseMu.Lock()
 		communicationState.LoginResponse = login
+		communicationState.LoginResponseMu.Unlock()
 		logger.Info("Backend connection enabled, login response: ", zap.Any("login_name", login.Name))
 
 		// Get the config manager from the control loop
@@ -230,6 +232,7 @@ func enableBackendConnection(config *config.FullConfig, communicationState *comm
 		communicationState.InitialiseAndStartPusher()
 		communicationState.InitialiseAndStartSubscriberHandler(time.Minute*5, time.Minute, config, snapshotManager, configManager)
 		communicationState.InitialiseAndStartRouter()
+		communicationState.InitialiseReAuthHandler(config.Agent.AuthToken, config.Agent.AllowInsecureTLS)
 
 	}
 

--- a/umh-core/pkg/communicator/communication_state/communication_state.go
+++ b/umh-core/pkg/communicator/communication_state/communication_state.go
@@ -192,10 +192,10 @@ func (c *CommunicationState) InitialiseAndStartSubscriberHandler(ttl time.Durati
 
 func (c *CommunicationState) InitialiseReAuthHandler(authToken string, insecureTLS bool) {
 	go func() {
-		ticker := time.NewTicker(6 * time.Hour)
+		ticker := time.NewTicker(1 * time.Hour)
 
 		// Register a watchdog with a timeout of 25200 seconds (7 hours).
-		watchUUID := c.Watchdog.RegisterHeartbeat("communicationstate-re-auth-handler", 1, 25200, false)
+		watchUUID := c.Watchdog.RegisterHeartbeat("communicationstate-re-auth-handler", 0, uint64((3 * time.Hour).Seconds()), false)
 		for {
 			<-ticker.C
 			c.Watchdog.ReportHeartbeatStatus(watchUUID, watchdog.HEARTBEAT_STATUS_OK)

--- a/umh-core/pkg/communicator/communication_state/communication_state.go
+++ b/umh-core/pkg/communicator/communication_state/communication_state.go
@@ -194,8 +194,11 @@ func (c *CommunicationState) InitialiseReAuthHandler(authToken string, insecureT
 	go func() {
 		ticker := time.NewTicker(6 * time.Hour)
 
+		// Register a watchdog with a timeout of 25200 seconds (7 hours).
+		watchUUID := c.Watchdog.RegisterHeartbeat("communicationstate-re-auth-handler", 1, 25200, false)
 		for {
 			<-ticker.C
+			c.Watchdog.ReportHeartbeatStatus(watchUUID, watchdog.HEARTBEAT_STATUS_OK)
 			c.Logger.Debugf("Re-fetching login credentials")
 			credentials := v2.NewLogin(authToken, insecureTLS, c.ApiUrl, c.Logger)
 			c.LoginResponseMu.Lock()

--- a/umh-core/pkg/communicator/communication_state/communication_state.go
+++ b/umh-core/pkg/communicator/communication_state/communication_state.go
@@ -204,15 +204,18 @@ func (c *CommunicationState) InitialiseReAuthHandler(authToken string, insecureT
 				continue
 			}
 			c.Watchdog.ReportHeartbeatStatus(watchUUID, watchdog.HEARTBEAT_STATUS_OK)
-			c.LoginResponseMu.Lock()
-			c.LoginResponse = credentials
-			c.LoginResponseMu.Unlock()
 
 			c.mu.Lock()
-			c.LoginResponseMu.RLock()
-			c.Puller.UpdateJWT(c.LoginResponse.JWT)
-			c.Pusher.UpdateJWT(c.LoginResponse.JWT)
-			c.LoginResponseMu.RUnlock()
+			c.LoginResponseMu.Lock()
+			c.LoginResponse = credentials
+
+			if c.Puller != nil {
+				c.Puller.UpdateJWT(c.LoginResponse.JWT)
+			}
+			if c.Pusher != nil {
+				c.Pusher.UpdateJWT(c.LoginResponse.JWT)
+			}
+			c.LoginResponseMu.Unlock()
 			c.mu.Unlock()
 		}
 


### PR DESCRIPTION
This implements a small routine which will attempt to update the auth token every 1 hours.
Our JWT currently has an expiry of 24 hours, giving it ~24 attempts to refresh before expiry (and even if expired it will continue to re-try).
Imo this is a good balance between reliabilty and keeping the API traffic low.
It also matches our old implementation

See also the companion implementation in https://github.com/united-manufacturing-hub/ManagementConsole/blob/staging/companion/cmd/appstate/appstate.go#L395

I did not implement the part where it decodes the expiry time, as for now i would try to keep this simple.
If on a later date we want to make the refresh interval dynamic based on token expiry time, it should be easily implementable.

It also uses the Watchdog to prevent any "hangs".
