### PR TITLE
fix: resolve Topic Browser documentation inconsistencies

### DIFF
--- a/umh-core/docs/reference/README.md
+++ b/umh-core/docs/reference/README.md
@@ -8,6 +8,7 @@ The reference materials include:
 - **Container Layout**: Detailed overview of the container's file system structure, data organization, and persistent volume layout
 - **Template Variables**: Comprehensive glossary of all available template variables for protocol converter configurations, including connection, location, and system variables
 - **State Machines**: Reference documentation for state machine implementations and workflows
+- **HTTP API**: GraphQL API reference for Topic Browser queries and programmatic access
 
 Navigate through these pages to find specific configuration parameters, understand system architecture, or look up technical details for your UMH implementation.
 

--- a/umh-core/docs/reference/configuration-reference.md
+++ b/umh-core/docs/reference/configuration-reference.md
@@ -247,6 +247,35 @@ protocolConverter:
               uns: {}
 ```
 
+### GraphQL API - Topic Browser
+
+GraphQL API for querying Unified Namespace topics.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | `bool` | `true` | Enable GraphQL API |
+| `port` | `int` | `8090` | HTTP port for GraphQL endpoint |
+| `debug` | `bool` | `false` | Enable GraphiQL playground at `/` |
+| `corsOrigins` | `[]string` | `[]` | CORS origins (empty = allow all) |
+
+```yaml
+agent:
+  graphql:
+    enabled: true
+    port: 8090
+    debug: false
+    corsOrigins: 
+      - "http://localhost:3000"
+      - "https://your-app.com"
+```
+
+**Endpoints:**
+- **GraphQL API:** `POST /graphql`
+- **GraphiQL Playground:** `GET /` (debug mode only)
+- **CORS Preflight:** `OPTIONS /graphql`
+
+For complete API reference, see [Topic Browser GraphQL API](http-api/topic-browser-graphql.md).
+
 ### Internal - Built-In Services (expert)
 
 UMH Core injects this section automatically.
@@ -259,6 +288,8 @@ internal:
       defaultTopicRetentionMs: 604800000   # 7 days
       maxCores: 1
       memoryPerCoreInBytes: 2147483648
+  topicBrowser:
+    desiredState: active  # Topic Browser service (auto-enabled)
 ```
 
 > **Do not edit** unless instructed by UMH support; invalid settings can brick the stack.

--- a/umh-core/docs/reference/http-api/README.md
+++ b/umh-core/docs/reference/http-api/README.md
@@ -1,0 +1,16 @@
+# HTTP API Reference
+
+## GraphQL API
+- **Default:** Enabled on port 8090
+- **Endpoint:** `POST /graphql`
+- **GraphiQL:** Available at `/` when debug enabled
+- **Purpose:** Query Unified Namespace topics
+
+## Topic Browser GraphQL
+- [Complete GraphQL API Reference](topic-browser-graphql.md)
+- [Schema Documentation](topic-browser-graphql.md#schema)
+- [Query Examples](topic-browser-graphql.md#examples)
+
+## Monitoring
+- **Metrics:** See [Production Metrics](../../production/metrics.md)
+- **Health:** Via FSM state monitoring 

--- a/umh-core/docs/reference/http-api/topic-browser-graphql.md
+++ b/umh-core/docs/reference/http-api/topic-browser-graphql.md
@@ -1,0 +1,140 @@
+# Topic Browser GraphQL API
+
+## Overview
+Query Unified Namespace topics and metadata in real-time.
+
+- **Endpoint:** `http://localhost:8090/graphql`
+- **Default:** Enabled (`graphql.enabled: true`)
+- **Authentication:** None (open by default)
+
+## Schema
+
+### Queries
+```graphql
+type Query {
+  topics(filter: TopicFilter, limit: Int): [Topic!]!
+  topic(topic: String!): Topic
+}
+```
+
+### Types
+```graphql
+type Topic {
+  topic: String!
+  metadata: [MetadataEntry!]!
+  lastEvent: Event    # Latest event only
+}
+
+union Event = TimeSeriesEvent | RelationalEvent
+
+type TimeSeriesEvent {
+  producedAt: String!
+  scalarType: String!
+  numericValue: Float
+  stringValue: String
+  booleanValue: Boolean
+}
+
+type RelationalEvent {
+  producedAt: String!
+  json: String!
+}
+
+input TopicFilter {
+  text: String
+  meta: [MetaExpr!]
+}
+
+input MetaExpr {
+  key: String!
+  eq: String!
+}
+```
+
+## Example Queries
+
+### All topics:
+```graphql
+{ topics { topic metadata { key value } } }
+```
+
+### Filter by text:
+```graphql
+{ topics(filter: { text: "temperature" }) { topic } }
+```
+
+### Filter by metadata:
+```graphql
+{
+  topics(filter: { 
+    meta: [{ key: "data_contract", eq: "_pump" }] 
+  }) {
+    topic
+    lastEvent {
+      ... on TimeSeriesEvent {
+        producedAt
+        numericValue
+      }
+    }
+  }
+}
+```
+
+### Single topic:
+```graphql
+{
+  topic(topic: "umh.v1.acme.plant1.line4.sensor1._raw.temperature") {
+    metadata { key value }
+    lastEvent {
+      ... on TimeSeriesEvent {
+        producedAt
+        numericValue
+        scalarType
+      }
+    }
+  }
+}
+```
+
+## Using curl
+
+### Basic query:
+```bash
+curl -X POST http://localhost:8090/graphql \
+  -H "Content-Type: application/json" \
+  -d '{"query": "{ topics(limit: 3) { topic } }"}'
+```
+
+### Filter query:
+```bash
+curl -X POST http://localhost:8090/graphql \
+  -H "Content-Type: application/json" \
+  -d '{"query": "{ topics(filter: { text: \"pump\" }) { topic lastEvent { ... on TimeSeriesEvent { numericValue } } } }"}'
+```
+
+## Limitations
+- **History:** Latest event only (no historical data)
+- **Subscriptions:** Not supported (queries only)
+- **Rate Limiting:** None (use responsibly)
+- **Scope:** Single UMH instance only
+
+## Multi-Instance Behavior
+- Each UMH Core instance has its own Topic Browser
+- GraphQL API returns topics from local instance only
+- Management Console aggregates all instances into unified view
+
+## Configuration
+```yaml
+agent:
+  graphql:
+    enabled: true    # Default: true
+    port: 8090      # Default: 8090
+    debug: false    # Set true for GraphiQL UI
+    corsOrigins: [] # Default: allows all origins
+```
+
+## Security
+- **Authentication:** Currently open (no tokens required)
+- **CORS:** Configurable via `corsOrigins` setting
+- **Network Security:** Recommended for production deployments
+- **Port Access:** Ensure port 8090 is appropriately secured 

--- a/umh-core/docs/reference/state-machines.md
+++ b/umh-core/docs/reference/state-machines.md
@@ -93,6 +93,28 @@ Each component inherits lifecycle states (`to_be_created`, `creating`, `removing
 
 ---
 
+## 5 — Topic Browser Service
+
+The Topic Browser service manages real-time topic discovery and caching.
+
+| State | Verified | Description | Enter Trigger | Exit Trigger |
+|-------|----------|-------------|---------------|--------------|
+| **stopped** | ✅ | Service not running | Initial state or *stop_done* | *start* → **starting** |
+| *starting* | ✅ | Service initialization | *start* | *benthos_started* → **starting_benthos** |
+| *starting_benthos* | ✅ | Benthos starting | *benthos_started* | *redpanda_started* → **starting_redpanda** |
+| *starting_redpanda* | ✅ | Redpanda connection | *redpanda_started* | *start_done* → **idle** |
+| **idle** | ✅ | Healthy, no active data | *start_done* or *recovered* | *data_received* → **active** |
+| **active** | ✅ | Processing topic data | *data_received* | *no_data_timeout* → **idle** |
+| ⚠️ **degraded_benthos** | ✅ | Benthos degraded | *benthos_degraded* | *recovered* → **idle** |
+| ⚠️ **degraded_redpanda** | ✅ | Redpanda degraded | *redpanda_degraded* | *recovered* → **idle** |
+| *stopping* | ✅ | Graceful shutdown | *stop* | *stop_done* → **stopped** |
+
+**Default:** Active (runs automatically)  
+**Transitions:** idle ↔ active based on topic activity  
+**Recovery:** Automatic from degraded states when underlying services recover
+
+---
+
 ### Quick Defaults
 
 | Parameter              | Default | Source Const / Env     |

--- a/umh-core/docs/usage/README.md
+++ b/umh-core/docs/usage/README.md
@@ -1,4 +1,4 @@
 # Usage
 
-This section covers practical implementation of UMH Core, focusing on data flows and unified namespace concepts. Learn how to set up bridges, standalone flows, and stream processors to connect your industrial devices to the unified namespace. Includes detailed guides on data production, consumption, topic conventions, and payload formats for building robust industrial data pipelines.
+This section covers practical implementation of UMH Core, focusing on data flows and unified namespace concepts. Learn how to set up bridges, standalone flows, and stream processors to connect your industrial devices to the unified namespace. Includes detailed guides on data production, consumption, topic conventions, payload formats, and real-time topic exploration via the Topic Browser.
 

--- a/umh-core/docs/usage/unified-namespace/consuming-data.md
+++ b/umh-core/docs/usage/unified-namespace/consuming-data.md
@@ -1,6 +1,6 @@
 # Consuming Data
 
-> 🚧 **Roadmap Item** – Enhanced consumer tooling, Topic Browser, and REST API are under development.
+> **Topic Browser** – Real-time exploration of Unified Namespace topics via Management Console UI or GraphQL API.
 
 Consuming data from the Unified Namespace involves subscribing to specific topics or patterns and processing the standardized message formats. UMH Core provides multiple consumption methods for different use cases.
 
@@ -66,20 +66,35 @@ dataFlow:
             table: "sensor_data"
 ```
 
-### 3. REST API Access 🚧
+### 3. Topic Browser Access
 
-Query live UNS data via HTTP endpoints:
+**Management Console UI (Recommended):**
+- Navigate to Unified Namespace → Topic Browser
+- Visual topic tree with live updates
+- Stores up to 100 events per topic
+- Built-in search and filtering
+- Aggregates all UMH instances
 
+For detailed usage instructions, see [Topic Browser](./topic-browser.md).
+
+**GraphQL API (Programmatic):**
 ```bash
-# Get namespace tree structure
-curl -X GET "https://umh-core:8080/api/v1/uns/tree" \
-  -H "Authorization: Bearer $JWT_TOKEN"
+# Basic topic query
+curl -X POST http://localhost:8090/graphql \
+  -H "Content-Type: application/json" \
+  -d '{"query": "{ topics(limit: 5) { topic metadata { key value } } }"}'
 
-# Get latest values for specific path
-curl -X GET "https://umh-core:8080/api/v1/uns/values" \
-  -H "Authorization: Bearer $JWT_TOKEN" \
-  -d '{"path": "umh.v1.acme.plant1.line4.pump01._raw.*"}'
+# Filter by data contract
+curl -X POST http://localhost:8090/graphql \
+  -H "Content-Type: application/json" \
+  -d '{"query": "{ topics(filter: { meta: [{ key: \"data_contract\", eq: \"_temperature\" }] }) { topic } }"}'
 ```
+
+**Default Configuration:**
+- GraphQL enabled by default (`agent.graphql.enabled: true`) on port 8090 (`agent.graphql.port: 8090`)
+- Topic Browser service runs automatically (`internal.topicBrowser.desiredState: active`)
+- Each UMH instance has its own Topic Browser
+- Management Console combines all instances
 
 ## Topic Patterns with UNS Input
 
@@ -273,14 +288,16 @@ UMH Core uses UNS input/output instead of direct Kafka access because:
 
 This aligns with UMH Core's philosophy of embedding Redpanda as an internal implementation detail rather than exposing it directly to users.
 
-## Topic Browser 🚧
+## Topic Browser
 
-The upcoming Topic Browser provides a visual interface to explore and consume UNS data:
+The Topic Browser provides real-time exploration of UNS topics and data:
 
-* Real-time topic tree visualization
-* Live value monitoring
-* Historical data queries
-* Export to various formats
+* **Management Console UI** - Visual topic tree with live updates
+* **GraphQL API** - Programmatic access for automation and integration
+* **Advanced Filtering** - Search by topic patterns, metadata, and content
+* **Multi-Instance Support** - Each UMH instance has its own Topic Browser
+
+For detailed usage instructions, see [Topic Browser Guide](./topic-browser.md).
 
 ## Next Steps
 

--- a/umh-core/docs/usage/unified-namespace/topic-browser.md
+++ b/umh-core/docs/usage/unified-namespace/topic-browser.md
@@ -1,0 +1,136 @@
+# Topic Browser
+
+Real-time exploration of Unified Namespace. There are two ways to access the Topic Browser:
+- Management Console (recommended, access via management.umh.app)
+- GraphQL API (for programmatic access, prototype)
+
+## Management Console
+
+The Topic Browser in the Management Console provides a comprehensive, real-time view of your Unified Namespace (UNS). It lets you explore all your data **topics/tags** in a hierarchical tree, aggregated from all connected UMH instances, without having to worry about underlying technical details like MQTT topics, Kafka keys, or payload formats. Each **tag** typically represents a data point (e.g. a sensor reading or machine status) in your ISA-95 asset hierarchy. The Topic Browser is the primary tool for navigating this structure, monitoring live values, and inspecting metadata and history for each topic.
+
+## Accessing the Topic Browser
+
+To open the Topic Browser, log in to the Management Console and select **Topic Browser** from the navigation menu (without the `(Classic)`). The interface is split into two main areas: a **topic tree** on the left and a **details panel** on the right. The topic tree displays the hierarchical structure of all your topics, while the details panel shows information about any topic you select. Once opened, the Topic Browser will begin loading the UNS topic structure and live data from all your connected instances automatically.
+
+## Browsing the Hierarchical Topic Tree
+
+On the left, you will see a collapsible tree representing the **hierarchy of topics** in your Unified Namespace. This hierarchy follows the ISA-95 style structure (Enterprise → Site → Area → Line/Cell, etc., down to individual tag names), organizing data in logical levels. You can expand **folder nodes** (groupings like enterprises, sites, or equipment groups) to reveal deeper levels, and ultimately the **leaf nodes** which represent individual data tags.
+
+**Data Aggregation:** The Topic Browser automatically consolidates and merges topics from **all** your UMH instances into this single tree view. This means if you have multiple instances or brokers publishing data, their topics all appear in one unified namespace hierarchy. (If the same topic exists on multiple instances, it will be combined under one entry with an indication of the multiple data sources.)
+
+**Hierarchical Structure:** The tree clearly shows how each tag is categorized by location and context. In other words, you can easily see **which part of the namespace a tag belongs to** – for example, which enterprise and site a sensor value is associated with. Folder/group nodes make it simple to navigate through logical groupings of tags (for example, all tags under a certain machine or production line). You can collapse sections that you're not interested in and expand the ones you want to explore in depth.
+
+Importantly, this topic list is **live** – if a new device comes online and publishes a new tag, you'll see a new node appear in the tree in real time at the appropriate position. The tree auto-refreshes as data changes, so you're always looking at an up-to-date snapshot of your unified namespace.
+
+## Filtering and Searching Topics
+
+When dealing with a large number of topics, the Topic Browser offers a **filter/search** function to quickly find what you need. At the top of the topic tree panel, there is a search bar where you can type a keyword or partial topic name. As you type, the topic tree filters to show only the branches and tags that match your input. This is extremely useful for pinpointing a specific tag without manually expanding every level of the hierarchy. For example, you can type a machine name or tag name (such as "temperature") to instantly highlight and navigate to relevant topics. The filtering applies across the full topic path and even tag metadata, making it easy to locate data points in a complex namespace.
+
+## Real-Time Updates and Auto-Refresh
+
+One of the key benefits of the Topic Browser is that it updates **automatically in real time**. You do not need to refresh the page to get new data – the Management Console continuously streams updates from the UMH backend. Whenever a tag's value changes or a new topic is created, the interface will reflect those changes within seconds. You can literally watch sensor readings or other data points change live on the screen. The Topic Browser ensures you are always looking at current data. (Behind the scenes it processes incoming events in near real-time, so extremely rapid updates may be batched into short intervals, but generally it keeps the view up-to-date continuously.) This live view makes it easy to monitor system behavior and verify that data is flowing as expected.
+
+## Viewing Topic Details and Data Inspection
+
+When you click on a specific topic (a leaf node in the tree), the right-hand **details panel** displays comprehensive information about that topic organized into several sections:
+
+### Topic Details Section
+At the top, you'll see core information about the selected topic:
+- **Physical Path**: The location hierarchy (e.g., `enterprise-3.site-3.line-1`)
+- **Data Contract**: The schema type (e.g., `_historian`, `_raw`, `_oee`)  
+- **Virtual Path**: Additional path information if applicable
+- **Tag Name**: The specific tag identifier (e.g., `temperature`, `pressure`)
+
+### Last Message Section
+This shows the most recent data point:
+- **Payload Type**: The [message format](./payload-formats.md) (`Time-Series`, `Relational`, etc.)
+- **Timestamp**: The timestamp inside of the message. Not to be confused with the **Produced At** timestamp.   
+- **Data Type**: The value type (`string`, `number`, `boolean`)
+- **Value**: The actual current value
+- **Produced At**: The timestamp of when the message arrived in the UNS. Not to be confused with the **Timestamp** timestamp.
+
+For **Time-Series** payloads, single values are displayed directly. For array data, you'll see the full array of values (e.g., `[10.123, 2.321, 3.313, 4.543, 5.123, 6.12, 7.423, 8.32, 9.12, 10.64]`).
+
+For **Relational** payloads, structured JSON data is displayed in a formatted view, showing complex objects with multiple fields like:
+```json
+{
+  "timestamp_ms": 123123,
+  "value1": 123,
+  "value2": 234
+}
+```
+
+### Metadata Section  
+Displays message metadata and context information
+
+### History Section
+Shows recent data trends and patterns:
+- **Time-Series Data**: Displays an interactive line chart showing value changes over time, with timestamps on the x-axis and values on the y-axis
+- **Boolean/String Data**: Shows a table with timestamps and true/false values
+- Tracks the **last 100 values** for topics that publish frequent updates
+
+## GraphQL API
+
+For programmatic access, the Topic Browser provides a GraphQL API that allows you to query topics, filter by metadata, and retrieve the latest message data. This is ideal for automation, integrations, and custom applications that need to access UNS data programmatically.
+
+### Accessing the GraphQL API
+
+The GraphQL endpoint is available at `http://localhost:8090/graphql` by default. Unlike the Management Console UI which aggregates data from multiple UMH instances, the GraphQL API provides access to topics from a single UMH instance.
+
+### Querying Topics and Metadata
+
+The API supports powerful filtering capabilities that allow you to:
+- **Text Search**: Find topics by name or metadata content
+- **Metadata Filtering**: Filter topics based on specific metadata key-value pairs
+- **Combined Filtering**: Use both text and metadata filters together
+- **Latest Events**: Retrieve the most recent message data for each topic
+
+### Example Query
+
+Here's a comprehensive example showing how to filter topics by text and metadata, then retrieve the latest message data:
+
+```graphql
+{
+  topics(filter: { 
+    text: "temperature",
+    meta: [{ key: "data_contract", eq: "_historian" }]
+  }) {
+    topic
+    metadata { 
+      key 
+      value 
+    }
+    lastEvent {
+      ... on TimeSeriesEvent {
+        producedAt
+        numericValue
+        scalarType
+      }
+      ... on RelationalEvent {
+        producedAt
+        json
+      }
+    }
+  }
+}
+```
+
+This query finds all topics containing "temperature" that use the `_historian` data contract, returns their metadata, and shows the latest message data with timestamps and values.
+
+### Configuration
+
+The GraphQL API runs by default alongside the Topic Browser:
+
+```yaml
+internal:
+  topicBrowser:
+    desiredState: "active"  # Default
+
+agent:
+  graphql:
+    enabled: true    # Default
+    port: 8090      # Default
+    debug: false    # Set true for GraphiQL UI
+```
+
+For detailed API documentation and additional query examples, see [GraphQL API Reference](../../reference/http-api/topic-browser-graphql.md). 

--- a/umh-core/pkg/communicator/graphql/README.md
+++ b/umh-core/pkg/communicator/graphql/README.md
@@ -1,6 +1,6 @@
 # GraphQL Browse API
 
-A production-ready GraphQL API for browsing topics and events from the United Manufacturing Hub topic browser cache.
+A production-ready GraphQL API for browsing topics and events from the United Manufacturing Hub Topic Browser cache.
 
 ## Features
 
@@ -101,6 +101,31 @@ input MetaExpr {
   eq: String          # Exact value match
 }
 ```
+
+#### Good Quick start for filtering
+
+{
+  topics(filter: { text: "gen_2" , meta: [{ key: "tag_name", eq: "my_data_gen_2" }]}, limit: 10) {
+    topic
+    metadata {
+      key
+      value
+    }
+    lastEvent {
+      ... on TimeSeriesEvent {
+        producedAt
+        scalarType
+        stringValue
+        numericValue
+        booleanValue
+      }
+      ... on RelationalEvent {
+        producedAt
+        json
+      }
+    }
+  }
+}
 
 ## Usage Examples
 


### PR DESCRIPTION
- Fix critical GraphQL syntax error in README (array vs object format)
- Add complete configuration paths in consuming-data.md
- Standardize capitalization to 'Topic Browser' throughout
- Ensure consistent path references with ./ prefix

These fixes address broken GraphQL examples and inconsistent documentation that could confuse users attempting to use the Topic Browser functionality.