### PR TITLE
[ENG-3128] 80% ctx for inner reconcile

### DIFF
--- a/umh-core/pkg/fsm/base_manager.go
+++ b/umh-core/pkg/fsm/base_manager.go
@@ -482,10 +482,19 @@ func (m *BaseFSMManager[C]) Reconcile(
 		delete(m.instances, instanceName)
 	}
 
+	// 80% ctx to ensure we finish in time.
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return ctx.Err(), false
+	}
+	deadline = deadline.Add(-time.Duration(float64(time.Until(deadline))*0.8) / 100)
+	eightyPercentCtx, cancel := context.WithDeadline(ctx, deadline)
+	defer cancel()
+
 	// Reconcile instances
 	// We do not use the returned ctx, as it cancles once any of the reconciles returns either an error or finishes (And the 2nd behaviour is undesired.)
 
-	errorgroup, _ := errgroup.WithContext(ctx)
+	errorgroup, _ := errgroup.WithContext(eightyPercentCtx)
 	// Limit the number of threads available, preventing CPU starvation for other system tasks
 	errorgroup.SetLimit(runtime.NumCPU())
 	hasAnyReconciles := false
@@ -498,7 +507,7 @@ func (m *BaseFSMManager[C]) Reconcile(
 	snapshot.Tick = m.managerTick
 	for name, instance := range m.instances {
 		// If the ctx is already expired, we can skip adding new goroutines
-		if ctx.Err() != nil {
+		if eightyPercentCtx.Err() != nil {
 			m.logger.Debugf("context expired, skipping reconciliation of instance %s", name)
 			break
 		}
@@ -511,7 +520,7 @@ func (m *BaseFSMManager[C]) Reconcile(
 			return fmt.Errorf("failed to get expected max p95 execution time for instance %s: %w", name, execTimeErr), false
 		}
 
-		remaining, sufficient, timeErr := ctxutil.HasSufficientTime(ctx, expectedMaxP95ExecutionTime)
+		remaining, sufficient, timeErr := ctxutil.HasSufficientTime(eightyPercentCtx, expectedMaxP95ExecutionTime)
 		if timeErr != nil {
 			if errors.Is(timeErr, ctxutil.ErrNoDeadline) {
 				return fmt.Errorf("no deadline set in context"), false
@@ -534,7 +543,7 @@ func (m *BaseFSMManager[C]) Reconcile(
 		instanceCaptured := instance
 
 		errorgroup.Go(func() error {
-			reconciled, shallBeRemoved, err := m.reconcileInstanceWithTimeout(ctx, instanceCaptured, services, nameCaptured, snapshot, expectedMaxP95ExecutionTime)
+			reconciled, shallBeRemoved, err := m.reconcileInstanceWithTimeout(eightyPercentCtx, instanceCaptured, services, nameCaptured, snapshot, expectedMaxP95ExecutionTime)
 			if err != nil {
 				return err
 			}
@@ -561,8 +570,8 @@ func (m *BaseFSMManager[C]) Reconcile(
 	select {
 	case wgErr := <-waitErrorChannel:
 		err = wgErr
-	case <-ctx.Done():
-		err = ctx.Err()
+	case <-eightyPercentCtx.Done():
+		err = eightyPercentCtx.Err()
 	}
 
 	instancesToRemoveMutex.Lock()


### PR DESCRIPTION
This pr changes the base_manager to only provide 80% of the context's deadline to the reconciles of the instances, thus ensuring they actually finish in time.