### PR TITLE
[ENG-3135] Parallel managers

### DIFF
--- a/umh-core/pkg/constants/base_manager.go
+++ b/umh-core/pkg/constants/base_manager.go
@@ -1,0 +1,22 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package constants
+
+const (
+
+	// factor is the factor by which we reduce the remaining time for the inner control loop.
+	// This is used to ensure that we finish in time.
+	BaseManagerControlLoopTimeFactor = 0.95
+)

--- a/umh-core/pkg/constants/loop.go
+++ b/umh-core/pkg/constants/loop.go
@@ -45,6 +45,10 @@ const (
 
 	// number of control‑loop ticks a manager stays in cooldown
 	CoolDownTicks = 5
+
+	// factor is the factor by which we reduce the remaining time for the inner control loop.
+	// This is used to ensure that we finish in time.
+	LoopControlLoopTimeFactor = 0.95
 )
 
 // FilesAndDirectoriesToIgnore is a list of files and directories that we will not read.

--- a/umh-core/pkg/control/loop.go
+++ b/umh-core/pkg/control/loop.go
@@ -316,13 +316,12 @@ func (c *ControlLoop) Reconcile(ctx context.Context, ticker uint64) error {
 	}
 
 	// <factor>% ctx to ensure we finish in time.
-	const factor = 0.95
 	deadline, ok := ctx.Deadline()
 	if !ok {
 		return ctxutil.ErrNoDeadline
 	}
 	remainingTime := time.Until(deadline)
-	timeToAdd := time.Duration(float64(remainingTime) * factor)
+	timeToAdd := time.Duration(float64(remainingTime) * constants.LoopControlLoopTimeFactor)
 	newDeadline := time.Now().Add(timeToAdd)
 	innerCtx, cancel := context.WithDeadline(ctx, newDeadline)
 	defer cancel()

--- a/umh-core/pkg/fsm/base_manager.go
+++ b/umh-core/pkg/fsm/base_manager.go
@@ -483,13 +483,12 @@ func (m *BaseFSMManager[C]) Reconcile(
 	}
 
 	// <factor>% ctx to ensure we finish in time.
-	const factor = 0.95
 	deadline, ok := ctx.Deadline()
 	if !ok {
 		return ctxutil.ErrNoDeadline, false
 	}
 	remainingTime := time.Until(deadline)
-	timeToAdd := time.Duration(float64(remainingTime) * factor)
+	timeToAdd := time.Duration(float64(remainingTime) * constants.BaseManagerControlLoopTimeFactor)
 	newDeadline := time.Now().Add(timeToAdd)
 	innerCtx, cancel := context.WithDeadline(ctx, newDeadline)
 	defer cancel()


### PR DESCRIPTION
This pr increases performance/reactivity by executing the managers in parallel.
Similar to the base_manager it uses a factor of the real ctx to execute them, ensuring we have some time for cleanup.