### PR TITLE
Block MacOS's annoying DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 
 .docker-cache
 .idea
+
+# .DS_Store from macos
+.DS_Store


### PR DESCRIPTION
I don't know why it suddenly tries to insert that everywhere on my machine but it is annoying and provides no value.