### PR TITLE
Use OS port allocation instead of range-based port management

### DIFF
--- a/umh-core/pkg/portmanager/portmanager.go
+++ b/umh-core/pkg/portmanager/portmanager.go
@@ -18,6 +18,7 @@ package portmanager
 import (
 	"context"
 	"fmt"
+	"net"
 	"sync"
 )
 
@@ -50,7 +51,7 @@ type PortManager interface {
 }
 
 // DefaultPortManager is a thread-safe implementation of PortManager
-// that keeps track of ports in a simple in-memory store
+// that uses OS port allocation (port 0) to get available ports from the OS
 type DefaultPortManager struct {
 	// mutex to protect concurrent access to maps
 	mutex sync.RWMutex
@@ -58,13 +59,8 @@ type DefaultPortManager struct {
 	// instanceToPorts maps instance names to their allocated ports
 	instanceToPorts map[string]uint16
 
-	// portToInstances maps ports to instance names
+	// portToInstances maps ports to instance names for reverse lookup
 	portToInstances map[uint16]string
-
-	// configuration
-	minPort  uint16
-	maxPort  uint16
-	nextPort uint16
 }
 
 // Global singleton instance of DefaultPortManager
@@ -82,100 +78,50 @@ func GetDefaultPortManager() *DefaultPortManager {
 	return defaultPortManagerInstance
 }
 
-// initDefaultPortManager initializes the singleton DefaultPortManager with the given port range.
+// initDefaultPortManager initializes the singleton DefaultPortManager.
 // It ensures the DefaultPortManager is initialized only once.
-// Returns error if initialization fails or if it was already initialized with different parameters.
-func initDefaultPortManager(minPort, maxPort uint16) (*DefaultPortManager, error) {
-	var initErr error
-
+func initDefaultPortManager() *DefaultPortManager {
 	defaultPortManagerOnce.Do(func() {
 		defaultPortManagerMutex.Lock()
 		defer defaultPortManagerMutex.Unlock()
 
-		manager, err := newDefaultPortManager(minPort, maxPort)
-		if err != nil {
-			initErr = err
-			return
-		}
+		manager := newDefaultPortManager()
 		defaultPortManagerInstance = manager
 	})
 
-	if initErr != nil {
-		return nil, initErr
-	}
-
-	// Check if already initialized with different parameters
+	// Get the initialized instance
 	defaultPortManagerMutex.RLock()
 	defer defaultPortManagerMutex.RUnlock()
-	inst := defaultPortManagerInstance
-	if inst == nil {
-		return nil, fmt.Errorf("port manager failed to initialize previously; call InitDefaultPortManager again with valid parameters")
-	}
-
-	if inst.minPort != minPort || inst.maxPort != maxPort {
-		return defaultPortManagerInstance, fmt.Errorf(
-			"port manager already initialized with different range (%d-%d)",
-			inst.minPort, inst.maxPort,
-		)
-	}
-
-	return inst, nil
+	return defaultPortManagerInstance
 }
 
-// NewDefaultPortManager creates a new DefaultPortManager with the given port range.
+// NewDefaultPortManager creates a new DefaultPortManager using OS port allocation.
 // If a singleton instance already exists, it returns that instance.
 // Otherwise, it creates and initializes the singleton instance.
-func NewDefaultPortManager(minPort, maxPort uint16) (*DefaultPortManager, error) {
-	// First validate inputs before checking the singleton
-	if minPort <= 0 || maxPort <= 0 {
-		return nil, fmt.Errorf("port range must be positive")
-	}
-	if minPort >= maxPort {
-		return nil, fmt.Errorf("minPort must be less than maxPort")
-	}
-	if minPort < 1024 {
-		return nil, fmt.Errorf("minPort must be at least 1024 (non-privileged)")
-	}
-
-	// Only check existing singleton if inputs are valid
+func NewDefaultPortManager() (*DefaultPortManager, error) {
+	// Check if singleton already exists
 	if existing := GetDefaultPortManager(); existing != nil {
-		// Return the existing instance along with a warning if parameters don't match
-		if existing.minPort != minPort || existing.maxPort != maxPort {
-			return existing, fmt.Errorf(
-				"warning: using existing port manager with different range (%d-%d) than requested (%d-%d)",
-				existing.minPort, existing.maxPort, minPort, maxPort,
-			)
-		}
 		return existing, nil
 	}
 
 	// Initialize singleton if it doesn't exist
-	return initDefaultPortManager(minPort, maxPort)
+	instance := initDefaultPortManager()
+	if instance == nil {
+		return nil, fmt.Errorf("failed to initialize port manager")
+	}
+	return instance, nil
 }
 
 // newDefaultPortManager is an internal function that creates a new DefaultPortManager instance
-// without using the singleton pattern. This is used by InitDefaultPortManager.
-func newDefaultPortManager(minPort, maxPort uint16) (*DefaultPortManager, error) {
-	if minPort <= 0 || maxPort <= 0 {
-		return nil, fmt.Errorf("port range must be positive")
-	}
-	if minPort >= maxPort {
-		return nil, fmt.Errorf("minPort must be less than maxPort")
-	}
-	if minPort < 1024 {
-		return nil, fmt.Errorf("minPort must be at least 1024 (non-privileged)")
-	}
-
+// without using the singleton pattern. This is used by initDefaultPortManager.
+func newDefaultPortManager() *DefaultPortManager {
 	return &DefaultPortManager{
 		instanceToPorts: make(map[string]uint16),
 		portToInstances: make(map[uint16]string),
-		minPort:         minPort,
-		maxPort:         maxPort,
-		nextPort:        minPort,
-	}, nil
+	}
 }
 
-// AllocatePort allocates the next available port for a given instance
+// AllocatePort allocates an available port for a given instance using OS port allocation
 func (pm *DefaultPortManager) AllocatePort(instanceName string) (uint16, error) {
 	pm.mutex.Lock()
 	defer pm.mutex.Unlock()
@@ -185,44 +131,26 @@ func (pm *DefaultPortManager) AllocatePort(instanceName string) (uint16, error) 
 		return port, nil
 	}
 
-	// Find an available port
-	startingPort := pm.nextPort
-	if startingPort < pm.minPort {
-		startingPort = pm.minPort
-	}
-	if startingPort > pm.maxPort {
-		startingPort = pm.maxPort
+	// Use OS port allocation (port 0) to get an available port
+	listener, err := net.Listen("tcp", ":0")
+	if err != nil {
+		return 0, fmt.Errorf("failed to allocate port: %w", err)
 	}
 
-	port := startingPort
+	// Extract the port from the listener's address
+	addr := listener.Addr().(*net.TCPAddr)
+	port := uint16(addr.Port)
 
-	for {
-		// Check if this port is available
-		if _, exists := pm.portToInstances[port]; !exists {
-			// Found an available port, allocate it
-			pm.instanceToPorts[instanceName] = port
-			pm.portToInstances[port] = instanceName
-
-			// Update next port for the next allocation
-			pm.nextPort = port + 1
-			if pm.nextPort > pm.maxPort {
-				pm.nextPort = pm.minPort
-			}
-
-			return port, nil
-		}
-
-		// Try the next port
-		port++
-		if port > pm.maxPort {
-			port = pm.minPort
-		}
-
-		// If we've checked all ports, none are available
-		if port == startingPort {
-			return 0, fmt.Errorf("no available ports in range %d-%d", pm.minPort, pm.maxPort)
-		}
+	// Close the listener immediately to allow external apps to use the port
+	if err := listener.Close(); err != nil {
+		return 0, fmt.Errorf("failed to close listener for port %d: %w", port, err)
 	}
+
+	// Store the mappings
+	pm.instanceToPorts[instanceName] = port
+	pm.portToInstances[port] = instanceName
+
+	return port, nil
 }
 
 // ReleasePort releases a port previously allocated to an instance
@@ -235,10 +163,8 @@ func (pm *DefaultPortManager) ReleasePort(instanceName string) error {
 		return fmt.Errorf("instance %s has no allocated port", instanceName)
 	}
 
-	// Remove the instance-to-port mapping
+	// Remove the mappings
 	delete(pm.instanceToPorts, instanceName)
-
-	// Remove the port-to-instance mapping
 	delete(pm.portToInstances, port)
 
 	return nil
@@ -258,14 +184,11 @@ func (pm *DefaultPortManager) ReservePort(instanceName string, port uint16) erro
 	if port <= 0 {
 		return fmt.Errorf("invalid port: %d (must be positive)", port)
 	}
-	if port < pm.minPort || port > pm.maxPort {
-		return fmt.Errorf("port %d is outside the allowed range (%d-%d)", port, pm.minPort, pm.maxPort)
-	}
 
 	pm.mutex.Lock()
 	defer pm.mutex.Unlock()
 
-	// Check if port is already in use
+	// Check if port is already in use by our port manager
 	if existingInstance, exists := pm.portToInstances[port]; exists {
 		if existingInstance != instanceName {
 			return fmt.Errorf("port %d is already in use by instance %s", port, existingInstance)
@@ -283,7 +206,19 @@ func (pm *DefaultPortManager) ReservePort(instanceName string, port uint16) erro
 		return nil
 	}
 
-	// Reserve the port
+	// Try to bind to the specific port to verify it's available
+	addr := fmt.Sprintf(":%d", port)
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("port %d is not available: %w", port, err)
+	}
+
+	// Close the listener immediately to allow external apps to use the port
+	if err := listener.Close(); err != nil {
+		return fmt.Errorf("failed to close listener for port %d: %w", port, err)
+	}
+
+	// Successfully reserved the port
 	pm.instanceToPorts[instanceName] = port
 	pm.portToInstances[port] = instanceName
 
@@ -292,63 +227,25 @@ func (pm *DefaultPortManager) ReservePort(instanceName string, port uint16) erro
 
 // PreReconcile implements the PreReconcile method for DefaultPortManager
 func (pm *DefaultPortManager) PreReconcile(ctx context.Context, instanceNames []string) error {
-	pm.mutex.Lock()
-	defer pm.mutex.Unlock()
-
 	// Track any errors during allocation
 	var errs []error
 
 	// Try to allocate ports for all instances that don't have one
 	for _, name := range instanceNames {
 		// Skip if instance already has a port
-		if _, exists := pm.instanceToPorts[name]; exists {
+		pm.mutex.RLock()
+		_, exists := pm.instanceToPorts[name]
+		pm.mutex.RUnlock()
+
+		if exists {
 			continue
 		}
 
-		// Try to allocate a port
-		port := pm.nextPort
-		if port < pm.minPort {
-			port = pm.minPort
-		}
-		if port > pm.maxPort {
-			port = pm.maxPort
-		}
-
-		startingPort := port
-		allocated := false
-
-		// Try to find an available port
-		for {
-			if _, exists := pm.portToInstances[port]; !exists {
-				// Found an available port, allocate it
-				pm.instanceToPorts[name] = port
-				pm.portToInstances[port] = name
-
-				// Update next port for the next allocation
-				pm.nextPort = port + 1
-				if pm.nextPort > pm.maxPort {
-					pm.nextPort = pm.minPort
-				}
-
-				allocated = true
-				break
-			}
-
-			// Try the next port
-			port++
-			if port > pm.maxPort {
-				port = pm.minPort
-			}
-
-			// If we've checked all ports, none are available
-			if port == startingPort {
-				errs = append(errs, fmt.Errorf("no available ports for instance %s", name))
-				break
-			}
-		}
-
-		if !allocated {
-			errs = append(errs, fmt.Errorf("failed to allocate port for instance %s", name))
+		// Allocate a port using our standard allocation method
+		// This will handle the locking internally
+		_, err := pm.AllocatePort(name)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("failed to allocate port for instance %s: %w", name, err))
 		}
 	}
 

--- a/umh-core/pkg/portmanager/portmanager_test.go
+++ b/umh-core/pkg/portmanager/portmanager_test.go
@@ -36,42 +36,35 @@ var _ = Describe("PortManager", func() {
 	})
 
 	Describe("NewDefaultPortManager", func() {
-		DescribeTable("initialization scenarios",
-			func(minPort, maxPort uint16, shouldSucceed bool) {
-				pm, err := NewDefaultPortManager(minPort, maxPort)
-				if shouldSucceed {
-					Expect(err).NotTo(HaveOccurred())
-					Expect(pm.minPort).To(Equal(minPort))
-					Expect(pm.maxPort).To(Equal(maxPort))
-					Expect(pm.nextPort).To(Equal(minPort))
-				} else {
-					Expect(err).To(HaveOccurred())
-					Expect(pm).To(BeNil())
-				}
-			},
-			Entry("valid range", uint16(8000), uint16(9000), true),
-			//Entry("invalid min port (negative)", uint16(-1), uint16(9000), false), // This is not allowed, uint16 is unsigned
-			//Entry("invalid max port (negative)", uint16(8000), uint16(-1), false), // This is not allowed, uint16 is unsigned
-			Entry("min port greater than max port", uint16(9000), uint16(8000), false),
-			Entry("min port equals max port", uint16(8000), uint16(8000), false),
-			Entry("min port too low (privileged)", uint16(80), uint16(9000), false),
-			//Entry("max port too high", uint16(8000), uint16(70000), false), // This is not allowed, uint16 max is 65535
-		)
+		It("creates a port manager successfully", func() {
+			pm, err := NewDefaultPortManager()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pm).NotTo(BeNil())
+			Expect(pm.instanceToPorts).NotTo(BeNil())
+			Expect(pm.portToInstances).NotTo(BeNil())
+		})
+
+		It("returns the same instance when called multiple times", func() {
+			pm1, err := NewDefaultPortManager()
+			Expect(err).NotTo(HaveOccurred())
+
+			pm2, err := NewDefaultPortManager()
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(pm1).To(BeIdenticalTo(pm2))
+		})
 	})
 
 	Describe("AllocatePort", func() {
 		Context("basic allocation", func() {
 			It("allocates a port successfully", func() {
-				pm, err := NewDefaultPortManager(8000, 9000)
+				pm, err := NewDefaultPortManager()
 				Expect(err).NotTo(HaveOccurred())
 
 				instance := "test-instance"
 				port, err := pm.AllocatePort(instance)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(port).To(Equal(uint16(8000)))
-
-				// Verify internal state
-				Expect(pm.nextPort).To(Equal(uint16(8001)))
+				Expect(port).To(BeNumerically(">", 0))
 
 				gotPort, exists := pm.GetPort(instance)
 				Expect(exists).To(BeTrue())
@@ -79,7 +72,7 @@ var _ = Describe("PortManager", func() {
 			})
 
 			It("returns the same port for an existing instance", func() {
-				pm, err := NewDefaultPortManager(8000, 9000)
+				pm, err := NewDefaultPortManager()
 				Expect(err).NotTo(HaveOccurred())
 
 				instance := "test-instance"
@@ -92,62 +85,60 @@ var _ = Describe("PortManager", func() {
 				Expect(port2).To(Equal(port1))
 			})
 
-			It("returns an error when all ports are allocated", func() {
-				// Small range to make testing easier
-				minPort := uint16(8000)
-				maxPort := uint16(8002)
-				pm, err := NewDefaultPortManager(minPort, maxPort)
+			It("allocates multiple different ports", func() {
+				pm, err := NewDefaultPortManager()
 				Expect(err).NotTo(HaveOccurred())
 
-				// Allocate all ports
-				for i := 0; i < int(maxPort)-int(minPort)+1; i++ {
-					instance := fmt.Sprintf("instance-%d", i)
-					_, err := pm.AllocatePort(instance)
+				// Allocate ports for multiple instances
+				instances := []string{"instance-1", "instance-2", "instance-3"}
+				ports := make(map[uint16]bool)
+
+				for _, instance := range instances {
+					port, err := pm.AllocatePort(instance)
 					Expect(err).NotTo(HaveOccurred())
+					Expect(port).To(BeNumerically(">", 0))
+
+					// Ensure we don't get duplicate ports
+					Expect(ports[port]).To(BeFalse(), "Port %d was allocated twice", port)
+					ports[port] = true
 				}
 
-				// Try to allocate one more port
-				_, err = pm.AllocatePort("one-too-many")
-				Expect(err).To(HaveOccurred())
+				// Verify we got 3 different ports
+				Expect(len(ports)).To(Equal(3))
 			})
 
-			It("handles port wraparound correctly", func() {
-				minPort := uint16(8000)
-				maxPort := uint16(8002)
-				pm, err := NewDefaultPortManager(minPort, maxPort)
+			It("handles port release and reallocation", func() {
+				pm, err := NewDefaultPortManager()
 				Expect(err).NotTo(HaveOccurred())
 
-				// Fill all ports
-				ports := make(map[uint16]string)
-				for i := 0; i <= int(maxPort)-int(minPort); i++ {
-					instName := fmt.Sprintf("instance-%d", i+1)
-					port, err := pm.AllocatePort(instName)
-					Expect(err).NotTo(HaveOccurred())
-					ports[port] = instName
-				}
-
-				// Release the first port
-				err = pm.ReleasePort("instance-1")
+				// Allocate a port
+				instance1 := "instance-1"
+				_, err = pm.AllocatePort(instance1)
 				Expect(err).NotTo(HaveOccurred())
 
-				// Force nextPort to wrap around
-				pm.nextPort = maxPort + 1
-
-				// Allocate a port after wraparound
-				port, err := pm.AllocatePort("new-instance")
+				// Release the port
+				err = pm.ReleasePort(instance1)
 				Expect(err).NotTo(HaveOccurred())
 
-				// Actual implementation may continue past maxPort or use a different algorithm
-				// Just verify we got a valid port
-				Expect(port).To(BeNumerically(">=", minPort))
-				Expect(port).To(BeNumerically("<=", maxPort))
+				// Verify the port is released
+				_, exists := pm.GetPort(instance1)
+				Expect(exists).To(BeFalse())
+
+				// Allocate a new port for a different instance
+				instance2 := "instance-2"
+				port2, err := pm.AllocatePort(instance2)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(port2).To(BeNumerically(">", 0))
+
+				// The new port might be the same as the old one (since it was released)
+				// or different - both are valid with OS allocation
 			})
 		})
 	})
 
 	Describe("ReleasePort", func() {
 		It("releases an allocated port", func() {
-			pm, err := NewDefaultPortManager(8000, 9000)
+			pm, err := NewDefaultPortManager()
 			Expect(err).NotTo(HaveOccurred())
 
 			instance := "test-instance"
@@ -162,19 +153,13 @@ var _ = Describe("PortManager", func() {
 			Expect(exists).To(BeFalse())
 
 			// Verify we can allocate a port again
-			// Note: The implementation may not reuse the exact same port immediately
-			// It depends on the allocation strategy
 			newPort, err := pm.AllocatePort("another-instance")
 			Expect(err).NotTo(HaveOccurred())
-
-			// Update test to match actual implementation behavior
-			// We just need to ensure we got a valid port, not necessarily the same one
-			Expect(newPort).To(BeNumerically(">=", pm.minPort))
-			Expect(newPort).To(BeNumerically("<=", pm.maxPort))
+			Expect(newPort).To(BeNumerically(">", 0))
 		})
 
 		It("returns an error for non-existent instance", func() {
-			pm, err := NewDefaultPortManager(8000, 9000)
+			pm, err := NewDefaultPortManager()
 			Expect(err).NotTo(HaveOccurred())
 
 			err = pm.ReleasePort("non-existent")
@@ -184,7 +169,7 @@ var _ = Describe("PortManager", func() {
 
 	Describe("GetPort", func() {
 		It("returns the correct port for an existing instance", func() {
-			pm, err := NewDefaultPortManager(8000, 9000)
+			pm, err := NewDefaultPortManager()
 			Expect(err).NotTo(HaveOccurred())
 
 			instance := "test-instance"
@@ -197,7 +182,7 @@ var _ = Describe("PortManager", func() {
 		})
 
 		It("returns false for a non-existent instance", func() {
-			pm, err := NewDefaultPortManager(8000, 9000)
+			pm, err := NewDefaultPortManager()
 			Expect(err).NotTo(HaveOccurred())
 
 			gotPort, exists := pm.GetPort("non-existent")
@@ -208,67 +193,79 @@ var _ = Describe("PortManager", func() {
 
 	Describe("ReservePort", func() {
 		It("reserves an available port", func() {
-			pm, err := NewDefaultPortManager(8000, 9000)
+			pm, err := NewDefaultPortManager()
 			Expect(err).NotTo(HaveOccurred())
 
 			instance := "test-instance"
-			portToReserve := uint16(8500)
+			// Use a likely available port in a safe range
+			portToReserve := uint16(55000)
 			err = pm.ReservePort(instance, portToReserve)
-			Expect(err).NotTo(HaveOccurred())
 
-			// Verify the port is reserved
-			gotPort, exists := pm.GetPort(instance)
-			Expect(exists).To(BeTrue())
-			Expect(gotPort).To(Equal(portToReserve))
-		})
-
-		It("returns an error for port outside range", func() {
-			pm, err := NewDefaultPortManager(8000, 9000)
-			Expect(err).NotTo(HaveOccurred())
-
-			err = pm.ReservePort("test-instance", 7000)
-			Expect(err).To(HaveOccurred())
-
-			err = pm.ReservePort("test-instance", 10000)
-			Expect(err).To(HaveOccurred())
+			// Note: This might fail if the port is already in use by another process
+			// That's expected behavior with real OS allocation
+			if err == nil {
+				// Verify the port is reserved
+				gotPort, exists := pm.GetPort(instance)
+				Expect(exists).To(BeTrue())
+				Expect(gotPort).To(Equal(portToReserve))
+			} else {
+				// Port was not available, which is valid
+				Expect(err.Error()).To(ContainSubstring("not available"))
+			}
 		})
 
 		It("returns an error when port is already in use", func() {
-			pm, err := NewDefaultPortManager(8000, 9000)
+			pm, err := NewDefaultPortManager()
 			Expect(err).NotTo(HaveOccurred())
 
-			portToReserve := uint16(8500)
+			portToReserve := uint16(55001)
+
+			// Try to reserve the port for first instance
 			err = pm.ReservePort("instance-1", portToReserve)
-			Expect(err).NotTo(HaveOccurred())
+			if err != nil {
+				// Port might already be in use by system, skip this test
+				Skip("Port not available for testing")
+				return
+			}
 
 			// Try to reserve the same port for another instance
 			err = pm.ReservePort("instance-2", portToReserve)
 			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("already in use"))
 		})
 
 		It("returns an error when instance already has a different port", func() {
-			pm, err := NewDefaultPortManager(8000, 9000)
+			pm, err := NewDefaultPortManager()
 			Expect(err).NotTo(HaveOccurred())
 
 			instance := "test-instance"
-			port1 := uint16(8500)
+			port1 := uint16(55002)
 			err = pm.ReservePort(instance, port1)
-			Expect(err).NotTo(HaveOccurred())
+			if err != nil {
+				// Port might already be in use by system, skip this test
+				Skip("Port not available for testing")
+				return
+			}
 
 			// Try to reserve a different port for the same instance
-			port2 := uint16(8600)
+			port2 := uint16(55003)
 			err = pm.ReservePort(instance, port2)
 			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("already has port"))
 		})
 
 		It("succeeds when reserving same port for same instance", func() {
-			pm, err := NewDefaultPortManager(8000, 9000)
+			pm, err := NewDefaultPortManager()
 			Expect(err).NotTo(HaveOccurred())
 
 			instance := "test-instance"
-			port := uint16(8500)
+			port := uint16(55004)
 			err = pm.ReservePort(instance, port)
-			Expect(err).NotTo(HaveOccurred())
+			if err != nil {
+				// Port might already be in use by system, skip this test
+				Skip("Port not available for testing")
+				return
+			}
 
 			// Reserve the same port for the same instance again
 			err = pm.ReservePort(instance, port)
@@ -276,21 +273,18 @@ var _ = Describe("PortManager", func() {
 		})
 
 		It("returns an error for invalid ports", func() {
-			pm, err := NewDefaultPortManager(8000, 9000)
+			pm, err := NewDefaultPortManager()
 			Expect(err).NotTo(HaveOccurred())
 
 			err = pm.ReservePort("test-instance", 0)
 			Expect(err).To(HaveOccurred())
-
-			// This is not allowed (statically), as uint16 is unsigned
-			//err = pm.ReservePort("test-instance", uint16(-1))
-			//Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("invalid port"))
 		})
 	})
 
 	Describe("Concurrent operations", func() {
 		It("handles concurrent allocations safely", func() {
-			pm, err := NewDefaultPortManager(8000, 9000)
+			pm, err := NewDefaultPortManager()
 			Expect(err).NotTo(HaveOccurred())
 
 			numGoroutines := 100
@@ -319,8 +313,7 @@ var _ = Describe("PortManager", func() {
 			for i, err := range errors {
 				if err == nil {
 					port := ports[i]
-					Expect(port).To(BeNumerically(">=", pm.minPort))
-					Expect(port).To(BeNumerically("<=", pm.maxPort))
+					Expect(port).To(BeNumerically(">", 0))
 
 					// Verify no port duplications
 					instance, exists := allocatedPorts[port]
@@ -337,7 +330,7 @@ var _ = Describe("PortManager", func() {
 		})
 
 		It("handles mixed concurrent operations safely", func() {
-			pm, err := NewDefaultPortManager(8000, 9000)
+			pm, err := NewDefaultPortManager()
 			Expect(err).NotTo(HaveOccurred())
 
 			numGoroutines := 50
@@ -358,7 +351,7 @@ var _ = Describe("PortManager", func() {
 					defer GinkgoRecover()
 					defer wg.Done()
 					instance := fmt.Sprintf("new-instance-%d", id)
-					_, err := pm.AllocatePort(instance) // Ignore errors, we might run out of ports
+					_, err := pm.AllocatePort(instance)
 					Expect(err).NotTo(HaveOccurred())
 				}(i)
 			}
@@ -369,11 +362,12 @@ var _ = Describe("PortManager", func() {
 					defer GinkgoRecover()
 					defer wg.Done()
 					instance := fmt.Sprintf("reserve-instance-%d", id)
-					port := uint16(8000 + id%1000)        // Ensure we stay in range
-					err := pm.ReservePort(instance, port) // Ignore errors, some might fail
+					port := uint16(55000 + id%1000)       // Use high port range to avoid conflicts
+					err := pm.ReservePort(instance, port) // Some might fail due to system usage
 					if err != nil {
-						// Error is expected - should be "port already in use" or "instance already has port"
+						// Error is expected - should be "port not available", "already in use" or "instance already has port"
 						Expect(err.Error()).To(Or(
+							ContainSubstring("not available"),
 							ContainSubstring("already in use"),
 							ContainSubstring("already has port"),
 						))
@@ -398,7 +392,7 @@ var _ = Describe("PortManager", func() {
 
 	Describe("PreReconcile", func() {
 		It("allocates ports for new instances", func() {
-			pm, err := NewDefaultPortManager(8000, 9000)
+			pm, err := NewDefaultPortManager()
 			Expect(err).NotTo(HaveOccurred())
 
 			// Test with multiple instances
@@ -410,13 +404,12 @@ var _ = Describe("PortManager", func() {
 			for _, name := range instanceNames {
 				port, exists := pm.GetPort(name)
 				Expect(exists).To(BeTrue())
-				Expect(port).To(BeNumerically(">=", pm.minPort))
-				Expect(port).To(BeNumerically("<=", pm.maxPort))
+				Expect(port).To(BeNumerically(">", 0))
 			}
 		})
 
 		It("handles instances that already have ports", func() {
-			pm, err := NewDefaultPortManager(8000, 9000)
+			pm, err := NewDefaultPortManager()
 			Expect(err).NotTo(HaveOccurred())
 
 			// Pre-allocate a port
@@ -437,26 +430,33 @@ var _ = Describe("PortManager", func() {
 			// Verify new instance got a port
 			port, exists = pm.GetPort("new-instance")
 			Expect(exists).To(BeTrue())
-			Expect(port).To(BeNumerically(">=", pm.minPort))
-			Expect(port).To(BeNumerically("<=", pm.maxPort))
+			Expect(port).To(BeNumerically(">", 0))
 		})
 
-		It("handles port exhaustion", func() {
-			// Create a port manager with very limited ports
-			pm, err := NewDefaultPortManager(8000, 8001)
+		It("allocates successfully with OS port allocation", func() {
+			pm, err := NewDefaultPortManager()
 			Expect(err).NotTo(HaveOccurred())
 
-			// Try to allocate more ports than available
-			instanceNames := []string{"instance-1", "instance-2", "instance-3"}
+			// With OS allocation, we should be able to allocate many ports
+			instanceNames := []string{"instance-1", "instance-2", "instance-3", "instance-4", "instance-5"}
 			err = pm.PreReconcile(context.Background(), instanceNames)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("port allocation failed"))
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify all ports were allocated and are unique
+			allocatedPorts := make(map[uint16]bool)
+			for _, name := range instanceNames {
+				port, exists := pm.GetPort(name)
+				Expect(exists).To(BeTrue())
+				Expect(port).To(BeNumerically(">", 0))
+				Expect(allocatedPorts[port]).To(BeFalse(), "Port %d was allocated twice", port)
+				allocatedPorts[port] = true
+			}
 		})
 	})
 
 	Describe("PostReconcile", func() {
 		It("completes without error", func() {
-			pm, err := NewDefaultPortManager(8000, 9000)
+			pm, err := NewDefaultPortManager()
 			Expect(err).NotTo(HaveOccurred())
 
 			err = pm.PostReconcile(context.Background())

--- a/umh-core/pkg/serviceregistry/factory.go
+++ b/umh-core/pkg/serviceregistry/factory.go
@@ -38,9 +38,7 @@ func NewRegistry() (*Registry, error) {
 		panic("NewRegistry called more than once - registry must be initialized once and explicitly passed between components")
 	}
 
-	minPort := uint16(9000)
-	maxPort := uint16(9999)
-	pm, portErr := portmanager.NewDefaultPortManager(minPort, maxPort)
+	pm, portErr := portmanager.NewDefaultPortManager()
 	if portErr != nil {
 		return nil, fmt.Errorf("failed to create port manager: %w", portErr)
 	}


### PR DESCRIPTION
- Replace range-based port allocation with OS port allocation (port 0)
- Remove minPort, maxPort, nextPort fields from DefaultPortManager
- Close listeners immediately after port allocation to allow external usage
- Add proper error handling for listener.Close() operations
- Update NewDefaultPortManager() to remove port range parameters
- Update tests to work with OS-allocated ports