### PR TITLE
ENG-3298 Fix to_be_created issue after agent restarts

### DIFF
--- a/umh-core/.gitignore
+++ b/umh-core/.gitignore
@@ -10,3 +10,4 @@ tmp/
 
 # Compiled binaries
 main
+tools/loganalyzer/loganalyzer

--- a/umh-core/Makefile
+++ b/umh-core/Makefile
@@ -656,7 +656,7 @@ test-no-copy: stop-and-remove-umh-core-latest $(BUILD_TARGET)
 	docker run \
 		--name $(IMAGE_NAME) \
 		-v $(PWD)/data:/data \
-		-e LOGGING_LEVEL=INFO \
+		-e LOGGING_LEVEL=DEBUG \
 		-p 8081:8080 \
 		-p 4195:4195 \
 		-p 6060:6060 \

--- a/umh-core/pkg/fsm/agent_monitor/reconcile.go
+++ b/umh-core/pkg/fsm/agent_monitor/reconcile.go
@@ -81,9 +81,12 @@ func (a *AgentInstance) Reconcile(ctx context.Context, snapshot fsm.SystemSnapsh
 			return nil, false
 		}
 
-		// For other errors, set the error for backoff
-		a.baseFSMInstance.SetError(err, snapshot.Tick)
-		return nil, false
+		// Log the error but always continue reconciling - we need reconcileStateTransition to run
+		// to restore services after restart, even if we can't read their status yet
+		a.baseFSMInstance.GetLogger().Warnf("failed to update observed state (continuing reconciliation): %s", err)
+		
+		// For all other errors, just continue reconciling without setting backoff
+		err = nil
 	}
 
 	// Print system state every 100 ticks

--- a/umh-core/pkg/fsm/benthos/reconcile.go
+++ b/umh-core/pkg/fsm/benthos/reconcile.go
@@ -25,7 +25,6 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/metrics"
-	benthos_service "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/benthos"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/serviceregistry"
 	standarderrors "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/standarderrors"
 )

--- a/umh-core/pkg/fsm/benthos/reconcile.go
+++ b/umh-core/pkg/fsm/benthos/reconcile.go
@@ -101,6 +101,12 @@ func (b *BenthosInstance) Reconcile(ctx context.Context, snapshot fsm.SystemSnap
 				return nil, false
 			}
 
+			// Check if this is a permanent error that should trigger removal
+			if backoff.IsPermanentFailureError(err) {
+				b.baseFSMInstance.SetError(err, snapshot.Tick)
+				return nil, false
+			}
+
 			// Log the error but always continue reconciling - we need reconcileStateTransition to run
 			// to restore services after restart, even if we can't read their status yet
 			b.baseFSMInstance.GetLogger().Warnf("failed to update observed state (continuing reconciliation): %s", err)

--- a/umh-core/pkg/fsm/benthos/reconcile.go
+++ b/umh-core/pkg/fsm/benthos/reconcile.go
@@ -101,12 +101,6 @@ func (b *BenthosInstance) Reconcile(ctx context.Context, snapshot fsm.SystemSnap
 				return nil, false
 			}
 
-			// Check if this is a permanent error that should trigger removal
-			if backoff.IsPermanentFailureError(err) {
-				b.baseFSMInstance.SetError(err, snapshot.Tick)
-				return nil, false
-			}
-
 			// Log the error but always continue reconciling - we need reconcileStateTransition to run
 			// to restore services after restart, even if we can't read their status yet
 			b.baseFSMInstance.GetLogger().Warnf("failed to update observed state (continuing reconciliation): %s", err)

--- a/umh-core/pkg/fsm/benthos_monitor/reconcile.go
+++ b/umh-core/pkg/fsm/benthos_monitor/reconcile.go
@@ -91,32 +91,19 @@ func (b *BenthosMonitorInstance) Reconcile(ctx context.Context, snapshot fsm.Sys
 
 	// Step 2: Detect external changes.
 	if err = b.reconcileExternalChanges(ctx, services, snapshot); err != nil {
-
-		// I am using strings.Contains as i cannot get it working with errors.Is
-		isExpectedError := strings.Contains(err.Error(), benthos_monitor_service.ErrServiceNotExist.Error()) ||
-			strings.Contains(err.Error(), benthos_monitor_service.ErrServiceNoLogFile.Error()) ||
-			strings.Contains(err.Error(), monitor.ErrServiceConnectionRefused.Error()) ||
-			strings.Contains(err.Error(), monitor.ErrServiceConnectionTimedOut.Error()) ||
-			strings.Contains(err.Error(), benthos_monitor_service.ErrServiceNoSectionsFound.Error()) ||
-			strings.Contains(err.Error(), monitor.ErrServiceStopped.Error()) // This is expected when the service is stopped or stopping, no need to fetch logs, metrics, etc.
-
-		if !isExpectedError {
-
-			if errors.Is(err, context.DeadlineExceeded) {
-				// Context deadline exceeded should be retried with backoff, not ignored
-				b.baseFSMInstance.SetError(err, snapshot.Tick)
-				b.baseFSMInstance.GetLogger().Warnf("Context deadline exceeded in reconcileExternalChanges, will retry with backoff")
-				err = nil // Clear error so reconciliation continues
-				return nil, false
-			}
-
+		if errors.Is(err, context.DeadlineExceeded) {
+			// Context deadline exceeded should be retried with backoff, not ignored
 			b.baseFSMInstance.SetError(err, snapshot.Tick)
-			b.baseFSMInstance.GetLogger().Errorf("error reconciling external changes: %s", err)
-
-			return nil, false // We don't want to return an error here, because we want to continue reconciling
+			b.baseFSMInstance.GetLogger().Warnf("Context deadline exceeded in reconcileExternalChanges, will retry with backoff")
+			return nil, false
 		}
 
-		err = nil // The service does not exist or has troubles fetching the observed state (which will cause the service to be in degraded state)
+		// Log the error but always continue reconciling - we need reconcileStateTransition to run
+		// to restore services after restart, even if we can't read their status yet
+		b.baseFSMInstance.GetLogger().Warnf("failed to update observed state (continuing reconciliation): %s", err)
+		
+		// For all other errors, just continue reconciling without setting backoff
+		err = nil
 	}
 
 	// Step 3: Attempt to reconcile the state.

--- a/umh-core/pkg/fsm/benthos_monitor/reconcile.go
+++ b/umh-core/pkg/fsm/benthos_monitor/reconcile.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	internal_fsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/internal/fsm"
@@ -26,8 +25,6 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/metrics"
-	benthos_monitor_service "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/benthos_monitor"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/monitor"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/serviceregistry"
 	standarderrors "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/standarderrors"
 )

--- a/umh-core/pkg/fsm/connection/reconcile.go
+++ b/umh-core/pkg/fsm/connection/reconcile.go
@@ -101,18 +101,16 @@ func (c *ConnectionInstance) Reconcile(ctx context.Context, snapshot fsm.SystemS
 		c.baseFSMInstance.GetLogger().Debugf("Skipping external changes detection during removal")
 	} else {
 		if err = c.reconcileExternalChanges(ctx, services, snapshot); err != nil {
-			// If the service is not running, we don't want to return an error here, because we want to continue reconciling
-			if !errors.Is(err, connectionsvc.ErrServiceNotExist) {
-
-				if c.baseFSMInstance.IsDeadlineExceededAndHandle(err, snapshot.Tick, "reconcileExternalChanges") {
-					return nil, false
-				}
-				c.baseFSMInstance.SetError(err, snapshot.Tick)
-				c.baseFSMInstance.GetLogger().Errorf("error reconciling external changes: %s", err)
-				return nil, false // We don't want to return an error here, because we want to continue reconciling
+			if c.baseFSMInstance.IsDeadlineExceededAndHandle(err, snapshot.Tick, "reconcileExternalChanges") {
+				return nil, false
 			}
 
-			err = nil // The service does not exist, which is fine as this happens in the reconcileStateTransition
+			// Log the error but always continue reconciling - we need reconcileStateTransition to run
+			// to restore services after restart, even if we can't read their status yet
+			c.baseFSMInstance.GetLogger().Warnf("failed to update observed state (continuing reconciliation): %s", err)
+			
+			// For all other errors, just continue reconciling without setting backoff
+			err = nil
 		}
 	}
 

--- a/umh-core/pkg/fsm/connection/reconcile.go
+++ b/umh-core/pkg/fsm/connection/reconcile.go
@@ -24,7 +24,6 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/backoff"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/metrics"
-	connectionsvc "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/connection"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/serviceregistry"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/standarderrors"
 

--- a/umh-core/pkg/fsm/container/reconcile.go
+++ b/umh-core/pkg/fsm/container/reconcile.go
@@ -92,9 +92,12 @@ func (c *ContainerInstance) Reconcile(ctx context.Context, snapshot fsm.SystemSn
 			return nil, false
 		}
 
-		// For other errors, set the error for backoff
-		c.baseFSMInstance.SetError(err, snapshot.Tick)
-		return nil, false
+		// Log the error but always continue reconciling - we need reconcileStateTransition to run
+		// to restore services after restart, even if we can't read their status yet
+		c.baseFSMInstance.GetLogger().Warnf("failed to update observed state (continuing reconciliation): %s", err)
+		
+		// For all other errors, just continue reconciling without setting backoff
+		err = nil
 	}
 
 	// Print system state every 100 ticks

--- a/umh-core/pkg/fsm/dataflowcomponent/reconcile.go
+++ b/umh-core/pkg/fsm/dataflowcomponent/reconcile.go
@@ -25,8 +25,6 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/metrics"
-	dataflowcomponentservice "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/dataflowcomponent"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/s6"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/serviceregistry"
 	standarderrors "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/standarderrors"
 )

--- a/umh-core/pkg/fsm/dataflowcomponent/reconcile.go
+++ b/umh-core/pkg/fsm/dataflowcomponent/reconcile.go
@@ -102,30 +102,18 @@ func (d *DataflowComponentInstance) Reconcile(ctx context.Context, snapshot fsm.
 	} else {
 		err = d.reconcileExternalChanges(ctx, services, snapshot)
 		if err != nil {
-			// If the service is not running, we don't want to return an error here, because we want to continue reconciling
-			if !errors.Is(err, dataflowcomponentservice.ErrServiceNotExists) && !errors.Is(err, s6.ErrServiceNotExist) {
-				// errors.Is(err, s6.ErrServiceNotExist)
-				// Consider a special case for DFC FSM here
-				// While creating for the first time, reconcileExternalChanges function will throw an error such as
-				// s6 service not found in the path since DFC fsm is relying on BenthosFSM and Benthos in turn relies on S6 fsm
-				// Inorder for DFC fsm to start, benthosManager.Reconcile should be called and this is called at the end of the function
-				// So set the err to nil in this case
-				// An example error: "failed to update observed state: failed to get observed DataflowComponent config: failed to get benthos config: failed to get benthos config file for service benthos-dataflow-hello-world-dfc: service does not exist"
-
-				if errors.Is(err, context.DeadlineExceeded) {
-					// Context deadline exceeded should be retried with backoff, not ignored
-					d.baseFSMInstance.SetError(err, snapshot.Tick)
-					d.baseFSMInstance.GetLogger().Warnf("Context deadline exceeded in reconcileExternalChanges, will retry with backoff")
-					err = nil // Clear error so reconciliation continues
-					return nil, false
-				}
-
+			if errors.Is(err, context.DeadlineExceeded) {
+				// Context deadline exceeded should be retried with backoff, not ignored
 				d.baseFSMInstance.SetError(err, snapshot.Tick)
-				d.baseFSMInstance.GetLogger().Errorf("error reconciling external changes: %s", err)
-
-				return nil, false // We don't want to return an error here, because we want to continue reconciling
+				d.baseFSMInstance.GetLogger().Warnf("Context deadline exceeded in reconcileExternalChanges, will retry with backoff")
+				return nil, false
 			}
 
+			// Log the error but always continue reconciling - we need reconcileStateTransition to run
+			// to restore services after restart, even if we can't read their status yet
+			d.baseFSMInstance.GetLogger().Warnf("failed to update observed state (continuing reconciliation): %s", err)
+			
+			// For all other errors, just continue reconciling without setting backoff
 			err = nil
 		}
 	}

--- a/umh-core/pkg/fsm/nmap/reconcile.go
+++ b/umh-core/pkg/fsm/nmap/reconcile.go
@@ -95,12 +95,6 @@ func (n *NmapInstance) Reconcile(ctx context.Context, snapshot fsm.SystemSnapsho
 			return nil, false
 		}
 
-		// Check if this is a permanent error that should trigger removal
-		if backoff.IsPermanentFailureError(err) {
-			n.baseFSMInstance.SetError(err, snapshot.Tick)
-			return nil, false
-		}
-
 		// Log the error but always continue reconciling - we need reconcileStateTransition to run
 		// to restore services after restart, even if we can't read their status yet
 		n.baseFSMInstance.GetLogger().Warnf("failed to update observed state (continuing reconciliation): %s", err)

--- a/umh-core/pkg/fsm/nmap/reconcile.go
+++ b/umh-core/pkg/fsm/nmap/reconcile.go
@@ -26,7 +26,6 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/metrics"
-	nmap_service "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/nmap"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/serviceregistry"
 	standarderrors "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/standarderrors"
 )

--- a/umh-core/pkg/fsm/nmap/reconcile.go
+++ b/umh-core/pkg/fsm/nmap/reconcile.go
@@ -92,23 +92,16 @@ func (n *NmapInstance) Reconcile(ctx context.Context, snapshot fsm.SystemSnapsho
 
 	// Step 2: Detect external changes.
 	if err = n.reconcileExternalChanges(ctx, services, snapshot); err != nil {
-		// If the service is not running, we don't want to return an error here, because we want to continue reconciling
-		if !errors.Is(err, nmap_service.ErrServiceNotExist) {
-
-			if n.baseFSMInstance.IsDeadlineExceededAndHandle(err, snapshot.Tick, "reconcileExternalChanges") {
-				return nil, false
-			}
-
-			n.baseFSMInstance.SetError(err, snapshot.Tick)
-			n.baseFSMInstance.GetLogger().Errorf("error reconciling external changes: %s", err)
-
-			// We want to return the error here, to stop reconciling since this would
-			// lead the fsm going into degraded. But Nmap-scans are triggered once per second
-			// and each tick is 100ms, therefore it could fail, because it doesn't get
-			// complete logs from which it parses.
-			return nil, false // We don't want to return an error here, because we want to continue reconciling
+		if n.baseFSMInstance.IsDeadlineExceededAndHandle(err, snapshot.Tick, "reconcileExternalChanges") {
+			return nil, false
 		}
-		err = nil // The service does not exist, which is fine as this happens in the reconcileStateTransition}
+
+		// Log the error but always continue reconciling - we need reconcileStateTransition to run
+		// to restore services after restart, even if we can't read their status yet
+		n.baseFSMInstance.GetLogger().Warnf("failed to update observed state (continuing reconciliation): %s", err)
+		
+		// For all other errors, just continue reconciling without setting backoff
+		err = nil
 	}
 
 	// Step 3: Attempt to reconcile the state.

--- a/umh-core/pkg/fsm/nmap/reconcile.go
+++ b/umh-core/pkg/fsm/nmap/reconcile.go
@@ -95,6 +95,12 @@ func (n *NmapInstance) Reconcile(ctx context.Context, snapshot fsm.SystemSnapsho
 			return nil, false
 		}
 
+		// Check if this is a permanent error that should trigger removal
+		if backoff.IsPermanentFailureError(err) {
+			n.baseFSMInstance.SetError(err, snapshot.Tick)
+			return nil, false
+		}
+
 		// Log the error but always continue reconciling - we need reconcileStateTransition to run
 		// to restore services after restart, even if we can't read their status yet
 		n.baseFSMInstance.GetLogger().Warnf("failed to update observed state (continuing reconciliation): %s", err)

--- a/umh-core/pkg/fsm/protocolconverter/reconcile.go
+++ b/umh-core/pkg/fsm/protocolconverter/reconcile.go
@@ -101,30 +101,18 @@ func (p *ProtocolConverterInstance) Reconcile(ctx context.Context, snapshot fsm.
 		p.baseFSMInstance.GetLogger().Debugf("Skipping external changes detection during removal")
 	} else {
 		if err = p.reconcileExternalChanges(ctx, services, snapshot); err != nil {
-			// If the service is not running, we don't want to return an error here, because we want to continue reconciling
-			if !errors.Is(err, protocolconvertersvc.ErrServiceNotExist) && !errors.Is(err, s6.ErrServiceNotExist) {
-				// errors.Is(err, s6.ErrServiceNotExist)
-				// Consider a special case for DFC FSM here
-				// While creating for the first time, reconcileExternalChanges function will throw an error such as
-				// s6 service not found in the path since DFC fsm is relying on BenthosFSM and Benthos in turn relies on S6 fsm
-				// Inorder for DFC fsm to start, benthosManager.Reconcile should be called and this is called at the end of the function
-				// So set the err to nil in this case
-				// An example error: "failed to update observed state: failed to get observed DataflowComponent config: failed to get benthos config: failed to get benthos config file for service benthos-dataflow-hello-world-dfc: service does not exist"
-
-				if errors.Is(err, context.DeadlineExceeded) {
-					// Context deadline exceeded should be retried with backoff, not ignored
-					p.baseFSMInstance.SetError(err, snapshot.Tick)
-					p.baseFSMInstance.GetLogger().Warnf("Context deadline exceeded in reconcileExternalChanges, will retry with backoff")
-					err = nil // Clear error so reconciliation continues
-					return nil, false
-				}
-
+			if errors.Is(err, context.DeadlineExceeded) {
+				// Context deadline exceeded should be retried with backoff, not ignored
 				p.baseFSMInstance.SetError(err, snapshot.Tick)
-				p.baseFSMInstance.GetLogger().Errorf("error reconciling external changes: %s", err)
-
-				return nil, false // We don't want to return an error here, because we want to continue reconciling
+				p.baseFSMInstance.GetLogger().Warnf("Context deadline exceeded in reconcileExternalChanges, will retry with backoff")
+				return nil, false
 			}
 
+			// Log the error but always continue reconciling - we need reconcileStateTransition to run
+			// to restore services after restart, even if we can't read their status yet
+			p.baseFSMInstance.GetLogger().Warnf("failed to update observed state (continuing reconciliation): %s", err)
+			
+			// For all other errors, just continue reconciling without setting backoff
 			err = nil
 		}
 	}

--- a/umh-core/pkg/fsm/protocolconverter/reconcile.go
+++ b/umh-core/pkg/fsm/protocolconverter/reconcile.go
@@ -25,8 +25,6 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/metrics"
-	protocolconvertersvc "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/protocolconverter"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/s6"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/serviceregistry"
 	standarderrors "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/standarderrors"
 )

--- a/umh-core/pkg/fsm/redpanda/reconcile.go
+++ b/umh-core/pkg/fsm/redpanda/reconcile.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	internal_fsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/internal/fsm"
@@ -26,9 +25,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/metrics"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/monitor"
 	redpanda_service "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/redpanda"
-	redpanda_monitor_service "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/redpanda_monitor"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/serviceregistry"
 	standarderrors "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/standarderrors"
 )

--- a/umh-core/pkg/fsm/redpanda/reconcile.go
+++ b/umh-core/pkg/fsm/redpanda/reconcile.go
@@ -101,27 +101,17 @@ func (r *RedpandaInstance) Reconcile(ctx context.Context, snapshot fsm.SystemSna
 	} else {
 		err, externalReconciled = r.reconcileExternalChanges(ctx, services, snapshot)
 		if err != nil {
-			// I am using strings.Contains as i cannot get it working with errors.Is
-			isExpectedError := strings.Contains(err.Error(), redpanda_monitor_service.ErrServiceNotExist.Error()) ||
-				strings.Contains(err.Error(), redpanda_monitor_service.ErrServiceNoLogFile.Error()) ||
-				strings.Contains(err.Error(), monitor.ErrServiceConnectionRefused.Error()) ||
-				strings.Contains(err.Error(), monitor.ErrServiceConnectionTimedOut.Error()) ||
-				strings.Contains(err.Error(), redpanda_monitor_service.ErrServiceNoSectionsFound.Error()) ||
-				strings.Contains(err.Error(), monitor.ErrServiceStopped.Error()) // This is expected when the service is stopped or stopping, no need to fetch logs, metrics, etc.
-
-			if !isExpectedError {
-
-				if r.baseFSMInstance.IsDeadlineExceededAndHandle(err, snapshot.Tick, "reconcileExternalChanges") {
-					return nil, false
-				}
-
-				r.baseFSMInstance.SetError(err, snapshot.Tick)
-				r.baseFSMInstance.GetLogger().Errorf("error reconciling external changes: %s", err)
-				return nil, false // We don't want to return an error here, because we want to continue reconciling
+			if r.baseFSMInstance.IsDeadlineExceededAndHandle(err, snapshot.Tick, "reconcileExternalChanges") {
+				return nil, false
 			}
 
+			// Log the error but always continue reconciling - we need reconcileStateTransition to run
+			// to restore services after restart, even if we can't read their status yet
+			r.baseFSMInstance.GetLogger().Warnf("failed to update observed state (continuing reconciliation): %s", err)
+			
+			// For all other errors, just continue reconciling without setting backoff
 			//nolint:ineffassign
-			err = nil // The service does not exist, which is fine as this happens in the reconcileStateTransition
+			err = nil
 		}
 	}
 

--- a/umh-core/pkg/fsm/redpanda_monitor/reconcile.go
+++ b/umh-core/pkg/fsm/redpanda_monitor/reconcile.go
@@ -91,28 +91,16 @@ func (b *RedpandaMonitorInstance) Reconcile(ctx context.Context, snapshot fsm.Sy
 
 	// Step 2: Detect external changes.
 	if err = b.reconcileExternalChanges(ctx, services, snapshot); err != nil {
-
-		// I am using strings.Contains as i cannot get it working with errors.Is
-		isExpectedError := strings.Contains(err.Error(), redpanda_monitor_service.ErrServiceNotExist.Error()) ||
-			strings.Contains(err.Error(), redpanda_monitor_service.ErrServiceNoLogFile.Error()) ||
-			strings.Contains(err.Error(), monitor.ErrServiceConnectionRefused.Error()) ||
-			strings.Contains(err.Error(), monitor.ErrServiceConnectionTimedOut.Error()) ||
-			strings.Contains(err.Error(), redpanda_monitor_service.ErrServiceNoSectionsFound.Error()) ||
-			strings.Contains(err.Error(), monitor.ErrServiceStopped.Error()) // This is expected when the service is stopped or stopping, no need to fetch logs, metrics, etc.
-
-		if !isExpectedError {
-
-			if b.baseFSMInstance.IsDeadlineExceededAndHandle(err, snapshot.Tick, "reconcileExternalChanges") {
-				return nil, false
-			}
-
-			b.baseFSMInstance.SetError(err, snapshot.Tick)
-			b.baseFSMInstance.GetLogger().Errorf("error reconciling external changes: %s", err)
-
-			return nil, false // We don't want to return an error here, because we want to continue reconciling
+		if b.baseFSMInstance.IsDeadlineExceededAndHandle(err, snapshot.Tick, "reconcileExternalChanges") {
+			return nil, false
 		}
 
-		err = nil // The service does not exist or has troubles fetching the observed state (which will cause the service to be in degraded state)
+		// Log the error but always continue reconciling - we need reconcileStateTransition to run
+		// to restore services after restart, even if we can't read their status yet
+		b.baseFSMInstance.GetLogger().Warnf("failed to update observed state (continuing reconciliation): %s", err)
+		
+		// For all other errors, just continue reconciling without setting backoff
+		err = nil
 	}
 
 	// Step 3: Attempt to reconcile the state.

--- a/umh-core/pkg/fsm/redpanda_monitor/reconcile.go
+++ b/umh-core/pkg/fsm/redpanda_monitor/reconcile.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	internal_fsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/internal/fsm"
@@ -26,8 +25,6 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/metrics"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/monitor"
-	redpanda_monitor_service "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/redpanda_monitor"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/serviceregistry"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/standarderrors"
 )

--- a/umh-core/pkg/fsm/streamprocessor/reconcile.go
+++ b/umh-core/pkg/fsm/streamprocessor/reconcile.go
@@ -25,8 +25,6 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/metrics"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/s6"
-	spsvc "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/streamprocessor"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/serviceregistry"
 	standarderrors "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/standarderrors"
 )

--- a/umh-core/pkg/fsm/streamprocessor/reconcile.go
+++ b/umh-core/pkg/fsm/streamprocessor/reconcile.go
@@ -98,31 +98,23 @@ func (i *Instance) Reconcile(ctx context.Context, snapshot fsm.SystemSnapshot, s
 		i.baseFSMInstance.GetLogger().Debugf("Skipping external changes detection during removal")
 	} else {
 		if err = i.reconcileExternalChanges(ctx, services, snapshot); err != nil {
-			// If the service is not running, we don't want to return an error here, because we want to continue reconciling
-			if !errors.Is(err, spsvc.ErrServiceNotExist) && !errors.Is(err, s6.ErrServiceNotExist) {
-				// errors.Is(err, s6.ErrServiceNotExist)
-				// Consider a special case for DFC FSM here
-				// While creating for the first time, reconcileExternalChanges function will throw an error such as
-				// s6 service not found in the path since DFC fsm is relying on BenthosFSM and Benthos in turn relies on S6 fsm
-				// Inorder for DFC fsm to start, benthosManager.Reconcile should be called and this is called at the end of the function
-				// So set the err to nil in this case
-				// An example error: "failed to update observed state: failed to get observed DataflowComponent config: failed to get benthos config: failed to get benthos config file for service benthos-dataflow-hello-world-dfc: service does not exist"
-
+			if errors.Is(err, context.DeadlineExceeded) {
+				// Healthchecks occasionally take longer (sometimes up to 70ms),
+				// resulting in context.DeadlineExceeded errors. In this case, we want to
+				// mark the reconciliation as complete for this tick since we've likely
+				// already consumed significant time. We return reconciled=true to prevent
+				// further reconciliation attempts in the current tick.
 				i.baseFSMInstance.SetError(err, snapshot.Tick)
-				i.baseFSMInstance.GetLogger().Errorf("error reconciling external changes: %s", err)
-
-				if errors.Is(err, context.DeadlineExceeded) {
-					// Healthchecks occasionally take longer (sometimes up to 70ms),
-					// resulting in context.DeadlineExceeded errors. In this case, we want to
-					// mark the reconciliation as complete for this tick since we've likely
-					// already consumed significant time. We return reconciled=true to prevent
-					// further reconciliation attempts in the current tick.
-					return nil, true // We don't want to return an error here, as this can happen in normal operations
-				}
-				return nil, false // We don't want to return an error here, because we want to continue reconciling
+				i.baseFSMInstance.GetLogger().Warnf("Context deadline exceeded in reconcileExternalChanges, will retry with backoff")
+				return nil, true // We don't want to return an error here, as this can happen in normal operations
 			}
 
-			err = nil // The service does not exist, which is fine as this happens in the reconcileStateTransition
+			// Log the error but always continue reconciling - we need reconcileStateTransition to run
+			// to restore services after restart, even if we can't read their status yet
+			i.baseFSMInstance.GetLogger().Warnf("failed to update observed state (continuing reconciliation): %s", err)
+			
+			// For all other errors, just continue reconciling without setting backoff
+			err = nil
 		}
 	}
 

--- a/umh-core/pkg/fsm/topicbrowser/reconcile.go
+++ b/umh-core/pkg/fsm/topicbrowser/reconcile.go
@@ -24,8 +24,6 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/backoff"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/metrics"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/s6"
-	topicbrowsersvc "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/topicbrowser"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/serviceregistry"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/standarderrors"
 

--- a/umh-core/test/fsm/protocolconverter/protocolconverter_test.go
+++ b/umh-core/test/fsm/protocolconverter/protocolconverter_test.go
@@ -1176,7 +1176,7 @@ var _ = Describe("ProtocolConverter FSM", func() {
 	//  CONFIGURATION VALIDATION
 	// =========================================================================
 	Context("Configuration Validation", func() {
-		It("should handle invalid config gracefully and transition to stopped state", func() {
+		It("should get stuck in creating state with error message when config is invalid", func() {
 			var err error
 
 			// Create an instance with invalid port configuration
@@ -1190,20 +1190,18 @@ var _ = Describe("ProtocolConverter FSM", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(finalTick).To(BeNumerically(">", tick))
 
-			// With the new reconciliation behavior, the instance should continue reconciling
-			// and eventually transition to stopped state rather than getting stuck in creating
+			// The instance should get stuck in creating state
 			currentState := invalidInstance.GetCurrentFSMState()
-			Expect(currentState).To(Equal(protocolconverterfsm.OperationalStateStopped))
+			Expect(currentState).To(Equal(internalfsm.LifecycleStateCreating))
 
-			// With the new behavior, the observed state might be nil or empty since
-			// we continue reconciling despite UpdateObservedState errors
+			// The observed state should contain the configuration error in StatusReason
 			observedState := invalidInstance.GetLastObservedState()
-			if observedState != nil {
-				if pcObservedState, ok := observedState.(protocolconverterfsm.ProtocolConverterObservedState); ok {
-					// The StatusReason might be empty or contain error info
-					// We can't guarantee it contains the config error with the new behavior
-					_ = pcObservedState
-				}
+			Expect(observedState).NotTo(BeNil())
+			if pcObservedState, ok := observedState.(protocolconverterfsm.ProtocolConverterObservedState); ok {
+				Expect(pcObservedState.ServiceInfo.StatusReason).To(ContainSubstring("config error"))
+				Expect(pcObservedState.ServiceInfo.StatusReason).To(ContainSubstring("invalid syntax"))
+			} else {
+				Fail("Could not cast observed state to ProtocolConverterObservedState")
 			}
 		})
 

--- a/umh-core/test/fsm/streamprocessor/manager_test.go
+++ b/umh-core/test/fsm/streamprocessor/manager_test.go
@@ -505,18 +505,14 @@ var _ = Describe("StreamProcessorManager", func() {
 			tick = newTick
 			Expect(err).NotTo(HaveOccurred())
 
-			// Verify instance exists and continues reconciling despite config errors
-			// With the new behavior, it transitions to operational states rather than
-			// getting stuck in creating state
+			// Verify instance exists and progressed to creating state
+			// Config validation errors occur during reconciliation, not lifecycle transitions
 			instances := manager.GetInstances()
 			Expect(instances).To(HaveLen(1))
 			inst, exists := instances[fmt.Sprintf("streamprocessor-%s", processorName)]
 			Expect(exists).To(BeTrue())
-			// Should progress past creating state with the new reconciliation behavior
-			currentState := inst.GetCurrentFSMState()
-			Expect(currentState).ToNot(Equal("creating"))
-			// It might be in stopped or starting_redpanda state
-			Expect(currentState).To(Or(Equal("stopped"), Equal("starting_redpanda")))
+			// Should progress to creating state, config errors occur during reconciliation
+			Expect(inst.GetCurrentFSMState()).To(Equal("creating"))
 		})
 
 		It("should recover from temporary service failures", func() {

--- a/umh-core/tools/loganalyzer/Makefile
+++ b/umh-core/tools/loganalyzer/Makefile
@@ -1,0 +1,25 @@
+.PHONY: build clean test run-example
+
+BINARY_NAME=loganalyzer
+GO=go
+
+build:
+	$(GO) build -o $(BINARY_NAME) .
+
+clean:
+	rm -f $(BINARY_NAME)
+
+test:
+	$(GO) test -v ./...
+
+run-example:
+	./$(BINARY_NAME) -f ../../data/logs/umh-core/current -i
+
+install:
+	$(GO) install
+
+fmt:
+	$(GO) fmt ./...
+
+vet:
+	$(GO) vet ./...

--- a/umh-core/tools/loganalyzer/README.md
+++ b/umh-core/tools/loganalyzer/README.md
@@ -1,0 +1,140 @@
+# UMH Core Log Analyzer
+
+A specialized tool for analyzing UMH Core logs, particularly focusing on FSM (Finite State Machine) state transitions and tick-based reconciliation events.
+
+## Features
+
+- **Tick Timeline Analysis**: View all events organized by tick number
+- **FSM State Tracking**: Track individual FSM journeys through state transitions
+- **Visual Timeline**: ASCII visualization of concurrent FSM activities
+- **Stuck FSM Detection**: Identify FSMs that may be stuck in failed transitions
+- **Error Analysis**: Group and analyze errors by type and frequency
+- **Multiple Starts Detection**: Automatically detect multiple UMH Core restarts in logs
+- **Session Analysis**: Track errors and activity across different run sessions
+- **Interactive Mode**: Explore logs interactively with various commands
+
+## Building
+
+From the `umh-core` directory:
+
+```bash
+cd tools/loganalyzer
+go build -o loganalyzer
+```
+
+## Usage
+
+### Basic Usage
+
+```bash
+# Show summary of log file
+./loganalyzer -f /path/to/umh-core/current
+
+# Run specific command
+./loganalyzer -f /path/to/umh-core/current -c timeline -start 1 -end 50
+
+# Interactive mode
+./loganalyzer -f /path/to/umh-core/current -i
+```
+
+### Command Line Options
+
+- `-f <file>`: Path to the log file (required)
+- `-i`: Run in interactive mode
+- `-c <command>`: Run specific command (summary, timeline, fsm, list-fsms, stuck)
+- `-fsm <name>`: FSM name for fsm command
+- `-start <tick>`: Start tick for timeline (default: 1)
+- `-end <tick>`: End tick for timeline (default: 100)
+
+### Interactive Commands
+
+- `summary` - Show overall analysis summary with multiple starts detection
+- `timeline [start end]` - Show tick timeline (default: 1-100)
+- `fsm <name>` - Show history of a specific FSM
+- `list-fsms` - List all FSMs
+- `stuck` - Find potentially stuck FSMs
+- `filter <pattern>` - Filter FSMs by name pattern
+- `visual [start end]` - Show visual FSM timeline (default: 1-20)
+- `concurrent` - Show concurrent FSM activity analysis
+- `errors` - Show error analysis and grouping
+- `errors-tick <tick>` - Show errors at a specific tick
+- `help` - Show available commands
+- `quit` - Exit the program
+
+## Understanding the Output
+
+### Timeline View
+
+Shows events grouped by tick:
+- **Desired State Changes**: FSMs being told to change state
+- **FSM Transitions**: Actual state transitions (✓ success, → attempt, ✗ failed)
+- **Reconciliations**: Components reconciling their state
+- **Actions**: Service actions (→ starting, ✓ completed)
+- **Errors**: Any errors that occurred
+
+### Visual Timeline
+
+Provides a grid view showing FSM states over time:
+- Each row represents an FSM
+- Each column represents a tick
+- State symbols: C=created, S=stopped, R=running, A=active, etc.
+- Transition symbols: → = transition, ✗ = failed attempt
+
+### FSM History
+
+Shows the complete journey of a single FSM through its states, including:
+- State transitions with tick numbers
+- Success/failure of each transition
+- Current state
+
+### Stuck FSM Detection
+
+Identifies FSMs that have:
+- Multiple consecutive failed transition attempts
+- Not reached their desired state
+- May need manual intervention
+
+### Error Analysis
+
+The `errors` command provides:
+- Grouped errors by pattern/type
+- Error frequency and timing
+- First and last occurrence of each error type
+- Errors distributed across sessions
+- Ticks with the most errors
+
+### Multiple Starts Detection
+
+The summary automatically detects when UMH Core was restarted:
+- Shows number of sessions
+- Duration of each session
+- Error count per session
+- Tick range for each session
+
+## Example Output
+
+```
+=== Tick Timeline (Ticks 1-10) ===
+
+Tick 7 (13:16:07.938):
+  Desired State Changes:
+    • redpanda → active
+    • generate-1 → active
+  FSM Transitions:
+    ✓ Core: creating → monitoring_stopped (event: create_done)
+    → redpanda: to_be_created → ? (event: create)
+  Reconciliations:
+    • ProtocolConverterServicegenerate-1
+    • StreamProcessorServicetest
+  Actions:
+    → Starting redpanda service
+    ✓ Redpanda service started
+```
+
+## Tips
+
+1. Start with `summary` to get an overview
+2. Use `stuck` to quickly identify problematic FSMs
+3. Use `visual` for a quick overview of system activity
+4. Filter FSMs by pattern to focus on specific components
+5. Check `concurrent` to identify performance bottlenecks

--- a/umh-core/tools/loganalyzer/display.go
+++ b/umh-core/tools/loganalyzer/display.go
@@ -1,3 +1,17 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (
@@ -135,7 +149,9 @@ func (a *LogAnalyzer) ShowFSMHistory(fsmName string) {
 }
 
 func (a *LogAnalyzer) ListFSMs() {
-	fmt.Println("\n=== FSM List ===\n")
+	fmt.Println("")
+	fmt.Println("=== FSM List ===")
+	fmt.Println("")
 	
 	fsms := make([]string, 0, len(a.FSMHistories))
 	for name := range a.FSMHistories {
@@ -170,7 +186,9 @@ func (a *LogAnalyzer) ListFSMs() {
 }
 
 func (a *LogAnalyzer) FindStuckFSMs() {
-	fmt.Println("\n=== Potentially Stuck FSMs ===\n")
+	fmt.Println("")
+	fmt.Println("=== Potentially Stuck FSMs ===")
+	fmt.Println("")
 	
 	stuck := make([]string, 0)
 	
@@ -223,7 +241,9 @@ func countRecentFailures(history *FSMHistory) int {
 }
 
 func (a *LogAnalyzer) ShowSummary() {
-	fmt.Println("\n=== Log Analysis Summary ===\n")
+	fmt.Println("")
+	fmt.Println("=== Log Analysis Summary ===")
+	fmt.Println("")
 	
 	totalTicks := len(a.TickMap)
 	totalFSMs := len(a.FSMHistories)

--- a/umh-core/tools/loganalyzer/display.go
+++ b/umh-core/tools/loganalyzer/display.go
@@ -1,0 +1,286 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+func (a *LogAnalyzer) ShowTickTimeline(startTick, endTick int) {
+	fmt.Printf("\n=== Tick Timeline (Ticks %d-%d) ===\n\n", startTick, endTick)
+
+	ticks := make([]int, 0)
+	for tick := range a.TickMap {
+		if tick >= startTick && tick <= endTick {
+			ticks = append(ticks, tick)
+		}
+	}
+	sort.Ints(ticks)
+
+	for _, tick := range ticks {
+		tickData := a.TickMap[tick]
+		fmt.Printf("Tick %d (%s):\n", tick, tickData.Timestamp.Format("15:04:05.000"))
+		
+		fsmEvents := make([]LogEntry, 0)
+		reconciliations := make([]LogEntry, 0)
+		desiredStates := make([]LogEntry, 0)
+		actions := make([]LogEntry, 0)
+		errors := make([]LogEntry, 0)
+		
+		for _, event := range tickData.Events {
+			switch event.EntryType {
+			case EntryTypeFSMTransition, EntryTypeFSMAttempt, EntryTypeFSMFailed:
+				fsmEvents = append(fsmEvents, event)
+			case EntryTypeReconciliation:
+				reconciliations = append(reconciliations, event)
+			case EntryTypeFSMDesiredState:
+				desiredStates = append(desiredStates, event)
+			case EntryTypeActionStart, EntryTypeActionDone:
+				actions = append(actions, event)
+			case EntryTypeError:
+				errors = append(errors, event)
+			}
+		}
+
+		if len(desiredStates) > 0 {
+			fmt.Println("  Desired State Changes:")
+			for _, event := range desiredStates {
+				fmt.Printf("    • %s → %s\n", event.FSMName, event.DesiredState)
+			}
+		}
+
+		if len(fsmEvents) > 0 {
+			fmt.Println("  FSM Transitions:")
+			for _, event := range fsmEvents {
+				status := "✓"
+				if event.EntryType == EntryTypeFSMAttempt {
+					status = "→"
+				} else if event.EntryType == EntryTypeFSMFailed {
+					status = "✗"
+				}
+				toState := event.ToState
+				if toState == "" {
+					toState = "?"
+				}
+				fmt.Printf("    %s %s: %s → %s (event: %s)\n", 
+					status, event.FSMName, event.FromState, 
+					toState, event.Event)
+			}
+		}
+
+		if len(reconciliations) > 0 {
+			fmt.Println("  Reconciliations:")
+			for _, event := range reconciliations {
+				fmt.Printf("    • %s\n", event.Component)
+			}
+		}
+		
+		if len(actions) > 0 {
+			fmt.Println("  Actions:")
+			for _, event := range actions {
+				marker := "→"
+				if event.EntryType == EntryTypeActionDone {
+					marker = "✓"
+				}
+				fmt.Printf("    %s %s\n", marker, event.Message)
+			}
+		}
+		
+		if len(errors) > 0 {
+			fmt.Println("  Errors:")
+			for _, event := range errors {
+				fmt.Printf("    ✗ %s\n", event.Message)
+			}
+		}
+		
+		fmt.Println()
+	}
+}
+
+func (a *LogAnalyzer) ShowFSMHistory(fsmName string) {
+	history, exists := a.FSMHistories[fsmName]
+	if !exists {
+		fmt.Printf("No history found for FSM: %s\n", fsmName)
+		return
+	}
+
+	fmt.Printf("\n=== FSM History: %s ===\n\n", fsmName)
+	
+	currentState := ""
+	for i, transition := range history.Transitions {
+		if i == 0 || transition.FromState != currentState {
+			if i > 0 {
+				fmt.Println()
+			}
+			fmt.Printf("State: %s\n", transition.FromState)
+		}
+		
+		arrow := "→"
+		if transition.Success {
+			arrow = "✓→"
+			currentState = transition.ToState
+		} else {
+			arrow = "✗→"
+		}
+		
+		fmt.Printf("  Tick %d: %s %s (event: %s, desired: %s)\n",
+			transition.Tick, arrow, transition.ToState, 
+			transition.Event, transition.DesiredState)
+	}
+	
+	if currentState != "" {
+		fmt.Printf("\nCurrent State: %s\n", currentState)
+	}
+}
+
+func (a *LogAnalyzer) ListFSMs() {
+	fmt.Println("\n=== FSM List ===\n")
+	
+	fsms := make([]string, 0, len(a.FSMHistories))
+	for name := range a.FSMHistories {
+		fsms = append(fsms, name)
+	}
+	sort.Strings(fsms)
+
+	maxNameLen := 0
+	for _, name := range fsms {
+		if len(name) > maxNameLen {
+			maxNameLen = len(name)
+		}
+	}
+
+	fmt.Printf("%-*s  Transitions  Last State\n", maxNameLen, "FSM Name")
+	fmt.Println(strings.Repeat("-", maxNameLen+30))
+	
+	for _, name := range fsms {
+		history := a.FSMHistories[name]
+		lastState := "unknown"
+		
+		for i := len(history.Transitions) - 1; i >= 0; i-- {
+			if history.Transitions[i].Success {
+				lastState = history.Transitions[i].ToState
+				break
+			}
+		}
+		
+		fmt.Printf("%-*s  %11d  %s\n", maxNameLen, name, 
+			len(history.Transitions), lastState)
+	}
+}
+
+func (a *LogAnalyzer) FindStuckFSMs() {
+	fmt.Println("\n=== Potentially Stuck FSMs ===\n")
+	
+	stuck := make([]string, 0)
+	
+	for name, history := range a.FSMHistories {
+		if len(history.Transitions) == 0 {
+			continue
+		}
+
+		failedAttempts := 0
+		for i := len(history.Transitions) - 1; i >= 0 && i >= len(history.Transitions)-5; i-- {
+			if !history.Transitions[i].Success {
+				failedAttempts++
+			} else {
+				break
+			}
+		}
+		
+		if failedAttempts >= 3 {
+			stuck = append(stuck, name)
+		}
+	}
+	
+	if len(stuck) == 0 {
+		fmt.Println("No stuck FSMs detected.")
+		return
+	}
+	
+	for _, name := range stuck {
+		history := a.FSMHistories[name]
+		lastTransition := history.Transitions[len(history.Transitions)-1]
+		
+		fmt.Printf("FSM: %s\n", name)
+		fmt.Printf("  Stuck in state: %s\n", lastTransition.FromState)
+		fmt.Printf("  Trying to reach: %s\n", lastTransition.DesiredState)
+		fmt.Printf("  Failed attempts: %d\n", countRecentFailures(history))
+		fmt.Printf("  Last attempt: Tick %d\n\n", lastTransition.Tick)
+	}
+}
+
+func countRecentFailures(history *FSMHistory) int {
+	count := 0
+	for i := len(history.Transitions) - 1; i >= 0; i-- {
+		if !history.Transitions[i].Success {
+			count++
+		} else {
+			break
+		}
+	}
+	return count
+}
+
+func (a *LogAnalyzer) ShowSummary() {
+	fmt.Println("\n=== Log Analysis Summary ===\n")
+	
+	totalTicks := len(a.TickMap)
+	totalFSMs := len(a.FSMHistories)
+	totalTransitions := 0
+	failedTransitions := 0
+	
+	for _, history := range a.FSMHistories {
+		for _, transition := range history.Transitions {
+			totalTransitions++
+			if !transition.Success {
+				failedTransitions++
+			}
+		}
+	}
+	
+	fmt.Printf("Total Entries:     %d\n", len(a.Entries))
+	fmt.Printf("Total Errors:      %d\n", len(a.Errors))
+	fmt.Printf("Total Ticks:       %d\n", totalTicks)
+	fmt.Printf("Total FSMs:        %d\n", totalFSMs)
+	fmt.Printf("Total Transitions: %d\n", totalTransitions)
+	fmt.Printf("Failed Attempts:   %d (%.1f%%)\n", 
+		failedTransitions, 
+		float64(failedTransitions)/float64(totalTransitions)*100)
+	
+	// Show multiple starts
+	if len(a.Starts) > 1 {
+		fmt.Printf("\n⚠️  Multiple UMH Core starts detected: %d\n", len(a.Starts))
+		fmt.Println("\nSessions:")
+		for i, session := range a.Sessions {
+			duration := session.EndTime.Sub(session.StartTime)
+			fmt.Printf("  Session %d: %s - %s (duration: %s)\n", 
+				i+1, 
+				session.StartTime.Format("15:04:05"),
+				session.EndTime.Format("15:04:05"),
+				duration.Round(time.Second))
+			if session.StartTick >= 0 && session.EndTick >= 0 {
+				fmt.Printf("    Ticks: %d - %d\n", session.StartTick, session.EndTick)
+			}
+			fmt.Printf("    Errors: %d\n", session.Errors)
+		}
+	} else if len(a.Starts) == 1 {
+		fmt.Printf("\nSingle session detected\n")
+	}
+	
+	if totalTicks > 0 {
+		ticks := make([]int, 0, len(a.TickMap))
+		for tick := range a.TickMap {
+			ticks = append(ticks, tick)
+		}
+		sort.Ints(ticks)
+		
+		firstTick := a.TickMap[ticks[0]]
+		lastTick := a.TickMap[ticks[len(ticks)-1]]
+		
+		fmt.Printf("\nOverall Time Range: %s - %s\n", 
+			firstTick.Timestamp.Format("15:04:05"),
+			lastTick.Timestamp.Format("15:04:05"))
+		fmt.Printf("Overall Tick Range: %d - %d\n", ticks[0], ticks[len(ticks)-1])
+	}
+}

--- a/umh-core/tools/loganalyzer/errors.go
+++ b/umh-core/tools/loganalyzer/errors.go
@@ -1,3 +1,17 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/umh-core/tools/loganalyzer/errors.go
+++ b/umh-core/tools/loganalyzer/errors.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+func (a *LogAnalyzer) ShowErrors() {
+	fmt.Printf("\n=== Error Analysis (%d total errors) ===\n\n", len(a.Errors))
+
+	if len(a.Errors) == 0 {
+		fmt.Println("No errors found in the log file.")
+		return
+	}
+
+	// Group errors by message pattern
+	errorGroups := make(map[string][]LogEntry)
+	
+	for _, err := range a.Errors {
+		// Extract key parts of error for grouping
+		key := extractErrorKey(err)
+		errorGroups[key] = append(errorGroups[key], err)
+	}
+
+	// Sort groups by frequency
+	type errorGroup struct {
+		Key   string
+		Count int
+		First LogEntry
+		Last  LogEntry
+	}
+	
+	groups := make([]errorGroup, 0, len(errorGroups))
+	for key, errors := range errorGroups {
+		group := errorGroup{
+			Key:   key,
+			Count: len(errors),
+			First: errors[0],
+			Last:  errors[len(errors)-1],
+		}
+		groups = append(groups, group)
+	}
+	
+	sort.Slice(groups, func(i, j int) bool {
+		return groups[i].Count > groups[j].Count
+	})
+
+	// Show top error groups
+	fmt.Println("Error Summary (grouped by type):")
+	for i, group := range groups {
+		if i >= 10 && len(groups) > 10 {
+			fmt.Printf("\n... and %d more error types\n", len(groups)-10)
+			break
+		}
+		
+		fmt.Printf("\n%d. %s (count: %d)\n", i+1, group.Key, group.Count)
+		fmt.Printf("   First: %s\n", group.First.Timestamp.Format("15:04:05.000"))
+		fmt.Printf("   Last:  %s\n", group.Last.Timestamp.Format("15:04:05.000"))
+		
+		if group.First.Component != "" {
+			fmt.Printf("   Component: %s\n", group.First.Component)
+		}
+	}
+
+	// Show errors over time
+	a.showErrorTimeline()
+}
+
+func extractErrorKey(entry LogEntry) string {
+	msg := entry.Message
+	
+	// For standard error format, extract the error message
+	if entry.EntryType == EntryTypeError {
+		return entry.Message
+	}
+	
+	// Extract error message from log line
+	if idx := strings.Index(msg, "Error "); idx >= 0 {
+		errorPart := msg[idx:]
+		// Remove specific details like IDs, keeping just the pattern
+		errorPart = strings.ReplaceAll(errorPart, "agent instance not found", "instance not found")
+		return errorPart
+	}
+	
+	// Fallback to full message
+	return msg
+}
+
+func (a *LogAnalyzer) showErrorTimeline() {
+	fmt.Println("\n=== Error Timeline ===")
+	
+	if len(a.Sessions) > 1 {
+		fmt.Println("\nErrors by session:")
+		for i, session := range a.Sessions {
+			fmt.Printf("  Session %d: %d errors\n", i+1, session.Errors)
+		}
+	}
+	
+	// Group errors by tick
+	errorsByTick := make(map[int]int)
+	for _, err := range a.Errors {
+		// Find which tick this error belongs to
+		for tick, tickData := range a.TickMap {
+			if err.Timestamp.After(tickData.Timestamp.Add(-time.Second)) &&
+			   err.Timestamp.Before(tickData.Timestamp.Add(time.Second)) {
+				errorsByTick[tick]++
+				break
+			}
+		}
+	}
+	
+	if len(errorsByTick) > 0 {
+		fmt.Println("\nTicks with most errors:")
+		
+		type tickErrors struct {
+			Tick  int
+			Count int
+		}
+		
+		tickList := make([]tickErrors, 0, len(errorsByTick))
+		for tick, count := range errorsByTick {
+			tickList = append(tickList, tickErrors{Tick: tick, Count: count})
+		}
+		
+		sort.Slice(tickList, func(i, j int) bool {
+			return tickList[i].Count > tickList[j].Count
+		})
+		
+		for i, te := range tickList {
+			if i >= 5 {
+				break
+			}
+			fmt.Printf("  Tick %d: %d errors\n", te.Tick, te.Count)
+		}
+	}
+}
+
+func (a *LogAnalyzer) ShowErrorsForTick(tick int) {
+	fmt.Printf("\n=== Errors at Tick %d ===\n\n", tick)
+	
+	found := false
+	for _, err := range a.Errors {
+		// Check if error is near this tick
+		if tickData, exists := a.TickMap[tick]; exists {
+			if err.Timestamp.After(tickData.Timestamp.Add(-time.Second)) &&
+			   err.Timestamp.Before(tickData.Timestamp.Add(time.Second)) {
+				found = true
+				fmt.Printf("[%s] %s\n", err.Timestamp.Format("15:04:05.000"), err.Message)
+			}
+		}
+	}
+	
+	if !found {
+		fmt.Println("No errors found at this tick.")
+	}
+}

--- a/umh-core/tools/loganalyzer/main.go
+++ b/umh-core/tools/loganalyzer/main.go
@@ -1,0 +1,213 @@
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+func main() {
+	var (
+		logFile     = flag.String("f", "", "Path to the log file to analyze")
+		interactive = flag.Bool("i", false, "Run in interactive mode")
+		command     = flag.String("c", "", "Command to run (summary, timeline, fsm, list-fsms, stuck)")
+		fsmName     = flag.String("fsm", "", "FSM name for fsm command")
+		startTick   = flag.Int("start", 1, "Start tick for timeline")
+		endTick     = flag.Int("end", 100, "End tick for timeline")
+	)
+	
+	flag.Parse()
+
+	if *logFile == "" {
+		fmt.Println("Error: Log file path is required (-f flag)")
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	analyzer, err := ParseLogFile(*logFile)
+	if err != nil {
+		fmt.Printf("Error parsing log file: %v\n", err)
+		os.Exit(1)
+	}
+
+	if *interactive {
+		runInteractive(analyzer)
+	} else if *command != "" {
+		runCommand(analyzer, *command, *fsmName, *startTick, *endTick)
+	} else {
+		analyzer.ShowSummary()
+	}
+}
+
+func runCommand(analyzer *LogAnalyzer, command, fsmName string, startTick, endTick int) {
+	switch command {
+	case "summary":
+		analyzer.ShowSummary()
+	case "timeline":
+		analyzer.ShowTickTimeline(startTick, endTick)
+	case "fsm":
+		if fsmName == "" {
+			fmt.Println("Error: FSM name required for fsm command (-fsm flag)")
+			return
+		}
+		analyzer.ShowFSMHistory(fsmName)
+	case "list-fsms":
+		analyzer.ListFSMs()
+	case "stuck":
+		analyzer.FindStuckFSMs()
+	case "errors":
+		analyzer.ShowErrors()
+	case "recovery":
+		analyzer.AnalyzeRecovery()
+	case "orphans":
+		analyzer.AnalyzeOrphanedServices()
+	default:
+		fmt.Printf("Unknown command: %s\n", command)
+		fmt.Println("Available commands: summary, timeline, fsm, list-fsms, stuck, errors, recovery, orphans")
+	}
+}
+
+func runInteractive(analyzer *LogAnalyzer) {
+	reader := bufio.NewReader(os.Stdin)
+	
+	fmt.Println("\n=== UMH Core Log Analyzer ===")
+	fmt.Println("Type 'help' for available commands or 'quit' to exit\n")
+
+	for {
+		fmt.Print("> ")
+		input, err := reader.ReadString('\n')
+		if err != nil {
+			break
+		}
+
+		input = strings.TrimSpace(input)
+		if input == "" {
+			continue
+		}
+
+		parts := strings.Fields(input)
+		command := parts[0]
+
+		switch command {
+		case "help":
+			showHelp()
+			
+		case "quit", "exit":
+			fmt.Println("Goodbye!")
+			return
+			
+		case "summary":
+			analyzer.ShowSummary()
+			
+		case "timeline":
+			start, end := 1, 100
+			if len(parts) >= 3 {
+				start, _ = strconv.Atoi(parts[1])
+				end, _ = strconv.Atoi(parts[2])
+			}
+			analyzer.ShowTickTimeline(start, end)
+			
+		case "fsm":
+			if len(parts) < 2 {
+				fmt.Println("Usage: fsm <fsm-name>")
+				continue
+			}
+			analyzer.ShowFSMHistory(parts[1])
+			
+		case "list-fsms", "list":
+			analyzer.ListFSMs()
+			
+		case "stuck":
+			analyzer.FindStuckFSMs()
+			
+		case "filter":
+			if len(parts) < 2 {
+				fmt.Println("Usage: filter <fsm-pattern>")
+				continue
+			}
+			filterFSMs(analyzer, parts[1])
+			
+		case "visual":
+			start, end := 1, 20
+			if len(parts) >= 3 {
+				start, _ = strconv.Atoi(parts[1])
+				end, _ = strconv.Atoi(parts[2])
+			}
+			analyzer.ShowVisualTimeline(start, end)
+			
+		case "concurrent":
+			analyzer.ShowConcurrentActivity()
+			
+		case "errors":
+			analyzer.ShowErrors()
+			
+		case "errors-tick":
+			if len(parts) < 2 {
+				fmt.Println("Usage: errors-tick <tick-number>")
+				continue
+			}
+			tick, _ := strconv.Atoi(parts[1])
+			analyzer.ShowErrorsForTick(tick)
+			
+		case "recovery":
+			analyzer.AnalyzeRecovery()
+			
+		case "compare-sessions":
+			analyzer.CompareSessionStates()
+			
+		case "orphans":
+			analyzer.AnalyzeOrphanedServices()
+			
+		case "instance-timeline":
+			analyzer.ShowInstanceNotFoundTimeline()
+			
+		case "analyze-issue":
+			analyzer.AnalyzeRecoveryIssue()
+			
+		default:
+			fmt.Printf("Unknown command: %s\n", command)
+			fmt.Println("Type 'help' for available commands")
+		}
+	}
+}
+
+func showHelp() {
+	fmt.Println(`
+Available Commands:
+  summary              - Show overall analysis summary
+  timeline [start end] - Show tick timeline (default: 1-100)
+  fsm <name>          - Show history of a specific FSM
+  list-fsms           - List all FSMs
+  stuck               - Find potentially stuck FSMs
+  filter <pattern>    - Filter FSMs by name pattern
+  visual [start end]  - Show visual FSM timeline (default: 1-20)
+  concurrent          - Show concurrent FSM activity analysis
+  errors              - Show error analysis and grouping
+  errors-tick <tick>  - Show errors at a specific tick
+  recovery            - Analyze FSM recovery after restart
+  compare-sessions    - Compare FSM states between sessions
+  orphans             - Analyze orphaned S6 services
+  instance-timeline   - Show timeline of instance not found errors
+  help                - Show this help
+  quit                - Exit the program
+`)
+}
+
+func filterFSMs(analyzer *LogAnalyzer, pattern string) {
+	fmt.Printf("\n=== FSMs matching '%s' ===\n", pattern)
+	
+	found := false
+	for name := range analyzer.FSMHistories {
+		if strings.Contains(name, pattern) {
+			found = true
+			fmt.Printf("  • %s\n", name)
+		}
+	}
+	
+	if !found {
+		fmt.Println("No FSMs found matching the pattern")
+	}
+}

--- a/umh-core/tools/loganalyzer/main.go
+++ b/umh-core/tools/loganalyzer/main.go
@@ -1,3 +1,17 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (
@@ -73,8 +87,10 @@ func runCommand(analyzer *LogAnalyzer, command, fsmName string, startTick, endTi
 func runInteractive(analyzer *LogAnalyzer) {
 	reader := bufio.NewReader(os.Stdin)
 	
-	fmt.Println("\n=== UMH Core Log Analyzer ===")
-	fmt.Println("Type 'help' for available commands or 'quit' to exit\n")
+	fmt.Println("")
+	fmt.Println("=== UMH Core Log Analyzer ===")
+	fmt.Println("Type 'help' for available commands or 'quit' to exit")
+	fmt.Println("")
 
 	for {
 		fmt.Print("> ")
@@ -175,9 +191,9 @@ func runInteractive(analyzer *LogAnalyzer) {
 }
 
 func showHelp() {
-	fmt.Println(`
-Available Commands:
-  summary              - Show overall analysis summary
+	fmt.Println("")
+	fmt.Println("Available Commands:")
+	fmt.Print(`  summary              - Show overall analysis summary
   timeline [start end] - Show tick timeline (default: 1-100)
   fsm <name>          - Show history of a specific FSM
   list-fsms           - List all FSMs

--- a/umh-core/tools/loganalyzer/orphans.go
+++ b/umh-core/tools/loganalyzer/orphans.go
@@ -1,0 +1,232 @@
+package main
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+var (
+	instanceNotFoundRegex = regexp.MustCompile(`instance (\S+) not found`)
+	s6ServiceExistsRegex  = regexp.MustCompile(`S6 service (\S+) (?:exists|already exists)`)
+	s6ServiceNotExistRegex = regexp.MustCompile(`S6 service (\S+) does not exist`)
+	reconcileErrorRegex   = regexp.MustCompile(`error reconciling external changes:.*instance (\S+) not found`)
+	backoffSuspendRegex   = regexp.MustCompile(`Suspending operations for (\d+) ticks.*instance (\S+) not found`)
+)
+
+type OrphanedService struct {
+	InstanceName string
+	Component    string
+	FirstSeen    time.Time
+	ErrorCount   int
+	BackoffTicks int
+	ManagerType  string
+}
+
+// AnalyzeOrphanedServices finds services that exist in S6 but not in FSM managers
+func (a *LogAnalyzer) AnalyzeOrphanedServices() {
+	fmt.Println("\n=== Orphaned Service Analysis ===")
+	fmt.Println("(S6 services that exist but have no FSM manager instance)\n")
+	
+	orphans := make(map[string]*OrphanedService)
+	s6Services := make(map[string]bool)
+	
+	// First pass: collect all "instance not found" errors
+	for _, entry := range a.Entries {
+		// Check for instance not found
+		if match := instanceNotFoundRegex.FindStringSubmatch(entry.Message); match != nil {
+			instanceName := match[1]
+			if _, exists := orphans[instanceName]; !exists {
+				orphans[instanceName] = &OrphanedService{
+					InstanceName: instanceName,
+					Component:    entry.Component,
+					FirstSeen:    entry.Timestamp,
+					ManagerType:  extractManagerType(entry.Message),
+				}
+			}
+			orphans[instanceName].ErrorCount++
+		}
+		
+		// Check for backoff suspensions
+		if match := backoffSuspendRegex.FindStringSubmatch(entry.Message); match != nil {
+			ticks := 0
+			fmt.Sscanf(match[1], "%d", &ticks)
+			instanceName := match[2]
+			if orphan, exists := orphans[instanceName]; exists {
+				if ticks > orphan.BackoffTicks {
+					orphan.BackoffTicks = ticks
+				}
+			}
+		}
+		
+		// Track S6 services
+		if match := s6ServiceExistsRegex.FindStringSubmatch(entry.Message); match != nil {
+			s6Services[match[1]] = true
+		}
+		if match := s6ServiceNotExistRegex.FindStringSubmatch(entry.Message); match != nil {
+			s6Services[match[1]] = false
+		}
+	}
+	
+	// Analyze by session
+	if len(a.Sessions) >= 2 {
+		fmt.Println("Orphaned services after restart:")
+		
+		session2Start := a.Sessions[1].StartTime
+		orphansAfterRestart := make([]*OrphanedService, 0)
+		
+		for _, orphan := range orphans {
+			if orphan.FirstSeen.After(session2Start) {
+				orphansAfterRestart = append(orphansAfterRestart, orphan)
+			}
+		}
+		
+		// Sort by error count
+		sort.Slice(orphansAfterRestart, func(i, j int) bool {
+			return orphansAfterRestart[i].ErrorCount > orphansAfterRestart[j].ErrorCount
+		})
+		
+		for _, orphan := range orphansAfterRestart {
+			fmt.Printf("\n• %s\n", orphan.InstanceName)
+			fmt.Printf("  Component: %s\n", orphan.Component)
+			fmt.Printf("  Manager Type: %s\n", orphan.ManagerType)
+			fmt.Printf("  Error Count: %d\n", orphan.ErrorCount)
+			fmt.Printf("  Max Backoff: %d ticks\n", orphan.BackoffTicks)
+			fmt.Printf("  First Error: %s\n", orphan.FirstSeen.Format("15:04:05.000"))
+			
+			// Check if S6 service exists
+			serviceName := guessS6ServiceName(orphan.InstanceName)
+			if exists, found := s6Services[serviceName]; found && exists {
+				fmt.Printf("  ⚠️  S6 service '%s' exists on filesystem!\n", serviceName)
+			}
+		}
+		
+		fmt.Printf("\nTotal orphaned instances after restart: %d\n", len(orphansAfterRestart))
+	}
+	
+	// Show recovery attempts
+	a.showRecoveryAttempts()
+}
+
+func extractManagerType(message string) string {
+	patterns := []struct {
+		regex *regexp.Regexp
+		typ   string
+	}{
+		{regexp.MustCompile(`BenthosManager`), "Benthos"},
+		{regexp.MustCompile(`ConnectionManager`), "Connection"},
+		{regexp.MustCompile(`DataFlowCompManager`), "DataFlowComponent"},
+		{regexp.MustCompile(`benthos observed state`), "Benthos"},
+		{regexp.MustCompile(`connection observed state`), "Connection"},
+		{regexp.MustCompile(`dataflowcomponent`), "DataFlowComponent"},
+	}
+	
+	for _, p := range patterns {
+		if p.regex.MatchString(message) {
+			return p.typ
+		}
+	}
+	return "Unknown"
+}
+
+func guessS6ServiceName(instanceName string) string {
+	// Common patterns for S6 service names
+	if strings.HasPrefix(instanceName, "topicbrowser-") {
+		return "benthos-" + instanceName
+	}
+	if strings.HasPrefix(instanceName, "protocolconverter-") {
+		return "nmap-connection-" + instanceName
+	}
+	if strings.HasPrefix(instanceName, "dfc-") {
+		return "benthos-dataflow-" + instanceName
+	}
+	return instanceName
+}
+
+func (a *LogAnalyzer) showRecoveryAttempts() {
+	fmt.Println("\n=== Recovery Attempt Analysis ===")
+	
+	// Look for patterns where system tries to recover
+	addingToManagerRegex := regexp.MustCompile(`Adding (\S+) service (\S+) to (\S+) manager`)
+	creatingServiceRegex := regexp.MustCompile(`Creating (\S+) service (\S+)`)
+	
+	recoveryAttempts := make(map[string][]string)
+	
+	for _, entry := range a.Entries {
+		if len(a.Sessions) >= 2 && entry.Timestamp.After(a.Sessions[1].StartTime) {
+			if match := addingToManagerRegex.FindStringSubmatch(entry.Message); match != nil {
+				key := fmt.Sprintf("%s:%s", match[1], match[2])
+				recoveryAttempts[key] = append(recoveryAttempts[key], 
+					fmt.Sprintf("Added to %s manager at %s", match[3], entry.Timestamp.Format("15:04:05.000")))
+			}
+			if match := creatingServiceRegex.FindStringSubmatch(entry.Message); match != nil {
+				key := fmt.Sprintf("%s:%s", match[1], match[2])
+				recoveryAttempts[key] = append(recoveryAttempts[key],
+					fmt.Sprintf("Created at %s", entry.Timestamp.Format("15:04:05.000")))
+			}
+		}
+	}
+	
+	if len(recoveryAttempts) == 0 {
+		fmt.Println("\nNo recovery attempts found after restart!")
+		fmt.Println("⚠️  This suggests the system is not detecting or recovering orphaned services.")
+	} else {
+		fmt.Printf("\nFound %d recovery attempts:\n", len(recoveryAttempts))
+		for service, attempts := range recoveryAttempts {
+			fmt.Printf("\n%s:\n", service)
+			for _, attempt := range attempts {
+				fmt.Printf("  • %s\n", attempt)
+			}
+		}
+	}
+}
+
+// ShowInstanceNotFoundTimeline shows when instance not found errors occur
+func (a *LogAnalyzer) ShowInstanceNotFoundTimeline() {
+	fmt.Println("\n=== Instance Not Found Timeline ===")
+	
+	// Group by tick
+	errorsByTick := make(map[int][]string)
+	
+	for _, entry := range a.Entries {
+		if match := instanceNotFoundRegex.FindStringSubmatch(entry.Message); match != nil {
+			// Find the tick this belongs to
+			tick := a.findTickForTimestamp(entry.Timestamp)
+			if tick > 0 {
+				errorsByTick[tick] = append(errorsByTick[tick], match[1])
+			}
+		}
+	}
+	
+	// Show timeline
+	ticks := make([]int, 0, len(errorsByTick))
+	for tick := range errorsByTick {
+		ticks = append(ticks, tick)
+	}
+	sort.Ints(ticks)
+	
+	for _, tick := range ticks {
+		instances := errorsByTick[tick]
+		unique := make(map[string]bool)
+		for _, inst := range instances {
+			unique[inst] = true
+		}
+		
+		fmt.Printf("\nTick %d: %d unique instances not found\n", tick, len(unique))
+		for inst := range unique {
+			fmt.Printf("  • %s\n", inst)
+		}
+	}
+}
+
+func (a *LogAnalyzer) findTickForTimestamp(t time.Time) int {
+	for tick, tickData := range a.TickMap {
+		if t.After(tickData.Timestamp.Add(-time.Second)) &&
+		   t.Before(tickData.Timestamp.Add(time.Second)) {
+			return tick
+		}
+	}
+	return -1
+}

--- a/umh-core/tools/loganalyzer/orphans.go
+++ b/umh-core/tools/loganalyzer/orphans.go
@@ -1,3 +1,17 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (
@@ -27,8 +41,10 @@ type OrphanedService struct {
 
 // AnalyzeOrphanedServices finds services that exist in S6 but not in FSM managers
 func (a *LogAnalyzer) AnalyzeOrphanedServices() {
-	fmt.Println("\n=== Orphaned Service Analysis ===")
-	fmt.Println("(S6 services that exist but have no FSM manager instance)\n")
+	fmt.Println("")
+	fmt.Println("=== Orphaned Service Analysis ===")
+	fmt.Println("(S6 services that exist but have no FSM manager instance)")
+	fmt.Println("")
 	
 	orphans := make(map[string]*OrphanedService)
 	s6Services := make(map[string]bool)

--- a/umh-core/tools/loganalyzer/parser.go
+++ b/umh-core/tools/loganalyzer/parser.go
@@ -1,3 +1,17 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/umh-core/tools/loganalyzer/parser.go
+++ b/umh-core/tools/loganalyzer/parser.go
@@ -48,7 +48,7 @@ func ParseLogFile(filename string) (*LogAnalyzer, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to open log file: %w", err)
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	analyzer := &LogAnalyzer{
 		Entries:      make([]LogEntry, 0),

--- a/umh-core/tools/loganalyzer/parser.go
+++ b/umh-core/tools/loganalyzer/parser.go
@@ -1,0 +1,259 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var (
+	timestampRegex = regexp.MustCompile(`^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+)`)
+	levelRegex     = regexp.MustCompile(`\[(DEBUG|INFO|WARN|ERROR)\]`)
+	sourceRegex    = regexp.MustCompile(`\[([^\]]+)\]`)
+	componentRegex = regexp.MustCompile(`\[([^\]]+)\]\s+(?:FSM|Reconciling|Setting desired state|Updated system snapshot|Starting Action|Action:)`)
+	
+	tickRegex         = regexp.MustCompile(`Updated system snapshot at tick (\d+)`)
+	fsmAttemptRegex   = regexp.MustCompile(`FSM (\S+) attempting transition: current_state='([^']+)' -> event='([^']+)' \(desired_state='([^']+)'\)`)
+	fsmSuccessRegex   = regexp.MustCompile(`FSM (\S+) successful transition: '([^']+)' -> '([^']+)' via event='([^']+)' \(desired_state='([^']+)'\)`)
+	fsmFailedRegex    = regexp.MustCompile(`FSM (\S+) failed transition: current_state='([^']+)' -> event='([^']+)' \(desired_state='([^']+)'\)`)
+	fsmDesiredRegex   = regexp.MustCompile(`Setting desired state of FSM (\S+) to (\S+)`)
+	reconcileRegex    = regexp.MustCompile(`Reconciling (\S+) (?:manager )?at tick (\d+)`)
+	actionStartRegex  = regexp.MustCompile(`Starting Action: (.+)`)
+	actionDoneRegex   = regexp.MustCompile(`Action: (.+) done`)
+	errorRegex        = regexp.MustCompile(`Error (?:executing action|removing|creating|starting|stopping): (.+)`)
+	startupRegex      = regexp.MustCompile(`Starting umh-core\.\.\.`)
+)
+
+func ParseLogFile(filename string) (*LogAnalyzer, error) {
+	file, err := os.Open(filename)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open log file: %w", err)
+	}
+	defer file.Close()
+
+	analyzer := &LogAnalyzer{
+		Entries:      make([]LogEntry, 0),
+		TickMap:      make(map[int]*TickData),
+		FSMHistories: make(map[string]*FSMHistory),
+		Errors:       make([]LogEntry, 0),
+		Starts:       make([]time.Time, 0),
+		Sessions:     make([]SessionInfo, 0),
+	}
+
+	scanner := bufio.NewScanner(file)
+	lineNum := 0
+	
+	for scanner.Scan() {
+		lineNum++
+		line := scanner.Text()
+		
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+
+		entry, err := parseLine(line)
+		if err != nil {
+			continue
+		}
+
+		analyzer.processEntry(entry)
+		analyzer.Entries = append(analyzer.Entries, entry)
+		
+		// Check for startup
+		if startupRegex.MatchString(line) {
+			analyzer.Starts = append(analyzer.Starts, entry.Timestamp)
+		}
+		
+		// Collect errors
+		if entry.Level == "ERROR" || entry.EntryType == EntryTypeError {
+			analyzer.Errors = append(analyzer.Errors, entry)
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("error reading log file: %w", err)
+	}
+
+	// Build sessions
+	analyzer.buildSessions()
+
+	return analyzer, nil
+}
+
+func parseLine(line string) (LogEntry, error) {
+	entry := LogEntry{
+		EntryType: EntryTypeUnknown,
+	}
+
+	if match := timestampRegex.FindStringSubmatch(line); match != nil {
+		t, err := time.Parse("2006-01-02 15:04:05.000000000", match[1])
+		if err == nil {
+			entry.Timestamp = t
+		}
+	}
+
+	if match := levelRegex.FindStringSubmatch(line); match != nil {
+		entry.Level = match[1]
+	}
+
+	sourceMatches := sourceRegex.FindAllStringSubmatch(line, -1)
+	if len(sourceMatches) >= 2 {
+		entry.Source = sourceMatches[1][1]
+	}
+	
+	if match := componentRegex.FindStringSubmatch(line); match != nil {
+		entry.Component = match[1]
+	}
+
+	entry.Message = line
+
+	if match := tickRegex.FindStringSubmatch(line); match != nil {
+		entry.EntryType = EntryTypeTick
+		entry.TickNumber, _ = strconv.Atoi(match[1])
+	} else if match := fsmAttemptRegex.FindStringSubmatch(line); match != nil {
+		entry.EntryType = EntryTypeFSMAttempt
+		entry.FSMName = match[1]
+		entry.FromState = match[2]
+		entry.Event = match[3]
+		entry.DesiredState = match[4]
+	} else if match := fsmSuccessRegex.FindStringSubmatch(line); match != nil {
+		entry.EntryType = EntryTypeFSMTransition
+		entry.FSMName = match[1]
+		entry.FromState = match[2]
+		entry.ToState = match[3]
+		entry.Event = match[4]
+		entry.DesiredState = match[5]
+	} else if match := fsmFailedRegex.FindStringSubmatch(line); match != nil {
+		entry.EntryType = EntryTypeFSMFailed
+		entry.FSMName = match[1]
+		entry.FromState = match[2]
+		entry.Event = match[3]
+		entry.DesiredState = match[4]
+	} else if match := fsmDesiredRegex.FindStringSubmatch(line); match != nil {
+		entry.EntryType = EntryTypeFSMDesiredState
+		entry.FSMName = match[1]
+		entry.DesiredState = match[2]
+	} else if match := reconcileRegex.FindStringSubmatch(line); match != nil {
+		entry.EntryType = EntryTypeReconciliation
+		entry.Component = match[1]
+		entry.TickNumber, _ = strconv.Atoi(match[2])
+	} else if match := actionStartRegex.FindStringSubmatch(line); match != nil {
+		entry.EntryType = EntryTypeActionStart
+		entry.Message = match[1]
+	} else if match := actionDoneRegex.FindStringSubmatch(line); match != nil {
+		entry.EntryType = EntryTypeActionDone
+		entry.Message = match[1]
+	} else if match := errorRegex.FindStringSubmatch(line); match != nil {
+		entry.EntryType = EntryTypeError
+		entry.Message = match[1]
+	}
+
+	return entry, nil
+}
+
+func (a *LogAnalyzer) processEntry(entry LogEntry) {
+	switch entry.EntryType {
+	case EntryTypeTick:
+		a.CurrentTick = entry.TickNumber
+		if _, exists := a.TickMap[entry.TickNumber]; !exists {
+			a.TickMap[entry.TickNumber] = &TickData{
+				Number:    entry.TickNumber,
+				Timestamp: entry.Timestamp,
+				Events:    make([]LogEntry, 0),
+			}
+		}
+		
+	case EntryTypeFSMTransition:
+		a.recordFSMTransition(entry, true)
+		
+	case EntryTypeFSMAttempt:
+		a.recordFSMTransition(entry, false)
+		
+	case EntryTypeFSMFailed:
+		a.recordFSMTransition(entry, false)
+	}
+
+	if a.CurrentTick > 0 {
+		if tick, exists := a.TickMap[a.CurrentTick]; exists {
+			tick.Events = append(tick.Events, entry)
+		}
+	}
+}
+
+func (a *LogAnalyzer) recordFSMTransition(entry LogEntry, success bool) {
+	if _, exists := a.FSMHistories[entry.FSMName]; !exists {
+		a.FSMHistories[entry.FSMName] = &FSMHistory{
+			Name:        entry.FSMName,
+			Transitions: make([]FSMTransition, 0),
+		}
+	}
+
+	transition := FSMTransition{
+		Tick:         a.CurrentTick,
+		Timestamp:    entry.Timestamp,
+		FromState:    entry.FromState,
+		ToState:      entry.ToState,
+		Event:        entry.Event,
+		DesiredState: entry.DesiredState,
+		Success:      success,
+	}
+
+	a.FSMHistories[entry.FSMName].Transitions = append(
+		a.FSMHistories[entry.FSMName].Transitions,
+		transition,
+	)
+}
+
+func (a *LogAnalyzer) buildSessions() {
+	if len(a.Starts) == 0 {
+		return
+	}
+
+	// Sort starts by time
+	sort.Slice(a.Starts, func(i, j int) bool {
+		return a.Starts[i].Before(a.Starts[j])
+	})
+
+	for i := 0; i < len(a.Starts); i++ {
+		session := SessionInfo{
+			StartTime: a.Starts[i],
+			StartTick: -1,
+			EndTick:   -1,
+		}
+
+		// Find end time (next start or last entry)
+		if i+1 < len(a.Starts) {
+			session.EndTime = a.Starts[i+1]
+		} else if len(a.Entries) > 0 {
+			session.EndTime = a.Entries[len(a.Entries)-1].Timestamp
+		}
+
+		// Find tick range for this session
+		for tick, tickData := range a.TickMap {
+			if tickData.Timestamp.After(session.StartTime) && 
+			   (session.EndTime.IsZero() || tickData.Timestamp.Before(session.EndTime)) {
+				if session.StartTick == -1 || tick < session.StartTick {
+					session.StartTick = tick
+				}
+				if tick > session.EndTick {
+					session.EndTick = tick
+				}
+			}
+		}
+
+		// Count errors in this session
+		for _, err := range a.Errors {
+			if err.Timestamp.After(session.StartTime) && 
+			   (session.EndTime.IsZero() || err.Timestamp.Before(session.EndTime)) {
+				session.Errors++
+			}
+		}
+
+		a.Sessions = append(a.Sessions, session)
+	}
+}

--- a/umh-core/tools/loganalyzer/recovery.go
+++ b/umh-core/tools/loganalyzer/recovery.go
@@ -71,6 +71,9 @@ func (a *LogAnalyzer) findFSMsAtTime(t time.Time) map[string]string {
 	states := make(map[string]string)
 	
 	for fsmName, history := range a.FSMHistories {
+		if history == nil {
+			continue
+		}
 		var lastState string
 		for _, transition := range history.Transitions {
 			if transition.Timestamp.Before(t) && transition.Success {

--- a/umh-core/tools/loganalyzer/recovery.go
+++ b/umh-core/tools/loganalyzer/recovery.go
@@ -1,0 +1,220 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// AnalyzeRecovery analyzes FSM recovery issues between sessions
+func (a *LogAnalyzer) AnalyzeRecovery() {
+	fmt.Println("\n=== Recovery Analysis ===\n")
+	
+	if len(a.Sessions) < 2 {
+		fmt.Println("Single session detected. No recovery analysis needed.")
+		return
+	}
+	
+	// Analyze FSM states at end of first session and start of second
+	fmt.Println("Checking FSM states across restart...\n")
+	
+	// Find FSMs that were active before restart
+	activeBeforeRestart := a.findFSMsAtTime(a.Sessions[0].EndTime.Add(-time.Second))
+	activeAfterRestart := a.findFSMsAtTime(a.Sessions[1].StartTime.Add(time.Second * 5))
+	
+	// Find FSMs that didn't recover
+	notRecovered := make(map[string]string)
+	for fsmName, beforeState := range activeBeforeRestart {
+		afterState, exists := activeAfterRestart[fsmName]
+		if !exists {
+			notRecovered[fsmName] = fmt.Sprintf("was %s, not found after restart", beforeState)
+		} else if isFailedState(afterState) {
+			notRecovered[fsmName] = fmt.Sprintf("was %s, now %s", beforeState, afterState)
+		}
+	}
+	
+	if len(notRecovered) > 0 {
+		fmt.Println("❌ FSMs that failed to recover properly:")
+		for fsm, issue := range notRecovered {
+			fmt.Printf("  • %s: %s\n", fsm, issue)
+		}
+	} else {
+		fmt.Println("✓ All FSMs recovered successfully")
+	}
+	
+	// Check for persistent errors across sessions
+	a.checkPersistentErrors()
+	
+	// Analyze agent-specific issues
+	a.analyzeAgentRecovery()
+}
+
+func (a *LogAnalyzer) findFSMsAtTime(t time.Time) map[string]string {
+	states := make(map[string]string)
+	
+	for fsmName, history := range a.FSMHistories {
+		var lastState string
+		for _, transition := range history.Transitions {
+			if transition.Timestamp.Before(t) && transition.Success {
+				lastState = transition.ToState
+			}
+		}
+		if lastState != "" {
+			states[fsmName] = lastState
+		}
+	}
+	
+	return states
+}
+
+func isFailedState(state string) bool {
+	failedStates := []string{"failed", "error", "removing", "to_be_removed"}
+	stateLower := strings.ToLower(state)
+	for _, failed := range failedStates {
+		if strings.Contains(stateLower, failed) {
+			return true
+		}
+	}
+	return false
+}
+
+func (a *LogAnalyzer) checkPersistentErrors() {
+	fmt.Println("\n=== Persistent Errors Across Sessions ===")
+	
+	// Group errors by pattern
+	session1Errors := make(map[string]int)
+	session2Errors := make(map[string]int)
+	
+	for _, err := range a.Errors {
+		key := extractErrorKey(err)
+		if err.Timestamp.Before(a.Sessions[0].EndTime) {
+			session1Errors[key]++
+		} else {
+			session2Errors[key]++
+		}
+	}
+	
+	// Find errors that appear in both sessions
+	persistent := make([]string, 0)
+	for errType := range session1Errors {
+		if _, exists := session2Errors[errType]; exists {
+			persistent = append(persistent, errType)
+		}
+	}
+	
+	if len(persistent) > 0 {
+		fmt.Println("\nErrors that persist across restart:")
+		sort.Strings(persistent)
+		for _, err := range persistent {
+			fmt.Printf("  • %s (Session 1: %d, Session 2: %d)\n", 
+				err, session1Errors[err], session2Errors[err])
+		}
+	} else {
+		fmt.Println("\nNo persistent errors found across sessions.")
+	}
+}
+
+func (a *LogAnalyzer) analyzeAgentRecovery() {
+	fmt.Println("\n=== Agent Recovery Analysis ===")
+	
+	// Look for agent-related patterns
+	agentErrors := 0
+	agentNotFound := 0
+	
+	for _, err := range a.Errors {
+		if strings.Contains(err.Message, "agent") {
+			agentErrors++
+			if strings.Contains(err.Message, "instance not found") {
+				agentNotFound++
+			}
+		}
+	}
+	
+	fmt.Printf("\nAgent-related errors: %d\n", agentErrors)
+	fmt.Printf("Agent instance not found errors: %d\n", agentNotFound)
+	
+	// Check if agent FSM exists
+	agentFSMs := make([]string, 0)
+	for fsmName := range a.FSMHistories {
+		if strings.Contains(strings.ToLower(fsmName), "agent") {
+			agentFSMs = append(agentFSMs, fsmName)
+		}
+	}
+	
+	if len(agentFSMs) == 0 {
+		fmt.Println("\n⚠️  No agent FSM found in logs!")
+		fmt.Println("This explains why 'agent instance not found' errors occur.")
+		fmt.Println("The agent monitor FSM may not be creating the agent instance properly.")
+	} else {
+		fmt.Printf("\nAgent FSMs found: %v\n", agentFSMs)
+		for _, fsm := range agentFSMs {
+			a.ShowFSMHistory(fsm)
+		}
+	}
+}
+
+// CompareSessionStates compares FSM states between two sessions
+func (a *LogAnalyzer) CompareSessionStates() {
+	if len(a.Sessions) < 2 {
+		fmt.Println("Need at least 2 sessions to compare.")
+		return
+	}
+	
+	fmt.Println("\n=== Session State Comparison ===\n")
+	
+	// Get final states from first session
+	session1End := a.Sessions[0].EndTime.Add(-time.Second)
+	session1States := a.findFSMsAtTime(session1End)
+	
+	// Get initial states from second session  
+	session2Start := a.Sessions[1].StartTime.Add(time.Second * 5)
+	session2States := a.findFSMsAtTime(session2Start)
+	
+	fmt.Printf("Session 1 end FSMs: %d\n", len(session1States))
+	fmt.Printf("Session 2 start FSMs: %d\n\n", len(session2States))
+	
+	// Compare
+	allFSMs := make(map[string]bool)
+	for fsm := range session1States {
+		allFSMs[fsm] = true
+	}
+	for fsm := range session2States {
+		allFSMs[fsm] = true
+	}
+	
+	fmt.Println("FSM State Changes:")
+	fmt.Printf("%-30s %-20s %-20s\n", "FSM", "Session 1 End", "Session 2 Start")
+	fmt.Println(strings.Repeat("-", 72))
+	
+	fsmList := make([]string, 0, len(allFSMs))
+	for fsm := range allFSMs {
+		fsmList = append(fsmList, fsm)
+	}
+	sort.Strings(fsmList)
+	
+	for _, fsm := range fsmList {
+		state1 := session1States[fsm]
+		state2 := session2States[fsm]
+		
+		if state1 == "" {
+			state1 = "not found"
+		}
+		if state2 == "" {
+			state2 = "not found"
+		}
+		
+		marker := " "
+		if state1 != state2 {
+			if state2 == "not found" {
+				marker = "❌"
+			} else if state1 == "not found" {
+				marker = "✓"
+			} else {
+				marker = "⚠️"
+			}
+		}
+		
+		fmt.Printf("%s %-28s %-20s %-20s\n", marker, fsm, state1, state2)
+	}
+}

--- a/umh-core/tools/loganalyzer/recovery.go
+++ b/umh-core/tools/loganalyzer/recovery.go
@@ -1,3 +1,17 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (
@@ -9,7 +23,9 @@ import (
 
 // AnalyzeRecovery analyzes FSM recovery issues between sessions
 func (a *LogAnalyzer) AnalyzeRecovery() {
-	fmt.Println("\n=== Recovery Analysis ===\n")
+	fmt.Println("")
+	fmt.Println("=== Recovery Analysis ===")
+	fmt.Println("")
 	
 	if len(a.Sessions) < 2 {
 		fmt.Println("Single session detected. No recovery analysis needed.")
@@ -17,7 +33,8 @@ func (a *LogAnalyzer) AnalyzeRecovery() {
 	}
 	
 	// Analyze FSM states at end of first session and start of second
-	fmt.Println("Checking FSM states across restart...\n")
+	fmt.Println("Checking FSM states across restart...")
+	fmt.Println("")
 	
 	// Find FSMs that were active before restart
 	activeBeforeRestart := a.findFSMsAtTime(a.Sessions[0].EndTime.Add(-time.Second))
@@ -161,7 +178,9 @@ func (a *LogAnalyzer) CompareSessionStates() {
 		return
 	}
 	
-	fmt.Println("\n=== Session State Comparison ===\n")
+	fmt.Println("")
+	fmt.Println("=== Session State Comparison ===")
+	fmt.Println("")
 	
 	// Get final states from first session
 	session1End := a.Sessions[0].EndTime.Add(-time.Second)

--- a/umh-core/tools/loganalyzer/summary_analysis.go
+++ b/umh-core/tools/loganalyzer/summary_analysis.go
@@ -1,3 +1,17 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (
@@ -7,7 +21,9 @@ import (
 
 // AnalyzeRecoveryIssue provides a comprehensive analysis of the recovery problem
 func (a *LogAnalyzer) AnalyzeRecoveryIssue() {
-	fmt.Println("\n=== Recovery Issue Analysis ===\n")
+	fmt.Println("")
+	fmt.Println("=== Recovery Issue Analysis ===")
+	fmt.Println("")
 	
 	fmt.Println("PROBLEM SUMMARY:")
 	fmt.Println("After force-killing UMH Core, the system fails to recover properly on restart.")

--- a/umh-core/tools/loganalyzer/summary_analysis.go
+++ b/umh-core/tools/loganalyzer/summary_analysis.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+// AnalyzeRecoveryIssue provides a comprehensive analysis of the recovery problem
+func (a *LogAnalyzer) AnalyzeRecoveryIssue() {
+	fmt.Println("\n=== Recovery Issue Analysis ===\n")
+	
+	fmt.Println("PROBLEM SUMMARY:")
+	fmt.Println("After force-killing UMH Core, the system fails to recover properly on restart.")
+	fmt.Println("\nROOT CAUSE:")
+	fmt.Println("1. S6 services persist on the filesystem after force-kill")
+	fmt.Println("2. FSM managers lose their in-memory instance mappings")
+	fmt.Println("3. On restart, managers don't recreate instances for existing S6 services")
+	fmt.Println("4. Reconciliation fails with 'instance not found' errors")
+	
+	// Count affected components
+	orphanCount := 0
+	affectedComponents := make(map[string]bool)
+	
+	for _, entry := range a.Errors {
+		if strings.Contains(entry.Message, "instance") && strings.Contains(entry.Message, "not found") {
+			if match := instanceNotFoundRegex.FindStringSubmatch(entry.Message); match != nil {
+				instanceName := match[1]
+				componentType := detectComponentType(instanceName)
+				affectedComponents[componentType] = true
+				orphanCount++
+			}
+		}
+	}
+	
+	fmt.Printf("\nIMPACT:")
+	fmt.Printf("\n• %d orphaned instances detected", len(affectedComponents))
+	fmt.Printf("\n• Affected component types:")
+	for comp := range affectedComponents {
+		fmt.Printf("\n  - %s", comp)
+	}
+	
+	// Analyze recovery patterns
+	fmt.Println("\n\nRECOVERY PATTERNS OBSERVED:")
+	
+	// Check which components recover
+	recoveredComponents := []string{"Redpanda"}
+	failedComponents := []string{"TopicBrowser", "ProtocolConverter", "DataFlowComponent", "Agent"}
+	
+	fmt.Println("\n✓ Components that recover properly:")
+	for _, comp := range recoveredComponents {
+		fmt.Printf("  • %s - Actively recreates instances on startup\n", comp)
+	}
+	
+	fmt.Println("\n✗ Components that fail to recover:")
+	for _, comp := range failedComponents {
+		fmt.Printf("  • %s - Does not detect/recreate orphaned S6 services\n", comp)
+	}
+	
+	// Backoff analysis
+	fmt.Println("\nBACKOFF BEHAVIOR:")
+	fmt.Println("• Failed reconciliations trigger exponential backoff")
+	fmt.Println("• Backoff increases from 1 to 5 ticks")
+	fmt.Println("• This delays recovery attempts but doesn't fix the root issue")
+	
+	// Solution suggestions
+	fmt.Println("\nSUGGESTED FIXES:")
+	fmt.Println("1. On startup, managers should scan existing S6 services")
+	fmt.Println("2. For each S6 service without a manager instance:")
+	fmt.Println("   - Either recreate the FSM instance")
+	fmt.Println("   - Or clean up the orphaned S6 service")
+	fmt.Println("3. Implement a 'recovery mode' for detecting state mismatches")
+	fmt.Println("4. Add health checks that validate S6 services match manager instances")
+	
+	// Code location hints
+	fmt.Println("\nCODE LOCATIONS TO INVESTIGATE:")
+	fmt.Println("• Manager initialization/startup code")
+	fmt.Println("• ServiceExists() checks in reconciliation")
+	fmt.Println("• Instance creation logic in FSM managers")
+	fmt.Println("• S6 service discovery/enumeration")
+}
+
+func detectComponentType(instanceName string) string {
+	switch {
+	case strings.Contains(instanceName, "topicbrowser"):
+		return "TopicBrowser"
+	case strings.Contains(instanceName, "protocolconverter"):
+		return "ProtocolConverter"
+	case strings.Contains(instanceName, "dfc-"):
+		return "DataFlowComponent"
+	case strings.Contains(instanceName, "agent"):
+		return "Agent"
+	case strings.Contains(instanceName, "redpanda"):
+		return "Redpanda"
+	default:
+		return "Unknown"
+	}
+}

--- a/umh-core/tools/loganalyzer/types.go
+++ b/umh-core/tools/loganalyzer/types.go
@@ -1,3 +1,17 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/umh-core/tools/loganalyzer/types.go
+++ b/umh-core/tools/loganalyzer/types.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"time"
+)
+
+type LogEntry struct {
+	Timestamp   time.Time
+	Level       string
+	Source      string
+	Component   string
+	Message     string
+	TickNumber  int
+	FSMName     string
+	FromState   string
+	ToState     string
+	Event       string
+	DesiredState string
+	EntryType   EntryType
+}
+
+type EntryType int
+
+const (
+	EntryTypeUnknown EntryType = iota
+	EntryTypeTick
+	EntryTypeFSMTransition
+	EntryTypeFSMAttempt
+	EntryTypeFSMFailed
+	EntryTypeFSMDesiredState
+	EntryTypeReconciliation
+	EntryTypeActionStart
+	EntryTypeActionDone
+	EntryTypeError
+)
+
+type TickData struct {
+	Number    int
+	Timestamp time.Time
+	Events    []LogEntry
+}
+
+type FSMHistory struct {
+	Name        string
+	Transitions []FSMTransition
+}
+
+type FSMTransition struct {
+	Tick         int
+	Timestamp    time.Time
+	FromState    string
+	ToState      string
+	Event        string
+	DesiredState string
+	Success      bool
+}
+
+type LogAnalyzer struct {
+	Entries      []LogEntry
+	TickMap      map[int]*TickData
+	FSMHistories map[string]*FSMHistory
+	CurrentTick  int
+	Errors       []LogEntry
+	Starts       []time.Time
+	Sessions     []SessionInfo
+}
+
+type SessionInfo struct {
+	StartTime time.Time
+	EndTime   time.Time
+	StartTick int
+	EndTick   int
+	Errors    int
+}

--- a/umh-core/tools/loganalyzer/types.go
+++ b/umh-core/tools/loganalyzer/types.go
@@ -19,18 +19,18 @@ import (
 )
 
 type LogEntry struct {
-	Timestamp   time.Time
-	Level       string
-	Source      string
-	Component   string
-	Message     string
-	TickNumber  int
-	FSMName     string
-	FromState   string
-	ToState     string
-	Event       string
+	Timestamp    time.Time
+	Level        string
+	Source       string
+	Component    string
+	Message      string
+	FSMName      string
+	FromState    string
+	ToState      string
+	Event        string
 	DesiredState string
-	EntryType   EntryType
+	TickNumber   int
+	EntryType    EntryType
 }
 
 type EntryType int
@@ -49,9 +49,9 @@ const (
 )
 
 type TickData struct {
-	Number    int
 	Timestamp time.Time
 	Events    []LogEntry
+	Number    int
 }
 
 type FSMHistory struct {
@@ -60,23 +60,23 @@ type FSMHistory struct {
 }
 
 type FSMTransition struct {
-	Tick         int
 	Timestamp    time.Time
 	FromState    string
 	ToState      string
 	Event        string
 	DesiredState string
+	Tick         int
 	Success      bool
 }
 
 type LogAnalyzer struct {
-	Entries      []LogEntry
 	TickMap      map[int]*TickData
 	FSMHistories map[string]*FSMHistory
-	CurrentTick  int
+	Entries      []LogEntry
 	Errors       []LogEntry
 	Starts       []time.Time
 	Sessions     []SessionInfo
+	CurrentTick  int
 }
 
 type SessionInfo struct {

--- a/umh-core/tools/loganalyzer/visualize.go
+++ b/umh-core/tools/loganalyzer/visualize.go
@@ -49,7 +49,10 @@ func (a *LogAnalyzer) ShowVisualTimeline(startTick, endTick int) {
 	fmt.Println()
 
 	for _, fsmName := range fsmNames {
-		history := a.FSMHistories[fsmName]
+		history, ok := a.FSMHistories[fsmName]
+		if !ok || history == nil {
+			continue
+		}
 		fmt.Printf("%-*s ", maxNameLen, truncateName(fsmName, maxNameLen))
 		
 		currentState := getInitialState(history)
@@ -90,10 +93,10 @@ func (a *LogAnalyzer) ShowVisualTimeline(startTick, endTick int) {
 }
 
 func getInitialState(history *FSMHistory) string {
-	if len(history.Transitions) > 0 {
-		return history.Transitions[0].FromState
+	if history == nil || len(history.Transitions) == 0 {
+		return ""
 	}
-	return ""
+	return history.Transitions[0].FromState
 }
 
 func getStateSymbol(state string) string {
@@ -138,6 +141,9 @@ func (a *LogAnalyzer) ShowConcurrentActivity() {
 	tickActivity := make(map[int][]string)
 	
 	for fsmName, history := range a.FSMHistories {
+		if history == nil {
+			continue
+		}
 		for _, transition := range history.Transitions {
 			if tickActivity[transition.Tick] == nil {
 				tickActivity[transition.Tick] = make([]string, 0)

--- a/umh-core/tools/loganalyzer/visualize.go
+++ b/umh-core/tools/loganalyzer/visualize.go
@@ -1,3 +1,17 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (
@@ -117,7 +131,9 @@ func truncateName(name string, maxLen int) string {
 }
 
 func (a *LogAnalyzer) ShowConcurrentActivity() {
-	fmt.Println("\n=== Concurrent FSM Activity Analysis ===\n")
+	fmt.Println("")
+	fmt.Println("=== Concurrent FSM Activity Analysis ===")
+	fmt.Println("")
 	
 	tickActivity := make(map[int][]string)
 	

--- a/umh-core/tools/loganalyzer/visualize.go
+++ b/umh-core/tools/loganalyzer/visualize.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+func (a *LogAnalyzer) ShowVisualTimeline(startTick, endTick int) {
+	fmt.Printf("\n=== Visual FSM Timeline (Ticks %d-%d) ===\n\n", startTick, endTick)
+
+	fsmNames := make([]string, 0, len(a.FSMHistories))
+	for name := range a.FSMHistories {
+		fsmNames = append(fsmNames, name)
+	}
+	sort.Strings(fsmNames)
+
+	maxNameLen := 0
+	for _, name := range fsmNames {
+		if len(name) > maxNameLen {
+			maxNameLen = len(name)
+		}
+	}
+
+	fmt.Printf("%-*s ", maxNameLen, "FSM/Tick")
+	for tick := startTick; tick <= endTick && tick <= a.CurrentTick; tick++ {
+		fmt.Printf("%3d ", tick)
+	}
+	fmt.Println()
+	
+	fmt.Print(strings.Repeat("-", maxNameLen+1))
+	for tick := startTick; tick <= endTick && tick <= a.CurrentTick; tick++ {
+		fmt.Print("----")
+	}
+	fmt.Println()
+
+	for _, fsmName := range fsmNames {
+		history := a.FSMHistories[fsmName]
+		fmt.Printf("%-*s ", maxNameLen, truncateName(fsmName, maxNameLen))
+		
+		currentState := getInitialState(history)
+		stateChanged := false
+		
+		for tick := startTick; tick <= endTick && tick <= a.CurrentTick; tick++ {
+			symbol := " . "
+			newState := currentState
+			
+			for _, transition := range history.Transitions {
+				if transition.Tick == tick {
+					if transition.Success {
+						symbol = " → "
+						newState = transition.ToState
+						stateChanged = true
+					} else {
+						symbol = " ✗ "
+					}
+					break
+				}
+			}
+			
+			if tick == startTick && currentState != "" {
+				symbol = fmt.Sprintf("%-3s", getStateSymbol(currentState))
+			} else if stateChanged && newState != currentState {
+				symbol = fmt.Sprintf("%-3s", getStateSymbol(newState))
+				currentState = newState
+				stateChanged = false
+			}
+			
+			fmt.Print(symbol + " ")
+		}
+		fmt.Println()
+	}
+	
+	fmt.Println("\nLegend: . = no change, → = transition, ✗ = failed attempt")
+	fmt.Println("States: C=created, S=stopped, R=running, A=active, M=monitoring")
+}
+
+func getInitialState(history *FSMHistory) string {
+	if len(history.Transitions) > 0 {
+		return history.Transitions[0].FromState
+	}
+	return ""
+}
+
+func getStateSymbol(state string) string {
+	switch {
+	case strings.Contains(state, "created"):
+		return "C"
+	case strings.Contains(state, "stopped"):
+		return "S"
+	case strings.Contains(state, "running"):
+		return "R"
+	case strings.Contains(state, "active"):
+		return "A"
+	case strings.Contains(state, "monitoring"):
+		return "M"
+	case strings.Contains(state, "up"):
+		return "U"
+	case strings.Contains(state, "down"):
+		return "D"
+	case strings.Contains(state, "creating"):
+		return "c"
+	case strings.Contains(state, "starting"):
+		return "s"
+	case strings.Contains(state, "stopping"):
+		return "x"
+	default:
+		return "?"
+	}
+}
+
+func truncateName(name string, maxLen int) string {
+	if len(name) <= maxLen {
+		return name
+	}
+	return name[:maxLen-3] + "..."
+}
+
+func (a *LogAnalyzer) ShowConcurrentActivity() {
+	fmt.Println("\n=== Concurrent FSM Activity Analysis ===\n")
+	
+	tickActivity := make(map[int][]string)
+	
+	for fsmName, history := range a.FSMHistories {
+		for _, transition := range history.Transitions {
+			if tickActivity[transition.Tick] == nil {
+				tickActivity[transition.Tick] = make([]string, 0)
+			}
+			
+			activity := fmt.Sprintf("%s: %s→%s", 
+				fsmName, transition.FromState, transition.ToState)
+			if !transition.Success {
+				activity = fmt.Sprintf("%s (failed)", activity)
+			}
+			
+			tickActivity[transition.Tick] = append(tickActivity[transition.Tick], activity)
+		}
+	}
+	
+	ticks := make([]int, 0, len(tickActivity))
+	for tick := range tickActivity {
+		ticks = append(ticks, tick)
+	}
+	sort.Ints(ticks)
+	
+	maxConcurrent := 0
+	maxConcurrentTick := 0
+	
+	for _, tick := range ticks {
+		activities := tickActivity[tick]
+		if len(activities) > maxConcurrent {
+			maxConcurrent = len(activities)
+			maxConcurrentTick = tick
+		}
+		
+		if len(activities) > 3 {
+			fmt.Printf("Tick %d: %d concurrent transitions\n", tick, len(activities))
+			for _, activity := range activities {
+				fmt.Printf("  • %s\n", activity)
+			}
+			fmt.Println()
+		}
+	}
+	
+	fmt.Printf("Peak concurrent activity: %d transitions at tick %d\n", 
+		maxConcurrent, maxConcurrentTick)
+}


### PR DESCRIPTION
Fixes ENG-3298

Introduces in the first commit ac8cab86365e275fea35feeadda6fc8532a3ec15 a log analyzer package. This is just a intermediary program that I thought we can extend over time to help us in analyzing the logs.

The second commit contains the actual fix here, that was recovered partly from the three large PRs: 8d631c1a0061d0a14ba3f83d3a0cbc4ce023bbc2


More information about what is happening exactly can be found in the ticket description: ENG-3298

After a restart, they will not be stuck anymore in "to_be_created" but might still be in a grey starting state as e.g., Redpanda is degraded (e.g., [ENG-3302](https://linear.app/united-manufacturing-hub/issue/ENG-3302/redpanda-degraded-after-restart-due-to-address-in-use-error))