### PR TITLE
docs: add troubleshooting for S6 service directory volume permission errors

### DIFF
--- a/umh-core/docs/getting-started.md
+++ b/umh-core/docs/getting-started.md
@@ -89,6 +89,9 @@ From the Console you can :
 
 ## Quick troubleshooting
 
+**Volume permission errors**\
+If you see `s6-svscan: warning: unable to stat benthos-dataflow-*` or protocol converters failing to activate, the container cannot write to the mounted volume. Test without `-v` flag to confirm, then fix permissions with `:z` flag on SELinux systems or ensure write access for the container user.
+
 **SELinux volume permissions**\
 On RHEL, Rocky, or other SELinux-enabled systems, append `:z` to the volume mount so Docker can relabel the directory:
 


### PR DESCRIPTION
## Summary
- Added troubleshooting documentation for the `s6-svscan: warning: unable to stat benthos-dataflow-*` error
- Explains the root cause (volume permission issues) and provides solutions
- Helps users quickly diagnose and fix protocol converter activation failures

## Context
This error occurs when Docker volume permissions prevent the S6 service manager from creating or accessing service directories for Benthos dataflow components. Users experience this as protocol converters failing to activate.

## Solution Documented
- Test without volume mount (`-v` flag) to confirm it's a permission issue
- Fix with `:z` flag on SELinux systems
- Ensure proper write permissions for the container user

## Related Issue
Fixes: [ENG-3370](https://linear.app/united-manufacturing-hub/issue/ENG-3370/s6-svscan-warning-unable-to-stat-benthos-dataflow-write)

🤖 Generated with [Claude Code](https://claude.ai/code)