### PR TITLE
[ENG-3350] Port Permission Validator and Cert System to UMH Core

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -21,6 +21,7 @@ header:
   paths-ignore:
     - "**/*.md"
     - "**/*.mdc"
+    - "**/*.json"
     - "LICENSE"
     - "NOTICE"
     - "CODEOWNERS"

--- a/umh-core/cmd/main.go
+++ b/umh-core/cmd/main.go
@@ -103,7 +103,7 @@ func main() {
 	// Initialize the communication state
 	communicationState := communication_state.NewCommunicationState(
 		watchdog.NewWatchdog(ctx, time.NewTicker(time.Second*10), true, logger.For(logger.ComponentCommunicator)),
-		make(chan *models.UMHMessage, 100),
+		make(chan *models.UMHMessageWithAdditionalInfo, 100),
 		make(chan *models.UMHMessage, 100),
 		configData.Agent.ReleaseChannel,
 		systemSnapshotManager,

--- a/umh-core/pkg/communicator/actions/actions.go
+++ b/umh-core/pkg/communicator/actions/actions.go
@@ -67,14 +67,12 @@ func HandleActionMessage(instanceUUID uuid.UUID, payload models.ActionMessagePay
 	log.Debugf("Handling action message: Type: %s, Payload: %v", payload.ActionType, payload.ActionPayload)
 
 	snapshot := systemSnapshotManager.GetSnapshot()
-
-	instanceLocation, err := validator.GetInstanceLocation(snapshot)
-	if err != nil {
-		SendActionReply(instanceUUID, sender, payload.ActionUUID, models.ActionFinishedWithFailure, err.Error(), outboundChannel, payload.ActionType)
+	if snapshot == nil {
+		SendActionReply(instanceUUID, sender, payload.ActionUUID, models.ActionFinishedWithFailure, fmt.Errorf("snapshot is nil").Error(), outboundChannel, payload.ActionType)
 		return
 	}
 
-	err = validator.ValidateUserCertificateForAction(log, senderCert, &payload.ActionType, models.Action, &instanceLocation)
+	err := validator.ValidateUserCertificateForAction(log, senderCert, &payload.ActionType, models.Action, snapshot.CurrentConfig.Agent.Location)
 	if err != nil {
 		SendActionReply(instanceUUID, sender, payload.ActionUUID, models.ActionFinishedWithFailure, err.Error(), outboundChannel, payload.ActionType)
 		return

--- a/umh-core/pkg/communicator/actions/permission/action-type-role-map.json
+++ b/umh-core/pkg/communicator/actions/permission/action-type-role-map.json
@@ -1,0 +1,148 @@
+{
+  "groups": {
+    "Get Actions": {
+      "description": "Read-only operations for viewing resources & states",
+      "actions": {
+        "get-protocol-converter": [
+          "Admin",
+          "Viewer",
+          "Editor"
+        ],
+        "get-data-flow-component": [
+          "Admin",
+          "Viewer",
+          "Editor"
+        ],
+        "get-data-flow-component-log": [
+          "Admin",
+          "Viewer",
+          "Editor"
+        ],
+        "get-logs": [
+          "Admin",
+          "Viewer",
+          "Editor"
+        ],
+        "get-datamodel": [
+          "Admin",
+          "Viewer",
+          "Editor"
+        ],
+        "get-streamprocessor": [
+          "Admin",
+          "Viewer",
+          "Editor"
+        ],
+      }
+    },
+    "Edit Actions": {
+      "description": "Operations that modify existing resources",
+      "actions": {
+        "edit-protocol-converter": [
+          "Admin",
+          "Editor"
+        ],
+        "edit-instance-location": [
+          "Admin"
+        ],
+        "edit-instance": [
+          "Admin"
+        ],
+        "edit-data-flow-component": [
+          "Admin",
+          "Editor"
+        ],
+        "edit-datamodel": [
+          "Admin",
+          "Editor"
+        ],
+        "edit-stream-processor": [
+          "Admin",
+          "Editor"
+        ],
+      }
+    },
+    "Delete Actions": {
+      "description": "Operations that remove resources",
+      "actions": {
+        "delete-protocol-converter": [
+          "Admin",
+          "Editor"
+        ],
+        "delete-data-flow-component": [
+          "Admin",
+          "Editor"
+        ]
+        "delete-datamodel": [
+          "Admin",
+          "Editor"
+        ]
+        "delete-stream-processor": [
+          "Admin",
+          "Editor"
+        ]
+      }
+    },
+    "Deploy Actions": {
+      "description": "Operations for deploying new resources",
+      "actions": {
+        "deploy-protocol-converter": [
+          "Admin",
+          "Editor"
+        ],
+        "deploy-data-flow-component": [
+          "Admin",
+          "Editor"
+        ]
+        "deploy-stream-processor": [
+          "Admin",
+          "Editor"
+        ]
+      }
+    },
+    "Test Actions": {
+      "description": "Operations for testing configurations",
+      "actions": {
+        # currently not in use
+      }
+    },
+    "Company Actions": {
+      "description": "Company-level operations",
+      "actions": {
+        "create-invite": [
+          "Admin"
+        ],
+        "get-company-invites": [
+          "Admin"
+        ],
+        "delete-invite": [
+          "Admin"
+        ],
+        "get-company-users": [
+          "Admin"
+        ],
+        "delete-company-user": [
+          "Admin"
+        ],
+        "change-user-role": [
+          "Admin"
+        ],
+        "change-user-permissions": [
+          "Admin"
+        ]
+      }
+    }
+  },
+  "ungrouped": {
+    "unknown": [
+      "Admin",
+      "Viewer",
+      "Editor"
+    ],
+    "dummy": [
+      "Admin",
+      "Viewer",
+      "Editor"
+    ]
+  }
+}

--- a/umh-core/pkg/communicator/actions/permission/action-type-role-map.json
+++ b/umh-core/pkg/communicator/actions/permission/action-type-role-map.json
@@ -28,11 +28,11 @@
           "Viewer",
           "Editor"
         ],
-        "get-streamprocessor": [
+        "get-stream-processor": [
           "Admin",
           "Viewer",
           "Editor"
-        ],
+        ]
       }
     },
     "Edit Actions": {
@@ -59,7 +59,7 @@
         "edit-stream-processor": [
           "Admin",
           "Editor"
-        ],
+        ]
       }
     },
     "Delete Actions": {
@@ -72,11 +72,11 @@
         "delete-data-flow-component": [
           "Admin",
           "Editor"
-        ]
+        ],
         "delete-datamodel": [
           "Admin",
           "Editor"
-        ]
+        ],
         "delete-stream-processor": [
           "Admin",
           "Editor"
@@ -93,7 +93,7 @@
         "deploy-data-flow-component": [
           "Admin",
           "Editor"
-        ]
+        ],
         "deploy-stream-processor": [
           "Admin",
           "Editor"
@@ -103,7 +103,6 @@
     "Test Actions": {
       "description": "Operations for testing configurations",
       "actions": {
-        # currently not in use
       }
     },
     "Company Actions": {
@@ -128,6 +127,14 @@
           "Admin"
         ],
         "change-user-permissions": [
+          "Admin"
+        ]
+      }
+    },
+    "System Actions": {
+      "description": "System-level operations",
+      "actions": {
+        "upgrade-companion": [
           "Admin"
         ]
       }

--- a/umh-core/pkg/communicator/actions/permission/extensions.go
+++ b/umh-core/pkg/communicator/actions/permission/extensions.go
@@ -30,30 +30,30 @@ var UMH_PEN = asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 59193}
 // OIDs for our custom extensions
 // 1: V1 of our extensions (backwards compatibility)
 // 1.1: Role extension (v1: global role, v2: per-location role scopes)
-// 1.2: Location extension (deprecated in favor of DNS SANs + Name Constraints)
+// 1.2: Location extension (deprecated in favor of DNS SANs + Name Constraints).
 var (
-	// OID for Role extension (supports both v1 and v2 payloads)
+	// OID for Role extension (supports both v1 and v2 payloads).
 	oidExtensionRole asn1.ObjectIdentifier = append(UMH_PEN, 1, 1)
 
-	// OID for Location extension (deprecated - keeping for backwards compatibility)
+	// OID for Location extension (deprecated - keeping for backwards compatibility).
 	oidExtensionLocation asn1.ObjectIdentifier = append(UMH_PEN, 1, 2)
 )
 
-// Role represents the role of a certificate holder
+// Role represents the role of a certificate holder.
 type Role string
 
 const (
-	// RoleAdmin represents an administrator role
+	// RoleAdmin represents an administrator role.
 	RoleAdmin Role = "Admin"
 
-	// RoleViewer represents a viewer role
+	// RoleViewer represents a viewer role.
 	RoleViewer Role = "Viewer"
 
-	// RoleEditor represents an editor role
+	// RoleEditor represents an editor role.
 	RoleEditor Role = "Editor"
 )
 
-// NEW: LocationDNS represents a location as a DNS name with arbitrary depth
+// NEW: LocationDNS represents a location as a DNS name with arbitrary depth.
 type LocationDNS string
 
 // Examples:
@@ -64,46 +64,46 @@ type LocationDNS string
 // - "*.area2.cologne.umh.internal"            (wildcard: all cells in area2)
 // - "*.cologne.umh.internal"                  (wildcard: all areas in cologne)
 
-// NEW: RoleScope represents a role that applies to a specific DNS subtree
+// NEW: RoleScope represents a role that applies to a specific DNS subtree.
 type RoleScope struct {
 	DNSSuffix LocationDNS `json:"dns_suffix"` // e.g. ".cologne.umh.internal"
 	Role      Role        `json:"role"`       // admin/editor/viewer
 }
 
-// NEW: V2 role extension payload structure
+// NEW: V2 role extension payload structure.
 type roleScopesV2 struct {
-	Version int         `json:"v"`                 // must be 2
-	Scopes  []RoleScope `json:"scopes"`            // per-location role mappings
 	Default Role        `json:"default,omitempty"` // fallback role if no suffix matches
+	Scopes  []RoleScope `json:"scopes"`            // per-location role mappings
+	Version int         `json:"v"`                 // must be 2
 }
 
-// LocationType represents the type of location in the hierarchy
+// LocationType represents the type of location in the hierarchy.
 type LocationType string
 
 const (
-	// LocationTypeEnterprise represents the enterprise level
+	// LocationTypeEnterprise represents the enterprise level.
 	LocationTypeEnterprise LocationType = "Enterprise"
 
-	// LocationTypeSite represents a site level
+	// LocationTypeSite represents a site level.
 	LocationTypeSite LocationType = "Site"
 
-	// LocationTypeArea represents an area level
+	// LocationTypeArea represents an area level.
 	LocationTypeArea LocationType = "Area"
 
-	// LocationTypeProductionLine represents a production line level
+	// LocationTypeProductionLine represents a production line level.
 	LocationTypeProductionLine LocationType = "ProductionLine"
 
-	// LocationTypeWorkCell represents a work cell level
+	// LocationTypeWorkCell represents a work cell level.
 	LocationTypeWorkCell LocationType = "WorkCell"
 )
 
-// Location represents a specific location with a type and value
+// Location represents a specific location with a type and value.
 type Location struct {
 	Type  LocationType
 	Value string
 }
 
-// NewLocation creates a new Location with the given type and value
+// NewLocation creates a new Location with the given type and value.
 func NewLocation(locType LocationType, value string) Location {
 	return Location{
 		Type:  locType,
@@ -111,7 +111,7 @@ func NewLocation(locType LocationType, value string) Location {
 	}
 }
 
-// NewWildcardLocation creates a new Location with the given type and a wildcard value
+// NewWildcardLocation creates a new Location with the given type and a wildcard value.
 func NewWildcardLocation(locType LocationType) Location {
 	return Location{
 		Type:  locType,
@@ -119,7 +119,7 @@ func NewWildcardLocation(locType LocationType) Location {
 	}
 }
 
-// IsWildcard returns true if the location is a wildcard (any value is allowed)
+// IsWildcard returns true if the location is a wildcard (any value is allowed).
 func (l Location) IsWildcard() bool {
 	return l.Value == "*"
 }
@@ -137,6 +137,7 @@ func (l Location) filterString(s string) string {
 	if slices.Contains(wildcardStrings, s) {
 		return "*"
 	}
+
 	if s == "" {
 		return "*"
 	}
@@ -144,12 +145,12 @@ func (l Location) filterString(s string) string {
 	return s
 }
 
-// String returns a string representation of the location
+// String returns a string representation of the location.
 func (l Location) String() string {
 	return fmt.Sprintf("%s:%s", l.Type, l.filterString(l.Value))
 }
 
-// LocationHierarchy represents a complete location hierarchy
+// LocationHierarchy represents a complete location hierarchy.
 type LocationHierarchy struct {
 	Enterprise     Location
 	Site           Location
@@ -158,7 +159,7 @@ type LocationHierarchy struct {
 	WorkCell       Location
 }
 
-// NewLocationHierarchy creates a new LocationHierarchy with the given locations
+// NewLocationHierarchy creates a new LocationHierarchy with the given locations.
 func NewLocationHierarchy(enterprise, site, area, productionLine, workCell Location) LocationHierarchy {
 	return LocationHierarchy{
 		Enterprise:     enterprise,
@@ -169,19 +170,19 @@ func NewLocationHierarchy(enterprise, site, area, productionLine, workCell Locat
 	}
 }
 
-// RoleExtension represents the role extension data
+// RoleExtension represents the role extension data.
 type RoleExtension struct {
 	Role Role
 }
 
-// LocationExtension represents the location extension data
+// LocationExtension represents the location extension data.
 type LocationExtension struct {
 	Hierarchies []LocationHierarchy
 }
 
 // ValidateLocationHierarchy validates that the location hierarchy is correct
 // All levels must be set, but can be wildcards (including Enterprise)
-// If a specific level has a non-wildcard value, all higher levels must also have non-wildcard values
+// If a specific level has a non-wildcard value, all higher levels must also have non-wildcard values.
 func ValidateLocationHierarchy(hierarchy LocationHierarchy) error {
 	// Enterprise must be set
 	if hierarchy.Enterprise.Type != LocationTypeEnterprise {
@@ -207,10 +208,11 @@ func ValidateLocationHierarchy(hierarchy LocationHierarchy) error {
 	if hierarchy.WorkCell.Type != LocationTypeWorkCell {
 		return errors.New("work cell location must be of type WorkCell")
 	}
+
 	return nil
 }
 
-// AddRoleExtension adds a role extension to the certificate template
+// AddRoleExtension adds a role extension to the certificate template.
 func AddRoleExtension(template *x509.Certificate, role Role) error {
 	// Validate role
 	if role != RoleAdmin && role != RoleViewer && role != RoleEditor {
@@ -233,7 +235,7 @@ func AddRoleExtension(template *x509.Certificate, role Role) error {
 	return nil
 }
 
-// AddLocationExtension adds a location extension to the certificate template
+// AddLocationExtension adds a location extension to the certificate template.
 func AddLocationExtension(template *x509.Certificate, hierarchies []LocationHierarchy) error {
 	if len(hierarchies) == 0 {
 		return errors.New("at least one location hierarchy must be specified")
@@ -280,7 +282,7 @@ func AddLocationExtension(template *x509.Certificate, hierarchies []LocationHier
 	return nil
 }
 
-// NEW: AddRoleScopesV2Extension adds a v2 role extension with per-location role mappings
+// NEW: AddRoleScopesV2Extension adds a v2 role extension with per-location role mappings.
 func AddRoleScopesV2Extension(template *x509.Certificate, scopes []RoleScope) error {
 	if len(scopes) == 0 {
 		return errors.New("role scopes cannot be empty")
@@ -291,9 +293,11 @@ func AddRoleScopesV2Extension(template *x509.Certificate, scopes []RoleScope) er
 		if scope.Role != RoleAdmin && scope.Role != RoleEditor && scope.Role != RoleViewer {
 			return fmt.Errorf("invalid role in scope: %s", scope.Role)
 		}
+
 		if scope.DNSSuffix == "" {
 			return errors.New("DNS suffix cannot be empty")
 		}
+
 		if !strings.HasPrefix(string(scope.DNSSuffix), ".") {
 			return fmt.Errorf("DNS suffix must start with '.': %s", scope.DNSSuffix)
 		}
@@ -320,7 +324,7 @@ func AddRoleScopesV2Extension(template *x509.Certificate, scopes []RoleScope) er
 	return nil
 }
 
-// NEW: ParseRoleInfo extracts role information from a certificate (backwards compatible)
+// NEW: ParseRoleInfo extracts role information from a certificate (backwards compatible).
 func ParseRoleInfo(cert *x509.Certificate) (v2 *roleScopesV2, v1 Role, hasV2 bool, hasV1 bool, err error) {
 	for _, ext := range cert.Extensions {
 		if ext.Id.Equal(oidExtensionRole) {
@@ -340,13 +344,14 @@ func ParseRoleInfo(cert *x509.Certificate) (v2 *roleScopesV2, v1 Role, hasV2 boo
 			}
 
 			// If we get here, the extension exists but we can't parse it
-			return nil, "", false, false, fmt.Errorf("unknown role extension payload format")
+			return nil, "", false, false, errors.New("unknown role extension payload format")
 		}
 	}
+
 	return nil, "", false, false, errors.New("role extension not found")
 }
 
-// NEW: EffectiveRoleFor determines the effective role for a given DNS name using v2 scopes
+// NEW: EffectiveRoleFor determines the effective role for a given DNS name using v2 scopes.
 func EffectiveRoleFor(dnsName string, v2 *roleScopesV2) Role {
 	if v2 == nil {
 		return ""
@@ -354,7 +359,9 @@ func EffectiveRoleFor(dnsName string, v2 *roleScopesV2) Role {
 
 	// Find the most specific (longest) matching DNS suffix
 	bestLen := -1
+
 	var bestRole Role
+
 	lowerName := strings.ToLower(dnsName)
 
 	for _, scope := range v2.Scopes {
@@ -368,15 +375,17 @@ func EffectiveRoleFor(dnsName string, v2 *roleScopesV2) Role {
 	if bestLen >= 0 {
 		return bestRole
 	}
+
 	return v2.Default
 }
 
-// NEW: Helper function to convert LocationDNS slice to string slice
+// NEW: Helper function to convert LocationDNS slice to string slice.
 func LocationDNSToStrings(locations []LocationDNS) []string {
 	result := make([]string, len(locations))
 	for i, loc := range locations {
 		result[i] = string(loc)
 	}
+
 	return result
 }
 
@@ -390,6 +399,7 @@ func validateHierarchies(hierarchies []LocationHierarchy) error {
 					symbol, fieldName, value)
 			}
 		}
+
 		return nil
 	}
 
@@ -397,19 +407,24 @@ func validateHierarchies(hierarchies []LocationHierarchy) error {
 		if err := checkValue(hierarchy.Enterprise.Value, "enterprise"); err != nil {
 			return err
 		}
+
 		if err := checkValue(hierarchy.Site.Value, "site"); err != nil {
 			return err
 		}
+
 		if err := checkValue(hierarchy.Area.Value, "area"); err != nil {
 			return err
 		}
+
 		if err := checkValue(hierarchy.ProductionLine.Value, "production line"); err != nil {
 			return err
 		}
+
 		if err := checkValue(hierarchy.WorkCell.Value, "work cell"); err != nil {
 			return err
 		}
 	}
+
 	return nil
 }
 
@@ -437,16 +452,18 @@ func GetRoleForLocation(cert *x509.Certificate, location map[int]string) (Role, 
 	if hasV2 {
 		// V2: Per-location roles
 		role := EffectiveRoleFor(locationDNS, v2)
+
 		return role, nil
 	} else if hasV1 {
 		// V1: Global role, but check if certificate has access to this location
 		if hasAccessToLocationV1(cert, location) {
 			return v1, nil
 		}
+
 		return "", nil // No access to this location
 	}
 
-	return "", fmt.Errorf("no valid role information found")
+	return "", errors.New("no valid role information found")
 }
 
 // GetRoleFromCertificate extracts the role from a certificate (DEPRECATED: use GetRoleForLocation)
@@ -455,6 +472,7 @@ func GetRoleFromCertificate(cert *x509.Certificate) (Role, error) {
 	for _, ext := range cert.Extensions {
 		if ext.Id.Equal(oidExtensionRole) {
 			var roleStr string
+
 			_, err := asn1.Unmarshal(ext.Value, &roleStr)
 			if err != nil {
 				return "", errors.Join(err, errors.New("failed to unmarshal role extension"))
@@ -473,7 +491,7 @@ func GetRoleFromCertificate(cert *x509.Certificate) (Role, error) {
 }
 
 // ConvertLocationMapToDNS converts a location map to DNS format
-// Example: map[int]string{0: "cologne", 1: "area2", 2: "cell1"} -> "cell1.area2.cologne.umh.internal"
+// Example: map[int]string{0: "cologne", 1: "area2", 2: "cell1"} -> "cell1.area2.cologne.umh.internal".
 func ConvertLocationMapToDNS(location map[int]string) string {
 	if len(location) == 0 {
 		return ""
@@ -489,6 +507,7 @@ func ConvertLocationMapToDNS(location map[int]string) string {
 
 	// Build the DNS name from highest level (maxKey) to lowest (0)
 	var parts []string
+
 	for i := maxKey; i >= 0; i-- {
 		if part, exists := location[i]; exists && part != "" {
 			parts = append(parts, part)
@@ -504,7 +523,7 @@ func ConvertLocationMapToDNS(location map[int]string) string {
 }
 
 // hasAccessToLocationV1 checks if a v1 certificate has access to the given location
-// based on the stored location hierarchies in the certificate
+// based on the stored location hierarchies in the certificate.
 func hasAccessToLocationV1(cert *x509.Certificate, location map[int]string) bool {
 	// Get the location hierarchies from the v1 certificate
 	hierarchies, err := GetLocationHierarchiesFromCertificate(cert)
@@ -525,22 +544,26 @@ func hasAccessToLocationV1(cert *x509.Certificate, location map[int]string) bool
 	return false
 }
 
-// convertLocationMapToHierarchy converts a location map to LocationHierarchy
+// convertLocationMapToHierarchy converts a location map to LocationHierarchy.
 func convertLocationMapToHierarchy(location map[int]string) LocationHierarchy {
 	hierarchy := LocationHierarchy{}
 
 	if enterprise, exists := location[0]; exists {
 		hierarchy.Enterprise = Location{Type: "Enterprise", Value: enterprise}
 	}
+
 	if site, exists := location[1]; exists {
 		hierarchy.Site = Location{Type: "Site", Value: site}
 	}
+
 	if area, exists := location[2]; exists {
 		hierarchy.Area = Location{Type: "Area", Value: area}
 	}
+
 	if productionLine, exists := location[3]; exists {
 		hierarchy.ProductionLine = Location{Type: "ProductionLine", Value: productionLine}
 	}
+
 	if workCell, exists := location[4]; exists {
 		hierarchy.WorkCell = Location{Type: "WorkCell", Value: workCell}
 	}
@@ -548,21 +571,25 @@ func convertLocationMapToHierarchy(location map[int]string) LocationHierarchy {
 	return hierarchy
 }
 
-// hierarchyContainsLocation checks if a certificate hierarchy contains or matches the requested location
+// hierarchyContainsLocation checks if a certificate hierarchy contains or matches the requested location.
 func hierarchyContainsLocation(certHierarchy, requestedHierarchy LocationHierarchy) bool {
 	// Check each level - certificate hierarchy must match or be a wildcard
 	if !levelMatches(certHierarchy.Enterprise, requestedHierarchy.Enterprise) {
 		return false
 	}
+
 	if !levelMatches(certHierarchy.Site, requestedHierarchy.Site) {
 		return false
 	}
+
 	if !levelMatches(certHierarchy.Area, requestedHierarchy.Area) {
 		return false
 	}
+
 	if !levelMatches(certHierarchy.ProductionLine, requestedHierarchy.ProductionLine) {
 		return false
 	}
+
 	if !levelMatches(certHierarchy.WorkCell, requestedHierarchy.WorkCell) {
 		return false
 	}
@@ -570,7 +597,7 @@ func hierarchyContainsLocation(certHierarchy, requestedHierarchy LocationHierarc
 	return true
 }
 
-// levelMatches checks if a certificate level matches the requested level
+// levelMatches checks if a certificate level matches the requested level.
 func levelMatches(certLevel, requestedLevel Location) bool {
 	// If certificate level is wildcard (*), it matches anything
 	if certLevel.Value == "*" {
@@ -586,14 +613,20 @@ func levelMatches(certLevel, requestedLevel Location) bool {
 	return certLevel.Value == requestedLevel.Value
 }
 
-// GetLocationHierarchiesFromCertificate extracts the location hierarchies from a certificate
+// GetLocationHierarchiesFromCertificate extracts the location hierarchies from a certificate.
 func GetLocationHierarchiesFromCertificate(cert *x509.Certificate) ([]LocationHierarchy, error) {
 	for _, ext := range cert.Extensions {
 		if ext.Id.Equal(oidExtensionLocation) {
 			var locStrings []string
+
 			_, err := asn1.Unmarshal(ext.Value, &locStrings)
 			if err != nil {
 				return nil, errors.Join(err, errors.New("failed to unmarshal location extension"))
+			}
+
+			// Ensure locStrings is not nil and has valid content
+			if locStrings == nil {
+				return nil, errors.New("location extension unmarshaled to nil")
 			}
 
 			// Each hierarchy consists of 5 location strings
@@ -604,11 +637,13 @@ func GetLocationHierarchiesFromCertificate(cert *x509.Certificate) ([]LocationHi
 			hierarchyCount := len(locStrings) / 5
 			hierarchies := make([]LocationHierarchy, hierarchyCount)
 
-			for h := 0; h < hierarchyCount; h++ {
+			for h := range hierarchyCount {
 				// Parse each location string for this hierarchy
 				locations := make([]Location, 5)
-				for i := 0; i < 5; i++ {
+
+				for i := range 5 {
 					locStr := locStrings[h*5+i]
+
 					parts := strings.SplitN(locStr, ":", 2)
 					if len(parts) != 2 {
 						return nil, fmt.Errorf("invalid location string format: %s", locStr)
@@ -646,11 +681,12 @@ func GetLocationHierarchiesFromCertificate(cert *x509.Certificate) ([]LocationHi
 
 // NEW V2 CONVENIENCE FUNCTIONS for easy migration and usage
 
-// CreateRoleScope creates a new RoleScope for a DNS suffix and role
+// CreateRoleScope creates a new RoleScope for a DNS suffix and role.
 func CreateRoleScope(dnsSuffix string, role Role) RoleScope {
 	if !strings.HasPrefix(dnsSuffix, ".") {
 		dnsSuffix = "." + dnsSuffix
 	}
+
 	return RoleScope{
 		DNSSuffix: LocationDNS(dnsSuffix),
 		Role:      role,
@@ -709,16 +745,17 @@ func CreateLocationDNSFromHierarchy(hierarchy LocationHierarchy) LocationDNS {
 	return LocationDNS(locationStr)
 }
 
-// ConvertHierarchiesToLocations converts old v1 hierarchies to v2 location DNS names
+// ConvertHierarchiesToLocations converts old v1 hierarchies to v2 location DNS names.
 func ConvertHierarchiesToLocations(hierarchies []LocationHierarchy) []LocationDNS {
 	locations := make([]LocationDNS, 0, len(hierarchies))
 	for _, hierarchy := range hierarchies {
 		locations = append(locations, CreateLocationDNSFromHierarchy(hierarchy))
 	}
+
 	return locations
 }
 
-// CreateUniformRoleScopes creates role scopes that give the same role to all locations
+// CreateUniformRoleScopes creates role scopes that give the same role to all locations.
 func CreateUniformRoleScopes(locations []LocationDNS, role Role) []RoleScope {
 	scopes := make([]RoleScope, 0, len(locations))
 	for _, location := range locations {
@@ -726,10 +763,11 @@ func CreateUniformRoleScopes(locations []LocationDNS, role Role) []RoleScope {
 		suffix := "." + string(location)
 		scopes = append(scopes, CreateRoleScope(suffix, role))
 	}
+
 	return scopes
 }
 
-// GetEffectiveRoleForLocation is a convenience wrapper around EffectiveRoleFor
+// GetEffectiveRoleForLocation is a convenience wrapper around EffectiveRoleFor.
 func GetEffectiveRoleForLocation(location LocationDNS, cert *x509.Certificate) (Role, error) {
 	v2, v1, hasV2, hasV1, err := ParseRoleInfo(cert)
 	if err != nil {
@@ -746,7 +784,7 @@ func GetEffectiveRoleForLocation(location LocationDNS, cert *x509.Certificate) (
 	return "", errors.New("no role information found")
 }
 
-// ValidateLocationDNS validates that a location DNS name follows proper hierarchy rules
+// ValidateLocationDNS validates that a location DNS name follows proper hierarchy rules.
 func ValidateLocationDNS(location LocationDNS) error {
 	locationStr := string(location)
 
@@ -762,11 +800,13 @@ func ValidateLocationDNS(location LocationDNS) error {
 
 	// Handle wildcard locations (must be exactly "*.something")
 	isWildcard := false
+
 	checkStr := locationStr
 	if strings.HasPrefix(locationStr, "*") {
 		if !strings.HasPrefix(locationStr, "*.") {
 			return fmt.Errorf("wildcard location DNS must use '*.domain' format: %s", locationStr)
 		}
+
 		isWildcard = true
 		checkStr = locationStr[2:] // Remove "*." from the start
 	}
@@ -785,6 +825,7 @@ func ValidateLocationDNS(location LocationDNS) error {
 		if len(parts) != 2 || parts[0] != "umh" || parts[1] != "internal" {
 			return fmt.Errorf("invalid global wildcard format: %s", locationStr)
 		}
+
 		return nil
 	}
 
@@ -811,7 +852,7 @@ func ValidateLocationDNS(location LocationDNS) error {
 	return nil
 }
 
-// IsWildcardLocation checks if a LocationDNS represents a wildcard location
+// IsWildcardLocation checks if a LocationDNS represents a wildcard location.
 func IsWildcardLocation(location LocationDNS) bool {
 	return strings.HasPrefix(string(location), "*.")
 }

--- a/umh-core/pkg/communicator/actions/permission/extensions.go
+++ b/umh-core/pkg/communicator/actions/permission/extensions.go
@@ -16,28 +16,26 @@ package permission_validator
 
 import (
 	"crypto/x509"
-	"crypto/x509/pkix"
 	"encoding/asn1"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"slices"
 	"strings"
+
+	"gopkg.in/yaml.v3"
 )
 
 var UMH_PEN = asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 59193}
 
 // OIDs for our custom extensions
-// 1: V1 of our extensions (backwards compatibility)
-// 1.1: Role extension (v1: global role, v2: per-location role scopes)
-// 1.2: Location extension (deprecated in favor of DNS SANs + Name Constraints).
+// 1: V1 of our extensions
+// 1.1: Role extension
+// 1.2: Location extension.
 var (
-	// OID for Role extension (supports both v1 and v2 payloads).
-	oidExtensionRole asn1.ObjectIdentifier = append(UMH_PEN, 1, 1)
-
-	// OID for Location extension (deprecated - keeping for backwards compatibility).
-	oidExtensionLocation asn1.ObjectIdentifier = append(UMH_PEN, 1, 2)
+	// OID for the location-role extension.
+	oidExtensionRoleLocation asn1.ObjectIdentifier = append(UMH_PEN, 2, 1)
 )
+
+var ERR_RoleLocation_Not_Found = errors.New("locationRoles extension not found in certificate")
 
 // Role represents the role of a certificate holder.
 type Role string
@@ -53,31 +51,7 @@ const (
 	RoleEditor Role = "Editor"
 )
 
-// NEW: LocationDNS represents a location as a DNS name with arbitrary depth.
-type LocationDNS string
-
-// Examples:
-// - "cell3.lineA.area2.cologne.umh.internal"  (most specific: cell level)
-// - "area2.cologne.umh.internal"              (area level)
-// - "cologne.umh.internal"                    (site level)
-// - "office.cologne.umh.internal"             (administrative locations)
-// - "*.area2.cologne.umh.internal"            (wildcard: all cells in area2)
-// - "*.cologne.umh.internal"                  (wildcard: all areas in cologne)
-
-// NEW: RoleScope represents a role that applies to a specific DNS subtree.
-type RoleScope struct {
-	DNSSuffix LocationDNS `json:"dns_suffix"` // e.g. ".cologne.umh.internal"
-	Role      Role        `json:"role"`       // admin/editor/viewer
-}
-
-// NEW: V2 role extension payload structure.
-type roleScopesV2 struct {
-	Default Role        `json:"default,omitempty"` // fallback role if no suffix matches
-	Scopes  []RoleScope `json:"scopes"`            // per-location role mappings
-	Version int         `json:"v"`                 // must be 2
-}
-
-// LocationType represents the type of location in the hierarchy.
+// LocationType represents the type of location in the hierarchy (for ExtensionLocation).
 type LocationType string
 
 const (
@@ -97,762 +71,55 @@ const (
 	LocationTypeWorkCell LocationType = "WorkCell"
 )
 
-// Location represents a specific location with a type and value.
-type Location struct {
-	Type  LocationType
-	Value string
-}
+// LocataionRoles maps the locations to roles for the LocationRoles extension.
+type LocationRoles map[string]Role
 
-// NewLocation creates a new Location with the given type and value.
-func NewLocation(locType LocationType, value string) Location {
-	return Location{
-		Type:  locType,
-		Value: value,
-	}
-}
-
-// NewWildcardLocation creates a new Location with the given type and a wildcard value.
-func NewWildcardLocation(locType LocationType) Location {
-	return Location{
-		Type:  locType,
-		Value: "*",
-	}
-}
-
-// IsWildcard returns true if the location is a wildcard (any value is allowed).
-func (l Location) IsWildcard() bool {
-	return l.Value == "*"
-}
-
-func (l Location) filterString(s string) string {
-	// The frontend often uses "All sites", "All areas", etc.
-	wildcardStrings := []string{
-		"All enterprises",
-		"All sites",
-		"All areas",
-		"All production lines",
-		"All work cells",
-	}
-
-	if slices.Contains(wildcardStrings, s) {
-		return "*"
-	}
-
-	if s == "" {
-		return "*"
-	}
-
-	return s
-}
-
-// String returns a string representation of the location.
-func (l Location) String() string {
-	return fmt.Sprintf("%s:%s", l.Type, l.filterString(l.Value))
-}
-
-// LocationHierarchy represents a complete location hierarchy.
-type LocationHierarchy struct {
-	Enterprise     Location
-	Site           Location
-	Area           Location
-	ProductionLine Location
-	WorkCell       Location
-}
-
-// NewLocationHierarchy creates a new LocationHierarchy with the given locations.
-func NewLocationHierarchy(enterprise, site, area, productionLine, workCell Location) LocationHierarchy {
-	return LocationHierarchy{
-		Enterprise:     enterprise,
-		Site:           site,
-		Area:           area,
-		ProductionLine: productionLine,
-		WorkCell:       workCell,
-	}
-}
-
-// RoleExtension represents the role extension data.
-type RoleExtension struct {
-	Role Role
-}
-
-// LocationExtension represents the location extension data.
-type LocationExtension struct {
-	Hierarchies []LocationHierarchy
-}
-
-// ValidateLocationHierarchy validates that the location hierarchy is correct
-// All levels must be set, but can be wildcards (including Enterprise)
-// If a specific level has a non-wildcard value, all higher levels must also have non-wildcard values.
-func ValidateLocationHierarchy(hierarchy LocationHierarchy) error {
-	// Enterprise must be set
-	if hierarchy.Enterprise.Type != LocationTypeEnterprise {
-		return errors.New("enterprise location must be of type Enterprise")
-	}
-
-	// Site must be set
-	if hierarchy.Site.Type != LocationTypeSite {
-		return errors.New("site location must be of type Site")
-	}
-
-	// Area must be set
-	if hierarchy.Area.Type != LocationTypeArea {
-		return errors.New("area location must be of type Area")
-	}
-
-	// ProductionLine must be set
-	if hierarchy.ProductionLine.Type != LocationTypeProductionLine {
-		return errors.New("production line location must be of type ProductionLine")
-	}
-
-	// WorkCell must be set
-	if hierarchy.WorkCell.Type != LocationTypeWorkCell {
-		return errors.New("work cell location must be of type WorkCell")
-	}
-
-	return nil
-}
-
-// AddRoleExtension adds a role extension to the certificate template.
-func AddRoleExtension(template *x509.Certificate, role Role) error {
-	// Validate role
-	if role != RoleAdmin && role != RoleViewer && role != RoleEditor {
-		return fmt.Errorf("invalid role: %s", role)
-	}
-
-	// Marshal the role to ASN.1 DER encoding
-	value, err := asn1.Marshal(string(role))
+func GetRoleForLocation(cert *x509.Certificate, location string) (Role, error) {
+	locationRoles, err := GetLocationRolesFromCertificate(cert)
 	if err != nil {
-		return errors.Join(err, errors.New("failed to marshal role extension"))
+		return "", errors.Join(err, errors.New("failed to get locationRoles from certificate"))
 	}
 
-	// Add the extension to the template
-	template.ExtraExtensions = append(template.ExtraExtensions, pkix.Extension{
-		Id:       oidExtensionRole,
-		Critical: false, // Non-critical so clients that don't understand it can ignore it
-		Value:    value,
-	})
-
-	return nil
-}
-
-// AddLocationExtension adds a location extension to the certificate template.
-func AddLocationExtension(template *x509.Certificate, hierarchies []LocationHierarchy) error {
-	if len(hierarchies) == 0 {
-		return errors.New("at least one location hierarchy must be specified")
-	}
-
-	// Validate each location hierarchy
-	for _, hierarchy := range hierarchies {
-		if err := ValidateLocationHierarchy(hierarchy); err != nil {
-			return err
-		}
-	}
-
-	// Convert hierarchies to a serializable format
-	// Format: [hierarchy1_enterprise, hierarchy1_site, hierarchy1_area, hierarchy1_productionline, hierarchy1_workcell, hierarchy2_enterprise, ...]
-	locStrings := make([]string, 0, len(hierarchies)*5)
-	for _, hierarchy := range hierarchies {
-		locStrings = append(locStrings,
-			hierarchy.Enterprise.String(),
-			hierarchy.Site.String(),
-			hierarchy.Area.String(),
-			hierarchy.ProductionLine.String(),
-			hierarchy.WorkCell.String(),
-		)
-	}
-
-	err := validateHierarchies(hierarchies)
-	if err != nil {
-		return err
-	}
-
-	// Marshal the locations to ASN.1 DER encoding
-	value, err := asn1.Marshal(locStrings)
-	if err != nil {
-		return errors.Join(err, errors.New("failed to marshal location extension"))
-	}
-
-	// Add the extension to the template
-	template.ExtraExtensions = append(template.ExtraExtensions, pkix.Extension{
-		Id:       oidExtensionLocation,
-		Critical: false, // Non-critical so clients that don't understand it can ignore it
-		Value:    value,
-	})
-
-	return nil
-}
-
-// NEW: AddRoleScopesV2Extension adds a v2 role extension with per-location role mappings.
-func AddRoleScopesV2Extension(template *x509.Certificate, scopes []RoleScope) error {
-	if len(scopes) == 0 {
-		return errors.New("role scopes cannot be empty")
-	}
-
-	// Validate all scopes
-	for _, scope := range scopes {
-		if scope.Role != RoleAdmin && scope.Role != RoleEditor && scope.Role != RoleViewer {
-			return fmt.Errorf("invalid role in scope: %s", scope.Role)
-		}
-
-		if scope.DNSSuffix == "" {
-			return errors.New("DNS suffix cannot be empty")
-		}
-
-		if !strings.HasPrefix(string(scope.DNSSuffix), ".") {
-			return fmt.Errorf("DNS suffix must start with '.': %s", scope.DNSSuffix)
-		}
-	}
-
-	payload := roleScopesV2{
-		Version: 2,
-		Scopes:  scopes,
-	}
-
-	// Marshal to JSON for simplicity and debuggability
-	value, err := json.Marshal(payload)
-	if err != nil {
-		return errors.Join(err, errors.New("failed to marshal role scopes v2"))
-	}
-
-	// Add the extension to the template
-	template.ExtraExtensions = append(template.ExtraExtensions, pkix.Extension{
-		Id:       oidExtensionRole,
-		Critical: false, // Non-critical for compatibility with standard X.509 validation
-		Value:    value,
-	})
-
-	return nil
-}
-
-// NEW: ParseRoleInfo extracts role information from a certificate (backwards compatible).
-func ParseRoleInfo(cert *x509.Certificate) (v2 *roleScopesV2, v1 Role, hasV2 bool, hasV1 bool, err error) {
-	for _, ext := range cert.Extensions {
-		if ext.Id.Equal(oidExtensionRole) {
-			// Try v2 JSON first
-			var rs roleScopesV2
-			if json.Unmarshal(ext.Value, &rs) == nil && rs.Version == 2 {
-				return &rs, "", true, false, nil
-			}
-
-			// Fallback to v1 ASN.1 format (existing format)
-			var roleStr string
-			if _, asnErr := asn1.Unmarshal(ext.Value, &roleStr); asnErr == nil {
-				role := Role(roleStr)
-				if role == RoleAdmin || role == RoleEditor || role == RoleViewer {
-					return nil, role, false, true, nil
-				}
-			}
-
-			// If we get here, the extension exists but we can't parse it
-			return nil, "", false, false, errors.New("unknown role extension payload format")
-		}
-	}
-
-	return nil, "", false, false, errors.New("role extension not found")
-}
-
-// NEW: EffectiveRoleFor determines the effective role for a given DNS name using v2 scopes.
-func EffectiveRoleFor(dnsName string, v2 *roleScopesV2) Role {
-	if v2 == nil {
-		return ""
-	}
-
-	// Find the most specific (longest) matching DNS suffix
-	bestLen := -1
-
-	var bestRole Role
-
-	lowerName := strings.ToLower(dnsName)
-
-	for _, scope := range v2.Scopes {
-		lowerSuffix := strings.ToLower(string(scope.DNSSuffix))
-		if strings.HasSuffix(lowerName, lowerSuffix) && len(lowerSuffix) > bestLen {
-			bestLen = len(lowerSuffix)
-			bestRole = scope.Role
-		}
-	}
-
-	if bestLen >= 0 {
-		return bestRole
-	}
-
-	return v2.Default
-}
-
-// NEW: Helper function to convert LocationDNS slice to string slice.
-func LocationDNSToStrings(locations []LocationDNS) []string {
-	result := make([]string, len(locations))
-	for i, loc := range locations {
-		result[i] = string(loc)
-	}
-
-	return result
-}
-
-func validateHierarchies(hierarchies []LocationHierarchy) error {
-	disallowedSymbols := []string{"."}
-
-	checkValue := func(value, fieldName string) error {
-		for _, symbol := range disallowedSymbols {
-			if strings.Contains(value, symbol) {
-				return fmt.Errorf("invalid symbol '%s' in %s location '%s'",
-					symbol, fieldName, value)
-			}
-		}
-
-		return nil
-	}
-
-	for _, hierarchy := range hierarchies {
-		if err := checkValue(hierarchy.Enterprise.Value, "enterprise"); err != nil {
-			return err
-		}
-
-		if err := checkValue(hierarchy.Site.Value, "site"); err != nil {
-			return err
-		}
-
-		if err := checkValue(hierarchy.Area.Value, "area"); err != nil {
-			return err
-		}
-
-		if err := checkValue(hierarchy.ProductionLine.Value, "production line"); err != nil {
-			return err
-		}
-
-		if err := checkValue(hierarchy.WorkCell.Value, "work cell"); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// GetRoleForLocation determines the effective role for a specific location from a certificate.
-// This function handles both v1 (global role) and v2 (per-location roles) certificates.
-//
-// Parameters:
-//   - cert: The X.509 certificate to examine
-//   - location: The location as map[int]string representing the hierarchy levels
-//     Example: map[int]string{0: "cologne", 1: "area2", 2: "cell1"} represents "cell1.area2.cologne.umh.internal"
-//
-// Returns:
-//   - Role: The effective role for the location ("admin", "editor", "viewer", or "" if no access)
-//   - error: Any parsing errors
-func GetRoleForLocation(cert *x509.Certificate, location map[int]string) (Role, error) {
-	// Parse role information from certificate (handles both v1 and v2)
-	v2, v1, hasV2, hasV1, err := ParseRoleInfo(cert)
-	if err != nil && !hasV1 && !hasV2 {
-		return "", fmt.Errorf("no role information found in certificate: %w", err)
-	}
-
-	// Convert location map to DNS name for v2 processing
-	locationDNS := ConvertLocationMapToDNS(location)
-
-	if hasV2 {
-		// V2: Per-location roles
-		role := EffectiveRoleFor(locationDNS, v2)
-
-		return role, nil
-	} else if hasV1 {
-		// V1: Global role, but check if certificate has access to this location
-		if hasAccessToLocationV1(cert, location) {
-			return v1, nil
-		}
-
-		return "", nil // No access to this location
-	}
-
-	return "", errors.New("no valid role information found")
-}
-
-// GetRoleFromCertificate extracts the role from a certificate (DEPRECATED: use GetRoleForLocation)
-// This function is kept for backwards compatibility but should not be used in new code.
-func GetRoleFromCertificate(cert *x509.Certificate) (Role, error) {
-	for _, ext := range cert.Extensions {
-		if ext.Id.Equal(oidExtensionRole) {
-			var roleStr string
-
-			_, err := asn1.Unmarshal(ext.Value, &roleStr)
-			if err != nil {
-				return "", errors.Join(err, errors.New("failed to unmarshal role extension"))
-			}
-
-			role := Role(roleStr)
-			if role != RoleAdmin && role != RoleViewer && role != RoleEditor {
-				return "", fmt.Errorf("invalid role in certificate: %s", role)
-			}
-
+	for currentLocation, role := range locationRoles {
+		if currentLocation == location {
 			return role, nil
 		}
 	}
 
-	return "", errors.New("role extension not found in certificate")
+	return "", errors.New("did not find this location")
 }
 
-// ConvertLocationMapToDNS converts a location map to DNS format
-// Example: map[int]string{0: "cologne", 1: "area2", 2: "cell1"} -> "cell1.area2.cologne.umh.internal".
-func ConvertLocationMapToDNS(location map[int]string) string {
-	if len(location) == 0 {
-		return ""
-	}
-
-	// Find the maximum key to determine the depth
-	maxKey := -1
-	for k := range location {
-		if k > maxKey {
-			maxKey = k
-		}
-	}
-
-	// Build the DNS name from highest level (maxKey) to lowest (0)
-	var parts []string
-
-	for i := maxKey; i >= 0; i-- {
-		if part, exists := location[i]; exists && part != "" {
-			parts = append(parts, part)
-		}
-	}
-
-	if len(parts) == 0 {
-		return ""
-	}
-
-	// Add the .umh.internal suffix
-	return strings.Join(parts, ".") + ".umh.internal"
-}
-
-// hasAccessToLocationV1 checks if a v1 certificate has access to the given location
-// based on the stored location hierarchies in the certificate.
-func hasAccessToLocationV1(cert *x509.Certificate, location map[int]string) bool {
-	// Get the location hierarchies from the v1 certificate
-	hierarchies, err := GetLocationHierarchiesFromCertificate(cert)
-	if err != nil {
-		return false
-	}
-
-	// Convert the requested location to a hierarchy for comparison
-	requestedHierarchy := convertLocationMapToHierarchy(location)
-
-	// Check if any hierarchy in the certificate matches or contains the requested location
-	for _, hierarchy := range hierarchies {
-		if hierarchyContainsLocation(hierarchy, requestedHierarchy) {
-			return true
-		}
-	}
-
-	return false
-}
-
-// convertLocationMapToHierarchy converts a location map to LocationHierarchy.
-func convertLocationMapToHierarchy(location map[int]string) LocationHierarchy {
-	hierarchy := LocationHierarchy{}
-
-	if enterprise, exists := location[0]; exists {
-		hierarchy.Enterprise = Location{Type: "Enterprise", Value: enterprise}
-	}
-
-	if site, exists := location[1]; exists {
-		hierarchy.Site = Location{Type: "Site", Value: site}
-	}
-
-	if area, exists := location[2]; exists {
-		hierarchy.Area = Location{Type: "Area", Value: area}
-	}
-
-	if productionLine, exists := location[3]; exists {
-		hierarchy.ProductionLine = Location{Type: "ProductionLine", Value: productionLine}
-	}
-
-	if workCell, exists := location[4]; exists {
-		hierarchy.WorkCell = Location{Type: "WorkCell", Value: workCell}
-	}
-
-	return hierarchy
-}
-
-// hierarchyContainsLocation checks if a certificate hierarchy contains or matches the requested location.
-func hierarchyContainsLocation(certHierarchy, requestedHierarchy LocationHierarchy) bool {
-	// Check each level - certificate hierarchy must match or be a wildcard
-	if !levelMatches(certHierarchy.Enterprise, requestedHierarchy.Enterprise) {
-		return false
-	}
-
-	if !levelMatches(certHierarchy.Site, requestedHierarchy.Site) {
-		return false
-	}
-
-	if !levelMatches(certHierarchy.Area, requestedHierarchy.Area) {
-		return false
-	}
-
-	if !levelMatches(certHierarchy.ProductionLine, requestedHierarchy.ProductionLine) {
-		return false
-	}
-
-	if !levelMatches(certHierarchy.WorkCell, requestedHierarchy.WorkCell) {
-		return false
-	}
-
-	return true
-}
-
-// levelMatches checks if a certificate level matches the requested level.
-func levelMatches(certLevel, requestedLevel Location) bool {
-	// If certificate level is wildcard (*), it matches anything
-	if certLevel.Value == "*" {
-		return true
-	}
-
-	// If certificate level is empty, it matches empty requested level
-	if certLevel.Value == "" && requestedLevel.Value == "" {
-		return true
-	}
-
-	// Otherwise, must be exact match
-	return certLevel.Value == requestedLevel.Value
-}
-
-// GetLocationHierarchiesFromCertificate extracts the location hierarchies from a certificate.
-func GetLocationHierarchiesFromCertificate(cert *x509.Certificate) ([]LocationHierarchy, error) {
+func GetLocationRolesFromCertificate(cert *x509.Certificate) (LocationRoles, error) {
 	for _, ext := range cert.Extensions {
-		if ext.Id.Equal(oidExtensionLocation) {
-			var locStrings []string
+		if ext.Id.Equal(oidExtensionRoleLocation) {
+			var locationRoles LocationRoles
 
-			_, err := asn1.Unmarshal(ext.Value, &locStrings)
+			var locataionRolesString string
+
+			_, err := asn1.Unmarshal(ext.Value, &locataionRolesString)
 			if err != nil {
-				return nil, errors.Join(err, errors.New("failed to unmarshal location extension"))
+				return LocationRoles{}, errors.Join(err, errors.New("failed to asn1 unmarshal locationRole extension"))
 			}
 
-			// Ensure locStrings is not nil and has valid content
-			if locStrings == nil {
-				return nil, errors.New("location extension unmarshaled to nil")
+			err = yaml.Unmarshal([]byte(locataionRolesString), &locationRoles)
+			if err != nil {
+				return LocationRoles{}, errors.Join(err, errors.New("failed to yaml unmarshal locationRole extension value"))
 			}
 
-			// Each hierarchy consists of 5 location strings
-			if len(locStrings)%5 != 0 {
-				return nil, fmt.Errorf("invalid number of location strings: %d (must be a multiple of 5)", len(locStrings))
-			}
-
-			hierarchyCount := len(locStrings) / 5
-			hierarchies := make([]LocationHierarchy, hierarchyCount)
-
-			for h := range hierarchyCount {
-				// Parse each location string for this hierarchy
-				locations := make([]Location, 5)
-
-				for i := range 5 {
-					locStr := locStrings[h*5+i]
-
-					parts := strings.SplitN(locStr, ":", 2)
-					if len(parts) != 2 {
-						return nil, fmt.Errorf("invalid location string format: %s", locStr)
-					}
-
-					locType := LocationType(parts[0])
-					locValue := parts[1]
-
-					locations[i] = Location{
-						Type:  locType,
-						Value: locValue,
-					}
+			// validate all roles and locations
+			for location, role := range locationRoles {
+				if role != RoleAdmin && role != RoleViewer && role != RoleEditor {
+					return LocationRoles{}, fmt.Errorf("invalid role: %s", role)
 				}
 
-				hierarchies[h] = LocationHierarchy{
-					Enterprise:     locations[0],
-					Site:           locations[1],
-					Area:           locations[2],
-					ProductionLine: locations[3],
-					WorkCell:       locations[4],
-				}
-
-				// Validate location hierarchy
-				if err := ValidateLocationHierarchy(hierarchies[h]); err != nil {
-					return nil, errors.Join(err, errors.New("invalid location hierarchy in certificate"))
+				if len(strings.Split(location, ".")) <= 0 {
+					return LocationRoles{}, fmt.Errorf("invalid location: %s", location)
 				}
 			}
 
-			return hierarchies, nil
+			return locationRoles, nil
 		}
 	}
 
-	return nil, errors.New("location extension not found in certificate")
-}
-
-// NEW V2 CONVENIENCE FUNCTIONS for easy migration and usage
-
-// CreateRoleScope creates a new RoleScope for a DNS suffix and role.
-func CreateRoleScope(dnsSuffix string, role Role) RoleScope {
-	if !strings.HasPrefix(dnsSuffix, ".") {
-		dnsSuffix = "." + dnsSuffix
-	}
-
-	return RoleScope{
-		DNSSuffix: LocationDNS(dnsSuffix),
-		Role:      role,
-	}
-}
-
-// CreateLocationDNSFromHierarchy converts old hierarchy format to new DNS format
-// Example: enterprise="umh", site="cologne", area="area2", line="lineA", cell="cell3"
-// becomes: "cell3.lineA.area2.cologne.umh.internal"
-// Example with wildcards: enterprise="umh", site="cologne", area="*"
-// becomes: "*.cologne.umh.internal"
-func CreateLocationDNSFromHierarchy(hierarchy LocationHierarchy) LocationDNS {
-	parts := []string{}
-	hasWildcard := false
-
-	// Build from most specific to least specific (reverse hierarchy)
-	// Stop at first wildcard and mark it
-	if !hierarchy.WorkCell.IsWildcard() {
-		parts = append(parts, hierarchy.WorkCell.Value)
-	} else if len(parts) == 0 {
-		hasWildcard = true
-	}
-
-	if !hierarchy.ProductionLine.IsWildcard() && !hasWildcard {
-		parts = append(parts, hierarchy.ProductionLine.Value)
-	} else if len(parts) == 0 && !hasWildcard {
-		hasWildcard = true
-	}
-
-	if !hierarchy.Area.IsWildcard() && !hasWildcard {
-		parts = append(parts, hierarchy.Area.Value)
-	} else if len(parts) == 0 && !hasWildcard {
-		hasWildcard = true
-	}
-
-	if !hierarchy.Site.IsWildcard() && !hasWildcard {
-		parts = append(parts, hierarchy.Site.Value)
-	} else if len(parts) == 0 && !hasWildcard {
-		hasWildcard = true
-	}
-
-	if !hierarchy.Enterprise.IsWildcard() && !hasWildcard {
-		parts = append(parts, hierarchy.Enterprise.Value)
-	}
-
-	// Add the domain suffix
-	parts = append(parts, "internal")
-
-	locationStr := strings.Join(parts, ".")
-
-	// Add wildcard prefix if we found a wildcard in the hierarchy
-	if hasWildcard {
-		locationStr = "*." + locationStr
-	}
-
-	return LocationDNS(locationStr)
-}
-
-// ConvertHierarchiesToLocations converts old v1 hierarchies to v2 location DNS names.
-func ConvertHierarchiesToLocations(hierarchies []LocationHierarchy) []LocationDNS {
-	locations := make([]LocationDNS, 0, len(hierarchies))
-	for _, hierarchy := range hierarchies {
-		locations = append(locations, CreateLocationDNSFromHierarchy(hierarchy))
-	}
-
-	return locations
-}
-
-// CreateUniformRoleScopes creates role scopes that give the same role to all locations.
-func CreateUniformRoleScopes(locations []LocationDNS, role Role) []RoleScope {
-	scopes := make([]RoleScope, 0, len(locations))
-	for _, location := range locations {
-		// Create a scope for this exact location (add leading dot)
-		suffix := "." + string(location)
-		scopes = append(scopes, CreateRoleScope(suffix, role))
-	}
-
-	return scopes
-}
-
-// GetEffectiveRoleForLocation is a convenience wrapper around EffectiveRoleFor.
-func GetEffectiveRoleForLocation(location LocationDNS, cert *x509.Certificate) (Role, error) {
-	v2, v1, hasV2, hasV1, err := ParseRoleInfo(cert)
-	if err != nil {
-		return "", err
-	}
-
-	if hasV2 {
-		return EffectiveRoleFor(string(location), v2), nil
-	} else if hasV1 {
-		// V1 certificates have global role for all locations
-		return v1, nil
-	}
-
-	return "", errors.New("no role information found")
-}
-
-// ValidateLocationDNS validates that a location DNS name follows proper hierarchy rules.
-func ValidateLocationDNS(location LocationDNS) error {
-	locationStr := string(location)
-
-	// Must not be empty
-	if locationStr == "" {
-		return errors.New("location DNS cannot be empty")
-	}
-
-	// Must end with .umh.internal
-	if !strings.HasSuffix(locationStr, ".umh.internal") {
-		return fmt.Errorf("location DNS must end with '.umh.internal': %s", locationStr)
-	}
-
-	// Handle wildcard locations (must be exactly "*.something")
-	isWildcard := false
-
-	checkStr := locationStr
-	if strings.HasPrefix(locationStr, "*") {
-		if !strings.HasPrefix(locationStr, "*.") {
-			return fmt.Errorf("wildcard location DNS must use '*.domain' format: %s", locationStr)
-		}
-
-		isWildcard = true
-		checkStr = locationStr[2:] // Remove "*." from the start
-	}
-
-	// Must not start with a dot (after wildcard handling)
-	if strings.HasPrefix(checkStr, ".") {
-		return fmt.Errorf("location DNS cannot start with '.': %s", locationStr)
-	}
-
-	// Split checkStr and validate parts
-	parts := strings.Split(checkStr, ".")
-
-	// Special validation for global wildcard: *.umh.internal is allowed
-	if isWildcard && checkStr == "umh.internal" {
-		// This is *.umh.internal which is valid for global access
-		if len(parts) != 2 || parts[0] != "umh" || parts[1] != "internal" {
-			return fmt.Errorf("invalid global wildcard format: %s", locationStr)
-		}
-
-		return nil
-	}
-
-	// Must have at least one level before .umh.internal (e.g., site.umh.internal or *.site.umh.internal)
-	if len(parts) < 3 { // minimum: [site, umh, internal]
-		return fmt.Errorf("location DNS must have at least one location level: %s", locationStr)
-	}
-
-	// Check for forbidden generic names (excluding the wildcard asterisk)
-	forbiddenNames := []string{"identity", "generic", "default", "any", "all"}
-	for _, part := range parts {
-		for _, forbidden := range forbiddenNames {
-			if strings.EqualFold(part, forbidden) {
-				return fmt.Errorf("location DNS contains forbidden generic name '%s': %s", forbidden, locationStr)
-			}
-		}
-	}
-
-	// Wildcard validation: must have at least one level after wildcard
-	if isWildcard && len(parts) < 3 {
-		return fmt.Errorf("wildcard location DNS must specify parent location: %s", locationStr)
-	}
-
-	return nil
-}
-
-// IsWildcardLocation checks if a LocationDNS represents a wildcard location.
-func IsWildcardLocation(location LocationDNS) bool {
-	return strings.HasPrefix(string(location), "*.")
+	return LocationRoles{}, ERR_RoleLocation_Not_Found
 }

--- a/umh-core/pkg/communicator/actions/permission/extensions.go
+++ b/umh-core/pkg/communicator/actions/permission/extensions.go
@@ -16,7 +16,9 @@ package permission_validator
 
 import (
 	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/asn1"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"slices"
@@ -26,14 +28,14 @@ import (
 var UMH_PEN = asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 59193}
 
 // OIDs for our custom extensions
-// 1: V1 of our extensions
-// 1.1: Role extension
-// 1.2: Location extension
+// 1: V1 of our extensions (backwards compatibility)
+// 1.1: Role extension (v1: global role, v2: per-location role scopes)
+// 1.2: Location extension (deprecated in favor of DNS SANs + Name Constraints)
 var (
-	// OID for Role extension
+	// OID for Role extension (supports both v1 and v2 payloads)
 	oidExtensionRole asn1.ObjectIdentifier = append(UMH_PEN, 1, 1)
 
-	// OID for Location extension
+	// OID for Location extension (deprecated - keeping for backwards compatibility)
 	oidExtensionLocation asn1.ObjectIdentifier = append(UMH_PEN, 1, 2)
 )
 
@@ -50,6 +52,30 @@ const (
 	// RoleEditor represents an editor role
 	RoleEditor Role = "Editor"
 )
+
+// NEW: LocationDNS represents a location as a DNS name with arbitrary depth
+type LocationDNS string
+
+// Examples:
+// - "cell3.lineA.area2.cologne.umh.internal"  (most specific: cell level)
+// - "area2.cologne.umh.internal"              (area level)
+// - "cologne.umh.internal"                    (site level)
+// - "office.cologne.umh.internal"             (administrative locations)
+// - "*.area2.cologne.umh.internal"            (wildcard: all cells in area2)
+// - "*.cologne.umh.internal"                  (wildcard: all areas in cologne)
+
+// NEW: RoleScope represents a role that applies to a specific DNS subtree
+type RoleScope struct {
+	DNSSuffix LocationDNS `json:"dns_suffix"` // e.g. ".cologne.umh.internal"
+	Role      Role        `json:"role"`       // admin/editor/viewer
+}
+
+// NEW: V2 role extension payload structure
+type roleScopesV2 struct {
+	Version int         `json:"v"`                 // must be 2
+	Scopes  []RoleScope `json:"scopes"`            // per-location role mappings
+	Default Role        `json:"default,omitempty"` // fallback role if no suffix matches
+}
 
 // LocationType represents the type of location in the hierarchy
 type LocationType string
@@ -132,6 +158,27 @@ type LocationHierarchy struct {
 	WorkCell       Location
 }
 
+// NewLocationHierarchy creates a new LocationHierarchy with the given locations
+func NewLocationHierarchy(enterprise, site, area, productionLine, workCell Location) LocationHierarchy {
+	return LocationHierarchy{
+		Enterprise:     enterprise,
+		Site:           site,
+		Area:           area,
+		ProductionLine: productionLine,
+		WorkCell:       workCell,
+	}
+}
+
+// RoleExtension represents the role extension data
+type RoleExtension struct {
+	Role Role
+}
+
+// LocationExtension represents the location extension data
+type LocationExtension struct {
+	Hierarchies []LocationHierarchy
+}
+
 // ValidateLocationHierarchy validates that the location hierarchy is correct
 // All levels must be set, but can be wildcards (including Enterprise)
 // If a specific level has a non-wildcard value, all higher levels must also have non-wildcard values
@@ -163,7 +210,247 @@ func ValidateLocationHierarchy(hierarchy LocationHierarchy) error {
 	return nil
 }
 
-// GetRoleFromCertificate extracts the role from a certificate
+// AddRoleExtension adds a role extension to the certificate template
+func AddRoleExtension(template *x509.Certificate, role Role) error {
+	// Validate role
+	if role != RoleAdmin && role != RoleViewer && role != RoleEditor {
+		return fmt.Errorf("invalid role: %s", role)
+	}
+
+	// Marshal the role to ASN.1 DER encoding
+	value, err := asn1.Marshal(string(role))
+	if err != nil {
+		return errors.Join(err, errors.New("failed to marshal role extension"))
+	}
+
+	// Add the extension to the template
+	template.ExtraExtensions = append(template.ExtraExtensions, pkix.Extension{
+		Id:       oidExtensionRole,
+		Critical: false, // Non-critical so clients that don't understand it can ignore it
+		Value:    value,
+	})
+
+	return nil
+}
+
+// AddLocationExtension adds a location extension to the certificate template
+func AddLocationExtension(template *x509.Certificate, hierarchies []LocationHierarchy) error {
+	if len(hierarchies) == 0 {
+		return errors.New("at least one location hierarchy must be specified")
+	}
+
+	// Validate each location hierarchy
+	for _, hierarchy := range hierarchies {
+		if err := ValidateLocationHierarchy(hierarchy); err != nil {
+			return err
+		}
+	}
+
+	// Convert hierarchies to a serializable format
+	// Format: [hierarchy1_enterprise, hierarchy1_site, hierarchy1_area, hierarchy1_productionline, hierarchy1_workcell, hierarchy2_enterprise, ...]
+	locStrings := make([]string, 0, len(hierarchies)*5)
+	for _, hierarchy := range hierarchies {
+		locStrings = append(locStrings,
+			hierarchy.Enterprise.String(),
+			hierarchy.Site.String(),
+			hierarchy.Area.String(),
+			hierarchy.ProductionLine.String(),
+			hierarchy.WorkCell.String(),
+		)
+	}
+
+	err := validateHierarchies(hierarchies)
+	if err != nil {
+		return err
+	}
+
+	// Marshal the locations to ASN.1 DER encoding
+	value, err := asn1.Marshal(locStrings)
+	if err != nil {
+		return errors.Join(err, errors.New("failed to marshal location extension"))
+	}
+
+	// Add the extension to the template
+	template.ExtraExtensions = append(template.ExtraExtensions, pkix.Extension{
+		Id:       oidExtensionLocation,
+		Critical: false, // Non-critical so clients that don't understand it can ignore it
+		Value:    value,
+	})
+
+	return nil
+}
+
+// NEW: AddRoleScopesV2Extension adds a v2 role extension with per-location role mappings
+func AddRoleScopesV2Extension(template *x509.Certificate, scopes []RoleScope) error {
+	if len(scopes) == 0 {
+		return errors.New("role scopes cannot be empty")
+	}
+
+	// Validate all scopes
+	for _, scope := range scopes {
+		if scope.Role != RoleAdmin && scope.Role != RoleEditor && scope.Role != RoleViewer {
+			return fmt.Errorf("invalid role in scope: %s", scope.Role)
+		}
+		if scope.DNSSuffix == "" {
+			return errors.New("DNS suffix cannot be empty")
+		}
+		if !strings.HasPrefix(string(scope.DNSSuffix), ".") {
+			return fmt.Errorf("DNS suffix must start with '.': %s", scope.DNSSuffix)
+		}
+	}
+
+	payload := roleScopesV2{
+		Version: 2,
+		Scopes:  scopes,
+	}
+
+	// Marshal to JSON for simplicity and debuggability
+	value, err := json.Marshal(payload)
+	if err != nil {
+		return errors.Join(err, errors.New("failed to marshal role scopes v2"))
+	}
+
+	// Add the extension to the template
+	template.ExtraExtensions = append(template.ExtraExtensions, pkix.Extension{
+		Id:       oidExtensionRole,
+		Critical: false, // Non-critical for compatibility with standard X.509 validation
+		Value:    value,
+	})
+
+	return nil
+}
+
+// NEW: ParseRoleInfo extracts role information from a certificate (backwards compatible)
+func ParseRoleInfo(cert *x509.Certificate) (v2 *roleScopesV2, v1 Role, hasV2 bool, hasV1 bool, err error) {
+	for _, ext := range cert.Extensions {
+		if ext.Id.Equal(oidExtensionRole) {
+			// Try v2 JSON first
+			var rs roleScopesV2
+			if json.Unmarshal(ext.Value, &rs) == nil && rs.Version == 2 {
+				return &rs, "", true, false, nil
+			}
+
+			// Fallback to v1 ASN.1 format (existing format)
+			var roleStr string
+			if _, asnErr := asn1.Unmarshal(ext.Value, &roleStr); asnErr == nil {
+				role := Role(roleStr)
+				if role == RoleAdmin || role == RoleEditor || role == RoleViewer {
+					return nil, role, false, true, nil
+				}
+			}
+
+			// If we get here, the extension exists but we can't parse it
+			return nil, "", false, false, fmt.Errorf("unknown role extension payload format")
+		}
+	}
+	return nil, "", false, false, errors.New("role extension not found")
+}
+
+// NEW: EffectiveRoleFor determines the effective role for a given DNS name using v2 scopes
+func EffectiveRoleFor(dnsName string, v2 *roleScopesV2) Role {
+	if v2 == nil {
+		return ""
+	}
+
+	// Find the most specific (longest) matching DNS suffix
+	bestLen := -1
+	var bestRole Role
+	lowerName := strings.ToLower(dnsName)
+
+	for _, scope := range v2.Scopes {
+		lowerSuffix := strings.ToLower(string(scope.DNSSuffix))
+		if strings.HasSuffix(lowerName, lowerSuffix) && len(lowerSuffix) > bestLen {
+			bestLen = len(lowerSuffix)
+			bestRole = scope.Role
+		}
+	}
+
+	if bestLen >= 0 {
+		return bestRole
+	}
+	return v2.Default
+}
+
+// NEW: Helper function to convert LocationDNS slice to string slice
+func LocationDNSToStrings(locations []LocationDNS) []string {
+	result := make([]string, len(locations))
+	for i, loc := range locations {
+		result[i] = string(loc)
+	}
+	return result
+}
+
+func validateHierarchies(hierarchies []LocationHierarchy) error {
+	disallowedSymbols := []string{"."}
+
+	checkValue := func(value, fieldName string) error {
+		for _, symbol := range disallowedSymbols {
+			if strings.Contains(value, symbol) {
+				return fmt.Errorf("invalid symbol '%s' in %s location '%s'",
+					symbol, fieldName, value)
+			}
+		}
+		return nil
+	}
+
+	for _, hierarchy := range hierarchies {
+		if err := checkValue(hierarchy.Enterprise.Value, "enterprise"); err != nil {
+			return err
+		}
+		if err := checkValue(hierarchy.Site.Value, "site"); err != nil {
+			return err
+		}
+		if err := checkValue(hierarchy.Area.Value, "area"); err != nil {
+			return err
+		}
+		if err := checkValue(hierarchy.ProductionLine.Value, "production line"); err != nil {
+			return err
+		}
+		if err := checkValue(hierarchy.WorkCell.Value, "work cell"); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// GetRoleForLocation determines the effective role for a specific location from a certificate.
+// This function handles both v1 (global role) and v2 (per-location roles) certificates.
+//
+// Parameters:
+//   - cert: The X.509 certificate to examine
+//   - location: The location as map[int]string representing the hierarchy levels
+//     Example: map[int]string{0: "cologne", 1: "area2", 2: "cell1"} represents "cell1.area2.cologne.umh.internal"
+//
+// Returns:
+//   - Role: The effective role for the location ("admin", "editor", "viewer", or "" if no access)
+//   - error: Any parsing errors
+func GetRoleForLocation(cert *x509.Certificate, location map[int]string) (Role, error) {
+	// Parse role information from certificate (handles both v1 and v2)
+	v2, v1, hasV2, hasV1, err := ParseRoleInfo(cert)
+	if err != nil && !hasV1 && !hasV2 {
+		return "", fmt.Errorf("no role information found in certificate: %w", err)
+	}
+
+	// Convert location map to DNS name for v2 processing
+	locationDNS := ConvertLocationMapToDNS(location)
+
+	if hasV2 {
+		// V2: Per-location roles
+		role := EffectiveRoleFor(locationDNS, v2)
+		return role, nil
+	} else if hasV1 {
+		// V1: Global role, but check if certificate has access to this location
+		if hasAccessToLocationV1(cert, location) {
+			return v1, nil
+		}
+		return "", nil // No access to this location
+	}
+
+	return "", fmt.Errorf("no valid role information found")
+}
+
+// GetRoleFromCertificate extracts the role from a certificate (DEPRECATED: use GetRoleForLocation)
+// This function is kept for backwards compatibility but should not be used in new code.
 func GetRoleFromCertificate(cert *x509.Certificate) (Role, error) {
 	for _, ext := range cert.Extensions {
 		if ext.Id.Equal(oidExtensionRole) {
@@ -183,6 +470,120 @@ func GetRoleFromCertificate(cert *x509.Certificate) (Role, error) {
 	}
 
 	return "", errors.New("role extension not found in certificate")
+}
+
+// ConvertLocationMapToDNS converts a location map to DNS format
+// Example: map[int]string{0: "cologne", 1: "area2", 2: "cell1"} -> "cell1.area2.cologne.umh.internal"
+func ConvertLocationMapToDNS(location map[int]string) string {
+	if len(location) == 0 {
+		return ""
+	}
+
+	// Find the maximum key to determine the depth
+	maxKey := -1
+	for k := range location {
+		if k > maxKey {
+			maxKey = k
+		}
+	}
+
+	// Build the DNS name from highest level (maxKey) to lowest (0)
+	var parts []string
+	for i := maxKey; i >= 0; i-- {
+		if part, exists := location[i]; exists && part != "" {
+			parts = append(parts, part)
+		}
+	}
+
+	if len(parts) == 0 {
+		return ""
+	}
+
+	// Add the .umh.internal suffix
+	return strings.Join(parts, ".") + ".umh.internal"
+}
+
+// hasAccessToLocationV1 checks if a v1 certificate has access to the given location
+// based on the stored location hierarchies in the certificate
+func hasAccessToLocationV1(cert *x509.Certificate, location map[int]string) bool {
+	// Get the location hierarchies from the v1 certificate
+	hierarchies, err := GetLocationHierarchiesFromCertificate(cert)
+	if err != nil {
+		return false
+	}
+
+	// Convert the requested location to a hierarchy for comparison
+	requestedHierarchy := convertLocationMapToHierarchy(location)
+
+	// Check if any hierarchy in the certificate matches or contains the requested location
+	for _, hierarchy := range hierarchies {
+		if hierarchyContainsLocation(hierarchy, requestedHierarchy) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// convertLocationMapToHierarchy converts a location map to LocationHierarchy
+func convertLocationMapToHierarchy(location map[int]string) LocationHierarchy {
+	hierarchy := LocationHierarchy{}
+
+	if enterprise, exists := location[0]; exists {
+		hierarchy.Enterprise = Location{Type: "Enterprise", Value: enterprise}
+	}
+	if site, exists := location[1]; exists {
+		hierarchy.Site = Location{Type: "Site", Value: site}
+	}
+	if area, exists := location[2]; exists {
+		hierarchy.Area = Location{Type: "Area", Value: area}
+	}
+	if productionLine, exists := location[3]; exists {
+		hierarchy.ProductionLine = Location{Type: "ProductionLine", Value: productionLine}
+	}
+	if workCell, exists := location[4]; exists {
+		hierarchy.WorkCell = Location{Type: "WorkCell", Value: workCell}
+	}
+
+	return hierarchy
+}
+
+// hierarchyContainsLocation checks if a certificate hierarchy contains or matches the requested location
+func hierarchyContainsLocation(certHierarchy, requestedHierarchy LocationHierarchy) bool {
+	// Check each level - certificate hierarchy must match or be a wildcard
+	if !levelMatches(certHierarchy.Enterprise, requestedHierarchy.Enterprise) {
+		return false
+	}
+	if !levelMatches(certHierarchy.Site, requestedHierarchy.Site) {
+		return false
+	}
+	if !levelMatches(certHierarchy.Area, requestedHierarchy.Area) {
+		return false
+	}
+	if !levelMatches(certHierarchy.ProductionLine, requestedHierarchy.ProductionLine) {
+		return false
+	}
+	if !levelMatches(certHierarchy.WorkCell, requestedHierarchy.WorkCell) {
+		return false
+	}
+
+	return true
+}
+
+// levelMatches checks if a certificate level matches the requested level
+func levelMatches(certLevel, requestedLevel Location) bool {
+	// If certificate level is wildcard (*), it matches anything
+	if certLevel.Value == "*" {
+		return true
+	}
+
+	// If certificate level is empty, it matches empty requested level
+	if certLevel.Value == "" && requestedLevel.Value == "" {
+		return true
+	}
+
+	// Otherwise, must be exact match
+	return certLevel.Value == requestedLevel.Value
 }
 
 // GetLocationHierarchiesFromCertificate extracts the location hierarchies from a certificate
@@ -241,4 +642,176 @@ func GetLocationHierarchiesFromCertificate(cert *x509.Certificate) ([]LocationHi
 	}
 
 	return nil, errors.New("location extension not found in certificate")
+}
+
+// NEW V2 CONVENIENCE FUNCTIONS for easy migration and usage
+
+// CreateRoleScope creates a new RoleScope for a DNS suffix and role
+func CreateRoleScope(dnsSuffix string, role Role) RoleScope {
+	if !strings.HasPrefix(dnsSuffix, ".") {
+		dnsSuffix = "." + dnsSuffix
+	}
+	return RoleScope{
+		DNSSuffix: LocationDNS(dnsSuffix),
+		Role:      role,
+	}
+}
+
+// CreateLocationDNSFromHierarchy converts old hierarchy format to new DNS format
+// Example: enterprise="umh", site="cologne", area="area2", line="lineA", cell="cell3"
+// becomes: "cell3.lineA.area2.cologne.umh.internal"
+// Example with wildcards: enterprise="umh", site="cologne", area="*"
+// becomes: "*.cologne.umh.internal"
+func CreateLocationDNSFromHierarchy(hierarchy LocationHierarchy) LocationDNS {
+	parts := []string{}
+	hasWildcard := false
+
+	// Build from most specific to least specific (reverse hierarchy)
+	// Stop at first wildcard and mark it
+	if !hierarchy.WorkCell.IsWildcard() {
+		parts = append(parts, hierarchy.WorkCell.Value)
+	} else if len(parts) == 0 {
+		hasWildcard = true
+	}
+
+	if !hierarchy.ProductionLine.IsWildcard() && !hasWildcard {
+		parts = append(parts, hierarchy.ProductionLine.Value)
+	} else if len(parts) == 0 && !hasWildcard {
+		hasWildcard = true
+	}
+
+	if !hierarchy.Area.IsWildcard() && !hasWildcard {
+		parts = append(parts, hierarchy.Area.Value)
+	} else if len(parts) == 0 && !hasWildcard {
+		hasWildcard = true
+	}
+
+	if !hierarchy.Site.IsWildcard() && !hasWildcard {
+		parts = append(parts, hierarchy.Site.Value)
+	} else if len(parts) == 0 && !hasWildcard {
+		hasWildcard = true
+	}
+
+	if !hierarchy.Enterprise.IsWildcard() && !hasWildcard {
+		parts = append(parts, hierarchy.Enterprise.Value)
+	}
+
+	// Add the domain suffix
+	parts = append(parts, "internal")
+
+	locationStr := strings.Join(parts, ".")
+
+	// Add wildcard prefix if we found a wildcard in the hierarchy
+	if hasWildcard {
+		locationStr = "*." + locationStr
+	}
+
+	return LocationDNS(locationStr)
+}
+
+// ConvertHierarchiesToLocations converts old v1 hierarchies to v2 location DNS names
+func ConvertHierarchiesToLocations(hierarchies []LocationHierarchy) []LocationDNS {
+	locations := make([]LocationDNS, 0, len(hierarchies))
+	for _, hierarchy := range hierarchies {
+		locations = append(locations, CreateLocationDNSFromHierarchy(hierarchy))
+	}
+	return locations
+}
+
+// CreateUniformRoleScopes creates role scopes that give the same role to all locations
+func CreateUniformRoleScopes(locations []LocationDNS, role Role) []RoleScope {
+	scopes := make([]RoleScope, 0, len(locations))
+	for _, location := range locations {
+		// Create a scope for this exact location (add leading dot)
+		suffix := "." + string(location)
+		scopes = append(scopes, CreateRoleScope(suffix, role))
+	}
+	return scopes
+}
+
+// GetEffectiveRoleForLocation is a convenience wrapper around EffectiveRoleFor
+func GetEffectiveRoleForLocation(location LocationDNS, cert *x509.Certificate) (Role, error) {
+	v2, v1, hasV2, hasV1, err := ParseRoleInfo(cert)
+	if err != nil {
+		return "", err
+	}
+
+	if hasV2 {
+		return EffectiveRoleFor(string(location), v2), nil
+	} else if hasV1 {
+		// V1 certificates have global role for all locations
+		return v1, nil
+	}
+
+	return "", errors.New("no role information found")
+}
+
+// ValidateLocationDNS validates that a location DNS name follows proper hierarchy rules
+func ValidateLocationDNS(location LocationDNS) error {
+	locationStr := string(location)
+
+	// Must not be empty
+	if locationStr == "" {
+		return errors.New("location DNS cannot be empty")
+	}
+
+	// Must end with .umh.internal
+	if !strings.HasSuffix(locationStr, ".umh.internal") {
+		return fmt.Errorf("location DNS must end with '.umh.internal': %s", locationStr)
+	}
+
+	// Handle wildcard locations (must be exactly "*.something")
+	isWildcard := false
+	checkStr := locationStr
+	if strings.HasPrefix(locationStr, "*") {
+		if !strings.HasPrefix(locationStr, "*.") {
+			return fmt.Errorf("wildcard location DNS must use '*.domain' format: %s", locationStr)
+		}
+		isWildcard = true
+		checkStr = locationStr[2:] // Remove "*." from the start
+	}
+
+	// Must not start with a dot (after wildcard handling)
+	if strings.HasPrefix(checkStr, ".") {
+		return fmt.Errorf("location DNS cannot start with '.': %s", locationStr)
+	}
+
+	// Split checkStr and validate parts
+	parts := strings.Split(checkStr, ".")
+
+	// Special validation for global wildcard: *.umh.internal is allowed
+	if isWildcard && checkStr == "umh.internal" {
+		// This is *.umh.internal which is valid for global access
+		if len(parts) != 2 || parts[0] != "umh" || parts[1] != "internal" {
+			return fmt.Errorf("invalid global wildcard format: %s", locationStr)
+		}
+		return nil
+	}
+
+	// Must have at least one level before .umh.internal (e.g., site.umh.internal or *.site.umh.internal)
+	if len(parts) < 3 { // minimum: [site, umh, internal]
+		return fmt.Errorf("location DNS must have at least one location level: %s", locationStr)
+	}
+
+	// Check for forbidden generic names (excluding the wildcard asterisk)
+	forbiddenNames := []string{"identity", "generic", "default", "any", "all"}
+	for _, part := range parts {
+		for _, forbidden := range forbiddenNames {
+			if strings.EqualFold(part, forbidden) {
+				return fmt.Errorf("location DNS contains forbidden generic name '%s': %s", forbidden, locationStr)
+			}
+		}
+	}
+
+	// Wildcard validation: must have at least one level after wildcard
+	if isWildcard && len(parts) < 3 {
+		return fmt.Errorf("wildcard location DNS must specify parent location: %s", locationStr)
+	}
+
+	return nil
+}
+
+// IsWildcardLocation checks if a LocationDNS represents a wildcard location
+func IsWildcardLocation(location LocationDNS) bool {
+	return strings.HasPrefix(string(location), "*.")
 }

--- a/umh-core/pkg/communicator/actions/permission/extensions.go
+++ b/umh-core/pkg/communicator/actions/permission/extensions.go
@@ -1,0 +1,244 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package permission_validator
+
+import (
+	"crypto/x509"
+	"encoding/asn1"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+)
+
+var UMH_PEN = asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 59193}
+
+// OIDs for our custom extensions
+// 1: V1 of our extensions
+// 1.1: Role extension
+// 1.2: Location extension
+var (
+	// OID for Role extension
+	oidExtensionRole asn1.ObjectIdentifier = append(UMH_PEN, 1, 1)
+
+	// OID for Location extension
+	oidExtensionLocation asn1.ObjectIdentifier = append(UMH_PEN, 1, 2)
+)
+
+// Role represents the role of a certificate holder
+type Role string
+
+const (
+	// RoleAdmin represents an administrator role
+	RoleAdmin Role = "Admin"
+
+	// RoleViewer represents a viewer role
+	RoleViewer Role = "Viewer"
+
+	// RoleEditor represents an editor role
+	RoleEditor Role = "Editor"
+)
+
+// LocationType represents the type of location in the hierarchy
+type LocationType string
+
+const (
+	// LocationTypeEnterprise represents the enterprise level
+	LocationTypeEnterprise LocationType = "Enterprise"
+
+	// LocationTypeSite represents a site level
+	LocationTypeSite LocationType = "Site"
+
+	// LocationTypeArea represents an area level
+	LocationTypeArea LocationType = "Area"
+
+	// LocationTypeProductionLine represents a production line level
+	LocationTypeProductionLine LocationType = "ProductionLine"
+
+	// LocationTypeWorkCell represents a work cell level
+	LocationTypeWorkCell LocationType = "WorkCell"
+)
+
+// Location represents a specific location with a type and value
+type Location struct {
+	Type  LocationType
+	Value string
+}
+
+// NewLocation creates a new Location with the given type and value
+func NewLocation(locType LocationType, value string) Location {
+	return Location{
+		Type:  locType,
+		Value: value,
+	}
+}
+
+// NewWildcardLocation creates a new Location with the given type and a wildcard value
+func NewWildcardLocation(locType LocationType) Location {
+	return Location{
+		Type:  locType,
+		Value: "*",
+	}
+}
+
+// IsWildcard returns true if the location is a wildcard (any value is allowed)
+func (l Location) IsWildcard() bool {
+	return l.Value == "*"
+}
+
+func (l Location) filterString(s string) string {
+	// The frontend often uses "All sites", "All areas", etc.
+	wildcardStrings := []string{
+		"All enterprises",
+		"All sites",
+		"All areas",
+		"All production lines",
+		"All work cells",
+	}
+
+	if slices.Contains(wildcardStrings, s) {
+		return "*"
+	}
+	if s == "" {
+		return "*"
+	}
+
+	return s
+}
+
+// String returns a string representation of the location
+func (l Location) String() string {
+	return fmt.Sprintf("%s:%s", l.Type, l.filterString(l.Value))
+}
+
+// LocationHierarchy represents a complete location hierarchy
+type LocationHierarchy struct {
+	Enterprise     Location
+	Site           Location
+	Area           Location
+	ProductionLine Location
+	WorkCell       Location
+}
+
+// ValidateLocationHierarchy validates that the location hierarchy is correct
+// All levels must be set, but can be wildcards (including Enterprise)
+// If a specific level has a non-wildcard value, all higher levels must also have non-wildcard values
+func ValidateLocationHierarchy(hierarchy LocationHierarchy) error {
+	// Enterprise must be set
+	if hierarchy.Enterprise.Type != LocationTypeEnterprise {
+		return errors.New("enterprise location must be of type Enterprise")
+	}
+
+	// Site must be set
+	if hierarchy.Site.Type != LocationTypeSite {
+		return errors.New("site location must be of type Site")
+	}
+
+	// Area must be set
+	if hierarchy.Area.Type != LocationTypeArea {
+		return errors.New("area location must be of type Area")
+	}
+
+	// ProductionLine must be set
+	if hierarchy.ProductionLine.Type != LocationTypeProductionLine {
+		return errors.New("production line location must be of type ProductionLine")
+	}
+
+	// WorkCell must be set
+	if hierarchy.WorkCell.Type != LocationTypeWorkCell {
+		return errors.New("work cell location must be of type WorkCell")
+	}
+	return nil
+}
+
+// GetRoleFromCertificate extracts the role from a certificate
+func GetRoleFromCertificate(cert *x509.Certificate) (Role, error) {
+	for _, ext := range cert.Extensions {
+		if ext.Id.Equal(oidExtensionRole) {
+			var roleStr string
+			_, err := asn1.Unmarshal(ext.Value, &roleStr)
+			if err != nil {
+				return "", errors.Join(err, errors.New("failed to unmarshal role extension"))
+			}
+
+			role := Role(roleStr)
+			if role != RoleAdmin && role != RoleViewer && role != RoleEditor {
+				return "", fmt.Errorf("invalid role in certificate: %s", role)
+			}
+
+			return role, nil
+		}
+	}
+
+	return "", errors.New("role extension not found in certificate")
+}
+
+// GetLocationHierarchiesFromCertificate extracts the location hierarchies from a certificate
+func GetLocationHierarchiesFromCertificate(cert *x509.Certificate) ([]LocationHierarchy, error) {
+	for _, ext := range cert.Extensions {
+		if ext.Id.Equal(oidExtensionLocation) {
+			var locStrings []string
+			_, err := asn1.Unmarshal(ext.Value, &locStrings)
+			if err != nil {
+				return nil, errors.Join(err, errors.New("failed to unmarshal location extension"))
+			}
+
+			// Each hierarchy consists of 5 location strings
+			if len(locStrings)%5 != 0 {
+				return nil, fmt.Errorf("invalid number of location strings: %d (must be a multiple of 5)", len(locStrings))
+			}
+
+			hierarchyCount := len(locStrings) / 5
+			hierarchies := make([]LocationHierarchy, hierarchyCount)
+
+			for h := 0; h < hierarchyCount; h++ {
+				// Parse each location string for this hierarchy
+				locations := make([]Location, 5)
+				for i := 0; i < 5; i++ {
+					locStr := locStrings[h*5+i]
+					parts := strings.SplitN(locStr, ":", 2)
+					if len(parts) != 2 {
+						return nil, fmt.Errorf("invalid location string format: %s", locStr)
+					}
+
+					locType := LocationType(parts[0])
+					locValue := parts[1]
+
+					locations[i] = Location{
+						Type:  locType,
+						Value: locValue,
+					}
+				}
+
+				hierarchies[h] = LocationHierarchy{
+					Enterprise:     locations[0],
+					Site:           locations[1],
+					Area:           locations[2],
+					ProductionLine: locations[3],
+					WorkCell:       locations[4],
+				}
+
+				// Validate location hierarchy
+				if err := ValidateLocationHierarchy(hierarchies[h]); err != nil {
+					return nil, errors.Join(err, errors.New("invalid location hierarchy in certificate"))
+				}
+			}
+
+			return hierarchies, nil
+		}
+	}
+
+	return nil, errors.New("location extension not found in certificate")
+}

--- a/umh-core/pkg/communicator/actions/permission/extensions.go
+++ b/umh-core/pkg/communicator/actions/permission/extensions.go
@@ -35,7 +35,7 @@ var (
 	oidExtensionRoleLocation asn1.ObjectIdentifier = append(UMH_PEN, 2, 1)
 )
 
-var ERR_RoleLocation_Not_Found = errors.New("locationRoles extension not found in certificate")
+var ErrRoleLocationNotFound = errors.New("locationRoles extension not found in certificate")
 
 // Role represents the role of a certificate holder.
 type Role string
@@ -112,7 +112,7 @@ func GetLocationRolesFromCertificate(cert *x509.Certificate) (LocationRoles, err
 					return LocationRoles{}, fmt.Errorf("invalid role: %s", role)
 				}
 
-				if len(strings.Split(location, ".")) <= 0 {
+				if len(strings.Split(location, ".")) == 0 {
 					return LocationRoles{}, fmt.Errorf("invalid location: %s", location)
 				}
 			}
@@ -121,5 +121,5 @@ func GetLocationRolesFromCertificate(cert *x509.Certificate) (LocationRoles, err
 		}
 	}
 
-	return LocationRoles{}, ERR_RoleLocation_Not_Found
+	return LocationRoles{}, ErrRoleLocationNotFound
 }

--- a/umh-core/pkg/communicator/actions/permission/user_certificate.go
+++ b/umh-core/pkg/communicator/actions/permission/user_certificate.go
@@ -1,0 +1,264 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package permission_validator
+
+import (
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	_ "embed"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/models"
+	"go.uber.org/zap"
+)
+
+func GetInstanceLocation(snap *fsm.SystemSnapshot) (models.InstanceLocation, error) {
+	if snap == nil {
+		return models.InstanceLocation{}, fmt.Errorf("snapshot is nil")
+	}
+
+	return configLocationToInstanceLocation(snap.CurrentConfig.Agent.Location), nil
+}
+
+// TODO: porting the map to InstanceLocation is only a helper for now
+func configLocationToInstanceLocation(configLocation map[int]string) models.InstanceLocation {
+	return models.InstanceLocation{
+		Enterprise: configLocation[0],
+		Site:       configLocation[1],
+		Area:       configLocation[2],
+		Line:       configLocation[3],
+		WorkCell:   configLocation[4],
+	}
+}
+
+// ValidateUserCertificateForAction validates that a user is authorized to perform an action based on their certificate
+func ValidateUserCertificateForAction(log *zap.SugaredLogger, cert *x509.Certificate, actionType *models.ActionType, messageType models.MessageType, instanceLocation *models.InstanceLocation) error {
+	log.Infof("Validating user certificate for action: %s, message type: %s", actionType, messageType)
+	if cert == nil {
+		log.Infof("No certificate found, skipping validation")
+		return nil // No certificate means no authorization
+	}
+
+	// Extract location hierarchies from the certificate using the cryptolib function
+	hierarchies, err := GetLocationHierarchiesFromCertificate(cert)
+	if err != nil {
+		return fmt.Errorf("failed to extract location hierarchies from certificate: %v", err)
+	}
+
+	log.Infof("Extracted location hierarchies: %v", hierarchies)
+
+	// Check if the user's certificate authorizes them for this location
+	if !IsLocationAuthorized(instanceLocation, hierarchies) {
+		return fmt.Errorf("user is not authorized for location: %+v", instanceLocation)
+	}
+
+	log.Infof("User is authorized to perform actions in this location")
+
+	// Extract role from the certificate (optional, can be used for additional authorization checks)
+	role, err := GetRoleFromCertificate(cert)
+	if err != nil {
+		log.Warnf("Failed to extract role from certificate: %v", err)
+		// Continue without role check for now
+	} else {
+		log.Infof("User role from certificate: %s", role)
+		// Additional role-based checks could be added here if needed
+	}
+
+	if !IsRoleAllowedForActionAndMessageType(role, actionType, messageType) {
+		if actionType != nil {
+			return fmt.Errorf("user is not authorized to perform actions of type %s and message type %s", *actionType, messageType)
+		}
+		return fmt.Errorf("user is not authorized to perform actions of message type %s", messageType)
+	}
+
+	return nil
+}
+
+// IsLocationAuthorized checks if a location is authorized by any of the provided hierarchies
+func IsLocationAuthorized(instanceLocation *models.InstanceLocation, hierarchies []LocationHierarchy) bool {
+	if instanceLocation == nil {
+		return true
+	}
+	// If there are no hierarchies, the location is not authorized
+	if len(hierarchies) == 0 {
+		return false
+	}
+
+	// Check if any of the hierarchies authorize the location
+	for _, hierarchy := range hierarchies {
+		if IsLocationAuthorizedByHierarchy(instanceLocation, hierarchy) {
+			return true
+		}
+	}
+
+	// If we get here, none of the hierarchies authorize the location
+	return false
+}
+
+// IsLocationAuthorizedByHierarchy checks if a location is authorized by a specific hierarchy
+func IsLocationAuthorizedByHierarchy(instanceLocation *models.InstanceLocation, hierarchy LocationHierarchy) bool {
+	// Check Enterprise
+	if !hierarchy.Enterprise.IsWildcard() && instanceLocation.Enterprise != hierarchy.Enterprise.Value {
+		return false
+	}
+
+	// Check Site
+	if !hierarchy.Site.IsWildcard() && instanceLocation.Site != hierarchy.Site.Value {
+		return false
+	}
+
+	// Check Area
+	if !hierarchy.Area.IsWildcard() && instanceLocation.Area != hierarchy.Area.Value {
+		return false
+	}
+
+	// Check Production Line
+	if !hierarchy.ProductionLine.IsWildcard() && instanceLocation.Line != hierarchy.ProductionLine.Value {
+		return false
+	}
+
+	// Check Work Cell
+	if !hierarchy.WorkCell.IsWildcard() && instanceLocation.WorkCell != hierarchy.WorkCell.Value {
+		return false
+	}
+
+	// If we get here, the location is authorized by this hierarchy
+	return true
+}
+
+// IsRoleAllowedForActionAndMessageType checks if a role is allowed to perform an action with a specific message type
+func IsRoleAllowedForActionAndMessageType(role Role, actionType *models.ActionType, messageType models.MessageType) bool {
+	// If the action type is not set, the user is authorized
+	if actionType == nil && messageType != models.Action {
+		// Subscribe, Status, ActionReply, EncryptedContent are always allowed
+		return true
+	}
+
+	// If we have an action type, check if the role is allowed for this action type
+	if actionType != nil {
+		if IsAllowedForAction(role, *actionType) {
+			return true
+		}
+	}
+
+	// Default deny if we get here
+	return false
+}
+
+//go:embed action-type-role-map.json
+var actionTypeRoleMapJSON []byte
+
+// RoleMap represents the complete role mapping structure
+type RoleMap struct {
+	Groups    map[string]ActionGroup `json:"groups"`
+	Ungrouped UngroupedActions       `json:"ungrouped"`
+}
+
+// ActionGroup represents a group of related actions
+type ActionGroup struct {
+	Description string              `json:"description"`
+	Actions     map[string][]string `json:"actions"`
+}
+
+// UngroupedActions represents actions that don't belong to any group
+type UngroupedActions struct {
+	Unknown []string `json:"unknown"`
+	Dummy   []string `json:"dummy"`
+}
+
+// actionTypeRoleMapCache holds the cached role map
+var (
+	roleMapCache     *RoleMap
+	roleMapCacheMu   sync.RWMutex
+	roleMapCacheInit sync.Once
+)
+
+// loadActionTypeRoleMap loads the action type to role mapping from the JSON file
+func loadActionTypeRoleMap() (*RoleMap, error) {
+	// Check if we have a cached version
+	roleMapCacheMu.RLock()
+	if roleMapCache != nil {
+		defer roleMapCacheMu.RUnlock()
+		return roleMapCache, nil
+	}
+	roleMapCacheMu.RUnlock()
+
+	// Initialize the cache once
+	var initErr error
+	roleMapCacheInit.Do(func() {
+		// Parse the JSON into our new structure
+		var roleMap RoleMap
+		if err := json.Unmarshal(actionTypeRoleMapJSON, &roleMap); err != nil {
+			initErr = fmt.Errorf("failed to parse role map: %w", err)
+			return
+		}
+
+		// Store in cache
+		roleMapCacheMu.Lock()
+		roleMapCache = &roleMap
+		roleMapCacheMu.Unlock()
+	})
+
+	if initErr != nil {
+		return nil, initErr
+	}
+
+	roleMapCacheMu.RLock()
+	defer roleMapCacheMu.RUnlock()
+	return roleMapCache, nil
+}
+
+// IsAllowedForAction checks if a role is allowed to perform an action
+func IsAllowedForAction(role Role, actionType models.ActionType) bool {
+	// Load the role map
+	roleMap, err := loadActionTypeRoleMap()
+	if err != nil {
+		zap.S().Errorf("Failed to load role map: %v", err)
+		return false
+	}
+
+	// Check in all groups
+	for _, group := range roleMap.Groups {
+		if allowedRoles, ok := group.Actions[string(actionType)]; ok {
+			// Check if the user's role is in the allowed roles for this action type
+			for _, allowedRole := range allowedRoles {
+				if string(role) == allowedRole {
+					return true
+				}
+			}
+			// If we found the action but the role wasn't allowed, return false
+			return false
+		}
+	}
+
+	// Check in ungrouped actions
+	if allowedRoles, ok := map[string][]string{
+		"unknown": roleMap.Ungrouped.Unknown,
+		"dummy":   roleMap.Ungrouped.Dummy,
+	}[string(actionType)]; ok {
+		for _, allowedRole := range allowedRoles {
+			if string(role) == allowedRole {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Default deny if we get here
+	return false
+}

--- a/umh-core/pkg/communicator/actions/permission/user_certificate_suite_test.go
+++ b/umh-core/pkg/communicator/actions/permission/user_certificate_suite_test.go
@@ -1,0 +1,29 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package permission_validator_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/communicator/pkg/tools"
+)
+
+func TestPermissionValidator(t *testing.T) {
+	tools.InitLogging()
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Permission Validator Suite")
+}

--- a/umh-core/pkg/communicator/actions/permission/user_certificate_test.go
+++ b/umh-core/pkg/communicator/actions/permission/user_certificate_test.go
@@ -15,667 +15,227 @@
 package permission_validator_test
 
 import (
+	"crypto/x509"
+
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/models"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	validator "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/communicator/actions/permission"
+	"go.uber.org/zap"
 )
 
 var _ = Describe("UserCertificate", func() {
-	Describe("IsLocationAuthorized", func() {
-		Context("when hierarchies are empty", func() {
-			It("should deny access", func() {
-				instanceLocation := models.InstanceLocation{
-					Enterprise: "TestEnterprise",
-					Site:       "TestSite",
-					Area:       "TestArea",
-					Line:       "TestLine",
-					WorkCell:   "TestWorkCell",
-				}
+	Describe("ValidateUserCertificateForAction", func() {
+		var mockLogger *zap.SugaredLogger
 
-				Expect(validator.IsLocationAuthorized(&instanceLocation, []validator.LocationHierarchy{})).To(BeFalse())
+		BeforeEach(func() {
+			mockLogger = zap.NewNop().Sugar()
+		})
+
+		Context("when certificate is nil", func() {
+			It("should return nil (no authorization)", func() {
+				actionType := models.GetProtocolConverter
+				err := validator.ValidateUserCertificateForAction(
+					mockLogger,
+					nil,
+					&actionType,
+					models.Action,
+					map[int]string{0: "test-enterprise"},
+				)
+				Expect(err).To(BeNil())
 			})
 		})
 
-		Context("when at least one hierarchy authorizes the location", func() {
-			It("should allow access", func() {
-				instanceLocation := models.InstanceLocation{
-					Enterprise: "TestEnterprise",
-					Site:       "TestSite",
-					Area:       "TestArea",
-					Line:       "TestLine",
-					WorkCell:   "TestWorkCell",
-				}
-
-				// Create a hierarchy that matches exactly
-				exactHierarchy := validator.LocationHierarchy{
-					Enterprise:     validator.NewLocation(validator.LocationTypeEnterprise, "TestEnterprise"),
-					Site:           validator.NewLocation(validator.LocationTypeSite, "TestSite"),
-					Area:           validator.NewLocation(validator.LocationTypeArea, "TestArea"),
-					ProductionLine: validator.NewLocation(validator.LocationTypeProductionLine, "TestLine"),
-					WorkCell:       validator.NewLocation(validator.LocationTypeWorkCell, "TestWorkCell"),
-				}
-
-				// Create a hierarchy that doesn't match
-				nonMatchingHierarchy := validator.LocationHierarchy{
-					Enterprise:     validator.NewLocation(validator.LocationTypeEnterprise, "OtherEnterprise"),
-					Site:           validator.NewLocation(validator.LocationTypeSite, "OtherSite"),
-					Area:           validator.NewLocation(validator.LocationTypeArea, "OtherArea"),
-					ProductionLine: validator.NewLocation(validator.LocationTypeProductionLine, "OtherLine"),
-					WorkCell:       validator.NewLocation(validator.LocationTypeWorkCell, "OtherWorkCell"),
-				}
-
-				// Test with only the matching hierarchy
-				Expect(validator.IsLocationAuthorized(&instanceLocation, []validator.LocationHierarchy{exactHierarchy})).To(BeTrue())
-
-				// Test with both hierarchies - should still allow because at least one matches
-				Expect(validator.IsLocationAuthorized(&instanceLocation, []validator.LocationHierarchy{nonMatchingHierarchy, exactHierarchy})).To(BeTrue())
-
-				// Test with only the non-matching hierarchy
-				Expect(validator.IsLocationAuthorized(&instanceLocation, []validator.LocationHierarchy{nonMatchingHierarchy})).To(BeFalse())
+		Context("when certificate has no role extension", func() {
+			It("should return error when role extraction fails", func() {
+				actionType := models.GetProtocolConverter
+				err := validator.ValidateUserCertificateForAction(
+					mockLogger,
+					&x509.Certificate{},
+					&actionType,
+					models.Action,
+					map[int]string{0: "test-enterprise"},
+				)
+				Expect(err).ToNot(BeNil())
+				Expect(err.Error()).To(ContainSubstring("no role information found in certificate"))
 			})
 		})
 
-		Context("when using wildcard hierarchies", func() {
-			It("should authorize when at least one wildcard hierarchy matches", func() {
-				instanceLocation := models.InstanceLocation{
-					Enterprise: "TestEnterprise",
-					Site:       "TestSite",
-					Area:       "TestArea",
-					Line:       "TestLine",
-					WorkCell:   "TestWorkCell",
-				}
-
-				// Create a hierarchy with wildcards
-				wildcardHierarchy := validator.LocationHierarchy{
-					Enterprise:     validator.NewLocation(validator.LocationTypeEnterprise, "TestEnterprise"),
-					Site:           validator.NewLocation(validator.LocationTypeSite, "TestSite"),
-					Area:           validator.NewWildcardLocation(validator.LocationTypeArea),
-					ProductionLine: validator.NewWildcardLocation(validator.LocationTypeProductionLine),
-					WorkCell:       validator.NewWildcardLocation(validator.LocationTypeWorkCell),
-				}
-
-				// Create a non-matching hierarchy
-				nonMatchingHierarchy := validator.LocationHierarchy{
-					Enterprise:     validator.NewLocation(validator.LocationTypeEnterprise, "OtherEnterprise"),
-					Site:           validator.NewLocation(validator.LocationTypeSite, "OtherSite"),
-					Area:           validator.NewLocation(validator.LocationTypeArea, "OtherArea"),
-					ProductionLine: validator.NewLocation(validator.LocationTypeProductionLine, "OtherLine"),
-					WorkCell:       validator.NewLocation(validator.LocationTypeWorkCell, "OtherWorkCell"),
-				}
-
-				// Test with only the wildcard hierarchy
-				Expect(validator.IsLocationAuthorized(&instanceLocation, []validator.LocationHierarchy{wildcardHierarchy})).To(BeTrue())
-
-				// Test with both hierarchies - should still allow because at least one matches
-				Expect(validator.IsLocationAuthorized(&instanceLocation, []validator.LocationHierarchy{nonMatchingHierarchy, wildcardHierarchy})).To(BeTrue())
-
-				// Test with all-wildcard hierarchy
-				allWildcardHierarchy := validator.LocationHierarchy{
-					Enterprise:     validator.NewWildcardLocation(validator.LocationTypeEnterprise),
-					Site:           validator.NewWildcardLocation(validator.LocationTypeSite),
-					Area:           validator.NewWildcardLocation(validator.LocationTypeArea),
-					ProductionLine: validator.NewWildcardLocation(validator.LocationTypeProductionLine),
-					WorkCell:       validator.NewWildcardLocation(validator.LocationTypeWorkCell),
-				}
-
-				Expect(validator.IsLocationAuthorized(&instanceLocation, []validator.LocationHierarchy{allWildcardHierarchy})).To(BeTrue())
-			})
-		})
-
-		Context("when using wildcard hierarchies with wildcards in the middle", func() {
-			It("should authorize when wildcards are in the middle of the hierarchy", func() {
-				instanceLocation := models.InstanceLocation{
-					Enterprise: "TestEnterprise",
-					Site:       "TestSite",
-					Area:       "TestArea",
-					Line:       "TestLine",
-					WorkCell:   "TestWorkCell",
-				}
-
-				// Create a hierarchy with wildcards in the middle
-				wildcardInMiddleHierarchy := validator.LocationHierarchy{
-					Enterprise:     validator.NewLocation(validator.LocationTypeEnterprise, "TestEnterprise"),
-					Site:           validator.NewWildcardLocation(validator.LocationTypeSite),
-					Area:           validator.NewWildcardLocation(validator.LocationTypeArea),
-					ProductionLine: validator.NewLocation(validator.LocationTypeProductionLine, "TestLine"),
-					WorkCell:       validator.NewLocation(validator.LocationTypeWorkCell, "TestWorkCell"),
-				}
-
-				Expect(validator.IsLocationAuthorized(&instanceLocation, []validator.LocationHierarchy{wildcardInMiddleHierarchy})).To(BeTrue())
-
-				// Another hierarchy with different wildcards in the middle
-				anotherWildcardInMiddleHierarchy := validator.LocationHierarchy{
-					Enterprise:     validator.NewLocation(validator.LocationTypeEnterprise, "TestEnterprise"),
-					Site:           validator.NewLocation(validator.LocationTypeSite, "TestSite"),
-					Area:           validator.NewWildcardLocation(validator.LocationTypeArea),
-					ProductionLine: validator.NewLocation(validator.LocationTypeProductionLine, "TestLine"),
-					WorkCell:       validator.NewWildcardLocation(validator.LocationTypeWorkCell),
-				}
-
-				Expect(validator.IsLocationAuthorized(&instanceLocation, []validator.LocationHierarchy{anotherWildcardInMiddleHierarchy})).To(BeTrue())
-			})
-		})
-	})
-
-	Describe("IsLocationAuthorizedByHierarchy", func() {
-		Context("when using exact matches", func() {
-			It("should authorize only when all fields match", func() {
-				instanceLocation := models.InstanceLocation{
-					Enterprise: "TestEnterprise",
-					Site:       "TestSite",
-					Area:       "TestArea",
-					Line:       "TestLine",
-					WorkCell:   "TestWorkCell",
-				}
-
-				// Create a hierarchy that matches exactly
-				exactHierarchy := validator.LocationHierarchy{
-					Enterprise:     validator.NewLocation(validator.LocationTypeEnterprise, "TestEnterprise"),
-					Site:           validator.NewLocation(validator.LocationTypeSite, "TestSite"),
-					Area:           validator.NewLocation(validator.LocationTypeArea, "TestArea"),
-					ProductionLine: validator.NewLocation(validator.LocationTypeProductionLine, "TestLine"),
-					WorkCell:       validator.NewLocation(validator.LocationTypeWorkCell, "TestWorkCell"),
-				}
-
-				Expect(validator.IsLocationAuthorizedByHierarchy(&instanceLocation, exactHierarchy)).To(BeTrue())
-
-				// Test with a mismatch at each level
-				enterpriseMismatch := exactHierarchy
-				enterpriseMismatch.Enterprise = validator.NewLocation(validator.LocationTypeEnterprise, "OtherEnterprise")
-				Expect(validator.IsLocationAuthorizedByHierarchy(&instanceLocation, enterpriseMismatch)).To(BeFalse())
-
-				siteMismatch := exactHierarchy
-				siteMismatch.Site = validator.NewLocation(validator.LocationTypeSite, "OtherSite")
-				Expect(validator.IsLocationAuthorizedByHierarchy(&instanceLocation, siteMismatch)).To(BeFalse())
-
-				areaMismatch := exactHierarchy
-				areaMismatch.Area = validator.NewLocation(validator.LocationTypeArea, "OtherArea")
-				Expect(validator.IsLocationAuthorizedByHierarchy(&instanceLocation, areaMismatch)).To(BeFalse())
-
-				lineMismatch := exactHierarchy
-				lineMismatch.ProductionLine = validator.NewLocation(validator.LocationTypeProductionLine, "OtherLine")
-				Expect(validator.IsLocationAuthorizedByHierarchy(&instanceLocation, lineMismatch)).To(BeFalse())
-
-				workCellMismatch := exactHierarchy
-				workCellMismatch.WorkCell = validator.NewLocation(validator.LocationTypeWorkCell, "OtherWorkCell")
-				Expect(validator.IsLocationAuthorizedByHierarchy(&instanceLocation, workCellMismatch)).To(BeFalse())
-			})
-		})
-
-		Context("when using wildcards", func() {
-			It("should authorize when wildcards are used", func() {
-				instanceLocation := models.InstanceLocation{
-					Enterprise: "TestEnterprise",
-					Site:       "TestSite",
-					Area:       "TestArea",
-					Line:       "TestLine",
-					WorkCell:   "TestWorkCell",
-				}
-
-				// Create a hierarchy with wildcards at different levels
-				wildcardHierarchy := validator.LocationHierarchy{
-					Enterprise:     validator.NewLocation(validator.LocationTypeEnterprise, "TestEnterprise"),
-					Site:           validator.NewLocation(validator.LocationTypeSite, "TestSite"),
-					Area:           validator.NewWildcardLocation(validator.LocationTypeArea),
-					ProductionLine: validator.NewWildcardLocation(validator.LocationTypeProductionLine),
-					WorkCell:       validator.NewWildcardLocation(validator.LocationTypeWorkCell),
-				}
-
-				Expect(validator.IsLocationAuthorizedByHierarchy(&instanceLocation, wildcardHierarchy)).To(BeTrue())
-
-				// Test with wildcards at different levels
-				enterpriseWildcard := validator.LocationHierarchy{
-					Enterprise:     validator.NewWildcardLocation(validator.LocationTypeEnterprise),
-					Site:           validator.NewLocation(validator.LocationTypeSite, "TestSite"),
-					Area:           validator.NewLocation(validator.LocationTypeArea, "TestArea"),
-					ProductionLine: validator.NewLocation(validator.LocationTypeProductionLine, "TestLine"),
-					WorkCell:       validator.NewLocation(validator.LocationTypeWorkCell, "TestWorkCell"),
-				}
-				Expect(validator.IsLocationAuthorizedByHierarchy(&instanceLocation, enterpriseWildcard)).To(BeTrue())
-
-				// Test with all wildcards
-				allWildcards := validator.LocationHierarchy{
-					Enterprise:     validator.NewWildcardLocation(validator.LocationTypeEnterprise),
-					Site:           validator.NewWildcardLocation(validator.LocationTypeSite),
-					Area:           validator.NewWildcardLocation(validator.LocationTypeArea),
-					ProductionLine: validator.NewWildcardLocation(validator.LocationTypeProductionLine),
-					WorkCell:       validator.NewWildcardLocation(validator.LocationTypeWorkCell),
-				}
-				Expect(validator.IsLocationAuthorizedByHierarchy(&instanceLocation, allWildcards)).To(BeTrue())
-			})
-
-			It("should test each level of the hierarchy independently", func() {
-				instanceLocation := models.InstanceLocation{
-					Enterprise: "TestEnterprise",
-					Site:       "TestSite",
-					Area:       "TestArea",
-					Line:       "TestLine",
-					WorkCell:   "TestWorkCell",
-				}
-
-				// Test wildcard at enterprise level only
-				enterpriseWildcard := validator.LocationHierarchy{
-					Enterprise:     validator.NewWildcardLocation(validator.LocationTypeEnterprise),
-					Site:           validator.NewLocation(validator.LocationTypeSite, "TestSite"),
-					Area:           validator.NewLocation(validator.LocationTypeArea, "TestArea"),
-					ProductionLine: validator.NewLocation(validator.LocationTypeProductionLine, "TestLine"),
-					WorkCell:       validator.NewLocation(validator.LocationTypeWorkCell, "TestWorkCell"),
-				}
-				Expect(validator.IsLocationAuthorizedByHierarchy(&instanceLocation, enterpriseWildcard)).To(BeTrue())
-
-				// Test wildcard at site level only
-				siteWildcard := validator.LocationHierarchy{
-					Enterprise:     validator.NewLocation(validator.LocationTypeEnterprise, "TestEnterprise"),
-					Site:           validator.NewWildcardLocation(validator.LocationTypeSite),
-					Area:           validator.NewLocation(validator.LocationTypeArea, "TestArea"),
-					ProductionLine: validator.NewLocation(validator.LocationTypeProductionLine, "TestLine"),
-					WorkCell:       validator.NewLocation(validator.LocationTypeWorkCell, "TestWorkCell"),
-				}
-				Expect(validator.IsLocationAuthorizedByHierarchy(&instanceLocation, siteWildcard)).To(BeTrue())
-
-				// Test wildcard at area level only
-				areaWildcard := validator.LocationHierarchy{
-					Enterprise:     validator.NewLocation(validator.LocationTypeEnterprise, "TestEnterprise"),
-					Site:           validator.NewLocation(validator.LocationTypeSite, "TestSite"),
-					Area:           validator.NewWildcardLocation(validator.LocationTypeArea),
-					ProductionLine: validator.NewLocation(validator.LocationTypeProductionLine, "TestLine"),
-					WorkCell:       validator.NewLocation(validator.LocationTypeWorkCell, "TestWorkCell"),
-				}
-				Expect(validator.IsLocationAuthorizedByHierarchy(&instanceLocation, areaWildcard)).To(BeTrue())
-
-				// Test wildcard at production line level only
-				lineWildcard := validator.LocationHierarchy{
-					Enterprise:     validator.NewLocation(validator.LocationTypeEnterprise, "TestEnterprise"),
-					Site:           validator.NewLocation(validator.LocationTypeSite, "TestSite"),
-					Area:           validator.NewLocation(validator.LocationTypeArea, "TestArea"),
-					ProductionLine: validator.NewWildcardLocation(validator.LocationTypeProductionLine),
-					WorkCell:       validator.NewLocation(validator.LocationTypeWorkCell, "TestWorkCell"),
-				}
-				Expect(validator.IsLocationAuthorizedByHierarchy(&instanceLocation, lineWildcard)).To(BeTrue())
-
-				// Test wildcard at work cell level only
-				workCellWildcard := validator.LocationHierarchy{
-					Enterprise:     validator.NewLocation(validator.LocationTypeEnterprise, "TestEnterprise"),
-					Site:           validator.NewLocation(validator.LocationTypeSite, "TestSite"),
-					Area:           validator.NewLocation(validator.LocationTypeArea, "TestArea"),
-					ProductionLine: validator.NewLocation(validator.LocationTypeProductionLine, "TestLine"),
-					WorkCell:       validator.NewWildcardLocation(validator.LocationTypeWorkCell),
-				}
-				Expect(validator.IsLocationAuthorizedByHierarchy(&instanceLocation, workCellWildcard)).To(BeTrue())
-			})
-
-			It("should verify that wildcards don't override mismatches at other levels", func() {
-				instanceLocation := models.InstanceLocation{
-					Enterprise: "TestEnterprise",
-					Site:       "TestSite",
-					Area:       "TestArea",
-					Line:       "TestLine",
-					WorkCell:   "TestWorkCell",
-				}
-
-				// Wildcard at one level but mismatch at another level
-				wildcardWithMismatch := validator.LocationHierarchy{
-					Enterprise:     validator.NewWildcardLocation(validator.LocationTypeEnterprise),
-					Site:           validator.NewLocation(validator.LocationTypeSite, "WrongSite"),
-					Area:           validator.NewWildcardLocation(validator.LocationTypeArea),
-					ProductionLine: validator.NewWildcardLocation(validator.LocationTypeProductionLine),
-					WorkCell:       validator.NewWildcardLocation(validator.LocationTypeWorkCell),
-				}
-				Expect(validator.IsLocationAuthorizedByHierarchy(&instanceLocation, wildcardWithMismatch)).To(BeFalse())
-
-				// Multiple wildcards but one mismatch
-				multipleWildcardsOneMismatch := validator.LocationHierarchy{
-					Enterprise:     validator.NewWildcardLocation(validator.LocationTypeEnterprise),
-					Site:           validator.NewWildcardLocation(validator.LocationTypeSite),
-					Area:           validator.NewWildcardLocation(validator.LocationTypeArea),
-					ProductionLine: validator.NewLocation(validator.LocationTypeProductionLine, "WrongLine"),
-					WorkCell:       validator.NewWildcardLocation(validator.LocationTypeWorkCell),
-				}
-				Expect(validator.IsLocationAuthorizedByHierarchy(&instanceLocation, multipleWildcardsOneMismatch)).To(BeFalse())
-			})
-
-			It("should handle empty location values correctly", func() {
-				// Instance location with some empty values
-				instanceLocation := models.InstanceLocation{
-					Enterprise: "TestEnterprise",
-					Site:       "TestSite",
-					Area:       "", // Empty area
-					Line:       "TestLine",
-					WorkCell:   "", // Empty work cell
-				}
-
-				// Hierarchy with exact matches for non-empty values and wildcards for empty values
-				hierarchyWithWildcards := validator.LocationHierarchy{
-					Enterprise:     validator.NewLocation(validator.LocationTypeEnterprise, "TestEnterprise"),
-					Site:           validator.NewLocation(validator.LocationTypeSite, "TestSite"),
-					Area:           validator.NewWildcardLocation(validator.LocationTypeArea),
-					ProductionLine: validator.NewLocation(validator.LocationTypeProductionLine, "TestLine"),
-					WorkCell:       validator.NewWildcardLocation(validator.LocationTypeWorkCell),
-				}
-				Expect(validator.IsLocationAuthorizedByHierarchy(&instanceLocation, hierarchyWithWildcards)).To(BeTrue())
-
-				// Hierarchy with exact matches for all values (including empty ones)
-				hierarchyWithExactMatches := validator.LocationHierarchy{
-					Enterprise:     validator.NewLocation(validator.LocationTypeEnterprise, "TestEnterprise"),
-					Site:           validator.NewLocation(validator.LocationTypeSite, "TestSite"),
-					Area:           validator.NewLocation(validator.LocationTypeArea, ""), // Match empty area
-					ProductionLine: validator.NewLocation(validator.LocationTypeProductionLine, "TestLine"),
-					WorkCell:       validator.NewLocation(validator.LocationTypeWorkCell, ""), // Match empty work cell
-				}
-				Expect(validator.IsLocationAuthorizedByHierarchy(&instanceLocation, hierarchyWithExactMatches)).To(BeTrue())
-
-				// Hierarchy with non-matching values for empty fields
-				hierarchyWithNonMatches := validator.LocationHierarchy{
-					Enterprise:     validator.NewLocation(validator.LocationTypeEnterprise, "TestEnterprise"),
-					Site:           validator.NewLocation(validator.LocationTypeSite, "TestSite"),
-					Area:           validator.NewLocation(validator.LocationTypeArea, "SomeArea"), // Non-matching area
-					ProductionLine: validator.NewLocation(validator.LocationTypeProductionLine, "TestLine"),
-					WorkCell:       validator.NewLocation(validator.LocationTypeWorkCell, "SomeWorkCell"), // Non-matching work cell
-				}
-				Expect(validator.IsLocationAuthorizedByHierarchy(&instanceLocation, hierarchyWithNonMatches)).To(BeFalse())
-			})
-		})
-
-		Context("when using wildcards in the middle of the hierarchy", func() {
-			It("should authorize with wildcards at any position in the hierarchy", func() {
-				instanceLocation := models.InstanceLocation{
-					Enterprise: "TestEnterprise",
-					Site:       "TestSite",
-					Area:       "TestArea",
-					Line:       "TestLine",
-					WorkCell:   "TestWorkCell",
-				}
-
-				// Test with wildcards at various positions in the hierarchy
-
-				// Wildcard in the middle (Site)
-				siteWildcardMiddle := validator.LocationHierarchy{
-					Enterprise:     validator.NewLocation(validator.LocationTypeEnterprise, "TestEnterprise"),
-					Site:           validator.NewWildcardLocation(validator.LocationTypeSite),
-					Area:           validator.NewLocation(validator.LocationTypeArea, "TestArea"),
-					ProductionLine: validator.NewLocation(validator.LocationTypeProductionLine, "TestLine"),
-					WorkCell:       validator.NewLocation(validator.LocationTypeWorkCell, "TestWorkCell"),
-				}
-				Expect(validator.IsLocationAuthorizedByHierarchy(&instanceLocation, siteWildcardMiddle)).To(BeTrue())
-
-				// Wildcard in the middle (Area)
-				areaWildcardMiddle := validator.LocationHierarchy{
-					Enterprise:     validator.NewLocation(validator.LocationTypeEnterprise, "TestEnterprise"),
-					Site:           validator.NewLocation(validator.LocationTypeSite, "TestSite"),
-					Area:           validator.NewWildcardLocation(validator.LocationTypeArea),
-					ProductionLine: validator.NewLocation(validator.LocationTypeProductionLine, "TestLine"),
-					WorkCell:       validator.NewLocation(validator.LocationTypeWorkCell, "TestWorkCell"),
-				}
-				Expect(validator.IsLocationAuthorizedByHierarchy(&instanceLocation, areaWildcardMiddle)).To(BeTrue())
-
-				// Multiple wildcards in the middle
-				multipleWildcardsMiddle := validator.LocationHierarchy{
-					Enterprise:     validator.NewLocation(validator.LocationTypeEnterprise, "TestEnterprise"),
-					Site:           validator.NewWildcardLocation(validator.LocationTypeSite),
-					Area:           validator.NewWildcardLocation(validator.LocationTypeArea),
-					ProductionLine: validator.NewLocation(validator.LocationTypeProductionLine, "TestLine"),
-					WorkCell:       validator.NewLocation(validator.LocationTypeWorkCell, "TestWorkCell"),
-				}
-				Expect(validator.IsLocationAuthorizedByHierarchy(&instanceLocation, multipleWildcardsMiddle)).To(BeTrue())
-
-				// Wildcards at start and end, specific values in middle
-				wildcardStartEndSpecificMiddle := validator.LocationHierarchy{
-					Enterprise:     validator.NewWildcardLocation(validator.LocationTypeEnterprise),
-					Site:           validator.NewLocation(validator.LocationTypeSite, "TestSite"),
-					Area:           validator.NewLocation(validator.LocationTypeArea, "TestArea"),
-					ProductionLine: validator.NewLocation(validator.LocationTypeProductionLine, "TestLine"),
-					WorkCell:       validator.NewWildcardLocation(validator.LocationTypeWorkCell),
-				}
-				Expect(validator.IsLocationAuthorizedByHierarchy(&instanceLocation, wildcardStartEndSpecificMiddle)).To(BeTrue())
-
-				// Alternating wildcards and specific values
-				alternatingWildcards := validator.LocationHierarchy{
-					Enterprise:     validator.NewWildcardLocation(validator.LocationTypeEnterprise),
-					Site:           validator.NewLocation(validator.LocationTypeSite, "TestSite"),
-					Area:           validator.NewWildcardLocation(validator.LocationTypeArea),
-					ProductionLine: validator.NewLocation(validator.LocationTypeProductionLine, "TestLine"),
-					WorkCell:       validator.NewWildcardLocation(validator.LocationTypeWorkCell),
-				}
-				Expect(validator.IsLocationAuthorizedByHierarchy(&instanceLocation, alternatingWildcards)).To(BeTrue())
-			})
-
-			It("should deny access when non-wildcard values don't match", func() {
-				instanceLocation := models.InstanceLocation{
-					Enterprise: "TestEnterprise",
-					Site:       "TestSite",
-					Area:       "TestArea",
-					Line:       "TestLine",
-					WorkCell:   "TestWorkCell",
-				}
-
-				// Wildcards in the middle but with non-matching values at other levels
-				wildcardMiddleNonMatchingOthers := validator.LocationHierarchy{
-					Enterprise:     validator.NewLocation(validator.LocationTypeEnterprise, "OtherEnterprise"),
-					Site:           validator.NewWildcardLocation(validator.LocationTypeSite),
-					Area:           validator.NewWildcardLocation(validator.LocationTypeArea),
-					ProductionLine: validator.NewLocation(validator.LocationTypeProductionLine, "TestLine"),
-					WorkCell:       validator.NewLocation(validator.LocationTypeWorkCell, "TestWorkCell"),
-				}
-				Expect(validator.IsLocationAuthorizedByHierarchy(&instanceLocation, wildcardMiddleNonMatchingOthers)).To(BeFalse())
-
-				// Another example with wildcards in different positions
-				anotherWildcardMiddleNonMatching := validator.LocationHierarchy{
-					Enterprise:     validator.NewLocation(validator.LocationTypeEnterprise, "TestEnterprise"),
-					Site:           validator.NewLocation(validator.LocationTypeSite, "TestSite"),
-					Area:           validator.NewWildcardLocation(validator.LocationTypeArea),
-					ProductionLine: validator.NewLocation(validator.LocationTypeProductionLine, "OtherLine"),
-					WorkCell:       validator.NewLocation(validator.LocationTypeWorkCell, "TestWorkCell"),
-				}
-				Expect(validator.IsLocationAuthorizedByHierarchy(&instanceLocation, anotherWildcardMiddleNonMatching)).To(BeFalse())
-			})
-
-			It("should handle complex hierarchies with mixed wildcards and specific values", func() {
-				// Test with a more complex instance location
-				complexInstanceLocation := models.InstanceLocation{
-					Enterprise: "MegaCorp",
-					Site:       "Headquarters",
-					Area:       "Manufacturing",
-					Line:       "Assembly",
-					WorkCell:   "Station5",
-				}
-
-				// Complex hierarchy with wildcards at various levels
-				complexHierarchy := validator.LocationHierarchy{
-					Enterprise:     validator.NewLocation(validator.LocationTypeEnterprise, "MegaCorp"),
-					Site:           validator.NewWildcardLocation(validator.LocationTypeSite),
-					Area:           validator.NewLocation(validator.LocationTypeArea, "Manufacturing"),
-					ProductionLine: validator.NewWildcardLocation(validator.LocationTypeProductionLine),
-					WorkCell:       validator.NewLocation(validator.LocationTypeWorkCell, "Station5"),
-				}
-				Expect(validator.IsLocationAuthorizedByHierarchy(&complexInstanceLocation, complexHierarchy)).To(BeTrue())
-
-				// Change one non-wildcard value to make it not match
-				complexHierarchyNonMatching := validator.LocationHierarchy{
-					Enterprise:     validator.NewLocation(validator.LocationTypeEnterprise, "MegaCorp"),
-					Site:           validator.NewWildcardLocation(validator.LocationTypeSite),
-					Area:           validator.NewLocation(validator.LocationTypeArea, "Research"), // Different from "Manufacturing"
-					ProductionLine: validator.NewWildcardLocation(validator.LocationTypeProductionLine),
-					WorkCell:       validator.NewLocation(validator.LocationTypeWorkCell, "Station5"),
-				}
-				Expect(validator.IsLocationAuthorizedByHierarchy(&complexInstanceLocation, complexHierarchyNonMatching)).To(BeFalse())
-			})
-		})
-	})
-
-	Describe("IsRoleAllowedForActionAndMessageType", func() {
 		Context("when action type is nil", func() {
-			It("should allow any role for non-Action message types", func() {
-				// Test with nil action type and non-Action message types
-				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleAdmin, nil, models.Subscribe)).To(BeTrue())
-				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleViewer, nil, models.Status)).To(BeTrue())
-				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleAdmin, nil, models.ActionReply)).To(BeTrue())
-				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleViewer, nil, models.EncryptedContent)).To(BeTrue())
-			})
-
-			It("should deny any role for Action message type", func() {
-				// Test with nil action type and Action message type
-				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleAdmin, nil, models.Action)).To(BeFalse())
-				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleViewer, nil, models.Action)).To(BeFalse())
-			})
-		})
-
-		Context("when action type is provided", func() {
-			It("should allow Admin role for admin-only actions", func() {
-				// Test with action types that only allow Admin role
-				getAuditLog := models.GetAuditLog
-				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleAdmin, &getAuditLog, models.Action)).To(BeTrue())
-				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleViewer, &getAuditLog, models.Action)).To(BeFalse())
-				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleEditor, &getAuditLog, models.Action)).To(BeFalse())
-
-				upgradeCompanion := models.UpgradeCompanion
-				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleAdmin, &upgradeCompanion, models.Action)).To(BeTrue())
-				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleViewer, &upgradeCompanion, models.Action)).To(BeFalse())
-				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleEditor, &upgradeCompanion, models.Action)).To(BeFalse())
-
-				editInstance := models.EditInstance
-				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleAdmin, &editInstance, models.Action)).To(BeTrue())
-				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleViewer, &editInstance, models.Action)).To(BeFalse())
-				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleEditor, &editInstance, models.Action)).To(BeFalse())
-			})
-
-			It("should allow both Admin and Viewer roles for viewer-allowed actions", func() {
-				// Test with action types that allow both Admin and Viewer roles
-				getConnectionNotes := models.GetConnectionNotes
-				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleAdmin, &getConnectionNotes, models.Action)).To(BeTrue())
-				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleViewer, &getConnectionNotes, models.Action)).To(BeTrue())
-				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleEditor, &getConnectionNotes, models.Action)).To(BeTrue())
-
-				getDatasourceBasic := models.GetDatasourceBasic
-				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleAdmin, &getDatasourceBasic, models.Action)).To(BeTrue())
-				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleViewer, &getDatasourceBasic, models.Action)).To(BeTrue())
-				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleEditor, &getDatasourceBasic, models.Action)).To(BeTrue())
-			})
-
-			It("should allow Admin and Editor roles for editor-allowed actions", func() {
-				// Test with action types that allow both Admin and Editor roles
-				testBenthosInput := models.TestBenthosInput
-				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleAdmin, &testBenthosInput, models.Action)).To(BeTrue())
-				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleViewer, &testBenthosInput, models.Action)).To(BeFalse())
-				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleEditor, &testBenthosInput, models.Action)).To(BeTrue())
-
-				editDataFlowComponent := models.EditDataFlowComponent
-				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleAdmin, &editDataFlowComponent, models.Action)).To(BeTrue())
-				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleViewer, &editDataFlowComponent, models.Action)).To(BeFalse())
-				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleEditor, &editDataFlowComponent, models.Action)).To(BeTrue())
-			})
-
-			It("should deny for unknown action types", func() {
-				// Create a custom action type that doesn't exist in the map
-				unknownAction := models.ActionType("non-existent-action")
-				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleAdmin, &unknownAction, models.Action)).To(BeFalse())
-				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleViewer, &unknownAction, models.Action)).To(BeFalse())
-			})
-		})
-
-		Context("when message type is not Action", func() {
-			It("should still check role permissions for the action type", func() {
-				// Even if message type is not Action, if action type is provided, it should check permissions
-				deployConnection := models.DeployConnection
-				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleAdmin, &deployConnection, models.Status)).To(BeTrue())
-				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleViewer, &deployConnection, models.Status)).To(BeFalse())
-
-				getConnectionNotes := models.GetConnectionNotes
-				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleAdmin, &getConnectionNotes, models.Subscribe)).To(BeTrue())
-				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleViewer, &getConnectionNotes, models.Subscribe)).To(BeTrue())
+			It("should allow for non-Action message types", func() {
+				err := validator.ValidateUserCertificateForAction(
+					mockLogger,
+					nil,
+					nil,
+					models.Subscribe,
+					map[int]string{0: "test-enterprise"},
+				)
+				Expect(err).To(BeNil())
 			})
 		})
 	})
 
-	Describe("IsAllowedForAction", func() {
-		Context("when checking Get Actions group", func() {
-			It("should allow appropriate roles for get actions", func() {
-				// Test get-connection-notes which allows Admin, Viewer, and Editor
-				getConnectionNotes := models.GetConnectionNotes
-				Expect(validator.IsAllowedForAction(validator.RoleAdmin, getConnectionNotes)).To(BeTrue())
-				Expect(validator.IsAllowedForAction(validator.RoleViewer, getConnectionNotes)).To(BeTrue())
-				Expect(validator.IsAllowedForAction(validator.RoleEditor, getConnectionNotes)).To(BeTrue())
+	DescribeTable("IsRoleAllowedForActionAndMessageType when action type is nil",
+		func(role validator.Role, messageType models.MessageType, expectedResult bool, description string) {
+			result := validator.IsRoleAllowedForActionAndMessageType(role, nil, messageType)
+			Expect(result).To(Equal(expectedResult), "Role %s should %s for message type %s when action type is nil",
+				role, map[bool]string{true: "be allowed", false: "be denied"}[expectedResult], messageType)
+		},
 
-				// Test get-audit-log which only allows Admin
-				getAuditLog := models.GetAuditLog
-				Expect(validator.IsAllowedForAction(validator.RoleAdmin, getAuditLog)).To(BeTrue())
-				Expect(validator.IsAllowedForAction(validator.RoleViewer, getAuditLog)).To(BeFalse())
-				Expect(validator.IsAllowedForAction(validator.RoleEditor, getAuditLog)).To(BeFalse())
-			})
-		})
+		// non-action message types - all roles should be allowed
+		Entry("Subscribe [Admin]", validator.RoleAdmin, models.Subscribe, true, "subscribe message type"),
+		Entry("Subscribe [Editor]", validator.RoleEditor, models.Subscribe, true, "subscribe message type"),
+		Entry("Subscribe [Viewer]", validator.RoleViewer, models.Subscribe, true, "subscribe message type"),
 
-		Context("when checking Edit Actions group", func() {
-			It("should allow Admin and Editor roles for edit actions", func() {
-				editConnection := models.EditConnection
-				Expect(validator.IsAllowedForAction(validator.RoleAdmin, editConnection)).To(BeTrue())
-				Expect(validator.IsAllowedForAction(validator.RoleEditor, editConnection)).To(BeTrue())
-				Expect(validator.IsAllowedForAction(validator.RoleViewer, editConnection)).To(BeFalse())
+		Entry("Status [Admin]", validator.RoleAdmin, models.Status, true, "status message type"),
+		Entry("Status [Editor]", validator.RoleEditor, models.Status, true, "status message type"),
+		Entry("Status [Viewer]", validator.RoleViewer, models.Status, true, "status message type"),
 
-				editInstance := models.EditInstance
-				Expect(validator.IsAllowedForAction(validator.RoleAdmin, editInstance)).To(BeTrue())
-				Expect(validator.IsAllowedForAction(validator.RoleEditor, editInstance)).To(BeFalse())
-				Expect(validator.IsAllowedForAction(validator.RoleViewer, editInstance)).To(BeFalse())
-			})
-		})
+		Entry("ActionReply [Admin]", validator.RoleAdmin, models.ActionReply, true, "action-reply message type"),
+		Entry("ActionReply [Editor]", validator.RoleEditor, models.ActionReply, true, "action-reply message type"),
+		Entry("ActionReply [Viewer]", validator.RoleViewer, models.ActionReply, true, "action-reply message type"),
 
-		Context("when checking Delete Actions group", func() {
-			It("should allow Admin and Editor roles for delete actions", func() {
-				deleteConnection := models.DeleteConnection
-				Expect(validator.IsAllowedForAction(validator.RoleAdmin, deleteConnection)).To(BeTrue())
-				Expect(validator.IsAllowedForAction(validator.RoleEditor, deleteConnection)).To(BeTrue())
-				Expect(validator.IsAllowedForAction(validator.RoleViewer, deleteConnection)).To(BeFalse())
-			})
-		})
+		Entry("EncryptedContent [Admin]", validator.RoleAdmin, models.EncryptedContent, true, "encrypted-content message type"),
+		Entry("EncryptedContent [Editor]", validator.RoleEditor, models.EncryptedContent, true, "encrypted-content message type"),
+		Entry("EncryptedContent [Viewer]", validator.RoleViewer, models.EncryptedContent, true, "encrypted-content message type"),
 
-		Context("when checking Deploy Actions group", func() {
-			It("should allow Admin and Editor roles for deploy actions", func() {
-				deployConnection := models.DeployConnection
-				Expect(validator.IsAllowedForAction(validator.RoleAdmin, deployConnection)).To(BeTrue())
-				Expect(validator.IsAllowedForAction(validator.RoleEditor, deployConnection)).To(BeTrue())
-				Expect(validator.IsAllowedForAction(validator.RoleViewer, deployConnection)).To(BeFalse())
-			})
-		})
+		// action message type - all roles should be denied
+		Entry("Action [Admin]", validator.RoleAdmin, models.Action, false, "action message type"),
+		Entry("Action [Editor]", validator.RoleEditor, models.Action, false, "action message type"),
+		Entry("Action [Viewer]", validator.RoleViewer, models.Action, false, "action message type"),
+	)
 
-		Context("when checking Test Actions group", func() {
-			It("should allow Admin and Editor roles for test actions", func() {
-				testBenthosInput := models.TestBenthosInput
-				Expect(validator.IsAllowedForAction(validator.RoleAdmin, testBenthosInput)).To(BeTrue())
-				Expect(validator.IsAllowedForAction(validator.RoleEditor, testBenthosInput)).To(BeTrue())
-				Expect(validator.IsAllowedForAction(validator.RoleViewer, testBenthosInput)).To(BeFalse())
-			})
-		})
+	DescribeTable("IsRoleAllowedForActionAndMessageType - Comprehensive Action Permission Matrix",
+		func(action models.ActionType, role validator.Role, expectedResult bool, description string) {
+			result := validator.IsRoleAllowedForActionAndMessageType(role, &action, models.Action)
+			Expect(result).To(Equal(expectedResult), "Role %s should %s for action %s", role, map[bool]string{true: "be allowed", false: "be denied"}[expectedResult], description)
+		},
 
-		Context("when checking System Actions group", func() {
-			It("should only allow Admin role for system actions", func() {
-				upgradeCompanion := models.UpgradeCompanion
-				Expect(validator.IsAllowedForAction(validator.RoleAdmin, upgradeCompanion)).To(BeTrue())
-				Expect(validator.IsAllowedForAction(validator.RoleEditor, upgradeCompanion)).To(BeFalse())
-				Expect(validator.IsAllowedForAction(validator.RoleViewer, upgradeCompanion)).To(BeFalse())
-			})
-		})
+		Entry("get-protocol-converter [Admin]", models.GetProtocolConverter, validator.RoleAdmin, true, "get-protocol-converter"),
+		Entry("get-protocol-converter [Editor]", models.GetProtocolConverter, validator.RoleEditor, true, "get-protocol-converter"),
+		Entry("get-protocol-converter [Viewer]", models.GetProtocolConverter, validator.RoleViewer, true, "get-protocol-converter"),
 
-		Context("when checking ungrouped actions", func() {
-			It("should handle unknown and dummy actions correctly", func() {
-				// Test unknown action (should allow Admin, Viewer, Editor)
-				unknownAction := models.ActionType("unknown")
-				Expect(validator.IsAllowedForAction(validator.RoleAdmin, unknownAction)).To(BeTrue())
-				Expect(validator.IsAllowedForAction(validator.RoleViewer, unknownAction)).To(BeTrue())
-				Expect(validator.IsAllowedForAction(validator.RoleEditor, unknownAction)).To(BeTrue())
+		Entry("get-data-flow-component [Admin]", models.GetDataFlowComponent, validator.RoleAdmin, true, "get-data-flow-component"),
+		Entry("get-data-flow-component [Editor]", models.GetDataFlowComponent, validator.RoleEditor, true, "get-data-flow-component"),
+		Entry("get-data-flow-component [Viewer]", models.GetDataFlowComponent, validator.RoleViewer, true, "get-data-flow-component"),
 
-				// Test dummy action (should allow Admin, Viewer, Editor)
-				dummyAction := models.ActionType("dummy")
-				Expect(validator.IsAllowedForAction(validator.RoleAdmin, dummyAction)).To(BeTrue())
-				Expect(validator.IsAllowedForAction(validator.RoleViewer, dummyAction)).To(BeTrue())
-				Expect(validator.IsAllowedForAction(validator.RoleEditor, dummyAction)).To(BeTrue())
-			})
+		Entry("get-data-flow-component-log [Admin]", models.GetDataFlowComponentLog, validator.RoleAdmin, true, "get-data-flow-component-log"),
+		Entry("get-data-flow-component-log [Editor]", models.GetDataFlowComponentLog, validator.RoleEditor, true, "get-data-flow-component-log"),
+		Entry("get-data-flow-component-log [Viewer]", models.GetDataFlowComponentLog, validator.RoleViewer, true, "get-data-flow-component-log"),
 
-			It("should deny access for non-existent actions", func() {
-				nonExistentAction := models.ActionType("non-existent-action")
-				Expect(validator.IsAllowedForAction(validator.RoleAdmin, nonExistentAction)).To(BeFalse())
-				Expect(validator.IsAllowedForAction(validator.RoleViewer, nonExistentAction)).To(BeFalse())
-				Expect(validator.IsAllowedForAction(validator.RoleEditor, nonExistentAction)).To(BeFalse())
-			})
-		})
-	})
+		Entry("get-logs [Admin]", models.GetLogs, validator.RoleAdmin, true, "get-logs"),
+		Entry("get-logs [Editor]", models.GetLogs, validator.RoleEditor, true, "get-logs"),
+		Entry("get-logs [Viewer]", models.GetLogs, validator.RoleViewer, true, "get-logs"),
+
+		Entry("get-datamodel [Admin]", models.GetDataModel, validator.RoleAdmin, true, "get-datamodel"),
+		Entry("get-datamodel [Editor]", models.GetDataModel, validator.RoleEditor, true, "get-datamodel"),
+		Entry("get-datamodel [Viewer]", models.GetDataModel, validator.RoleViewer, true, "get-datamodel"),
+
+		Entry("get-stream-processor [Admin]", models.GetStreamProcessor, validator.RoleAdmin, true, "get-stream-processor"),
+		Entry("get-stream-processor [Editor]", models.GetStreamProcessor, validator.RoleEditor, true, "get-stream-processor"),
+		Entry("get-stream-processor [Viewer]", models.GetStreamProcessor, validator.RoleViewer, true, "get-stream-processor"),
+
+		Entry("edit-protocol-converter [Admin]", models.EditProtocolConverter, validator.RoleAdmin, true, "edit-protocol-converter"),
+		Entry("edit-protocol-converter [Editor]", models.EditProtocolConverter, validator.RoleEditor, true, "edit-protocol-converter"),
+		Entry("edit-protocol-converter [Viewer]", models.EditProtocolConverter, validator.RoleViewer, false, "edit-protocol-converter"),
+
+		Entry("edit-data-flow-component [Admin]", models.EditDataFlowComponent, validator.RoleAdmin, true, "edit-data-flow-component"),
+		Entry("edit-data-flow-component [Editor]", models.EditDataFlowComponent, validator.RoleEditor, true, "edit-data-flow-component"),
+		Entry("edit-data-flow-component [Viewer]", models.EditDataFlowComponent, validator.RoleViewer, false, "edit-data-flow-component"),
+
+		Entry("edit-datamodel [Admin]", models.EditDataModel, validator.RoleAdmin, true, "edit-datamodel"),
+		Entry("edit-datamodel [Editor]", models.EditDataModel, validator.RoleEditor, true, "edit-datamodel"),
+		Entry("edit-datamodel [Viewer]", models.EditDataModel, validator.RoleViewer, false, "edit-datamodel"),
+
+		Entry("edit-stream-processor [Admin]", models.EditStreamProcessor, validator.RoleAdmin, true, "edit-stream-processor"),
+		Entry("edit-stream-processor [Editor]", models.EditStreamProcessor, validator.RoleEditor, true, "edit-stream-processor"),
+		Entry("edit-stream-processor [Viewer]", models.EditStreamProcessor, validator.RoleViewer, false, "edit-stream-processor"),
+
+		Entry("edit-instance [Admin]", models.EditInstance, validator.RoleAdmin, true, "edit-instance"),
+		Entry("edit-instance [Editor]", models.EditInstance, validator.RoleEditor, false, "edit-instance"),
+		Entry("edit-instance [Viewer]", models.EditInstance, validator.RoleViewer, false, "edit-instance"),
+
+		Entry("edit-instance-location [Admin]", models.EditInstanceLocation, validator.RoleAdmin, true, "edit-instance-location"),
+		Entry("edit-instance-location [Editor]", models.EditInstanceLocation, validator.RoleEditor, false, "edit-instance-location"),
+		Entry("edit-instance-location [Viewer]", models.EditInstanceLocation, validator.RoleViewer, false, "edit-instance-location"),
+
+		Entry("delete-protocol-converter [Admin]", models.DeleteProtocolConverter, validator.RoleAdmin, true, "delete-protocol-converter"),
+		Entry("delete-protocol-converter [Editor]", models.DeleteProtocolConverter, validator.RoleEditor, true, "delete-protocol-converter"),
+		Entry("delete-protocol-converter [Viewer]", models.DeleteProtocolConverter, validator.RoleViewer, false, "delete-protocol-converter"),
+
+		Entry("delete-data-flow-component [Admin]", models.DeleteDataFlowComponent, validator.RoleAdmin, true, "delete-data-flow-component"),
+		Entry("delete-data-flow-component [Editor]", models.DeleteDataFlowComponent, validator.RoleEditor, true, "delete-data-flow-component"),
+		Entry("delete-data-flow-component [Viewer]", models.DeleteDataFlowComponent, validator.RoleViewer, false, "delete-data-flow-component"),
+
+		Entry("delete-datamodel [Admin]", models.DeleteDataModel, validator.RoleAdmin, true, "delete-datamodel"),
+		Entry("delete-datamodel [Editor]", models.DeleteDataModel, validator.RoleEditor, true, "delete-datamodel"),
+		Entry("delete-datamodel [Viewer]", models.DeleteDataModel, validator.RoleViewer, false, "delete-datamodel"),
+
+		Entry("delete-stream-processor [Admin]", models.DeleteStreamProcessor, validator.RoleAdmin, true, "delete-stream-processor"),
+		Entry("delete-stream-processor [Editor]", models.DeleteStreamProcessor, validator.RoleEditor, true, "delete-stream-processor"),
+		Entry("delete-stream-processor [Viewer]", models.DeleteStreamProcessor, validator.RoleViewer, false, "delete-stream-processor"),
+
+		Entry("deploy-protocol-converter [Admin]", models.DeployProtocolConverter, validator.RoleAdmin, true, "deploy-protocol-converter"),
+		Entry("deploy-protocol-converter [Editor]", models.DeployProtocolConverter, validator.RoleEditor, true, "deploy-protocol-converter"),
+		Entry("deploy-protocol-converter [Viewer]", models.DeployProtocolConverter, validator.RoleViewer, false, "deploy-protocol-converter"),
+
+		Entry("deploy-data-flow-component [Admin]", models.DeployDataFlowComponent, validator.RoleAdmin, true, "deploy-data-flow-component"),
+		Entry("deploy-data-flow-component [Editor]", models.DeployDataFlowComponent, validator.RoleEditor, true, "deploy-data-flow-component"),
+		Entry("deploy-data-flow-component [Viewer]", models.DeployDataFlowComponent, validator.RoleViewer, false, "deploy-data-flow-component"),
+
+		Entry("deploy-stream-processor [Admin]", models.DeployStreamProcessor, validator.RoleAdmin, true, "deploy-stream-processor"),
+		Entry("deploy-stream-processor [Editor]", models.DeployStreamProcessor, validator.RoleEditor, true, "deploy-stream-processor"),
+		Entry("deploy-stream-processor [Viewer]", models.DeployStreamProcessor, validator.RoleViewer, false, "deploy-stream-processor"),
+
+		Entry("upgrade-companion [Admin]", models.UpgradeCompanion, validator.RoleAdmin, true, "upgrade-companion"),
+		Entry("upgrade-companion [Editor]", models.UpgradeCompanion, validator.RoleEditor, false, "upgrade-companion"),
+		Entry("upgrade-companion [Viewer]", models.UpgradeCompanion, validator.RoleViewer, false, "upgrade-companion"),
+
+		Entry("create-invite [Admin]", models.ActionType("create-invite"), validator.RoleAdmin, true, "create-invite"),
+		Entry("create-invite [Editor]", models.ActionType("create-invite"), validator.RoleEditor, false, "create-invite"),
+		Entry("create-invite [Viewer]", models.ActionType("create-invite"), validator.RoleViewer, false, "create-invite"),
+
+		Entry("get-company-invites [Admin]", models.ActionType("get-company-invites"), validator.RoleAdmin, true, "get-company-invites"),
+		Entry("get-company-invites [Editor]", models.ActionType("get-company-invites"), validator.RoleEditor, false, "get-company-invites"),
+		Entry("get-company-invites [Viewer]", models.ActionType("get-company-invites"), validator.RoleViewer, false, "get-company-invites"),
+
+		Entry("delete-invite [Admin]", models.ActionType("delete-invite"), validator.RoleAdmin, true, "delete-invite"),
+		Entry("delete-invite [Editor]", models.ActionType("delete-invite"), validator.RoleEditor, false, "delete-invite"),
+		Entry("delete-invite [Viewer]", models.ActionType("delete-invite"), validator.RoleViewer, false, "delete-invite"),
+
+		Entry("get-company-users [Admin]", models.ActionType("get-company-users"), validator.RoleAdmin, true, "get-company-users"),
+		Entry("get-company-users [Editor]", models.ActionType("get-company-users"), validator.RoleEditor, false, "get-company-users"),
+		Entry("get-company-users [Viewer]", models.ActionType("get-company-users"), validator.RoleViewer, false, "get-company-users"),
+
+		Entry("delete-company-user [Admin]", models.ActionType("delete-company-user"), validator.RoleAdmin, true, "delete-company-user"),
+		Entry("delete-company-user [Editor]", models.ActionType("delete-company-user"), validator.RoleEditor, false, "delete-company-user"),
+		Entry("delete-company-user [Viewer]", models.ActionType("delete-company-user"), validator.RoleViewer, false, "delete-company-user"),
+
+		Entry("change-user-role [Admin]", models.ActionType("change-user-role"), validator.RoleAdmin, true, "change-user-role"),
+		Entry("change-user-role [Editor]", models.ActionType("change-user-role"), validator.RoleEditor, false, "change-user-role"),
+		Entry("change-user-role [Viewer]", models.ActionType("change-user-role"), validator.RoleViewer, false, "change-user-role"),
+
+		Entry("change-user-permissions [Admin]", models.ActionType("change-user-permissions"), validator.RoleAdmin, true, "change-user-permissions"),
+		Entry("change-user-permissions [Editor]", models.ActionType("change-user-permissions"), validator.RoleEditor, false, "change-user-permissions"),
+		Entry("change-user-permissions [Viewer]", models.ActionType("change-user-permissions"), validator.RoleViewer, false, "change-user-permissions"),
+
+		// ungrouped actions - all roles allowed
+		Entry("unknown [Admin]", models.ActionType("unknown"), validator.RoleAdmin, true, "unknown"),
+		Entry("unknown [Editor]", models.ActionType("unknown"), validator.RoleEditor, true, "unknown"),
+		Entry("unknown [Viewer]", models.ActionType("unknown"), validator.RoleViewer, true, "unknown"),
+
+		Entry("dummy [Admin]", models.ActionType("dummy"), validator.RoleAdmin, true, "dummy"),
+		Entry("dummy [Editor]", models.ActionType("dummy"), validator.RoleEditor, true, "dummy"),
+		Entry("dummy [Viewer]", models.ActionType("dummy"), validator.RoleViewer, true, "dummy"),
+
+		// non-existent actions - all roles denied
+		Entry("non-existent-action [Admin]", models.ActionType("non-existent-action"), validator.RoleAdmin, false, "non-existent-action"),
+		Entry("non-existent-action [Editor]", models.ActionType("non-existent-action"), validator.RoleEditor, false, "non-existent-action"),
+		Entry("non-existent-action [Viewer]", models.ActionType("non-existent-action"), validator.RoleViewer, false, "non-existent-action"),
+
+		Entry("fake-action [Admin]", models.ActionType("fake-action"), validator.RoleAdmin, false, "fake-action"),
+		Entry("fake-action [Editor]", models.ActionType("fake-action"), validator.RoleEditor, false, "fake-action"),
+		Entry("fake-action [Viewer]", models.ActionType("fake-action"), validator.RoleViewer, false, "fake-action"),
+	)
 })

--- a/umh-core/pkg/communicator/actions/permission/user_certificate_test.go
+++ b/umh-core/pkg/communicator/actions/permission/user_certificate_test.go
@@ -43,7 +43,7 @@ var _ = Describe("UserCertificate", func() {
 					models.Action,
 					map[int]string{0: "test-enterprise"},
 				)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 			})
 		})
 
@@ -57,7 +57,7 @@ var _ = Describe("UserCertificate", func() {
 					models.Action,
 					map[int]string{0: "test-enterprise"},
 				)
-				Expect(err).ToNot(BeNil())
+				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("no role information found in certificate"))
 			})
 		})
@@ -71,7 +71,7 @@ var _ = Describe("UserCertificate", func() {
 					models.Subscribe,
 					map[int]string{0: "test-enterprise"},
 				)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 			})
 		})
 	})

--- a/umh-core/pkg/communicator/actions/permission/user_certificate_test.go
+++ b/umh-core/pkg/communicator/actions/permission/user_certificate_test.go
@@ -1,0 +1,681 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package permission_validator_test
+
+import (
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/models"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	validator "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/communicator/actions/permission"
+)
+
+var _ = Describe("UserCertificate", func() {
+	Describe("IsLocationAuthorized", func() {
+		Context("when hierarchies are empty", func() {
+			It("should deny access", func() {
+				instanceLocation := models.InstanceLocation{
+					Enterprise: "TestEnterprise",
+					Site:       "TestSite",
+					Area:       "TestArea",
+					Line:       "TestLine",
+					WorkCell:   "TestWorkCell",
+				}
+
+				Expect(validator.IsLocationAuthorized(&instanceLocation, []validator.LocationHierarchy{})).To(BeFalse())
+			})
+		})
+
+		Context("when at least one hierarchy authorizes the location", func() {
+			It("should allow access", func() {
+				instanceLocation := models.InstanceLocation{
+					Enterprise: "TestEnterprise",
+					Site:       "TestSite",
+					Area:       "TestArea",
+					Line:       "TestLine",
+					WorkCell:   "TestWorkCell",
+				}
+
+				// Create a hierarchy that matches exactly
+				exactHierarchy := validator.LocationHierarchy{
+					Enterprise:     validator.NewLocation(validator.LocationTypeEnterprise, "TestEnterprise"),
+					Site:           validator.NewLocation(validator.LocationTypeSite, "TestSite"),
+					Area:           validator.NewLocation(validator.LocationTypeArea, "TestArea"),
+					ProductionLine: validator.NewLocation(validator.LocationTypeProductionLine, "TestLine"),
+					WorkCell:       validator.NewLocation(validator.LocationTypeWorkCell, "TestWorkCell"),
+				}
+
+				// Create a hierarchy that doesn't match
+				nonMatchingHierarchy := validator.LocationHierarchy{
+					Enterprise:     validator.NewLocation(validator.LocationTypeEnterprise, "OtherEnterprise"),
+					Site:           validator.NewLocation(validator.LocationTypeSite, "OtherSite"),
+					Area:           validator.NewLocation(validator.LocationTypeArea, "OtherArea"),
+					ProductionLine: validator.NewLocation(validator.LocationTypeProductionLine, "OtherLine"),
+					WorkCell:       validator.NewLocation(validator.LocationTypeWorkCell, "OtherWorkCell"),
+				}
+
+				// Test with only the matching hierarchy
+				Expect(validator.IsLocationAuthorized(&instanceLocation, []validator.LocationHierarchy{exactHierarchy})).To(BeTrue())
+
+				// Test with both hierarchies - should still allow because at least one matches
+				Expect(validator.IsLocationAuthorized(&instanceLocation, []validator.LocationHierarchy{nonMatchingHierarchy, exactHierarchy})).To(BeTrue())
+
+				// Test with only the non-matching hierarchy
+				Expect(validator.IsLocationAuthorized(&instanceLocation, []validator.LocationHierarchy{nonMatchingHierarchy})).To(BeFalse())
+			})
+		})
+
+		Context("when using wildcard hierarchies", func() {
+			It("should authorize when at least one wildcard hierarchy matches", func() {
+				instanceLocation := models.InstanceLocation{
+					Enterprise: "TestEnterprise",
+					Site:       "TestSite",
+					Area:       "TestArea",
+					Line:       "TestLine",
+					WorkCell:   "TestWorkCell",
+				}
+
+				// Create a hierarchy with wildcards
+				wildcardHierarchy := validator.LocationHierarchy{
+					Enterprise:     validator.NewLocation(validator.LocationTypeEnterprise, "TestEnterprise"),
+					Site:           validator.NewLocation(validator.LocationTypeSite, "TestSite"),
+					Area:           validator.NewWildcardLocation(validator.LocationTypeArea),
+					ProductionLine: validator.NewWildcardLocation(validator.LocationTypeProductionLine),
+					WorkCell:       validator.NewWildcardLocation(validator.LocationTypeWorkCell),
+				}
+
+				// Create a non-matching hierarchy
+				nonMatchingHierarchy := validator.LocationHierarchy{
+					Enterprise:     validator.NewLocation(validator.LocationTypeEnterprise, "OtherEnterprise"),
+					Site:           validator.NewLocation(validator.LocationTypeSite, "OtherSite"),
+					Area:           validator.NewLocation(validator.LocationTypeArea, "OtherArea"),
+					ProductionLine: validator.NewLocation(validator.LocationTypeProductionLine, "OtherLine"),
+					WorkCell:       validator.NewLocation(validator.LocationTypeWorkCell, "OtherWorkCell"),
+				}
+
+				// Test with only the wildcard hierarchy
+				Expect(validator.IsLocationAuthorized(&instanceLocation, []validator.LocationHierarchy{wildcardHierarchy})).To(BeTrue())
+
+				// Test with both hierarchies - should still allow because at least one matches
+				Expect(validator.IsLocationAuthorized(&instanceLocation, []validator.LocationHierarchy{nonMatchingHierarchy, wildcardHierarchy})).To(BeTrue())
+
+				// Test with all-wildcard hierarchy
+				allWildcardHierarchy := validator.LocationHierarchy{
+					Enterprise:     validator.NewWildcardLocation(validator.LocationTypeEnterprise),
+					Site:           validator.NewWildcardLocation(validator.LocationTypeSite),
+					Area:           validator.NewWildcardLocation(validator.LocationTypeArea),
+					ProductionLine: validator.NewWildcardLocation(validator.LocationTypeProductionLine),
+					WorkCell:       validator.NewWildcardLocation(validator.LocationTypeWorkCell),
+				}
+
+				Expect(validator.IsLocationAuthorized(&instanceLocation, []validator.LocationHierarchy{allWildcardHierarchy})).To(BeTrue())
+			})
+		})
+
+		Context("when using wildcard hierarchies with wildcards in the middle", func() {
+			It("should authorize when wildcards are in the middle of the hierarchy", func() {
+				instanceLocation := models.InstanceLocation{
+					Enterprise: "TestEnterprise",
+					Site:       "TestSite",
+					Area:       "TestArea",
+					Line:       "TestLine",
+					WorkCell:   "TestWorkCell",
+				}
+
+				// Create a hierarchy with wildcards in the middle
+				wildcardInMiddleHierarchy := validator.LocationHierarchy{
+					Enterprise:     validator.NewLocation(validator.LocationTypeEnterprise, "TestEnterprise"),
+					Site:           validator.NewWildcardLocation(validator.LocationTypeSite),
+					Area:           validator.NewWildcardLocation(validator.LocationTypeArea),
+					ProductionLine: validator.NewLocation(validator.LocationTypeProductionLine, "TestLine"),
+					WorkCell:       validator.NewLocation(validator.LocationTypeWorkCell, "TestWorkCell"),
+				}
+
+				Expect(validator.IsLocationAuthorized(&instanceLocation, []validator.LocationHierarchy{wildcardInMiddleHierarchy})).To(BeTrue())
+
+				// Another hierarchy with different wildcards in the middle
+				anotherWildcardInMiddleHierarchy := validator.LocationHierarchy{
+					Enterprise:     validator.NewLocation(validator.LocationTypeEnterprise, "TestEnterprise"),
+					Site:           validator.NewLocation(validator.LocationTypeSite, "TestSite"),
+					Area:           validator.NewWildcardLocation(validator.LocationTypeArea),
+					ProductionLine: validator.NewLocation(validator.LocationTypeProductionLine, "TestLine"),
+					WorkCell:       validator.NewWildcardLocation(validator.LocationTypeWorkCell),
+				}
+
+				Expect(validator.IsLocationAuthorized(&instanceLocation, []validator.LocationHierarchy{anotherWildcardInMiddleHierarchy})).To(BeTrue())
+			})
+		})
+	})
+
+	Describe("IsLocationAuthorizedByHierarchy", func() {
+		Context("when using exact matches", func() {
+			It("should authorize only when all fields match", func() {
+				instanceLocation := models.InstanceLocation{
+					Enterprise: "TestEnterprise",
+					Site:       "TestSite",
+					Area:       "TestArea",
+					Line:       "TestLine",
+					WorkCell:   "TestWorkCell",
+				}
+
+				// Create a hierarchy that matches exactly
+				exactHierarchy := validator.LocationHierarchy{
+					Enterprise:     validator.NewLocation(validator.LocationTypeEnterprise, "TestEnterprise"),
+					Site:           validator.NewLocation(validator.LocationTypeSite, "TestSite"),
+					Area:           validator.NewLocation(validator.LocationTypeArea, "TestArea"),
+					ProductionLine: validator.NewLocation(validator.LocationTypeProductionLine, "TestLine"),
+					WorkCell:       validator.NewLocation(validator.LocationTypeWorkCell, "TestWorkCell"),
+				}
+
+				Expect(validator.IsLocationAuthorizedByHierarchy(&instanceLocation, exactHierarchy)).To(BeTrue())
+
+				// Test with a mismatch at each level
+				enterpriseMismatch := exactHierarchy
+				enterpriseMismatch.Enterprise = validator.NewLocation(validator.LocationTypeEnterprise, "OtherEnterprise")
+				Expect(validator.IsLocationAuthorizedByHierarchy(&instanceLocation, enterpriseMismatch)).To(BeFalse())
+
+				siteMismatch := exactHierarchy
+				siteMismatch.Site = validator.NewLocation(validator.LocationTypeSite, "OtherSite")
+				Expect(validator.IsLocationAuthorizedByHierarchy(&instanceLocation, siteMismatch)).To(BeFalse())
+
+				areaMismatch := exactHierarchy
+				areaMismatch.Area = validator.NewLocation(validator.LocationTypeArea, "OtherArea")
+				Expect(validator.IsLocationAuthorizedByHierarchy(&instanceLocation, areaMismatch)).To(BeFalse())
+
+				lineMismatch := exactHierarchy
+				lineMismatch.ProductionLine = validator.NewLocation(validator.LocationTypeProductionLine, "OtherLine")
+				Expect(validator.IsLocationAuthorizedByHierarchy(&instanceLocation, lineMismatch)).To(BeFalse())
+
+				workCellMismatch := exactHierarchy
+				workCellMismatch.WorkCell = validator.NewLocation(validator.LocationTypeWorkCell, "OtherWorkCell")
+				Expect(validator.IsLocationAuthorizedByHierarchy(&instanceLocation, workCellMismatch)).To(BeFalse())
+			})
+		})
+
+		Context("when using wildcards", func() {
+			It("should authorize when wildcards are used", func() {
+				instanceLocation := models.InstanceLocation{
+					Enterprise: "TestEnterprise",
+					Site:       "TestSite",
+					Area:       "TestArea",
+					Line:       "TestLine",
+					WorkCell:   "TestWorkCell",
+				}
+
+				// Create a hierarchy with wildcards at different levels
+				wildcardHierarchy := validator.LocationHierarchy{
+					Enterprise:     validator.NewLocation(validator.LocationTypeEnterprise, "TestEnterprise"),
+					Site:           validator.NewLocation(validator.LocationTypeSite, "TestSite"),
+					Area:           validator.NewWildcardLocation(validator.LocationTypeArea),
+					ProductionLine: validator.NewWildcardLocation(validator.LocationTypeProductionLine),
+					WorkCell:       validator.NewWildcardLocation(validator.LocationTypeWorkCell),
+				}
+
+				Expect(validator.IsLocationAuthorizedByHierarchy(&instanceLocation, wildcardHierarchy)).To(BeTrue())
+
+				// Test with wildcards at different levels
+				enterpriseWildcard := validator.LocationHierarchy{
+					Enterprise:     validator.NewWildcardLocation(validator.LocationTypeEnterprise),
+					Site:           validator.NewLocation(validator.LocationTypeSite, "TestSite"),
+					Area:           validator.NewLocation(validator.LocationTypeArea, "TestArea"),
+					ProductionLine: validator.NewLocation(validator.LocationTypeProductionLine, "TestLine"),
+					WorkCell:       validator.NewLocation(validator.LocationTypeWorkCell, "TestWorkCell"),
+				}
+				Expect(validator.IsLocationAuthorizedByHierarchy(&instanceLocation, enterpriseWildcard)).To(BeTrue())
+
+				// Test with all wildcards
+				allWildcards := validator.LocationHierarchy{
+					Enterprise:     validator.NewWildcardLocation(validator.LocationTypeEnterprise),
+					Site:           validator.NewWildcardLocation(validator.LocationTypeSite),
+					Area:           validator.NewWildcardLocation(validator.LocationTypeArea),
+					ProductionLine: validator.NewWildcardLocation(validator.LocationTypeProductionLine),
+					WorkCell:       validator.NewWildcardLocation(validator.LocationTypeWorkCell),
+				}
+				Expect(validator.IsLocationAuthorizedByHierarchy(&instanceLocation, allWildcards)).To(BeTrue())
+			})
+
+			It("should test each level of the hierarchy independently", func() {
+				instanceLocation := models.InstanceLocation{
+					Enterprise: "TestEnterprise",
+					Site:       "TestSite",
+					Area:       "TestArea",
+					Line:       "TestLine",
+					WorkCell:   "TestWorkCell",
+				}
+
+				// Test wildcard at enterprise level only
+				enterpriseWildcard := validator.LocationHierarchy{
+					Enterprise:     validator.NewWildcardLocation(validator.LocationTypeEnterprise),
+					Site:           validator.NewLocation(validator.LocationTypeSite, "TestSite"),
+					Area:           validator.NewLocation(validator.LocationTypeArea, "TestArea"),
+					ProductionLine: validator.NewLocation(validator.LocationTypeProductionLine, "TestLine"),
+					WorkCell:       validator.NewLocation(validator.LocationTypeWorkCell, "TestWorkCell"),
+				}
+				Expect(validator.IsLocationAuthorizedByHierarchy(&instanceLocation, enterpriseWildcard)).To(BeTrue())
+
+				// Test wildcard at site level only
+				siteWildcard := validator.LocationHierarchy{
+					Enterprise:     validator.NewLocation(validator.LocationTypeEnterprise, "TestEnterprise"),
+					Site:           validator.NewWildcardLocation(validator.LocationTypeSite),
+					Area:           validator.NewLocation(validator.LocationTypeArea, "TestArea"),
+					ProductionLine: validator.NewLocation(validator.LocationTypeProductionLine, "TestLine"),
+					WorkCell:       validator.NewLocation(validator.LocationTypeWorkCell, "TestWorkCell"),
+				}
+				Expect(validator.IsLocationAuthorizedByHierarchy(&instanceLocation, siteWildcard)).To(BeTrue())
+
+				// Test wildcard at area level only
+				areaWildcard := validator.LocationHierarchy{
+					Enterprise:     validator.NewLocation(validator.LocationTypeEnterprise, "TestEnterprise"),
+					Site:           validator.NewLocation(validator.LocationTypeSite, "TestSite"),
+					Area:           validator.NewWildcardLocation(validator.LocationTypeArea),
+					ProductionLine: validator.NewLocation(validator.LocationTypeProductionLine, "TestLine"),
+					WorkCell:       validator.NewLocation(validator.LocationTypeWorkCell, "TestWorkCell"),
+				}
+				Expect(validator.IsLocationAuthorizedByHierarchy(&instanceLocation, areaWildcard)).To(BeTrue())
+
+				// Test wildcard at production line level only
+				lineWildcard := validator.LocationHierarchy{
+					Enterprise:     validator.NewLocation(validator.LocationTypeEnterprise, "TestEnterprise"),
+					Site:           validator.NewLocation(validator.LocationTypeSite, "TestSite"),
+					Area:           validator.NewLocation(validator.LocationTypeArea, "TestArea"),
+					ProductionLine: validator.NewWildcardLocation(validator.LocationTypeProductionLine),
+					WorkCell:       validator.NewLocation(validator.LocationTypeWorkCell, "TestWorkCell"),
+				}
+				Expect(validator.IsLocationAuthorizedByHierarchy(&instanceLocation, lineWildcard)).To(BeTrue())
+
+				// Test wildcard at work cell level only
+				workCellWildcard := validator.LocationHierarchy{
+					Enterprise:     validator.NewLocation(validator.LocationTypeEnterprise, "TestEnterprise"),
+					Site:           validator.NewLocation(validator.LocationTypeSite, "TestSite"),
+					Area:           validator.NewLocation(validator.LocationTypeArea, "TestArea"),
+					ProductionLine: validator.NewLocation(validator.LocationTypeProductionLine, "TestLine"),
+					WorkCell:       validator.NewWildcardLocation(validator.LocationTypeWorkCell),
+				}
+				Expect(validator.IsLocationAuthorizedByHierarchy(&instanceLocation, workCellWildcard)).To(BeTrue())
+			})
+
+			It("should verify that wildcards don't override mismatches at other levels", func() {
+				instanceLocation := models.InstanceLocation{
+					Enterprise: "TestEnterprise",
+					Site:       "TestSite",
+					Area:       "TestArea",
+					Line:       "TestLine",
+					WorkCell:   "TestWorkCell",
+				}
+
+				// Wildcard at one level but mismatch at another level
+				wildcardWithMismatch := validator.LocationHierarchy{
+					Enterprise:     validator.NewWildcardLocation(validator.LocationTypeEnterprise),
+					Site:           validator.NewLocation(validator.LocationTypeSite, "WrongSite"),
+					Area:           validator.NewWildcardLocation(validator.LocationTypeArea),
+					ProductionLine: validator.NewWildcardLocation(validator.LocationTypeProductionLine),
+					WorkCell:       validator.NewWildcardLocation(validator.LocationTypeWorkCell),
+				}
+				Expect(validator.IsLocationAuthorizedByHierarchy(&instanceLocation, wildcardWithMismatch)).To(BeFalse())
+
+				// Multiple wildcards but one mismatch
+				multipleWildcardsOneMismatch := validator.LocationHierarchy{
+					Enterprise:     validator.NewWildcardLocation(validator.LocationTypeEnterprise),
+					Site:           validator.NewWildcardLocation(validator.LocationTypeSite),
+					Area:           validator.NewWildcardLocation(validator.LocationTypeArea),
+					ProductionLine: validator.NewLocation(validator.LocationTypeProductionLine, "WrongLine"),
+					WorkCell:       validator.NewWildcardLocation(validator.LocationTypeWorkCell),
+				}
+				Expect(validator.IsLocationAuthorizedByHierarchy(&instanceLocation, multipleWildcardsOneMismatch)).To(BeFalse())
+			})
+
+			It("should handle empty location values correctly", func() {
+				// Instance location with some empty values
+				instanceLocation := models.InstanceLocation{
+					Enterprise: "TestEnterprise",
+					Site:       "TestSite",
+					Area:       "", // Empty area
+					Line:       "TestLine",
+					WorkCell:   "", // Empty work cell
+				}
+
+				// Hierarchy with exact matches for non-empty values and wildcards for empty values
+				hierarchyWithWildcards := validator.LocationHierarchy{
+					Enterprise:     validator.NewLocation(validator.LocationTypeEnterprise, "TestEnterprise"),
+					Site:           validator.NewLocation(validator.LocationTypeSite, "TestSite"),
+					Area:           validator.NewWildcardLocation(validator.LocationTypeArea),
+					ProductionLine: validator.NewLocation(validator.LocationTypeProductionLine, "TestLine"),
+					WorkCell:       validator.NewWildcardLocation(validator.LocationTypeWorkCell),
+				}
+				Expect(validator.IsLocationAuthorizedByHierarchy(&instanceLocation, hierarchyWithWildcards)).To(BeTrue())
+
+				// Hierarchy with exact matches for all values (including empty ones)
+				hierarchyWithExactMatches := validator.LocationHierarchy{
+					Enterprise:     validator.NewLocation(validator.LocationTypeEnterprise, "TestEnterprise"),
+					Site:           validator.NewLocation(validator.LocationTypeSite, "TestSite"),
+					Area:           validator.NewLocation(validator.LocationTypeArea, ""), // Match empty area
+					ProductionLine: validator.NewLocation(validator.LocationTypeProductionLine, "TestLine"),
+					WorkCell:       validator.NewLocation(validator.LocationTypeWorkCell, ""), // Match empty work cell
+				}
+				Expect(validator.IsLocationAuthorizedByHierarchy(&instanceLocation, hierarchyWithExactMatches)).To(BeTrue())
+
+				// Hierarchy with non-matching values for empty fields
+				hierarchyWithNonMatches := validator.LocationHierarchy{
+					Enterprise:     validator.NewLocation(validator.LocationTypeEnterprise, "TestEnterprise"),
+					Site:           validator.NewLocation(validator.LocationTypeSite, "TestSite"),
+					Area:           validator.NewLocation(validator.LocationTypeArea, "SomeArea"), // Non-matching area
+					ProductionLine: validator.NewLocation(validator.LocationTypeProductionLine, "TestLine"),
+					WorkCell:       validator.NewLocation(validator.LocationTypeWorkCell, "SomeWorkCell"), // Non-matching work cell
+				}
+				Expect(validator.IsLocationAuthorizedByHierarchy(&instanceLocation, hierarchyWithNonMatches)).To(BeFalse())
+			})
+		})
+
+		Context("when using wildcards in the middle of the hierarchy", func() {
+			It("should authorize with wildcards at any position in the hierarchy", func() {
+				instanceLocation := models.InstanceLocation{
+					Enterprise: "TestEnterprise",
+					Site:       "TestSite",
+					Area:       "TestArea",
+					Line:       "TestLine",
+					WorkCell:   "TestWorkCell",
+				}
+
+				// Test with wildcards at various positions in the hierarchy
+
+				// Wildcard in the middle (Site)
+				siteWildcardMiddle := validator.LocationHierarchy{
+					Enterprise:     validator.NewLocation(validator.LocationTypeEnterprise, "TestEnterprise"),
+					Site:           validator.NewWildcardLocation(validator.LocationTypeSite),
+					Area:           validator.NewLocation(validator.LocationTypeArea, "TestArea"),
+					ProductionLine: validator.NewLocation(validator.LocationTypeProductionLine, "TestLine"),
+					WorkCell:       validator.NewLocation(validator.LocationTypeWorkCell, "TestWorkCell"),
+				}
+				Expect(validator.IsLocationAuthorizedByHierarchy(&instanceLocation, siteWildcardMiddle)).To(BeTrue())
+
+				// Wildcard in the middle (Area)
+				areaWildcardMiddle := validator.LocationHierarchy{
+					Enterprise:     validator.NewLocation(validator.LocationTypeEnterprise, "TestEnterprise"),
+					Site:           validator.NewLocation(validator.LocationTypeSite, "TestSite"),
+					Area:           validator.NewWildcardLocation(validator.LocationTypeArea),
+					ProductionLine: validator.NewLocation(validator.LocationTypeProductionLine, "TestLine"),
+					WorkCell:       validator.NewLocation(validator.LocationTypeWorkCell, "TestWorkCell"),
+				}
+				Expect(validator.IsLocationAuthorizedByHierarchy(&instanceLocation, areaWildcardMiddle)).To(BeTrue())
+
+				// Multiple wildcards in the middle
+				multipleWildcardsMiddle := validator.LocationHierarchy{
+					Enterprise:     validator.NewLocation(validator.LocationTypeEnterprise, "TestEnterprise"),
+					Site:           validator.NewWildcardLocation(validator.LocationTypeSite),
+					Area:           validator.NewWildcardLocation(validator.LocationTypeArea),
+					ProductionLine: validator.NewLocation(validator.LocationTypeProductionLine, "TestLine"),
+					WorkCell:       validator.NewLocation(validator.LocationTypeWorkCell, "TestWorkCell"),
+				}
+				Expect(validator.IsLocationAuthorizedByHierarchy(&instanceLocation, multipleWildcardsMiddle)).To(BeTrue())
+
+				// Wildcards at start and end, specific values in middle
+				wildcardStartEndSpecificMiddle := validator.LocationHierarchy{
+					Enterprise:     validator.NewWildcardLocation(validator.LocationTypeEnterprise),
+					Site:           validator.NewLocation(validator.LocationTypeSite, "TestSite"),
+					Area:           validator.NewLocation(validator.LocationTypeArea, "TestArea"),
+					ProductionLine: validator.NewLocation(validator.LocationTypeProductionLine, "TestLine"),
+					WorkCell:       validator.NewWildcardLocation(validator.LocationTypeWorkCell),
+				}
+				Expect(validator.IsLocationAuthorizedByHierarchy(&instanceLocation, wildcardStartEndSpecificMiddle)).To(BeTrue())
+
+				// Alternating wildcards and specific values
+				alternatingWildcards := validator.LocationHierarchy{
+					Enterprise:     validator.NewWildcardLocation(validator.LocationTypeEnterprise),
+					Site:           validator.NewLocation(validator.LocationTypeSite, "TestSite"),
+					Area:           validator.NewWildcardLocation(validator.LocationTypeArea),
+					ProductionLine: validator.NewLocation(validator.LocationTypeProductionLine, "TestLine"),
+					WorkCell:       validator.NewWildcardLocation(validator.LocationTypeWorkCell),
+				}
+				Expect(validator.IsLocationAuthorizedByHierarchy(&instanceLocation, alternatingWildcards)).To(BeTrue())
+			})
+
+			It("should deny access when non-wildcard values don't match", func() {
+				instanceLocation := models.InstanceLocation{
+					Enterprise: "TestEnterprise",
+					Site:       "TestSite",
+					Area:       "TestArea",
+					Line:       "TestLine",
+					WorkCell:   "TestWorkCell",
+				}
+
+				// Wildcards in the middle but with non-matching values at other levels
+				wildcardMiddleNonMatchingOthers := validator.LocationHierarchy{
+					Enterprise:     validator.NewLocation(validator.LocationTypeEnterprise, "OtherEnterprise"),
+					Site:           validator.NewWildcardLocation(validator.LocationTypeSite),
+					Area:           validator.NewWildcardLocation(validator.LocationTypeArea),
+					ProductionLine: validator.NewLocation(validator.LocationTypeProductionLine, "TestLine"),
+					WorkCell:       validator.NewLocation(validator.LocationTypeWorkCell, "TestWorkCell"),
+				}
+				Expect(validator.IsLocationAuthorizedByHierarchy(&instanceLocation, wildcardMiddleNonMatchingOthers)).To(BeFalse())
+
+				// Another example with wildcards in different positions
+				anotherWildcardMiddleNonMatching := validator.LocationHierarchy{
+					Enterprise:     validator.NewLocation(validator.LocationTypeEnterprise, "TestEnterprise"),
+					Site:           validator.NewLocation(validator.LocationTypeSite, "TestSite"),
+					Area:           validator.NewWildcardLocation(validator.LocationTypeArea),
+					ProductionLine: validator.NewLocation(validator.LocationTypeProductionLine, "OtherLine"),
+					WorkCell:       validator.NewLocation(validator.LocationTypeWorkCell, "TestWorkCell"),
+				}
+				Expect(validator.IsLocationAuthorizedByHierarchy(&instanceLocation, anotherWildcardMiddleNonMatching)).To(BeFalse())
+			})
+
+			It("should handle complex hierarchies with mixed wildcards and specific values", func() {
+				// Test with a more complex instance location
+				complexInstanceLocation := models.InstanceLocation{
+					Enterprise: "MegaCorp",
+					Site:       "Headquarters",
+					Area:       "Manufacturing",
+					Line:       "Assembly",
+					WorkCell:   "Station5",
+				}
+
+				// Complex hierarchy with wildcards at various levels
+				complexHierarchy := validator.LocationHierarchy{
+					Enterprise:     validator.NewLocation(validator.LocationTypeEnterprise, "MegaCorp"),
+					Site:           validator.NewWildcardLocation(validator.LocationTypeSite),
+					Area:           validator.NewLocation(validator.LocationTypeArea, "Manufacturing"),
+					ProductionLine: validator.NewWildcardLocation(validator.LocationTypeProductionLine),
+					WorkCell:       validator.NewLocation(validator.LocationTypeWorkCell, "Station5"),
+				}
+				Expect(validator.IsLocationAuthorizedByHierarchy(&complexInstanceLocation, complexHierarchy)).To(BeTrue())
+
+				// Change one non-wildcard value to make it not match
+				complexHierarchyNonMatching := validator.LocationHierarchy{
+					Enterprise:     validator.NewLocation(validator.LocationTypeEnterprise, "MegaCorp"),
+					Site:           validator.NewWildcardLocation(validator.LocationTypeSite),
+					Area:           validator.NewLocation(validator.LocationTypeArea, "Research"), // Different from "Manufacturing"
+					ProductionLine: validator.NewWildcardLocation(validator.LocationTypeProductionLine),
+					WorkCell:       validator.NewLocation(validator.LocationTypeWorkCell, "Station5"),
+				}
+				Expect(validator.IsLocationAuthorizedByHierarchy(&complexInstanceLocation, complexHierarchyNonMatching)).To(BeFalse())
+			})
+		})
+	})
+
+	Describe("IsRoleAllowedForActionAndMessageType", func() {
+		Context("when action type is nil", func() {
+			It("should allow any role for non-Action message types", func() {
+				// Test with nil action type and non-Action message types
+				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleAdmin, nil, models.Subscribe)).To(BeTrue())
+				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleViewer, nil, models.Status)).To(BeTrue())
+				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleAdmin, nil, models.ActionReply)).To(BeTrue())
+				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleViewer, nil, models.EncryptedContent)).To(BeTrue())
+			})
+
+			It("should deny any role for Action message type", func() {
+				// Test with nil action type and Action message type
+				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleAdmin, nil, models.Action)).To(BeFalse())
+				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleViewer, nil, models.Action)).To(BeFalse())
+			})
+		})
+
+		Context("when action type is provided", func() {
+			It("should allow Admin role for admin-only actions", func() {
+				// Test with action types that only allow Admin role
+				getAuditLog := models.GetAuditLog
+				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleAdmin, &getAuditLog, models.Action)).To(BeTrue())
+				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleViewer, &getAuditLog, models.Action)).To(BeFalse())
+				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleEditor, &getAuditLog, models.Action)).To(BeFalse())
+
+				upgradeCompanion := models.UpgradeCompanion
+				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleAdmin, &upgradeCompanion, models.Action)).To(BeTrue())
+				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleViewer, &upgradeCompanion, models.Action)).To(BeFalse())
+				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleEditor, &upgradeCompanion, models.Action)).To(BeFalse())
+
+				editInstance := models.EditInstance
+				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleAdmin, &editInstance, models.Action)).To(BeTrue())
+				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleViewer, &editInstance, models.Action)).To(BeFalse())
+				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleEditor, &editInstance, models.Action)).To(BeFalse())
+			})
+
+			It("should allow both Admin and Viewer roles for viewer-allowed actions", func() {
+				// Test with action types that allow both Admin and Viewer roles
+				getConnectionNotes := models.GetConnectionNotes
+				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleAdmin, &getConnectionNotes, models.Action)).To(BeTrue())
+				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleViewer, &getConnectionNotes, models.Action)).To(BeTrue())
+				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleEditor, &getConnectionNotes, models.Action)).To(BeTrue())
+
+				getDatasourceBasic := models.GetDatasourceBasic
+				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleAdmin, &getDatasourceBasic, models.Action)).To(BeTrue())
+				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleViewer, &getDatasourceBasic, models.Action)).To(BeTrue())
+				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleEditor, &getDatasourceBasic, models.Action)).To(BeTrue())
+			})
+
+			It("should allow Admin and Editor roles for editor-allowed actions", func() {
+				// Test with action types that allow both Admin and Editor roles
+				testBenthosInput := models.TestBenthosInput
+				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleAdmin, &testBenthosInput, models.Action)).To(BeTrue())
+				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleViewer, &testBenthosInput, models.Action)).To(BeFalse())
+				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleEditor, &testBenthosInput, models.Action)).To(BeTrue())
+
+				editDataFlowComponent := models.EditDataFlowComponent
+				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleAdmin, &editDataFlowComponent, models.Action)).To(BeTrue())
+				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleViewer, &editDataFlowComponent, models.Action)).To(BeFalse())
+				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleEditor, &editDataFlowComponent, models.Action)).To(BeTrue())
+			})
+
+			It("should deny for unknown action types", func() {
+				// Create a custom action type that doesn't exist in the map
+				unknownAction := models.ActionType("non-existent-action")
+				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleAdmin, &unknownAction, models.Action)).To(BeFalse())
+				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleViewer, &unknownAction, models.Action)).To(BeFalse())
+			})
+		})
+
+		Context("when message type is not Action", func() {
+			It("should still check role permissions for the action type", func() {
+				// Even if message type is not Action, if action type is provided, it should check permissions
+				deployConnection := models.DeployConnection
+				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleAdmin, &deployConnection, models.Status)).To(BeTrue())
+				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleViewer, &deployConnection, models.Status)).To(BeFalse())
+
+				getConnectionNotes := models.GetConnectionNotes
+				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleAdmin, &getConnectionNotes, models.Subscribe)).To(BeTrue())
+				Expect(validator.IsRoleAllowedForActionAndMessageType(validator.RoleViewer, &getConnectionNotes, models.Subscribe)).To(BeTrue())
+			})
+		})
+	})
+
+	Describe("IsAllowedForAction", func() {
+		Context("when checking Get Actions group", func() {
+			It("should allow appropriate roles for get actions", func() {
+				// Test get-connection-notes which allows Admin, Viewer, and Editor
+				getConnectionNotes := models.GetConnectionNotes
+				Expect(validator.IsAllowedForAction(validator.RoleAdmin, getConnectionNotes)).To(BeTrue())
+				Expect(validator.IsAllowedForAction(validator.RoleViewer, getConnectionNotes)).To(BeTrue())
+				Expect(validator.IsAllowedForAction(validator.RoleEditor, getConnectionNotes)).To(BeTrue())
+
+				// Test get-audit-log which only allows Admin
+				getAuditLog := models.GetAuditLog
+				Expect(validator.IsAllowedForAction(validator.RoleAdmin, getAuditLog)).To(BeTrue())
+				Expect(validator.IsAllowedForAction(validator.RoleViewer, getAuditLog)).To(BeFalse())
+				Expect(validator.IsAllowedForAction(validator.RoleEditor, getAuditLog)).To(BeFalse())
+			})
+		})
+
+		Context("when checking Edit Actions group", func() {
+			It("should allow Admin and Editor roles for edit actions", func() {
+				editConnection := models.EditConnection
+				Expect(validator.IsAllowedForAction(validator.RoleAdmin, editConnection)).To(BeTrue())
+				Expect(validator.IsAllowedForAction(validator.RoleEditor, editConnection)).To(BeTrue())
+				Expect(validator.IsAllowedForAction(validator.RoleViewer, editConnection)).To(BeFalse())
+
+				editInstance := models.EditInstance
+				Expect(validator.IsAllowedForAction(validator.RoleAdmin, editInstance)).To(BeTrue())
+				Expect(validator.IsAllowedForAction(validator.RoleEditor, editInstance)).To(BeFalse())
+				Expect(validator.IsAllowedForAction(validator.RoleViewer, editInstance)).To(BeFalse())
+			})
+		})
+
+		Context("when checking Delete Actions group", func() {
+			It("should allow Admin and Editor roles for delete actions", func() {
+				deleteConnection := models.DeleteConnection
+				Expect(validator.IsAllowedForAction(validator.RoleAdmin, deleteConnection)).To(BeTrue())
+				Expect(validator.IsAllowedForAction(validator.RoleEditor, deleteConnection)).To(BeTrue())
+				Expect(validator.IsAllowedForAction(validator.RoleViewer, deleteConnection)).To(BeFalse())
+			})
+		})
+
+		Context("when checking Deploy Actions group", func() {
+			It("should allow Admin and Editor roles for deploy actions", func() {
+				deployConnection := models.DeployConnection
+				Expect(validator.IsAllowedForAction(validator.RoleAdmin, deployConnection)).To(BeTrue())
+				Expect(validator.IsAllowedForAction(validator.RoleEditor, deployConnection)).To(BeTrue())
+				Expect(validator.IsAllowedForAction(validator.RoleViewer, deployConnection)).To(BeFalse())
+			})
+		})
+
+		Context("when checking Test Actions group", func() {
+			It("should allow Admin and Editor roles for test actions", func() {
+				testBenthosInput := models.TestBenthosInput
+				Expect(validator.IsAllowedForAction(validator.RoleAdmin, testBenthosInput)).To(BeTrue())
+				Expect(validator.IsAllowedForAction(validator.RoleEditor, testBenthosInput)).To(BeTrue())
+				Expect(validator.IsAllowedForAction(validator.RoleViewer, testBenthosInput)).To(BeFalse())
+			})
+		})
+
+		Context("when checking System Actions group", func() {
+			It("should only allow Admin role for system actions", func() {
+				upgradeCompanion := models.UpgradeCompanion
+				Expect(validator.IsAllowedForAction(validator.RoleAdmin, upgradeCompanion)).To(BeTrue())
+				Expect(validator.IsAllowedForAction(validator.RoleEditor, upgradeCompanion)).To(BeFalse())
+				Expect(validator.IsAllowedForAction(validator.RoleViewer, upgradeCompanion)).To(BeFalse())
+			})
+		})
+
+		Context("when checking ungrouped actions", func() {
+			It("should handle unknown and dummy actions correctly", func() {
+				// Test unknown action (should allow Admin, Viewer, Editor)
+				unknownAction := models.ActionType("unknown")
+				Expect(validator.IsAllowedForAction(validator.RoleAdmin, unknownAction)).To(BeTrue())
+				Expect(validator.IsAllowedForAction(validator.RoleViewer, unknownAction)).To(BeTrue())
+				Expect(validator.IsAllowedForAction(validator.RoleEditor, unknownAction)).To(BeTrue())
+
+				// Test dummy action (should allow Admin, Viewer, Editor)
+				dummyAction := models.ActionType("dummy")
+				Expect(validator.IsAllowedForAction(validator.RoleAdmin, dummyAction)).To(BeTrue())
+				Expect(validator.IsAllowedForAction(validator.RoleViewer, dummyAction)).To(BeTrue())
+				Expect(validator.IsAllowedForAction(validator.RoleEditor, dummyAction)).To(BeTrue())
+			})
+
+			It("should deny access for non-existent actions", func() {
+				nonExistentAction := models.ActionType("non-existent-action")
+				Expect(validator.IsAllowedForAction(validator.RoleAdmin, nonExistentAction)).To(BeFalse())
+				Expect(validator.IsAllowedForAction(validator.RoleViewer, nonExistentAction)).To(BeFalse())
+				Expect(validator.IsAllowedForAction(validator.RoleEditor, nonExistentAction)).To(BeFalse())
+			})
+		})
+	})
+})

--- a/umh-core/pkg/communicator/actions/permission/user_certificate_test.go
+++ b/umh-core/pkg/communicator/actions/permission/user_certificate_test.go
@@ -20,6 +20,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/asn1"
+	"errors"
 	"fmt"
 	"math/big"
 	"strings"
@@ -44,6 +45,7 @@ func createCertificateWithRoleExtension(locationRoles map[string]string) (*x509.
 
 	// Generate serial number (matching production code)
 	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+
 	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
 	if err != nil {
 		return nil, err
@@ -73,7 +75,7 @@ func createCertificateWithRoleExtension(locationRoles map[string]string) (*x509.
 
 	// Add the location role extension manually (based on production AddLocationRoleExtension)
 	if len(locationRolesMap) == 0 {
-		return nil, fmt.Errorf("must have locationRoles")
+		return nil, errors.New("must have locationRoles")
 	}
 
 	// Validate all roles and locations
@@ -81,7 +83,8 @@ func createCertificateWithRoleExtension(locationRoles map[string]string) (*x509.
 		if role != validator.RoleAdmin && role != validator.RoleViewer && role != validator.RoleEditor {
 			return nil, fmt.Errorf("invalid role: %s", role)
 		}
-		if len(strings.Split(location, ".")) <= 0 {
+
+		if len(strings.Split(location, ".")) == 0 {
 			return nil, fmt.Errorf("invalid location: %s", location)
 		}
 	}

--- a/umh-core/pkg/communicator/communication_state/communication_state.go
+++ b/umh-core/pkg/communicator/communication_state/communication_state.go
@@ -40,7 +40,7 @@ type CommunicationState struct {
 	LoginResponseMu       *sync.RWMutex
 	mu                    *sync.RWMutex
 	Watchdog              *watchdog.Watchdog
-	InboundChannel        chan *models.UMHMessage
+	InboundChannel        chan *models.UMHMessageWithAdditionalInfo
 	Puller                *pull.Puller
 	Pusher                *push.Pusher
 	SubscriberHandler     *subscriber.Handler
@@ -62,7 +62,7 @@ type CommunicationState struct {
 // NewCommunicationState creates a new CommunicationState with initialized mutex.
 func NewCommunicationState(
 	watchdog *watchdog.Watchdog,
-	inboundChannel chan *models.UMHMessage,
+	inboundChannel chan *models.UMHMessageWithAdditionalInfo,
 	outboundChannel chan *models.UMHMessage,
 	releaseChannel config.ReleaseChannel,
 	systemSnapshotManager *fsm.SnapshotManager,

--- a/umh-core/pkg/models/action_models.go
+++ b/umh-core/pkg/models/action_models.go
@@ -15,6 +15,8 @@
 package models
 
 import (
+	"crypto/x509"
+
 	"github.com/Masterminds/semver/v3"
 	"github.com/google/uuid"
 )
@@ -57,6 +59,14 @@ type EditInstanceLocationModel struct {
 	Enterprise string  `json:"enterprise"`
 }
 
+type InstanceLocation struct {
+	Enterprise string `json:"enterprise"`
+	Site       string `json:"site"`
+	Area       string `json:"area"`
+	Line       string `json:"line"`
+	WorkCell   string `json:"workCell"`
+}
+
 type MessageMetadata struct {
 	TraceID uuid.UUID `json:"traceId"`
 }
@@ -81,6 +91,11 @@ type UMHMessage struct {
 	Email        string           `json:"email"`
 	Content      string           `json:"content"`
 	InstanceUUID uuid.UUID        `json:"umhInstance"`
+}
+
+type UMHMessageWithAdditionalInfo struct {
+	UMHMessage
+	Certificate *x509.Certificate `json:"certificate"`
 }
 
 // Define MessageType as a custom type for better type safety.
@@ -172,7 +187,7 @@ const (
 	// GetDataFlowComponentMetrics represents the action type for retrieving metrics of a data flow component
 	//
 	// Deprecated: Use GetMetrics instead. Kept for backward compatibility.
-	GetDataFlowComponentMetrics ActionType = "get-data-flow-component-metrics"
+	GetDataFlowComponentMetrics ActionType = "gdatamodelet-data-flow-component-metrics"
 	// GetDataFlowComponentLog reperesents the action type for getting the audit log for a data flow component.
 	GetDataFlowComponentLog ActionType = "get-data-flow-component-log"
 	// GetKubernetesEvents represents the action type for retrieving Kubernetes events.
@@ -430,7 +445,6 @@ type EditDataflowcomponentRequestSchemaJson struct {
 type GetDataflowcomponentResponse map[string]GetDataflowcomponentResponseContent
 
 type GetDataflowcomponentResponseContent struct {
-
 	// Meta corresponds to the JSON schema field "meta".
 	Meta CommonDataFlowComponentMeta `json:"meta" mapstructure:"meta" yaml:"meta"`
 
@@ -473,7 +487,6 @@ type CommonDataFlowComponentCDFCPropertiesPayload struct {
 }
 
 type CommonDataFlowComponentCDFCProperties struct {
-
 	// Pipeline corresponds to the JSON schema field "pipeline".
 	Pipeline CommonDataFlowComponentPipelineConfig `json:"pipeline" mapstructure:"pipeline" yaml:"pipeline"`
 
@@ -717,10 +730,12 @@ type ActionReplyResponseSchemaJsonActionReplyPayloadV2 struct {
 
 type ActionReplyResponseSchemaJsonActionReplyState string
 
-const ActionReplyResponseSchemaJsonActionReplyStateActionConfirmed ActionReplyResponseSchemaJsonActionReplyState = "action-confirmed"
-const ActionReplyResponseSchemaJsonActionReplyStateActionExecuting ActionReplyResponseSchemaJsonActionReplyState = "action-executing"
-const ActionReplyResponseSchemaJsonActionReplyStateActionFailure ActionReplyResponseSchemaJsonActionReplyState = "action-failure"
-const ActionReplyResponseSchemaJsonActionReplyStateActionSuccess ActionReplyResponseSchemaJsonActionReplyState = "action-success"
+const (
+	ActionReplyResponseSchemaJsonActionReplyStateActionConfirmed ActionReplyResponseSchemaJsonActionReplyState = "action-confirmed"
+	ActionReplyResponseSchemaJsonActionReplyStateActionExecuting ActionReplyResponseSchemaJsonActionReplyState = "action-executing"
+	ActionReplyResponseSchemaJsonActionReplyStateActionFailure   ActionReplyResponseSchemaJsonActionReplyState = "action-failure"
+	ActionReplyResponseSchemaJsonActionReplyStateActionSuccess   ActionReplyResponseSchemaJsonActionReplyState = "action-success"
+)
 
 // var enumValues_ActionReplyResponseSchemaJsonActionReplyState = []interface{}{
 // 	"action-confirmed",
@@ -754,6 +769,9 @@ const (
 	// ErrGetCacheModTimeFailed is the error code for a failed cache mod time retrieval.
 	// It is not retryable because we already changed the config file and the user should refresh the page.
 	ErrGetCacheModTimeFailed = "ERR_GET_CACHE_MOD_TIME_FAILED"
+	// ErrPermissionDenied is the error code for when a user lacks the required permissions for an action.
+	// It is not retryable because the user would need additional permissions to be granted.
+	ErrPermissionDenied = "ERR_PERMISSION_DENIED"
 )
 
 type ProtocolConverterConnection struct {

--- a/umh-core/pkg/models/action_models.go
+++ b/umh-core/pkg/models/action_models.go
@@ -59,14 +59,6 @@ type EditInstanceLocationModel struct {
 	Enterprise string  `json:"enterprise"`
 }
 
-type InstanceLocation struct {
-	Enterprise string `json:"enterprise"`
-	Site       string `json:"site"`
-	Area       string `json:"area"`
-	Line       string `json:"line"`
-	WorkCell   string `json:"workCell"`
-}
-
 type MessageMetadata struct {
 	TraceID uuid.UUID `json:"traceId"`
 }
@@ -94,8 +86,8 @@ type UMHMessage struct {
 }
 
 type UMHMessageWithAdditionalInfo struct {
-	UMHMessage
 	Certificate *x509.Certificate `json:"certificate"`
+	UMHMessage
 }
 
 // Define MessageType as a custom type for better type safety.
@@ -187,7 +179,7 @@ const (
 	// GetDataFlowComponentMetrics represents the action type for retrieving metrics of a data flow component
 	//
 	// Deprecated: Use GetMetrics instead. Kept for backward compatibility.
-	GetDataFlowComponentMetrics ActionType = "gdatamodelet-data-flow-component-metrics"
+	GetDataFlowComponentMetrics ActionType = "get-data-flow-component-metrics"
 	// GetDataFlowComponentLog reperesents the action type for getting the audit log for a data flow component.
 	GetDataFlowComponentLog ActionType = "get-data-flow-component-log"
 	// GetKubernetesEvents represents the action type for retrieving Kubernetes events.

--- a/umh-core/pkg/service/container_monitor/macos_adjusted_metrics_darwin.go
+++ b/umh-core/pkg/service/container_monitor/macos_adjusted_metrics_darwin.go
@@ -17,7 +17,7 @@
 
 package container_monitor
 
-// getMacOSAdjustedDiskMetrics is not implemented for Darwin / MacOS
+// getMacOSAdjustedDiskMetrics is not implemented for Darwin / MacOS.
 func (c *ContainerMonitorService) getMacOSAdjustedDiskMetrics() (usedBytes, totalBytes uint64, err error) {
 	return 0, 0, nil
 }

--- a/umh-core/test/communicator/subscribe_and_receive_test.go
+++ b/umh-core/test/communicator/subscribe_and_receive_test.go
@@ -16,6 +16,7 @@ package communicator
 
 import (
 	"context"
+	"crypto/x509"
 	"fmt"
 	"sync"
 	"time"
@@ -173,6 +174,10 @@ var _ = Describe("Subscribe and Receive Test", func() {
 			false,
 			apiUrl,
 			log,
+			make(chan struct {
+				Cert  *x509.Certificate
+				Email string
+			}),
 		)
 
 		// Initialize subscriber handler

--- a/umh-core/test/communicator/subscribe_and_receive_test.go
+++ b/umh-core/test/communicator/subscribe_and_receive_test.go
@@ -145,7 +145,7 @@ var _ = Describe("Subscribe and Receive Test", func() {
 		state = &communication_state.CommunicationState{
 			LoginResponse:   login,
 			Watchdog:        dog.(*watchdog.Watchdog),
-			InboundChannel:  make(chan *models.UMHMessage, 100),
+			InboundChannel:  make(chan *models.UMHMessageWithAdditionalInfo, 100),
 			OutboundChannel: outboundChan, // Use our custom outbound channel
 			InsecureTLS:     false,
 			ReleaseChannel:  config.ReleaseChannel("stable"),


### PR DESCRIPTION
### Description:
- port the permission validator to umh-core to verify if the role is allowed to process the action message
- adds the `extensions.go` to umh-core to be able to use it later on as a minor lib from MC (possibly)
- adjust HandleActionMessage to use the senderCert 
- add the `UMHMessageWithAdditionalInfo` to make use of the certificate within the umhmessage
- adjust the tests to check each role for each action
- adjust the puller

### Important:
- certificate handling to the puller / in general via the new `UMHMessageWithAdditionalContent` is needed to be done