### PR TITLE
chore: bump benthos-umh from v0.10.2 to v0.11.1

### DIFF
--- a/umh-core/Makefile
+++ b/umh-core/Makefile
@@ -68,7 +68,7 @@ NMAP_VERSION = 7.97-r0
 S6_OVERLAY_VERSION = 3.2.0.2
 REDPANDA_VERSION = 24.3.8
 ## Benthos version is a tag or a sha-<commit hash> (e.g. 0.9.4 or sha-a51a685) to be used in the docker image
-BENTHOS_UMH_VERSION = 0.10.2
+BENTHOS_UMH_VERSION = 0.11.1
 BUF_VERSION = 1.55.1
 PROTOC_GEN_GO_VERSION = 1.36.6
 


### PR DESCRIPTION
## Summary

This PR updates benthos-umh from v0.10.2 to v0.11.1, bringing significant new functionality for industrial IoT protocol support.

## What's New

### Sparkplug B Plugin Support
- **Sparkplug B Input plugin** (Primary Host role) with MQTT session lifecycle management
- **Sparkplug B Output plugin** (Edge Node role) with device-level PARRIS implementation  
- **Sparkplug B Decode processor** for protobuf message processing

### Key Features
- Full Sparkplug B v3.0 specification compliance
- Device-level PARRIS method for dynamic device identification
- Automatic alias resolution and metric name mapping
- MQTT session management with rebirth requests
- Complete protobuf encoding/decoding
- Integration with UMH tag processor and unified namespace
- Support for all Sparkplug B message types: NBIRTH, DBIRTH, NDATA, DDATA, NDEATH, DDEATH

🤖 Generated with [Claude Code](https://claude.ai/code)