### PR TITLE
fix(fsm): prevent stuck transitions under CPU throttling

### DIFF
--- a/umh-core/internal/fsm/baseFSM.go
+++ b/umh-core/internal/fsm/baseFSM.go
@@ -238,7 +238,22 @@ func (s *BaseFSMInstance) SendEvent(ctx context.Context, eventName string, args 
 	s.logger.Debugf("FSM %s attempting transition: current_state='%s' -> event='%s' (desired_state='%s')",
 		instanceID, currentState, eventName, desiredState)
 
-	err := s.fsm.Event(ctx, eventName, args...)
+	// CRITICAL: Always give FSM a fresh context to prevent "previous transition did not complete" errors
+	// This ensures the FSM can complete even under CPU throttling (cgroups throttle for ~100ms periods)
+	// We ignore the parent context deadline to guarantee the transition completes
+	// See Linear ticket ENG-3419 for full context and analysis
+
+	fsmCtx, cancel := context.WithTimeout(context.Background(), constants.FSMTransitionTimeout)
+	defer cancel()
+
+	// Execute the FSM transition with guaranteed time to complete
+	err := s.fsm.Event(fsmCtx, eventName, args...)
+	
+	// Check if parent context expired while we were executing
+	if err == nil && ctx.Err() != nil {
+		s.logger.Warnf("FSM transition completed successfully but parent context expired - prevented stuck transition but now outside of cycle time (preventing bigger impact)")
+	}
+	
 	if err != nil {
 		// Enhanced error message with state context
 		enhancedErr := fmt.Errorf("FSM %s failed transition: current_state='%s' -> event='%s' (desired_state='%s'): %w",

--- a/umh-core/pkg/constants/fsm.go
+++ b/umh-core/pkg/constants/fsm.go
@@ -1,0 +1,26 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package constants
+
+import "time"
+
+// FSM Context Timeouts
+// These timeouts ensure critical operations can complete even under CPU throttling
+
+// FSMTransitionTimeout is the timeout for FSM state transitions.
+// Set to 200ms to survive CPU throttling via cgroups (which throttle for ~100ms periods).
+// This prevents "previous transition did not complete" errors.
+// See Linear ticket ENG-3419 for full context.
+const FSMTransitionTimeout = 200 * time.Millisecond


### PR DESCRIPTION
## Summary
- Fixes FSM instances getting permanently stuck with "previous transition did not complete" error
- Ensures FSM transitions complete even under CPU throttling in containerized environments
- Prevents service disruptions that previously required container restarts to recover

## Problem
FSM instances were getting stuck when the parent context expired during a transition, particularly under CPU throttling. The looplab/fsm library maintains an internal `transition` field that remains non-nil if the context expires mid-transition, causing all subsequent transitions to fail permanently.

## Solution
Always give FSM transitions a fresh 200ms context (2x the cgroup throttling period of ~100ms) to ensure they can complete. This prevents the stuck state while still maintaining a safety timeout.

## Technical Details
- CPU is throttled through cgroups (default ~100ms periods)
- FSM callbacks are lightweight (just logging, <1ms execution time)
- looplab/fsm has no recovery mechanism for cancelled context during transitions
- 200ms timeout ensures survival of at least one full throttle cycle

## Linear Issue
Fixes [ENG-3419](https://linear.app/united-manufacturing-hub/issue/ENG-3419)
Parent issue: [ENG-3393](https://linear.app/united-manufacturing-hub/issue/ENG-3393)

🤖 Generated with [Claude Code](https://claude.ai/code)