### PR TITLE
fix: implement GetConfig for BenthosMonitor to detect port changes (ENG-3383)

### DIFF
--- a/umh-core/pkg/fsm/benthos_monitor/models.go
+++ b/umh-core/pkg/fsm/benthos_monitor/models.go
@@ -88,6 +88,9 @@ type BenthosMonitorObservedState struct {
 	ServiceInfo *benthos_monitor.ServiceInfo
 
 	// Normally this would have also have an ObservedAgentConfig, but we don't need it here
+	
+	// ObservedMonitorConfig contains the actual monitor config from the running service
+	ObservedMonitorConfig config.BenthosMonitorConfig
 }
 
 // Ensure it implements the ObservedState interface.


### PR DESCRIPTION
## Summary

This PR fixes ENG-3383 where bridges were stuck in starting state due to healthcheck failures caused by port mismatches between Benthos services and their monitors.

## Problem

When Benthos services are updated and assigned new ports, the BenthosMonitor continues checking the old port, leading to permanent healthcheck failures. The monitor had no mechanism to detect configuration changes.

## Solution

Implemented `GetConfig` for BenthosMonitor following the S6 FSM pattern:
- Added `GetConfig` method to read current port from monitor script
- Detect config changes in `UpdateObservedStateOfInstance`
- Trigger removal/recreation when port changes are detected
- Comprehensive unit tests for all scenarios

## Changes

- **pkg/fsm/benthos_monitor/actions.go**: Added config change detection and recreation logic
- **pkg/fsm/benthos_monitor/models.go**: Added `ObservedMonitorConfig` field to track current config
- **pkg/service/benthos_monitor/benthos_monitor.go**: Implemented `GetConfig` method with regex-based port extraction
- **pkg/service/benthos_monitor/benthos_monitor_test.go**: Added comprehensive test coverage
- **pkg/service/benthos_monitor/mock.go**: Updated mock service with `GetConfig` support

## Testing

✅ All 31 existing tests pass
✅ Added 4 new test cases covering:
- Port extraction from various script formats
- Error handling for missing services
- Mock service behavior
- Edge cases (port 65535, invalid scripts)

## Pattern Compliance

This implementation follows the **S6 FSM pattern** for config change detection:
- Calls `Remove(ctx)` from `UpdateObservedStateOfInstance()` when config differs
- Lets the manager handle recreation with new config
- Maintains single-threaded FSM execution

## Linear Issue

Fixes: [ENG-3383](https://linear.app/united-manufacturing-hub/issue/ENG-3383/bridges-stuck-in-starting-state-due-to-healthcheck-failure)

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>