### PR TITLE
fix: add quotes to glob patterns in Snyk configuration

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -25,60 +25,61 @@ exclude:
       # Justification: This directory contains the legacy UMH Classic Kubernetes deployment
       # which is only supported for enterprise customers and is not under active development.
       # Security updates are handled through enterprise support channels only.
-      - deployment/**
+      - 'deployment/**'
 
       # Development and build tools - Non-production code
       # Justification: The tools directory contains development utilities, build scripts,
       # and testing tools that are not deployed to production environments. These are
       # internal development resources only.
-      - umh-core/tools/**
+      - 'umh-core/tools/**'
 
       # Third-party dependencies managed by package managers
       # Justification: Vendor directories are managed by Go modules and contain
       # third-party dependencies that are scanned at the module level
-      - **/vendor/**
+      - '**/vendor/**'
+      - 'umh-core/vendor/**'
 
       # Node.js dependencies
       # Justification: Node modules are scanned via package.json/package-lock.json
-      - node_modules/**
+      - 'node_modules/**'
 
       # Version control metadata
       # Justification: Git metadata does not contain executable code
-      - .git/**
-      - .github/**
+      - '.git/**'
+      - '.github/**'
 
       # Build artifacts and compiled binaries
       # Justification: These are generated files that are not source code.
       # Security scanning should focus on source code, not build outputs.
-      - dist/**
-      - build/**
-      - target/**
-      - out/**
-      - bin/**
+      - 'dist/**'
+      - 'build/**'
+      - 'target/**'
+      - 'out/**'
+      - 'bin/**'
 
       # Test and example code - Non-production
       # Justification: Test files and examples are not deployed to production.
       # They may contain intentionally vulnerable code for testing purposes.
-      - test/**
-      - tests/**
-      - examples/**
-      - integration/**
-      - e2e/**
+      - 'test/**'
+      - 'tests/**'
+      - 'examples/**'
+      - 'integration/**'
+      - 'e2e/**'
 
       # Documentation files - Non-executable
       # Justification: Documentation files do not contain executable code
-      - docs/**
-      - "*.md"
-      - LICENSE
-      - NOTICE
+      - 'docs/**'
+      - '*.md'
+      - 'LICENSE'
+      - 'NOTICE'
 
       # Auto-generated code files
       # Justification: These files are automatically generated from source definitions.
       # The source files that generate these should be scanned instead.
-      - "*.pb.go"        # Protocol buffer generated files
-      - "*_gen.go"       # Generic generated Go files
-      - "*.generated.go" # Explicitly marked generated files
-      - mock_*.go        # Mock files for testing
+      - '*.pb.go'        # Protocol buffer generated files
+      - '*_gen.go'       # Generic generated Go files
+      - '*.generated.go' # Explicitly marked generated files
+      - 'mock_*.go'      # Mock files for testing
 
 # Language-specific settings
 language-settings:


### PR DESCRIPTION
## Summary
- Fixed YAML parsing issues in Snyk configuration by adding quotes to glob patterns
- Reduced false positives from 44 issues to 2 actual source code issues
- Vendor directories are now properly excluded from security scanning

## Problem
The Snyk configuration file had unquoted glob patterns like `**/vendor/**` which caused YAML parsing errors. This prevented proper exclusion of vendor directories, resulting in Snyk scanning third-party dependencies and reporting 44 issues instead of just the 2 issues in our actual source code.

## Solution
Added quotes around all glob patterns in the `.snyk` exclude list to ensure proper YAML parsing:
- Changed `**/vendor/**` to `'**/vendor/**'`
- Applied quotes to all other glob patterns for consistency
- Added explicit `'umh-core/vendor/**'` exclusion for clarity

## Testing
Verified with `snyk code test`:
- **Before**: 44 issues (including vendor dependencies)
- **After**: 2 issues (only our source code)

The remaining 2 issues are legitimate findings in our codebase:
1. HIGH: Information exposure in `umh-core/pkg/sentry/strace.go:38`
2. MEDIUM: Insecure TLS configuration in `umh-core/pkg/communicator/api/v2/http/requester.go:73`

🤖 Generated with [Claude Code](https://claude.ai/code)