### PR TITLE
fix: use single quotes for secret to prevent variable expansion

### DIFF
--- a/.github/workflows/build-umh-core.yml
+++ b/.github/workflows/build-umh-core.yml
@@ -284,7 +284,7 @@ jobs:
         run: |
           set -euo pipefail
           VERSION="${{ github.ref_name }}"
-          SECRET="${{ secrets.UMH_MC_WEBHOOK_SECRET }}"
+          SECRET='${{ secrets.UMH_MC_WEBHOOK_SECRET }}'
 
           notify_mc() {
             local base_url=$1

--- a/.github/workflows/build-umh-core.yml
+++ b/.github/workflows/build-umh-core.yml
@@ -281,10 +281,12 @@ jobs:
       group: arc-runners-small
     steps:
       - name: Notify management console
+        env:
+          UMH_MC_WEBHOOK_SECRET: ${{ secrets.UMH_MC_WEBHOOK_SECRET }}
         run: |
           set -euo pipefail
           VERSION="${{ github.ref_name }}"
-          SECRET='${{ secrets.UMH_MC_WEBHOOK_SECRET }}'
+          SECRET="$UMH_MC_WEBHOOK_SECRET"
 
           notify_mc() {
             local base_url=$1


### PR DESCRIPTION
## Summary
- Fixed GitHub Actions workflow failing due to bash variable expansion in webhook secret
- Changed from double quotes to single quotes to prevent `$` characters in the secret from being interpreted as variables

## Problem
The `notify-management-console` job was failing with "unbound variable" errors because the webhook secret contains dollar signs (e.g., `$hDzSFUW`) that bash was trying to expand as variable references.

## Solution
Using single quotes instead of double quotes prevents bash from interpreting `$` as the start of a variable reference.

## Test Plan
- [ ] GitHub Actions workflow should complete successfully
- [ ] The `notify-management-console` job should run without "unbound variable" errors
- [ ] Management console should receive notifications as expected

## Linear Issue
Fixes: [ENG-3430](https://linear.app/united-manufacturing-hub/issue/ENG-3430)

🤖 Generated with [Claude Code](https://claude.ai/code)