### PR TITLE
fix: implement DirectoryHealth detection for S6 service self-healing

### DIFF
--- a/umh-core/internal/fsm/baseFSM.go
+++ b/umh-core/internal/fsm/baseFSM.go
@@ -248,12 +248,12 @@ func (s *BaseFSMInstance) SendEvent(ctx context.Context, eventName string, args 
 
 	// Execute the FSM transition with guaranteed time to complete
 	err := s.fsm.Event(fsmCtx, eventName, args...)
-	
+
 	// Check if parent context expired while we were executing
 	if err == nil && ctx.Err() != nil {
 		s.logger.Warnf("FSM transition completed successfully but parent context expired - prevented stuck transition but now outside of cycle time (preventing bigger impact)")
 	}
-	
+
 	if err != nil {
 		// Enhanced error message with state context
 		enhancedErr := fmt.Errorf("FSM %s failed transition: current_state='%s' -> event='%s' (desired_state='%s'): %w",
@@ -458,6 +458,7 @@ func (s *BaseFSMInstance) HandlePermanentError(
 		// and needs to be completely recreated.
 		s.SetCurrentFSMState(LifecycleStateRemoved)
 		logger.Infof("%s instance %s force removed and transitioned to removed state", s.cfg.ID, instanceID)
+
 		return err, true
 	} else {
 		// Not in a shutdown state yet, so try normal removal first

--- a/umh-core/internal/fsmtest/s6.go
+++ b/umh-core/internal/fsmtest/s6.go
@@ -320,6 +320,8 @@ func SetupS6Instance(
 	desiredState string,
 ) (*s6fsm.S6Instance, *s6service.MockService, string) {
 	mockService := s6service.NewMockService()
+	// Set MockExists to true so CheckServiceDirectoryIntegrity returns HealthOK
+	mockService.MockExists = true
 
 	// Create config
 	instanceConfig := CreateS6TestConfig(name, desiredState)

--- a/umh-core/pkg/fsm/benthos/actions.go
+++ b/umh-core/pkg/fsm/benthos/actions.go
@@ -53,7 +53,7 @@ import (
 func (b *BenthosInstance) logS6DirectoryState(ctx context.Context, trigger string) {
 	// Only log when S6FSMState is empty or shows problems
 	s6State := b.ObservedState.ServiceInfo.S6FSMState
-	if s6State != "" && s6State != "not existing" {
+	if s6State != "" && s6State != benthos_service.S6StateNotExisting {
 		return
 	}
 
@@ -166,7 +166,7 @@ func (b *BenthosInstance) logS6DirectoryState(ctx context.Context, trigger strin
 	}
 
 	// If we're in a problematic state, log additional context
-	if s6State == "" || s6State == "not existing" {
+	if s6State == "" || s6State == benthos_service.S6StateNotExisting {
 		// Log what files are actually present
 		if dirExists && isDir {
 			entries, err := os.ReadDir(servicePath)
@@ -500,7 +500,7 @@ func (b *BenthosInstance) IsBenthosS6Running() (bool, string) {
 		// Log diagnostic info when we encounter empty S6 state
 		b.logS6DirectoryState(context.Background(), "IsBenthosS6Running_empty_state")
 
-		currentState = "not existing"
+		currentState = benthos_service.S6StateNotExisting
 	}
 
 	return false, "s6 is not running, current state: " + currentState
@@ -525,7 +525,7 @@ func (b *BenthosInstance) IsBenthosS6Stopped() (bool, string) {
 		// Log diagnostic info when we encounter empty S6 state
 		b.logS6DirectoryState(context.Background(), "IsBenthosS6Stopped_empty_state")
 
-		fsmState = "not existing"
+		fsmState = benthos_service.S6StateNotExisting
 	case s6fsm.OperationalStateStopped:
 		return true, ""
 	}

--- a/umh-core/pkg/fsm/benthos/actions.go
+++ b/umh-core/pkg/fsm/benthos/actions.go
@@ -54,7 +54,7 @@ import (
 // logS6DirectoryState provides comprehensive diagnostic logging when S6 state is empty or problematic.
 // This helps troubleshoot "not existing" errors (ENG-3468) by capturing the full state of S6 directories.
 // This function spawns a short-lived goroutine for async logging to avoid blocking the reconciliation loop.
-func (b *BenthosInstance) logS6DirectoryState(ctx context.Context, trigger string) {
+func (b *BenthosInstance) logS6DirectoryState(trigger string) {
 	// Only log when S6FSMState is empty or shows problems
 	s6State := b.ObservedState.ServiceInfo.S6FSMState
 	if s6State != "" && s6State != benthos_service.S6StateNotExisting {
@@ -86,7 +86,7 @@ func (b *BenthosInstance) logS6DirectoryState(ctx context.Context, trigger strin
 	}
 
 	// Create a timeout context for the async logging goroutine to prevent leaks
-	logCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	logCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	
 	// Spawn short-lived goroutine for async diagnostic logging and Sentry reporting.
 	// This prevents blocking the reconciliation loop with I/O operations.
@@ -552,7 +552,7 @@ func (b *BenthosInstance) IsBenthosS6Running() (bool, string) {
 	currentState := b.ObservedState.ServiceInfo.S6FSMState
 	if currentState == "" {
 		// Log diagnostic info when we encounter empty S6 state
-		b.logS6DirectoryState(context.Background(), "IsBenthosS6Running_empty_state")
+		b.logS6DirectoryState("IsBenthosS6Running_empty_state")
 
 		currentState = benthos_service.S6StateNotExisting
 	}
@@ -577,7 +577,7 @@ func (b *BenthosInstance) IsBenthosS6Stopped() (bool, string) {
 	switch fsmState {
 	case "":
 		// Log diagnostic info when we encounter empty S6 state
-		b.logS6DirectoryState(context.Background(), "IsBenthosS6Stopped_empty_state")
+		b.logS6DirectoryState("IsBenthosS6Stopped_empty_state")
 
 		fsmState = benthos_service.S6StateNotExisting
 	case s6fsm.OperationalStateStopped:

--- a/umh-core/pkg/fsm/benthos/reconcile.go
+++ b/umh-core/pkg/fsm/benthos/reconcile.go
@@ -431,12 +431,12 @@ func (b *BenthosInstance) reconcileRunningStates(ctx context.Context, services s
 			b.baseFSMInstance.GetLogger().Debugf("S6 service stopped while in degraded state, attempting to restart")
 			
 			// Log diagnostic state before attempting restart
-			b.logS6DirectoryState(ctx, "degraded_before_restart")
+			b.logS6DirectoryState("degraded_before_restart")
 
 			err := b.StartInstance(ctx, services.GetFileSystem())
 			if err != nil {
 				// Log diagnostic state when restart fails
-				b.logS6DirectoryState(ctx, "degraded_restart_failed")
+				b.logS6DirectoryState("degraded_restart_failed")
 				b.ObservedState.ServiceInfo.BenthosStatus.StatusReason = fmt.Sprintf("degraded: failed to restart service: %v", err)
 
 				return err, false
@@ -482,7 +482,7 @@ func (b *BenthosInstance) reconcileTransitionToStopped(ctx context.Context, serv
 		if !isStopped {
 			// Log diagnostic info when stuck in stopping state
 			if strings.Contains(reason, benthos_service.S6StateNotExisting) {
-				b.logS6DirectoryState(ctx, "stopping_not_existing")
+				b.logS6DirectoryState("stopping_not_existing")
 			}
 			
 			b.ObservedState.ServiceInfo.BenthosStatus.StatusReason = "stopping: " + reason

--- a/umh-core/pkg/fsm/benthos/reconcile.go
+++ b/umh-core/pkg/fsm/benthos/reconcile.go
@@ -26,6 +26,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/metrics"
+	benthos_service "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/benthos"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/serviceregistry"
 	standarderrors "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/standarderrors"
 )
@@ -480,7 +481,7 @@ func (b *BenthosInstance) reconcileTransitionToStopped(ctx context.Context, serv
 	if currentState == OperationalStateStopping {
 		if !isStopped {
 			// Log diagnostic info when stuck in stopping state
-			if strings.Contains(reason, "not existing") {
+			if strings.Contains(reason, benthos_service.S6StateNotExisting) {
 				b.logS6DirectoryState(ctx, "stopping_not_existing")
 			}
 			

--- a/umh-core/pkg/fsm/benthos/reconcile.go
+++ b/umh-core/pkg/fsm/benthos/reconcile.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	internal_fsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/internal/fsm"
@@ -427,9 +428,14 @@ func (b *BenthosInstance) reconcileRunningStates(ctx context.Context, services s
 		s6Running, _ := b.IsBenthosS6Running()
 		if !s6Running {
 			b.baseFSMInstance.GetLogger().Debugf("S6 service stopped while in degraded state, attempting to restart")
+			
+			// Log diagnostic state before attempting restart
+			b.logS6DirectoryState(ctx, "degraded_before_restart")
 
 			err := b.StartInstance(ctx, services.GetFileSystem())
 			if err != nil {
+				// Log diagnostic state when restart fails
+				b.logS6DirectoryState(ctx, "degraded_restart_failed")
 				b.ObservedState.ServiceInfo.BenthosStatus.StatusReason = fmt.Sprintf("degraded: failed to restart service: %v", err)
 
 				return err, false
@@ -473,6 +479,11 @@ func (b *BenthosInstance) reconcileTransitionToStopped(ctx context.Context, serv
 	isStopped, reason := b.IsBenthosS6Stopped()
 	if currentState == OperationalStateStopping {
 		if !isStopped {
+			// Log diagnostic info when stuck in stopping state
+			if strings.Contains(reason, "not existing") {
+				b.logS6DirectoryState(ctx, "stopping_not_existing")
+			}
+			
 			b.ObservedState.ServiceInfo.BenthosStatus.StatusReason = "stopping: " + reason
 
 			return nil, false

--- a/umh-core/pkg/fsm/s6/actions.go
+++ b/umh-core/pkg/fsm/s6/actions.go
@@ -76,7 +76,10 @@ func (s *S6Instance) CreateInstance(ctx context.Context, filesystemService files
 	}
 	
 	if health == s6service.HealthUnknown {
-		return fmt.Errorf("service directory integrity unknown after creation for %s", s.baseFSMInstance.GetID())
+		// Return error to trigger retry via reconciliation backoff mechanism
+		// HealthUnknown indicates temporary I/O issues or timeouts that should resolve
+		// The FSM will retry this action with exponential backoff
+		return fmt.Errorf("service directory integrity unknown after creation for %s (temporary I/O issue, will retry)", s.baseFSMInstance.GetID())
 	}
 
 	s.baseFSMInstance.GetLogger().Debugf("S6 service %s directory structure created and verified", s.baseFSMInstance.GetID())

--- a/umh-core/pkg/fsm/s6/manager_mock.go
+++ b/umh-core/pkg/fsm/s6/manager_mock.go
@@ -65,6 +65,8 @@ func NewS6ManagerWithMockedServices(name string) *S6Manager {
 			mockService.ServiceStates[servicePath] = s6service.ServiceInfo{
 				Status: s6service.ServiceDown,
 			}
+			// Set MockExists to true so CheckServiceDirectoryIntegrity returns HealthOK
+			mockService.MockExists = true
 
 			// Setup mock to return the config we're setting
 			mockService.GetConfigResult = cfg.S6ServiceConfig

--- a/umh-core/pkg/fsm/s6/models.go
+++ b/umh-core/pkg/fsm/s6/models.go
@@ -75,6 +75,12 @@ type S6ObservedState struct {
 
 	// LastStateChange is the timestamp of the last observed state change
 	LastStateChange int64
+
+	// DirectoryHealth indicates the health of the S6 service directory
+	// HealthUnknown: I/O errors, timeouts, etc. (retry next tick)
+	// HealthOK: Service directory is healthy and complete
+	// HealthBad: Service directory is broken (triggers FSM transition)
+	DirectoryHealth s6svc.HealthStatus
 }
 
 // IsObservedState implements the ObservedState interface.

--- a/umh-core/pkg/fsm/s6/reconcile.go
+++ b/umh-core/pkg/fsm/s6/reconcile.go
@@ -332,7 +332,8 @@ func (s *S6Instance) reconcileTransitionToStopped(ctx context.Context, services 
 		// This prevents the FSM from getting stuck in "stopping" state when the directory
 		// is deleted while the service is stopping. Without this, IsS6Stopped() returns false
 		// because it can't read the service status from the missing directory.
-		// NOTE: This is a temporary fix until ENG-3473 is resolved (manager health awareness)
+		// TODO(ENG-3473): Remove this workaround once manager is health-aware and allows
+		// FSM-initiated self-healing without override conflicts
 		if s.IsS6Stopped() || s.ObservedState.DirectoryHealth == s6service.HealthBad {
 			if s.ObservedState.DirectoryHealth == s6service.HealthBad {
 				s.baseFSMInstance.GetLogger().Infof("Directory missing/corrupted while stopping - considering service stopped")

--- a/umh-core/pkg/service/benthos/errors.go
+++ b/umh-core/pkg/service/benthos/errors.go
@@ -16,6 +16,14 @@ package benthos
 
 import "errors"
 
+// S6StateNotExisting is the display string used when S6FSMState is empty.
+// This occurs when:
+//   - The service has been removed from S6 manager (returns ErrServiceNotExist)
+//   - The service directory is corrupted or missing
+//   - The service has never been created
+// This is used as a user-friendly representation of an undefined/empty S6 state.
+const S6StateNotExisting = "not existing"
+
 var (
 	// ErrServiceNotExist indicates the requested service does not exist.
 	ErrServiceNotExist = errors.New("service does not exist")

--- a/umh-core/pkg/service/s6/mock.go
+++ b/umh-core/pkg/service/s6/mock.go
@@ -264,3 +264,19 @@ func (m *MockService) EnsureSupervision(ctx context.Context, servicePath string,
 
 	return true, nil
 }
+
+// CheckServiceDirectoryIntegrity is a mock implementation that checks directory integrity.
+func (m *MockService) CheckServiceDirectoryIntegrity(ctx context.Context, servicePath string, fsService filesystem.Service) HealthStatus {
+	// If error mode is on, return HealthUnknown
+	if m.ErrorMode {
+		return HealthUnknown
+	}
+	
+	// If service doesn't exist, return HealthBad
+	if !m.MockExists {
+		return HealthBad
+	}
+	
+	// Default to HealthOK
+	return HealthOK
+}

--- a/umh-core/pkg/service/s6/s6.go
+++ b/umh-core/pkg/service/s6/s6.go
@@ -190,6 +190,9 @@ type Service interface {
 	// s6-svscan if it doesn't, to trigger supervision setup.
 	// Returns true if supervise directory exists (ready for supervision), false otherwise.
 	EnsureSupervision(ctx context.Context, servicePath string, fsService filesystem.Service) (bool, error)
+	// CheckServiceDirectoryIntegrity checks the integrity of the S6 service directory structure
+	// Returns HealthUnknown for I/O errors, HealthOK for intact structure, HealthBad for broken/missing directories
+	CheckServiceDirectoryIntegrity(ctx context.Context, servicePath string, fsService filesystem.Service) HealthStatus
 }
 
 // logState is the per-log-file cursor used by GetLogs.
@@ -435,10 +438,7 @@ func (s *DefaultService) Start(ctx context.Context, servicePath string, fsServic
 				// Continue anyway - s6-svc -u might still work
 			} else {
 				s.logger.Debugf("Removed down file %s", downFile)
-				// Update artifacts to remove the down file from tracking
-				if s.artifacts != nil {
-					s.removeFileFromArtifacts(downFile)
-				}
+				// Down files are not tracked in artifacts - see lifecycle.go:383
 			}
 		}
 	}
@@ -515,10 +515,7 @@ func (s *DefaultService) Stop(ctx context.Context, servicePath string, fsService
 			// Continue anyway - service is already stopped
 		} else {
 			s.logger.Debugf("Created down file %s", downFile)
-			// Update artifacts to track the down file
-			if s.artifacts != nil {
-				s.addFileToArtifacts(downFile)
-			}
+			// Down files are not tracked in artifacts - see lifecycle.go:383
 		}
 	}
 
@@ -637,6 +634,36 @@ func (s *DefaultService) ServiceExists(ctx context.Context, servicePath string, 
 	}
 
 	return true, nil
+}
+
+// CheckServiceDirectoryIntegrity checks the integrity of the S6 service directory structure.
+// It verifies that the service was properly created and has all required files.
+// Returns:
+// - HealthOK: Service directory structure is intact and valid
+// - HealthBad: Service directory is missing or corrupted
+// - HealthUnknown: Cannot determine health (no artifacts tracked or I/O errors).
+func (s *DefaultService) CheckServiceDirectoryIntegrity(ctx context.Context, servicePath string, fsService filesystem.Service) HealthStatus {
+	// If we have no artifacts tracked, we can't determine directory health
+	// This is expected in two cases:
+	// 1. Before Create() is called on a new instance
+	// 2. After agent restart when in-memory tracking is lost
+	// Return HealthUnknown to indicate we need more information
+	if s.artifacts == nil {
+		s.logger.Debugf("No artifacts tracked for service %s - directory integrity unknown", servicePath)
+		
+		return HealthUnknown
+	}
+	
+	// Delegate to CheckArtifactsHealth which validates all tracked files exist
+	health, err := s.CheckArtifactsHealth(ctx, s.artifacts, fsService)
+	if err != nil {
+		s.logger.Debugf("Error checking artifacts health for %s: %v", servicePath, err)
+		// CheckArtifactsHealth returns error for context cancellation or nil artifacts
+		// Both cases mean we can't determine health, so return Unknown
+		return HealthUnknown
+	}
+	
+	return health
 }
 
 // GetConfig gets the actual service config from s6.

--- a/umh-core/test/fsm/benthos/manager_test.go
+++ b/umh-core/test/fsm/benthos/manager_test.go
@@ -590,6 +590,8 @@ var _ = Describe("BenthosManager", func() {
 			myMockS6Svc.GetS6ConfigFileResult = []byte("logger:\n  level: info\n")
 			// we also return a stub S6ServiceConfig for GetConfig()
 			myMockS6Svc.GetConfigResult = s6Config
+			// Set MockExists to true so CheckServiceDirectoryIntegrity returns HealthOK
+			myMockS6Svc.MockExists = true
 
 			mockBenthosMonitorSvc := benthos_monitor_service.NewMockBenthosMonitorService()
 			mockBenthosMonitorMgr := benthos_monitor_fsm.NewBenthosMonitorManagerWithMockedService("rm-test-mgr", *mockBenthosMonitorSvc)
@@ -641,6 +643,9 @@ var _ = Describe("BenthosManager", func() {
 
 			innerMockS6Svc, ok := s6Inst.GetService().(*s6service.MockService)
 			Expect(ok).To(BeTrue(), "internal service is not a MockService")
+
+			// Set MockExists to true on the inner mock so CheckServiceDirectoryIntegrity returns HealthOK
+			innerMockS6Svc.MockExists = true
 
 			//----------------------------------------------------------------------
 			// 4. Hand the manager an *empty* Benthos section → instance must vanish

--- a/umh-core/test/fsm/redpanda/state_transition_monitor_test.go
+++ b/umh-core/test/fsm/redpanda/state_transition_monitor_test.go
@@ -188,6 +188,9 @@ var _ = Describe("RedpandaMonitor Service State Transitions", func() {
 			Status: s6service.ServiceDown,
 		}
 
+		// Set MockExists to true so CheckServiceDirectoryIntegrity returns HealthOK
+		mockS6Service.MockExists = true
+
 		// Create a mocked S6 manager with mocked services to prevent using real S6 functionality
 		mockedS6Manager := s6fsm.NewS6ManagerWithMockedServices("test-redpanda")
 


### PR DESCRIPTION
## Summary
This PR implements directory health detection for S6 services to automatically recover when service directories are missing or corrupted. This fixes the critical issue where FSMs get stuck in infinite loops showing "stopping: not existing" when S6 service directories are deleted or force-removed.

**Fixes:**
- [[ENG-3468](https://linear.app/united-manufacturing-hub/issue/ENG-3468)](https://linear.app/united-manufacturing-hub/issue/ENG-3468): Parent FSM stuck when S6 service returns empty string "not existing"
- [[ENG-3469](https://linear.app/united-manufacturing-hub/issue/ENG-3469)](https://linear.app/united-manufacturing-hub/issue/ENG-3469): Add S6 directory diagnostic logging for troubleshooting

## Context: The User-Visible Problem

Users are experiencing services stuck in states like:
- `"stopping: S6 is not stopped, current state: not existing"`
- Services showing green/active in UI while processes are actually dead
- Bridge FSMs stuck in "Starting" while underlying services are in "Stopping"

This creates a cascade of issues where services can't recover and require manual intervention.

## Investigation Journey & Experiments

### Experiment 1: Manual Directory Deletion
- Deleted individual files → Not detected
- Deleted supervise directory → Not detected
- Deleted entire service directory → Detected as "service does not exist" error
- **Finding**: No automatic recovery mechanism exists

### Experiment 2: Directory Deletion + State Change
- Deleted directory, then set desired state to stopped
- Result: UI stays green, but internally shows "fail to update observed state: service does not exist"
- When transitioning states: Gets stuck with "stopping: not existing"
- **Finding**: State transitions fail silently when directories are missing

### Experiment 3: Self-Healing Attempt
- Tried to make FSM self-remove when detecting bad directory
- **Discovery**: FSMs can't self-remove! Manager immediately overrides stop→running
- Created [[ENG-3473](https://linear.app/united-manufacturing-hub/issue/ENG-3473)](https://linear.app/united-manufacturing-hub/issue/ENG-3473) to track this architectural limitation

## Root Cause Analysis

The issue occurs through this sequence:
1. High system load causes status update failures (5x in a row)
2. System triggers force removal to clean up
3. Directory gets deleted but FSM remains in "running" state
4. User deploys new config or system tries to stop service
5. FSM enters "stopping" state but can't verify stop completion
6. Stuck in infinite loop: "not existing" error

## Solution Implementation

### 1. Directory Health Detection (Core Fix)
- Added `DirectoryHealth` field to S6ObservedState with three states:
  - `HealthOK`: All tracked files exist
  - `HealthBad`: Missing/corrupted directory
  - `HealthUnknown`: I/O errors or untracked state (e.g., after restart)
- Check integrity on every tick in `UpdateObservedStateOfInstance`
- Handle unhealthy directories based on current FSM state

### 2. Comprehensive Diagnostic Logging (ENG-3469)
- Added `logS6DirectoryState()` function that captures:
  - Directory structure (exists, supervise, status, run, down files)
  - Process state (PID, running status)
  - S6 service info (uptime, exit history, etc.)
  - FSM state context
- Triggers on: empty state, "not existing" errors, degraded state, stopping failures
- Performance optimized: Only logs during error conditions

### 3. Critical Bug Fixes Discovered

#### Config File Path Bug
```go
// BUG: Tracked with relative path
createdFiles = append(createdFiles, filepath.Join("config", originalPath))
// FIX: Track with absolute path
createdFiles = append(createdFiles, path)
```

#### Down File Tracking Issue
```go
// Down files are temporary control files - should NOT be tracked
// They're removed when starting, created when stopping
// After agent restart, missing down file ≠ unhealthy directory
```

#### artifacts==nil Interpretation
```go
// BUG: Returned HealthBad when artifacts==nil
// FIX: Return HealthUnknown (normal during init/restart)
```
## Testing Performed

### Cold Start Test ✅
- Services reach active in ~14s

### Restart Test ✅
- 5 transient errors (expected)
- Recovery within 2-3 cycles
- No false positives

### Missing File Detection ✅
- Correctly identifies missing files
- Comprehensive diagnostic logs
- ⚠️ Full recovery blocked by manager (ENG-3473)

## Known Limitations

**Manager Override Issue (ENG-3473)**
- FSM detects bad directory → sets state to "stopped"
- Manager sees config says "running" → forces back to running
- Creates ping-pong effect
- **Workaround**: For "stopping" state, we consider bad directory as successfully stopped

## Review Guide

1. **Start with models.go**: New DirectoryHealth field
2. **Then s6/lifecycle.go**: Down file management explanation (line 383+)
3. **Check s6/actions.go**: 
   - CreateInstance verification
   - UpdateObservedStateOfInstance changes
4. **Review s6/reconcile.go**: handleUnhealthyDirectory logic
5. **Finally benthos/**: Diagnostic logging implementation

## Related Issues
- Prerequisite for proper fix: [[ENG-3473](https://linear.app/united-manufacturing-hub/issue/ENG-3473)](https://linear.app/united-manufacturing-hub/issue/ENG-3473) (Manager health awareness)
- Load-related trigger: [[ENG-3417](https://linear.app/united-manufacturing-hub/issue/ENG-3417)](https://linear.app/united-manufacturing-hub/issue/ENG-3417) (Prevent force removal under load)
- Parent issue: [[ENG-3400](https://linear.app/united-manufacturing-hub/issue/ENG-3400)](https://linear.app/united-manufacturing-hub/issue/ENG-3400) (Grey state investigation)