### PR TITLE
fix: pin lefthook to v1.13.2 for Go 1.24 compatibility

### DIFF
--- a/umh-core/Makefile
+++ b/umh-core/Makefile
@@ -57,6 +57,7 @@ TARGETARCH := $(shell go env GOARCH)
 # Default values for go tools
 GINKGO_VERSION = v2.23.4
 NILWAY_VERSION = latest
+LEFTHOOK_VERSION = v1.13.2
 GOLANGCI_LINT_VERSION = v2.3.1
 BETTERALIGN_VERSION = v0.7.1
 DLV_VERSION = v1.25.1
@@ -87,7 +88,7 @@ install:
 	sudo chown vscode:vscode tmp || true
 	go install go.uber.org/nilaway/cmd/nilaway@$(NILWAY_VERSION)
 	go install github.com/onsi/ginkgo/v2/ginkgo@$(GINKGO_VERSION)
-	go install github.com/evilmartians/lefthook@latest
+	go install github.com/evilmartians/lefthook@$(LEFTHOOK_VERSION)
 	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 	go install github.com/dkorunic/betteralign/cmd/betteralign@$(BETTERALIGN_VERSION)
 


### PR DESCRIPTION
## Summary
- Pins lefthook to v1.13.2 to fix CI/CD pipeline failures
- Lefthook v1.13.3 (released today) requires Go >= 1.25, but our codebase uses Go 1.24.4
- Follows the same version management pattern as other tools in the Makefile

## Context
All CI/CD pipelines have been failing since 07:53 UTC today because lefthook v1.13.3 automatically gets installed due to `@latest` tag, but it requires Go >= 1.25 while we're using Go 1.24.4 for golangci-lint compatibility.

## Changes
- Added `LEFTHOOK_VERSION = v1.13.2` variable to Makefile
- Updated install command to use `$(LEFTHOOK_VERSION)` instead of `@latest`

## Linear Issue
Fixes ENG-3526

## Test Plan
- [x] Verified golangci-lint runs successfully
- [x] Verified go vet passes
- [ ] CI/CD pipeline should pass with this change

🤖 Generated with [Claude Code](https://claude.ai/code)