### PR TITLE
[ENG-3057] Bridge -  inject downsampler

### DIFF
--- a/umh-core/pkg/communicator/actions/get-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/get-protocolconverter.go
@@ -138,30 +138,7 @@ func determineProcessingMode(readDFC *models.ProtocolConverterDFC) string {
 		return "" // reply with empty string to indicate that no DFC is present
 	}
 
-	processors := readDFC.Pipeline.Processors
-
-	// If more than one processor, return custom
-	if len(processors) > 1 {
-		return "custom"
-	}
-
-	// If exactly one processor, check its type
-	if len(processors) == 1 {
-		// Get the first (and only) processor from the map
-		for _, processor := range processors {
-			switch processor.Type {
-			case "nodered_js":
-				return "nodered_js"
-			case "tag_processor":
-				return "tag_processor"
-			default:
-				return "custom"
-			}
-		}
-	}
-
-	// No processors found, fall back to custom
-	return "custom"
+	return constants.DetermineProcessorType(readDFC.Pipeline.Processors)
 }
 
 // determineProtocol analyzes the input processors to determine the protocol.

--- a/umh-core/pkg/constants/communicator.go
+++ b/umh-core/pkg/constants/communicator.go
@@ -1,0 +1,92 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package constants
+
+// these constants are used to make processors in communicator actions more applicable.
+const (
+	// nodered_js processor of benthos-umh, used for relational data.
+	RelationalProcessor = "nodered_js"
+	// tag_processor of benthos-umh, used for timeseries data.
+	TimeseriesProcessor = "tag_processor"
+)
+
+// DetermineProcessorType returns the processor of the according category.
+func DetermineProcessorType(processors any) string {
+	switch p := processors.(type) {
+	// case for the communicator-actions
+	case map[string]struct{ Type, Data string }:
+		if len(p) != 1 {
+			return "custom"
+		}
+
+		for _, processor := range p {
+			switch processor.Type {
+			case TimeseriesProcessor:
+				return TimeseriesProcessor
+			case RelationalProcessor:
+				return RelationalProcessor
+			default:
+				return "custom"
+			}
+		}
+
+	// case for appending downsampler
+	case []any:
+		hasTagProcessor := false
+		hasOtherProcessors := false
+
+		for _, proc := range p {
+			procMap, ok := proc.(map[string]any)
+			if !ok {
+				continue
+			}
+
+			// Check what type of processor this is
+			for key := range procMap {
+				if key == TimeseriesProcessor {
+					hasTagProcessor = true
+				} else if key != "downsampler" {
+					hasOtherProcessors = true
+				}
+
+				break
+			}
+		}
+
+		if hasTagProcessor {
+			return TimeseriesProcessor
+		}
+
+		if len(p) == 1 && hasOtherProcessors {
+			procMap, ok := p[0].(map[string]any)
+			if ok {
+				for key := range procMap {
+					if key == RelationalProcessor {
+						return RelationalProcessor
+					}
+
+					break
+				}
+			}
+		}
+
+		return "custom"
+
+	default:
+		return "custom"
+	}
+
+	return "custom"
+}

--- a/umh-core/pkg/constants/communicator.go
+++ b/umh-core/pkg/constants/communicator.go
@@ -16,10 +16,17 @@ package constants
 
 // these constants are used to make processors in communicator actions more applicable.
 const (
-	// nodered_js processor of benthos-umh, used for relational data.
+	// RelationalProcessor is the benthos-umh processor for relational data, currently nodered_js.
 	RelationalProcessor = "nodered_js"
-	// tag_processor of benthos-umh, used for timeseries data.
+
+	// TimeseriesProcessor is the benthos-umh processor for timeseries data, currently the tag_processor.
 	TimeseriesProcessor = "tag_processor"
+
+	// DownsamplerProcessor is the benthos-umh processor for the downsampler.
+	DownsamplerProcessor = "downsampler"
+
+	// CustomProcessor is a custom processing set of benthos-umh processors.
+	CustomProcessor = "custom"
 )
 
 // DetermineProcessorType returns the processor of the according category.
@@ -28,7 +35,7 @@ func DetermineProcessorType(processors any) string {
 	// case for the communicator-actions
 	case map[string]struct{ Type, Data string }:
 		if len(p) != 1 {
-			return "custom"
+			return CustomProcessor
 		}
 
 		for _, processor := range p {
@@ -38,7 +45,7 @@ func DetermineProcessorType(processors any) string {
 			case RelationalProcessor:
 				return RelationalProcessor
 			default:
-				return "custom"
+				return CustomProcessor
 			}
 		}
 
@@ -57,7 +64,7 @@ func DetermineProcessorType(processors any) string {
 			for key := range procMap {
 				if key == TimeseriesProcessor {
 					hasTagProcessor = true
-				} else if key != "downsampler" {
+				} else if key != DownsamplerProcessor {
 					hasOtherProcessors = true
 				}
 
@@ -82,11 +89,11 @@ func DetermineProcessorType(processors any) string {
 			}
 		}
 
-		return "custom"
+		return CustomProcessor
 
 	default:
-		return "custom"
+		return CustomProcessor
 	}
 
-	return "custom"
+	return CustomProcessor
 }

--- a/umh-core/pkg/service/protocolconverter/runtime_config/runtime_config.go
+++ b/umh-core/pkg/service/protocolconverter/runtime_config/runtime_config.go
@@ -324,7 +324,7 @@ func appendDownsampler(dfc dataflowcomponentserviceconfig.DataflowComponentServi
 	}
 
 	defaultDownsampler := map[string]any{
-		"downsampler": map[string]any{}, // Empty config - reads from metadata
+		constants.DownsamplerProcessor: map[string]any{}, // Empty config - reads from metadata
 	}
 
 	processors = append(processors, defaultDownsampler)
@@ -359,7 +359,7 @@ func getProcessors(pipeline map[string]any) []any {
 func hasDownsampler(processors []any) bool {
 	for _, proc := range processors {
 		if procMap, ok := proc.(map[string]any); ok {
-			if _, hasDownsampler := procMap["downsampler"]; hasDownsampler {
+			if _, hasDownsampler := procMap[constants.DownsamplerProcessor]; hasDownsampler {
 				return true
 			}
 		}

--- a/umh-core/pkg/service/protocolconverter/runtime_config/runtime_config.go
+++ b/umh-core/pkg/service/protocolconverter/runtime_config/runtime_config.go
@@ -295,8 +295,13 @@ func renderConfig(
 		return protocolconverterserviceconfig.ProtocolConverterServiceConfigRuntime{}, err
 	}
 
-	// the downsampler will be appended only for timeseries data
-	read = appendDownsampler(read)
+	processors := getProcessors(read.BenthosConfig.Pipeline)
+
+	dataType := constants.DetermineDataType(processors)
+	if dataType == constants.TimeseriesData {
+		// the downsampler will be appended only for timeseries data
+		read = appendDownsampler(read)
+	}
 
 	write, err := config.RenderTemplate(spec.GetDFCWriteServiceConfig(), scope)
 	if err != nil {
@@ -313,15 +318,6 @@ func renderConfig(
 // appendDownsampler appends a downsampler as the last processor if one doesn't already exist.
 func appendDownsampler(dfc dataflowcomponentserviceconfig.DataflowComponentServiceConfig) dataflowcomponentserviceconfig.DataflowComponentServiceConfig {
 	processors := getProcessors(dfc.BenthosConfig.Pipeline)
-
-	processorType := constants.DetermineProcessorType(processors)
-	if processorType != constants.TimeseriesProcessor {
-		return dfc
-	}
-
-	if hasDownsampler(processors) {
-		return dfc // User has already configured downsampling
-	}
 
 	defaultDownsampler := map[string]any{
 		constants.DownsamplerProcessor: map[string]any{}, // Empty config - reads from metadata
@@ -353,17 +349,4 @@ func getProcessors(pipeline map[string]any) []any {
 	}
 
 	return []any{}
-}
-
-// hasDownsampler checks if any processor in the pipeline is a downsampler.
-func hasDownsampler(processors []any) bool {
-	for _, proc := range processors {
-		if procMap, ok := proc.(map[string]any); ok {
-			if _, hasDownsampler := procMap[constants.DownsamplerProcessor]; hasDownsampler {
-				return true
-			}
-		}
-	}
-
-	return false
 }


### PR DESCRIPTION
#### Description:
This PR should make sure that the `downsampler` is added by default to the bridges processor-configuration.
It must ensure that the downsampler is always the last processor and every bridge consists in its pipeline of it.

This should be done via the runtime_config package, where we resolve the templating and transform the different configuration specs.