### PR TITLE
chore: bump benthos-umh to v0.11.3

### DIFF
--- a/umh-core/Makefile
+++ b/umh-core/Makefile
@@ -69,7 +69,7 @@ NMAP_VERSION = 7.97-r0
 S6_OVERLAY_VERSION = 3.2.0.2
 REDPANDA_VERSION = 24.3.8
 ## Benthos version is a tag or a sha-<commit hash> (e.g. 0.9.4 or sha-a51a685) to be used in the docker image
-BENTHOS_UMH_VERSION = 0.11.2
+BENTHOS_UMH_VERSION = 0.11.3
 BUF_VERSION = 1.55.1
 PROTOC_GEN_GO_VERSION = 1.36.6
 

--- a/umh-core/pkg/config/manager.go
+++ b/umh-core/pkg/config/manager.go
@@ -1107,6 +1107,7 @@ func (m *FileConfigManager) WriteYAMLConfigFromString(ctx context.Context, confi
 		m.cacheRawConfig = ""
 		m.cacheError = err
 		m.cacheMu.Unlock()
+
 		return fmt.Errorf("failed to parse new config for cache update: %w", err)
 	}
 


### PR DESCRIPTION
## Summary
- Bumps benthos-umh from v0.11.2 to v0.11.3 to include pre-sanitized metadata fields for SparkplugB processing
- Required for updating the Management Console's default SparkplugB template (ENG-3502)

## Context
This dependency update adds the following pre-sanitized metadata fields that were implemented in [benthos-umh PR #208](https://github.com/united-manufacturing-hub/benthos-umh/pull/208):
- `spb_group_id_sanitized` - Group ID with special chars replaced
- `spb_edge_node_id_sanitized` - Edge node ID sanitized  
- `spb_device_id_sanitized` - Device ID sanitized
- `spb_metric_name_sanitized` - Metric name sanitized
- `spb_device_key_sanitized` - Device key sanitized

These fields simplify UMH topic construction in user-defined processing by providing alphanumeric versions of SparkplugB metadata fields, eliminating the need for custom sanitization functions.

## Changes
- Updated `BENTHOS_UMH_VERSION` in Makefile from `0.11.2` to `0.11.3`

## Testing
- ✅ Build successful (`make build`)
- ✅ Unit tests passing (`make unit-test`)
- ✅ Linting checks passing (`golangci-lint run`, `go vet ./...`)

## Linear Issues
- Closes: [ENG-3530](https://linear.app/united-manufacturing-hub/issue/ENG-3530/bump-benthos-umh-to-v0113-for-sparkplugb-sanitized-metadata)
- Blocks: [ENG-3502](https://linear.app/united-manufacturing-hub/issue/ENG-3502/update-sparkplugb-default-template-to-document-new-sanitized-metadata)
- Related: [ENG-3496](https://linear.app/united-manufacturing-hub/issue/ENG-3496/sparkplugb-default-processing-not-generating-expected-hierarchical)

🤖 Generated with [Claude Code](https://claude.ai/code)