### PR TITLE
feat: update status reason strings and documentation to new terminology (ENG-3541)

### DIFF
--- a/umh-core/docs/reference/state-machines.md
+++ b/umh-core/docs/reference/state-machines.md
@@ -15,38 +15,38 @@ Each component inherits lifecycle states (`to_be_created`, `creating`, `removing
 
 ## 1 — Redpanda Service
 
-| State           | Verified | What it means                                                                         | How it is entered                                     | How it leaves                                                                        |
-| --------------- | -------- | ------------------------------------------------------------------------------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| **stopped**     | ✅        | `redpanda` process not running.                                                       | *stop\_done* from **stopping**, or initial create.    | *start* → **starting**                                                               |
-| *starting*      | ✅        | S6 launching broker; health checks pending.                                           | *start* event from **stopped**.                       | *start\_done* → **idle**<br>*start\_failed* → **stopped**                            |
-| **idle**        | ✅        | Broker healthy, **no data for 30 s** (default idle window).                           | *start\_done* or *no\_data\_timeout* from **active**. | *data\_received* → **active**<br>*degraded* → **degraded**<br>*stop* → **stopping**  |
-| **active**      | ✅        | Broker healthy & `BytesIn/OutPerSec` > 0.                                             | *data\_received* from **idle**.                       | *no\_data\_timeout* → **idle**<br>*degraded* → **degraded**<br>*stop* → **stopping** |
-| ⚠️ **degraded** | ✅        | Broker running but ≥1 health‑check failing (`disk-space-low`, `cpu-saturated`, etc.). | *degraded* from **idle/active**.                      | *recovered* → **idle**<br>*stop* → **stopping**                                      |
-| *stopping*      | ✅        | Graceful shutdown (draining clients).                                                 | *stop* from any running state.                        | *stop\_done* → **stopped**                                                           |
+| State           | What it means                                                                         | How it is entered                                     | How it leaves                                                                        |
+| --------------- | ------------------------------------------------------------------------------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| **stopped**     | `redpanda` process not running.                                                       | *stop\_done* from **stopping**, or initial create.    | *start* → **starting**                                                               |
+| *starting*      | S6 launching broker; health checks pending.                                           | *start* event from **stopped**.                       | *start\_done* → **idle**<br>*start\_failed* → **stopped**                            |
+| **idle**        | Broker healthy, **no data for 30 s** (default idle window).                           | *start\_done* or *no\_data\_timeout* from **active**. | *data\_received* → **active**<br>*degraded* → **degraded**<br>*stop* → **stopping**  |
+| **active**      | Broker healthy & `BytesIn/OutPerSec` > 0.                                             | *data\_received* from **idle**.                       | *no\_data\_timeout* → **idle**<br>*degraded* → **degraded**<br>*stop* → **stopping** |
+| ⚠️ **degraded** | Broker running but ≥1 health‑check failing (`disk-space-low`, `cpu-saturated`, etc.). | *degraded* from **idle/active**.                      | *recovered* → **idle**<br>*stop* → **stopping**                                      |
+| *stopping*      | Graceful shutdown (draining clients).                                                 | *stop* from any running state.                        | *stop\_done* → **stopped**                                                           |
 
 ---
 
 ## 2 — Container Monitor
 
-| State                | Verified | Meaning                                    | Enter trigger                                                    | Exit trigger                                       |
-| -------------------- | -------- | ------------------------------------------ | ---------------------------------------------------------------- | -------------------------------------------------- |
-| **active**           | ✅        | CPU < 85 %, RAM < 90 %, Disk < 90 %.       | *metrics\_all\_ok* after monitor start **or** from **degraded**. | *metrics\_not\_ok* → **degraded**                  |
-| ⚠️ **degraded**      | ✅        | One of the above limits breached for 15 s. | *metrics\_not\_ok*                                               | *metrics\_all\_ok* → **active**                    |
-| monitoring\_stopped  | ✅        | Watchdog disabled.                         | *stop\_monitoring\_done*                                         | *start\_monitoring* → monitoring\_starting         |
-| monitoring\_starting | ✅        | Monitor service booting.                   | *start\_monitoring*                                              | *start\_monitoring\_done* → **degraded** (initial) |
-| monitoring\_stopping | ✅        | Monitor shutting down.                     | *stop\_monitoring*                                               | *stop\_monitoring\_done* → monitoring\_stopped     |
+| State                | Meaning                                    | Enter trigger                                                    | Exit trigger                                       |
+| -------------------- | ------------------------------------------ | ---------------------------------------------------------------- | -------------------------------------------------- |
+| **active**           | CPU < 85 %, RAM < 90 %, Disk < 90 %.       | *metrics\_all\_ok* after monitor start **or** from **degraded**. | *metrics\_not\_ok* → **degraded**                  |
+| ⚠️ **degraded**      | One of the above limits breached for 15 s. | *metrics\_not\_ok*                                               | *metrics\_all\_ok* → **active**                    |
+| monitoring\_stopped  | Watchdog disabled.                         | *stop\_monitoring\_done*                                         | *start\_monitoring* → monitoring\_starting         |
+| monitoring\_starting | Monitor service booting.                   | *start\_monitoring*                                              | *start\_monitoring\_done* → **degraded** (initial) |
+| monitoring\_stopping | Monitor shutting down.                     | *stop\_monitoring*                                               | *stop\_monitoring\_done* → monitoring\_stopped     |
 
 ---
 
 ## 3 — Agent Monitor
 
-| State                | Verified | Meaning                                      | Enter                    | Exit                                               |
-| -------------------- | -------- | -------------------------------------------- | ------------------------ | -------------------------------------------------- |
-| **active**           | ✅        | Agent connected & internal tasks OK.         | *metrics\_all\_ok*       | *metrics\_not\_ok* → **degraded**                  |
-| ⚠️ **degraded**      | ✅        | Cloud unreachable / auth error / task panic. | *metrics\_not\_ok*       | *metrics\_all\_ok* → **active**                    |
-| monitoring\_stopped  | ✅        | Agent health monitor off.                    | *stop\_monitoring\_done* | *start\_monitoring* → monitoring\_starting         |
-| monitoring\_starting | ✅        | Starting health checks.                      | *start\_monitoring*      | *start\_monitoring\_done* → **degraded** (initial) |
-| monitoring\_stopping | ✅        | Halting checks.                              | *stop\_monitoring*       | *stop\_monitoring\_done* → monitoring\_stopped     |
+| State                | Meaning                                      | Enter                    | Exit                                               |
+| -------------------- | -------------------------------------------- | ------------------------ | -------------------------------------------------- |
+| **active**           | Agent connected & internal tasks OK.         | *metrics\_all\_ok*       | *metrics\_not\_ok* → **degraded**                  |
+| ⚠️ **degraded**      | Cloud unreachable / auth error / task panic. | *metrics\_not\_ok*       | *metrics\_all\_ok* → **active**                    |
+| monitoring\_stopped  | Agent health monitor off.                    | *stop\_monitoring\_done* | *start\_monitoring* → monitoring\_starting         |
+| monitoring\_starting | Starting health checks.                      | *start\_monitoring*      | *start\_monitoring\_done* → **degraded** (initial) |
+| monitoring\_stopping | Halting checks.                              | *stop\_monitoring*       | *stop\_monitoring\_done* → monitoring\_stopped     |
 
 ---
 
@@ -54,46 +54,46 @@ Each component inherits lifecycle states (`to_be_created`, `creating`, `removing
 
 ### Aggregate Bridge FSM
 
-| State                              | Verified | Meaning                                                      | Status Reason Examples                                           | Enter                                            | Exit                                                                                           |
-| ---------------------------------- | -------- | ------------------------------------------------------------ | ---------------------------------------------------------------- | ------------------------------------------------ | ---------------------------------------------------------------------------------------------- |
-| **stopped**                        | ✅        | All sub‑services stopped.                                    | `"stopped"`                                                      | *stop\_done* or after create.                    | *start* → **starting\_connection**                                                             |
-| *starting\_connection*             | ✅        | Waiting for connection to establish.                         | `"starting: waiting for connection"`                            | *start*                                          | *start\_connection\_up* → **starting\_redpanda**                                               |
-| *starting\_redpanda*                | ✅        | Connection up, waiting for message broker.                   | `"starting: redpanda not healthy"`                              | *start\_connection\_up*                          | *start\_redpanda\_up* → **starting\_dfc**                                                      |
-| *starting\_dfc*                     | ✅        | Connection + Redpanda up, waiting for flow.                  | `"starting: flow not running"`                                  | *start\_redpanda\_up*                            | *start\_dfc\_up* → **idle**<br>*start\_failed\_dfc\_missing* → **starting\_failed\_dfc\_missing** |
-| **starting\_failed\_dfc**           | ✅        | Flow component failed to start.                              | `"starting failed: flow in error state"`                        | *start\_failed\_dfc*                             | Manual retry or removal                                                                       |
-| **starting\_failed\_dfc\_missing**   | ✅        | No flow configured.                                          | `"starting failed: no flows configured"`                        | *start\_failed\_dfc\_missing*                    | *start\_retry* (when flow added) or removal                                                   |
-| **idle**                           | ✅        | All healthy, **no data for 30 s**.                           | `"idling: no messages processed in 60s"`                        | *start\_dfc\_up*, *no\_data\_timeout*, *recovered* | *data\_received* → **active**<br>*degraded* events → **degraded\_***<br>*stop* → **stopping**   |
-| **active**                         | ✅        | Processing data through flows.                               | `""` (empty when fully healthy)                                 | *data\_received*                                 | *no\_data\_timeout* → **idle**<br>*degraded* events → **degraded\_***<br>*stop* → **stopping**   |
-| ⚠️ **degraded\_connection**        | ✅        | Connection lost/flaky after successful start.                | `"connection degraded: probe timeout after 30s"`                | *connection\_unhealthy*                          | *recovered* → **idle**<br>*stop* → **stopping**                                               |
-| ⚠️ **degraded\_redpanda**          | ✅        | Message broker issues after successful start.                | `"redpanda degraded: not responding"`                           | *redpanda\_degraded*                             | *recovered* → **idle**<br>*stop* → **stopping**                                               |
-| ⚠️ **degraded\_dfc**               | ✅        | Flow component issues after successful start.                | `"flow degraded: benthos service not running"`                  | *dfc\_degraded*                                  | *recovered* → **idle**<br>*stop* → **stopping**                                               |
-| ⚠️ **degraded\_other**             | ✅        | Inconsistent component states detected.                      | `"other degraded: inconsistent states"`                         | *degraded\_other*                                | *recovered* → **idle**<br>*stop* → **stopping**                                               |
-| *stopping*                         | ✅        | Stopping all components.                                     | `"stopping"`                                                     | *stop*                                           | *stop\_done* → **stopped**                                                                     |
+| State                              | Meaning                                                      | Status Reason Examples                                           | Enter                                            | Exit                                                                                           |
+| ---------------------------------- | ------------------------------------------------------------ | ---------------------------------------------------------------- | ------------------------------------------------ | ---------------------------------------------------------------------------------------------- |
+| **stopped**                        | All sub‑services stopped.                                    | `"stopped"`                                                      | *stop\_done* or after create.                    | *start* → **starting\_connection**                                                             |
+| *starting\_connection*             | Waiting for connection to establish.                         | `"starting: waiting for connection"`                            | *start*                                          | *start\_connection\_up* → **starting\_redpanda**                                               |
+| *starting\_redpanda*                | Connection up, waiting for message broker.                   | `"starting: redpanda not healthy"`                              | *start\_connection\_up*                          | *start\_redpanda\_up* → **starting\_dfc**                                                      |
+| *starting\_dfc*                     | Connection + Redpanda up, waiting for flow.                  | `"starting: flow not running"`                                  | *start\_redpanda\_up*                            | *start\_dfc\_up* → **idle**<br>*start\_failed\_dfc\_missing* → **starting\_failed\_dfc\_missing** |
+| **starting\_failed\_dfc**           | Flow component failed to start.                              | `"starting failed: flow in error state"`                        | *start\_failed\_dfc*                             | Manual retry or removal                                                                       |
+| **starting\_failed\_dfc\_missing**   | No flow configured.                                          | `"starting failed: no flows configured"`                        | *start\_failed\_dfc\_missing*                    | *start\_retry* (when flow added) or removal                                                   |
+| **idle**                           | All healthy, **no data for 30 s**.                           | `"idling: no messages processed in 60s"`                        | *start\_dfc\_up*, *no\_data\_timeout*, *recovered* | *data\_received* → **active**<br>*degraded* events → **degraded\_***<br>*stop* → **stopping**   |
+| **active**                         | Processing data through flows.                               | `""` (empty when fully healthy)                                 | *data\_received*                                 | *no\_data\_timeout* → **idle**<br>*degraded* events → **degraded\_***<br>*stop* → **stopping**   |
+| ⚠️ **degraded\_connection**        | Connection lost/flaky after successful start.                | `"connection degraded: probe timeout after 30s"`                | *connection\_unhealthy*                          | *recovered* → **idle**<br>*stop* → **stopping**                                               |
+| ⚠️ **degraded\_redpanda**          | Message broker issues after successful start.                | `"redpanda degraded: not responding"`                           | *redpanda\_degraded*                             | *recovered* → **idle**<br>*stop* → **stopping**                                               |
+| ⚠️ **degraded\_dfc**               | Flow component issues after successful start.                | `"flow degraded: benthos service not running"`                  | *dfc\_degraded*                                  | *recovered* → **idle**<br>*stop* → **stopping**                                               |
+| ⚠️ **degraded\_other**             | Inconsistent component states detected.                      | `"other degraded: inconsistent states"`                         | *degraded\_other*                                | *recovered* → **idle**<br>*stop* → **stopping**                                               |
+| *stopping*                         | Stopping all components.                                     | `"stopping"`                                                     | *stop*                                           | *stop\_done* → **stopped**                                                                     |
 
 ### 4.1 Connection Service FSM
 
-| State           | Verified | Meaning                         |
-| --------------- | -------- | ------------------------------- |
-| *starting*      | ✅        | Probe service launching.        |
-| **up**          | ✅        | Target reachable.               |
-| **down**        | ✅        | Target unreachable.             |
-| ⚠️ **degraded** | ✅        | Flaky / intermittent responses. |
-| *stopping*      | ✅        | Probe shutting down.            |
-| **stopped**     | ✅        | Probe disabled.                 |
+| State           | Meaning                         |
+| --------------- | ------------------------------- |
+| *starting*      | Probe service launching.        |
+| **up**          | Target reachable.               |
+| **down**        | Target unreachable.             |
+| ⚠️ **degraded** | Flaky / intermittent responses. |
+| *stopping*      | Probe shutting down.            |
+| **stopped**     | Probe disabled.                 |
 
 ### 4.2 Benthos Flow (Source /Sink)
 
-| State                                                  | Verified | Meaning                                                |
-| ------------------------------------------------------ | -------- | ------------------------------------------------------ |
-| **stopped**                                            | ✅        | Service file present, process not running.             |
-| *starting*                                             | ✅        | S6 launched process.                                   |
-| *starting\_config\_loading*                            | ✅        | Benthos parsing YAML pipeline.                         |
-| *starting\_waiting\_for\_healthchecks*                 | ✅        | Pipeline loaded; waiting for plugin health.            |
-| *starting\_waiting\_for\_service\_to\_remain\_running* | ✅        | Stability grace period.                                |
-| **idle**                                               | ✅        | Flow running, no msgs for idle window.                 |
-| **active**                                             | ✅        | Processing messages.                                   |
-| ⚠️ **degraded**                                        | ✅        | Flow running but error state (e.g., endpoint retries). |
-| *stopping*                                             | ✅        | Graceful SIGTERM underway.                             |
+| State                                                  | Meaning                                                |
+| ------------------------------------------------------ | ------------------------------------------------------ |
+| **stopped**                                            | Service file present, process not running.             |
+| *starting*                                             | S6 launched process.                                   |
+| *starting\_config\_loading*                            | Benthos parsing YAML pipeline.                         |
+| *starting\_waiting\_for\_healthchecks*                 | Pipeline loaded; waiting for plugin health.            |
+| *starting\_waiting\_for\_service\_to\_remain\_running* | Stability grace period.                                |
+| **idle**                                               | Flow running, no msgs for idle window.                 |
+| **active**                                             | Processing messages.                                   |
+| ⚠️ **degraded**                                        | Flow running but error state (e.g., endpoint retries). |
+| *stopping*                                             | Graceful SIGTERM underway.                             |
 
 > **Idle/Active timeout:** default 30 s (`BRIDGE_IDLE_WINDOW`).
 
@@ -103,17 +103,17 @@ Each component inherits lifecycle states (`to_be_created`, `creating`, `removing
 
 The Topic Browser service manages real-time topic discovery and caching.
 
-| State | Verified | Description | Enter Trigger | Exit Trigger |
-|-------|----------|-------------|---------------|--------------|
-| **stopped** | ✅ | Service not running | Initial state or *stop_done* | *start* → **starting** |
-| *starting* | ✅ | Service initialization | *start* | *benthos_started* → **starting_benthos** |
-| *starting_benthos* | ✅ | Benthos starting | *benthos_started* | *redpanda_started* → **starting_redpanda** |
-| *starting_redpanda* | ✅ | Redpanda connection | *redpanda_started* | *start_done* → **idle** |
-| **idle** | ✅ | Healthy, no active data | *start_done* or *recovered* | *data_received* → **active** |
-| **active** | ✅ | Processing topic data | *data_received* | *no_data_timeout* → **idle** |
-| ⚠️ **degraded_benthos** | ✅ | Benthos degraded | *benthos_degraded* | *recovered* → **idle** |
-| ⚠️ **degraded_redpanda** | ✅ | Redpanda degraded | *redpanda_degraded* | *recovered* → **idle** |
-| *stopping* | ✅ | Graceful shutdown | *stop* | *stop_done* → **stopped** |
+| State | Description | Enter Trigger | Exit Trigger |
+|-------|-------------|---------------|--------------|
+| **stopped** | Service not running | Initial state or *stop_done* | *start* → **starting** |
+| *starting* | Service initialization | *start* | *benthos_started* → **starting_benthos** |
+| *starting_benthos* | Benthos starting | *benthos_started* | *redpanda_started* → **starting_redpanda** |
+| *starting_redpanda* | Redpanda connection | *redpanda_started* | *start_done* → **idle** |
+| **idle** | Healthy, no active data | *start_done* or *recovered* | *data_received* → **active** |
+| **active** | Processing topic data | *data_received* | *no_data_timeout* → **idle** |
+| ⚠️ **degraded_benthos** | Benthos degraded | *benthos_degraded* | *recovered* → **idle** |
+| ⚠️ **degraded_redpanda** | Redpanda degraded | *redpanda_degraded* | *recovered* → **idle** |
+| *stopping* | Graceful shutdown | *stop* | *stop_done* → **stopped** |
 
 **Default:** Active (runs automatically)  
 **Transitions:** idle ↔ active based on topic activity  

--- a/umh-core/docs/reference/state-machines.md
+++ b/umh-core/docs/reference/state-machines.md
@@ -6,7 +6,7 @@
 
 UMH Core uses hierarchical state machines where components build upon each other:
 
-- **Bridge** = Connection + Source Flow + Sink Flow
+- **Bridge** = Connection + Read Flow + Write Flow
 - **Flow** = Benthos instance with lifecycle management  
 - **Benthos Flow** = Individual Benthos process with detailed startup phases
 - **Connection** = Network probe service (typically nmap-based)

--- a/umh-core/pkg/fsm/protocolconverter/actions.go
+++ b/umh-core/pkg/fsm/protocolconverter/actions.go
@@ -63,7 +63,7 @@ import (
 // already configured when this function returns – they will be updated in
 // the next reconciliation cycle.
 func (p *ProtocolConverterInstance) CreateInstance(ctx context.Context, filesystemService filesystem.Service) error {
-	p.baseFSMInstance.GetLogger().Debugf("Starting Action: Adding ProtocolConverter service %s to flow and Connection manager ...", p.baseFSMInstance.GetID())
+	p.baseFSMInstance.GetLogger().Debugf("Starting Action: Adding bridge %s to flow and Connection manager ...", p.baseFSMInstance.GetID())
 
 	// AddToManager intentionally receives an empty runtime config because template
 	// rendering requires SystemSnapshot data not available at creation time.
@@ -71,15 +71,15 @@ func (p *ProtocolConverterInstance) CreateInstance(ctx context.Context, filesyst
 	err := p.service.AddToManager(ctx, filesystemService, &p.runtimeConfig, p.baseFSMInstance.GetID())
 	if err != nil {
 		if errors.Is(err, protocolconvertersvc.ErrServiceAlreadyExists) {
-			p.baseFSMInstance.GetLogger().Debugf("ProtocolConverter service %s already exists in flow and Connection manager", p.baseFSMInstance.GetID())
+			p.baseFSMInstance.GetLogger().Debugf("Bridge %s already exists in flow and Connection manager", p.baseFSMInstance.GetID())
 
 			return nil // do not throw an error, as each action is expected to be idempotent
 		}
 
-		return fmt.Errorf("failed to add ProtocolConverter service %s to flow and Connection manager: %w", p.baseFSMInstance.GetID(), err)
+		return fmt.Errorf("failed to add bridge %s to flow and Connection manager: %w", p.baseFSMInstance.GetID(), err)
 	}
 
-	p.baseFSMInstance.GetLogger().Debugf("ProtocolConverter service %s added to flow and Connection manager", p.baseFSMInstance.GetID())
+	p.baseFSMInstance.GetLogger().Debugf("Bridge %s added to flow and Connection manager", p.baseFSMInstance.GetID())
 
 	return nil
 }
@@ -87,7 +87,7 @@ func (p *ProtocolConverterInstance) CreateInstance(ctx context.Context, filesyst
 // RemoveInstance attempts to remove the ProtocolConverter from the Benthos and connection manager.
 // It requires the service to be stopped before removal.
 func (p *ProtocolConverterInstance) RemoveInstance(ctx context.Context, filesystemService filesystem.Service) error {
-	p.baseFSMInstance.GetLogger().Debugf("Starting Action: Removing ProtocolConverter service %s from flow and Connection manager ...", p.baseFSMInstance.GetID())
+	p.baseFSMInstance.GetLogger().Debugf("Starting Action: Removing bridge %s from flow and Connection manager ...", p.baseFSMInstance.GetID())
 
 	// Remove the initiateDataflowComponent from the Benthos manager
 	err := p.service.RemoveFromManager(ctx, filesystemService, p.baseFSMInstance.GetID())
@@ -141,15 +141,15 @@ func (p *ProtocolConverterInstance) StartInstance(ctx context.Context, filesyste
 // This method is used during the "starting_connection" FSM state and only brings
 // the connection to "up" state without touching DFCs.
 func (p *ProtocolConverterInstance) StartConnectionInstance(ctx context.Context, filesystemService filesystem.Service) error {
-	p.baseFSMInstance.GetLogger().Debugf("Starting Action: Starting Connection for ProtocolConverter service %s ...", p.baseFSMInstance.GetID())
+	p.baseFSMInstance.GetLogger().Debugf("Starting Action: Starting Connection for bridge %s ...", p.baseFSMInstance.GetID())
 
 	// Start only the connection component
 	err := p.service.StartConnection(ctx, filesystemService, p.baseFSMInstance.GetID())
 	if err != nil {
-		return fmt.Errorf("failed to start connection for ProtocolConverter service %s: %w", p.baseFSMInstance.GetID(), err)
+		return fmt.Errorf("failed to start connection for bridge %s: %w", p.baseFSMInstance.GetID(), err)
 	}
 
-	p.baseFSMInstance.GetLogger().Debugf("ProtocolConverter service %s connection start command executed", p.baseFSMInstance.GetID())
+	p.baseFSMInstance.GetLogger().Debugf("Bridge %s connection start command executed", p.baseFSMInstance.GetID())
 
 	return nil
 }
@@ -158,31 +158,31 @@ func (p *ProtocolConverterInstance) StartConnectionInstance(ctx context.Context,
 // This method evaluates which DFCs should be active based on their configurations
 // and is used during the "starting_dfc" FSM state.
 func (p *ProtocolConverterInstance) StartDFCInstance(ctx context.Context, filesystemService filesystem.Service) error {
-	p.baseFSMInstance.GetLogger().Debugf("Starting Action: Starting flows for ProtocolConverter service %s ...", p.baseFSMInstance.GetID())
+	p.baseFSMInstance.GetLogger().Debugf("Starting Action: Starting flows for bridge %s ...", p.baseFSMInstance.GetID())
 
 	// Start the DFC components with conditional evaluation
 	err := p.service.StartDFC(ctx, filesystemService, p.baseFSMInstance.GetID())
 	if err != nil {
-		return fmt.Errorf("failed to start flows for ProtocolConverter service %s: %w", p.baseFSMInstance.GetID(), err)
+		return fmt.Errorf("failed to start flows for bridge %s: %w", p.baseFSMInstance.GetID(), err)
 	}
 
-	p.baseFSMInstance.GetLogger().Debugf("ProtocolConverter service %s flow start command executed", p.baseFSMInstance.GetID())
+	p.baseFSMInstance.GetLogger().Debugf("Bridge %s flow start command executed", p.baseFSMInstance.GetID())
 
 	return nil
 }
 
 // StopInstance attempts to stop the DataflowComponent by setting the desired state to stopped for the given instance.
 func (p *ProtocolConverterInstance) StopInstance(ctx context.Context, filesystemService filesystem.Service) error {
-	p.baseFSMInstance.GetLogger().Debugf("Starting Action: Stopping ProtocolConverter service %s ...", p.baseFSMInstance.GetID())
+	p.baseFSMInstance.GetLogger().Debugf("Starting Action: Stopping bridge %s ...", p.baseFSMInstance.GetID())
 
 	// Set the desired state to stopped for the given instance
 	err := p.service.StopProtocolConverter(ctx, filesystemService, p.baseFSMInstance.GetID())
 	if err != nil {
 		// if the service is not there yet but we attempt to stop it, we need to throw an error
-		return fmt.Errorf("failed to stop ProtocolConverter service %s: %w", p.baseFSMInstance.GetID(), err)
+		return fmt.Errorf("failed to stop bridge %s: %w", p.baseFSMInstance.GetID(), err)
 	}
 
-	p.baseFSMInstance.GetLogger().Debugf("ProtocolConverter service %s stop command executed", p.baseFSMInstance.GetID())
+	p.baseFSMInstance.GetLogger().Debugf("Bridge %s stop command executed", p.baseFSMInstance.GetID())
 
 	return nil
 }
@@ -280,7 +280,7 @@ func (p *ProtocolConverterInstance) UpdateObservedStateOfInstance(ctx context.Co
 
 			return nil
 		} else {
-			return fmt.Errorf("failed to get observed ProtocolConverter config: %w", err)
+			return fmt.Errorf("failed to get observed bridge config: %w", err)
 		}
 	}
 
@@ -328,7 +328,7 @@ func (p *ProtocolConverterInstance) UpdateObservedStateOfInstance(ctx context.Co
 	if !protocolconverterserviceconfig.ConfigsEqualRuntime(p.runtimeConfig, p.ObservedState.ObservedProtocolConverterRuntimeConfig) {
 		// Check if the service exists before attempting to update
 		if p.service.ServiceExists(ctx, services.GetFileSystem(), p.baseFSMInstance.GetID()) {
-			p.baseFSMInstance.GetLogger().Debugf("Observed ProtocolConverter config is different from desired config, updating ProtocolConverter configuration")
+			p.baseFSMInstance.GetLogger().Debugf("Observed bridge config is different from desired config, updating bridge configuration")
 
 			diffStr := protocolconverterserviceconfig.ConfigDiffRuntime(p.runtimeConfig, p.ObservedState.ObservedProtocolConverterRuntimeConfig)
 			p.baseFSMInstance.GetLogger().Debugf("Configuration differences: %s", diffStr)
@@ -336,7 +336,7 @@ func (p *ProtocolConverterInstance) UpdateObservedStateOfInstance(ctx context.Co
 			// Update the config in the Benthos manager
 			err := p.service.UpdateInManager(ctx, services.GetFileSystem(), &p.runtimeConfig, p.baseFSMInstance.GetID())
 			if err != nil {
-				return fmt.Errorf("failed to update ProtocolConverter service configuration: %w", err)
+				return fmt.Errorf("failed to update bridge configuration: %w", err)
 			}
 
 			p.baseFSMInstance.GetLogger().Debugf("config updated")

--- a/umh-core/pkg/fsm/protocolconverter/actions.go
+++ b/umh-core/pkg/fsm/protocolconverter/actions.go
@@ -63,7 +63,7 @@ import (
 // already configured when this function returns – they will be updated in
 // the next reconciliation cycle.
 func (p *ProtocolConverterInstance) CreateInstance(ctx context.Context, filesystemService filesystem.Service) error {
-	p.baseFSMInstance.GetLogger().Debugf("Starting Action: Adding ProtocolConverter service %s to DFC and Connection manager ...", p.baseFSMInstance.GetID())
+	p.baseFSMInstance.GetLogger().Debugf("Starting Action: Adding ProtocolConverter service %s to flow and Connection manager ...", p.baseFSMInstance.GetID())
 
 	// AddToManager intentionally receives an empty runtime config because template
 	// rendering requires SystemSnapshot data not available at creation time.
@@ -71,15 +71,15 @@ func (p *ProtocolConverterInstance) CreateInstance(ctx context.Context, filesyst
 	err := p.service.AddToManager(ctx, filesystemService, &p.runtimeConfig, p.baseFSMInstance.GetID())
 	if err != nil {
 		if errors.Is(err, protocolconvertersvc.ErrServiceAlreadyExists) {
-			p.baseFSMInstance.GetLogger().Debugf("ProtocolConverter service %s already exists in DFC and Connection manager", p.baseFSMInstance.GetID())
+			p.baseFSMInstance.GetLogger().Debugf("ProtocolConverter service %s already exists in flow and Connection manager", p.baseFSMInstance.GetID())
 
 			return nil // do not throw an error, as each action is expected to be idempotent
 		}
 
-		return fmt.Errorf("failed to add ProtocolConverter service %s to DFC and Connection manager: %w", p.baseFSMInstance.GetID(), err)
+		return fmt.Errorf("failed to add ProtocolConverter service %s to flow and Connection manager: %w", p.baseFSMInstance.GetID(), err)
 	}
 
-	p.baseFSMInstance.GetLogger().Debugf("ProtocolConverter service %s added to DFC and Connection manager", p.baseFSMInstance.GetID())
+	p.baseFSMInstance.GetLogger().Debugf("ProtocolConverter service %s added to flow and Connection manager", p.baseFSMInstance.GetID())
 
 	return nil
 }
@@ -87,7 +87,7 @@ func (p *ProtocolConverterInstance) CreateInstance(ctx context.Context, filesyst
 // RemoveInstance attempts to remove the ProtocolConverter from the Benthos and connection manager.
 // It requires the service to be stopped before removal.
 func (p *ProtocolConverterInstance) RemoveInstance(ctx context.Context, filesystemService filesystem.Service) error {
-	p.baseFSMInstance.GetLogger().Debugf("Starting Action: Removing ProtocolConverter service %s from DFC and Connection manager ...", p.baseFSMInstance.GetID())
+	p.baseFSMInstance.GetLogger().Debugf("Starting Action: Removing ProtocolConverter service %s from flow and Connection manager ...", p.baseFSMInstance.GetID())
 
 	// Remove the initiateDataflowComponent from the Benthos manager
 	err := p.service.RemoveFromManager(ctx, filesystemService, p.baseFSMInstance.GetID())
@@ -158,15 +158,15 @@ func (p *ProtocolConverterInstance) StartConnectionInstance(ctx context.Context,
 // This method evaluates which DFCs should be active based on their configurations
 // and is used during the "starting_dfc" FSM state.
 func (p *ProtocolConverterInstance) StartDFCInstance(ctx context.Context, filesystemService filesystem.Service) error {
-	p.baseFSMInstance.GetLogger().Debugf("Starting Action: Starting DFCs for ProtocolConverter service %s ...", p.baseFSMInstance.GetID())
+	p.baseFSMInstance.GetLogger().Debugf("Starting Action: Starting flows for ProtocolConverter service %s ...", p.baseFSMInstance.GetID())
 
 	// Start the DFC components with conditional evaluation
 	err := p.service.StartDFC(ctx, filesystemService, p.baseFSMInstance.GetID())
 	if err != nil {
-		return fmt.Errorf("failed to start DFCs for ProtocolConverter service %s: %w", p.baseFSMInstance.GetID(), err)
+		return fmt.Errorf("failed to start flows for ProtocolConverter service %s: %w", p.baseFSMInstance.GetID(), err)
 	}
 
-	p.baseFSMInstance.GetLogger().Debugf("ProtocolConverter service %s DFC start command executed", p.baseFSMInstance.GetID())
+	p.baseFSMInstance.GetLogger().Debugf("ProtocolConverter service %s flow start command executed", p.baseFSMInstance.GetID())
 
 	return nil
 }
@@ -348,14 +348,14 @@ func (p *ProtocolConverterInstance) UpdateObservedStateOfInstance(ctx context.Co
 			// 2. Empty DFCs should remain stopped, populated DFCs should be started
 			// 3. This ensures we don't start broken Benthos instances with empty configs
 			if p.baseFSMInstance.GetDesiredFSMState() == OperationalStateActive {
-				p.baseFSMInstance.GetLogger().Debugf("re-evaluating DFC desired states and will be active")
+				p.baseFSMInstance.GetLogger().Debugf("re-evaluating flow desired states and will be active")
 
 				err := p.service.EvaluateDFCDesiredStates(p.baseFSMInstance.GetID(), "active", p.baseFSMInstance.GetCurrentFSMState()) // NOTE: Hardcoded to avoid circular import
 				if err != nil {
-					p.baseFSMInstance.GetLogger().Debugf("Failed to re-evaluate DFC states after config update: %v", err)
+					p.baseFSMInstance.GetLogger().Debugf("Failed to re-evaluate flow states after config update: %v", err)
 					// Don't fail the entire update - this is a best-effort re-evaluation
 				} else {
-					p.baseFSMInstance.GetLogger().Debugf("Re-evaluated DFC desired states after config update")
+					p.baseFSMInstance.GetLogger().Debugf("Re-evaluated flow desired states after config update")
 				}
 			}
 		} else {
@@ -427,7 +427,7 @@ func (p *ProtocolConverterInstance) IsDFCHealthy() (bool, string) {
 
 	statusReason := p.ObservedState.ServiceInfo.DataflowComponentReadObservedState.ServiceInfo.StatusReason
 	if statusReason == "" {
-		statusReason = "DFC Health status unknown"
+		statusReason = "flow health status unknown"
 	}
 
 	// TODO: check the write DFC as well
@@ -471,7 +471,7 @@ func (p *ProtocolConverterInstance) IsOtherDegraded() (bool, string) {
 	// Check for case 1.1
 	if p.ObservedState.ServiceInfo.DataflowComponentReadFSMState == dataflowfsm.OperationalStateActive &&
 		p.ObservedState.ServiceInfo.RedpandaFSMState == redpandafsm.OperationalStateIdle {
-		return true, "DFC is active, but redpanda is idle"
+		return true, "flow is active, but redpanda is idle"
 	}
 
 	// Safely extract Benthos metrics to avoid nil pointer panics
@@ -482,14 +482,14 @@ func (p *ProtocolConverterInstance) IsOtherDegraded() (bool, string) {
 	if (p.ObservedState.ServiceInfo.RedpandaFSMState == redpandafsm.OperationalStateIdle ||
 		p.ObservedState.ServiceInfo.RedpandaFSMState == redpandafsm.OperationalStateActive) &&
 		!isBenthosOutputActive {
-		return true, fmt.Sprintf("Redpanda is %s, but the DFC has no output active (connection up: %d, connection lost: %d)", p.ObservedState.ServiceInfo.RedpandaFSMState, outputMetrics.ConnectionUp, outputMetrics.ConnectionLost)
+		return true, fmt.Sprintf("Redpanda is %s, but the flow has no output active (connection up: %d, connection lost: %d)", p.ObservedState.ServiceInfo.RedpandaFSMState, outputMetrics.ConnectionUp, outputMetrics.ConnectionLost)
 	}
 
 	// Check for case 3
 	isBenthosInputActive := inputMetrics.ConnectionUp-inputMetrics.ConnectionLost > 0 // if the amount of connection losts is bigger than the amount of connection ups, the input is not active
 	if p.ObservedState.ServiceInfo.ConnectionFSMState != connectionfsm.OperationalStateUp &&
 		isBenthosInputActive {
-		return true, fmt.Sprintf("Connection is %s, but the DFC has input active (connection up: %d, connection lost: %d)", p.ObservedState.ServiceInfo.ConnectionFSMState, inputMetrics.ConnectionUp, inputMetrics.ConnectionLost)
+		return true, fmt.Sprintf("Connection is %s, but the flow has input active (connection up: %d, connection lost: %d)", p.ObservedState.ServiceInfo.ConnectionFSMState, inputMetrics.ConnectionUp, inputMetrics.ConnectionLost)
 	}
 
 	return false, ""
@@ -513,7 +513,7 @@ func (p *ProtocolConverterInstance) IsDataflowComponentWithProcessingActivity() 
 		dfcState = "not existing"
 	}
 
-	return false, "DFC is " + dfcState
+	return false, "flow is " + dfcState
 }
 
 // IsProtocolConverterStopped checks whether the ProtocolConverter is stopped
@@ -540,7 +540,7 @@ func (p *ProtocolConverterInstance) IsProtocolConverterStopped() (bool, string) 
 		dfcState = "not existing"
 	}
 
-	return false, fmt.Sprintf("connection is %s, DFC is %s", connState, dfcState)
+	return false, fmt.Sprintf("connection is %s, flow is %s", connState, dfcState)
 }
 
 // IsDFCExisting checks whether either the read or write DFC is existing
@@ -555,5 +555,5 @@ func (p *ProtocolConverterInstance) IsDFCExisting() (bool, string) {
 		return true, ""
 	}
 
-	return false, "no DFCs configured"
+	return false, "no flows configured"
 }

--- a/umh-core/pkg/fsm/protocolconverter/fsm_callbacks.go
+++ b/umh-core/pkg/fsm/protocolconverter/fsm_callbacks.go
@@ -71,7 +71,7 @@ func (instance *ProtocolConverterInstance) registerCallbacks() {
 	})
 
 	instance.baseFSMInstance.AddCallback("enter_"+OperationalStateStartingDFC, func(ctx context.Context, e *fsm.Event) {
-		instance.baseFSMInstance.GetLogger().Infof("Entering starting dfc state for %s", instance.baseFSMInstance.GetID())
+		instance.baseFSMInstance.GetLogger().Infof("Entering starting flow state for %s", instance.baseFSMInstance.GetID())
 		// NOTE: StartDFCInstance will be called from reconciliation loop, not here
 		// This callback is kept lightweight per FSM pattern requirements
 		// instance.archiveStorage.StoreDataPoint(ctx, storage.DataPoint{
@@ -84,7 +84,7 @@ func (instance *ProtocolConverterInstance) registerCallbacks() {
 	})
 
 	instance.baseFSMInstance.AddCallback("enter_"+OperationalStateStartingFailedDFC, func(ctx context.Context, e *fsm.Event) {
-		instance.baseFSMInstance.GetLogger().Errorf("Entering starting-failed-dfc state for %s", instance.baseFSMInstance.GetID())
+		instance.baseFSMInstance.GetLogger().Errorf("Entering starting-failed-flow state for %s", instance.baseFSMInstance.GetID())
 		// instance.archiveStorage.StoreDataPoint(ctx, storage.DataPoint{
 		//	Record: storage.Record{
 		//		State:       OperationalStateStartingFailedDFC,
@@ -95,7 +95,7 @@ func (instance *ProtocolConverterInstance) registerCallbacks() {
 	})
 
 	instance.baseFSMInstance.AddCallback("enter_"+OperationalStateStartingFailedDFCMissing, func(ctx context.Context, e *fsm.Event) {
-		instance.baseFSMInstance.GetLogger().Errorf("Entering starting-failed-dfc-missing state for %s", instance.baseFSMInstance.GetID())
+		instance.baseFSMInstance.GetLogger().Errorf("Entering starting-failed-flow-missing state for %s", instance.baseFSMInstance.GetID())
 		// instance.archiveStorage.StoreDataPoint(ctx, storage.DataPoint{
 		//	Record: storage.Record{
 		//		State:       OperationalStateStartingFailedDFCMissing,
@@ -151,7 +151,7 @@ func (instance *ProtocolConverterInstance) registerCallbacks() {
 	})
 
 	instance.baseFSMInstance.AddCallback("enter_"+OperationalStateDegradedDFC, func(ctx context.Context, e *fsm.Event) {
-		instance.baseFSMInstance.GetLogger().Warnf("Entering degraded dfc state for %s", instance.baseFSMInstance.GetID())
+		instance.baseFSMInstance.GetLogger().Warnf("Entering degraded flow state for %s", instance.baseFSMInstance.GetID())
 		// instance.archiveStorage.StoreDataPoint(ctx, storage.DataPoint{
 		//	Record: storage.Record{
 		//		State:       OperationalStateDegradedDFC,

--- a/umh-core/pkg/fsm/protocolconverter/machine.go
+++ b/umh-core/pkg/fsm/protocolconverter/machine.go
@@ -191,7 +191,7 @@ func (d *ProtocolConverterInstance) IsStopped() bool {
 func (d *ProtocolConverterInstance) PrintState() {
 	d.baseFSMInstance.GetLogger().Debugf("Current state: %s", d.baseFSMInstance.GetCurrentFSMState())
 	d.baseFSMInstance.GetLogger().Debugf("Desired state: %s", d.baseFSMInstance.GetDesiredFSMState())
-	d.baseFSMInstance.GetLogger().Debugf("Connection: %s, Read DFC: %s, Write DFC: %s, Status: %s",
+	d.baseFSMInstance.GetLogger().Debugf("Connection: %s, Read Flow: %s, Write Flow: %s, Status: %s",
 		d.ObservedState.ServiceInfo.ConnectionFSMState,
 		d.ObservedState.ServiceInfo.DataflowComponentReadFSMState,
 		d.ObservedState.ServiceInfo.DataflowComponentWriteFSMState,

--- a/umh-core/pkg/fsm/protocolconverter/reconcile.go
+++ b/umh-core/pkg/fsm/protocolconverter/reconcile.go
@@ -45,7 +45,7 @@ func (p *ProtocolConverterInstance) Reconcile(ctx context.Context, snapshot fsm.
 		metrics.ObserveReconcileTime(metrics.ComponentProtocolConverterInstance, protocolConverterInstanceName, time.Since(start))
 
 		if err != nil {
-			p.baseFSMInstance.GetLogger().Errorf("error reconciling protocolconverter instance %s: %v", protocolConverterInstanceName, err)
+			p.baseFSMInstance.GetLogger().Errorf("error reconciling bridge %s: %v", protocolConverterInstanceName, err)
 			p.PrintState()
 			// Add metrics for error
 			metrics.IncErrorCountAndLog(metrics.ComponentProtocolConverterInstance, protocolConverterInstanceName, err, p.baseFSMInstance.GetLogger())
@@ -64,7 +64,7 @@ func (p *ProtocolConverterInstance) Reconcile(ctx context.Context, snapshot fsm.
 	// Step 1: If there's a lastError, see if we've waited enough.
 	if p.baseFSMInstance.ShouldSkipReconcileBecauseOfError(snapshot.Tick) {
 		err := p.baseFSMInstance.GetBackoffError(snapshot.Tick)
-		p.baseFSMInstance.GetLogger().Debugf("Skipping reconcile for Protocolconverter pipeline %s: %v", protocolConverterInstanceName, err)
+		p.baseFSMInstance.GetLogger().Debugf("Skipping reconcile for bridge %s: %v", protocolConverterInstanceName, err)
 
 		// if it is a permanent error, start the removal process and reset the error (so that we can reconcile towards a stopped / removed state)
 		if backoff.IsPermanentFailureError(err) {

--- a/umh-core/pkg/fsm/protocolconverter/reconcile.go
+++ b/umh-core/pkg/fsm/protocolconverter/reconcile.go
@@ -373,7 +373,7 @@ func (p *ProtocolConverterInstance) reconcileStartingStates(ctx context.Context,
 			return p.baseFSMInstance.SendEvent(ctx, EventStartRetry), false // a previous succeeding check failed, so let's retry the whole start process
 		}
 
-		// If neither read not write DFC is existing, then go into OperationalStateStartingFailedDFCMissing
+		// If neither read nor write flow is existing, then go into OperationalStateStartingFailedDFCMissing
 		existing, reason := p.IsDFCExisting()
 		if !existing {
 			p.ObservedState.ServiceInfo.StatusReason = "starting: " + reason
@@ -381,14 +381,14 @@ func (p *ProtocolConverterInstance) reconcileStartingStates(ctx context.Context,
 			return p.baseFSMInstance.SendEvent(ctx, EventStartFailedDFCMissing), true
 		}
 
-		// Start the DFC components now that prerequisites are met
+		// Start the flow components now that prerequisites are met
 		if err := p.StartDFCInstance(ctx, services.GetFileSystem()); err != nil {
-			p.baseFSMInstance.GetLogger().Debugf("Failed to start DFC: %v", err)
+			p.baseFSMInstance.GetLogger().Debugf("Failed to start flow: %v", err)
 
 			return err, false
 		}
 
-		// Now check whether the DFC is healthy
+		// Now check whether the flow is healthy
 		running, reason = p.IsDFCHealthy()
 		if !running {
 			p.ObservedState.ServiceInfo.StatusReason = "starting: " + reason
@@ -439,16 +439,16 @@ func (p *ProtocolConverterInstance) reconcileStartingStates(ctx context.Context,
 		// 2. If DFC exists, send EventStartRetry to restart the startup sequence
 		// 3. EventStartRetry transitions back to OperationalStateStartingConnection
 		// 4. Normal startup flow continues: connection → redpanda → dfc → idle/active
-		// 5. If DFC still missing, remain in failed state with clear status reason
+		// 5. If flow still missing, remain in failed state with clear status reason
 		//
 		existing, reason := p.IsDFCExisting()
 		if existing {
-			// DFC is now available, retry the start process
-			p.ObservedState.ServiceInfo.StatusReason = "retrying start: DFC now available"
+			// flow is now available, retry the start process
+			p.ObservedState.ServiceInfo.StatusReason = "retrying start: flow now available"
 
 			return p.baseFSMInstance.SendEvent(ctx, EventStartRetry), true
 		}
-		// Still no DFC available, stay in failed state
+		// Still no flow available, stay in failed state
 		p.ObservedState.ServiceInfo.StatusReason = "starting failed: " + reason
 
 		return nil, false
@@ -507,7 +507,7 @@ func (p *ProtocolConverterInstance) reconcileRunningState(ctx context.Context, s
 
 			return nil, false
 		case !dfcHealthy:
-			p.ObservedState.ServiceInfo.StatusReason = "DFC degraded: " + reasonDFC
+			p.ObservedState.ServiceInfo.StatusReason = "flow degraded: " + reasonDFC
 			if currentState != OperationalStateDegradedDFC {
 				return p.baseFSMInstance.SendEvent(ctx, EventDFCDegraded), true
 			}
@@ -554,7 +554,7 @@ func (p *ProtocolConverterInstance) reconcileRunningState(ctx context.Context, s
 
 			return nil, false
 		case !dfcHealthy:
-			p.ObservedState.ServiceInfo.StatusReason = "DFC degraded: " + reasonDFC
+			p.ObservedState.ServiceInfo.StatusReason = "flow degraded: " + reasonDFC
 			if currentState != OperationalStateDegradedDFC {
 				return p.baseFSMInstance.SendEvent(ctx, EventDFCDegraded), true
 			}
@@ -618,7 +618,7 @@ func (p *ProtocolConverterInstance) reconcileRunningState(ctx context.Context, s
 
 			return nil, false
 		case !dfcHealthy:
-			p.ObservedState.ServiceInfo.StatusReason = "DFC degraded: " + reasonDFC
+			p.ObservedState.ServiceInfo.StatusReason = "flow degraded: " + reasonDFC
 			if currentState != OperationalStateDegradedDFC {
 				return p.baseFSMInstance.SendEvent(ctx, EventDFCDegraded), true
 			}


### PR DESCRIPTION
## Summary
Updates all user-facing status reason strings and documentation to use the new terminology:
- "DFC" → "flow"
- "Protocol Converter" → "bridge"  
- "Source/Sink Flow" → "Read/Write Flow"

## Linear Issue
[ENG-3541](https://linear.app/united-manufacturing-hub/issue/ENG-3541)

## Changes Made

### Status Reason Strings
- Updated 18+ status reason strings from "DFC" to "flow"
- Updated 19 log/error messages from "ProtocolConverter" to "bridge"
- All user-facing strings now use consistent terminology

### Documentation
- Added complete bridge state machine with all 15 states (was only showing 7)
- Added status reason examples for each state
- Updated Bridge definition to "Connection + Read Flow + Write Flow"
- Fixed environment variable references (DFC_IDLE_WINDOW → BRIDGE_IDLE_WINDOW)

### Backward Compatibility
- ✅ All state constants unchanged (e.g., `OperationalStateStartingDFC`)
- ✅ All event constants unchanged (e.g., `EventDFCDegraded`)
- ✅ All type/function names unchanged (e.g., `ProtocolConverterInstance`)
- ✅ No API breaking changes

## Files Changed
- `pkg/fsm/protocolconverter/actions.go` - 35 changes
- `pkg/fsm/protocolconverter/reconcile.go` - 10 changes
- `pkg/fsm/protocolconverter/fsm_callbacks.go` - 4 changes
- `pkg/fsm/protocolconverter/machine.go` - 1 change
- `docs/reference/state-machines.md` - Complete overhaul of bridge states

## Testing
- [x] `golangci-lint run` - 0 issues
- [x] `go build ./pkg/fsm/protocolconverter/...` - Success
- [x] No focused tests present
- [x] All constants verified unchanged

## Impact
This provides clearer user-facing messages while maintaining full backward compatibility. The UI team can now build better user experiences based on the complete state information and consistent terminology.

🤖 Generated with [Claude Code](https://claude.ai/code)