### PR TITLE
build: bump benthos-umh to v0.11.5 for downsampler NULL-padding fix

### DIFF
--- a/umh-core/Makefile
+++ b/umh-core/Makefile
@@ -69,7 +69,7 @@ NMAP_VERSION = 7.97-r0
 S6_OVERLAY_VERSION = 3.2.0.2
 REDPANDA_VERSION = 24.3.8
 ## Benthos version is a tag or a sha-<commit hash> (e.g. 0.9.4 or sha-a51a685) to be used in the docker image
-BENTHOS_UMH_VERSION = 0.11.3
+BENTHOS_UMH_VERSION = 0.11.5
 BUF_VERSION = 1.55.1
 PROTOC_GEN_GO_VERSION = 1.36.6
 


### PR DESCRIPTION
This PR bumps benthos-umh from v0.11.3 to v0.11.5

🐛 Bug Fixes

**Fixed OPC UA Server Overflow** (from v0.11.4)
Resolved an issue where OPC UA servers would return bad-status errors due to server overflow. The connection now properly handles high-frequency data collection without overwhelming the OPC UA server.

**Fixed Bridges for certain data sources (e.g., S7 or generate with random numbers) Getting Stuck in Starting State** (from v0.11.5)
Resolved an issue where S7 protocol converters (and other industrial protocols using fixed-length strings) would fail with continuous error messages and never reach "active" state. This occurred because S7 returns strings with NULL byte padding (e.g., "thisIsAt\x00\x00"), which the downsampler couldn't process. Also json.number were not properly parsed and were throwing the same issue as above.

📝 Notes

- This version bump is high priority as the v0.11.5 fix is currently blocking all ManagementConsole PRs that require Playwright E2E testing. The staging umh-core image contains the buggy version, causing test failures. [Failed test run](https://github.com/united-manufacturing-hub/ManagementConsole/actions/runs/18197372558). [Evidence](https://playwright-traces.management.umh.app/staging-f4b1dc63ceca873a4963acebce2b22e62a33bdf2/trace/index.html)
- Release Notes from benthos-umh: [v0.11.4](https://github.com/united-manufacturing-hub/benthos-umh/releases/tag/v0.11.4) and [v0.11.5](https://github.com/united-manufacturing-hub/benthos-umh/releases/tag/v0.11.5)