### PR TITLE
[ENG-3596] Idle fsm states should show green active health 

### DIFF
--- a/umh-core/pkg/communicator/pkg/generator/dfc.go
+++ b/umh-core/pkg/communicator/pkg/generator/dfc.go
@@ -68,6 +68,8 @@ func buildDfc(
 	switch instance.CurrentState {
 	case dataflowcomponent.OperationalStateActive:
 		healthCat = models.Active
+	case dataflowcomponent.OperationalStateIdle:
+		healthCat = models.Active
 	case dataflowcomponent.OperationalStateDegraded:
 		healthCat = models.Degraded
 	}

--- a/umh-core/pkg/communicator/pkg/generator/protocolconverter.go
+++ b/umh-core/pkg/communicator/pkg/generator/protocolconverter.go
@@ -75,7 +75,7 @@ func buildProtocolConverterAsDfc(
 		protocolconverter.OperationalStateDegradedOther:
 		healthCat = models.Degraded
 	case protocolconverter.OperationalStateIdle:
-		healthCat = models.Neutral
+		healthCat = models.Active
 	}
 
 	// Generate UUID from the protocol converter name
@@ -271,7 +271,7 @@ func getHealthCategoryFromState(state string) models.HealthCategory {
 	case connection.OperationalStateDown, connection.OperationalStateDegraded, connection.OperationalStateStopped:
 		return models.Degraded
 	case protocolconverter.OperationalStateIdle:
-		return models.Neutral
+		return models.Active
 	default:
 		return models.Neutral
 	}

--- a/umh-core/pkg/communicator/pkg/generator/redpanda.go
+++ b/umh-core/pkg/communicator/pkg/generator/redpanda.go
@@ -61,6 +61,8 @@ func buildRedpanda(
 	switch instance.CurrentState {
 	case redpanda.OperationalStateActive:
 		healthCat = models.Active
+	case redpanda.OperationalStateIdle:
+		healthCat = models.Active
 	case redpanda.OperationalStateDegraded:
 		healthCat = models.Degraded
 	}

--- a/umh-core/pkg/communicator/pkg/generator/redpanda_test.go
+++ b/umh-core/pkg/communicator/pkg/generator/redpanda_test.go
@@ -1,0 +1,137 @@
+package generator
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
+	benthosfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/benthos"
+	redpandafsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/redpanda"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/models"
+	redpandasvc "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/redpanda"
+	"go.uber.org/zap"
+)
+
+var _ = Describe("buildRedpanda", func() {
+	var (
+		logger *zap.SugaredLogger
+	)
+
+	BeforeEach(func() {
+		logger = zap.NewNop().Sugar()
+	})
+
+	DescribeTable("state to health category mapping",
+		func(currentState string, expectedHealthCat models.HealthCategory, expectedDesiredState string) {
+			observedState := &redpandafsm.RedpandaObservedStateSnapshot{
+				ServiceInfoSnapshot: redpandasvc.ServiceInfo{
+					StatusReason: "test reason",
+				},
+			}
+
+			instance := fsm.FSMInstanceSnapshot{
+				ID:                "test-redpanda",
+				CurrentState:      currentState,
+				DesiredState:      expectedDesiredState,
+				LastObservedState: observedState,
+			}
+
+			redpanda, err := buildRedpanda(instance, logger)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(redpanda.Health).NotTo(BeNil())
+			Expect(redpanda.Health.Category).To(Equal(expectedHealthCat))
+			Expect(redpanda.Health.ObservedState).To(Equal(currentState))
+			Expect(redpanda.Health.DesiredState).To(Equal(expectedDesiredState))
+			Expect(redpanda.Health.Message).To(Equal("test reason"))
+		},
+		Entry("OperationalStateActive -> Active",
+			redpandafsm.OperationalStateActive,
+			models.Active,
+			"active",
+		),
+		Entry("OperationalStateIdle -> Active",
+			redpandafsm.OperationalStateIdle,
+			models.Active,
+			"active",
+		),
+		Entry("OperationalStateDegraded -> Degraded",
+			redpandafsm.OperationalStateDegraded,
+			models.Degraded,
+			"active",
+		),
+		Entry("OperationalStateStarting -> Neutral",
+			redpandafsm.OperationalStateStarting,
+			models.Neutral,
+			"active",
+		),
+		Entry("OperationalStateStopping -> Neutral",
+			redpandafsm.OperationalStateStopping,
+			models.Neutral,
+			"active",
+		),
+		Entry("OperationalStateStopped -> Neutral",
+			redpandafsm.OperationalStateStopped,
+			models.Neutral,
+			"stopped",
+		),
+		Entry("Unknown state -> Neutral",
+			"not_a_real_state",
+			models.Neutral,
+			"active",
+		),
+	)
+
+	It("should return error when observed state is not redpanda snapshot", func() {
+		invalidObservedState := &benthosfsm.BenthosObservedStateSnapshot{}
+
+		instance := fsm.FSMInstanceSnapshot{
+			ID:                "test-redpanda",
+			CurrentState:      redpandafsm.OperationalStateActive,
+			DesiredState:      "active",
+			LastObservedState: invalidObservedState,
+		}
+
+		redpanda, err := buildRedpanda(instance, logger)
+
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("invalid observed-state"))
+		Expect(redpanda).To(Equal(models.Redpanda{}))
+	})
+
+	It("should return error when observed state is nil", func() {
+		instance := fsm.FSMInstanceSnapshot{
+			ID:                "test-redpanda",
+			CurrentState:      redpandafsm.OperationalStateActive,
+			DesiredState:      "active",
+			LastObservedState: nil,
+		}
+
+		redpanda, err := buildRedpanda(instance, logger)
+
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("invalid observed-state"))
+		Expect(redpanda).To(Equal(models.Redpanda{}))
+	})
+
+	It("should preserve status reason in health message", func() {
+		expectedMessage := "custom status reason for testing"
+		observedState := &redpandafsm.RedpandaObservedStateSnapshot{
+			ServiceInfoSnapshot: redpandasvc.ServiceInfo{
+				StatusReason: expectedMessage,
+				// RedpandaStatus is empty, so MetricsState will be nil
+			},
+		}
+
+		instance := fsm.FSMInstanceSnapshot{
+			ID:                "test-redpanda",
+			CurrentState:      redpandafsm.OperationalStateActive,
+			DesiredState:      "active",
+			LastObservedState: observedState,
+		}
+
+		redpanda, err := buildRedpanda(instance, logger)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(redpanda.Health.Message).To(Equal(expectedMessage))
+	})
+})

--- a/umh-core/pkg/communicator/pkg/generator/redpanda_test.go
+++ b/umh-core/pkg/communicator/pkg/generator/redpanda_test.go
@@ -1,3 +1,17 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package generator
 
 import (

--- a/umh-core/pkg/communicator/pkg/generator/streamprocessor.go
+++ b/umh-core/pkg/communicator/pkg/generator/streamprocessor.go
@@ -70,7 +70,7 @@ func buildStreamProcessorAsDfc(
 		streamprocessor.OperationalStateDegradedOther:
 		healthCat = models.Degraded
 	case streamprocessor.OperationalStateIdle:
-		healthCat = models.Neutral
+		healthCat = models.Active
 	}
 
 	// Generate UUID from the stream processor name

--- a/umh-core/pkg/communicator/pkg/generator/topicbrowser.go
+++ b/umh-core/pkg/communicator/pkg/generator/topicbrowser.go
@@ -103,8 +103,9 @@ func buildTopicBrowserAsDfc(
 	case topicbrowserfsm.OperationalStateDegradedBenthos,
 		topicbrowserfsm.OperationalStateDegradedRedpanda:
 		healthCat = models.Degraded
-	case topicbrowserfsm.OperationalStateIdle,
-		topicbrowserfsm.OperationalStateStarting,
+	case topicbrowserfsm.OperationalStateIdle:
+		healthCat = models.Active
+	case topicbrowserfsm.OperationalStateStarting,
 		topicbrowserfsm.OperationalStateStopping:
 		healthCat = models.Neutral
 	}

--- a/umh-core/pkg/communicator/pkg/generator/topicbrowser_test.go
+++ b/umh-core/pkg/communicator/pkg/generator/topicbrowser_test.go
@@ -1,0 +1,121 @@
+package generator
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
+	benthosfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/benthos"
+	topicbrowserfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/topicbrowser"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/models"
+	topicbrowsersvc "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/topicbrowser"
+	"go.uber.org/zap"
+)
+
+var _ = Describe("buildTopicBrowserAsDfc", func() {
+	var (
+		logger *zap.SugaredLogger
+	)
+
+	BeforeEach(func() {
+		logger = zap.NewNop().Sugar()
+	})
+
+	DescribeTable("state to health category mapping",
+		func(benthosFSMState string, expectedHealthCat models.HealthCategory, expectedDesiredState string) {
+			observedState := &topicbrowserfsm.ObservedStateSnapshot{
+				ServiceInfo: topicbrowsersvc.ServiceInfo{
+					BenthosFSMState: benthosFSMState,
+					StatusReason:    "test reason",
+				},
+			}
+
+			instance := fsm.FSMInstanceSnapshot{
+				ID:                "test-topicbrowser",
+				CurrentState:      benthosFSMState,
+				LastObservedState: observedState,
+			}
+
+			health, err := buildTopicBrowserAsDfc(instance, logger)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(health).NotTo(BeNil())
+			Expect(health.Category).To(Equal(expectedHealthCat))
+			Expect(health.ObservedState).To(Equal(benthosFSMState))
+			Expect(health.DesiredState).To(Equal(expectedDesiredState))
+			Expect(health.Message).To(Equal("test reason"))
+		},
+		Entry("OperationalStateInitializing -> Neutral",
+			"not_a_real_state",
+			models.Neutral,
+			"active",
+		),
+		Entry("OperationalStateActive -> Active",
+			topicbrowserfsm.OperationalStateActive,
+			models.Active,
+			"active",
+		),
+		Entry("OperationalStateIdle -> Active",
+			topicbrowserfsm.OperationalStateIdle,
+			models.Active,
+			"active",
+		),
+		Entry("OperationalStateDegradedBenthos -> Degraded",
+			topicbrowserfsm.OperationalStateDegradedBenthos,
+			models.Degraded,
+			"active",
+		),
+		Entry("OperationalStateDegradedRedpanda -> Degraded",
+			topicbrowserfsm.OperationalStateDegradedRedpanda,
+			models.Degraded,
+			"active",
+		),
+		Entry("OperationalStateStarting -> Neutral",
+			topicbrowserfsm.OperationalStateStarting,
+			models.Neutral,
+			"active",
+		),
+		Entry("OperationalStateStopping -> Neutral",
+			topicbrowserfsm.OperationalStateStopping,
+			models.Neutral,
+			"active",
+		),
+	)
+
+	It("should return error when observed state is not topicbrowser snapshot", func() {
+		// use wrong type for observed state
+		invalidObservedState := &benthosfsm.BenthosObservedStateSnapshot{}
+
+		instance := fsm.FSMInstanceSnapshot{
+			ID:                "test-topicbrowser",
+			CurrentState:      topicbrowserfsm.OperationalStateActive,
+			LastObservedState: invalidObservedState,
+		}
+
+		health, err := buildTopicBrowserAsDfc(instance, logger)
+
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("last observed state is not a topic browser observed state snapshot"))
+		Expect(health).To(BeNil())
+	})
+
+	It("should preserve status reason in health message", func() {
+		expectedMessage := "custom status reason for testing"
+		observedState := &topicbrowserfsm.ObservedStateSnapshot{
+			ServiceInfo: topicbrowsersvc.ServiceInfo{
+				BenthosFSMState: topicbrowserfsm.OperationalStateActive,
+				StatusReason:    expectedMessage,
+			},
+		}
+
+		instance := fsm.FSMInstanceSnapshot{
+			ID:                "test-topicbrowser",
+			CurrentState:      topicbrowserfsm.OperationalStateActive,
+			LastObservedState: observedState,
+		}
+
+		health, err := buildTopicBrowserAsDfc(instance, logger)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(health.Message).To(Equal(expectedMessage))
+	})
+})

--- a/umh-core/pkg/communicator/pkg/generator/topicbrowser_test.go
+++ b/umh-core/pkg/communicator/pkg/generator/topicbrowser_test.go
@@ -1,3 +1,17 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package generator
 
 import (


### PR DESCRIPTION
**Current Behavior**

When FSM components (protocol converters, stream processors, etc.) are in idle state, they display with a gray/neutral status indicator, which suggests something might be wrong when the system is actually healthy.

**Expected Behavior**

Idle states should display as green/active to clearly indicate:
- The component is healthy
- No errors or issues present
- Simply waiting for work (which is a normal operational state)