### PR TITLE
chore: bump benthos-umh version to 0.11.6

### DIFF
--- a/umh-core/Makefile
+++ b/umh-core/Makefile
@@ -69,7 +69,7 @@ NMAP_VERSION = 7.97-r0
 S6_OVERLAY_VERSION = 3.2.0.2
 REDPANDA_VERSION = 24.3.8
 ## Benthos version is a tag or a sha-<commit hash> (e.g. 0.9.4 or sha-a51a685) to be used in the docker image
-BENTHOS_UMH_VERSION = 0.11.5
+BENTHOS_UMH_VERSION = 0.11.6
 BUF_VERSION = 1.55.1
 PROTOC_GEN_GO_VERSION = 1.36.6
 


### PR DESCRIPTION
## Changelog

### 🎯 Improvements

- **OPC UA Quality Tag Support** - OPC UA data connections now capture the quality/status code tag that OPC UA servers provide for each data point. This information appears in the metadata as `opcua_attr_statuscode`, giving you visibility into data quality indicators from industrial equipment. Particularly useful for Ignition-based OPC UA servers where quality tags indicate data reliability.

### 🐛 Bug Fixes

- **Stream Processor Data Type Validation** - Fixed an issue where stream processors silently dropped non-time-series data without any error message or warning. Stream processors now show clear warning messages when they receive incompatible data formats (like JSON objects instead of time-series data), making debugging much easier. Previously, this silent failure could block troubleshooting for hours - you'd see messages coming in but nothing going out with no explanation why.

### 📝 Technical Notes

- Updated benthos-umh from v0.11.5 to v0.11.6
- Added `opcua_attr_statuscode` metadata field to OPC UA processor
- Stream processor now returns errors and emits metrics for invalid data types
- Improved observability for data pipeline debugging

---

**Changes included:**
* [ENG-3436] Add OPC UA quality tag to metadata (#214)
* [ENG-3620] Stream processor data type validation warnings (#213)

---

## Prompts Used

```
https://github.com/united-manufacturing-hub/united-manufacturing-hub/pull/2291

Can you add changelogs here for thiss benthos-umh bump?
```