### PR TITLE
docs: clarify IP address input instruction (ENG-3689)

### DIFF
--- a/umh-core/docs/getting-started/2-organize-data.md
+++ b/umh-core/docs/getting-started/2-organize-data.md
@@ -88,7 +88,7 @@ The addresses automatically become tags - no manual mapping needed!
 
 ### Template Variables
 
-When you entered `192.168.1.100` in the Connection settings, it automatically became available as `{{ .IP }}` in your configuration code. Template variables connect your Connection settings to the processing code:
+When you entered your PLC's IP address in the Connection settings, it automatically became available as `{{ .IP }}` in your configuration code. Template variables connect your Connection settings to the processing code:
 - `{{ .IP }}` - The IP address you entered in Connection settings
 - `{{ .PORT }}` - The port you entered in Connection settings
 - `{{ .location_path }}` - The location from Bridge configuration

--- a/umh-core/docs/getting-started/2-organize-data.md
+++ b/umh-core/docs/getting-started/2-organize-data.md
@@ -34,7 +34,7 @@ We'll use Siemens S7 as an example, but this works identically with OPC UA, Modb
 2. **Name:** `s7-plc`
 3. **Protocol:** Select **Siemens S7** (or your protocol)
 4. **Connection:**
-   - **IP:** Use `{{ .IP }}` (we'll set this in variables)
+   - **IP:** Enter your PLC's IP address (example: 192.168.1.100)
    - **Rack:** 0
    - **Slot:** 1
 
@@ -88,12 +88,12 @@ The addresses automatically become tags - no manual mapping needed!
 
 ### Template Variables
 
-The `{{ .IP }}` and `{{ .PORT }}` in your configuration are template variables. They come from the Connection settings you entered earlier:
-- `{{ .IP }}` - The IP address from Connection settings
-- `{{ .PORT }}` - The port from Connection settings  
+When you entered `192.168.1.100` in the Connection settings, it automatically became available as `{{ .IP }}` in your configuration code. Template variables connect your Connection settings to the processing code:
+- `{{ .IP }}` - The IP address you entered in Connection settings
+- `{{ .PORT }}` - The port you entered in Connection settings
 - `{{ .location_path }}` - The location from Bridge configuration
 
-This makes configurations reusable across different sites - just change the Connection settings.
+This makes configurations reusable across different sites - just change the Connection settings and the template variables update automatically.
 
 Learn more: [Template Variables Reference](../reference/variables.md)
 


### PR DESCRIPTION
## Problem

New users were confused by the instruction to "Use {{ .IP }}" when entering connection details, interpreting it as needing to type the literal template expression into the IP address field instead of their actual IP address.

**User report** (daniel.kupczak, 4-day-old account):
> "To me it sounded like I needed to type the template expression `{{ .IP }}` into the input field as it would be defined in some other place."

## Solution

Simplified the instruction to follow UMH's **Progressive Power** principle from UX_STANDARDS:
- **Week 1 user**: Enter actual IP address immediately (simple, clear, works)
- **Month 1 user**: Discover template variables when viewing generated configuration
- **Year 1 user**: Use variables to manage multiple bridges efficiently

## Changes

### 1. Simplified IP Instruction (Line 37)

**Before:**
```markdown
- **IP:** Use {{ .IP }} (we'll set this in variables)
```

**After:**
```markdown
- **IP:** Enter your PLC's IP address (example: 192.168.1.100)
```

### 2. Enhanced Template Variables Explanation (Lines 89-96)

Made the connection explicit with concrete example:
> "When you entered `192.168.1.100` in the Connection settings, it automatically became available as `{{ .IP }}` in your configuration code."

## UX_STANDARDS Alignment

✅ **Opinionated Simplicity** - ONE clear instruction, no alternatives  
✅ **Progressive Power** - Simple action now, discover complexity through usage  
✅ **Immediate Trust** - Real example shows correct format  
✅ **Error Excellence** - Prevents confusion entirely

## Screenshot Updates Needed

User also reported: "screenshots need to be updated as well"

**Priority review**: `./images/2-protocol.png` - If it shows Connection settings with `{{ .IP }}` in the input field, update to show actual IP example.

## Testing

- [x] Documentation change only (no code changes)
- [x] Follows UX_STANDARDS Progressive Power principle
- [x] Concrete example provided (192.168.1.100)
- [x] Template Variables section enhanced for clarity

Related: ENG-3689

🤖 Generated with [Claude Code](https://claude.com/claude-code)