### PR TITLE
docs: fix GraphQL API documentation ordering for ENG-3711

### DIFF
--- a/umh-core/docs/usage/unified-namespace/topic-browser.md
+++ b/umh-core/docs/usage/unified-namespace/topic-browser.md
@@ -33,6 +33,22 @@ When selecting a topic, view:
 
 Programmatic access at `http://localhost:8090/graphql` (per instance).
 
+> **Note:** The GraphQL API is disabled by default. You must enable it in your configuration before using the examples below.
+
+### Configuration
+
+```yaml
+internal:
+  topicBrowser:
+    desiredState: "active"  # Enable/disable
+
+agent:
+  graphql:
+    enabled: true           # Enable GraphQL API (required!)
+    port: 8090             # API port
+    debug: false           # Set true for GraphiQL UI
+```
+
 ### Basic Query
 ```graphql
 {
@@ -61,20 +77,6 @@ Programmatic access at `http://localhost:8090/graphql` (per instance).
 curl -X POST http://localhost:8090/graphql \
   -H "Content-Type: application/json" \
   -d '{"query": "{ topics(limit: 10) { topic } }"}'
-```
-
-## Configuration
-
-```yaml
-internal:
-  topicBrowser:
-    desiredState: "active"  # Enable/disable
-
-agent:
-  graphql:
-    enabled: true           # Enable GraphQL API
-    port: 8090             # API port
-    debug: false           # Set true for GraphiQL UI
 ```
 
 ## Common Use Cases


### PR DESCRIPTION
## Summary

Fixes documentation ordering in GraphQL API section to prevent users from encountering errors when following the examples.

**Problem:** Users saw the curl example first, tried it immediately, and got errors because the GraphQL API is disabled by default. The configuration to enable it appeared further down the page with no prior warning.

**Solution:**
- Added prominent note at top warning API is disabled by default
- Moved Configuration section BEFORE code examples
- Added "(required!)" emphasis to the `enabled: true` line

## Changes

- `umh-core/docs/usage/unified-namespace/topic-browser.md`: Reordered GraphQL API section

## Related

- Linear: ENG-3711
- Reported by: @daniel.kupczak

🤖 Generated with [Claude Code](https://claude.com/claude-code)