### PR TITLE
[ENG-3730] Enhance component name validation

### DIFF
--- a/umh-core/pkg/communicator/actions/dataflow-component-parser.go
+++ b/umh-core/pkg/communicator/actions/dataflow-component-parser.go
@@ -531,16 +531,16 @@ func BuildCommonDataFlowComponentPropertiesFromConfig(dfcConfig dataflowcomponen
 // and is not empty. Valid characters are lowercase letters (a-z), numbers (0-9), underscores (_) and hyphens (-).
 func ValidateComponentName(name string) error {
 	if name == "" {
-		return errors.New("Name cannot be empty")
+		return errors.New("name cannot be empty")
 	}
 
 	if name[0] == '-' || name[0] == '_' || name[len(name)-1] == '-' || name[len(name)-1] == '_' {
-		return errors.New("Name has to start and end with a letter or number")
+		return errors.New("name has to start and end with a letter or number")
 	}
 
 	for _, char := range name {
 		if (char < 'a' || char > 'z') && (char < '0' || char > '9') && char != '-' && char != '_' {
-			return errors.New("Only lowercase letters, numbers, dashes and underscores are allowed")
+			return errors.New("only lowercase letters, numbers, dashes and underscores are allowed")
 		}
 	}
 

--- a/umh-core/pkg/communicator/actions/dataflow-component-parser.go
+++ b/umh-core/pkg/communicator/actions/dataflow-component-parser.go
@@ -528,15 +528,19 @@ func BuildCommonDataFlowComponentPropertiesFromConfig(dfcConfig dataflowcomponen
 }
 
 // ValidateComponentName validates that a component name contains only valid characters
-// and is not empty. Valid characters are letters (a-z, A-Z), numbers (0-9), and hyphens (-).
+// and is not empty. Valid characters are lowercase letters (a-z), numbers (0-9), underscores (_) and hyphens (-).
 func ValidateComponentName(name string) error {
 	if name == "" {
-		return errors.New("name cannot be empty")
+		return errors.New("Name cannot be empty")
+	}
+
+	if name[0] == '-' || name[0] == '_' || name[len(name)-1] == '-' || name[len(name)-1] == '_' {
+		return errors.New("Name has to start and end with a letter or number")
 	}
 
 	for _, char := range name {
-		if (char < 'a' || char > 'z') && (char < 'A' || char > 'Z') && (char < '0' || char > '9') && char != '-' {
-			return errors.New("name can only contain letters (a-z, A-Z) and numbers (0-9) and hyphens (-)")
+		if (char < 'a' || char > 'z') && (char < '0' || char > '9') && char != '-' && char != '_' {
+			return errors.New("Only lowercase letters, numbers, dashes and underscores are allowed")
 		}
 	}
 

--- a/umh-core/pkg/communicator/actions/dataflow-component-parser_test.go
+++ b/umh-core/pkg/communicator/actions/dataflow-component-parser_test.go
@@ -92,12 +92,6 @@ var _ = Describe("ValidateComponentName", func() {
 			Expect(err.Error()).To(Equal("Name has to start and end with a letter or number"))
 		})
 
-		It("should reject names starting with hyphen", func() {
-			err := actions.ValidateComponentName("-component")
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("Name has to start and end with a letter or number"))
-		})
-
 		It("should reject names ending with hyphen", func() {
 			err := actions.ValidateComponentName("component-")
 			Expect(err).To(HaveOccurred())

--- a/umh-core/pkg/communicator/actions/dataflow-component-parser_test.go
+++ b/umh-core/pkg/communicator/actions/dataflow-component-parser_test.go
@@ -15,6 +15,8 @@
 package actions_test
 
 import (
+	"strings"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/communicator/actions"
@@ -177,10 +179,7 @@ var _ = Describe("ValidateComponentName", func() {
 		})
 
 		It("should accept very long valid names", func() {
-			longName := "a" + string(make([]byte, 100)) // Create a long string
-			for i := range longName[1:] {
-				longName = longName[:i+1] + "a" + longName[i+2:]
-			}
+			longName := strings.Repeat("a", 100)
 			err := actions.ValidateComponentName(longName)
 			Expect(err).NotTo(HaveOccurred())
 		})

--- a/umh-core/pkg/communicator/actions/dataflow-component-parser_test.go
+++ b/umh-core/pkg/communicator/actions/dataflow-component-parser_test.go
@@ -22,6 +22,12 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/communicator/actions"
 )
 
+const (
+	errEmptyName         = "name cannot be empty"
+	errInvalidStartEnd   = "name has to start and end with a letter or number"
+	errInvalidCharacters = "only lowercase letters, numbers, dashes and underscores are allowed"
+)
+
 var _ = Describe("ValidateComponentName", func() {
 	Context("Valid component names", func() {
 		It("should accept lowercase letters only", func() {
@@ -79,79 +85,79 @@ var _ = Describe("ValidateComponentName", func() {
 		It("should reject empty names", func() {
 			err := actions.ValidateComponentName("")
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("Name cannot be empty"))
+			Expect(err.Error()).To(Equal(errEmptyName))
 		})
 
 		It("should reject names starting with hyphen", func() {
 			err := actions.ValidateComponentName("-component")
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("Name has to start and end with a letter or number"))
+			Expect(err.Error()).To(Equal(errInvalidStartEnd))
 		})
 
 		It("should reject names starting with underscore", func() {
 			err := actions.ValidateComponentName("_component")
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("Name has to start and end with a letter or number"))
+			Expect(err.Error()).To(Equal(errInvalidStartEnd))
 		})
 
 		It("should reject names ending with hyphen", func() {
 			err := actions.ValidateComponentName("component-")
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("Name has to start and end with a letter or number"))
+			Expect(err.Error()).To(Equal(errInvalidStartEnd))
 		})
 
 		It("should reject names ending with underscore", func() {
 			err := actions.ValidateComponentName("component_")
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("Name has to start and end with a letter or number"))
+			Expect(err.Error()).To(Equal(errInvalidStartEnd))
 		})
 
 		It("should reject uppercase letters", func() {
 			err := actions.ValidateComponentName("Component")
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("Only lowercase letters, numbers, dashes and underscores are allowed"))
+			Expect(err.Error()).To(Equal(errInvalidCharacters))
 		})
 
 		It("should reject special characters", func() {
 			err := actions.ValidateComponentName("component@123")
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("Only lowercase letters, numbers, dashes and underscores are allowed"))
+			Expect(err.Error()).To(Equal(errInvalidCharacters))
 		})
 
 		It("should reject spaces", func() {
 			err := actions.ValidateComponentName("component name")
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("Only lowercase letters, numbers, dashes and underscores are allowed"))
+			Expect(err.Error()).To(Equal(errInvalidCharacters))
 		})
 
 		It("should reject dots", func() {
 			err := actions.ValidateComponentName("component.name")
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("Only lowercase letters, numbers, dashes and underscores are allowed"))
+			Expect(err.Error()).To(Equal(errInvalidCharacters))
 		})
 
 		It("should reject slashes", func() {
 			err := actions.ValidateComponentName("component/name")
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("Only lowercase letters, numbers, dashes and underscores are allowed"))
+			Expect(err.Error()).To(Equal(errInvalidCharacters))
 		})
 
 		It("should reject exclamation marks", func() {
 			err := actions.ValidateComponentName("component!")
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("Only lowercase letters, numbers, dashes and underscores are allowed"))
+			Expect(err.Error()).To(Equal(errInvalidCharacters))
 		})
 
 		It("should reject question marks", func() {
 			err := actions.ValidateComponentName("component?")
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("Only lowercase letters, numbers, dashes and underscores are allowed"))
+			Expect(err.Error()).To(Equal(errInvalidCharacters))
 		})
 
 		It("should reject hash symbols", func() {
 			err := actions.ValidateComponentName("component#123")
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("Only lowercase letters, numbers, dashes and underscores are allowed"))
+			Expect(err.Error()).To(Equal(errInvalidCharacters))
 		})
 	})
 
@@ -169,13 +175,13 @@ var _ = Describe("ValidateComponentName", func() {
 		It("should reject single hyphen", func() {
 			err := actions.ValidateComponentName("-")
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("Name has to start and end with a letter or number"))
+			Expect(err.Error()).To(Equal(errInvalidStartEnd))
 		})
 
 		It("should reject single underscore", func() {
 			err := actions.ValidateComponentName("_")
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("Name has to start and end with a letter or number"))
+			Expect(err.Error()).To(Equal(errInvalidStartEnd))
 		})
 
 		It("should accept very long valid names", func() {

--- a/umh-core/pkg/communicator/actions/dataflow-component-parser_test.go
+++ b/umh-core/pkg/communicator/actions/dataflow-component-parser_test.go
@@ -1,0 +1,194 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package actions_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/communicator/actions"
+)
+
+var _ = Describe("ValidateComponentName", func() {
+	Context("Valid component names", func() {
+		It("should accept lowercase letters only", func() {
+			err := actions.ValidateComponentName("validname")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should accept numbers only", func() {
+			err := actions.ValidateComponentName("123456")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should accept mix of lowercase letters and numbers", func() {
+			err := actions.ValidateComponentName("component123")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should accept hyphens in the middle", func() {
+			err := actions.ValidateComponentName("valid-name")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should accept underscores in the middle", func() {
+			err := actions.ValidateComponentName("valid_name")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should accept complex valid names", func() {
+			err := actions.ValidateComponentName("my-component_123")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should accept names starting with letters", func() {
+			err := actions.ValidateComponentName("a123")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should accept names starting with numbers", func() {
+			err := actions.ValidateComponentName("1component")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should accept names ending with letters", func() {
+			err := actions.ValidateComponentName("123a")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should accept names ending with numbers", func() {
+			err := actions.ValidateComponentName("component1")
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("Invalid component names", func() {
+		It("should reject empty names", func() {
+			err := actions.ValidateComponentName("")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("Name cannot be empty"))
+		})
+
+		It("should reject names starting with hyphen", func() {
+			err := actions.ValidateComponentName("-component")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("Name has to start and end with a letter or number"))
+		})
+
+		It("should reject names starting with underscore", func() {
+			err := actions.ValidateComponentName("_component")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("Name has to start and end with a letter or number"))
+		})
+
+		It("should reject names starting with hyphen", func() {
+			err := actions.ValidateComponentName("-component")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("Name has to start and end with a letter or number"))
+		})
+
+		It("should reject names ending with hyphen", func() {
+			err := actions.ValidateComponentName("component-")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("Name has to start and end with a letter or number"))
+		})
+
+		It("should reject names ending with underscore", func() {
+			err := actions.ValidateComponentName("component_")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("Name has to start and end with a letter or number"))
+		})
+
+		It("should reject uppercase letters", func() {
+			err := actions.ValidateComponentName("Component")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("Only lowercase letters, numbers, dashes and underscores are allowed"))
+		})
+
+		It("should reject special characters", func() {
+			err := actions.ValidateComponentName("component@123")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("Only lowercase letters, numbers, dashes and underscores are allowed"))
+		})
+
+		It("should reject spaces", func() {
+			err := actions.ValidateComponentName("component name")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("Only lowercase letters, numbers, dashes and underscores are allowed"))
+		})
+
+		It("should reject dots", func() {
+			err := actions.ValidateComponentName("component.name")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("Only lowercase letters, numbers, dashes and underscores are allowed"))
+		})
+
+		It("should reject slashes", func() {
+			err := actions.ValidateComponentName("component/name")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("Only lowercase letters, numbers, dashes and underscores are allowed"))
+		})
+
+		It("should reject exclamation marks", func() {
+			err := actions.ValidateComponentName("component!")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("Only lowercase letters, numbers, dashes and underscores are allowed"))
+		})
+
+		It("should reject question marks", func() {
+			err := actions.ValidateComponentName("component?")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("Only lowercase letters, numbers, dashes and underscores are allowed"))
+		})
+
+		It("should reject hash symbols", func() {
+			err := actions.ValidateComponentName("component#123")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("Only lowercase letters, numbers, dashes and underscores are allowed"))
+		})
+	})
+
+	Context("Edge cases", func() {
+		It("should accept single character names", func() {
+			err := actions.ValidateComponentName("a")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should accept single digit names", func() {
+			err := actions.ValidateComponentName("1")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should reject single hyphen", func() {
+			err := actions.ValidateComponentName("-")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("Name has to start and end with a letter or number"))
+		})
+
+		It("should reject single underscore", func() {
+			err := actions.ValidateComponentName("_")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("Name has to start and end with a letter or number"))
+		})
+
+		It("should accept very long valid names", func() {
+			longName := "a" + string(make([]byte, 100)) // Create a long string
+			for i := range longName[1:] {
+				longName = longName[:i+1] + "a" + longName[i+2:]
+			}
+			err := actions.ValidateComponentName(longName)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})

--- a/umh-core/pkg/communicator/actions/deploy-streamprocessor_test.go
+++ b/umh-core/pkg/communicator/actions/deploy-streamprocessor_test.go
@@ -312,7 +312,7 @@ var _ = Describe("DeployStreamProcessor", func() {
 			Expect(err).ToNot(HaveOccurred())
 			err = action.Validate()
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("name can only contain letters"))
+			Expect(err.Error()).To(ContainSubstring("Only lowercase letters, numbers, dashes and underscores are allowed"))
 		})
 	})
 

--- a/umh-core/pkg/communicator/actions/deploy-streamprocessor_test.go
+++ b/umh-core/pkg/communicator/actions/deploy-streamprocessor_test.go
@@ -312,7 +312,7 @@ var _ = Describe("DeployStreamProcessor", func() {
 			Expect(err).ToNot(HaveOccurred())
 			err = action.Validate()
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("Only lowercase letters, numbers, dashes and underscores are allowed"))
+			Expect(err.Error()).To(ContainSubstring("only lowercase letters, numbers, dashes and underscores are allowed"))
 		})
 	})
 

--- a/umh-core/pkg/communicator/actions/edit-streamprocessor_test.go
+++ b/umh-core/pkg/communicator/actions/edit-streamprocessor_test.go
@@ -331,7 +331,7 @@ var _ = Describe("EditStreamProcessor", func() {
 			Expect(err).ToNot(HaveOccurred())
 			err = action.Validate()
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("name cannot be empty"))
+			Expect(err.Error()).To(ContainSubstring("Name cannot be empty"))
 		})
 
 		It("should fail validation with missing model name", func() {
@@ -390,7 +390,7 @@ var _ = Describe("EditStreamProcessor", func() {
 			Expect(err).ToNot(HaveOccurred())
 			err = action.Validate()
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("name can only contain letters"))
+			Expect(err.Error()).To(ContainSubstring("Only lowercase letters, numbers, dashes and underscores are allowed"))
 		})
 	})
 

--- a/umh-core/pkg/communicator/actions/edit-streamprocessor_test.go
+++ b/umh-core/pkg/communicator/actions/edit-streamprocessor_test.go
@@ -331,7 +331,7 @@ var _ = Describe("EditStreamProcessor", func() {
 			Expect(err).ToNot(HaveOccurred())
 			err = action.Validate()
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("Name cannot be empty"))
+			Expect(err.Error()).To(ContainSubstring("name cannot be empty"))
 		})
 
 		It("should fail validation with missing model name", func() {
@@ -390,7 +390,7 @@ var _ = Describe("EditStreamProcessor", func() {
 			Expect(err).ToNot(HaveOccurred())
 			err = action.Validate()
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("Only lowercase letters, numbers, dashes and underscores are allowed"))
+			Expect(err.Error()).To(ContainSubstring("only lowercase letters, numbers, dashes and underscores are allowed"))
 		})
 	})
 


### PR DESCRIPTION
This PR updates the ValidateComponentName function to:

- Allow underscores (_) in component names alongside existing allowed characters
- Restrict names to lowercase letters only (no uppercase)
- Prevent names from starting or ending with hyphens or underscores
- Update error messages to be more descriptive and consistent
- Add comprehensive test coverage for the ValidateComponentName function

The validation now ensures component names follow a more strict naming convention while allowing underscores for better readability (e.g., "my_component" is now valid).

Tests have been updated to reflect the new validation rules.