### PR TITLE
build: Bump benthos-umh to v0.11.7

### DIFF
--- a/umh-core/Makefile
+++ b/umh-core/Makefile
@@ -69,7 +69,7 @@ NMAP_VERSION = 7.97-r0
 S6_OVERLAY_VERSION = 3.2.0.2
 REDPANDA_VERSION = 24.3.18
 ## Benthos version is a tag or a sha-<commit hash> (e.g. 0.9.4 or sha-a51a685) to be used in the docker image
-BENTHOS_UMH_VERSION = 0.11.6
+BENTHOS_UMH_VERSION = 0.11.7
 BUF_VERSION = 1.55.1
 PROTOC_GEN_GO_VERSION = 1.36.6
 


### PR DESCRIPTION
This PR bumps benthos-umh from v0.11.6 to v0.11.7 to include critical security updates and bug fixes.

## 🐛 Bug Fixes

**Tag processor timestamp handling corrected for zero timestamps** (v0.11.7 - PR #210)

Fixed a critical bug where `timestamp_ms = "0"` (Unix epoch: 1970-01-01T00:00:00Z) was incorrectly treated as a parsing failure, causing the system to use current time instead. This affected OPC UA, Sparkplug B, and other protocol converters using explicit zero timestamps. The fix changes the sentinel value from `0` to `math.MinInt64` to distinguish parse failures from valid zero timestamps, ensuring accurate historical data representation.

## 💪 Improvements

**Tag processor metadata timestamp parsing** (v0.11.7 - PR #210)

Added support for parsing numerical metadata fields as timestamps with `timestamp_ms` as primary field and `timestamp` as fallback. This solves timestamp issues for batched messages by using `meta("timestamp_ms")` for the tag processor's `timestamp_ms` field. Primarily uses RFC3339Nano format which works with different OPC servers (Kepware/Wago/Siemens). Also improved downsampler log messages to inform users about the `timestamp_ms` metadata field for batched messages, and fixed OPC UA logging for `serverCertificateFingerprint`.

## 🎉 New Features

**Redpanda Connect v4.67.5 upgrade with parquet_encode schema_metadata support** (v0.11.7 - PR #216)

Upgraded Redpanda Connect from v4.49.1 to v4.67.5, enabling the `parquet_encode` `schema_metadata` field (added in v4.62.0). This enables dynamic Parquet schema inference when batching UNS messages to S3/Minio with hive-style partitioning for DuckDB. Users can now use schema_metadata to dynamically generate Parquet schemas based on message content.

## 🔒 Security Updates

**Go 1.25.1 upgrade addressing 10 CVEs** (v0.11.7 - PR #215)

Upgraded Go from 1.24.1 to 1.25.1 to address critical vulnerabilities in the Go standard library:
- **Critical:** CVE-2025-22871 (arbitrary code execution via malformed certificates)
- **High:** CVE-2025-4674 (improper multi-line header parsing), CVE-2025-22874 (elliptic curve key retrieval), CVE-2025-47907 (arbitrary file write on Windows)
- **Medium:** 6 additional CVEs covering command injection, credential exposure, and DoS vulnerabilities

This security update applies patches with no changes to benthos-umh functionality - workflows remain unchanged while benefiting from enhanced security.

## 📝 Notes

- This bump is required to unblock ManagementConsole PR #2656 (timestamp handling improvements in templates)
- Related Linear issues: ENG-3402 (tag processor timestamp), ENG-3695 (Go security update), ENG-3728 (Redpanda Connect upgrade)
- Full release notes: https://github.com/united-manufacturing-hub/benthos-umh/releases/tag/v0.11.7