### PR TITLE
build: bump benthos-umh to v0.11.8 for OPC UA and array serialization fixes

### DIFF
--- a/umh-core/Makefile
+++ b/umh-core/Makefile
@@ -69,7 +69,7 @@ NMAP_VERSION = 7.97-r0
 S6_OVERLAY_VERSION = 3.2.0.2
 REDPANDA_VERSION = 24.3.18
 ## Benthos version is a tag or a sha-<commit hash> (e.g. 0.9.4 or sha-a51a685) to be used in the docker image
-BENTHOS_UMH_VERSION = 0.11.7
+BENTHOS_UMH_VERSION = 0.11.8
 BUF_VERSION = 1.55.1
 PROTOC_GEN_GO_VERSION = 1.36.6
 


### PR DESCRIPTION
This PR bumps benthos-umh from v0.11.7 to v0.11.8

🐛 Bug Fixes

**OPC UA Certificate Validation Fix** (from v0.11.8)
Fixed certificate generation to comply with OPC UA Part 6 specification, resolving connection failures to servers like Ignition 8.3 using Basic256Sha256 security policy or Sign security mode (KEPServerEX was already working). Benthos-UMH client certificates now include all required Key Usage bits (DigitalSignature, ContentCommitment, KeyEncipherment, DataEncipherment) regardless of security mode, and Extended Key Usage correctly identifies certificates as client-only. This fixes connection rejections from compliant OPC UA servers that strictly validate certificate structure. No configuration changes needed - certificates are automatically generated with correct Key Usage bits. (#221)

**Array Serialization Fix** (from v0.11.8)
Fixed tag processor array handling to preserve type information using JSON format. Arrays from protocols like OPC UA are now serialized as `["a","b","c"]` instead of `[a b c]`, which means downstream processors can correctly distinguish between `[1,2,3]` (numbers) and `["1","2","3"]` (strings). This enables proper array parsing in data flows without losing type information. **Breaking change**: If you're parsing arrays in downstream processors, you'll need to use `JSON.parse(value)` instead of splitting on spaces. (#219)

**Sparkplug B Shutdown Panic Fix** (from v0.11.8)
Fixed a race condition that caused benthos-umh to crash when shutting down or restarting with active Sparkplug B inputs. Previously, the message handler goroutine could panic by sending to a closed channel during shutdown. Sparkplug B users can now safely restart services without unexpected panics during shutdown operations. (#218)

📝 Notes

- OPC UA certificate fix enables connections to compliant servers with strict certificate validation
- Array serialization breaking change requires updating downstream processors to use JSON.parse() for array handling
- All fixes are backward compatible except array serialization format
- Release Notes: [v0.11.8](https://github.com/united-manufacturing-hub/benthos-umh/releases/tag/v0.11.8)