### PR TITLE
2025-10-30

### DIFF
--- a/umh-core/Makefile
+++ b/umh-core/Makefile
@@ -69,7 +69,7 @@ NMAP_VERSION = 7.97-r0
 S6_OVERLAY_VERSION = 3.2.0.2
 REDPANDA_VERSION = 24.3.18
 ## Benthos version is a tag or a sha-<commit hash> (e.g. 0.9.4 or sha-a51a685) to be used in the docker image
-BENTHOS_UMH_VERSION = 0.11.7
+BENTHOS_UMH_VERSION = 0.11.8
 BUF_VERSION = 1.55.1
 PROTOC_GEN_GO_VERSION = 1.36.6
 


### PR DESCRIPTION
# Release v0.43.13

🐛 **Bug Fixes:**

- **OPC UA Connection Improvements** - Fixed certificate generation issues that prevented connections to OPC UA servers with strict security requirements (like Ignition 8.3 using Basic256Sha256 security policy). Certificates now include all required security attributes, so connections work reliably with compliant OPC UA servers. No configuration changes needed.

- **Array Data Type Preservation** - Fixed array handling to preserve whether values are numbers or text when passing data between systems. Previously, arrays like `[1,2,3]` could be confused with `["1","2","3"]`, causing data processing errors. Arrays now maintain their original data types correctly.

- **Service Restart Stability** - Fixed crashes that could occur when restarting services with active Sparkplug B connections. Services now shut down cleanly without unexpected errors.

📝 **Technical Notes:**
- Bumped benthos-umh from v0.11.7 to v0.11.8
- OPC UA certificates now comply with Part 6 specification (DigitalSignature, ContentCommitment, KeyEncipherment, DataEncipherment Key Usage bits)
- Array serialization changed from space-separated to JSON format (`["a","b","c"]` instead of `[a b c]`)
- Breaking change: Downstream processors using array splitting need to use `JSON.parse()` instead of space splitting
- Fixed Sparkplug B shutdown race condition preventing channel-closed panics
- Pull Requests: #2309

**Contributors:** @JeremyTheocharis

**Pull Requests:**
- #2309: build: bump benthos-umh to v0.11.8 for OPC UA and array serialization fixes