### PR TITLE
test: Bump benthos-umh to PR223 for OPC UA deadband testing

### DIFF
--- a/umh-core/Makefile
+++ b/umh-core/Makefile
@@ -69,7 +69,7 @@ NMAP_VERSION = 7.97-r0
 S6_OVERLAY_VERSION = 3.2.0.2
 REDPANDA_VERSION = 24.3.18
 ## Benthos version is a tag or a sha-<commit hash> (e.g. 0.9.4 or sha-a51a685) to be used in the docker image
-BENTHOS_UMH_VERSION = 0.11.8
+BENTHOS_UMH_VERSION = ENG-3799-fix3-deadband
 BUF_VERSION = 1.55.1
 PROTOC_GEN_GO_VERSION = 1.36.6
 


### PR DESCRIPTION
## Testing Only - DO NOT MERGE

This PR bumps benthos-umh to the PR223 branch tag to test OPC UA deadband filtering fixes with a customer.

**Benthos version:** `ENG-3799-fix3-deadband` (PR223 branch)
**Docker image:** `ghcr.io/united-manufacturing-hub/benthos-umh:ENG-3799-fix3-deadband`

**What's being tested:**
- PR: https://github.com/united-manufacturing-hub/benthos-umh/pull/223
- Deadband filtering with hardcoded threshold=0 (duplicate suppression only)
- Type-aware filter application (numeric nodes only)
- Server capability detection with graceful fallback
- Subscription failure metrics for visibility

**Features implemented:**
1. Server-side deadband filtering (suppresses exact duplicate values)
2. Bug fix: Only apply filters to numeric node types (prevents data loss)
3. Bug fix: Detect server capabilities and fallback gracefully
4. Bug fix: Add Prometheus metrics for subscription failures

**Expected impact:** 50-70% reduction in OPC UA notifications for stable values

**Next steps:**
1. This PR creates branch-specific docker tag (e.g., `eng-3845-test-pr223-deadband-fixes`)
2. Customer uses that tag for testing OPC UA with 100k+ tags
3. After successful testing, close this PR and create proper release

**DO NOT MERGE** - This is for testing only.