### PR TITLE
build: bump benthos-umh to v0.11.9 for OPC UA performance and reliability

### DIFF
--- a/umh-core/Makefile
+++ b/umh-core/Makefile
@@ -69,7 +69,7 @@ NMAP_VERSION = 7.97-r0
 S6_OVERLAY_VERSION = 3.2.0.2
 REDPANDA_VERSION = 24.3.18
 ## Benthos version is a tag or a sha-<commit hash> (e.g. 0.9.4 or sha-a51a685) to be used in the docker image
-BENTHOS_UMH_VERSION = 0.11.8
+BENTHOS_UMH_VERSION = 0.11.9
 BUF_VERSION = 1.55.1
 PROTOC_GEN_GO_VERSION = 1.36.6
 


### PR DESCRIPTION
This PR bumps benthos-umh from v0.11.8 to v0.11.9

🐛 Bug Fixes

**GitHub Actions Supply Chain Security** (from v0.11.9)
Pinned third-party GitHub Actions to their commit SHA to mitigate potential supply chain attacks. This hardens the CI/CD pipeline security for benthos-umh releases with no impact on functionality. Your protocol converters are now protected against compromised GitHub Actions in the build pipeline. (#225)

**OPC UA Browse Deadlock at Scale** (from v0.11.9)
Fixed critical deadlock when browsing more than 100,000 OPC UA nodes. The browse operation would hang indefinitely when the 100k channel buffer filled up, requiring container restarts to recover. Now uses a streaming consumer pattern that processes nodes concurrently with discovery, eliminating the deadlock entirely. Tested with 110,000 nodes - completes successfully in under 1 second. This enables large-scale OPC UA deployments that were previously impossible. (#224)

**Node-RED JavaScript Console Debugging** (from v0.11.9)
Fixed `console.log()`, `console.info()`, `console.warn()`, and `console.error()` in Node-RED JavaScript processor to work like browser and Node.js environments. Console methods now accept multiple arguments of any type (not just strings) and properly serialize objects instead of printing `[object Object]`. This makes debugging JavaScript transformations in data flows significantly easier - you can now log complex objects and see their actual structure. (#226)

💪 Improvements

**OPC UA Browse Performance Optimization** (from v0.11.9)
Browse operations now complete up to 173x faster with 75-90% less memory usage for large OPC UA servers. Fixed two critical bottlenecks: pre-compiled regex patterns (eliminating 2.4M allocations for 100k nodes) and replaced O(n²) deduplication with O(n) hash map algorithm. Benchmarked at 5000 nodes: browse phase improved from 80ms to 0.44ms. This enables efficient browsing of large OPC UA servers with 100k+ tags without CPU exhaustion or long startup delays. (#222)

🎉 New Features

**OPC UA Deadband Filtering** (from v0.11.9)
Automatically suppresses duplicate value notifications from OPC UA servers, reducing unnecessary network traffic and processing overhead. The deadband filter (threshold=0) only suppresses exact duplicates (e.g., 123.0 → 123.0 reported twice), ensuring all meaningful value changes are still captured. This optimization is enabled by default for all numeric node types in OPC UA bridges - no configuration needed. Testing with opc-plc servers showed significant reduction in redundant notifications for stable values, improving system efficiency at scale. (#223)

📝 Notes

- Enables large-scale OPC UA deployments with 100k+ nodes that were previously blocked by deadlock and performance issues
- No configuration changes needed - all improvements are backward compatible
- Performance optimizations are most noticeable with large node counts (10k+ tags)
- Security fixes applied to CI/CD pipeline protect against supply chain attacks
- Release Notes: [v0.11.9](https://github.com/united-manufacturing-hub/benthos-umh/releases/tag/v0.11.9)