### PR TITLE
fix: use debug loglevel for printing config diffs

### DIFF
--- a/umh-core/pkg/config/benthosserviceconfig/comparator.go
+++ b/umh-core/pkg/config/benthosserviceconfig/comparator.go
@@ -40,12 +40,12 @@ func (c *Comparator) ConfigsEqual(desired, observed BenthosServiceConfig) (isEqu
 	normDesired := c.normalizer.NormalizeConfig(desired)
 	normObserved := c.normalizer.NormalizeConfig(observed)
 
-	defer func() {
+	defer func(normDesired, normObserved *BenthosServiceConfig) {
 		if !isEqual {
-			zap.S().Infof("Normalized desired:  %+v", normDesired)
-			zap.S().Infof("Normalized observed: %+v", normObserved)
+			zap.S().Debugf("Normalized desired:  %+v", normDesired)
+			zap.S().Debugf("Normalized observed: %+v", normObserved)
 		}
-	}()
+	}(&normDesired, &normObserved) // configs are passed as pointers to make the copy cheap
 
 	// Compare essential fields that must match exactly
 	// Ignoring MetricsPort since it's allocated by the port manager

--- a/umh-core/pkg/config/nmapserviceconfig/comparator.go
+++ b/umh-core/pkg/config/nmapserviceconfig/comparator.go
@@ -39,12 +39,12 @@ func (c *Comparator) ConfigsEqual(desired, observed NmapServiceConfig) (isEqual 
 	normDesired := c.normalizer.NormalizeConfig(desired)
 	normObserved := c.normalizer.NormalizeConfig(observed)
 
-	defer func() {
+	defer func(normDesired, normObserved *NmapServiceConfig) {
 		if !isEqual {
-			zap.S().Infof("Normalized desired:  %+v", normDesired)
-			zap.S().Infof("Normalized observed: %+v", normObserved)
+			zap.S().Debugf("Normalized desired:  %+v", normDesired)
+			zap.S().Debugf("Normalized observed: %+v", normObserved)
 		}
-	}()
+	}(&normDesired, &normObserved) // configs are passed as pointers to make the copy cheap
 
 	// Compare essential fields that must match exactly
 	if normDesired.Target != normObserved.Target {

--- a/umh-core/pkg/config/redpandaserviceconfig/comparator.go
+++ b/umh-core/pkg/config/redpandaserviceconfig/comparator.go
@@ -40,12 +40,12 @@ func (c *Comparator) ConfigsEqual(desired, observed RedpandaServiceConfig) (isEq
 	normDesired := c.normalizer.NormalizeConfig(desired)
 	normObserved := c.normalizer.NormalizeConfig(observed)
 
-	defer func() {
+	defer func(normDesired, normObserved *RedpandaServiceConfig) {
 		if !isEqual {
-			zap.S().Infof("Normalized desired:  %+v", normDesired)
-			zap.S().Infof("Normalized observed: %+v", normObserved)
+			zap.S().Debugf("Normalized desired:  %+v", normDesired)
+			zap.S().Debugf("Normalized observed: %+v", normObserved)
 		}
-	}()
+	}(&normDesired, &normObserved) // configs are passed as pointers to make the copy cheap
 
 	return reflect.DeepEqual(normDesired, normObserved)
 }

--- a/umh-core/pkg/config/topicbrowserserviceconfig/comparator.go
+++ b/umh-core/pkg/config/topicbrowserserviceconfig/comparator.go
@@ -39,12 +39,12 @@ func (c *Comparator) ConfigsEqual(desired, observed Config) (isEqual bool) {
 	normDesired := c.normalizer.NormalizeConfig(desired)
 	normObserved := c.normalizer.NormalizeConfig(observed)
 
-	defer func() {
+	defer func(normDesired, normObserved *Config) {
 		if !isEqual {
-			zap.S().Infof("Normalized desired:  %+v", normDesired)
-			zap.S().Infof("Normalized observed: %+v", normObserved)
+			zap.S().Debugf("Normalized desired:  %+v", normDesired)
+			zap.S().Debugf("Normalized observed: %+v", normObserved)
 		}
-	}()
+	}(&normDesired, &normObserved) // configs are passed as pointers to make the copy cheap
 
 	// Since Config is currently empty, they are always equal
 	// When fields are added to Config, add comparison logic here


### PR DESCRIPTION
Fixes: ENG-3823

Use Debug LogLevel for printing configuration diffs. Also pass referenced configs by pointer to reduce memory allocation cost.
