### PR TITLE
build: bump benthos-umh to eng-3852 for server auto-optimization

### DIFF
--- a/umh-core/Makefile
+++ b/umh-core/Makefile
@@ -69,7 +69,7 @@ NMAP_VERSION = 7.97-r0
 S6_OVERLAY_VERSION = 3.2.0.2
 REDPANDA_VERSION = 24.3.18
 ## Benthos version is a tag or a sha-<commit hash> (e.g. 0.9.4 or sha-a51a685) to be used in the docker image
-BENTHOS_UMH_VERSION = 0.11.9
+BENTHOS_UMH_VERSION = eng-3852-server-auto-optimization-profiles
 BUF_VERSION = 1.55.1
 PROTOC_GEN_GO_VERSION = 1.36.6
 


### PR DESCRIPTION
This PR bumps benthos-umh from v0.11.9 to eng-3852-server-auto-optimization-profiles (branch version for testing)

## 🎉 New Features

**Server Auto-Optimization Profiles** (from eng-3852)
Your OPC UA bridges now automatically detect and optimize for your specific server type. When connecting to Ignition Gateway, Kepware KEPServerEX, Siemens S7-1200/S7-1500, or Prosys Simulation servers, benthos-umh recognizes the server manufacturer and product name, then applies vendor-specific optimization settings for MaxBatchSize and worker pool limits. This eliminates manual tuning and prevents common issues like EOF errors from overwhelming servers with too many concurrent requests. For unknown servers, defensive defaults are applied to ensure stable operation. No configuration changes needed - optimization happens automatically during connection.

**Hardware-Aware Subscription Limits** (from eng-3852)
OPC UA bridges now respect PLC hardware constraints for monitored items. Siemens S7-1200 PLCs are limited to 1,000 monitored items (hardware constraint), S7-1500 PLCs support up to 10,000, and other servers have no artificial limits. This prevents subscription failures when you try to monitor more tags than your PLC can handle, giving you clear feedback about hardware limitations rather than cryptic OPC UA errors.

**Server Capability Discovery** (from eng-3852)
During connection, benthos-umh now queries your OPC UA server's OperationLimits (the ns=0;i=11704 attribute) and logs discovered limits alongside the profile defaults. If your profile settings exceed what the server reports it can handle, you'll see warnings in the logs. This is Phase 1 (read-only logging) - no behavior changes yet, just visibility to help diagnose issues and prepare for future automatic limit enforcement.

## 💪 Improvements

**Better EOF Error Handling** (from eng-3852)
The combination of server profiles and capability discovery addresses the root cause of customer EOF errors reported in ENG-3822 and ENG-3833. By automatically optimizing connection parameters based on server capabilities, you'll see fewer connection drops and better stability, especially with Ignition Gateway and Kepware servers that were previously experiencing worker pool issues.

## 📝 Notes

- ⚠️ **This is a development/testing version** - using branch `eng-3852-server-auto-optimization-profiles` instead of a released version
- This version enables testing of server optimization features before the official v0.11.10 release
- All features are backward compatible and require no configuration changes
- Tested with 4 server types: Ignition Gateway, Kepware KEPServerEX, Siemens S7-1200, Prosys Simulation
- 128/128 tests passing in benthos-umh
- Related Issues: ENG-3852 (Server Auto-Optimization), ENG-3822 (Customer EOF errors), ENG-3833 (Worker pool issues)
- benthos-umh PR: https://github.com/united-manufacturing-hub/benthos-umh/pull/229

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>