### PR TITLE
docs: Standardize folder name to umh-core-data

### DIFF
--- a/umh-core/docs/getting-started/README.md
+++ b/umh-core/docs/getting-started/README.md
@@ -46,7 +46,7 @@ Your instance will appear as **"Online"** in the Management Console within secon
 If you can't use the cloud Management Console:
 
 ```bash
-mkdir umh-data && cd umh-data
+mkdir umh-core-data && cd umh-core-data
 docker run -d --name umh-core \
   -v $(pwd):/data \
   management.umh.app/oci/united-manufacturing-hub/umh-core:latest


### PR DESCRIPTION
## Summary

Fixes ENG-3041 - Folder name inconsistency in documentation

## Changes

- Updated getting-started/README.md line 49 to use `umh-core-data` instead of `umh-data`
- Aligns with naming used in production/updating.md and reference/container-layout.md

## Testing

✅ Verified no other instances of `umh-data` exist in docs/
✅ Confirmed all docs now consistently reference `umh-core-data`
✅ No functional changes, documentation only

## Impact

- Low risk: documentation-only change
- Improves user experience by eliminating folder name confusion
- Aligns with established naming convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)