### PR TITLE
chore: bump benthos-umh version to 0.11.11

### DIFF
--- a/umh-core/Makefile
+++ b/umh-core/Makefile
@@ -69,7 +69,7 @@ NMAP_VERSION = 7.97-r0
 S6_OVERLAY_VERSION = 3.2.0.2
 REDPANDA_VERSION = 24.3.18
 ## Benthos version is a tag or a sha-<commit hash> (e.g. 0.9.4 or sha-a51a685) to be used in the docker image
-BENTHOS_UMH_VERSION = 0.11.9
+BENTHOS_UMH_VERSION = 0.11.11
 BUF_VERSION = 1.55.1
 PROTOC_GEN_GO_VERSION = 1.36.6
 


### PR DESCRIPTION
  ## Key Updates

 ### **New Features:**
  OPC UA integrations gain automatic DataChangeFilter capability detection for servers lacking filter support, particularly Siemens S7-1200 PLCs implementing the Micro Embedded Device Profile. The
  system now uses a three-way hybrid logic (profile-based detection, S7-1200 special-casing, and trial-based runtime discovery) to prevent `StatusBadFilterNotAllowed` subscription errors while
  maintaining optimal filtering on capable servers.

 ### **Improvements:**
  - Browse operations migrated to a shared GlobalWorkerPool architecture, fixing high-concurrency issues where browsing 300+ nodes could create thousands of workers and exhaust server session
  limits (preventing EOF errors on servers like Ignition with 64-session limits)
  - Server auto-optimization profiles now include automatic detection for Ignition, Kepware, Siemens S7-1200/S7-1500, and Prosys servers with vendor-specific tuning
  - Kafka headers in `uns_input` now convert to strings by default (fixing byte array display issues), with backward compatibility via `metadata_format: "bytes"` flag

 ### **Security Fixes:**
  Go was upgraded from 1.25.2 to 1.25.3, resolving 10 security vulnerabilities in the standard library (4 high severity, 6 medium severity).

 ### **Bug Fixes:**
  - S7-1200 PLCs no longer reject subscriptions when DataChangeFilter is applied (StatusBadFilterNotAllowed errors eliminated)
  - Profile validation strengthened with compile-time checks for invalid MinWorkers/MaxWorkers configurations
  - Browse operation deadlock test stability improved for reliable CI execution

  ### Compatibility

  All existing configurations remain compatible - no migration needed. The Kafka metadata format change defaults to string conversion (recommended), but legacy byte array behavior is preserved via
  `metadata_format: "bytes"` for existing flows with workarounds.