### PR TITLE
fix: resolve data race in MockFSMManager concurrent access (ENG-3924)

### DIFF
--- a/umh-core/pkg/control/loop_test.go
+++ b/umh-core/pkg/control/loop_test.go
@@ -176,7 +176,7 @@ var _ = Describe("ControlLoop", func() {
 		})
 
 		It("should return error if manager returns error", func() {
-			mockManager.ReconcileError = errors.New("reconcile error")
+			mockManager.SetReconcileError(errors.New("reconcile error"))
 
 			err := controlLoop.Reconcile(ctx, 0)
 			Expect(err).To(HaveOccurred())
@@ -265,7 +265,7 @@ var _ = Describe("ControlLoop", func() {
 		})
 
 		It("should stop execution if Reconcile returns a non-timeout error", func() {
-			mockManager.ReconcileError = errors.New("reconcile error")
+			mockManager.SetReconcileError(errors.New("reconcile error"))
 
 			// Start executing in a goroutine
 			execDone := make(chan error)
@@ -364,7 +364,7 @@ var _ = Describe("ControlLoop", func() {
 
 			// Set up random delays in mocks
 			mockConfig.ConfigDelay = time.Duration(rng.Intn(30)) * time.Millisecond
-			mockManager.ReconcileDelay = time.Duration(rng.Intn(30)) * time.Millisecond
+			mockManager.SetReconcileDelay(time.Duration(rng.Intn(30)) * time.Millisecond)
 
 			// Use a context with longer timeout for random delays
 			fuzzCtx, fuzzCancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
@@ -468,13 +468,13 @@ var _ = Describe("ControlLoop", func() {
 				// Mix of defective configs, file system failures, and delays
 				mockConfig.Config = generateDefectiveConfig()
 				mockConfig.ConfigDelay = time.Duration(rng.Intn(30)) * time.Millisecond
-				mockManager.ReconcileDelay = time.Duration(rng.Intn(30)) * time.Millisecond
+				mockManager.SetReconcileDelay(time.Duration(rng.Intn(30)) * time.Millisecond)
 
 				// Add random manager failures
 				if rng.Float64() < 0.3 {
-					mockManager.ReconcileError = fmt.Errorf("random manager error #%d", i)
+					mockManager.SetReconcileError(fmt.Errorf("random manager error #%d", i))
 				} else {
-					mockManager.ReconcileError = nil
+					mockManager.SetReconcileError(nil)
 				}
 
 				// Run the control loop

--- a/umh-core/pkg/fsm/fsm_suite_test.go
+++ b/umh-core/pkg/fsm/fsm_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fsm
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestFSM(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "FSM Suite")
+}

--- a/umh-core/pkg/fsm/mock.go
+++ b/umh-core/pkg/fsm/mock.go
@@ -58,6 +58,9 @@ func (m *MockFSMManager) Reconcile(ctx context.Context, snapshot SystemSnapshot,
 
 // WithReconcileError configures the mock to return the given error.
 func (m *MockFSMManager) WithReconcileError(err error) *MockFSMManager {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
 	m.ReconcileError = err
 
 	return m
@@ -65,9 +68,28 @@ func (m *MockFSMManager) WithReconcileError(err error) *MockFSMManager {
 
 // WithReconcileDelay configures the mock to delay for the given duration.
 func (m *MockFSMManager) WithReconcileDelay(delay time.Duration) *MockFSMManager {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
 	m.ReconcileDelay = delay
 
 	return m
+}
+
+// SetReconcileDelay sets the reconcile delay in a thread-safe manner.
+func (m *MockFSMManager) SetReconcileDelay(d time.Duration) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	m.ReconcileDelay = d
+}
+
+// SetReconcileError sets the reconcile error in a thread-safe manner.
+func (m *MockFSMManager) SetReconcileError(err error) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	m.ReconcileError = err
 }
 
 // ResetCalls clears the called flags for testing multiple calls.

--- a/umh-core/pkg/fsm/mock_race_test.go
+++ b/umh-core/pkg/fsm/mock_race_test.go
@@ -18,136 +18,139 @@ import (
 	"context"
 	"errors"
 	"sync"
-	"testing"
 	"time"
+
+	. "github.com/onsi/ginkgo/v2"
 )
 
-// TestMockFSMManager_RaceCondition verifies that concurrent writes to
-// ReconcileDelay/ReconcileError and reads in Reconcile() are thread-safe.
-//
-// This test should PASS with the race detector enabled (-race flag) because:
-// - Reconcile() acquires mutex and reads ReconcileDelay and ReconcileError
-// - SetReconcileDelay/SetReconcileError and WithReconcileDelay/WithReconcileError
-//   all acquire the mutex before writing
-//
-// This is the GREEN phase of TDD - proving thread-safety is implemented.
-func TestMockFSMManager_RaceCondition(t *testing.T) {
-	mock := NewMockFSMManager()
+var _ = Describe("MockFSMManager", func() {
+	Describe("thread safety", func() {
+		// These tests verify that concurrent writes to ReconcileDelay/ReconcileError
+		// and reads in Reconcile() are thread-safe.
+		//
+		// Tests should PASS with the race detector enabled (-race flag) because:
+		// - Reconcile() acquires mutex and reads ReconcileDelay and ReconcileError
+		// - SetReconcileDelay/SetReconcileError and WithReconcileDelay/WithReconcileError
+		//   all acquire the mutex before writing
+		//
+		// This is the GREEN phase of TDD - proving thread-safety is implemented.
 
-	// Use a context with timeout to ensure goroutines stay alive during writes
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
+		It("should handle concurrent Reconcile calls and field modifications", func() {
+			mock := NewMockFSMManager()
 
-	var wg sync.WaitGroup
+			// Use a context with timeout to ensure goroutines stay alive during writes
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
 
-	// Start multiple goroutines calling Reconcile() concurrently
-	// These goroutines will read ReconcileDelay and ReconcileError inside the mutex
-	numReaders := 10
-	for range numReaders {
-		wg.Add(1)
+			var wg sync.WaitGroup
 
-		go func() {
-			defer wg.Done()
+			// Start multiple goroutines calling Reconcile() concurrently
+			// These goroutines will read ReconcileDelay and ReconcileError inside the mutex
+			numReaders := 10
+			for range numReaders {
+				wg.Add(1)
 
-			for {
-				select {
-				case <-ctx.Done():
-					return
-				default:
-					// Reconcile() locks mutex and reads ReconcileDelay and ReconcileError
-					_, _ = mock.Reconcile(ctx, SystemSnapshot{}, nil)
+				go func() {
+					defer wg.Done()
+
+					for {
+						select {
+						case <-ctx.Done():
+							return
+						default:
+							// Reconcile() locks mutex and reads ReconcileDelay and ReconcileError
+							_, _ = mock.Reconcile(ctx, SystemSnapshot{}, nil)
+						}
+					}
+				}()
+			}
+
+			// Main goroutine writes to fields using thread-safe setter methods
+			// This should NOT create a race condition with the reads inside Reconcile()
+			numWrites := 1000
+			for i := range numWrites {
+				// Use thread-safe setter methods
+				mock.SetReconcileDelay(time.Duration(i) * time.Microsecond)
+				mock.SetReconcileError(errors.New("test error"))
+
+				// Also test the builder methods which now acquire mutex
+				mock.WithReconcileDelay(time.Duration(i) * time.Microsecond)
+				mock.WithReconcileError(errors.New("another error"))
+
+				// Small sleep to ensure overlap with Reconcile() calls
+				time.Sleep(10 * time.Microsecond)
+			}
+
+			// Cancel context to stop reader goroutines
+			cancel()
+			wg.Wait()
+		})
+
+		It("should handle concurrent modification from multiple goroutines", func() {
+			mock := NewMockFSMManager()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+
+			var wg sync.WaitGroup
+
+			// Goroutine 1: Continuously calls Reconcile()
+			wg.Add(1)
+
+			go func() {
+				defer wg.Done()
+
+				for {
+					select {
+					case <-ctx.Done():
+						return
+					default:
+						_, _ = mock.Reconcile(ctx, SystemSnapshot{}, nil)
+					}
 				}
-			}
-		}()
-	}
+			}()
 
-	// Main goroutine writes to fields using thread-safe setter methods
-	// This should NOT create a race condition with the reads inside Reconcile()
-	numWrites := 1000
-	for i := range numWrites {
-		// Use thread-safe setter methods
-		mock.SetReconcileDelay(time.Duration(i) * time.Microsecond)
-		mock.SetReconcileError(errors.New("test error"))
+			// Goroutine 2: Continuously modifies ReconcileDelay using thread-safe setter
+			wg.Add(1)
 
-		// Also test the builder methods which now acquire mutex
-		mock.WithReconcileDelay(time.Duration(i) * time.Microsecond)
-		mock.WithReconcileError(errors.New("another error"))
+			go func() {
+				defer wg.Done()
 
-		// Small sleep to ensure overlap with Reconcile() calls
-		time.Sleep(10 * time.Microsecond)
-	}
-
-	// Cancel context to stop reader goroutines
-	cancel()
-	wg.Wait()
-}
-
-// TestMockFSMManager_ConcurrentModification is another test case that focuses
-// on demonstrating the race between WithReconcileDelay/WithReconcileError methods
-// and Reconcile() when called concurrently.
-func TestMockFSMManager_ConcurrentModification(t *testing.T) {
-	mock := NewMockFSMManager()
-
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-
-	var wg sync.WaitGroup
-
-	// Goroutine 1: Continuously calls Reconcile()
-	wg.Add(1)
-
-	go func() {
-		defer wg.Done()
-
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			default:
-				_, _ = mock.Reconcile(ctx, SystemSnapshot{}, nil)
-			}
-		}
-	}()
-
-	// Goroutine 2: Continuously modifies ReconcileDelay using thread-safe setter
-	wg.Add(1)
-
-	go func() {
-		defer wg.Done()
-
-		for i := 0; ; i++ {
-			select {
-			case <-ctx.Done():
-				return
-			default:
-				// Use thread-safe setter method
-				mock.SetReconcileDelay(time.Duration(i%100) * time.Millisecond)
-			}
-		}
-	}()
-
-	// Goroutine 3: Continuously modifies ReconcileError using thread-safe setter
-	wg.Add(1)
-
-	go func() {
-		defer wg.Done()
-
-		for i := 0; ; i++ {
-			select {
-			case <-ctx.Done():
-				return
-			default:
-				// Use thread-safe setter method
-				if i%2 == 0 {
-					mock.SetReconcileError(errors.New("error"))
-				} else {
-					mock.SetReconcileError(nil)
+				for i := 0; ; i++ {
+					select {
+					case <-ctx.Done():
+						return
+					default:
+						// Use thread-safe setter method
+						mock.SetReconcileDelay(time.Duration(i%100) * time.Millisecond)
+					}
 				}
-			}
-		}
-	}()
+			}()
 
-	// Wait for context timeout
-	<-ctx.Done()
-	wg.Wait()
-}
+			// Goroutine 3: Continuously modifies ReconcileError using thread-safe setter
+			wg.Add(1)
+
+			go func() {
+				defer wg.Done()
+
+				for i := 0; ; i++ {
+					select {
+					case <-ctx.Done():
+						return
+					default:
+						// Use thread-safe setter method
+						if i%2 == 0 {
+							mock.SetReconcileError(errors.New("error"))
+						} else {
+							mock.SetReconcileError(nil)
+						}
+					}
+				}
+			}()
+
+			// Wait for context timeout
+			<-ctx.Done()
+			wg.Wait()
+		})
+	})
+})

--- a/umh-core/pkg/fsm/mock_race_test.go
+++ b/umh-core/pkg/fsm/mock_race_test.go
@@ -43,10 +43,12 @@ func TestMockFSMManager_RaceCondition(t *testing.T) {
 	// Start multiple goroutines calling Reconcile() concurrently
 	// These goroutines will read ReconcileDelay and ReconcileError inside the mutex
 	numReaders := 10
-	for i := 0; i < numReaders; i++ {
+	for range numReaders {
 		wg.Add(1)
+
 		go func() {
 			defer wg.Done()
+
 			for {
 				select {
 				case <-ctx.Done():
@@ -62,7 +64,7 @@ func TestMockFSMManager_RaceCondition(t *testing.T) {
 	// Main goroutine writes to fields using thread-safe setter methods
 	// This should NOT create a race condition with the reads inside Reconcile()
 	numWrites := 1000
-	for i := 0; i < numWrites; i++ {
+	for i := range numWrites {
 		// Use thread-safe setter methods
 		mock.SetReconcileDelay(time.Duration(i) * time.Microsecond)
 		mock.SetReconcileError(errors.New("test error"))
@@ -93,8 +95,10 @@ func TestMockFSMManager_ConcurrentModification(t *testing.T) {
 
 	// Goroutine 1: Continuously calls Reconcile()
 	wg.Add(1)
+
 	go func() {
 		defer wg.Done()
+
 		for {
 			select {
 			case <-ctx.Done():
@@ -107,8 +111,10 @@ func TestMockFSMManager_ConcurrentModification(t *testing.T) {
 
 	// Goroutine 2: Continuously modifies ReconcileDelay using thread-safe setter
 	wg.Add(1)
+
 	go func() {
 		defer wg.Done()
+
 		for i := 0; ; i++ {
 			select {
 			case <-ctx.Done():
@@ -122,8 +128,10 @@ func TestMockFSMManager_ConcurrentModification(t *testing.T) {
 
 	// Goroutine 3: Continuously modifies ReconcileError using thread-safe setter
 	wg.Add(1)
+
 	go func() {
 		defer wg.Done()
+
 		for i := 0; ; i++ {
 			select {
 			case <-ctx.Done():

--- a/umh-core/pkg/fsm/mock_race_test.go
+++ b/umh-core/pkg/fsm/mock_race_test.go
@@ -22,15 +22,15 @@ import (
 	"time"
 )
 
-// TestMockFSMManager_RaceCondition demonstrates the race condition between
-// concurrent writes to ReconcileDelay/ReconcileError and reads in Reconcile().
+// TestMockFSMManager_RaceCondition verifies that concurrent writes to
+// ReconcileDelay/ReconcileError and reads in Reconcile() are thread-safe.
 //
-// This test should FAIL with the race detector enabled (-race flag) because:
+// This test should PASS with the race detector enabled (-race flag) because:
 // - Reconcile() acquires mutex and reads ReconcileDelay and ReconcileError
-// - Direct writes to these public fields (or via WithReconcileDelay/WithReconcileError)
-//   do not acquire the mutex
+// - SetReconcileDelay/SetReconcileError and WithReconcileDelay/WithReconcileError
+//   all acquire the mutex before writing
 //
-// This is the RED phase of TDD - proving the race condition exists.
+// This is the GREEN phase of TDD - proving thread-safety is implemented.
 func TestMockFSMManager_RaceCondition(t *testing.T) {
 	mock := NewMockFSMManager()
 

--- a/umh-core/pkg/fsm/mock_race_test.go
+++ b/umh-core/pkg/fsm/mock_race_test.go
@@ -1,0 +1,145 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fsm
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestMockFSMManager_RaceCondition demonstrates the race condition between
+// concurrent writes to ReconcileDelay/ReconcileError and reads in Reconcile().
+//
+// This test should FAIL with the race detector enabled (-race flag) because:
+// - Reconcile() acquires mutex and reads ReconcileDelay and ReconcileError
+// - Direct writes to these public fields (or via WithReconcileDelay/WithReconcileError)
+//   do not acquire the mutex
+//
+// This is the RED phase of TDD - proving the race condition exists.
+func TestMockFSMManager_RaceCondition(t *testing.T) {
+	mock := NewMockFSMManager()
+
+	// Use a context with timeout to ensure goroutines stay alive during writes
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var wg sync.WaitGroup
+
+	// Start multiple goroutines calling Reconcile() concurrently
+	// These goroutines will read ReconcileDelay and ReconcileError inside the mutex
+	numReaders := 10
+	for i := 0; i < numReaders; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				default:
+					// Reconcile() locks mutex and reads ReconcileDelay and ReconcileError
+					_, _ = mock.Reconcile(ctx, SystemSnapshot{}, nil)
+				}
+			}
+		}()
+	}
+
+	// Main goroutine writes to fields without mutex protection
+	// This creates a race condition with the reads inside Reconcile()
+	numWrites := 1000
+	for i := 0; i < numWrites; i++ {
+		// Direct field writes - these are not protected by mutex
+		mock.ReconcileDelay = time.Duration(i) * time.Microsecond
+		mock.ReconcileError = errors.New("test error")
+
+		// Also test the builder methods which don't acquire mutex
+		mock.WithReconcileDelay(time.Duration(i) * time.Microsecond)
+		mock.WithReconcileError(errors.New("another error"))
+
+		// Small sleep to ensure overlap with Reconcile() calls
+		time.Sleep(10 * time.Microsecond)
+	}
+
+	// Cancel context to stop reader goroutines
+	cancel()
+	wg.Wait()
+}
+
+// TestMockFSMManager_ConcurrentModification is another test case that focuses
+// on demonstrating the race between WithReconcileDelay/WithReconcileError methods
+// and Reconcile() when called concurrently.
+func TestMockFSMManager_ConcurrentModification(t *testing.T) {
+	mock := NewMockFSMManager()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	var wg sync.WaitGroup
+
+	// Goroutine 1: Continuously calls Reconcile()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				_, _ = mock.Reconcile(ctx, SystemSnapshot{}, nil)
+			}
+		}
+	}()
+
+	// Goroutine 2: Continuously modifies ReconcileDelay
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; ; i++ {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				// This write is not protected by mutex
+				mock.ReconcileDelay = time.Duration(i%100) * time.Millisecond
+			}
+		}
+	}()
+
+	// Goroutine 3: Continuously modifies ReconcileError
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; ; i++ {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				// This write is not protected by mutex
+				if i%2 == 0 {
+					mock.ReconcileError = errors.New("error")
+				} else {
+					mock.ReconcileError = nil
+				}
+			}
+		}
+	}()
+
+	// Wait for context timeout
+	<-ctx.Done()
+	wg.Wait()
+}


### PR DESCRIPTION
## Summary

- Fixed data race in `MockFSMManager` where concurrent writes to `ReconcileDelay` and `ReconcileError` fields could race with reads in `Reconcile()`
- Added thread-safe setter methods (`SetReconcileDelay`, `SetReconcileError`) that acquire mutex before writing
- Updated `WithReconcileDelay` and `WithReconcileError` builder methods to also acquire mutex
- Updated all test usages to use the new thread-safe setters
- Added dedicated race condition tests to verify thread-safety

## Root Cause

The `MockFSMManager` struct had a mutex protecting reads in `Reconcile()`, but the `WithReconcileDelay` and `WithReconcileError` builder methods wrote directly to fields without acquiring the mutex. When tests modified these fields concurrently with `Reconcile()` calls, Go's race detector correctly identified the data race.

## Implementation (TDD Workflow)

1. **RED**: Added failing test that demonstrates the race condition (`mock_race_test.go`)
2. **GREEN**: Added thread-safe setter methods with mutex protection (`mock.go`)
3. **REFACTOR**: Updated `loop_test.go` to use the new setters instead of direct field access

## Test plan

- [x] Race detection tests pass with `-race` flag
- [x] ControlLoop fuzz tests pass (originally failing test suite)
- [x] Full unit test suite passes
- [x] golangci-lint passes with 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)