### PR TITLE
build: bump benthos-umh to v0.11.12 for SparkplugB and OPC UA fixes

### DIFF
--- a/umh-core/Makefile
+++ b/umh-core/Makefile
@@ -69,7 +69,7 @@ NMAP_VERSION = 7.97-r0
 S6_OVERLAY_VERSION = 3.2.0.2
 REDPANDA_VERSION = 24.3.18
 ## Benthos version is a tag or a sha-<commit hash> (e.g. 0.9.4 or sha-a51a685) to be used in the docker image
-BENTHOS_UMH_VERSION = 0.11.11
+BENTHOS_UMH_VERSION = 0.11.12
 BUF_VERSION = 1.55.1
 PROTOC_GEN_GO_VERSION = 1.36.6
 


### PR DESCRIPTION
This PR bumps benthos-umh from v0.11.11 to v0.11.12

🐛 Bug Fixes

**OPC UA Browse Deadlock Prevention** (from v0.11.12)
Fixed critical deadlock in GlobalWorkerPool when OPC UA browse operations were cancelled during task submission. Previously, the system would hang indefinitely when connection issues or shutdowns occurred while workers were submitting child tasks, requiring manual intervention. Browse operations now respond properly to context cancellation through a select statement that checks for context.Done() during channel sends, preventing system hangs during server connection problems or graceful shutdowns. This fix ensures OPC UA browse operations remain responsive under all conditions, particularly important for large-scale deployments with 300+ nodes. (#238)

**SparkplugB Device Discovery via Passive Rebirth** (from v0.11.12)
Fixed critical bug where device-level tags (motors, sensors, compressors, control configurations) were completely undiscoverable via passive discovery. The protocol converter was incorrectly using "Node Control/Rebirth" metric for both node-level (NCMD) and device-level (DCMD) rebirth commands, violating SparkplugB 3.0 specification section 6.4.24. Device-level rebirth requests now correctly use "Device Control/Rebirth" metric, enabling full device tag discovery through passive mechanisms. In production testing with Ignition Edge servers, this fix increased device tag discovery from 0 to 103 unique tags (90.1% discovery rate) with 309 DBIRTH messages captured. This is critical for achieving complete brownfield device inventory without requiring manual OPC UA browsing or pre-configuration - users can now discover all device-level tags (configuration parameters, motor states, sensor values, compressor metrics, tower controls, palletizer settings) automatically through SparkplugB's passive discovery protocol. (#217)

**SparkplugB NDATA Processing Restored** (from v0.11.12)
Fixed bug where node-level SparkplugB data (NDATA messages) were being dropped with `umh_conversion_status: skipped_insufficient_data` error status. NDATA messages don't have device IDs by design - they carry node-level data using edge_node_id as the identifier. The protocol converter was incorrectly rejecting these messages during validation, treating the absence of device_id as an error condition. The plugin now correctly processes NDATA messages using edge_node_id as the device identifier while maintaining strict validation for DDATA (device-level) messages. In production PCAP analysis from customer deployment, 262 NDATA messages that were being silently lost are now processed correctly. Nodes sending NDATA (edge-level metrics, node status information) now appear in Topic Browser with complete SparkplugB hierarchy visibility, ensuring no data loss for customers using node-level instrumentation. (#217)

**Configuration Example Syntax Errors Fixed** (from v0.11.12)
Corrected Sparkplug B input documentation example that contained syntax errors preventing successful copy-paste usage. Changed `processing:` to `pipeline:` (the correct benthos configuration term for processor sections) and fixed JavaScript comment syntax from `#` to `//` (required by the goja JavaScript engine used in benthos). Users copying the example from documentation were experiencing immediate configuration validation errors ("unknown field processing") and JavaScript syntax errors during execution. With this fix, the documented example now works correctly when copied directly, reducing friction for new users implementing SparkplugB integrations. (#236)

💪 Improvements

**JavaScript console.debug Support** (from v0.11.12)
Added `console.debug()` to the JavaScript processor logging API, completing the console logging interface to match standard browser console behavior. You can now use debug-level logging in your JavaScript processors for verbose diagnostic output that can be filtered in production environments through log level configuration. This fills the gap in the console API (which previously only supported log/info/warn/error) and enables proper separation of development debugging output from production logging, following standard JavaScript logging patterns that developers expect. (#235)

**Developer Experience Enhancement** (from v0.11.12)
Added `make run` and `make run-debug` commands to the benthos-umh Makefile for easier local testing and development workflows. Set the `CONFIG=./path/to/your/config` environment variable and run `make run` to test benthos configurations during development without requiring full deployment or complex setup steps. The debug variant enables additional logging and diagnostic output. This streamlines the development workflow by reducing the friction between code changes and testing, making configuration iteration and debugging significantly faster for protocol converter development. (#237)

🎉 New Features

**SparkplugB Message Observability via Split Tracking** (from v0.11.12)
Added `spb_metric_index` and `spb_metrics_in_payload` metadata fields to enable tracing of message splitting behavior. When SparkplugB NDATA/DDATA messages are split into multiple UNS messages (1 MQTT message with N metrics → N separate UNS messages for individual metric subscriptions), you can now trace each split message back to its original source message using these metadata fields. This explains why duplicate sequence numbers appear when subscribing to `*._raw.*` patterns - they're valid splits from the same source message, not protocol errors or data duplication issues. The `spb_metric_index` shows the position of the metric within the original payload (0-based), while `spb_metrics_in_payload` shows the total number of metrics that were split. Useful for debugging SparkplugB message flows, understanding sequence number behavior in split scenarios, and validating that message transformation is working correctly without data loss. (#217)

📝 Notes

- SparkplugB improvements span three critical areas: passive discovery (device-level tags now discoverable), message processing (NDATA support restored), and observability (dual-sequence metadata for split tracking)
- OPC UA browse operations are now resilient to cancellation and connection issues under high-load scenarios
- Developer tooling improvements reduce friction for local testing and debugging workflows
- All changes are backward compatible - no configuration migration needed
- Release Notes: [v0.11.12](https://github.com/united-manufacturing-hub/benthos-umh/releases/tag/v0.11.12)
- Unblocks device discovery workflows for brownfield deployments relying on SparkplugB passive enumeration
- Resolves data loss issues for customers using node-level SparkplugB instrumentation
- All 233 SparkplugB tests passing with comprehensive coverage of edge cases, lock management, and production PCAP patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>