### PR TITLE
chore: update benthos-umh-version to v0.11.13

### DIFF
--- a/umh-core/Makefile
+++ b/umh-core/Makefile
@@ -69,7 +69,7 @@ NMAP_VERSION = 7.97-r0
 S6_OVERLAY_VERSION = 3.2.0.2
 REDPANDA_VERSION = 24.3.18
 ## Benthos version is a tag or a sha-<commit hash> (e.g. 0.9.4 or sha-a51a685) to be used in the docker image
-BENTHOS_UMH_VERSION = 0.11.12
+BENTHOS_UMH_VERSION = 0.11.13
 BUF_VERSION = 1.55.1
 PROTOC_GEN_GO_VERSION = 1.36.6
 


### PR DESCRIPTION
## 🐛 Bug Fixes

  JavaScript Node-RED Plugin Stringify Improvements (from v0.11.13)
  Implemented stringify functionality close to Node.js representation for better JSON readability and
  resolved handling of edge cases that JSON doesn't natively support (Infinity, NaN, large integers).
  Previously, console output contained excessive escaped characters making bridge configuration
  debugging difficult. The Node.js-style representation is more efficient for use within JSON as it
  doesn't use double-quotes for formatting, resulting in fewer backslashes and significantly improved
  readability when debugging bridge configurations. (#239)

  OPC UA Virtual Path Handling (from v0.11.13)
  Fixed handling of null or empty virtual paths for OPC UA connections. Previously, OPC UA
  configurations without virtual paths would fail validation. The tag processor plugin now correctly
  accepts empty or null virtual path values, enabling broader compatibility with OPC UA server
  configurations that don't require virtual paths. (498986d)

##  💪 Improvements

  Automated Version Bumping Workflow (from v0.11.13)
  Added new GitHub Actions workflow for automated benthos-umh version updates in the
  united-manufacturing-hub repository. When a new benthos-umh release is published, the workflow
  automatically generates app tokens, checks out the united-manufacturing-hub repository, updates
  BENTHOS_UMH_VERSION in the Makefile, validates the version replacement, and creates pull requests with
   team reviewers assigned. Release notes are automatically extracted and included in PR descriptions,
  streamlining the release process and reducing manual coordination between repositories. (#242)

  ## 📝 Notes

  - JavaScript logging improvements make debugging bridge configurations significantly easier with
  cleaner output
  - OPC UA configurations are now more flexible with optional virtual path support
  - CI/CD automation reduces manual effort for version coordination across repositories
  - All changes are backward compatible - no configuration migration needed
  - Release Notes: https://github.com/united-manufacturing-hub/benthos-umh/releases/tag/v0.11.12

  ---
  Full Changelog: https://github.com/united-manufacturing-hub/benthos-umh/compare/v0.11.12...v0.11.13