### PR TITLE
2025-12-01

### DIFF
--- a/umh-core/Makefile
+++ b/umh-core/Makefile
@@ -69,7 +69,7 @@ NMAP_VERSION = 7.97-r0
 S6_OVERLAY_VERSION = 3.2.0.2
 REDPANDA_VERSION = 24.3.18
 ## Benthos version is a tag or a sha-<commit hash> (e.g. 0.9.4 or sha-a51a685) to be used in the docker image
-BENTHOS_UMH_VERSION = 0.11.12
+BENTHOS_UMH_VERSION = 0.11.13
 BUF_VERSION = 1.55.1
 PROTOC_GEN_GO_VERSION = 1.36.6
 


### PR DESCRIPTION
Updates benthos-umh to v0.11.13

## 🐛 Bug Fixes

- **Cleaner JavaScript Debugging Output** - Bridge configuration debugging is now significantly easier. Previously, console output from JavaScript processors contained excessive escaped characters (like `\"` everywhere), making it difficult to read and debug bridge configurations. The output now uses a Node.js-style representation that's more readable and requires fewer backslashes, helping you troubleshoot data transformations faster.

- **OPC UA Subscriptions Without Tag Hierarchy** - Fixed an issue where subscribing directly to OPC UA child nodes (without a parent folder hierarchy) would cause validation errors or malformed topics with double dots. When you subscribe to leaf nodes directly instead of browsing through a folder structure, the `opcua_tag_path` metadata is empty - this is now handled correctly. Topics are properly constructed without the optional virtual path segment, so `umh.v1.site._raw.temperature` works correctly instead of failing or producing `umh.v1.site._raw..temperature`.

## 💪 Improvements

- **Automated Version Coordination** - Added CI/CD automation to streamline benthos-umh version updates across repositories, reducing manual coordination effort during releases.

## 📝 Key Notes

- All changes are backward compatible - no configuration migration needed
- JavaScript logging improvements are automatically applied to all JavaScript processors
- OPC UA virtual path handling affects configurations where nodes are subscribed directly without folder hierarchy