### PR TITLE
fix: propagate DebugLevel through config comparison chain

### DIFF
--- a/umh-core/examples/example-config-protocolconverter.yaml
+++ b/umh-core/examples/example-config-protocolconverter.yaml
@@ -29,7 +29,7 @@ protocolConverter:
       config:
         connection:
           nmap:
-            target:   "{{ .HOST }}"
+            target:   "{{ .IP }}"
             port:     "{{ .PORT }}"    # Now templatable! Resolves to proper uint16 at runtime
         dataflowcomponent_read:
           benthos:
@@ -47,10 +47,10 @@ protocolConverter:
                         msg.meta.location_path = "{{ .location_path }}"; // auto-generated path from agent and protocol converter location
                         msg.meta.data_contract = "_raw";
                         msg.meta.tag_name      = "random_int";
-                        msg.meta.host          = "{{ .HOST }}"; // optional metadata
+                        msg.meta.host          = "{{ .IP }}"; // optional metadata
                         msg.meta.port          = "{{ .PORT }}"; // optional metadata
                         // tag_processor now auto-creates msg.meta.topic
                         return msg;
       variables:
-        HOST:   "localhost"
+        IP:   "localhost"
         PORT: "8080"

--- a/umh-core/pkg/config/dataflowcomponentserviceconfig/config_test.go
+++ b/umh-core/pkg/config/dataflowcomponentserviceconfig/config_test.go
@@ -58,7 +58,7 @@ var _ = Describe("DataFlowComponentConfig", func() {
 			Expect(fullConfig.DebugLevel).To(BeFalse())         // Default value
 		})
 
-		It("should convert BenthosServiceConfig to BenthosConfig, ignoring advanced fields", func() {
+		It("should convert BenthosServiceConfig to BenthosConfig, preserving DebugLevel but ignoring MetricsPort", func() {
 			// Create a full BenthosServiceConfig
 			fullConfig := benthosserviceconfig.BenthosServiceConfig{
 				Input: map[string]interface{}{
@@ -71,7 +71,7 @@ var _ = Describe("DataFlowComponentConfig", func() {
 					"stdout": map[string]interface{}{},
 				},
 				MetricsPort: 8080, // This should be ignored in conversion
-				DebugLevel:  true, // This should be ignored in conversion
+				DebugLevel:  true, // This MUST be preserved for config comparison to work
 			}
 
 			// Convert to simplified BenthosConfig
@@ -80,13 +80,14 @@ var _ = Describe("DataFlowComponentConfig", func() {
 			// Verify conversion
 			Expect(simplified.BenthosConfig.Input).To(Equal(fullConfig.Input))
 			Expect(simplified.BenthosConfig.Output).To(Equal(fullConfig.Output))
+			Expect(simplified.DebugLevel).To(BeTrue()) // DebugLevel must be preserved
 
 			// Convert back to BenthosServiceConfig
 			convertedBack := simplified.GetBenthosServiceConfig()
 
-			// Verify advanced fields use defaults, not original values
+			// Verify MetricsPort uses default, but DebugLevel is preserved
 			Expect(convertedBack.MetricsPort).To(Equal(uint16(0))) // Default, not 8080
-			Expect(convertedBack.DebugLevel).To(BeFalse())         // Default, not DEBUG
+			Expect(convertedBack.DebugLevel).To(BeTrue())          // Preserved from original
 		})
 	})
 

--- a/umh-core/pkg/config/dataflowcomponentserviceconfig/utils.go
+++ b/umh-core/pkg/config/dataflowcomponentserviceconfig/utils.go
@@ -57,6 +57,7 @@ func FromBenthosServiceConfig(benthos benthosserviceconfig.BenthosServiceConfig)
 			RateLimitResources: benthos.RateLimitResources,
 			Buffer:             benthos.Buffer,
 		},
+		DebugLevel: benthos.DebugLevel,
 	}
 }
 

--- a/umh-core/pkg/config/protocolconverterserviceconfig/config_customized.go
+++ b/umh-core/pkg/config/protocolconverterserviceconfig/config_customized.go
@@ -85,5 +85,6 @@ func FromConnectionAndDFCServiceConfig(
 		ConnectionServiceConfig:             connection,
 		DataflowComponentReadServiceConfig:  dfcRead,
 		DataflowComponentWriteServiceConfig: dfcWrite,
+		DebugLevel:                          dfcRead.DebugLevel,
 	}
 }

--- a/umh-core/pkg/config/protocolconverterserviceconfig/config_customized_test.go
+++ b/umh-core/pkg/config/protocolconverterserviceconfig/config_customized_test.go
@@ -1,0 +1,77 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package protocolconverterserviceconfig
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/connectionserviceconfig"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/dataflowcomponentserviceconfig"
+)
+
+var _ = Describe("FromConnectionAndDFCServiceConfig", func() {
+	Describe("DebugLevel propagation", func() {
+		It("should propagate DebugLevel=true from DFC read config", func() {
+			// Arrange: DFC read config has DebugLevel=true
+			connection := connectionserviceconfig.ConnectionServiceConfig{}
+			dfcRead := dataflowcomponentserviceconfig.DataflowComponentServiceConfig{
+				DebugLevel: true,
+			}
+			dfcWrite := dataflowcomponentserviceconfig.DataflowComponentServiceConfig{
+				DebugLevel: false,
+			}
+
+			// Act
+			result := FromConnectionAndDFCServiceConfig(connection, dfcRead, dfcWrite)
+
+			// Assert: The runtime config should have DebugLevel=true
+			Expect(result.DebugLevel).To(BeTrue(), "DebugLevel should be propagated from DFC read config")
+		})
+
+		It("should propagate DebugLevel=false from DFC read config", func() {
+			// Arrange: DFC read config has DebugLevel=false
+			connection := connectionserviceconfig.ConnectionServiceConfig{}
+			dfcRead := dataflowcomponentserviceconfig.DataflowComponentServiceConfig{
+				DebugLevel: false,
+			}
+			dfcWrite := dataflowcomponentserviceconfig.DataflowComponentServiceConfig{
+				DebugLevel: false,
+			}
+
+			// Act
+			result := FromConnectionAndDFCServiceConfig(connection, dfcRead, dfcWrite)
+
+			// Assert: The runtime config should have DebugLevel=false
+			Expect(result.DebugLevel).To(BeFalse(), "DebugLevel should be propagated from DFC read config")
+		})
+
+		It("should use DFC read DebugLevel even when DFC write differs", func() {
+			// Arrange: DFC read=true, DFC write=false
+			connection := connectionserviceconfig.ConnectionServiceConfig{}
+			dfcRead := dataflowcomponentserviceconfig.DataflowComponentServiceConfig{
+				DebugLevel: true,
+			}
+			dfcWrite := dataflowcomponentserviceconfig.DataflowComponentServiceConfig{
+				DebugLevel: false,
+			}
+
+			// Act
+			result := FromConnectionAndDFCServiceConfig(connection, dfcRead, dfcWrite)
+
+			// Assert: Should use DFC read's DebugLevel
+			Expect(result.DebugLevel).To(BeTrue(), "DebugLevel should come from DFC read config")
+		})
+	})
+})


### PR DESCRIPTION
## fix: propagate DebugLevel through config comparison chain

### Problem

Changing `debug_level` in config.yaml did not always trigger bridge restarts. Specifically:
- ✅ Changing `debug_level: false` → `true` worked
- ❌ **Adding** `debug_level: true` when field was not present did NOT trigger restart
- ❌ **Removing** `debug_level` field did NOT trigger restart

### Root Cause

The config comparison chain for "observed" (deployed) config was broken:

```
benthos.yaml → BenthosServiceConfig         ✅ DebugLevel read from file
            → DataflowComponentServiceConfig ❌ DebugLevel NOT copied (Bug #1)
            → ProtocolConverterRuntimeConfig ❌ DebugLevel NOT copied (Bug #2)
```

Because `FromBenthosServiceConfig()` did not copy `DebugLevel`, the observed config always had `DebugLevel=false` (Go zero value). This meant:
- Adding `debug_level: true` → compared `true` vs `false` → should detect change, but...
- The comparison happened at the wrong layer, so the S6 config diff check could not see it

### Fix

Two one-line additions to complete the propagation chain:

**1. `pkg/config/dataflowcomponentserviceconfig/utils.go:60`**
```go
DebugLevel: benthos.DebugLevel,
```

**2. `pkg/config/protocolconverterserviceconfig/config_customized.go:88`**
```go
DebugLevel: dfcRead.DebugLevel,
```

### Testing

**Unit Tests**: Added/updated tests verifying DebugLevel propagation through both conversion functions

**Manual Verification** on test server:
```
# Added debug_level: true to config.yaml (field was not present before)
18:21:27 - Configuration differences detected ✅
18:21:27 - Entering stopping state
18:21:28 - Entering starting state
Result: Benthos logger changed from INFO to DEBUG ✅
```

### Checklist

- [x] Unit tests pass
- [x] Manual verification on test server
- [x] CI checks pass (go vet, nilaway, build)
- [x] No focused tests

Fixes ENG-3960