### PR TITLE
[ENG-3907] fix for Idle status shown instead of degraded

### DIFF
--- a/umh-core/pkg/service/benthos/benthos.go
+++ b/umh-core/pkg/service/benthos/benthos.go
@@ -140,7 +140,6 @@ type ServiceInfo struct {
 }
 
 type BenthosStatus struct {
-
 	// StatusReason contains the reason for the status of the Benthos service
 	// If the service is degraded, this will contain the log entry that caused the degradation together with the information that it is degraded because of the log entry
 	// If the service is currently starting up, it will contain the s6 status of the service
@@ -233,7 +232,6 @@ type BenthosService struct {
 // yaml.Unmarshal and simply hand the already-normalised struct back to the
 // caller – a ~20× speed-up on the hot path.
 type configCacheEntry struct {
-
 	// parsed is the *fully normalised* BenthosServiceConfig that callers
 	// expect.  It is treated as **read-only** after being cached; if callers
 	// ever start mutating the struct, we must clone it before returning.
@@ -248,7 +246,8 @@ type configCacheEntry struct {
 func hash(buf []byte) uint64 { return xxhash.Sum64(buf) }
 
 // benthosLogRe is a helper function for BenthosService.IsLogsFine.
-var benthosLogRe = regexp.MustCompile(`^level=(error|warning)\s+msg=(.+)`)
+// no ^ anchor since redpanda-connect logs may start with time= prefix.
+var benthosLogRe = regexp.MustCompile(`level=(error|warning)\s+msg=(.+)`)
 
 // BenthosServiceOption is a function that modifies a BenthosService.
 type BenthosServiceOption func(*BenthosService)


### PR DESCRIPTION
## Description:

Regarding [ENG-3907](https://linear.app/united-manufacturing-hub/issue/ENG-3907/investigate-why-the-bridge-shows-green-despite-connection-errors) the Bridges/DFCs showed `Idle` when being e.g. `degraded`. 
-> This was caused from the upgrade of redpanda-connect [update-commit](https://github.com/united-manufacturing-hub/benthos-umh/commit/e1a41cc368e7a9e82341e1330696f7e8bc4b4a93).

In some of the version-changes seemingly timestamp logs were added from redpanda-connect.
Therefore as a fix, we now check for error on line-level, not beginning of the line.

I would like to have this as kind of a "quick-fix" and in a follow-up there seems to be a flag for the benthos-config `add_timestamp: false` which we then can set internally for benthosConfigs.