### PR TITLE
ci: add ARM64 binary architecture verification

### DIFF
--- a/.github/workflows/build-umh-core.yml
+++ b/.github/workflows/build-umh-core.yml
@@ -97,14 +97,31 @@ jobs:
             VERSION=${{ steps.version.outputs.VERSION }} \
             TAGS="$TAGS"
 
-  verify-arm64-binaries:
-    name: Verify ARM64 Image
+  verify-binaries:
+    name: Verify ${{ matrix.arch }} Image
     needs: build
-    runs-on: depot-ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 10
     permissions:
       contents: read
       packages: read
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [arm64, amd64]
+        include:
+          - arch: arm64
+            runner: depot-ubuntu-24.04-arm
+            platform: linux/arm64
+            expected_machine: "b700"
+            expected_uname: "aarch64"
+            arch_name: "ARM aarch64"
+          - arch: amd64
+            runner: depot-ubuntu-24.04
+            platform: linux/amd64
+            expected_machine: "3e00"
+            expected_uname: "x86_64"
+            arch_name: "x86-64"
     steps:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -113,28 +130,29 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Verify we're on ARM64 runner
+      - name: Verify runner architecture
         run: |
           ARCH=$(uname -m)
           echo "Runner architecture: $ARCH"
-          if [ "$ARCH" != "aarch64" ]; then
-            echo "::error::Not running on ARM64 runner! Got: $ARCH"
+          echo "Expected: ${{ matrix.expected_uname }}"
+          if [ "$ARCH" != "${{ matrix.expected_uname }}" ]; then
+            echo "::error::Not running on expected architecture! Expected: ${{ matrix.expected_uname }}, Got: $ARCH"
             exit 1
           fi
 
-      - name: Pull ARM64 image with retry
+      - name: Pull ${{ matrix.arch }} image with retry
         run: |
           set -euo pipefail
           SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
           IMAGE="ghcr.io/united-manufacturing-hub/umh-core:sha-${SHORT_SHA}"
           echo "IMAGE=$IMAGE" >> $GITHUB_ENV
 
-          echo "Pulling ARM64 image: $IMAGE"
+          echo "Pulling ${{ matrix.arch }} image: $IMAGE"
           MAX_RETRIES=5
           RETRY_DELAY=10
 
           for i in $(seq 1 $MAX_RETRIES); do
-            if docker pull --platform linux/arm64 "$IMAGE"; then
+            if docker pull --platform ${{ matrix.platform }} "$IMAGE"; then
               echo "Image pulled successfully"
               exit 0
             fi
@@ -149,22 +167,30 @@ jobs:
           exit 1
 
       - name: Verify binary architectures
+        env:
+          EXPECTED_MACHINE: ${{ matrix.expected_machine }}
+          ARCH_NAME: ${{ matrix.arch_name }}
         run: |
           set -euo pipefail
 
           echo "Checking binary architectures..."
+          echo "Expected machine type: $EXPECTED_MACHINE ($ARCH_NAME)"
           # Use od to read ELF header machine type (bytes 18-19)
           # ARM64 = b700, x86-64 = 3e00 (little-endian)
-          docker run --rm --platform linux/arm64 "$IMAGE" sh -c '
+          docker run --rm --platform ${{ matrix.platform }} \
+            -e EXPECTED_MACHINE="$EXPECTED_MACHINE" \
+            -e ARCH_NAME="$ARCH_NAME" \
+            "$IMAGE" sh -c '
             check_binary() {
               local binary=$1
               local machine=$(od -An -tx1 -j18 -N2 "$binary" 2>/dev/null | tr -d " ")
 
-              case "$machine" in
-                "b700") echo "$binary: ARM aarch64" ;;
-                "3e00") echo "$binary: x86-64 (ERROR!)"; return 1 ;;
-                *) echo "$binary: unknown arch ($machine)"; return 1 ;;
-              esac
+              if [ "$machine" = "$EXPECTED_MACHINE" ]; then
+                echo "$binary: $ARCH_NAME"
+              else
+                echo "$binary: wrong arch ($machine, expected $EXPECTED_MACHINE)"
+                return 1
+              fi
             }
 
             failed=0
@@ -177,21 +203,14 @@ jobs:
             exit $failed
           ' | tee /tmp/arch-check.txt
 
-          # Fail if any binary is x86-64
-          if grep -q "x86-64" /tmp/arch-check.txt; then
-            echo "::error::ARM64 image contains x86-64 binaries!"
+          # Verify expected architecture found
+          if ! grep -q "$ARCH_NAME" /tmp/arch-check.txt; then
+            echo "::error::Binaries are not $ARCH_NAME!"
             cat /tmp/arch-check.txt
             exit 1
           fi
 
-          # Verify ARM64
-          if ! grep -q "ARM aarch64" /tmp/arch-check.txt; then
-            echo "::error::Binaries are not ARM64!"
-            cat /tmp/arch-check.txt
-            exit 1
-          fi
-
-          echo "All binaries are native ARM64"
+          echo "All binaries are native $ARCH_NAME"
 
       - name: Smoke test - verify binaries execute
         run: |
@@ -199,15 +218,15 @@ jobs:
           echo "Running smoke tests..."
 
           # Test benthos
-          docker run --rm --platform linux/arm64 "$IMAGE" benthos --version
+          docker run --rm --platform ${{ matrix.platform }} "$IMAGE" benthos --version
           echo "benthos executes"
 
           # Test umh-core
-          docker run --rm --platform linux/arm64 "$IMAGE" umh-core --help || true
+          docker run --rm --platform ${{ matrix.platform }} "$IMAGE" umh-core --help || true
           echo "umh-core executes"
 
           # Test S6 (just check it runs, version flag may not exist)
-          docker run --rm --platform linux/arm64 "$IMAGE" /command/s6-svscan --help 2>&1 || true
+          docker run --rm --platform ${{ matrix.platform }} "$IMAGE" /command/s6-svscan --help 2>&1 || true
           echo "s6-svscan executes"
 
           echo "All smoke tests passed"
@@ -215,7 +234,10 @@ jobs:
       - name: Add to job summary
         if: always()
         run: |
-          echo "## ARM64 Binary Verification" >> $GITHUB_STEP_SUMMARY
+          echo "## ${{ matrix.arch }} Binary Verification" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Architecture**: ${{ matrix.arch_name }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Platform**: ${{ matrix.platform }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           if [ -f /tmp/arch-check.txt ]; then
             echo '```' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/build-umh-core.yml
+++ b/.github/workflows/build-umh-core.yml
@@ -97,6 +97,117 @@ jobs:
             VERSION=${{ steps.version.outputs.VERSION }} \
             TAGS="$TAGS"
 
+  verify-arm64-binaries:
+    name: Verify ARM64 Image
+    needs: build
+    runs-on: depot-ubuntu-24.04-arm
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify we're on ARM64 runner
+        run: |
+          ARCH=$(uname -m)
+          echo "Runner architecture: $ARCH"
+          if [ "$ARCH" != "aarch64" ]; then
+            echo "::error::Not running on ARM64 runner! Got: $ARCH"
+            exit 1
+          fi
+
+      - name: Pull ARM64 image with retry
+        run: |
+          set -euo pipefail
+          SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
+          IMAGE="ghcr.io/united-manufacturing-hub/umh-core:sha-${SHORT_SHA}"
+          echo "IMAGE=$IMAGE" >> $GITHUB_ENV
+
+          echo "Pulling ARM64 image: $IMAGE"
+          MAX_RETRIES=5
+          RETRY_DELAY=10
+
+          for i in $(seq 1 $MAX_RETRIES); do
+            if docker pull --platform linux/arm64 "$IMAGE"; then
+              echo "Image pulled successfully"
+              exit 0
+            fi
+            if [ $i -lt $MAX_RETRIES ]; then
+              echo "Pull failed, retrying in ${RETRY_DELAY}s... (attempt $i/$MAX_RETRIES)"
+              sleep $RETRY_DELAY
+              RETRY_DELAY=$((RETRY_DELAY * 2))
+            fi
+          done
+
+          echo "::error::Failed to pull image after $MAX_RETRIES attempts"
+          exit 1
+
+      - name: Verify binary architectures
+        run: |
+          set -euo pipefail
+
+          echo "Checking binary architectures..."
+          docker run --rm --platform linux/arm64 "$IMAGE" sh -c '
+            file /usr/local/bin/benthos \
+                 /opt/redpanda/bin/redpanda \
+                 /usr/local/bin/umh-core \
+                 /command/s6-svscan \
+                 /command/s6-supervise \
+                 /command/execlineb
+          ' | tee /tmp/arch-check.txt
+
+          # Fail if any binary is x86-64
+          if grep -q "x86-64" /tmp/arch-check.txt; then
+            echo "::error::ARM64 image contains x86-64 binaries!"
+            cat /tmp/arch-check.txt
+            exit 1
+          fi
+
+          # Verify ARM64 (pattern confirmed correct for all ELF types)
+          if ! grep -q "ARM aarch64" /tmp/arch-check.txt; then
+            echo "::error::Binaries are not ARM64!"
+            cat /tmp/arch-check.txt
+            exit 1
+          fi
+
+          echo "All binaries are native ARM64"
+
+      - name: Smoke test - verify binaries execute
+        run: |
+          set -euo pipefail
+          echo "Running smoke tests..."
+
+          # Test benthos
+          docker run --rm --platform linux/arm64 "$IMAGE" benthos --version
+          echo "benthos executes"
+
+          # Test umh-core
+          docker run --rm --platform linux/arm64 "$IMAGE" umh-core --help || true
+          echo "umh-core executes"
+
+          # Test S6 (just check it runs, version flag may not exist)
+          docker run --rm --platform linux/arm64 "$IMAGE" /command/s6-svscan --help 2>&1 || true
+          echo "s6-svscan executes"
+
+          echo "All smoke tests passed"
+
+      - name: Add to job summary
+        if: always()
+        run: |
+          echo "## ARM64 Binary Verification" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [ -f /tmp/arch-check.txt ]; then
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            cat /tmp/arch-check.txt >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+          fi
+
   notify-management-console:
     needs: build
     if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/build-umh-core.yml
+++ b/.github/workflows/build-umh-core.yml
@@ -141,30 +141,26 @@ jobs:
           fi
 
       - name: Pull ${{ matrix.arch }} image with retry
-        run: |
-          set -euo pipefail
-          SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
-          IMAGE="ghcr.io/united-manufacturing-hub/umh-core:sha-${SHORT_SHA}"
-          echo "IMAGE=$IMAGE" >> $GITHUB_ENV
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+        with:
+          timeout_seconds: 120
+          max_attempts: 5
+          retry_wait_seconds: 10
+          command: |
+            set -euo pipefail
+            SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
+            IMAGE="ghcr.io/united-manufacturing-hub/umh-core:sha-${SHORT_SHA}"
+            echo "IMAGE=$IMAGE" >> $GITHUB_ENV
 
-          echo "Pulling ${{ matrix.arch }} image: $IMAGE"
-          MAX_RETRIES=5
-          RETRY_DELAY=10
+            echo "Pulling ${{ matrix.arch }} image: $IMAGE"
 
-          for i in $(seq 1 $MAX_RETRIES); do
             if docker pull --platform ${{ matrix.platform }} "$IMAGE"; then
               echo "Image pulled successfully"
               exit 0
             fi
-            if [ $i -lt $MAX_RETRIES ]; then
-              echo "Pull failed, retrying in ${RETRY_DELAY}s... (attempt $i/$MAX_RETRIES)"
-              sleep $RETRY_DELAY
-              RETRY_DELAY=$((RETRY_DELAY * 2))
-            fi
-          done
 
-          echo "::error::Failed to pull image after $MAX_RETRIES attempts"
-          exit 1
+            echo "::error::Failed to pull image"
+            exit 1
 
       - name: Verify binary architectures
         env:
@@ -211,25 +207,6 @@ jobs:
           fi
 
           echo "All binaries are native $ARCH_NAME"
-
-      - name: Smoke test - verify binaries execute
-        run: |
-          set -euo pipefail
-          echo "Running smoke tests..."
-
-          # Test benthos
-          docker run --rm --platform ${{ matrix.platform }} "$IMAGE" benthos --version
-          echo "benthos executes"
-
-          # Test umh-core
-          docker run --rm --platform ${{ matrix.platform }} "$IMAGE" umh-core --help || true
-          echo "umh-core executes"
-
-          # Test S6 (just check it runs, version flag may not exist)
-          docker run --rm --platform ${{ matrix.platform }} "$IMAGE" /command/s6-svscan --help 2>&1 || true
-          echo "s6-svscan executes"
-
-          echo "All smoke tests passed"
 
       - name: Add to job summary
         if: always()

--- a/.github/workflows/build-umh-core.yml
+++ b/.github/workflows/build-umh-core.yml
@@ -153,13 +153,26 @@ jobs:
           set -euo pipefail
 
           echo "Checking binary architectures..."
+          # Use od to read ELF header machine type (bytes 18-19)
+          # ARM64 = b700, x86-64 = 3e00 (little-endian)
           docker run --rm --platform linux/arm64 "$IMAGE" sh -c '
-            file /usr/local/bin/benthos \
-                 /opt/redpanda/bin/redpanda \
-                 /usr/local/bin/umh-core \
-                 /command/s6-svscan \
-                 /command/s6-supervise \
-                 /command/execlineb
+            check_binary() {
+              local binary=$1
+              local machine=$(od -An -tx1 -j18 -N2 "$binary" 2>/dev/null | tr -d " ")
+
+              case "$machine" in
+                "b700") echo "$binary: ARM aarch64" ;;
+                "3e00") echo "$binary: x86-64 (ERROR!)"; return 1 ;;
+                *) echo "$binary: unknown arch ($machine)"; return 1 ;;
+              esac
+            }
+
+            failed=0
+            for bin in /usr/local/bin/benthos /opt/redpanda/bin/redpanda /usr/local/bin/umh-core \
+                       /command/s6-svscan /command/s6-supervise /command/execlineb; do
+              check_binary "$bin" || failed=1
+            done
+            exit $failed
           ' | tee /tmp/arch-check.txt
 
           # Fail if any binary is x86-64
@@ -169,7 +182,7 @@ jobs:
             exit 1
           fi
 
-          # Verify ARM64 (pattern confirmed correct for all ELF types)
+          # Verify ARM64
           if ! grep -q "ARM aarch64" /tmp/arch-check.txt; then
             echo "::error::Binaries are not ARM64!"
             cat /tmp/arch-check.txt

--- a/.github/workflows/build-umh-core.yml
+++ b/.github/workflows/build-umh-core.yml
@@ -168,7 +168,9 @@ jobs:
             }
 
             failed=0
-            for bin in /usr/local/bin/benthos /opt/redpanda/bin/redpanda /usr/local/bin/umh-core \
+            # Note: /opt/redpanda/bin/redpanda is a shell wrapper script
+            # The actual ELF binary is at /opt/redpanda/libexec/redpanda
+            for bin in /usr/local/bin/benthos /opt/redpanda/libexec/redpanda /usr/local/bin/umh-core \
                        /command/s6-svscan /command/s6-supervise /command/execlineb; do
               check_binary "$bin" || failed=1
             done


### PR DESCRIPTION
## Summary

Add CI verification to prevent future ARM64 image regressions like the TARGETARCH issue (ENG-4058, #2356).

## Changes

Add `verify-arm64-binaries` job to `build-umh-core.yml` that:

- **Runs on native ARM64**: Uses `depot-ubuntu-24.04-arm` (no QEMU emulation)
- **Retry logic**: 5 retries with exponential backoff for image pull race conditions
- **Binary verification**: Checks all critical binaries are ARM64:
  - `/usr/local/bin/benthos`
  - `/opt/redpanda/bin/redpanda`
  - `/usr/local/bin/umh-core`
  - `/command/s6-svscan`
  - `/command/s6-supervise`
  - `/command/execlineb`
- **Smoke tests**: Verifies binaries actually execute (catches CGO/linking issues)
- **Job summary**: Adds architecture check results to GitHub Actions summary

## Cost

~$0.008 per run (1-2 minutes on ARM runner) - runs on every build

## Stacked PR

This PR is stacked on top of #2356 (ENG-4058 - TARGETARCH fix). Once #2356 is merged, this PR's base should be updated to `staging`.

## Test Plan

- [ ] Verify workflow syntax is valid
- [ ] After base PR merges, CI should run and verify ARM64 binaries
- [ ] Check job summary shows architecture verification results

ENG-4060

🤖 Generated with [Claude Code](https://claude.com/claude-code)