### PR TITLE
2025-12-19

### DIFF
--- a/umh-core/Makefile
+++ b/umh-core/Makefile
@@ -69,7 +69,7 @@ NMAP_VERSION = 7.97-r0
 S6_OVERLAY_VERSION = 3.2.0.2
 REDPANDA_VERSION = 24.3.18
 ## Benthos version is a tag or a sha-<commit hash> (e.g. 0.9.4 or sha-a51a685) to be used in the docker image
-BENTHOS_UMH_VERSION = 0.11.14
+BENTHOS_UMH_VERSION = 0.11.15
 BUF_VERSION = 1.55.1
 PROTOC_GEN_GO_VERSION = 1.36.6
 


### PR DESCRIPTION
# Release v0.44.2

  ### 💪 Improvements

  - **Sparkplug B Reliability** - Fixed false "Sequence gap detected" errors that occurred when
   NDATA and DDATA messages interleaved from the same Sparkplug node. If you were seeing
  spurious sequence gap warnings in your Sparkplug bridges, this release eliminates them.

  - **OPC UA Ignition Compatibility** - Added proper DNS hostname validation for X.509
  certificates, preventing connection issues with strict OPC UA servers like Ignition 8.1+.

  - **Monaco Editor Validation** - Fixed incorrect validation warnings in the Management
  Console when entering array values for fields like `modbus.slaveIDs`, `s7comm.addresses`, and
   `opcua.nodeIDs`. The editor no longer incorrectly flags valid array syntax.

  ### 📝 Documentation

  - **S7comm Address Limit** - Documented that each S7 connection supports a maximum of 20
  addresses. If you need more than 20 addresses, create multiple connections to the same PLC.

  ### 🔧 Technical Notes

  - Bumped benthos-umh to v0.11.15
  - Sparkplug B: Added `MessageType` enum for compile-time type safety
  - Sparkplug B: Added `NodeKey()` and `DeviceKey()` methods to `TopicInfo`

  ### Pull Requests

  - #2359: chore: bump benthos-umh to v0.11.15

  **Full Changelog**: https://github.com/united-manufacturing-hub/united-manufacturing-hub/compare/v0.44.1...v0.44.2
