### PR TITLE
chore: mark graphql api as experimental

### DIFF
--- a/umh-core/docs/reference/configuration-reference.md
+++ b/umh-core/docs/reference/configuration-reference.md
@@ -251,7 +251,7 @@ protocolConverter:
               uns: {}
 ```
 
-### GraphQL API - Topic Browser
+### GraphQL API - Topic Browser 🚧
 
 GraphQL API for querying Unified Namespace topics.
 


### PR DESCRIPTION
Fixes ENG-3958

---

Users are trying the GraphQl endpoints and reported issues getting them to work. Testing with these endpoints they proved to be hard to use. Both unclear server errors and empty responses happen regularly.

Until the GraphQl API is fixed it should be marked as experimental to align user expectations.