### PR TITLE
fix(ci): Use license pattern for year 20XX

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -18,6 +18,18 @@ header:
     copyright-owner: UMH Systems GmbH
     software-name: United Manufacturing Hub
 
+    pattern: |
+      Copyright\s+20[0-9]{2}\s+UMH Systems GmbH
+      Licensed under the Apache License, Version 2\.0 \(the "License"\);
+      you may not use this file except in compliance with the License.
+      You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+      Unless required by applicable law or agreed to in writing,
+      software distributed under the License is distributed on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      See the License for the specific language governing permissions and
+      limitations under the License.
+
   paths-ignore:
     - "**/*.md"
     - "**/*.mdc"


### PR DESCRIPTION
Fixes CI.
Is now the same as in Benthos and as it should be :)