### PR TITLE
fix(ci): Reduce depot runner to 4x for integration tests

### DIFF
--- a/.github/workflows/test-umh-core.yml
+++ b/.github/workflows/test-umh-core.yml
@@ -53,7 +53,7 @@ jobs:
 
   integration-tests:
     name: Integration Tests
-    runs-on: depot-ubuntu-24.04-8
+    runs-on: depot-ubuntu-24.04-4
     strategy:
       matrix:
         instance: [1, 2, 3]
@@ -88,7 +88,7 @@ jobs:
         working-directory: ./umh-core
         run: |
           make download-docker-binaries
-          
+
       - name: Stop containers & cleanup
         working-directory: ./umh-core
         run: |
@@ -97,7 +97,7 @@ jobs:
       - name: Run integration tests
         env:
           CI: true
-          FORCE_DOCKER: true  # Force Docker usage since image is built with docker buildx
+          FORCE_DOCKER: true # Force Docker usage since image is built with docker buildx
           VERSION: ${{ github.ref_name }}
         run: make integration-test-ci
 

--- a/umh-core/.golangci.yaml
+++ b/umh-core/.golangci.yaml
@@ -14,12 +14,15 @@
 
 version: "2"
 
+run:
+  concurrency: 2
+
 linters:
   # Default set of linters.
   # The value can be: `standard`, `all`, `none`, or `fast`.
   # Default: standard
   default: standard
-  
+
   enable:
     - canonicalheader
     - copyloopvar


### PR DESCRIPTION
We only need the `4x` depot runner.
Saves a lot of build minutes.