### PR TITLE
docs: add High Availability documentation

### DIFF
--- a/umh-core/docs/CLAUDE.md
+++ b/umh-core/docs/CLAUDE.md
@@ -1,0 +1,5 @@
+# Documentation Guidelines
+
+## GitBook Navigation
+
+When adding new documentation pages, you must add them to `SUMMARY.md` for them to appear in GitBook navigation.

--- a/umh-core/docs/SUMMARY.md
+++ b/umh-core/docs/SUMMARY.md
@@ -35,6 +35,7 @@
       * [Advanced](production/deployment/docker-compose/advanced/README.md)
         * [Nginx](production/deployment/docker-compose/advanced/nginx.md)
   * [Sizing Guide](production/sizing-guide.md)
+  * [High Availability](production/high-availability.md)
   * [Corporate Firewalls](production/corporate-firewalls.md)
   * [Metrics](production/metrics.md)
   * [Migration from Classic](production/migration-from-classic.md)

--- a/umh-core/docs/production/high-availability.md
+++ b/umh-core/docs/production/high-availability.md
@@ -1,0 +1,45 @@
+# High Availability
+
+UMH Core uses Kubernetes-native high availability. Your cluster handles restart and rescheduling. No custom failover daemons required.
+
+## How Failover Works
+
+All state lives in the `/data` volume (see [Container Layout](../reference/container-layout.md) for structure). When a pod or node fails, Kubernetes schedules a new pod that mounts the same volume. Redpanda replays its write-ahead log and resumes processing.
+
+**Expected recovery times:**
+
+| Failure | Recovery |
+|---------|----------|
+| Process crash inside container | Sub-second (S6 supervisor restarts process) |
+| Pod crash | 30–60 seconds |
+| Node failure | 1–2 minutes |
+
+## Storage Requirement
+
+For multi-node failover, you need storage accessible from multiple nodes.
+
+The default k3s storage (`local-path`) binds the volume to one node. If that node dies, Kubernetes cannot reschedule the pod elsewhere because the data is stuck on the failed node.
+
+Storage that works: vSAN, SAN, EBS, Azure Disk, GCE PD, Longhorn, Rook-Ceph. All of these allow Kubernetes to mount the volume on any node.
+
+**Performance note:** Software-defined storage like Longhorn provides roughly 20–30% of native disk IOPS due to synchronous replication. For most UMH Core workloads, this is acceptable. For high-throughput scenarios, test before committing.
+
+### Single-Node Deployments
+
+If you have one node, storage choice does not affect failover. The node itself is the single point of failure. Redundancy comes from your underlying infrastructure (for example, a VM on vSAN survives host failure).
+
+### Longhorn on k3s
+
+If you do not have enterprise storage, Longhorn is a good choice for k3s clusters. See the [Longhorn Quick Installation Guide](https://longhorn.io/docs/1.10.1/deploy/install/) and [K3s-specific configuration](https://longhorn.io/docs/1.10.1/advanced-resources/os-distro-specific/csi-on-k3s/).
+
+## Why Kubernetes-Native?
+
+Some industrial software implements custom heartbeat-based failover. This made sense before container orchestration existed. Today, it duplicates what your cluster already does and introduces split-brain risk when the heartbeat network partitions but both nodes remain up.
+
+UMH Core trusts Kubernetes as the single source of truth for scheduling.
+
+## Zero-Downtime Requirements
+
+The standard approach accepts 30–60 second recovery on pod failure. If your process cannot tolerate any interruption, contact UMH to discuss active-active architectures.
+
+Note: OPC UA sessions must be re-established after any failover. This is a protocol limitation.

--- a/umh-core/docs/production/high-availability.md
+++ b/umh-core/docs/production/high-availability.md
@@ -6,13 +6,13 @@ UMH Core uses Kubernetes-native high availability. Your cluster handles restart 
 
 All state lives in the `/data` volume (see [Container Layout](../reference/container-layout.md) for structure). When a pod or node fails, Kubernetes schedules a new pod that mounts the same volume. Redpanda replays its write-ahead log and resumes processing.
 
-**Expected recovery times:**
+**Typical recovery times** (actual times depend on cluster configuration and workload):
 
 | Failure | Recovery |
 |---------|----------|
 | Process crash inside container | Sub-second (S6 supervisor restarts process) |
-| Pod crash | 30–60 seconds |
-| Node failure | 1–2 minutes |
+| Pod crash | 30–60 seconds (depends on pod restart policy and resource availability) |
+| Node failure | 1–2 minutes (depends on node failure detection timeout and storage reattachment) |
 
 ## Storage Requirement
 
@@ -22,7 +22,7 @@ The default k3s storage (`local-path`) binds the volume to one node. If that nod
 
 Storage that works: vSAN, SAN, EBS, Azure Disk, GCE PD, Longhorn, Rook-Ceph. All of these allow Kubernetes to mount the volume on any node.
 
-**Performance note:** Software-defined storage like Longhorn provides roughly 20–30% of native disk IOPS due to synchronous replication. For most UMH Core workloads, this is acceptable. For high-throughput scenarios, test before committing.
+**Performance note:** Software-defined storage like Longhorn adds latency due to synchronous replication. For most UMH Core workloads, this is acceptable. For high-throughput scenarios, benchmark your specific workload before committing.
 
 ### Single-Node Deployments
 
@@ -30,7 +30,7 @@ If you have one node, storage choice does not affect failover. The node itself i
 
 ### Longhorn on k3s
 
-If you do not have enterprise storage, Longhorn is a good choice for k3s clusters. See the [Longhorn Quick Installation Guide](https://longhorn.io/docs/1.10.1/deploy/install/) and [K3s-specific configuration](https://longhorn.io/docs/1.10.1/advanced-resources/os-distro-specific/csi-on-k3s/).
+If you do not have enterprise storage, Longhorn is a good choice for k3s clusters. See the [Longhorn Quick Installation Guide](https://longhorn.io/docs/latest/deploy/install/) and [K3s-specific configuration](https://longhorn.io/docs/latest/advanced-resources/os-distro-specific/csi-on-k3s/).
 
 ## Why Kubernetes-Native?
 

--- a/umh-core/docs/production/high-availability.md
+++ b/umh-core/docs/production/high-availability.md
@@ -12,7 +12,7 @@ UMH Core handles high availability without custom failover daemons. Inside the c
 
 ## How Failover Works
 
-All state lives in the `/data` volume (see [Container Layout](../reference/container-layout.md) for structure). When a container or node fails, your container manager starts a new container that mounts the same volume. Redpanda recovers from its commit log on disk and resumes processing.
+All state lives in the `/data` volume (see [Container Layout](../reference/container-layout.md) for structure). When a container or node fails, your container manager starts a new container that mounts the same volume. Redpanda recovers from its on-disk data and resumes processing.
 
 ## Why Not Custom Failover?
 
@@ -48,6 +48,6 @@ If you do not have enterprise storage, Longhorn is a good choice for k3s cluster
 
 The standard approach accepts 30-60 second recovery on container failure. If your process cannot tolerate any interruption, contact UMH to discuss active-active architectures.
 
-### OPC UA Sessions
+## OPC UA Sessions After Failover
 
-Your OPC UA clients must re-establish sessions after any failover. UMH Core reconnects automatically, but the re-establishment takes a few seconds during which no data is collected from OPC UA sources. The OPC UA protocol requires this.
+OPC UA sessions must be re-established after any failover. UMH Core reconnects to OPC UA servers automatically, but re-establishment takes a few seconds during which no data is collected from OPC UA sources. The OPC UA protocol requires this.

--- a/umh-core/docs/production/high-availability.md
+++ b/umh-core/docs/production/high-availability.md
@@ -1,45 +1,53 @@
 # High Availability
 
-UMH Core uses Kubernetes-native high availability. Your cluster handles restart and rescheduling. No custom failover daemons required.
+UMH Core handles high availability without custom failover daemons. Inside the container, [S6](https://skarnet.org/software/s6/) supervises all processes and restarts them on failure (see [Container Layout](../reference/container-layout.md) for details). Outside the container, your container manager (Docker, Kubernetes, Docker Swarm, Portainer, or any other) handles container restarts and rescheduling.
 
-## How Failover Works
-
-All state lives in the `/data` volume (see [Container Layout](../reference/container-layout.md) for structure). When a pod or node fails, Kubernetes schedules a new pod that mounts the same volume. Redpanda replays its write-ahead log and resumes processing.
-
-**Typical recovery times** (actual times depend on cluster configuration and workload):
+**Typical recovery times** (actual times depend on configuration and workload):
 
 | Failure | Recovery |
 |---------|----------|
-| Process crash inside container | Sub-second (S6 supervisor restarts process) |
-| Pod crash | 30–60 seconds (depends on pod restart policy and resource availability) |
-| Node failure | 1–2 minutes (depends on node failure detection timeout and storage reattachment) |
+| Process crash inside container | Sub-second (S6 restarts the process) |
+| Container/pod crash | 30-60 seconds (depends on restart policy and resource availability) |
+| Node failure | 2-5 minutes (depends on failure detection timeout and storage reattachment) |
 
-## Storage Requirement
+## How Failover Works
 
-For multi-node failover, you need storage accessible from multiple nodes.
+All state lives in the `/data` volume (see [Container Layout](../reference/container-layout.md) for structure). When a container or node fails, your container manager starts a new container that mounts the same volume. Redpanda recovers from its commit log on disk and resumes processing.
 
-The default k3s storage (`local-path`) binds the volume to one node. If that node dies, Kubernetes cannot reschedule the pod elsewhere because the data is stuck on the failed node.
+## Why Not Custom Failover?
 
-Storage that works: vSAN, SAN, EBS, Azure Disk, GCE PD, Longhorn, Rook-Ceph. All of these allow Kubernetes to mount the volume on any node.
+Some industrial software implements custom heartbeat-based failover. This approach predates container orchestration. Today, it duplicates what your container manager already does. It also introduces split-brain risk: the heartbeat network can partition while both nodes remain up, causing both to assume primary ownership.
 
-**Performance note:** Software-defined storage like Longhorn adds latency due to synchronous replication. For most UMH Core workloads, this is acceptable. For high-throughput scenarios, benchmark your specific workload before committing.
+UMH Core relies on your container manager as the single source of truth for scheduling.
+
+## Storage Requirements
 
 ### Single-Node Deployments
 
-If you have one node, storage choice does not affect failover. The node itself is the single point of failure. Redundancy comes from your underlying infrastructure (for example, a VM on vSAN survives host failure).
+If you have one node, storage choice does not affect failover. The node itself is the single point of failure. Redundancy comes from your underlying infrastructure. For example, a VM on vSAN survives host failure, and RAID storage survives disk failure.
+
+### Multi-Node Deployments
+
+For multi-node failover, you need storage accessible from multiple nodes.
+
+The default k3s storage (`local-path`) binds the volume to one node. If that node dies, the container manager cannot reschedule the container elsewhere because the data is stuck on the failed node.
+
+**Compatible storage options** (all support mounting volumes on any node):
+
+- Enterprise SAN or vSAN
+- Cloud block storage: EBS, Azure Disk, GCE PD
+- Software-defined: Longhorn, Rook-Ceph
+
+**Performance note:** Software-defined storage like Longhorn adds latency due to synchronous replication. For most UMH Core workloads, this is acceptable. For high-throughput scenarios, benchmark your specific workload before committing.
 
 ### Longhorn on k3s
 
 If you do not have enterprise storage, Longhorn is a good choice for k3s clusters. See the [Longhorn Quick Installation Guide](https://longhorn.io/docs/latest/deploy/install/) and [K3s-specific configuration](https://longhorn.io/docs/latest/advanced-resources/os-distro-specific/csi-on-k3s/).
 
-## Why Kubernetes-Native?
+## If You Need Zero Downtime
 
-Some industrial software implements custom heartbeat-based failover. This made sense before container orchestration existed. Today, it duplicates what your cluster already does and introduces split-brain risk when the heartbeat network partitions but both nodes remain up.
+The standard approach accepts 30-60 second recovery on container failure. If your process cannot tolerate any interruption, contact UMH to discuss active-active architectures.
 
-UMH Core trusts Kubernetes as the single source of truth for scheduling.
+### OPC UA Sessions
 
-## Zero-Downtime Requirements
-
-The standard approach accepts 30–60 second recovery on pod failure. If your process cannot tolerate any interruption, contact UMH to discuss active-active architectures.
-
-Note: OPC UA sessions must be re-established after any failover. This is a protocol limitation.
+Your OPC UA clients must re-establish sessions after any failover. UMH Core reconnects automatically, but the re-establishment takes a few seconds during which no data is collected from OPC UA sources. The OPC UA protocol requires this.

--- a/umh-core/docs/production/security/umh-core/deployment-security.md
+++ b/umh-core/docs/production/security/umh-core/deployment-security.md
@@ -19,7 +19,7 @@
 - **Physical security** (secure deployment locations and restrict physical access per IEC 62443-3-3 SR 5.1)
 - **OT safety systems** (umh-core must not be integrated into safety-instrumented systems; see IEC 61508/61511)
 - **Backup and disaster recovery** (configuration backups, persistent volume snapshots, tested restore procedures per business continuity requirements)
-- **High availability** (deploying multiple instances if required for critical production lines)
+- **High availability**: use storage accessible from multiple nodes. See [High Availability](../../high-availability.md).
 - **Security event monitoring** (SIEM integration if required, intrusion detection systems)
 - **Corporate CA certificate management** (adding certificates for TLS inspection scenarios)
 - **Reading this documentation** - we provide secure software, you must deploy it securely

--- a/umh-core/docs/production/sizing-guide.md
+++ b/umh-core/docs/production/sizing-guide.md
@@ -90,3 +90,7 @@ UMH Core is stateless besides the **`/data`** volume. To grow:
 1. Stop the container
 2. Move or resize the volume / attach it to a bigger VM
 3. Start the same image — no reinstall or re-configuration required
+
+#### High availability
+
+For multi-node failover, mount `/data` on storage accessible from multiple nodes. See [High Availability](./high-availability.md).

--- a/umh-core/docs/umh-core-vs-classic-faq.md
+++ b/umh-core/docs/umh-core-vs-classic-faq.md
@@ -48,9 +48,9 @@ We didn't ditch it—**we de-coupled from it**.
 
 No – the two big ones are still there:
 
-**Scalability**: Run multiple `umh-core` replicas behind a Service/LB. Future: Redpanda clustering to shard partitions**Fail-over**: Shared volume (NFS/Longhorn) lets a standby replay Redpanda's log; any scheduler (k8s, Portainer, systemd-docker) restarts the pod/container.
+**Scalability**: Deploy one UMH Core instance per production line, each forwarding to a central site instance. This ISA-95 style hierarchy naturally distributes workload across your infrastructure.
 
-Manufacturing rarely needs layer-7 load-balancing (100 k msg/s is peanuts vs IT), but it's still possible if you want it.
+**Failover**: Kubernetes restarts crashed pods (30–60 seconds) and reschedules after node failure (1–2 minutes). See [High Availability](../production/high-availability.md).
 
 ## Why is Kafka (Redpanda) embedded instead of its own container?
 

--- a/umh-core/docs/umh-core-vs-classic-faq.md
+++ b/umh-core/docs/umh-core-vs-classic-faq.md
@@ -50,7 +50,7 @@ No – the two big ones are still there:
 
 **Scalability**: Deploy one UMH Core instance per production line, each forwarding to a central site instance. This ISA-95 style hierarchy naturally distributes workload across your infrastructure.
 
-**Failover**: Kubernetes restarts crashed pods (30–60 seconds) and reschedules after node failure (1–2 minutes). See [High Availability](../production/high-availability.md).
+**Failover**: Your container manager restarts crashed containers (30-60 seconds) and reschedules after node failure (2-5 minutes). See [High Availability](../production/high-availability.md).
 
 ## Why is Kafka (Redpanda) embedded instead of its own container?
 


### PR DESCRIPTION
## Summary

Add focused high-availability.md explaining K8s-native failover strategy for UMH Core.

**Key points documented:**
- Storage requirement: multi-node accessible storage (vSAN, SAN, EBS, Longhorn, etc.)
- Failover timing: sub-second (S6), 30-60s (pod), 1-2min (node)
- Why K8s-native vs custom heartbeat daemons (avoids split-brain)
- ISA-95 style scalability (instance per production line → central site)

**Files changed:**
- `docs/production/high-availability.md` - NEW
- `docs/production/sizing-guide.md` - Link to HA page
- `docs/production/security/umh-core/deployment-security.md` - Update HA line
- `docs/umh-core-vs-classic-faq.md` - Fix scalability/failover sections

Closes ENG-4201

## Test plan

- [ ] Verify all internal links resolve
- [ ] Verify Longhorn external links work

🤖 Generated with [Claude Code](https://claude.com/claude-code)