### PR TITLE
fix(fsmv2): complete race condition audit and fixes

### DIFF
--- a/umh-core/pkg/fsmv2/supervisor/api.go
+++ b/umh-core/pkg/fsmv2/supervisor/api.go
@@ -317,8 +317,15 @@ func (s *Supervisor[TObserved, TDesired]) AddWorker(identity deps.Identity, work
 
 		// Trigger immediate observation after action completes.
 		// This eliminates the delay between action and FSM progression.
-		if workerCtx != nil && workerCtx.collector != nil && workerCtx.collector.IsRunning() {
-			workerCtx.collector.TriggerNow()
+		// Capture collector under lock to prevent race with RemoveWorker().
+		if workerCtx != nil {
+			workerCtx.mu.RLock()
+			collector := workerCtx.collector
+			workerCtx.mu.RUnlock()
+
+			if collector != nil && collector.IsRunning() {
+				collector.TriggerNow()
+			}
 		}
 	})
 

--- a/umh-core/pkg/fsmv2/supervisor/internal/execution/action_executor.go
+++ b/umh-core/pkg/fsmv2/supervisor/internal/execution/action_executor.go
@@ -46,6 +46,7 @@ type ActionExecutor struct {
 	defaultTimeout   time.Duration
 	mu               sync.RWMutex
 	closeOnce        sync.Once
+	stopped          bool
 }
 
 type actionWork struct {
@@ -90,7 +91,9 @@ func NewActionExecutorWithTimeout(workerCount int, timeouts map[string]time.Dura
 }
 
 func (ae *ActionExecutor) Start(ctx context.Context) {
+	ae.mu.Lock()
 	ae.ctx, ae.cancel = context.WithCancel(ctx)
+	ae.mu.Unlock()
 
 	for range ae.workerCount {
 		ae.wg.Add(1)
@@ -99,7 +102,11 @@ func (ae *ActionExecutor) Start(ctx context.Context) {
 	}
 
 	metricsCtx, metricsCancel := context.WithCancel(ctx)
+
+	ae.mu.Lock()
 	ae.metricsCancel = metricsCancel
+	ae.mu.Unlock()
+
 	ae.metricsWg.Add(1)
 
 	go ae.metricsReporter(metricsCtx)
@@ -217,9 +224,22 @@ func (ae *ActionExecutor) executeWorkWithRecovery(work actionWork) {
 }
 
 // EnqueueAction adds an action to the execution queue without blocking.
-// Returns error if action is already in progress or queue is full.
+// Returns error if action is already in progress, queue is full, or executor is stopped.
 func (ae *ActionExecutor) EnqueueAction(actionID string, action fsmv2.Action[any], deps any) error {
 	ae.mu.Lock()
+
+	// Check if executor is stopped to prevent sending on closed channel
+	if ae.stopped {
+		ae.mu.Unlock()
+
+		ae.logger.Warnw("action_enqueue_rejected",
+			"hierarchy_path", ae.identity.HierarchyPath,
+			"correlation_id", actionID,
+			"action_name", action.Name(),
+			"reason", "executor_stopped")
+
+		return errors.New("executor stopped")
+	}
 
 	if ae.inProgress[actionID] {
 		ae.mu.Unlock()
@@ -316,8 +336,15 @@ func (ae *ActionExecutor) SetOnActionComplete(fn func(deps.ActionResult)) {
 }
 
 func (ae *ActionExecutor) Shutdown() {
-	if ae.metricsCancel != nil {
-		ae.metricsCancel()
+	// Mark as stopped and capture cancel functions under lock to prevent race with Start()
+	ae.mu.Lock()
+	ae.stopped = true
+	metricsCancel := ae.metricsCancel
+	cancel := ae.cancel
+	ae.mu.Unlock()
+
+	if metricsCancel != nil {
+		metricsCancel()
 	}
 
 	ae.metricsWg.Wait()
@@ -326,8 +353,8 @@ func (ae *ActionExecutor) Shutdown() {
 		close(ae.actionQueue)
 	})
 
-	if ae.cancel != nil {
-		ae.cancel()
+	if cancel != nil {
+		cancel()
 	}
 
 	ae.wg.Wait()

--- a/umh-core/pkg/fsmv2/supervisor/internal/execution/action_executor.go
+++ b/umh-core/pkg/fsmv2/supervisor/internal/execution/action_executor.go
@@ -115,9 +115,14 @@ func (ae *ActionExecutor) Start(ctx context.Context) {
 func (ae *ActionExecutor) worker() {
 	defer ae.wg.Done()
 
+	// Capture context under lock to prevent race with Start()/Shutdown()
+	ae.mu.RLock()
+	ctx := ae.ctx
+	ae.mu.RUnlock()
+
 	for {
 		select {
-		case <-ae.ctx.Done():
+		case <-ctx.Done():
 			return
 
 		case work, ok := <-ae.actionQueue:
@@ -125,16 +130,17 @@ func (ae *ActionExecutor) worker() {
 				return
 			}
 
-			ae.executeWorkWithRecovery(work)
+			ae.executeWorkWithRecovery(ctx, work)
 		}
 	}
 }
 
 // executeWorkWithRecovery handles action execution with panic recovery.
-func (ae *ActionExecutor) executeWorkWithRecovery(work actionWork) {
+// ctx is passed from worker() which captures it under lock to prevent races.
+func (ae *ActionExecutor) executeWorkWithRecovery(ctx context.Context, work actionWork) {
 	startTime := time.Now()
 
-	actionCtx, cancel := context.WithTimeout(ae.ctx, work.timeout)
+	actionCtx, cancel := context.WithTimeout(ctx, work.timeout)
 	defer cancel()
 
 	var err error
@@ -156,6 +162,7 @@ func (ae *ActionExecutor) executeWorkWithRecovery(work actionWork) {
 
 		ae.mu.Lock()
 		delete(ae.inProgress, work.actionID)
+		callback := ae.onActionComplete
 		ae.mu.Unlock()
 
 		duration := time.Since(startTime)
@@ -174,13 +181,13 @@ func (ae *ActionExecutor) executeWorkWithRecovery(work actionWork) {
 
 		metrics.RecordActionExecutionDuration(ae.identity.HierarchyPath, work.action.Name(), status, duration)
 
-		if ae.onActionComplete != nil {
+		if callback != nil {
 			errorMsg := ""
 			if err != nil {
 				errorMsg = err.Error()
 			}
 
-			ae.onActionComplete(deps.ActionResult{
+			callback(deps.ActionResult{
 				Timestamp:  time.Now(),
 				ActionType: work.action.Name(),
 				Success:    status == "success",
@@ -254,12 +261,13 @@ func (ae *ActionExecutor) EnqueueAction(actionID string, action fsmv2.Action[any
 	}
 
 	ae.inProgress[actionID] = true
-	ae.mu.Unlock()
 
+	// Read timeout while still holding lock to prevent race with concurrent access
 	timeout, exists := ae.timeouts[actionID]
 	if !exists {
 		timeout = ae.defaultTimeout
 	}
+	ae.mu.Unlock()
 
 	work := actionWork{
 		actionID: actionID,
@@ -331,8 +339,11 @@ func (ae *ActionExecutor) GetActiveActionCount() int {
 
 // SetOnActionComplete sets a callback invoked after each action execution.
 // Should be called during executor setup, before Start().
+// Thread-safe: can be called concurrently with action execution.
 func (ae *ActionExecutor) SetOnActionComplete(fn func(deps.ActionResult)) {
+	ae.mu.Lock()
 	ae.onActionComplete = fn
+	ae.mu.Unlock()
 }
 
 func (ae *ActionExecutor) Shutdown() {

--- a/umh-core/pkg/fsmv2/supervisor/internal/execution/action_executor.go
+++ b/umh-core/pkg/fsmv2/supervisor/internal/execution/action_executor.go
@@ -93,11 +93,14 @@ func NewActionExecutorWithTimeout(workerCount int, timeouts map[string]time.Dura
 func (ae *ActionExecutor) Start(ctx context.Context) {
 	ae.mu.Lock()
 	ae.ctx, ae.cancel = context.WithCancel(ctx)
-	ae.mu.Unlock()
-
+	// Pre-add all workers to WaitGroup under lock to prevent race with Shutdown()
 	for range ae.workerCount {
 		ae.wg.Add(1)
+	}
+	ae.mu.Unlock()
 
+	// Start workers - they're already counted in the WaitGroup
+	for range ae.workerCount {
 		go ae.worker()
 	}
 
@@ -105,9 +108,8 @@ func (ae *ActionExecutor) Start(ctx context.Context) {
 
 	ae.mu.Lock()
 	ae.metricsCancel = metricsCancel
+	ae.metricsWg.Add(1) // Add inside lock to prevent race with Shutdown()
 	ae.mu.Unlock()
-
-	ae.metricsWg.Add(1)
 
 	go ae.metricsReporter(metricsCtx)
 }

--- a/umh-core/pkg/fsmv2/supervisor/reconciliation.go
+++ b/umh-core/pkg/fsmv2/supervisor/reconciliation.go
@@ -648,10 +648,16 @@ func (s *Supervisor[TObserved, TDesired]) tick(ctx context.Context) error {
 		userSpecWithVars.Variables.User = make(map[string]any)
 	}
 
+	// Deep copy globalVars to prevent race with SetGlobalVariables().
+	// The map reference could be replaced while we use it for template expansion.
 	s.mu.RLock()
-	userSpecWithVars.Variables.Global = s.globalVars
-	globalVarCount := len(s.globalVars)
+	globalVarsCopy := make(map[string]any, len(s.globalVars))
+	for k, v := range s.globalVars {
+		globalVarsCopy[k] = v
+	}
+	globalVarCount := len(globalVarsCopy)
 	s.mu.RUnlock()
+	userSpecWithVars.Variables.Global = globalVarsCopy
 
 	userSpecWithVars.Variables.Internal = map[string]any{
 		FieldID:                firstWorkerID,


### PR DESCRIPTION
## Summary

This PR addresses the `panic: send on closed channel` error (ENG-4217) and performs a comprehensive race condition audit of the FSMv2 supervisor package.

## Race Conditions Fixed

### HIGH Severity

1. **Send on closed channel** (`action_executor.go`)
   - Added `stopped` flag checked before enqueueing actions
   - Ensures channel is not written to after `Shutdown()` closes it

2. **Unsynchronized timeout map read** (`action_executor.go:266`)
   - Moved timeout map read inside the lock

3. **Unsynchronized callback read/write** (`action_executor.go`)
   - `SetOnActionComplete()` now uses mutex
   - `executeWorkWithRecovery()` captures callback under lock before use

4. **Unsynchronized workerCtx.collector access** (`api.go:315-323`)
   - Callback closure now captures collector under `workerCtx.mu.RLock()`

### MEDIUM Severity

5. **worker() reads ae.ctx without lock** (`action_executor.go`)
   - Worker now captures context under lock at function start

6. **executeWorkWithRecovery receives context unsafely** (`action_executor.go`)
   - Context now passed as parameter from worker (which captures it under lock)

7. **globalVars map reference after lock release** (`reconciliation.go:651`)
   - Changed from reference copy to deep copy of map

8. **WaitGroup race between Start() and Shutdown()** (`action_executor.go`)
   - Moved `wg.Add()` and `metricsWg.Add()` operations inside the lock
   - Ensures Add() completes before Shutdown() can proceed to Wait()

## Verification

- All tests pass with race detector enabled
- Extended testing with `ginkgo --race --repeat=5` (6 iterations) - all 215 specs pass consistently
- No race conditions detected after fixes

## Test plan

- [x] Run `make unit-test` - passes with race detector
- [x] Run FSMv2 supervisor tests with race flag - passes
- [x] Extended race testing (6 iterations) - all pass

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)