### PR TITLE
fix: make `/tmp` folder writable for everyone

### DIFF
--- a/.github/workflows/build-umh-core.yml
+++ b/.github/workflows/build-umh-core.yml
@@ -222,6 +222,34 @@ jobs:
             echo '```' >> $GITHUB_STEP_SUMMARY
           fi
 
+  comment-pr:
+    name: Comment PR with Image Tag
+    needs: build
+    if: github.event_name == 'pull_request'
+    runs-on: depot-ubuntu-24.04
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Compute short SHA
+        id: short-sha
+        run: echo "SHORT_SHA=$(echo '${{ github.sha }}' | cut -c1-7)" >> $GITHUB_OUTPUT
+
+      - name: Comment image tag on PR
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+        with:
+          header: docker-image
+          message: |
+            **Docker Image Built**
+
+            ```
+            ghcr.io/united-manufacturing-hub/umh-core:sha-${{ steps.short-sha.outputs.SHORT_SHA }}
+            ```
+
+            Pull with:
+            ```bash
+            docker pull ghcr.io/united-manufacturing-hub/umh-core:sha-${{ steps.short-sha.outputs.SHORT_SHA }}
+            ```
+
   notify-management-console:
     needs: build
     if: startsWith(github.ref, 'refs/tags/')

--- a/umh-core/Dockerfile
+++ b/umh-core/Dockerfile
@@ -183,6 +183,9 @@ ENV S6_YES_I_WANT_A_WORLD_WRITABLE_RUN_BECAUSE_KUBERNETES=1 \
     PATH="/opt/redpanda/bin:$PATH"
 VOLUME ["/data"]
 
+# set /tmp permissions to drwxrwxrwt
+RUN chmod 1777 /tmp
+
 # Switch to non-root user - S6 overlay will run as umhuser (UID 1000)
 USER umhuser:umhuser
 

--- a/umh-core/Dockerfile
+++ b/umh-core/Dockerfile
@@ -183,7 +183,13 @@ ENV S6_YES_I_WANT_A_WORLD_WRITABLE_RUN_BECAUSE_KUBERNETES=1 \
     PATH="/opt/redpanda/bin:$PATH"
 VOLUME ["/data"]
 
-# set /tmp permissions to drwxrwxrwt
+# Fix /tmp permissions for non-root user (umhuser, UID 1000).
+# Docker's COPY --from does not preserve top-level directory permissions,
+# causing /tmp to have mode 0755 instead of standard 1777.
+# This is a known Docker BuildKit behavior documented in:
+# - https://github.com/moby/moby/issues/38710
+# - https://github.com/moby/buildkit/issues/3602
+# The chmod restores standard Linux /tmp permissions (sticky bit + world-writable).
 RUN chmod 1777 /tmp
 
 # Switch to non-root user - S6 overlay will run as umhuser (UID 1000)


### PR DESCRIPTION
## Summary

Fix `/tmp` permission issue that causes container startup failure on fresh deployments.

Set the folder permission to `drwxrwxrwt` (mode 1777) to restore standard Linux `/tmp` permissions.

## Root Cause

Docker's `COPY --from=downloader / /` pattern does not preserve top-level directory permissions. Combined with Alpine's default umask (0022), `/tmp` gets mode `0755` instead of standard `1777`.

This is a known Docker BuildKit behavior with no official fix:
- [moby/moby#38710](https://github.com/moby/moby/issues/38710) - COPY --from does not preserve permissions on top folder
- [moby/buildkit#3602](https://github.com/moby/buildkit/issues/3602) - COPY command changes /tmp permissions from 777 to 755

## Why Now?

The bug has existed since v0.44.0 (non-root migration). Fresh Depot builds with no cached layers always trigger the issue, while local builds often work due to BuildKit cache preserving permissions from previous builds.

## Recommended Changelog Entry (for v0.44.5)

**Title**: Container Startup Reliability Fix

**Entry**:
- **Fixed container failing to start on fresh image pulls** - Containers could fail to start with "permission denied" errors when creating the S6 service directory. This was caused by a Docker BuildKit behavior that doesn't preserve `/tmp` directory permissions during multi-stage builds. The issue primarily affected fresh deployments without cached container layers.