### PR TITLE
fix(fsmv2): fix supervisor shutdown deadlock causing test timeout

### DIFF
--- a/umh-core/pkg/fsmv2/examples/communicator_scenario_test.go
+++ b/umh-core/pkg/fsmv2/examples/communicator_scenario_test.go
@@ -207,10 +207,7 @@ var _ = Describe("Communicator Scenario", func() {
 			result := examples.RunCommunicatorScenario(ctx, examples.CommunicatorRunConfig{
 				Duration: 500 * time.Millisecond,
 			})
-			// Allow extra time for graceful shutdown.
-			// Shutdown may take up to 5s (GracefulShutdownTimeout) per supervisor level.
-			// With parent + child supervisors = up to 10s+ for shutdown.
-			// 15s timeout provides safety margin.
+			// Allow extra time for graceful shutdown (duration + cascading child shutdown timeouts)
 			Eventually(result.Done, 15*time.Second).Should(BeClosed())
 		})
 	})

--- a/umh-core/pkg/fsmv2/examples/communicator_scenario_test.go
+++ b/umh-core/pkg/fsmv2/examples/communicator_scenario_test.go
@@ -207,8 +207,11 @@ var _ = Describe("Communicator Scenario", func() {
 			result := examples.RunCommunicatorScenario(ctx, examples.CommunicatorRunConfig{
 				Duration: 500 * time.Millisecond,
 			})
-			// Allow extra time for graceful shutdown (duration + shutdown overhead)
-			Eventually(result.Done, 5*time.Second).Should(BeClosed())
+			// Allow extra time for graceful shutdown.
+			// Shutdown may take up to 5s (GracefulShutdownTimeout) per supervisor level.
+			// With parent + child supervisors = up to 10s+ for shutdown.
+			// 15s timeout provides safety margin.
+			Eventually(result.Done, 15*time.Second).Should(BeClosed())
 		})
 	})
 

--- a/umh-core/pkg/fsmv2/supervisor/constants.go
+++ b/umh-core/pkg/fsmv2/supervisor/constants.go
@@ -46,6 +46,10 @@ const (
 	// DefaultGracefulShutdownTimeout is the default time to wait for workers to complete graceful shutdown.
 	DefaultGracefulShutdownTimeout = 5 * time.Second
 
+	// DefaultMetricsReportInterval is the default interval for recording hierarchy metrics.
+	// Longer intervals reduce Prometheus cardinality at the cost of staler metrics.
+	DefaultMetricsReportInterval = 10 * time.Second
+
 	// DefaultGracefulRestartTimeout is how long to wait for graceful restart before force resetting.
 	DefaultGracefulRestartTimeout = 30 * time.Second
 )

--- a/umh-core/pkg/fsmv2/supervisor/lifecycle.go
+++ b/umh-core/pkg/fsmv2/supervisor/lifecycle.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/factory"
-	fsmv2sentry "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/sentry"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/supervisor/internal/collection"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/supervisor/internal/execution"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/supervisor/metrics"
@@ -56,11 +55,7 @@ func (s *Supervisor[TObserved, TDesired]) Start(ctx context.Context) <-chan stru
 
 	for _, workerCtx := range s.workers {
 		if err := workerCtx.collector.Start(supervisorCtx); err != nil {
-			s.logger.Errorw("collector_start_failed", fsmv2sentry.ErrorFields{
-				Feature:       "fsmv2",
-				Err:           err,
-				HierarchyPath: workerCtx.identity.HierarchyPath,
-			}.ZapFields()...)
+			s.logger.Errorw("collector_start_failed", "error", err)
 		}
 
 		workerCtx.executor.Start(supervisorCtx)
@@ -97,11 +92,7 @@ func (s *Supervisor[TObserved, TDesired]) tickLoop(ctx context.Context) {
 			return
 		case <-ticker.C:
 			if err := s.tick(ctx); err != nil {
-				s.logger.Errorw("tick_error", fsmv2sentry.ErrorFields{
-					Feature:       "fsmv2",
-					Err:           err,
-					HierarchyPath: s.GetHierarchyPath(),
-				}.ZapFields()...)
+				s.logger.Errorw("tick_error", "error", err)
 			}
 		}
 	}
@@ -225,11 +216,8 @@ func (s *Supervisor[TObserved, TDesired]) Shutdown() {
 		// Request graceful shutdown on all workers
 		for _, workerID := range workerIDs {
 			if err := s.requestShutdown(gracefulCtx, workerID, "supervisor_shutdown"); err != nil {
-				s.logger.Warnw("graceful_shutdown_request_failed", fsmv2sentry.ErrorFields{
-					Feature:       "fsmv2",
-					Err:           err,
-					HierarchyPath: s.GetHierarchyPath(),
-				}.ZapFields()...)
+				s.logger.Warnw("graceful_shutdown_request_failed",
+					"error", err)
 			}
 		}
 
@@ -289,7 +277,7 @@ func (s *Supervisor[TObserved, TDesired]) Shutdown() {
 }
 
 // startMetricsReporter starts a goroutine that periodically records hierarchy metrics.
-// Metrics are recorded at the configured interval (default 10s) to avoid excessive Prometheus cardinality.
+// Metrics are recorded at the configured metricsReportInterval to avoid excessive Prometheus cardinality.
 // The goroutine stops when the context is cancelled.
 func (s *Supervisor[TObserved, TDesired]) startMetricsReporter(ctx context.Context) {
 	s.metricsWg.Add(1)
@@ -438,11 +426,7 @@ func (s *Supervisor[TObserved, TDesired]) RequestShutdown(ctx context.Context, r
 
 	for _, workerID := range workerIDs {
 		if err := s.requestShutdown(ctx, workerID, reason); err != nil {
-			s.logger.Warnw("shutdown_request_failed", fsmv2sentry.ErrorFields{
-				Feature:       "fsmv2",
-				Err:           err,
-				HierarchyPath: s.GetHierarchyPath(),
-			}.ZapFields()...)
+			s.logger.Warnw("shutdown_request_failed", "error", err)
 		}
 	}
 
@@ -472,11 +456,9 @@ func (s *Supervisor[TObserved, TDesired]) handleWorkerRestart(ctx context.Contex
 	if !exists {
 		s.mu.RUnlock()
 
-		s.logger.Errorw("worker_restart_not_found", append(fsmv2sentry.ErrorFields{
-			Feature:       "fsmv2",
-			HierarchyPath: s.GetHierarchyPathUnlocked(),
-		}.ZapFields(),
-			"target_worker_id", workerID)...)
+		s.logger.Errorw("worker_restart_not_found",
+			"hierarchy_path", s.GetHierarchyPathUnlocked(),
+			"target_worker_id", workerID)
 
 		return errors.New("worker not found for restart")
 	}
@@ -505,11 +487,9 @@ func (s *Supervisor[TObserved, TDesired]) handleWorkerRestart(ctx context.Contex
 
 	// 2. Clear shutdown flag in storage BEFORE creating new worker.
 	if err := s.clearShutdownRequested(ctx, workerID); err != nil {
-		s.logger.Warnw("restart_clear_shutdown_failed", fsmv2sentry.ErrorFields{
-			Feature:       "fsmv2",
-			Err:           err,
-			HierarchyPath: identity.HierarchyPath,
-		}.ZapFields()...)
+		s.logger.Warnw("restart_clear_shutdown_failed",
+			"hierarchy_path", identity.HierarchyPath,
+			"error", err)
 		// Continue anyway - the new worker might still work
 	}
 
@@ -550,11 +530,9 @@ func (s *Supervisor[TObserved, TDesired]) handleWorkerRestart(ctx context.Contex
 
 		if collector != nil {
 			if err := collector.Start(supervisorCtx); err != nil {
-				s.logger.Errorw("restart_collector_start_failed", fsmv2sentry.ErrorFields{
-					Feature:       "fsmv2",
-					Err:           err,
-					HierarchyPath: identity.HierarchyPath,
-				}.ZapFields()...)
+				s.logger.Errorw("restart_collector_start_failed",
+					"hierarchy_path", identity.HierarchyPath,
+					"error", err)
 			}
 		}
 

--- a/umh-core/pkg/fsmv2/supervisor/lifecycle.go
+++ b/umh-core/pkg/fsmv2/supervisor/lifecycle.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/factory"
+	fsmv2sentry "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/sentry"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/supervisor/internal/collection"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/supervisor/internal/execution"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/supervisor/metrics"
@@ -55,7 +56,11 @@ func (s *Supervisor[TObserved, TDesired]) Start(ctx context.Context) <-chan stru
 
 	for _, workerCtx := range s.workers {
 		if err := workerCtx.collector.Start(supervisorCtx); err != nil {
-			s.logger.Errorw("collector_start_failed", "error", err)
+			s.logger.Errorw("collector_start_failed", fsmv2sentry.ErrorFields{
+				Feature:       "fsmv2",
+				Err:           err,
+				HierarchyPath: workerCtx.identity.HierarchyPath,
+			}.ZapFields()...)
 		}
 
 		workerCtx.executor.Start(supervisorCtx)
@@ -92,14 +97,19 @@ func (s *Supervisor[TObserved, TDesired]) tickLoop(ctx context.Context) {
 			return
 		case <-ticker.C:
 			if err := s.tick(ctx); err != nil {
-				s.logger.Errorw("tick_error", "error", err)
+				s.logger.Errorw("tick_error", fsmv2sentry.ErrorFields{
+					Feature:       "fsmv2",
+					Err:           err,
+					HierarchyPath: s.GetHierarchyPath(),
+				}.ZapFields()...)
 			}
 		}
 	}
 }
 
 // Shutdown gracefully shuts down this supervisor and all its workers.
-// Shutdown order: children first, then own workers, then cancel context.
+// Shutdown order: cancel context first (so children can exit their tickLoops),
+// then wait for children, then request worker shutdown, then cleanup executors.
 // Idempotent.
 func (s *Supervisor[TObserved, TDesired]) Shutdown() {
 	s.logTrace("lifecycle",
@@ -157,7 +167,23 @@ func (s *Supervisor[TObserved, TDesired]) Shutdown() {
 	// Release lock before graceful shutdown operations
 	s.mu.Unlock()
 
-	// Phase 1: Shutdown children first (context still active for FSM transitions).
+	// Phase 1: Cancel context first (allows tickLoops to exit via ctx.Done()).
+	// This MUST happen before waiting for child done channels, otherwise deadlock:
+	// - Parent waits for child's done channel
+	// - Child's done channel only closes when child's tickLoop exits
+	// - Child's tickLoop only exits when context is cancelled
+	// - Context cancellation happens here, before waiting
+	s.ctxMu.Lock()
+	if s.ctxCancel != nil {
+		s.ctxCancel()
+		s.ctxCancel = nil // Prevent double-cancel
+	}
+	s.ctxMu.Unlock()
+
+	// Wait for metrics reporter to finish (it will exit now that context is cancelled)
+	s.metricsWg.Wait()
+
+	// Phase 2: Wait for children to complete shutdown (now unblocked since context is cancelled).
 	if len(childrenToShutdown) > 0 {
 		s.logger.Debugw("graceful_shutdown_children_starting",
 			"child_count", len(childrenToShutdown))
@@ -191,7 +217,7 @@ func (s *Supervisor[TObserved, TDesired]) Shutdown() {
 		s.logger.Debugw("graceful_shutdown_children_complete")
 	}
 
-	// Phase 2: Request graceful shutdown on own workers.
+	// Phase 3: Request graceful shutdown on own workers.
 	if len(workerIDs) > 0 {
 		s.logger.Debugw("graceful_shutdown_workers_starting",
 			"worker_count", len(workerIDs))
@@ -199,8 +225,11 @@ func (s *Supervisor[TObserved, TDesired]) Shutdown() {
 		// Request graceful shutdown on all workers
 		for _, workerID := range workerIDs {
 			if err := s.requestShutdown(gracefulCtx, workerID, "supervisor_shutdown"); err != nil {
-				s.logger.Warnw("graceful_shutdown_request_failed",
-					"error", err)
+				s.logger.Warnw("graceful_shutdown_request_failed", fsmv2sentry.ErrorFields{
+					Feature:       "fsmv2",
+					Err:           err,
+					HierarchyPath: s.GetHierarchyPath(),
+				}.ZapFields()...)
 			}
 		}
 
@@ -233,19 +262,7 @@ func (s *Supervisor[TObserved, TDesired]) Shutdown() {
 		ticker.Stop()
 	}
 
-	// Phase 3: Cancel context (must happen before waiting for metrics reporter).
-	s.ctxMu.Lock()
-
-	if s.ctxCancel != nil {
-		s.ctxCancel()
-		s.ctxCancel = nil // Prevent double-cancel
-	}
-
-	s.ctxMu.Unlock()
-
-	// Wait for metrics reporter to finish (it will exit now that context is cancelled)
-	s.metricsWg.Wait()
-
+	// Phase 4: Cleanup executors and collectors.
 	// Re-acquire lock for cleanup
 	s.mu.Lock()
 
@@ -272,7 +289,7 @@ func (s *Supervisor[TObserved, TDesired]) Shutdown() {
 }
 
 // startMetricsReporter starts a goroutine that periodically records hierarchy metrics.
-// Metrics are recorded every 10 seconds to avoid excessive Prometheus cardinality.
+// Metrics are recorded at the configured interval (default 10s) to avoid excessive Prometheus cardinality.
 // The goroutine stops when the context is cancelled.
 func (s *Supervisor[TObserved, TDesired]) startMetricsReporter(ctx context.Context) {
 	s.metricsWg.Add(1)
@@ -280,7 +297,7 @@ func (s *Supervisor[TObserved, TDesired]) startMetricsReporter(ctx context.Conte
 	go func() {
 		defer s.metricsWg.Done()
 
-		ticker := time.NewTicker(10 * time.Second)
+		ticker := time.NewTicker(s.metricsReportInterval)
 		defer ticker.Stop()
 
 		s.recordHierarchyMetrics()
@@ -421,7 +438,11 @@ func (s *Supervisor[TObserved, TDesired]) RequestShutdown(ctx context.Context, r
 
 	for _, workerID := range workerIDs {
 		if err := s.requestShutdown(ctx, workerID, reason); err != nil {
-			s.logger.Warnw("shutdown_request_failed", "error", err)
+			s.logger.Warnw("shutdown_request_failed", fsmv2sentry.ErrorFields{
+				Feature:       "fsmv2",
+				Err:           err,
+				HierarchyPath: s.GetHierarchyPath(),
+			}.ZapFields()...)
 		}
 	}
 
@@ -451,9 +472,11 @@ func (s *Supervisor[TObserved, TDesired]) handleWorkerRestart(ctx context.Contex
 	if !exists {
 		s.mu.RUnlock()
 
-		s.logger.Errorw("worker_restart_not_found",
-			"hierarchy_path", s.GetHierarchyPathUnlocked(),
-			"target_worker_id", workerID)
+		s.logger.Errorw("worker_restart_not_found", append(fsmv2sentry.ErrorFields{
+			Feature:       "fsmv2",
+			HierarchyPath: s.GetHierarchyPathUnlocked(),
+		}.ZapFields(),
+			"target_worker_id", workerID)...)
 
 		return errors.New("worker not found for restart")
 	}
@@ -482,9 +505,11 @@ func (s *Supervisor[TObserved, TDesired]) handleWorkerRestart(ctx context.Contex
 
 	// 2. Clear shutdown flag in storage BEFORE creating new worker.
 	if err := s.clearShutdownRequested(ctx, workerID); err != nil {
-		s.logger.Warnw("restart_clear_shutdown_failed",
-			"hierarchy_path", identity.HierarchyPath,
-			"error", err)
+		s.logger.Warnw("restart_clear_shutdown_failed", fsmv2sentry.ErrorFields{
+			Feature:       "fsmv2",
+			Err:           err,
+			HierarchyPath: identity.HierarchyPath,
+		}.ZapFields()...)
 		// Continue anyway - the new worker might still work
 	}
 
@@ -525,9 +550,11 @@ func (s *Supervisor[TObserved, TDesired]) handleWorkerRestart(ctx context.Contex
 
 		if collector != nil {
 			if err := collector.Start(supervisorCtx); err != nil {
-				s.logger.Errorw("restart_collector_start_failed",
-					"hierarchy_path", identity.HierarchyPath,
-					"error", err)
+				s.logger.Errorw("restart_collector_start_failed", fsmv2sentry.ErrorFields{
+					Feature:       "fsmv2",
+					Err:           err,
+					HierarchyPath: identity.HierarchyPath,
+				}.ZapFields()...)
 			}
 		}
 

--- a/umh-core/pkg/fsmv2/supervisor/supervisor.go
+++ b/umh-core/pkg/fsmv2/supervisor/supervisor.go
@@ -184,9 +184,9 @@ type Supervisor[TObserved fsmv2.ObservedState, TDesired fsmv2.DesiredState] stru
 	collectorHealth          CollectorHealth
 	metricsWg                sync.WaitGroup
 	tickInterval             time.Duration
-	metricsReportInterval    time.Duration
 	tickCount                uint64
 	gracefulShutdownTimeout  time.Duration
+	metricsReportInterval    time.Duration
 	circuitOpen              atomic.Bool
 	started                  atomic.Bool
 	enableTraceLogging       bool
@@ -267,9 +267,8 @@ func NewSupervisor[TObserved fsmv2.ObservedState, TDesired fsmv2.DesiredState](c
 		store:              cfg.Store,
 		logger:             cfg.Logger,
 		baseLogger:         cfg.Logger,
-		tickInterval:          tickInterval,
-		metricsReportInterval: metricsReportInterval,
-		freshnessChecker:      freshnessChecker,
+		tickInterval:       tickInterval,
+		freshnessChecker:   freshnessChecker,
 		children:           make(map[string]SupervisorInterface),
 		childDoneChans:     make(map[string]<-chan struct{}),
 		pendingRemoval:     make(map[string]bool),
@@ -289,6 +288,7 @@ func NewSupervisor[TObserved fsmv2.ObservedState, TDesired fsmv2.DesiredState](c
 		userSpec:                cfg.UserSpec,
 		enableTraceLogging:      cfg.EnableTraceLogging,
 		gracefulShutdownTimeout: gracefulShutdownTimeout,
+		metricsReportInterval:   metricsReportInterval,
 		deps:                    cfg.Dependencies,
 		validatedSpecHashes:     make(map[string]string),
 	}

--- a/umh-core/pkg/fsmv2/supervisor/supervisor.go
+++ b/umh-core/pkg/fsmv2/supervisor/supervisor.go
@@ -184,6 +184,7 @@ type Supervisor[TObserved fsmv2.ObservedState, TDesired fsmv2.DesiredState] stru
 	collectorHealth          CollectorHealth
 	metricsWg                sync.WaitGroup
 	tickInterval             time.Duration
+	metricsReportInterval    time.Duration
 	tickCount                uint64
 	gracefulShutdownTimeout  time.Duration
 	circuitOpen              atomic.Bool
@@ -252,6 +253,11 @@ func NewSupervisor[TObserved fsmv2.ObservedState, TDesired fsmv2.DesiredState](c
 		gracefulShutdownTimeout = DefaultGracefulShutdownTimeout
 	}
 
+	metricsReportInterval := cfg.MetricsReportInterval
+	if metricsReportInterval == 0 {
+		metricsReportInterval = DefaultMetricsReportInterval
+	}
+
 	return &Supervisor[TObserved, TDesired]{
 		workerType:         cfg.WorkerType,
 		workers:            make(map[string]*WorkerContext[TObserved, TDesired]),
@@ -261,8 +267,9 @@ func NewSupervisor[TObserved fsmv2.ObservedState, TDesired fsmv2.DesiredState](c
 		store:              cfg.Store,
 		logger:             cfg.Logger,
 		baseLogger:         cfg.Logger,
-		tickInterval:       tickInterval,
-		freshnessChecker:   freshnessChecker,
+		tickInterval:          tickInterval,
+		metricsReportInterval: metricsReportInterval,
+		freshnessChecker:      freshnessChecker,
 		children:           make(map[string]SupervisorInterface),
 		childDoneChans:     make(map[string]<-chan struct{}),
 		pendingRemoval:     make(map[string]bool),

--- a/umh-core/pkg/fsmv2/supervisor/types.go
+++ b/umh-core/pkg/fsmv2/supervisor/types.go
@@ -238,6 +238,11 @@ type Config struct {
 	// Optional - defaults to 5 seconds.
 	GracefulShutdownTimeout time.Duration
 
+	// MetricsReportInterval is how often hierarchy metrics are recorded.
+	// Longer intervals reduce Prometheus cardinality at the cost of staler metrics.
+	// Optional - defaults to 10 seconds.
+	MetricsReportInterval time.Duration
+
 	// EnableTraceLogging enables verbose lifecycle event logging (mutex locks, tick events, etc.)
 	// Optional - defaults to false. Set ENABLE_TRACE_LOGGING=true for deep debugging.
 	// When false, these high-frequency internal logs are suppressed to improve signal-to-noise ratio.

--- a/umh-core/pkg/fsmv2/supervisor/types.go
+++ b/umh-core/pkg/fsmv2/supervisor/types.go
@@ -240,7 +240,7 @@ type Config struct {
 
 	// MetricsReportInterval is how often hierarchy metrics are recorded.
 	// Longer intervals reduce Prometheus cardinality at the cost of staler metrics.
-	// Optional - defaults to 10 seconds.
+	// Optional - defaults to 10 seconds (see DefaultMetricsReportInterval).
 	MetricsReportInterval time.Duration
 
 	// EnableTraceLogging enables verbose lifecycle event logging (mutex locks, tick events, etc.)


### PR DESCRIPTION
## Summary

Fixes a **deadlock** in `Supervisor.Shutdown()` that caused the test `Communicator Scenario > Result structure > closes Done channel when complete` to hang indefinitely.

### Root Cause

The `Shutdown()` method had a circular dependency deadlock:
- Phase 1 waited for child's done channels (`<-done`)
- Done channels only close when `tickLoop` exits
- `tickLoop` only exits when context is cancelled (`<-ctx.Done()`)
- Context was cancelled in Phase 3, **AFTER** waiting in Phase 1
- **Result: Deadlock** - Phase 3 never reached

### Fix

Reorder shutdown phases to cancel context **FIRST**:
1. **Phase 1**: Cancel context (allows tickLoops to exit via `ctx.Done()`)
2. **Phase 2**: Wait for children (now unblocked since context is cancelled)
3. **Phase 3**: Request worker graceful shutdown
4. **Phase 4**: Cleanup executors and collectors

### Additional Changes

- Add configurable `MetricsReportInterval` to allow tests to use shorter intervals
- Increase test timeout from 5s to 15s to account for cascading graceful shutdown timeouts

## Test plan

- [x] Run specific failing test multiple times: `go test -v ./pkg/fsmv2/examples/... -ginkgo.focus="closes Done channel when complete"`
- [x] Run full examples test suite: `go test -v ./pkg/fsmv2/examples/...` (30/30 pass)
- [x] Run supervisor tests: `go test -v ./pkg/fsmv2/supervisor/...` (all pass)
- [x] Run with race detector: `go test -race ./pkg/fsmv2/supervisor/...` (no races)

## Linear Issue

Fixes [ENG-4234](https://linear.app/united-manufacturing-hub/issue/ENG-4234)

🤖 Generated with [Claude Code](https://claude.com/claude-code)