### PR TITLE
fix(fsmv2): prevent panic in collector health race test

### DIFF
--- a/umh-core/pkg/fsmv2/supervisor/collector_health_race_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/collector_health_race_test.go
@@ -43,6 +43,13 @@ var _ = Describe("CollectorHealth Race Conditions", func() {
 			WorkerType: "test",
 			Store:      triangularStore,
 			Logger:     zap.NewNop().Sugar(),
+			// Use very high MaxRestartAttempts to prevent panic during race testing.
+			// The test's non-atomic sequence (SetRestartCount → RestartCollector) allows
+			// multiple concurrent RestartCollector calls to increment restartCount before
+			// any goroutine resets it, easily exceeding the default limit (3-5).
+			CollectorHealth: supervisor.CollectorHealthConfig{
+				MaxRestartAttempts: 100000,
+			},
 		})
 
 		// Add a worker so tick operations can proceed


### PR DESCRIPTION
## Summary

Fixes a flaky panic in the `CollectorHealth Race Conditions` test that was blocking PR #2388.

**Root cause:** The test's non-atomic sequence (`SetRestartCount(0)` → `RestartCollector()`) allows multiple concurrent calls to exceed `maxRestartAttempts` before any goroutine resets the count, triggering an intentional panic guard.

**Fix:** Set `MaxRestartAttempts: 100000` in the test config. This is appropriate because the test validates mutex protection for race safety, not restart limit logic.

## Test plan

- [x] Specific failing test now passes: `go test -race ./pkg/fsmv2/supervisor -ginkgo.focus="should not have data races on restartCount"`
- [x] All supervisor tests pass (excluding pre-existing TOCTOU timeout in PR #2390)
- [x] No new lint issues introduced

## Stack

This PR is stacked on #2390 (shutdown deadlock fix).

## Linear Issue

Fixes [ENG-4241](https://linear.app/united-manufacturing-hub/issue/ENG-4241)

🤖 Generated with [Claude Code](https://claude.com/claude-code)