### PR TITLE
chore: group PRs by non-major and use `on sunday` schedule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "group:allNonMajor"
   ],
   "includePaths": [
     "umh-core/**"
@@ -15,5 +16,5 @@
   ],
   "minimumReleaseAge": "7 days",
   "timezone": "Europe/Berlin",
-  "schedule": ["* 8 * * 0"]
+  "schedule": ["* * * * 0"]
 }


### PR DESCRIPTION
- Group all `nonMajor` versions into single PR - Otherwise we have too many PRs
- Increase time window to `entire sunday` - This will certainly then trigger on sunday