### PR TITLE
[PR 4 of ENG-4260] feat(fsmv2): wire TransportWorker into CommunicatorWorker hierarchy (ENG-4264)

### DIFF
--- a/umh-core/cmd/main.go
+++ b/umh-core/cmd/main.go
@@ -47,6 +47,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator/snapshot"
 	_ "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/persistence"
+	transportWorker "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/logger"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/metrics"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/models"

--- a/umh-core/cmd/main.go
+++ b/umh-core/cmd/main.go
@@ -480,6 +480,7 @@ func enableFSMv2BackendConnection(
 	// Phase 1 architecture: singleton is THE ONLY way to provide channels to the communicator.
 	// The factory will panic if this is not set.
 	communicator.SetChannelProvider(channelAdapter)
+	transportWorker.SetChannelProvider(channelAdapter)
 
 	// Build YAML config for FSMv2 ApplicationSupervisor
 	// Note: instanceUUID in config is a placeholder - the real UUID is returned by the backend

--- a/umh-core/pkg/fsmv2/examples/communicator_scenario.go
+++ b/umh-core/pkg/fsmv2/examples/communicator_scenario.go
@@ -24,6 +24,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator/testutil"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator/transport"
+	transportWorker "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport"
 )
 
 // TestChannelProvider implements communicator.ChannelProvider for test scenarios.
@@ -162,6 +163,7 @@ func RunCommunicatorScenario(ctx context.Context, cfg CommunicatorRunConfig) *Co
 
 	channelProvider := NewTestChannelProvider(100)
 	communicator.SetChannelProvider(channelProvider)
+	transportWorker.SetChannelProvider(channelProvider)
 
 	for _, msg := range cfg.InitialOutboundMessages {
 		channelProvider.QueueOutbound(msg)
@@ -212,6 +214,7 @@ children:
 	if err != nil {
 		if channelProvider != nil {
 			communicator.ClearChannelProvider()
+			transportWorker.ClearChannelProvider()
 		}
 
 		if ownsMockServer {
@@ -261,6 +264,7 @@ children:
 
 		if channelProvider != nil {
 			communicator.ClearChannelProvider()
+			transportWorker.ClearChannelProvider()
 		}
 
 		if ownsMockServer {

--- a/umh-core/pkg/fsmv2/examples/communicator_scenario_test.go
+++ b/umh-core/pkg/fsmv2/examples/communicator_scenario_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Communicator Scenario", func() {
 	var cancel context.CancelFunc
 
 	BeforeEach(func() {
-		ctx, cancel = context.WithTimeout(context.Background(), 30*time.Second)
+		ctx, cancel = context.WithTimeout(context.Background(), 45*time.Second)
 	})
 
 	AfterEach(func() {
@@ -203,8 +203,9 @@ var _ = Describe("Communicator Scenario", func() {
 			result := examples.RunCommunicatorScenario(ctx, examples.CommunicatorRunConfig{
 				Duration: 500 * time.Millisecond,
 			})
-			// Allow extra time for graceful shutdown (duration + cascading child shutdown timeouts)
-			Eventually(result.Done, GracefulShutdownCascadingTimeout).Should(BeClosed())
+			// Communicator has 4-level nesting (App → Communicator → Transport → Push/Pull),
+			// requiring ~20-25s for cascading graceful shutdown. Use 35s for margin.
+			Eventually(result.Done, 35*time.Second).Should(BeClosed())
 		})
 	})
 

--- a/umh-core/pkg/fsmv2/examples/communicator_scenario_test.go
+++ b/umh-core/pkg/fsmv2/examples/communicator_scenario_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator/testutil"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator/transport"
+	transportWorker "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport"
 )
 
 var _ = Describe("Communicator Scenario", func() {
@@ -38,8 +39,9 @@ var _ = Describe("Communicator Scenario", func() {
 
 	AfterEach(func() {
 		cancel()
-		// CRITICAL: Clean up global channel provider to prevent test pollution
+		// CRITICAL: Clean up global channel providers to prevent test pollution
 		communicator.ClearChannelProvider()
+		transportWorker.ClearChannelProvider()
 	})
 
 	Describe("Using FSMv2 worker via ApplicationSupervisor", func() {

--- a/umh-core/pkg/fsmv2/examples/transport_scenario_test.go
+++ b/umh-core/pkg/fsmv2/examples/transport_scenario_test.go
@@ -27,11 +27,8 @@ import (
 )
 
 const (
-	// GracefulShutdownCascadingTimeout accounts for nested supervisor graceful shutdown:
-	// - Grandchild supervisor timeout: 5s (push worker) + 5s (pull worker) — sequential
-	// - Child supervisor timeout: 5s (transport worker)
-	// - Parent supervisor timeout: 5s (application supervisor)
-	// - Scenario duration + processing overhead: 5s.
+	// GracefulShutdownCascadingTimeout is for transport-only scenario tests (3-level cascade).
+	// Communicator scenario tests use a longer inline timeout (35s) due to 4-level nesting.
 	GracefulShutdownCascadingTimeout = 25 * time.Second
 )
 

--- a/umh-core/pkg/fsmv2/workers/communicator/action/authenticate.go
+++ b/umh-core/pkg/fsmv2/workers/communicator/action/authenticate.go
@@ -107,7 +107,16 @@ func NewAuthenticateAction(relayURL, instanceUUID, authToken string, timeout tim
 // Creates transport if not present, then POSTs auth request and stores JWT in deps.
 // Records auth attempt timestamp and error type for intelligent backoff.
 func (a *AuthenticateAction) Execute(ctx context.Context, depsAny any) error {
-	deps := depsAny.(CommunicatorDependencies)
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
+	deps, ok := depsAny.(CommunicatorDependencies)
+	if !ok {
+		return errors.New("invalid dependencies type: expected CommunicatorDependencies")
+	}
 
 	if deps.GetTransport() == nil {
 		newTransport := httpTransport.NewHTTPTransport(a.RelayURL, a.Timeout)

--- a/umh-core/pkg/fsmv2/workers/communicator/action/authenticate.go
+++ b/umh-core/pkg/fsmv2/workers/communicator/action/authenticate.go
@@ -72,6 +72,9 @@ const AuthenticateActionName = "authenticate"
 // Idempotent: safe to retry on failure, multiple calls won't create multiple tokens.
 // Creates transport on first execution if not present.
 //
+// Deprecated: TransportWorker handles authentication (ENG-4264).
+// CommunicatorWorker no longer authenticates. Will be deleted in ENG-4265.
+//
 // Returns error on network failure, invalid credentials (non-200), or malformed response.
 // See worker.go C1 (authentication precedence) and C3 (transport lifecycle).
 type AuthenticateAction struct {

--- a/umh-core/pkg/fsmv2/workers/communicator/action/authenticate.go
+++ b/umh-core/pkg/fsmv2/workers/communicator/action/authenticate.go
@@ -76,7 +76,6 @@ const AuthenticateActionName = "authenticate"
 // CommunicatorWorker no longer authenticates. Will be deleted in ENG-4265.
 //
 // Returns error on network failure, invalid credentials (non-200), or malformed response.
-// See worker.go C1 (authentication precedence) and C3 (transport lifecycle).
 type AuthenticateAction struct {
 	RelayURL     string
 	InstanceUUID string

--- a/umh-core/pkg/fsmv2/workers/communicator/action/reset_transport.go
+++ b/umh-core/pkg/fsmv2/workers/communicator/action/reset_transport.go
@@ -25,11 +25,11 @@ const ResetTransportActionName = "reset_transport"
 
 // ResetTransportAction resets the HTTP transport to establish fresh connections.
 //
-// Deprecated: Transport reset is now handled by TransportWorker (ENG-4264). Will be deleted in ENG-4265.
-//
-// Triggered by RecoveringState at multiples of TransportResetThreshold (5, 10, 15...).
-// Resolves stale TCP connections, DNS caching, corrupted connection pool, or TLS issues.
-// Idempotent: creates fresh HTTP client while preserving JWT tokens.
+// Deprecated: Transport reset is now handled by TransportWorker (ENG-4264).
+// Will be deleted in ENG-4265. Previously triggered by RecoveringState at
+// multiples of TransportResetThreshold (5, 10, 15...) to resolve stale TCP
+// connections, DNS caching, corrupted connection pools, or TLS issues.
+// Idempotent: creates a fresh HTTP client while preserving JWT tokens.
 type ResetTransportAction struct{}
 
 func NewResetTransportAction() *ResetTransportAction {
@@ -40,7 +40,7 @@ func (a *ResetTransportAction) Name() string {
 	return ResetTransportActionName
 }
 
-// Execute resets the transport. Transport guaranteed non-nil per worker.go C3.
+// Execute resets the transport and advances the retry counter.
 func (a *ResetTransportAction) Execute(ctx context.Context, depsAny any) error {
 	// Check for context cancellation before proceeding
 	if err := ctx.Err(); err != nil {

--- a/umh-core/pkg/fsmv2/workers/communicator/action/reset_transport.go
+++ b/umh-core/pkg/fsmv2/workers/communicator/action/reset_transport.go
@@ -24,6 +24,9 @@ import (
 const ResetTransportActionName = "reset_transport"
 
 // ResetTransportAction resets the HTTP transport to establish fresh connections.
+//
+// Deprecated: Transport reset is now handled by TransportWorker (ENG-4264). Will be deleted in ENG-4265.
+//
 // Triggered by RecoveringState at multiples of TransportResetThreshold (5, 10, 15...).
 // Resolves stale TCP connections, DNS caching, corrupted connection pool, or TLS issues.
 // Idempotent: creates fresh HTTP client while preserving JWT tokens.

--- a/umh-core/pkg/fsmv2/workers/communicator/action/sync.go
+++ b/umh-core/pkg/fsmv2/workers/communicator/action/sync.go
@@ -45,6 +45,9 @@ const (
 // Pull: HTTPTransport.Pull() → inboundChan (backend → edge).
 // Push: outboundChan → HTTPTransport.Push() (edge → backend).
 //
+// Deprecated: Superseded by TransportWorker Push/Pull children (ENG-4264).
+// CommunicatorWorker no longer dispatches SyncAction. Will be deleted in ENG-4265.
+//
 // Records metrics and error counts for health monitoring. See worker.go C5 (syncing loop).
 type SyncAction struct {
 	JWTToken           string

--- a/umh-core/pkg/fsmv2/workers/communicator/action/sync.go
+++ b/umh-core/pkg/fsmv2/workers/communicator/action/sync.go
@@ -42,13 +42,11 @@ const (
 
 // SyncAction performs bidirectional message sync via HTTP transport.
 //
-// Pull: HTTPTransport.Pull() → inboundChan (backend → edge).
-// Push: outboundChan → HTTPTransport.Push() (edge → backend).
+// Pull: HTTPTransport.Pull() delivers messages to inboundChan (backend to edge).
+// Push: outboundChan messages go to HTTPTransport.Push() (edge to backend).
 //
 // Deprecated: Superseded by TransportWorker Push/Pull children (ENG-4264).
 // CommunicatorWorker no longer dispatches SyncAction. Will be deleted in ENG-4265.
-//
-// Records metrics and error counts for health monitoring. See worker.go C5 (syncing loop).
 type SyncAction struct {
 	JWTToken           string
 	MessagesToBePushed []*transport.UMHMessage

--- a/umh-core/pkg/fsmv2/workers/communicator/snapshot/snapshot.go
+++ b/umh-core/pkg/fsmv2/workers/communicator/snapshot/snapshot.go
@@ -56,6 +56,7 @@ type CommunicatorDesiredState struct {
 	Timeout          time.Duration          `json:"timeout"`
 }
 
+// GetChildrenSpecs returns the children specifications for the communicator worker.
 func (d *CommunicatorDesiredState) GetChildrenSpecs() []config.ChildSpec {
 	return d.ChildrenSpecs
 }

--- a/umh-core/pkg/fsmv2/workers/communicator/snapshot/snapshot.go
+++ b/umh-core/pkg/fsmv2/workers/communicator/snapshot/snapshot.go
@@ -119,11 +119,11 @@ func (o CommunicatorObservedState) IsTokenExpired() bool {
 	return time.Now().Add(refreshBuffer).After(o.JWTExpiry)
 }
 
-// IsSyncHealthy returns true when all children are healthy.
-// Authentication, token management, error tracking, and backpressure are now
-// internal to TransportWorker and its Push/Pull children (ENG-4264).
+// IsSyncHealthy returns true when at least one child is healthy and no children
+// are unhealthy. Returns false when no children exist, which is a transient
+// state during startup that resolves within 1-2 supervisor ticks.
 func (o CommunicatorObservedState) IsSyncHealthy() bool {
-	return o.ChildrenUnhealthy == 0
+	return o.ChildrenHealthy > 0 && o.ChildrenUnhealthy == 0
 }
 
 func (o CommunicatorObservedState) GetConsecutiveErrors() int {

--- a/umh-core/pkg/fsmv2/workers/communicator/snapshot/snapshot.go
+++ b/umh-core/pkg/fsmv2/workers/communicator/snapshot/snapshot.go
@@ -38,6 +38,7 @@ type CommunicatorSnapshot struct {
 }
 
 var _ fsmv2.DesiredState = (*CommunicatorDesiredState)(nil)
+var _ config.ChildSpecProvider = (*CommunicatorDesiredState)(nil)
 
 // CommunicatorDesiredState represents the target configuration for the communicator.
 type CommunicatorDesiredState struct {
@@ -48,9 +49,15 @@ type CommunicatorDesiredState struct {
 	AuthToken    string `json:"authToken"`
 	RelayURL     string `json:"relayURL"`
 
+	ChildrenSpecs []config.ChildSpec `json:"childrenSpecs,omitempty"`
+
 	// Messages
 	MessagesToBeSent []transport.UMHMessage `json:"messagesToBeSent,omitempty"`
 	Timeout          time.Duration          `json:"timeout"`
+}
+
+func (d *CommunicatorDesiredState) GetChildrenSpecs() []config.ChildSpec {
+	return d.ChildrenSpecs
 }
 
 // GetState returns the desired lifecycle state ("running" or "stopped").
@@ -90,10 +97,15 @@ type CommunicatorObservedState struct {
 
 	// Backpressure indicates inbound channel is near full capacity.
 	// When true, pull operations are skipped to prevent message loss.
+	// Deprecated: Backpressure is now tracked internally by PullWorker (ENG-4264).
 	IsBackpressured bool `json:"isBackpressured,omitempty"`
 
 	// Authentication
+	// Deprecated: Authentication is now handled by TransportWorker (ENG-4264).
 	Authenticated bool
+
+	ChildrenHealthy   int `json:"children_healthy"`
+	ChildrenUnhealthy int `json:"children_unhealthy"`
 }
 
 // IsTokenExpired returns true if the JWT token is expired or will expire within 10 minutes.
@@ -107,10 +119,11 @@ func (o CommunicatorObservedState) IsTokenExpired() bool {
 	return time.Now().Add(refreshBuffer).After(o.JWTExpiry)
 }
 
-// IsSyncHealthy returns true if authenticated, token valid, no consecutive errors, and not backpressured.
-// Any error immediately makes sync unhealthy, triggering transition to RecoveringState.
+// IsSyncHealthy returns true when all children are healthy.
+// Authentication, token management, error tracking, and backpressure are now
+// internal to TransportWorker and its Push/Pull children (ENG-4264).
 func (o CommunicatorObservedState) IsSyncHealthy() bool {
-	return o.Authenticated && !o.IsTokenExpired() && o.ConsecutiveErrors == 0 && !o.IsBackpressured
+	return o.ChildrenUnhealthy == 0
 }
 
 func (o CommunicatorObservedState) GetConsecutiveErrors() int {
@@ -135,6 +148,14 @@ func (o CommunicatorObservedState) SetState(s string) fsmv2.ObservedState {
 // SetShutdownRequested sets the shutdown requested status on this observed state.
 func (o CommunicatorObservedState) SetShutdownRequested(v bool) fsmv2.ObservedState {
 	o.ShutdownRequested = v
+
+	return o
+}
+
+// SetChildrenCounts sets the children health counts on this observed state.
+func (o CommunicatorObservedState) SetChildrenCounts(healthy, unhealthy int) fsmv2.ObservedState {
+	o.ChildrenHealthy = healthy
+	o.ChildrenUnhealthy = unhealthy
 
 	return o
 }

--- a/umh-core/pkg/fsmv2/workers/communicator/snapshot/snapshot_test.go
+++ b/umh-core/pkg/fsmv2/workers/communicator/snapshot/snapshot_test.go
@@ -118,11 +118,10 @@ var _ = Describe("CommunicatorObservedState", func() {
 	})
 
 	Describe("IsSyncHealthy", func() {
-		Context("when authenticated with valid token and no errors", func() {
+		Context("when all children are healthy", func() {
 			BeforeEach(func() {
-				observed.Authenticated = true
-				observed.JWTExpiry = time.Now().Add(1 * time.Hour) // Token valid for 1 hour
-				observed.ConsecutiveErrors = 0
+				observed.ChildrenHealthy = 1
+				observed.ChildrenUnhealthy = 0
 			})
 
 			It("should return true", func() {
@@ -130,114 +129,55 @@ var _ = Describe("CommunicatorObservedState", func() {
 			})
 		})
 
-		Context("when authenticated with valid token but has any consecutive errors", func() {
-			BeforeEach(func() {
-				observed.Authenticated = true
-				observed.JWTExpiry = time.Now().Add(1 * time.Hour)
-				observed.ConsecutiveErrors = 1 // Any error makes sync unhealthy
-			})
-
-			It("should return false (first error triggers degraded)", func() {
-				Expect(observed.IsSyncHealthy()).To(BeFalse())
-			})
-		})
-
-		Context("when authenticated with valid token but multiple errors", func() {
-			BeforeEach(func() {
-				observed.Authenticated = true
-				observed.JWTExpiry = time.Now().Add(1 * time.Hour)
-				observed.ConsecutiveErrors = 5 // Multiple errors
-			})
-
-			It("should return false", func() {
-				Expect(observed.IsSyncHealthy()).To(BeFalse())
-			})
-		})
-
-		Context("when authenticated with valid token but many errors", func() {
-			BeforeEach(func() {
-				observed.Authenticated = true
-				observed.JWTExpiry = time.Now().Add(1 * time.Hour)
-				observed.ConsecutiveErrors = 10 // Many errors
-			})
-
-			It("should return false", func() {
-				Expect(observed.IsSyncHealthy()).To(BeFalse())
-			})
-		})
-
-		Context("when not authenticated", func() {
-			BeforeEach(func() {
-				observed.Authenticated = false
-				observed.JWTExpiry = time.Now().Add(1 * time.Hour)
-				observed.ConsecutiveErrors = 0
-			})
-
-			It("should return false", func() {
-				Expect(observed.IsSyncHealthy()).To(BeFalse())
-			})
-		})
-
-		Context("when token is expired", func() {
-			BeforeEach(func() {
-				observed.Authenticated = true
-				observed.JWTExpiry = time.Now().Add(-1 * time.Hour) // Expired 1 hour ago
-				observed.ConsecutiveErrors = 0
-			})
-
-			It("should return false", func() {
-				Expect(observed.IsSyncHealthy()).To(BeFalse())
-			})
-		})
-
-		Context("when token is about to expire (within 10-minute buffer)", func() {
-			BeforeEach(func() {
-				observed.Authenticated = true
-				observed.JWTExpiry = time.Now().Add(5 * time.Minute) // Expires in 5 minutes
-				observed.ConsecutiveErrors = 0
-			})
-
-			It("should return false", func() {
-				Expect(observed.IsSyncHealthy()).To(BeFalse())
-			})
-		})
-
-		Context("when all conditions fail", func() {
-			BeforeEach(func() {
-				observed.Authenticated = false
-				observed.JWTExpiry = time.Now().Add(-1 * time.Hour)
-				observed.ConsecutiveErrors = 10
-			})
-
-			It("should return false", func() {
-				Expect(observed.IsSyncHealthy()).To(BeFalse())
-			})
-		})
-
-		Context("when backpressured with otherwise healthy state", func() {
-			BeforeEach(func() {
-				observed.Authenticated = true
-				observed.JWTExpiry = time.Now().Add(1 * time.Hour)
-				observed.ConsecutiveErrors = 0
-				observed.IsBackpressured = true
-			})
-
-			It("should return false (backpressure means not healthy)", func() {
-				Expect(observed.IsSyncHealthy()).To(BeFalse())
-			})
-		})
-
-		Context("when not backpressured with healthy state", func() {
-			BeforeEach(func() {
-				observed.Authenticated = true
-				observed.JWTExpiry = time.Now().Add(1 * time.Hour)
-				observed.ConsecutiveErrors = 0
-				observed.IsBackpressured = false
-			})
-
-			It("should return true", func() {
+		Context("when no children exist yet", func() {
+			It("should return true (zero unhealthy)", func() {
 				Expect(observed.IsSyncHealthy()).To(BeTrue())
 			})
+		})
+
+		Context("when some children are unhealthy", func() {
+			BeforeEach(func() {
+				observed.ChildrenHealthy = 1
+				observed.ChildrenUnhealthy = 1
+			})
+
+			It("should return false", func() {
+				Expect(observed.IsSyncHealthy()).To(BeFalse())
+			})
+		})
+
+		Context("when all children are unhealthy", func() {
+			BeforeEach(func() {
+				observed.ChildrenHealthy = 0
+				observed.ChildrenUnhealthy = 2
+			})
+
+			It("should return false", func() {
+				Expect(observed.IsSyncHealthy()).To(BeFalse())
+			})
+		})
+	})
+
+	Describe("SetChildrenCounts", func() {
+		It("should set both healthy and unhealthy counts", func() {
+			result := observed.SetChildrenCounts(3, 1)
+			updated := result.(snapshot.CommunicatorObservedState)
+			Expect(updated.ChildrenHealthy).To(Equal(3))
+			Expect(updated.ChildrenUnhealthy).To(Equal(1))
+		})
+
+		It("should handle zero counts", func() {
+			result := observed.SetChildrenCounts(0, 0)
+			updated := result.(snapshot.CommunicatorObservedState)
+			Expect(updated.ChildrenHealthy).To(Equal(0))
+			Expect(updated.ChildrenUnhealthy).To(Equal(0))
+		})
+	})
+
+	Describe("GetChildrenSpecs", func() {
+		It("should return nil when no specs set", func() {
+			desired := &snapshot.CommunicatorDesiredState{}
+			Expect(desired.GetChildrenSpecs()).To(BeNil())
 		})
 	})
 })

--- a/umh-core/pkg/fsmv2/workers/communicator/snapshot/snapshot_test.go
+++ b/umh-core/pkg/fsmv2/workers/communicator/snapshot/snapshot_test.go
@@ -21,6 +21,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/config"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator/snapshot"
 )
 
@@ -130,7 +131,18 @@ var _ = Describe("CommunicatorObservedState", func() {
 		})
 
 		Context("when no children exist yet", func() {
-			It("should return true (zero unhealthy)", func() {
+			It("should return false (no healthy children)", func() {
+				Expect(observed.IsSyncHealthy()).To(BeFalse())
+			})
+		})
+
+		Context("when multiple children are healthy and none unhealthy", func() {
+			BeforeEach(func() {
+				observed.ChildrenHealthy = 2
+				observed.ChildrenUnhealthy = 0
+			})
+
+			It("should return true", func() {
 				Expect(observed.IsSyncHealthy()).To(BeTrue())
 			})
 		})
@@ -178,6 +190,29 @@ var _ = Describe("CommunicatorObservedState", func() {
 		It("should return nil when no specs set", func() {
 			desired := &snapshot.CommunicatorDesiredState{}
 			Expect(desired.GetChildrenSpecs()).To(BeNil())
+		})
+
+		It("should return specs when set", func() {
+			desired := &snapshot.CommunicatorDesiredState{
+				ChildrenSpecs: []config.ChildSpec{
+					{Name: "transport", WorkerType: "transport"},
+				},
+			}
+			specs := desired.GetChildrenSpecs()
+			Expect(specs).To(HaveLen(1))
+			Expect(specs[0].Name).To(Equal("transport"))
+		})
+	})
+
+	Describe("SetChildrenCounts copy semantics", func() {
+		It("should not mutate the original struct", func() {
+			observed.ChildrenHealthy = 0
+			observed.ChildrenUnhealthy = 0
+
+			_ = observed.SetChildrenCounts(5, 3)
+
+			Expect(observed.ChildrenHealthy).To(Equal(0))
+			Expect(observed.ChildrenUnhealthy).To(Equal(0))
 		})
 	})
 })

--- a/umh-core/pkg/fsmv2/workers/communicator/state/state_recovering.go
+++ b/umh-core/pkg/fsmv2/workers/communicator/state/state_recovering.go
@@ -16,17 +16,15 @@ package state
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/internal/helpers"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator/action"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator/backoff"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator/snapshot"
-	httpTransport "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator/transport/http"
 )
 
-// RecoveringState handles error recovery with exponential backoff and periodic transport resets.
+// RecoveringState monitors child health and transitions back to SyncingState
+// when children recover. Error handling, backoff, and transport reset are
+// internal to TransportWorker and its Push/Pull children (ENG-4264).
 type RecoveringState struct {
 	helpers.RunningDegradedBase
 }
@@ -38,84 +36,17 @@ func (s *RecoveringState) Next(snapAny any) fsmv2.NextResult[any, any] {
 		return fsmv2.Result[any, any](&StoppedState{}, fsmv2.SignalNone, nil, "Shutdown requested during recovering state")
 	}
 
-	// If token is invalid, re-authenticate
-	if snap.Observed.LastErrorType == httpTransport.ErrorTypeInvalidToken {
-		return fsmv2.Result[any, any](&TryingToAuthenticateState{}, fsmv2.SignalNone, nil, "Token invalid, re-authenticating")
+	if snap.Observed.IsSyncHealthy() {
+		return fsmv2.Result[any, any](&SyncingState{}, fsmv2.SignalNone, nil,
+			fmt.Sprintf("recovered: healthy=%d, unhealthy=%d",
+				snap.Observed.ChildrenHealthy, snap.Observed.ChildrenUnhealthy))
 	}
 
-	if snap.Observed.IsSyncHealthy() && snap.Observed.GetConsecutiveErrors() == 0 {
-		return fsmv2.Result[any, any](&SyncingState{}, fsmv2.SignalNone, nil, "Recovered from recovering state")
-	}
-
-	consecutiveErrors := snap.Observed.GetConsecutiveErrors()
-	backoffDelay := backoff.CalculateDelayForErrorType(
-		snap.Observed.LastErrorType,
-		consecutiveErrors,
-		snap.Observed.LastRetryAfter,
-	)
-
-	// Build dynamic reason based on current error state
-	reason := buildRecoveringReason(snap.Observed.LastErrorType, consecutiveErrors, backoffDelay)
-
-	// Check if we should still be waiting before retrying.
-	// When Retry-After is provided, use LastErrorAt (when the error occurred).
-	// Otherwise, fall back to DegradedEnteredAt + calculated backoff.
-	if snap.Observed.LastRetryAfter > 0 && !snap.Observed.LastErrorAt.IsZero() {
-		// Retry-After from when it was issued
-		if time.Since(snap.Observed.LastErrorAt) < snap.Observed.LastRetryAfter {
-			return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil, reason)
-		}
-	} else {
-		enteredAt := snap.Observed.DegradedEnteredAt
-		if !enteredAt.IsZero() && time.Since(enteredAt) < backoffDelay {
-			return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil, reason)
-		}
-	}
-
-	// Reset transport periodically to recover from connection-level issues
-	if backoff.ShouldResetTransport(snap.Observed.LastErrorType, consecutiveErrors) {
-		return fsmv2.Result[any, any](s, fsmv2.SignalNone, action.NewResetTransportAction(), "Resetting transport due to repeated failures")
-	}
-
-	syncAction := action.NewSyncAction(snap.Observed.JWTToken)
-
-	return fsmv2.Result[any, any](s, fsmv2.SignalNone, syncAction, reason)
+	return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil,
+		fmt.Sprintf("recovering: healthy=%d, unhealthy=%d",
+			snap.Observed.ChildrenHealthy, snap.Observed.ChildrenUnhealthy))
 }
 
 func (s *RecoveringState) String() string {
 	return "Recovering"
-}
-
-// buildRecoveringReason creates a dynamic reason string based on the current error state.
-func buildRecoveringReason(errorType httpTransport.ErrorType, consecutiveErrors int, backoffDelay time.Duration) string {
-	errorTypeStr := mapErrorTypeToReason(errorType)
-
-	return fmt.Sprintf("sync recovering: %d consecutive errors (%s), backoff %s",
-		consecutiveErrors, errorTypeStr, backoffDelay.Round(time.Second))
-}
-
-// mapErrorTypeToReason maps error types to human-readable strings.
-func mapErrorTypeToReason(errType httpTransport.ErrorType) string {
-	switch errType {
-	case httpTransport.ErrorTypeUnknown:
-		return "unclassified_error"
-	case httpTransport.ErrorTypeInvalidToken:
-		return "authentication_failure"
-	case httpTransport.ErrorTypeBackendRateLimit:
-		return "backend_rate_limited"
-	case httpTransport.ErrorTypeNetwork:
-		return "network_connectivity_failure"
-	case httpTransport.ErrorTypeServerError:
-		return "server_error_response"
-	case httpTransport.ErrorTypeCloudflareChallenge:
-		return "cloudflare_challenge_encountered"
-	case httpTransport.ErrorTypeProxyBlock:
-		return "proxy_block_page_received"
-	case httpTransport.ErrorTypeInstanceDeleted:
-		return "instance_not_found_on_backend"
-	case httpTransport.ErrorTypeChannelFull:
-		return "inbound_channel_full"
-	default:
-		return "consecutive_errors_threshold_exceeded"
-	}
 }

--- a/umh-core/pkg/fsmv2/workers/communicator/state/state_recovering_integration_test.go
+++ b/umh-core/pkg/fsmv2/workers/communicator/state/state_recovering_integration_test.go
@@ -15,15 +15,41 @@
 package state_test
 
 import (
+	"context"
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator/snapshot"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator/state"
+	commTransport "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator/transport"
 )
+
+type mockResettableTransport struct {
+	resetCount int
+}
+
+func (m *mockResettableTransport) Authenticate(_ context.Context, _ commTransport.AuthRequest) (commTransport.AuthResponse, error) {
+	return commTransport.AuthResponse{}, nil
+}
+
+func (m *mockResettableTransport) Pull(_ context.Context, _ string) ([]*commTransport.UMHMessage, error) {
+	return nil, nil
+}
+
+func (m *mockResettableTransport) Push(_ context.Context, _ string, _ []*commTransport.UMHMessage) error {
+	return nil
+}
+
+func (m *mockResettableTransport) Close() {}
+
+func (m *mockResettableTransport) Reset() {
+	m.resetCount++
+}
 
 const (
 	// DegradedBackoffDelay is the minimum wait time in RecoveringState before emitting actions.
@@ -36,17 +62,16 @@ const (
 // ResetTransportAction didn't advance the retry counter.
 var _ = Describe("RecoveringState Integration - Infinite Loop Prevention", func() {
 	var (
-		stateObj     *state.RecoveringState
-		dependencies *communicator.CommunicatorDependencies
-		logger       deps.FSMLogger
-		mockTransp   *mockResettableTransport
+		stateObj   *state.RecoveringState
+		logger     deps.FSMLogger
+		mockTransp *mockResettableTransport
 	)
 
 	BeforeEach(func() {
 		logger = deps.NewNopFSMLogger()
 		mockTransp = &mockResettableTransport{}
 		identity := deps.Identity{ID: "test-id", WorkerType: "communicator"}
-		dependencies = communicator.NewCommunicatorDependencies(mockTransp, logger, nil, identity)
+		_ = communicator.NewCommunicatorDependencies(mockTransp, logger, nil, identity)
 		stateObj = &state.RecoveringState{}
 	})
 

--- a/umh-core/pkg/fsmv2/workers/communicator/state/state_recovering_integration_test.go
+++ b/umh-core/pkg/fsmv2/workers/communicator/state/state_recovering_integration_test.go
@@ -15,22 +15,14 @@
 package state_test
 
 import (
-	"context"
-	"time"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator/action"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator/backoff"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator/snapshot"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator/state"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator/transport"
-	httpTransport "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator/transport/http"
 )
 
 const (
@@ -58,286 +50,49 @@ var _ = Describe("RecoveringState Integration - Infinite Loop Prevention", func(
 		stateObj = &state.RecoveringState{}
 	})
 
-	Describe("Reset Transport Loop Prevention", func() {
-		// This test documents the exact bug that was found and verifies the fix.
-		// Bug: ResetTransportAction didn't call Attempt(), so counter stayed at threshold,
-		// causing ShouldResetTransport() to return true indefinitely.
-		It("should NOT cause infinite reset_transport loop at reset threshold", func() {
-			// Simulate network errors to reach reset threshold (backoff.TransportResetThreshold = 5)
-			for range backoff.TransportResetThreshold {
-				dependencies.RecordTypedError(httpTransport.ErrorTypeNetwork, 0)
-			}
-
-			Expect(dependencies.GetConsecutiveErrors()).To(Equal(backoff.TransportResetThreshold),
-				"Should have exactly TransportResetThreshold errors")
-
-			// First evaluation: Should emit ResetTransportAction at threshold
-			snap1 := buildSnapshot(dependencies, httpTransport.ErrorTypeNetwork)
-			result1 := stateObj.Next(snap1)
-
-			Expect(result1.State).To(BeAssignableToTypeOf(&state.RecoveringState{}),
-				"Should stay in RecoveringState")
-			Expect(result1.Action).NotTo(BeNil(),
-				"Should emit an action")
-			Expect(result1.Action.Name()).To(Equal("reset_transport"),
-				"At threshold errors, should emit reset_transport")
-
-			// Execute the ResetTransportAction - this is where the fix is
-			resetAction := result1.Action.(*action.ResetTransportAction)
-			err := resetAction.Execute(context.Background(), dependencies)
-			Expect(err).NotTo(HaveOccurred())
-
-			// BUG FIX VERIFICATION: Counter should now be threshold+1, not still at threshold
-			Expect(dependencies.GetConsecutiveErrors()).To(Equal(backoff.TransportResetThreshold+1),
-				"After ResetTransportAction, counter should advance past threshold to break modulo-N trigger")
-
-			// Second evaluation: Should emit SyncAction (NOT another reset_transport!)
-			snap2 := buildSnapshot(dependencies, httpTransport.ErrorTypeNetwork)
-			result2 := stateObj.Next(snap2)
-
-			Expect(result2.State).To(BeAssignableToTypeOf(&state.RecoveringState{}),
-				"Should stay in RecoveringState")
-			Expect(result2.Action).NotTo(BeNil(),
-				"Should emit an action")
-			Expect(result2.Action.Name()).To(Equal("sync"),
-				"At threshold+1 errors, should emit sync (not reset_transport) - THIS BREAKS THE INFINITE LOOP")
-		})
-
-		It("should emit reset_transport again at 2x threshold after proper progression", func() {
-			threshold := backoff.TransportResetThreshold
-			doubleThreshold := threshold * 2
-
-			// Start at threshold errors
-			for range threshold {
-				dependencies.RecordTypedError(httpTransport.ErrorTypeNetwork, 0)
-			}
-
-			// First reset at threshold errors
-			snap1 := buildSnapshot(dependencies, httpTransport.ErrorTypeNetwork)
-			result1 := stateObj.Next(snap1)
-			Expect(result1.Action.Name()).To(Equal("reset_transport"),
-				"At threshold, should emit reset_transport")
-
-			// Execute reset - advances counter to threshold+1
-			resetAction1 := result1.Action.(*action.ResetTransportAction)
-			_ = resetAction1.Execute(context.Background(), dependencies)
-			Expect(dependencies.GetConsecutiveErrors()).To(Equal(threshold+1),
-				"After reset, counter should be threshold+1")
-
-			// Simulate sync failures from threshold+1 to 2*threshold-1
-			for i := threshold + 2; i < doubleThreshold; i++ {
-				dependencies.RecordTypedError(httpTransport.ErrorTypeNetwork, 0)
-				Expect(dependencies.GetConsecutiveErrors()).To(Equal(i),
-					"Counter should be %d", i)
-
-				snap := buildSnapshot(dependencies, httpTransport.ErrorTypeNetwork)
-				result := stateObj.Next(snap)
-				Expect(result.Action.Name()).To(Equal("sync"),
-					"At %d errors, should emit sync (not reset_transport)", i)
-			}
-
-			// Error at 2*threshold - should trigger another reset
-			dependencies.RecordTypedError(httpTransport.ErrorTypeNetwork, 0)
-			Expect(dependencies.GetConsecutiveErrors()).To(Equal(doubleThreshold),
-				"Counter should be at 2x threshold")
-
-			snap2x := buildSnapshot(dependencies, httpTransport.ErrorTypeNetwork)
-			result2x := stateObj.Next(snap2x)
-			Expect(result2x.Action.Name()).To(Equal("reset_transport"),
-				"At 2x threshold errors, should emit reset_transport again")
-		})
-
-		It("should recover to Syncing when sync succeeds", func() {
-			// Start in degraded with threshold+1 errors
-			errorCount := backoff.TransportResetThreshold + 1
-			for range errorCount {
-				dependencies.RecordTypedError(httpTransport.ErrorTypeNetwork, 0)
-			}
-
-			Expect(dependencies.GetConsecutiveErrors()).To(Equal(errorCount),
-				"Should have threshold+1 errors")
-
-			// Simulate successful sync - this resets the counter
-			dependencies.RecordSuccess()
-
-			Expect(dependencies.GetConsecutiveErrors()).To(Equal(0),
-				"RecordSuccess() should reset counter to 0")
-
-			// Build snapshot with recovered state
-			snap := fsmv2.Snapshot{
+	Describe("Recovery Cycle", func() {
+		It("should complete full cycle: healthy -> degraded -> recovery", func() {
+			// Phase 1: Children go unhealthy — stay in Recovering
+			snap1 := fsmv2.Snapshot{
 				Identity: deps.Identity{ID: "test", Name: "test", WorkerType: "communicator"},
 				Observed: snapshot.CommunicatorObservedState{
-					Authenticated:     true,
-					JWTExpiry:         time.Now().Add(time.Hour),
-					ConsecutiveErrors: dependencies.GetConsecutiveErrors(),
+					ChildrenHealthy:   0,
+					ChildrenUnhealthy: 1,
 				},
 				Desired: &snapshot.CommunicatorDesiredState{},
 			}
 
-			result := stateObj.Next(snap)
+			result1 := stateObj.Next(snap1)
+			Expect(result1.State).To(BeAssignableToTypeOf(&state.RecoveringState{}))
+			Expect(result1.Action).To(BeNil())
 
-			Expect(result.State).To(BeAssignableToTypeOf(&state.SyncingState{}),
-				"Should transition to SyncingState when errors are cleared")
-			Expect(result.Action).To(BeNil())
-		})
-
-		It("should handle rapid consecutive resets correctly", func() {
-			// This tests that even if somehow we get multiple resets in sequence,
-			// each one advances the counter properly
-			threshold := backoff.TransportResetThreshold
-
-			// Start at threshold errors
-			for range threshold {
-				dependencies.RecordTypedError(httpTransport.ErrorTypeNetwork, 0)
+			// Phase 2: Children still unhealthy — stay in Recovering
+			snap2 := fsmv2.Snapshot{
+				Identity: deps.Identity{ID: "test", Name: "test", WorkerType: "communicator"},
+				Observed: snapshot.CommunicatorObservedState{
+					ChildrenHealthy:   0,
+					ChildrenUnhealthy: 1,
+				},
+				Desired: &snapshot.CommunicatorDesiredState{},
 			}
 
-			// First reset
-			resetAction := action.NewResetTransportAction()
-			_ = resetAction.Execute(context.Background(), dependencies)
-			Expect(dependencies.GetConsecutiveErrors()).To(Equal(threshold+1),
-				"After first reset, counter should be threshold+1")
-
-			// Force counter back to 5 manually (simulating a bug where something resets it)
-			// This shouldn't happen in real code, but let's verify robustness
-			// Actually, we can't easily do this without accessing internals...
-
-			// Instead, verify that calling Attempt() multiple times is safe
-			tracker := dependencies.RetryTracker()
-			tracker.Attempt()
-			Expect(dependencies.GetConsecutiveErrors()).To(Equal(threshold+2),
-				"After second Attempt(), counter should be threshold+2")
-
-			tracker.Attempt()
-			Expect(dependencies.GetConsecutiveErrors()).To(Equal(threshold+3),
-				"After third Attempt(), counter should be threshold+3")
-
-			// At threshold+3 errors, should still emit sync (not reset_transport)
-			snap := buildSnapshot(dependencies, httpTransport.ErrorTypeNetwork)
-			result := stateObj.Next(snap)
-			Expect(result.Action.Name()).To(Equal("sync"),
-				"At non-threshold error count, should emit sync")
-		})
-	})
-
-	Describe("Full Recovery Cycle", func() {
-		It("should complete full cycle: healthy -> degraded -> reset -> sync retry -> recovery", func() {
-			threshold := backoff.TransportResetThreshold
-
-			// Phase 1: Healthy state (simulated by having 0 errors initially)
-			Expect(dependencies.GetConsecutiveErrors()).To(Equal(0),
-				"Should start with 0 errors")
-
-			// Phase 2: Network failures accumulate to threshold
-			for range threshold {
-				dependencies.RecordTypedError(httpTransport.ErrorTypeNetwork, 0)
-			}
-
-			// Phase 3: At threshold errors, reset_transport fires
-			snap := buildSnapshot(dependencies, httpTransport.ErrorTypeNetwork)
-			result := stateObj.Next(snap)
-			Expect(result.Action.Name()).To(Equal("reset_transport"),
-				"At threshold, should emit reset_transport")
-
-			// Execute reset
-			resetAction := result.Action.(*action.ResetTransportAction)
-			_ = resetAction.Execute(context.Background(), dependencies)
-
-			// Phase 4: Counter at threshold+1, sync fires
-			Expect(dependencies.GetConsecutiveErrors()).To(Equal(threshold+1),
-				"After reset, counter should be threshold+1")
-			snap2 := buildSnapshot(dependencies, httpTransport.ErrorTypeNetwork)
 			result2 := stateObj.Next(snap2)
-			Expect(result2.Action.Name()).To(Equal("sync"),
-				"At threshold+1, should emit sync")
+			Expect(result2.State).To(BeAssignableToTypeOf(&state.RecoveringState{}))
+			Expect(result2.Action).To(BeNil())
 
-			// Phase 5: Sync succeeds (network comes back)
-			dependencies.RecordSuccess()
-
-			// Phase 6: Recovery - should transition to Syncing
+			// Phase 3: Children recover — transition to Syncing
 			snap3 := fsmv2.Snapshot{
 				Identity: deps.Identity{ID: "test", Name: "test", WorkerType: "communicator"},
 				Observed: snapshot.CommunicatorObservedState{
-					Authenticated:     true,
-					JWTExpiry:         time.Now().Add(time.Hour),
-					ConsecutiveErrors: dependencies.GetConsecutiveErrors(),
+					ChildrenHealthy:   1,
+					ChildrenUnhealthy: 0,
 				},
 				Desired: &snapshot.CommunicatorDesiredState{},
 			}
 
 			result3 := stateObj.Next(snap3)
 			Expect(result3.State).To(BeAssignableToTypeOf(&state.SyncingState{}))
-			Expect(dependencies.GetConsecutiveErrors()).To(Equal(0))
-		})
-	})
-
-	Describe("Retry Tracker Synchronization", func() {
-		It("should keep RetryTracker and GetConsecutiveErrors in sync", func() {
-			// RecordError should sync both
-			dependencies.RecordError()
-			Expect(dependencies.GetConsecutiveErrors()).To(Equal(1))
-			Expect(dependencies.RetryTracker().ConsecutiveErrors()).To(Equal(1))
-
-			// RecordTypedError should sync both
-			dependencies.RecordTypedError(httpTransport.ErrorTypeNetwork, 0)
-			Expect(dependencies.GetConsecutiveErrors()).To(Equal(2))
-			Expect(dependencies.RetryTracker().ConsecutiveErrors()).To(Equal(2))
-
-			// Attempt() should advance the tracker (and GetConsecutiveErrors reads from tracker)
-			dependencies.RetryTracker().Attempt()
-			Expect(dependencies.GetConsecutiveErrors()).To(Equal(3))
-			Expect(dependencies.RetryTracker().ConsecutiveErrors()).To(Equal(3))
-
-			// RecordSuccess should reset both
-			dependencies.RecordSuccess()
-			Expect(dependencies.GetConsecutiveErrors()).To(Equal(0))
-			Expect(dependencies.RetryTracker().ConsecutiveErrors()).To(Equal(0))
+			Expect(result3.Action).To(BeNil())
 		})
 	})
 })
-
-// buildSnapshot creates a snapshot with the current dependencies state for RecoveringState evaluation.
-// Uses GetWorkerID()/GetWorkerType() from BaseDependencies (no production code changes needed).
-func buildSnapshot(d *communicator.CommunicatorDependencies, lastErrorType httpTransport.ErrorType) fsmv2.Snapshot {
-	return fsmv2.Snapshot{
-		Identity: deps.Identity{
-			ID:         d.GetWorkerID(),
-			WorkerType: d.GetWorkerType(),
-		},
-		Observed: snapshot.CommunicatorObservedState{
-			Authenticated:     false,
-			ConsecutiveErrors: d.GetConsecutiveErrors(),
-			LastErrorType:     lastErrorType,
-			// Use time > DegradedBackoffDelay (60s) to ensure backoff has elapsed
-			DegradedEnteredAt: time.Now().Add(-DegradedBackoffDelay - 5*time.Second),
-		},
-		Desired: &snapshot.CommunicatorDesiredState{},
-	}
-}
-
-// mockResettableTransport implements the Transport interface with Reset() tracking.
-type mockResettableTransport struct {
-	resetCallCount int
-}
-
-func (m *mockResettableTransport) Reset() {
-	m.resetCallCount++
-}
-
-func (m *mockResettableTransport) Authenticate(_ context.Context, _ transport.AuthRequest) (transport.AuthResponse, error) {
-	return transport.AuthResponse{}, nil
-}
-
-func (m *mockResettableTransport) Pull(_ context.Context, _ string) ([]*transport.UMHMessage, error) {
-	return nil, nil
-}
-
-func (m *mockResettableTransport) Push(_ context.Context, _ string, _ []*transport.UMHMessage) error {
-	return nil
-}
-
-func (m *mockResettableTransport) Close() {
-	// No-op for mock
-}
-
-// Ensure mockResettableTransport implements transport.Transport at compile time.
-var _ transport.Transport = (*mockResettableTransport)(nil)

--- a/umh-core/pkg/fsmv2/workers/communicator/state/state_recovering_test.go
+++ b/umh-core/pkg/fsmv2/workers/communicator/state/state_recovering_test.go
@@ -164,6 +164,23 @@ var _ = Describe("RecoveringState Transitions", func() {
 	})
 
 	Describe("Recovering -> self (waiting)", func() {
+		It("should stay in RecoveringState when no children exist yet", func() {
+			snap := fsmv2.Snapshot{
+				Identity: deps.Identity{ID: "test", Name: "test", WorkerType: "communicator"},
+				Observed: snapshot.CommunicatorObservedState{
+					ChildrenHealthy:   0,
+					ChildrenUnhealthy: 0,
+				},
+				Desired: &snapshot.CommunicatorDesiredState{},
+			}
+
+			result := stateObj.Next(snap)
+
+			Expect(result.State).To(BeAssignableToTypeOf(&state.RecoveringState{}))
+			Expect(result.Signal).To(Equal(fsmv2.SignalNone))
+			Expect(result.Action).To(BeNil())
+		})
+
 		It("should stay in RecoveringState with nil action when children unhealthy", func() {
 			snap := fsmv2.Snapshot{
 				Identity: deps.Identity{ID: "test", Name: "test", WorkerType: "communicator"},

--- a/umh-core/pkg/fsmv2/workers/communicator/state/state_recovering_test.go
+++ b/umh-core/pkg/fsmv2/workers/communicator/state/state_recovering_test.go
@@ -15,8 +15,6 @@
 package state_test
 
 import (
-	"time"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -25,7 +23,6 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator/snapshot"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator/state"
-	httpTransport "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator/transport/http"
 )
 
 var _ = Describe("RecoveringState", func() {
@@ -41,62 +38,39 @@ var _ = Describe("RecoveringState", func() {
 	})
 
 	Describe("Next", func() {
-		Context("when sync recovers", func() {
-			var snap fsmv2.Snapshot
-
-			BeforeEach(func() {
-				snap = fsmv2.Snapshot{
+		Context("when children recover", func() {
+			It("should transition to SyncingState", func() {
+				snap := fsmv2.Snapshot{
 					Identity: deps.Identity{ID: "test", Name: "test", WorkerType: "communicator"},
 					Observed: snapshot.CommunicatorObservedState{
-						Authenticated: true,
+						ChildrenHealthy:   1,
+						ChildrenUnhealthy: 0,
 					},
 					Desired: &snapshot.CommunicatorDesiredState{},
 				}
-			})
 
-			It("should transition to SyncingState", func() {
 				result := stateObj.Next(snap)
 				Expect(result.State).To(BeAssignableToTypeOf(&state.SyncingState{}))
-			})
-
-			It("should not signal anything", func() {
-				result := stateObj.Next(snap)
 				Expect(result.Signal).To(Equal(fsmv2.SignalNone))
-			})
-
-			It("should not return an action", func() {
-				result := stateObj.Next(snap)
 				Expect(result.Action).To(BeNil())
 			})
 		})
 
-		Context("when sync is still unhealthy", func() {
-			var snap fsmv2.Snapshot
-
-			BeforeEach(func() {
-				snap = fsmv2.Snapshot{
+		Context("when children are still unhealthy", func() {
+			It("should stay in RecoveringState with nil action", func() {
+				snap := fsmv2.Snapshot{
 					Identity: deps.Identity{ID: "test", Name: "test", WorkerType: "communicator"},
 					Observed: snapshot.CommunicatorObservedState{
-						Authenticated: false,
+						ChildrenHealthy:   0,
+						ChildrenUnhealthy: 1,
 					},
 					Desired: &snapshot.CommunicatorDesiredState{},
 				}
-			})
 
-			It("should stay in RecoveringState", func() {
 				result := stateObj.Next(snap)
 				Expect(result.State).To(BeAssignableToTypeOf(&state.RecoveringState{}))
-			})
-
-			It("should emit SyncAction to retry", func() {
-				result := stateObj.Next(snap)
-				Expect(result.Action).NotTo(BeNil())
-				Expect(result.Action.Name()).To(Equal("sync"))
-			})
-
-			It("should not signal anything", func() {
-				result := stateObj.Next(snap)
 				Expect(result.Signal).To(Equal(fsmv2.SignalNone))
+				Expect(result.Action).To(BeNil())
 			})
 		})
 	})
@@ -108,240 +82,6 @@ var _ = Describe("RecoveringState", func() {
 	})
 })
 
-var _ = Describe("RecoveringState Transport Reset", func() {
-	Context("for network errors", func() {
-		It("should emit ResetTransportAction at exactly 5 consecutive errors", func() {
-			stateObj := &state.RecoveringState{}
-
-			snap := fsmv2.Snapshot{
-				Identity: deps.Identity{ID: "test", Name: "test", WorkerType: "communicator"},
-				Observed: snapshot.CommunicatorObservedState{
-					Authenticated:     false,
-					ConsecutiveErrors: 5,
-					LastErrorType:     httpTransport.ErrorTypeNetwork,
-					DegradedEnteredAt: time.Now().Add(-35 * time.Second),
-				},
-				Desired: &snapshot.CommunicatorDesiredState{},
-			}
-
-			result := stateObj.Next(snap)
-
-			Expect(result.State).To(BeAssignableToTypeOf(&state.RecoveringState{}))
-			Expect(result.Signal).To(Equal(fsmv2.SignalNone))
-			Expect(result.Action).NotTo(BeNil())
-			Expect(result.Action.Name()).To(Equal("reset_transport"))
-		})
-
-		It("should NOT emit ResetTransportAction at 6 consecutive errors", func() {
-			stateObj := &state.RecoveringState{}
-
-			snap := fsmv2.Snapshot{
-				Identity: deps.Identity{ID: "test", Name: "test", WorkerType: "communicator"},
-				Observed: snapshot.CommunicatorObservedState{
-					Authenticated:     false,
-					ConsecutiveErrors: 6,
-					LastErrorType:     httpTransport.ErrorTypeNetwork,
-					DegradedEnteredAt: time.Now().Add(-65 * time.Second),
-				},
-				Desired: &snapshot.CommunicatorDesiredState{},
-			}
-
-			result := stateObj.Next(snap)
-
-			Expect(result.Action).NotTo(BeNil())
-			Expect(result.Action.Name()).To(Equal("sync"))
-		})
-
-		It("should emit ResetTransportAction again at 10 consecutive errors", func() {
-			stateObj := &state.RecoveringState{}
-
-			snap := fsmv2.Snapshot{
-				Identity: deps.Identity{ID: "test", Name: "test", WorkerType: "communicator"},
-				Observed: snapshot.CommunicatorObservedState{
-					Authenticated:     false,
-					ConsecutiveErrors: 10,
-					LastErrorType:     httpTransport.ErrorTypeNetwork,
-					DegradedEnteredAt: time.Now().Add(-65 * time.Second),
-				},
-				Desired: &snapshot.CommunicatorDesiredState{},
-			}
-
-			result := stateObj.Next(snap)
-
-			Expect(result.Action).NotTo(BeNil())
-			Expect(result.Action.Name()).To(Equal("reset_transport"))
-		})
-
-		It("should NOT emit ResetTransportAction at 0 errors", func() {
-			stateObj := &state.RecoveringState{}
-
-			snap := fsmv2.Snapshot{
-				Identity: deps.Identity{ID: "test", Name: "test", WorkerType: "communicator"},
-				Observed: snapshot.CommunicatorObservedState{
-					Authenticated:     false,
-					ConsecutiveErrors: 0,
-					LastErrorType:     httpTransport.ErrorTypeNetwork,
-					DegradedEnteredAt: time.Now().Add(-1 * time.Second),
-				},
-				Desired: &snapshot.CommunicatorDesiredState{},
-			}
-
-			result := stateObj.Next(snap)
-
-			Expect(result.Action).NotTo(BeNil())
-			Expect(result.Action.Name()).To(Equal("sync"))
-		})
-	})
-
-	Context("for server errors", func() {
-		It("should NOT emit ResetTransportAction at 5 errors (needs 10)", func() {
-			stateObj := &state.RecoveringState{}
-
-			snap := fsmv2.Snapshot{
-				Identity: deps.Identity{ID: "test", Name: "test", WorkerType: "communicator"},
-				Observed: snapshot.CommunicatorObservedState{
-					Authenticated:     false,
-					ConsecutiveErrors: 5,
-					LastErrorType:     httpTransport.ErrorTypeServerError,
-					DegradedEnteredAt: time.Now().Add(-35 * time.Second),
-				},
-				Desired: &snapshot.CommunicatorDesiredState{},
-			}
-
-			result := stateObj.Next(snap)
-
-			Expect(result.Action).NotTo(BeNil())
-			Expect(result.Action.Name()).To(Equal("sync"))
-		})
-
-		It("should emit ResetTransportAction at 10 consecutive errors", func() {
-			stateObj := &state.RecoveringState{}
-
-			snap := fsmv2.Snapshot{
-				Identity: deps.Identity{ID: "test", Name: "test", WorkerType: "communicator"},
-				Observed: snapshot.CommunicatorObservedState{
-					Authenticated:     false,
-					ConsecutiveErrors: 10,
-					LastErrorType:     httpTransport.ErrorTypeServerError,
-					DegradedEnteredAt: time.Now().Add(-65 * time.Second),
-				},
-				Desired: &snapshot.CommunicatorDesiredState{},
-			}
-
-			result := stateObj.Next(snap)
-
-			Expect(result.Action).NotTo(BeNil())
-			Expect(result.Action.Name()).To(Equal("reset_transport"))
-		})
-
-		It("should emit ResetTransportAction at 20 consecutive errors", func() {
-			stateObj := &state.RecoveringState{}
-
-			snap := fsmv2.Snapshot{
-				Identity: deps.Identity{ID: "test", Name: "test", WorkerType: "communicator"},
-				Observed: snapshot.CommunicatorObservedState{
-					Authenticated:     false,
-					ConsecutiveErrors: 20,
-					LastErrorType:     httpTransport.ErrorTypeServerError,
-					DegradedEnteredAt: time.Now().Add(-65 * time.Second),
-				},
-				Desired: &snapshot.CommunicatorDesiredState{},
-			}
-
-			result := stateObj.Next(snap)
-
-			Expect(result.Action).NotTo(BeNil())
-			Expect(result.Action.Name()).To(Equal("reset_transport"))
-		})
-	})
-
-	Context("for unknown/other error types", func() {
-		It("should NOT emit ResetTransportAction regardless of error count", func() {
-			stateObj := &state.RecoveringState{}
-
-			snap := fsmv2.Snapshot{
-				Identity: deps.Identity{ID: "test", Name: "test", WorkerType: "communicator"},
-				Observed: snapshot.CommunicatorObservedState{
-					Authenticated:     false,
-					ConsecutiveErrors: 100,
-					LastErrorType:     httpTransport.ErrorTypeBackendRateLimit,
-					DegradedEnteredAt: time.Now().Add(-600 * time.Second),
-				},
-				Desired: &snapshot.CommunicatorDesiredState{},
-			}
-
-			result := stateObj.Next(snap)
-
-			Expect(result.Action).NotTo(BeNil())
-			Expect(result.Action.Name()).To(Equal("sync"))
-		})
-	})
-})
-
-var _ = Describe("RecoveringState Auth Transition", func() {
-	It("should transition to TryingToAuthenticateState when last error is InvalidToken", func() {
-		stateObj := &state.RecoveringState{}
-
-		snap := fsmv2.Snapshot{
-			Identity: deps.Identity{ID: "test", Name: "test", WorkerType: "communicator"},
-			Observed: snapshot.CommunicatorObservedState{
-				LastErrorType:     httpTransport.ErrorTypeInvalidToken,
-				ConsecutiveErrors: 1,
-				DegradedEnteredAt: time.Now().Add(-65 * time.Second), // Past backoff
-			},
-			Desired: &snapshot.CommunicatorDesiredState{},
-		}
-
-		result := stateObj.Next(snap)
-
-		Expect(result.State).To(BeAssignableToTypeOf(&state.TryingToAuthenticateState{}))
-		Expect(result.Signal).To(Equal(fsmv2.SignalNone))
-		Expect(result.Action).To(BeNil())
-	})
-})
-
-var _ = Describe("RecoveringState Backoff", func() {
-	It("stays in degraded state during backoff period", func() {
-		stateObj := &state.RecoveringState{}
-
-		snap := fsmv2.Snapshot{
-			Identity: deps.Identity{ID: "test", Name: "test", WorkerType: "communicator"},
-			Observed: snapshot.CommunicatorObservedState{
-				Authenticated:     false,
-				ConsecutiveErrors: 3,
-				DegradedEnteredAt: time.Now(), // Just entered degraded
-			},
-			Desired: &snapshot.CommunicatorDesiredState{},
-		}
-
-		result := stateObj.Next(snap)
-
-		Expect(result.State).To(BeAssignableToTypeOf(&state.RecoveringState{}))
-		Expect(result.Signal).To(Equal(fsmv2.SignalNone))
-		Expect(result.Action).To(BeNil(), "Should NOT emit action during backoff period")
-	})
-
-	It("attempts sync after backoff period expires", func() {
-		stateObj := &state.RecoveringState{}
-
-		snap := fsmv2.Snapshot{
-			Identity: deps.Identity{ID: "test", Name: "test", WorkerType: "communicator"},
-			Observed: snapshot.CommunicatorObservedState{
-				Authenticated:     false,
-				ConsecutiveErrors: 3,
-				DegradedEnteredAt: time.Now().Add(-10 * time.Second), // Past backoff period
-			},
-			Desired: &snapshot.CommunicatorDesiredState{},
-		}
-
-		result := stateObj.Next(snap)
-
-		Expect(result.State).To(BeAssignableToTypeOf(&state.RecoveringState{}))
-		Expect(result.Action).NotTo(BeNil(), "Should emit SyncAction after backoff expires")
-		Expect(result.Action.Name()).To(Equal("sync"))
-	})
-})
-
 var _ = Describe("RecoveringState Transitions", func() {
 	var stateObj *state.RecoveringState
 
@@ -349,14 +89,13 @@ var _ = Describe("RecoveringState Transitions", func() {
 		stateObj = &state.RecoveringState{}
 	})
 
-	Describe("Degraded -> StoppedState", func() {
+	Describe("Recovering -> StoppedState", func() {
 		It("should transition to StoppedState when shutdown is requested", func() {
 			snap := fsmv2.Snapshot{
 				Identity: deps.Identity{ID: "test", Name: "test", WorkerType: "communicator"},
 				Observed: snapshot.CommunicatorObservedState{
-					Authenticated:     true,
-					ConsecutiveErrors: 10,
-					DegradedEnteredAt: time.Now().Add(-5 * time.Minute),
+					ChildrenHealthy:   0,
+					ChildrenUnhealthy: 1,
 				},
 				Desired: &snapshot.CommunicatorDesiredState{
 					BaseDesiredState: config.BaseDesiredState{ShutdownRequested: true},
@@ -374,9 +113,8 @@ var _ = Describe("RecoveringState Transitions", func() {
 			snap := fsmv2.Snapshot{
 				Identity: deps.Identity{ID: "test", Name: "test", WorkerType: "communicator"},
 				Observed: snapshot.CommunicatorObservedState{
-					Authenticated:     true,
-					ConsecutiveErrors: 0,
-					DegradedEnteredAt: time.Time{},
+					ChildrenHealthy:   1,
+					ChildrenUnhealthy: 0,
 				},
 				Desired: &snapshot.CommunicatorDesiredState{
 					BaseDesiredState: config.BaseDesiredState{ShutdownRequested: true},
@@ -391,52 +129,13 @@ var _ = Describe("RecoveringState Transitions", func() {
 		})
 	})
 
-	Describe("Degraded -> TryingToAuthenticateState", func() {
-		It("should transition to TryingToAuthenticateState when last error is InvalidToken", func() {
+	Describe("Recovering -> SyncingState", func() {
+		It("should transition when all children become healthy", func() {
 			snap := fsmv2.Snapshot{
 				Identity: deps.Identity{ID: "test", Name: "test", WorkerType: "communicator"},
 				Observed: snapshot.CommunicatorObservedState{
-					LastErrorType:     httpTransport.ErrorTypeInvalidToken,
-					ConsecutiveErrors: 1,
-					DegradedEnteredAt: time.Now().Add(-65 * time.Second),
-				},
-				Desired: &snapshot.CommunicatorDesiredState{},
-			}
-
-			result := stateObj.Next(snap)
-
-			Expect(result.State).To(BeAssignableToTypeOf(&state.TryingToAuthenticateState{}))
-			Expect(result.Signal).To(Equal(fsmv2.SignalNone))
-			Expect(result.Action).To(BeNil())
-		})
-
-		It("should transition to TryingToAuthenticateState on InvalidToken regardless of consecutive errors", func() {
-			snap := fsmv2.Snapshot{
-				Identity: deps.Identity{ID: "test", Name: "test", WorkerType: "communicator"},
-				Observed: snapshot.CommunicatorObservedState{
-					LastErrorType:     httpTransport.ErrorTypeInvalidToken,
-					ConsecutiveErrors: 100,
-					DegradedEnteredAt: time.Now().Add(-5 * time.Minute),
-				},
-				Desired: &snapshot.CommunicatorDesiredState{},
-			}
-
-			result := stateObj.Next(snap)
-
-			Expect(result.State).To(BeAssignableToTypeOf(&state.TryingToAuthenticateState{}))
-			Expect(result.Signal).To(Equal(fsmv2.SignalNone))
-			Expect(result.Action).To(BeNil())
-		})
-	})
-
-	Describe("Degraded -> SyncingState", func() {
-		It("should transition to SyncingState when sync is healthy and no errors", func() {
-			snap := fsmv2.Snapshot{
-				Identity: deps.Identity{ID: "test", Name: "test", WorkerType: "communicator"},
-				Observed: snapshot.CommunicatorObservedState{
-					Authenticated:     true,
-					JWTExpiry:         time.Now().Add(time.Hour),
-					ConsecutiveErrors: 0,
+					ChildrenHealthy:   1,
+					ChildrenUnhealthy: 0,
 				},
 				Desired: &snapshot.CommunicatorDesiredState{},
 			}
@@ -448,36 +147,12 @@ var _ = Describe("RecoveringState Transitions", func() {
 			Expect(result.Action).To(BeNil())
 		})
 
-		It("should transition to SyncingState after full recovery", func() {
+		It("should NOT transition when some children are still unhealthy", func() {
 			snap := fsmv2.Snapshot{
 				Identity: deps.Identity{ID: "test", Name: "test", WorkerType: "communicator"},
 				Observed: snapshot.CommunicatorObservedState{
-					Authenticated:     true,
-					JWTToken:          "valid-token",
-					JWTExpiry:         time.Now().Add(30 * time.Minute),
-					ConsecutiveErrors: 0,
-					DegradedEnteredAt: time.Time{},
-				},
-				Desired: &snapshot.CommunicatorDesiredState{
-					BaseDesiredState: config.BaseDesiredState{ShutdownRequested: false},
-				},
-			}
-
-			result := stateObj.Next(snap)
-
-			Expect(result.State).To(BeAssignableToTypeOf(&state.SyncingState{}))
-			Expect(result.Signal).To(Equal(fsmv2.SignalNone))
-			Expect(result.Action).To(BeNil())
-		})
-
-		It("should NOT transition to SyncingState if sync is healthy but has errors", func() {
-			snap := fsmv2.Snapshot{
-				Identity: deps.Identity{ID: "test", Name: "test", WorkerType: "communicator"},
-				Observed: snapshot.CommunicatorObservedState{
-					Authenticated:     true,
-					JWTExpiry:         time.Now().Add(time.Hour),
-					ConsecutiveErrors: 3,
-					DegradedEnteredAt: time.Now().Add(-20 * time.Second),
+					ChildrenHealthy:   1,
+					ChildrenUnhealthy: 1,
 				},
 				Desired: &snapshot.CommunicatorDesiredState{},
 			}
@@ -488,14 +163,13 @@ var _ = Describe("RecoveringState Transitions", func() {
 		})
 	})
 
-	Describe("Degraded -> self (backoff/retry)", func() {
-		It("should stay in RecoveringState during backoff period", func() {
+	Describe("Recovering -> self (waiting)", func() {
+		It("should stay in RecoveringState with nil action when children unhealthy", func() {
 			snap := fsmv2.Snapshot{
 				Identity: deps.Identity{ID: "test", Name: "test", WorkerType: "communicator"},
 				Observed: snapshot.CommunicatorObservedState{
-					Authenticated:     false,
-					ConsecutiveErrors: 3,
-					DegradedEnteredAt: time.Now(),
+					ChildrenHealthy:   0,
+					ChildrenUnhealthy: 2,
 				},
 				Desired: &snapshot.CommunicatorDesiredState{},
 			}
@@ -505,84 +179,6 @@ var _ = Describe("RecoveringState Transitions", func() {
 			Expect(result.State).To(BeAssignableToTypeOf(&state.RecoveringState{}))
 			Expect(result.Signal).To(Equal(fsmv2.SignalNone))
 			Expect(result.Action).To(BeNil())
-		})
-
-		It("should stay in RecoveringState and emit SyncAction after backoff", func() {
-			snap := fsmv2.Snapshot{
-				Identity: deps.Identity{ID: "test", Name: "test", WorkerType: "communicator"},
-				Observed: snapshot.CommunicatorObservedState{
-					Authenticated:     false,
-					ConsecutiveErrors: 3,
-					DegradedEnteredAt: time.Now().Add(-10 * time.Second),
-				},
-				Desired: &snapshot.CommunicatorDesiredState{},
-			}
-
-			result := stateObj.Next(snap)
-
-			Expect(result.State).To(BeAssignableToTypeOf(&state.RecoveringState{}))
-			Expect(result.Signal).To(Equal(fsmv2.SignalNone))
-			Expect(result.Action).NotTo(BeNil())
-			Expect(result.Action.Name()).To(Equal("sync"))
-		})
-
-		It("should emit ResetTransportAction at 5 consecutive network errors after backoff", func() {
-			snap := fsmv2.Snapshot{
-				Identity: deps.Identity{ID: "test", Name: "test", WorkerType: "communicator"},
-				Observed: snapshot.CommunicatorObservedState{
-					Authenticated:     false,
-					ConsecutiveErrors: 5,
-					LastErrorType:     httpTransport.ErrorTypeNetwork,
-					DegradedEnteredAt: time.Now().Add(-35 * time.Second),
-				},
-				Desired: &snapshot.CommunicatorDesiredState{},
-			}
-
-			result := stateObj.Next(snap)
-
-			Expect(result.State).To(BeAssignableToTypeOf(&state.RecoveringState{}))
-			Expect(result.Signal).To(Equal(fsmv2.SignalNone))
-			Expect(result.Action).NotTo(BeNil())
-			Expect(result.Action.Name()).To(Equal("reset_transport"))
-		})
-
-		It("should emit ResetTransportAction at 10 consecutive network errors", func() {
-			snap := fsmv2.Snapshot{
-				Identity: deps.Identity{ID: "test", Name: "test", WorkerType: "communicator"},
-				Observed: snapshot.CommunicatorObservedState{
-					Authenticated:     false,
-					ConsecutiveErrors: 10,
-					LastErrorType:     httpTransport.ErrorTypeNetwork,
-					DegradedEnteredAt: time.Now().Add(-65 * time.Second),
-				},
-				Desired: &snapshot.CommunicatorDesiredState{},
-			}
-
-			result := stateObj.Next(snap)
-
-			Expect(result.State).To(BeAssignableToTypeOf(&state.RecoveringState{}))
-			Expect(result.Signal).To(Equal(fsmv2.SignalNone))
-			Expect(result.Action).NotTo(BeNil())
-			Expect(result.Action.Name()).To(Equal("reset_transport"))
-		})
-
-		It("should emit SyncAction at 6 consecutive errors (not a reset threshold)", func() {
-			snap := fsmv2.Snapshot{
-				Identity: deps.Identity{ID: "test", Name: "test", WorkerType: "communicator"},
-				Observed: snapshot.CommunicatorObservedState{
-					Authenticated:     false,
-					ConsecutiveErrors: 6,
-					DegradedEnteredAt: time.Now().Add(-65 * time.Second),
-				},
-				Desired: &snapshot.CommunicatorDesiredState{},
-			}
-
-			result := stateObj.Next(snap)
-
-			Expect(result.State).To(BeAssignableToTypeOf(&state.RecoveringState{}))
-			Expect(result.Signal).To(Equal(fsmv2.SignalNone))
-			Expect(result.Action).NotTo(BeNil())
-			Expect(result.Action.Name()).To(Equal("sync"))
 		})
 	})
 })

--- a/umh-core/pkg/fsmv2/workers/communicator/state/state_stopped.go
+++ b/umh-core/pkg/fsmv2/workers/communicator/state/state_stopped.go
@@ -20,9 +20,9 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator/snapshot"
 )
 
-// StoppedState is the initial state before authentication.
-// Transitions to TryingToAuthenticateState on first tick, or emits SignalNeedsRemoval if shutdown.
-// No actions emitted. Enforces C1 (auth precedence) and C4 (shutdown priority).
+// StoppedState is the initial state.
+// Transitions to SyncingState when running, or emits SignalNeedsRemoval if shutdown.
+// Authentication is handled by TransportWorker (ENG-4264).
 type StoppedState struct {
 	helpers.StoppedBase
 }
@@ -34,7 +34,7 @@ func (s *StoppedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 		return fsmv2.Result[any, any](s, fsmv2.SignalNeedsRemoval, nil, "Communicator is stopped and shutdown was requested")
 	}
 
-	return fsmv2.Result[any, any](&TryingToAuthenticateState{}, fsmv2.SignalNone, nil, "Starting authentication")
+	return fsmv2.Result[any, any](&SyncingState{}, fsmv2.SignalNone, nil, "Starting sync orchestration")
 }
 
 func (s *StoppedState) String() string {

--- a/umh-core/pkg/fsmv2/workers/communicator/state/state_stopped_test.go
+++ b/umh-core/pkg/fsmv2/workers/communicator/state/state_stopped_test.go
@@ -128,10 +128,7 @@ var _ = Describe("StoppedState Transitions", func() {
 		It("should stay in StoppedState and emit SignalNeedsRemoval on shutdown", func() {
 			snap := fsmv2.Snapshot{
 				Identity: deps.Identity{ID: "comm-shutdown", Name: "communicator", WorkerType: "communicator"},
-				Observed: snapshot.CommunicatorObservedState{
-					Authenticated: true,
-					JWTToken:      "valid-token",
-				},
+				Observed: snapshot.CommunicatorObservedState{},
 				Desired: &snapshot.CommunicatorDesiredState{
 					BaseDesiredState: config.BaseDesiredState{ShutdownRequested: true},
 				},

--- a/umh-core/pkg/fsmv2/workers/communicator/state/state_stopped_test.go
+++ b/umh-core/pkg/fsmv2/workers/communicator/state/state_stopped_test.go
@@ -45,9 +45,9 @@ var _ = Describe("StoppedState", func() {
 				}
 			})
 
-			It("should transition to TryingToAuthenticateState", func() {
+			It("should transition to SyncingState (ENG-4264: skip auth)", func() {
 				result := stateObj.Next(snap)
-				Expect(result.State).To(BeAssignableToTypeOf(&state.TryingToAuthenticateState{}))
+				Expect(result.State).To(BeAssignableToTypeOf(&state.SyncingState{}))
 			})
 
 			It("should not signal anything", func() {
@@ -76,7 +76,7 @@ var _ = Describe("StoppedState Transitions", func() {
 		stateObj = &state.StoppedState{}
 	})
 
-	Describe("Stopped -> TryingToAuthenticateState", func() {
+	Describe("Stopped -> SyncingState", func() {
 		It("should transition when shutdown is not requested", func() {
 			snap := fsmv2.Snapshot{
 				Identity: deps.Identity{ID: "test", Name: "test", WorkerType: "communicator"},
@@ -86,7 +86,7 @@ var _ = Describe("StoppedState Transitions", func() {
 
 			result := stateObj.Next(snap)
 
-			Expect(result.State).To(BeAssignableToTypeOf(&state.TryingToAuthenticateState{}))
+			Expect(result.State).To(BeAssignableToTypeOf(&state.SyncingState{}))
 			Expect(result.Signal).To(Equal(fsmv2.SignalNone))
 			Expect(result.Action).To(BeNil())
 		})
@@ -102,7 +102,7 @@ var _ = Describe("StoppedState Transitions", func() {
 
 			result := stateObj.Next(snap)
 
-			Expect(result.State).To(BeAssignableToTypeOf(&state.TryingToAuthenticateState{}))
+			Expect(result.State).To(BeAssignableToTypeOf(&state.SyncingState{}))
 			Expect(result.Signal).To(Equal(fsmv2.SignalNone))
 			Expect(result.Action).To(BeNil())
 		})

--- a/umh-core/pkg/fsmv2/workers/communicator/state/state_syncing.go
+++ b/umh-core/pkg/fsmv2/workers/communicator/state/state_syncing.go
@@ -15,25 +15,22 @@
 package state
 
 import (
-	"time"
+	"fmt"
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/internal/helpers"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator/action"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator/backoff"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator/snapshot"
 )
 
-// SyncingState is the primary operational state for bidirectional message sync.
-// Emits SyncAction continuously while healthy and authenticated.
+// SyncingState is the primary operational state for the communicator orchestrator.
+// TransportWorker (child) handles authentication, push, and pull operations.
+// CommunicatorWorker monitors child health and transitions to RecoveringState
+// when children report unhealthy.
 //
 // Transitions:
-//   - → TryingToAuthenticateState: on token expiry or auth loss
-//   - → RecoveringState: when !IsSyncHealthy()
+//   - → RecoveringState: when ChildrenUnhealthy > 0
 //   - → StoppedState: if shutdown requested
-//   - → self: continuous sync loop (C5)
-//
-// Enforces C2 (token expiry), C4 (shutdown priority), C5 (syncing loop).
+//   - → self: children healthy, continue orchestration
 type SyncingState struct {
 	helpers.RunningHealthyBase
 }
@@ -45,28 +42,17 @@ func (s *SyncingState) Next(snapAny any) fsmv2.NextResult[any, any] {
 		return fsmv2.Result[any, any](&StoppedState{}, fsmv2.SignalNone, nil, "Shutdown requested during sync")
 	}
 
-	if snap.Observed.IsTokenExpired() {
-		return fsmv2.Result[any, any](&TryingToAuthenticateState{}, fsmv2.SignalNone, nil, "Token expired, re-authenticating")
-	}
-
-	if !snap.Observed.Authenticated {
-		return fsmv2.Result[any, any](&TryingToAuthenticateState{}, fsmv2.SignalNone, nil, "Not authenticated, re-authenticating")
-	}
-
 	if !snap.Observed.IsSyncHealthy() {
-		return fsmv2.Result[any, any](&RecoveringState{}, fsmv2.SignalNone, nil, "Sync health check failed")
+		return fsmv2.Result[any, any](&RecoveringState{}, fsmv2.SignalNone, nil,
+			fmt.Sprintf("children unhealthy: healthy=%d, unhealthy=%d",
+				snap.Observed.ChildrenHealthy, snap.Observed.ChildrenUnhealthy))
 	}
 
-	syncAction := action.NewSyncAction(snap.Observed.JWTToken)
-
-	return fsmv2.Result[any, any](s, fsmv2.SignalNone, syncAction, "Syncing with relay server")
+	return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil,
+		fmt.Sprintf("syncing: healthy=%d, unhealthy=%d",
+			snap.Observed.ChildrenHealthy, snap.Observed.ChildrenUnhealthy))
 }
 
 func (s *SyncingState) String() string {
 	return "Syncing"
-}
-
-// GetBackoffDelay calculates exponential backoff based on consecutive errors.
-func (s *SyncingState) GetBackoffDelay(observed snapshot.CommunicatorObservedState) time.Duration {
-	return backoff.CalculateDelay(observed.ConsecutiveErrors)
 }

--- a/umh-core/pkg/fsmv2/workers/communicator/state/state_syncing_test.go
+++ b/umh-core/pkg/fsmv2/workers/communicator/state/state_syncing_test.go
@@ -16,7 +16,6 @@ package state_test
 
 import (
 	"testing"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -47,47 +46,6 @@ var _ = Describe("SyncingState", func() {
 	})
 })
 
-var _ = Describe("SyncingState Circuit Breaker", func() {
-	It("applies backoff delay based on ConsecutiveErrors", func() {
-		observed := snapshot.CommunicatorObservedState{
-			ConsecutiveErrors: 5,
-			Authenticated:     true,
-		}
-
-		syncingState := &state.SyncingState{}
-		delay := syncingState.GetBackoffDelay(observed)
-
-		// 5 errors = 2^5 = 32 seconds (exponential backoff capped at 60s)
-		Expect(delay).To(BeNumerically(">=", 10*time.Second))
-		Expect(delay).To(BeNumerically("<=", 60*time.Second))
-	})
-
-	It("returns zero delay when no errors", func() {
-		observed := snapshot.CommunicatorObservedState{
-			ConsecutiveErrors: 0,
-			Authenticated:     true,
-		}
-
-		syncingState := &state.SyncingState{}
-		delay := syncingState.GetBackoffDelay(observed)
-
-		Expect(delay).To(Equal(time.Duration(0)))
-	})
-
-	It("caps backoff at 60 seconds for many errors", func() {
-		observed := snapshot.CommunicatorObservedState{
-			ConsecutiveErrors: 100, // Many errors
-			Authenticated:     true,
-		}
-
-		syncingState := &state.SyncingState{}
-		delay := syncingState.GetBackoffDelay(observed)
-
-		// 2^100 seconds would be huge, but should be capped at 60s
-		Expect(delay).To(Equal(60 * time.Second))
-	})
-})
-
 var _ = Describe("SyncingState Transitions", func() {
 	var stateObj *state.SyncingState
 
@@ -100,9 +58,8 @@ var _ = Describe("SyncingState Transitions", func() {
 			snap := fsmv2.Snapshot{
 				Identity: deps.Identity{ID: "test", Name: "test", WorkerType: "communicator"},
 				Observed: snapshot.CommunicatorObservedState{
-					Authenticated: true,
-					JWTToken:      "valid-token",
-					JWTExpiry:     time.Now().Add(time.Hour),
+					ChildrenHealthy:   1,
+					ChildrenUnhealthy: 0,
 				},
 				Desired: &snapshot.CommunicatorDesiredState{
 					BaseDesiredState: config.BaseDesiredState{ShutdownRequested: true},
@@ -116,12 +73,12 @@ var _ = Describe("SyncingState Transitions", func() {
 			Expect(result.Action).To(BeNil())
 		})
 
-		It("should prioritize shutdown over other conditions", func() {
+		It("should prioritize shutdown over unhealthy children", func() {
 			snap := fsmv2.Snapshot{
 				Identity: deps.Identity{ID: "test", Name: "test", WorkerType: "communicator"},
 				Observed: snapshot.CommunicatorObservedState{
-					Authenticated:     false,
-					ConsecutiveErrors: 10,
+					ChildrenHealthy:   0,
+					ChildrenUnhealthy: 1,
 				},
 				Desired: &snapshot.CommunicatorDesiredState{
 					BaseDesiredState: config.BaseDesiredState{ShutdownRequested: true},
@@ -131,93 +88,18 @@ var _ = Describe("SyncingState Transitions", func() {
 			result := stateObj.Next(snap)
 
 			Expect(result.State).To(BeAssignableToTypeOf(&state.StoppedState{}))
-			Expect(result.Signal).To(Equal(fsmv2.SignalNone))
-			Expect(result.Action).To(BeNil())
-		})
-	})
-
-	Describe("Syncing -> TryingToAuthenticateState", func() {
-		It("should transition to TryingToAuthenticateState when token is expired", func() {
-			snap := fsmv2.Snapshot{
-				Identity: deps.Identity{ID: "test", Name: "test", WorkerType: "communicator"},
-				Observed: snapshot.CommunicatorObservedState{
-					Authenticated: true,
-					JWTToken:      "expired-token",
-					JWTExpiry:     time.Now().Add(-time.Hour),
-				},
-				Desired: &snapshot.CommunicatorDesiredState{},
-			}
-
-			result := stateObj.Next(snap)
-
-			Expect(result.State).To(BeAssignableToTypeOf(&state.TryingToAuthenticateState{}))
-			Expect(result.Signal).To(Equal(fsmv2.SignalNone))
-			Expect(result.Action).To(BeNil())
-		})
-
-		It("should transition to TryingToAuthenticateState when token expires within 10 minutes", func() {
-			snap := fsmv2.Snapshot{
-				Identity: deps.Identity{ID: "test", Name: "test", WorkerType: "communicator"},
-				Observed: snapshot.CommunicatorObservedState{
-					Authenticated: true,
-					JWTToken:      "expiring-token",
-					JWTExpiry:     time.Now().Add(5 * time.Minute),
-				},
-				Desired: &snapshot.CommunicatorDesiredState{},
-			}
-
-			result := stateObj.Next(snap)
-
-			Expect(result.State).To(BeAssignableToTypeOf(&state.TryingToAuthenticateState{}))
-			Expect(result.Signal).To(Equal(fsmv2.SignalNone))
-			Expect(result.Action).To(BeNil())
-		})
-
-		It("should transition to TryingToAuthenticateState when not authenticated", func() {
-			snap := fsmv2.Snapshot{
-				Identity: deps.Identity{ID: "test", Name: "test", WorkerType: "communicator"},
-				Observed: snapshot.CommunicatorObservedState{
-					Authenticated: false,
-					JWTToken:      "",
-				},
-				Desired: &snapshot.CommunicatorDesiredState{},
-			}
-
-			result := stateObj.Next(snap)
-
-			Expect(result.State).To(BeAssignableToTypeOf(&state.TryingToAuthenticateState{}))
-			Expect(result.Signal).To(Equal(fsmv2.SignalNone))
-			Expect(result.Action).To(BeNil())
-		})
-
-		It("should transition to TryingToAuthenticateState when authenticated but token empty", func() {
-			snap := fsmv2.Snapshot{
-				Identity: deps.Identity{ID: "test", Name: "test", WorkerType: "communicator"},
-				Observed: snapshot.CommunicatorObservedState{
-					Authenticated: false,
-					JWTToken:      "some-token",
-					JWTExpiry:     time.Now().Add(time.Hour),
-				},
-				Desired: &snapshot.CommunicatorDesiredState{},
-			}
-
-			result := stateObj.Next(snap)
-
-			Expect(result.State).To(BeAssignableToTypeOf(&state.TryingToAuthenticateState{}))
 			Expect(result.Signal).To(Equal(fsmv2.SignalNone))
 			Expect(result.Action).To(BeNil())
 		})
 	})
 
 	Describe("Syncing -> RecoveringState", func() {
-		It("should transition to RecoveringState when sync is not healthy", func() {
+		It("should transition when children are unhealthy", func() {
 			snap := fsmv2.Snapshot{
 				Identity: deps.Identity{ID: "test", Name: "test", WorkerType: "communicator"},
 				Observed: snapshot.CommunicatorObservedState{
-					Authenticated:     true,
-					JWTToken:          "valid-token",
-					JWTExpiry:         time.Now().Add(time.Hour),
-					ConsecutiveErrors: 5,
+					ChildrenHealthy:   0,
+					ChildrenUnhealthy: 1,
 				},
 				Desired: &snapshot.CommunicatorDesiredState{},
 			}
@@ -229,33 +111,12 @@ var _ = Describe("SyncingState Transitions", func() {
 			Expect(result.Action).To(BeNil())
 		})
 
-		It("should transition to RecoveringState at exactly 5 consecutive errors", func() {
+		It("should transition when multiple children are unhealthy", func() {
 			snap := fsmv2.Snapshot{
 				Identity: deps.Identity{ID: "test", Name: "test", WorkerType: "communicator"},
 				Observed: snapshot.CommunicatorObservedState{
-					Authenticated:     true,
-					JWTToken:          "valid-token",
-					JWTExpiry:         time.Now().Add(time.Hour),
-					ConsecutiveErrors: 5,
-				},
-				Desired: &snapshot.CommunicatorDesiredState{},
-			}
-
-			result := stateObj.Next(snap)
-
-			Expect(result.State).To(BeAssignableToTypeOf(&state.RecoveringState{}))
-			Expect(result.Signal).To(Equal(fsmv2.SignalNone))
-			Expect(result.Action).To(BeNil())
-		})
-
-		It("should transition to RecoveringState with high consecutive errors", func() {
-			snap := fsmv2.Snapshot{
-				Identity: deps.Identity{ID: "test", Name: "test", WorkerType: "communicator"},
-				Observed: snapshot.CommunicatorObservedState{
-					Authenticated:     true,
-					JWTToken:          "valid-token",
-					JWTExpiry:         time.Now().Add(time.Hour),
-					ConsecutiveErrors: 100,
+					ChildrenHealthy:   1,
+					ChildrenUnhealthy: 2,
 				},
 				Desired: &snapshot.CommunicatorDesiredState{},
 			}
@@ -268,15 +129,13 @@ var _ = Describe("SyncingState Transitions", func() {
 		})
 	})
 
-	Describe("Syncing -> self (continuous sync)", func() {
-		It("should stay in SyncingState and emit SyncAction when healthy", func() {
+	Describe("Syncing -> self (healthy orchestration)", func() {
+		It("should stay in SyncingState with nil action when children are healthy", func() {
 			snap := fsmv2.Snapshot{
 				Identity: deps.Identity{ID: "test", Name: "test", WorkerType: "communicator"},
 				Observed: snapshot.CommunicatorObservedState{
-					Authenticated:     true,
-					JWTToken:          "valid-token",
-					JWTExpiry:         time.Now().Add(time.Hour),
-					ConsecutiveErrors: 0,
+					ChildrenHealthy:   1,
+					ChildrenUnhealthy: 0,
 				},
 				Desired: &snapshot.CommunicatorDesiredState{},
 			}
@@ -285,49 +144,24 @@ var _ = Describe("SyncingState Transitions", func() {
 
 			Expect(result.State).To(BeAssignableToTypeOf(&state.SyncingState{}))
 			Expect(result.Signal).To(Equal(fsmv2.SignalNone))
-			Expect(result.Action).NotTo(BeNil())
-			Expect(result.Action.Name()).To(Equal("sync"))
+			Expect(result.Action).To(BeNil())
 		})
 
-		It("should transition to RecoveringState on first consecutive error", func() {
+		It("should stay in SyncingState when no children exist yet", func() {
 			snap := fsmv2.Snapshot{
 				Identity: deps.Identity{ID: "test", Name: "test", WorkerType: "communicator"},
 				Observed: snapshot.CommunicatorObservedState{
-					Authenticated:     true,
-					JWTToken:          "valid-token",
-					JWTExpiry:         time.Now().Add(time.Hour),
-					ConsecutiveErrors: 1, // Any error triggers degraded state
+					ChildrenHealthy:   0,
+					ChildrenUnhealthy: 0,
 				},
 				Desired: &snapshot.CommunicatorDesiredState{},
 			}
 
 			result := stateObj.Next(snap)
 
-			// First error immediately transitions to RecoveringState
-			Expect(result.State).To(BeAssignableToTypeOf(&state.RecoveringState{}))
-			Expect(result.Signal).To(Equal(fsmv2.SignalNone))
-		})
-
-		It("should stay in SyncingState and emit SyncAction after successful recovery", func() {
-			snap := fsmv2.Snapshot{
-				Identity: deps.Identity{ID: "test", Name: "test", WorkerType: "communicator"},
-				Observed: snapshot.CommunicatorObservedState{
-					Authenticated:     true,
-					JWTToken:          "valid-token",
-					JWTExpiry:         time.Now().Add(30 * time.Minute),
-					ConsecutiveErrors: 0,
-				},
-				Desired: &snapshot.CommunicatorDesiredState{
-					BaseDesiredState: config.BaseDesiredState{ShutdownRequested: false},
-				},
-			}
-
-			result := stateObj.Next(snap)
-
 			Expect(result.State).To(BeAssignableToTypeOf(&state.SyncingState{}))
 			Expect(result.Signal).To(Equal(fsmv2.SignalNone))
-			Expect(result.Action).NotTo(BeNil())
-			Expect(result.Action.Name()).To(Equal("sync"))
+			Expect(result.Action).To(BeNil())
 		})
 	})
 })

--- a/umh-core/pkg/fsmv2/workers/communicator/state/state_syncing_test.go
+++ b/umh-core/pkg/fsmv2/workers/communicator/state/state_syncing_test.go
@@ -147,7 +147,7 @@ var _ = Describe("SyncingState Transitions", func() {
 			Expect(result.Action).To(BeNil())
 		})
 
-		It("should stay in SyncingState when no children exist yet", func() {
+		It("should transition to RecoveringState when no children exist yet", func() {
 			snap := fsmv2.Snapshot{
 				Identity: deps.Identity{ID: "test", Name: "test", WorkerType: "communicator"},
 				Observed: snapshot.CommunicatorObservedState{
@@ -159,7 +159,7 @@ var _ = Describe("SyncingState Transitions", func() {
 
 			result := stateObj.Next(snap)
 
-			Expect(result.State).To(BeAssignableToTypeOf(&state.SyncingState{}))
+			Expect(result.State).To(BeAssignableToTypeOf(&state.RecoveringState{}))
 			Expect(result.Signal).To(Equal(fsmv2.SignalNone))
 			Expect(result.Action).To(BeNil())
 		})

--- a/umh-core/pkg/fsmv2/workers/communicator/state/state_trying_to_authenticate.go
+++ b/umh-core/pkg/fsmv2/workers/communicator/state/state_trying_to_authenticate.go
@@ -30,11 +30,9 @@ import (
 // This state is unreachable but kept to avoid breaking architecture tests. Will be deleted in ENG-4265.
 //
 // Transitions:
-//   - → SyncingState: when authenticated && !tokenExpired
-//   - → StoppedState: if shutdown requested
-//   - → self: loops emitting AuthenticateAction until success
-//
-// Enforces C1 (auth precedence), C2 (token expiry), C4 (shutdown priority).
+//   - SyncingState: when authenticated and token is valid.
+//   - StoppedState: if shutdown requested.
+//   - self: loops emitting AuthenticateAction with backoff until token acquired.
 type TryingToAuthenticateState struct {
 	helpers.StartingBase
 }

--- a/umh-core/pkg/fsmv2/workers/communicator/state/state_trying_to_authenticate.go
+++ b/umh-core/pkg/fsmv2/workers/communicator/state/state_trying_to_authenticate.go
@@ -26,6 +26,9 @@ import (
 
 // TryingToAuthenticateState obtains a JWT token via AuthenticateAction.
 //
+// Deprecated: CommunicatorWorker no longer authenticates. TransportWorker handles auth (ENG-4264).
+// This state is unreachable but kept to avoid breaking architecture tests. Will be deleted in ENG-4265.
+//
 // Transitions:
 //   - → SyncingState: when authenticated && !tokenExpired
 //   - → StoppedState: if shutdown requested

--- a/umh-core/pkg/fsmv2/workers/communicator/state/state_trying_to_authenticate.go
+++ b/umh-core/pkg/fsmv2/workers/communicator/state/state_trying_to_authenticate.go
@@ -27,7 +27,7 @@ import (
 // TryingToAuthenticateState obtains a JWT token via AuthenticateAction.
 //
 // Deprecated: CommunicatorWorker no longer authenticates. TransportWorker handles auth (ENG-4264).
-// This state is unreachable but kept to avoid breaking architecture tests. Will be deleted in ENG-4265.
+// This state is unreachable but kept to avoid churn until ENG-4265 cleanup.
 //
 // Transitions:
 //   - SyncingState: when authenticated and token is valid.

--- a/umh-core/pkg/fsmv2/workers/communicator/worker.go
+++ b/umh-core/pkg/fsmv2/workers/communicator/worker.go
@@ -138,7 +138,9 @@ func (w *CommunicatorWorker) CollectObservedState(ctx context.Context) (fsmv2.Ob
 	stateReader := deps.GetStateReader()
 	if stateReader != nil {
 		var prev snapshot.CommunicatorObservedState
-		if err := stateReader.LoadObservedTyped(ctx, deps.GetWorkerType(), deps.GetWorkerID(), &prev); err == nil {
+		if err := stateReader.LoadObservedTyped(ctx, deps.GetWorkerType(), deps.GetWorkerID(), &prev); err != nil {
+			deps.GetLogger().Debug("observed_state_load_failed", depspkg.Err(err))
+		} else {
 			prevWorkerMetrics = prev.Metrics.Worker
 		}
 	}
@@ -260,7 +262,7 @@ func init() {
 	if err := factory.RegisterWorkerType[snapshot.CommunicatorObservedState, *snapshot.CommunicatorDesiredState](
 		func(id depspkg.Identity, logger depspkg.FSMLogger, stateReader depspkg.StateReader, _ map[string]any) fsmv2.Worker {
 			// ChannelProvider must be set via global singleton before factory is called (will panic if not set).
-			// Transport is created lazily by AuthenticateAction.
+			// Transport creation and auth are handled by TransportWorker (ENG-4264).
 			commDeps := NewCommunicatorDependencies(nil, logger, stateReader, id)
 
 			return &CommunicatorWorker{

--- a/umh-core/pkg/fsmv2/workers/communicator/worker.go
+++ b/umh-core/pkg/fsmv2/workers/communicator/worker.go
@@ -218,6 +218,7 @@ func (w *CommunicatorWorker) DeriveDesiredState(spec interface{}) (fsmv2.Desired
 			BaseDesiredState: fsmv2types.BaseDesiredState{
 				State: "running",
 			},
+			ChildrenSpecs: makeTransportChildSpec(fsmv2types.UserSpec{}),
 		}, nil
 	}
 
@@ -245,11 +246,23 @@ func (w *CommunicatorWorker) DeriveDesiredState(spec interface{}) (fsmv2.Desired
 		BaseDesiredState: fsmv2types.BaseDesiredState{
 			State: commSpec.GetState(),
 		},
-		RelayURL:     commSpec.RelayURL,
-		InstanceUUID: commSpec.InstanceUUID,
-		AuthToken:    commSpec.AuthToken,
-		Timeout:      commSpec.Timeout,
+		RelayURL:      commSpec.RelayURL,
+		InstanceUUID:  commSpec.InstanceUUID,
+		AuthToken:     commSpec.AuthToken,
+		Timeout:       commSpec.Timeout,
+		ChildrenSpecs: makeTransportChildSpec(userSpec),
 	}, nil
+}
+
+// makeTransportChildSpec creates the ChildSpec for the TransportWorker child.
+// TransportWorker handles authentication, push, and pull operations.
+func makeTransportChildSpec(parentSpec fsmv2types.UserSpec) []fsmv2types.ChildSpec {
+	return []fsmv2types.ChildSpec{{
+		Name:             "transport",
+		WorkerType:       "transport",
+		UserSpec:         fsmv2types.UserSpec{Config: parentSpec.Config},
+		ChildStartStates: []string{"Syncing", "Recovering"},
+	}}
 }
 
 // GetInitialState returns StoppedState as the initial FSM state.

--- a/umh-core/pkg/fsmv2/workers/communicator/worker.go
+++ b/umh-core/pkg/fsmv2/workers/communicator/worker.go
@@ -12,60 +12,40 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package communicator implements the Channel Communicator FSM worker for
-// bidirectional message exchange between Edge and Backend tiers.
+// Package communicator implements the CommunicatorWorker, a parent orchestrator
+// that manages bidirectional message exchange between Edge and Backend tiers.
 //
 // # Architecture
 //
-// The Communicator FSM manages the complete lifecycle of channel-based sync:
-//  1. Authentication: Obtain JWT token from relay server
-//  2. Synchronization: Push/pull messages via HTTP transport
-//  3. Connection management: Handle network failures and reconnects
+// CommunicatorWorker delegates all transport operations to a TransportWorker child.
+// TransportWorker handles authentication, push, pull, backoff, and transport reset.
+// CommunicatorWorker monitors child health and manages lifecycle transitions.
+//
+// Channel sharing: Both communicator and transport packages use a ChannelProvider
+// singleton to supply inbound and outbound message channels. Call
+// communicator.SetChannelProvider() and transport.SetChannelProvider() before
+// starting the supervisor.
 //
 // # FSM v2 Pattern
 //
 // This package follows the FSM v2 pattern:
 //   - worker.go: Implements Worker interface (CollectObservedState, DeriveDesiredState)
-//   - states.go: Defines state machine states and transitions
-//   - action_*.go: Idempotent actions executed during state transitions
-//   - models.go: Observed and desired state structures
-//
-// The FSM v2 Supervisor manages the worker, calling CollectObservedState
-// periodically and executing actions when state transitions occur.
+//   - state/*.go: Defines state machine states and transitions
+//   - action/*.go: Deprecated actions retained for architecture test compliance (ENG-4265)
+//   - snapshot/snapshot.go: Observed and desired state structures
 //
 // # States and Transitions
 //
 // State flow:
 //
-//	Stopped → Authenticating → Authenticated → Syncing → Syncing (loop)
-//	   ↓            ↓               ↓             ↓
-//	  Error ← ─── Error ← ─────── Error ← ───── Error
+//	Stopped → Syncing ↔ Recovering → Stopped
+//
+// TransportWorker runs as a child when the parent is in Syncing or Recovering.
 //
 // Actions by state:
-//   - Authenticating: AuthenticateAction obtains JWT token
-//   - Syncing: SyncAction performs push/pull operations via HTTP
-//
-// # Integration with Channel Protocol
-//
-// The worker operates using a 2-goroutine pattern with channels:
-//
-// Inbound flow (backend → edge):
-//   - Pull goroutine: HTTPTransport.Pull() → inboundChan
-//   - Messages arrive from backend and are queued for local processing
-//
-// Outbound flow (edge → backend):
-//   - Push goroutine: outboundChan → HTTPTransport.Push()
-//   - Messages from edge are batched and sent to backend
-//
-// HTTPTransport handles:
-//   - HTTP POST/GET operations to relay server
-//   - JWT token management and refresh
-//   - Network error handling and retries
-//
-// This channel-based approach eliminates:
-//   - CSE delta sync and conflict resolution
-//   - Distributed state synchronization
-//   - Bidirectional merge logic
+//   - Syncing: Monitors child health. Transitions to Recovering when any child is unhealthy.
+//   - Recovering: Waits for children to recover. Transitions to Syncing when all children are healthy.
+//   - Stopped: Transitions to Syncing on start, or emits SignalNeedsRemoval on shutdown.
 package communicator
 
 import (
@@ -119,6 +99,10 @@ func NewCommunicatorWorker(
 		BaseWorker: helpers.NewBaseWorker(dependencies),
 	}, nil
 }
+
+// TODO(ENG-4265): Remove deprecated fields (JWTToken, JWTExpiry, Authenticated,
+// AuthenticatedUUID, MessagesReceived, ConsecutiveErrors, IsBackpressured) from
+// CommunicatorObservedState. These are now tracked by TransportWorker.
 
 // CollectObservedState returns the current observed state of the communicator.
 func (w *CommunicatorWorker) CollectObservedState(ctx context.Context) (fsmv2.ObservedState, error) {
@@ -256,11 +240,13 @@ func (w *CommunicatorWorker) DeriveDesiredState(spec interface{}) (fsmv2.Desired
 
 // makeTransportChildSpec creates the ChildSpec for the TransportWorker child.
 // TransportWorker handles authentication, push, and pull operations.
+// ChildStartStates includes both Syncing and Recovering so the child remains
+// running during error recovery and does not restart on parent state oscillation.
 func makeTransportChildSpec(parentSpec fsmv2types.UserSpec) []fsmv2types.ChildSpec {
 	return []fsmv2types.ChildSpec{{
 		Name:             "transport",
 		WorkerType:       "transport",
-		UserSpec:         fsmv2types.UserSpec{Config: parentSpec.Config},
+		UserSpec:         parentSpec,
 		ChildStartStates: []string{"Syncing", "Recovering"},
 	}}
 }
@@ -277,13 +263,9 @@ func init() {
 			// Transport is created lazily by AuthenticateAction.
 			commDeps := NewCommunicatorDependencies(nil, logger, stateReader, id)
 
-			worker, err := NewCommunicatorWorker(id.ID, id.Name, nil, logger, stateReader)
-			if err != nil {
-				panic(fmt.Sprintf("failed to create communicator worker: %v", err))
+			return &CommunicatorWorker{
+				BaseWorker: helpers.NewBaseWorker(commDeps),
 			}
-			worker.BaseWorker = helpers.NewBaseWorker(commDeps)
-
-			return worker
 		},
 		func(cfg interface{}) interface{} {
 			return supervisor.NewSupervisor[snapshot.CommunicatorObservedState, *snapshot.CommunicatorDesiredState](

--- a/umh-core/pkg/fsmv2/workers/communicator/worker.go
+++ b/umh-core/pkg/fsmv2/workers/communicator/worker.go
@@ -106,6 +106,12 @@ func NewCommunicatorWorker(
 
 // CollectObservedState returns the current observed state of the communicator.
 func (w *CommunicatorWorker) CollectObservedState(ctx context.Context) (fsmv2.ObservedState, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
 	deps := w.GetDependencies()
 
 	jwtToken := deps.GetJWTToken()

--- a/umh-core/pkg/fsmv2/workers/communicator/worker_test.go
+++ b/umh-core/pkg/fsmv2/workers/communicator/worker_test.go
@@ -135,6 +135,18 @@ var _ = Describe("CommunicatorWorker", func() {
 				Expect(desired.GetState()).To(Equal("running"))
 				Expect(desired.IsShutdownRequested()).To(BeFalse())
 			})
+
+			It("should include TransportWorker child spec", func() {
+				desiredIface, err := worker.DeriveDesiredState(nil)
+				Expect(err).NotTo(HaveOccurred())
+
+				desired := desiredIface.(*snapshot.CommunicatorDesiredState)
+				specs := desired.GetChildrenSpecs()
+				Expect(specs).To(HaveLen(1))
+				Expect(specs[0].Name).To(Equal("transport"))
+				Expect(specs[0].WorkerType).To(Equal("transport"))
+				Expect(specs[0].ChildStartStates).To(ConsistOf("Syncing", "Recovering"))
+			})
 		})
 
 		Context("with valid UserSpec", func() {
@@ -162,6 +174,14 @@ state: "running"
 				Expect(desired.AuthToken).To(Equal("test-auth-token-secret"))
 				Expect(desired.Timeout).To(Equal(15 * time.Second))
 				Expect(desired.GetState()).To(Equal("running"))
+
+				// Verify TransportWorker child spec with config passthrough
+				specs := desired.GetChildrenSpecs()
+				Expect(specs).To(HaveLen(1))
+				Expect(specs[0].Name).To(Equal("transport"))
+				Expect(specs[0].WorkerType).To(Equal("transport"))
+				Expect(specs[0].ChildStartStates).To(ConsistOf("Syncing", "Recovering"))
+				Expect(specs[0].UserSpec.Config).To(Equal(spec.Config))
 			})
 
 			It("should apply default timeout when not specified", func() {

--- a/umh-core/pkg/fsmv2/workers/transport/pull/action/pull_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/action/pull_test.go
@@ -320,6 +320,44 @@ var _ = Describe("PullAction", func() {
 		})
 	})
 
+	Describe("Nil messages in pulled array", func() {
+		It("should skip nil messages and only deliver valid ones", func() {
+			// Edge case: Transport returns array containing nil pointers.
+			// The defensive code `if msg == nil { continue }` should skip them during delivery.
+			// Metrics count total messages from backend (including nils) - this is intentional
+			// since it reflects what the backend actually returned.
+			mockTrans.pullMessages = []*transport.UMHMessage{
+				{InstanceUUID: "uuid-1", Content: "msg1", Email: "a@b.com"},
+				nil,
+				{InstanceUUID: "uuid-2", Content: "msg2", Email: "c@d.com"},
+				nil,
+				{InstanceUUID: "uuid-3", Content: "msg3", Email: "e@f.com"},
+			}
+
+			err := act.Execute(context.Background(), mockDeps)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(mockTrans.pullCallCount).To(Equal(1))
+			Expect(mockDeps.recordSuccessCalls).To(Equal(1))
+
+			// Only 3 non-nil messages should be delivered to channel
+			Expect(inboundBi).To(HaveLen(3))
+
+			msg1 := <-inboundBi
+			Expect(msg1.Content).To(Equal("msg1"))
+			msg2 := <-inboundBi
+			Expect(msg2.Content).To(Equal("msg2"))
+			msg3 := <-inboundBi
+			Expect(msg3.Content).To(Equal("msg3"))
+
+			// Metrics count total messages from backend response (5), not delivered count (3)
+			drained := mockDeps.metricsRecorder.Drain()
+			Expect(drained.Counters[string(deps.CounterPullOps)]).To(Equal(int64(1)))
+			Expect(drained.Counters[string(deps.CounterPullSuccess)]).To(Equal(int64(1)))
+			Expect(drained.Counters[string(deps.CounterMessagesPulled)]).To(Equal(int64(5)))
+		})
+	})
+
 	Describe("Context cancellation", func() {
 		It("should return ctx.Err()", func() {
 			ctx, cancel := context.WithCancel(context.Background())

--- a/umh-core/pkg/fsmv2/workers/transport/pull/action/pull_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/action/pull_test.go
@@ -323,9 +323,8 @@ var _ = Describe("PullAction", func() {
 	Describe("Nil messages in pulled array", func() {
 		It("should skip nil messages and only deliver valid ones", func() {
 			// Edge case: Transport returns array containing nil pointers.
-			// The defensive code `if msg == nil { continue }` should skip them during delivery.
-			// Metrics count total messages from backend (including nils) - this is intentional
-			// since it reflects what the backend actually returned.
+			// The defensive code `if msg == nil { continue }` skips them during delivery.
+			// CounterMessagesPulled uses nonNilCount — only valid messages are counted.
 			mockTrans.pullMessages = []*transport.UMHMessage{
 				{InstanceUUID: "uuid-1", Content: "msg1", Email: "a@b.com"},
 				nil,
@@ -350,11 +349,11 @@ var _ = Describe("PullAction", func() {
 			msg3 := <-inboundBi
 			Expect(msg3.Content).To(Equal("msg3"))
 
-			// Metrics count total messages from backend response (5), not delivered count (3)
+			// Metrics count non-nil messages only (nonNilCount=3), not total backend response size (5)
 			drained := mockDeps.metricsRecorder.Drain()
 			Expect(drained.Counters[string(deps.CounterPullOps)]).To(Equal(int64(1)))
 			Expect(drained.Counters[string(deps.CounterPullSuccess)]).To(Equal(int64(1)))
-			Expect(drained.Counters[string(deps.CounterMessagesPulled)]).To(Equal(int64(5)))
+			Expect(drained.Counters[string(deps.CounterMessagesPulled)]).To(Equal(int64(3)))
 		})
 	})
 

--- a/umh-core/pkg/fsmv2/workers/transport/pull/dependencies.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/dependencies.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps/retry"
 	communicator_transport "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator/transport"
 	httpTransport "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator/transport/http"
 	transport_pkg "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport"
@@ -39,9 +40,11 @@ type PullDependencies struct {
 	*deps.BaseDependencies
 	parentDeps              *transport_pkg.TransportDependencies
 	pendingMessages         []*communicator_transport.UMHMessage
+	errorMu                 sync.RWMutex
 	pendingMu               sync.RWMutex
 	backpressureMu          sync.RWMutex
 	lastSeenResetGeneration uint64
+	lastErrorType           httpTransport.ErrorType
 	backpressured           bool
 }
 
@@ -74,23 +77,35 @@ func (d *PullDependencies) GetJWTToken() string {
 }
 
 func (d *PullDependencies) RecordTypedError(errType httpTransport.ErrorType, retryAfter time.Duration) {
+	d.errorMu.Lock()
+	d.lastErrorType = errType
+	d.errorMu.Unlock()
+
+	d.RetryTracker().RecordError(retry.WithClass(errType.String()), retry.WithRetryAfter(retryAfter))
 	d.parentDeps.RecordTypedError(errType, retryAfter)
 }
 
 func (d *PullDependencies) RecordSuccess() {
-	d.parentDeps.RecordSuccess()
+	d.errorMu.Lock()
+	d.lastErrorType = 0
+	d.errorMu.Unlock()
+
+	d.RetryTracker().RecordSuccess()
 }
 
 func (d *PullDependencies) RecordError() {
+	d.RetryTracker().RecordError()
 	d.parentDeps.RecordError()
 }
 
 func (d *PullDependencies) GetConsecutiveErrors() int {
-	return d.parentDeps.GetConsecutiveErrors()
+	return d.RetryTracker().ConsecutiveErrors()
 }
 
 func (d *PullDependencies) GetLastErrorType() httpTransport.ErrorType {
-	return d.parentDeps.GetLastErrorType()
+	d.errorMu.RLock()
+	defer d.errorMu.RUnlock()
+	return d.lastErrorType
 }
 
 // StorePendingMessages appends messages to the pending buffer for retry on the next tick.
@@ -170,15 +185,16 @@ func (d *PullDependencies) IsTokenValid() bool {
 }
 
 func (d *PullDependencies) GetLastRetryAfter() time.Duration {
-	return d.parentDeps.GetLastRetryAfter()
+	return d.RetryTracker().LastError().RetryAfter
 }
 
 func (d *PullDependencies) GetDegradedEnteredAt() time.Time {
-	return d.parentDeps.GetDegradedEnteredAt()
+	degradedSince, _ := d.RetryTracker().DegradedSince()
+	return degradedSince
 }
 
 func (d *PullDependencies) GetLastErrorAt() time.Time {
-	return d.parentDeps.GetLastErrorAt()
+	return d.RetryTracker().LastError().OccurredAt
 }
 
 func (d *PullDependencies) GetResetGeneration() uint64 {

--- a/umh-core/pkg/fsmv2/workers/transport/pull/dependencies.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/dependencies.go
@@ -85,6 +85,10 @@ func (d *PullDependencies) RecordTypedError(errType httpTransport.ErrorType, ret
 	d.parentDeps.RecordTypedError(errType, retryAfter)
 }
 
+// RecordSuccess resets the child's error state. It intentionally does NOT
+// propagate to the parent tracker. The parent tracker is only reset by auth
+// success (authenticate.go). This prevents a pull success from masking push
+// errors (or vice versa) on the shared parent counter.
 func (d *PullDependencies) RecordSuccess() {
 	d.errorMu.Lock()
 	d.lastErrorType = 0

--- a/umh-core/pkg/fsmv2/workers/transport/pull/dependencies_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/dependencies_test.go
@@ -361,46 +361,81 @@ var _ = Describe("PullDependencies", func() {
 		})
 
 		Describe("RecordTypedError", func() {
-			It("should delegate to parent", func() {
+			It("should record on both child and parent", func() {
 				d.RecordTypedError(httpTransport.ErrorTypeBackendRateLimit, 30*time.Second)
-				Expect(parentDeps.GetLastErrorType()).To(Equal(httpTransport.ErrorTypeBackendRateLimit))
+				Expect(d.GetConsecutiveErrors()).To(Equal(1))
 				Expect(parentDeps.GetConsecutiveErrors()).To(Equal(1))
+				Expect(parentDeps.GetLastErrorType()).To(Equal(httpTransport.ErrorTypeBackendRateLimit))
 			})
 		})
 
 		Describe("RecordSuccess", func() {
-			It("should delegate to parent", func() {
+			It("should zero child errors but not parent errors", func() {
 				parentDeps.RecordError()
 				parentDeps.RecordError()
 				Expect(parentDeps.GetConsecutiveErrors()).To(Equal(2))
 
+				d.RecordError()
+				d.RecordError()
+				Expect(d.GetConsecutiveErrors()).To(Equal(2))
+				Expect(parentDeps.GetConsecutiveErrors()).To(Equal(4))
+
 				d.RecordSuccess()
-				Expect(parentDeps.GetConsecutiveErrors()).To(Equal(0))
+				Expect(d.GetConsecutiveErrors()).To(Equal(0))
+				Expect(parentDeps.GetConsecutiveErrors()).To(Equal(4))
 			})
 		})
 
 		Describe("RecordError", func() {
-			It("should delegate to parent", func() {
+			It("should record on both child and parent", func() {
 				d.RecordError()
 				d.RecordError()
+				Expect(d.GetConsecutiveErrors()).To(Equal(2))
 				Expect(parentDeps.GetConsecutiveErrors()).To(Equal(2))
 			})
 		})
 
 		Describe("GetConsecutiveErrors", func() {
-			It("should return parent consecutive errors", func() {
+			It("should read from child tracker, not parent", func() {
 				Expect(d.GetConsecutiveErrors()).To(Equal(0))
 				parentDeps.RecordError()
 				parentDeps.RecordError()
 				parentDeps.RecordError()
-				Expect(d.GetConsecutiveErrors()).To(Equal(3))
+				Expect(d.GetConsecutiveErrors()).To(Equal(0))
 			})
 		})
 
 		Describe("GetLastErrorType", func() {
-			It("should return parent last error type", func() {
-				parentDeps.RecordTypedError(httpTransport.ErrorTypeNetwork, 0)
+			It("should read from child field", func() {
+				d.RecordTypedError(httpTransport.ErrorTypeNetwork, 0)
 				Expect(d.GetLastErrorType()).To(Equal(httpTransport.ErrorTypeNetwork))
+				d.RecordSuccess()
+				Expect(d.GetLastErrorType()).To(Equal(httpTransport.ErrorType(0)))
+			})
+		})
+
+		Describe("GetDegradedEnteredAt", func() {
+			It("should read from child tracker", func() {
+				Expect(d.GetDegradedEnteredAt().IsZero()).To(BeTrue())
+				d.RecordError()
+				Expect(d.GetDegradedEnteredAt().IsZero()).To(BeFalse())
+				d.RecordSuccess()
+				Expect(d.GetDegradedEnteredAt().IsZero()).To(BeTrue())
+			})
+		})
+
+		Describe("GetLastErrorAt", func() {
+			It("should read from child tracker", func() {
+				before := time.Now()
+				d.RecordTypedError(httpTransport.ErrorTypeNetwork, 0)
+				Expect(d.GetLastErrorAt()).To(BeTemporally(">=", before))
+			})
+		})
+
+		Describe("GetLastRetryAfter", func() {
+			It("should read from child tracker", func() {
+				d.RecordTypedError(httpTransport.ErrorTypeBackendRateLimit, 30*time.Second)
+				Expect(d.GetLastRetryAfter()).To(Equal(30 * time.Second))
 			})
 		})
 	})

--- a/umh-core/pkg/fsmv2/workers/transport/pull/dependencies_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/dependencies_test.go
@@ -322,7 +322,7 @@ var _ = Describe("PullDependencies", func() {
 		})
 	})
 
-	Describe("Delegation to parent", func() {
+	Describe("Per-child error tracking", func() {
 		var d *pull.PullDependencies
 
 		BeforeEach(func() {

--- a/umh-core/pkg/fsmv2/workers/transport/pull/worker.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/worker.go
@@ -109,6 +109,8 @@ func (w *PullWorker) CollectObservedState(ctx context.Context) (fsmv2.ObservedSt
 		var prev snapshot.PullObservedState
 		if err := stateReader.LoadObservedTyped(ctx, d.GetWorkerType(), d.GetWorkerID(), &prev); err == nil {
 			prevWorkerMetrics = prev.Metrics.Worker
+		} else {
+			d.GetLogger().Debug("observed_state_load_failed", deps.Err(err))
 		}
 	}
 

--- a/umh-core/pkg/fsmv2/workers/transport/pull/worker.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/worker.go
@@ -102,6 +102,37 @@ func (w *PullWorker) CollectObservedState(ctx context.Context) (fsmv2.ObservedSt
 		LastActionResults:   d.GetActionHistory(),
 	}
 
+	var prevWorkerMetrics deps.Metrics
+
+	stateReader := d.GetStateReader()
+	if stateReader != nil {
+		var prev snapshot.PullObservedState
+		if err := stateReader.LoadObservedTyped(ctx, d.GetWorkerType(), d.GetWorkerID(), &prev); err == nil {
+			prevWorkerMetrics = prev.Metrics.Worker
+		}
+	}
+
+	newWorkerMetrics := prevWorkerMetrics
+	if newWorkerMetrics.Counters == nil {
+		newWorkerMetrics.Counters = make(map[string]int64)
+	}
+
+	if newWorkerMetrics.Gauges == nil {
+		newWorkerMetrics.Gauges = make(map[string]float64)
+	}
+
+	tickMetrics := d.MetricsRecorder().Drain()
+
+	for name, delta := range tickMetrics.Counters {
+		newWorkerMetrics.Counters[name] += delta
+	}
+
+	for name, value := range tickMetrics.Gauges {
+		newWorkerMetrics.Gauges[name] = value
+	}
+
+	observed.Metrics.Worker = newWorkerMetrics
+
 	if fm := d.GetFrameworkState(); fm != nil {
 		observed.Metrics.Framework = *fm
 	}

--- a/umh-core/pkg/fsmv2/workers/transport/pull/worker_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/worker_test.go
@@ -35,14 +35,14 @@ var _ fsmv2.Worker = (*pull.PullWorker)(nil)
 var _ = Describe("PullWorker", func() {
 	var (
 		worker     *pull.PullWorker
-		logger     deps.FSMLogger
-		identity   deps.Identity
+		logger     depspkg.FSMLogger
+		identity   depspkg.Identity
 		parentDeps *transport.TransportDependencies
 	)
 
 	BeforeEach(func() {
-		logger = deps.NewNopFSMLogger()
-		identity = deps.Identity{ID: "test-pull", Name: "Test Pull"}
+		logger = depspkg.NewNopFSMLogger()
+		identity = depspkg.Identity{ID: "test-pull", Name: "Test Pull"}
 		transport.SetChannelProvider(newTestChannelProvider())
 		parentDeps = createParentDeps(logger)
 	})

--- a/umh-core/pkg/fsmv2/workers/transport/pull/worker_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/worker_test.go
@@ -125,9 +125,9 @@ var _ = Describe("PullWorker", func() {
 			Expect(typedObs.HasValidToken).To(BeTrue())
 		})
 
-		It("should report consecutive errors from parent deps", func() {
-			parentDeps.RecordError()
-			parentDeps.RecordError()
+		It("should report consecutive errors from child deps", func() {
+			worker.GetDependencies().RecordError()
+			worker.GetDependencies().RecordError()
 
 			ctx := context.Background()
 			observed, err := worker.CollectObservedState(ctx)

--- a/umh-core/pkg/fsmv2/workers/transport/pull/worker_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/worker_test.go
@@ -22,7 +22,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	fsmv2config "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/config"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
+	depspkg "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/factory"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/pull"
@@ -166,6 +166,46 @@ var _ = Describe("PullWorker", func() {
 			typedObs, ok := observed.(snapshot.PullObservedState)
 			Expect(ok).To(BeTrue())
 			Expect(typedObs.Metrics).NotTo(BeNil())
+		})
+
+		It("should drain worker metrics from MetricsRecorder into ObservedState", func() {
+			d := worker.GetDependencies()
+			d.MetricsRecorder().IncrementCounter(depspkg.CounterMessagesPulled, 10)
+			d.MetricsRecorder().IncrementCounter(depspkg.CounterBytesPulled, 2048)
+			d.MetricsRecorder().SetGauge(depspkg.GaugeLastPullLatencyMs, 35.0)
+
+			ctx := context.Background()
+			observed, err := worker.CollectObservedState(ctx)
+
+			Expect(err).ToNot(HaveOccurred())
+			typedObs, ok := observed.(snapshot.PullObservedState)
+			Expect(ok).To(BeTrue())
+
+			Expect(typedObs.Metrics.Worker.Counters).NotTo(BeNil())
+			Expect(typedObs.Metrics.Worker.Counters["messages_pulled"]).To(Equal(int64(10)))
+			Expect(typedObs.Metrics.Worker.Counters["bytes_pulled"]).To(Equal(int64(2048)))
+
+			Expect(typedObs.Metrics.Worker.Gauges).NotTo(BeNil())
+			Expect(typedObs.Metrics.Worker.Gauges["last_pull_latency_ms"]).To(Equal(35.0))
+		})
+
+		It("should drain metrics from recorder buffer on each tick", func() {
+			ctx := context.Background()
+
+			d := worker.GetDependencies()
+			d.MetricsRecorder().IncrementCounter(depspkg.CounterPullOps, 1)
+			observed1, err := worker.CollectObservedState(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			typedObs1, ok := observed1.(snapshot.PullObservedState)
+			Expect(ok).To(BeTrue())
+			Expect(typedObs1.Metrics.Worker.Counters["pull_ops"]).To(Equal(int64(1)))
+
+			d.MetricsRecorder().IncrementCounter(depspkg.CounterPullOps, 2)
+			observed2, err := worker.CollectObservedState(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			typedObs2, ok := observed2.(snapshot.PullObservedState)
+			Expect(ok).To(BeTrue())
+			Expect(typedObs2.Metrics.Worker.Counters["pull_ops"]).To(Equal(int64(2)))
 		})
 	})
 

--- a/umh-core/pkg/fsmv2/workers/transport/push/action/push.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/action/push.go
@@ -103,6 +103,13 @@ drainLoop:
 	}
 
 	jwtToken := pushDeps.GetJWTToken()
+	authenticatedUUID := pushDeps.GetAuthenticatedUUID()
+
+	for _, msg := range messagesToPush {
+		if msg != nil && authenticatedUUID != "" {
+			msg.InstanceUUID = authenticatedUUID
+		}
+	}
 
 	pushStart := time.Now()
 	if err := t.Push(ctx, jwtToken, messagesToPush); err != nil {
@@ -151,8 +158,13 @@ drainLoop:
 
 func (a *PushAction) retryPending(ctx context.Context, t transport.Transport, pushDeps snapshot.PushDependencies, pending []*transport.UMHMessage, metrics *depspkg.MetricsRecorder) ([]*transport.UMHMessage, error) {
 	jwtToken := pushDeps.GetJWTToken()
+	authenticatedUUID := pushDeps.GetAuthenticatedUUID()
 
 	for i, msg := range pending {
+		if msg != nil && authenticatedUUID != "" {
+			msg.InstanceUUID = authenticatedUUID
+		}
+
 		select {
 		case <-ctx.Done():
 			return pending[i:], ctx.Err()

--- a/umh-core/pkg/fsmv2/workers/transport/push/action/push.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/action/push.go
@@ -99,6 +99,8 @@ drainLoop:
 	}
 
 	if len(messagesToPush) == 0 {
+		pushDeps.RecordSuccess()
+
 		return nil
 	}
 

--- a/umh-core/pkg/fsmv2/workers/transport/push/action/push_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/action/push_test.go
@@ -282,16 +282,26 @@ var _ = Describe("PushAction", func() {
 	})
 
 	Describe("Empty outbound channel", func() {
-		It("should be a no-op with no metrics and no transport call", func() {
+		It("should record success to clear consecutive error counter", func() {
 			err := act.Execute(context.Background(), mockDeps)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(mockTrans.pushCallCount).To(Equal(0))
-			Expect(mockDeps.recordSuccessCalls).To(Equal(0))
+			Expect(mockDeps.recordSuccessCalls).To(Equal(1))
 
 			drained := mockDeps.metricsRecorder.Drain()
 			Expect(drained.Counters).To(BeEmpty())
 			Expect(drained.Gauges).To(BeEmpty())
+		})
+
+		It("should clear stale error state from shared RetryTracker when nothing to push", func() {
+			mockDeps.consecutiveErrors = 3
+
+			err := act.Execute(context.Background(), mockDeps)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(mockTrans.pushCallCount).To(Equal(0))
+			Expect(mockDeps.recordSuccessCalls).To(Equal(1))
 		})
 	})
 

--- a/umh-core/pkg/fsmv2/workers/transport/push/action/push_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/action/push_test.go
@@ -78,6 +78,7 @@ type mockPushDeps struct {
 	lastRetryAfter    time.Duration
 	degradedEnteredAt time.Time
 	lastErrorAt       time.Time
+	authenticatedUUID string
 }
 
 type typedErrorCall struct {

--- a/umh-core/pkg/fsmv2/workers/transport/push/action/push_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/action/push_test.go
@@ -194,6 +194,10 @@ func (m *mockPushDeps) GetLastErrorAt() time.Time {
 	return m.lastErrorAt
 }
 
+func (m *mockPushDeps) GetAuthenticatedUUID() string {
+	return m.authenticatedUUID
+}
+
 var _ = Describe("PushAction", func() {
 	var (
 		act           *action.PushAction
@@ -447,6 +451,51 @@ var _ = Describe("PushAction", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(mockTrans.pushCallCount).To(Equal(0))
+		})
+	})
+
+	Describe("UUID consistency (403 prevention)", func() {
+		It("should overwrite message InstanceUUID with authenticated UUID from dependencies", func() {
+			// Scenario: SubscriberHandler created messages with placeholder UUID before
+			// authentication completed. The backend validates JWT claims match message UUID.
+			// If they don't match → 403 Forbidden.
+			placeholderUUID := "placeholder-uuid-before-auth"
+			authenticatedUUID := "real-uuid-from-backend-jwt"
+
+			outboundBi <- &transport.UMHMessage{
+				InstanceUUID: placeholderUUID,
+				Content:      "status-update",
+				Email:        "user@example.com",
+			}
+
+			mockDeps.authenticatedUUID = authenticatedUUID
+
+			err := act.Execute(context.Background(), mockDeps)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(mockTrans.pushCallCount).To(Equal(1))
+			Expect(mockTrans.pushedMsgs).To(HaveLen(1))
+			// The pushed message MUST have the authenticated UUID, not the placeholder
+			Expect(mockTrans.pushedMsgs[0].InstanceUUID).To(Equal(authenticatedUUID))
+		})
+
+		It("should overwrite UUID in pending messages during retry", func() {
+			placeholderUUID := "placeholder-uuid"
+			authenticatedUUID := "real-authenticated-uuid"
+
+			mockDeps.pendingMessages = []*transport.UMHMessage{
+				{InstanceUUID: placeholderUUID, Content: "pending1"},
+				{InstanceUUID: placeholderUUID, Content: "pending2"},
+			}
+			mockDeps.authenticatedUUID = authenticatedUUID
+
+			err := act.Execute(context.Background(), mockDeps)
+			Expect(err).NotTo(HaveOccurred())
+
+			// All pushed messages should have the authenticated UUID
+			for _, pushed := range mockTrans.pushedMsgs {
+				Expect(pushed.InstanceUUID).To(Equal(authenticatedUUID))
+			}
 		})
 	})
 })

--- a/umh-core/pkg/fsmv2/workers/transport/push/action/push_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/action/push_test.go
@@ -497,5 +497,29 @@ var _ = Describe("PushAction", func() {
 				Expect(pushed.InstanceUUID).To(Equal(authenticatedUUID))
 			}
 		})
+
+		It("should preserve original UUID when authenticatedUUID is empty", func() {
+			// Edge case: If authenticatedUUID is empty (e.g., authentication not yet
+			// complete or failed), the original message UUID should be preserved.
+			// This prevents messages from having empty UUIDs which would cause
+			// different (possibly worse) backend errors.
+			originalUUID := "original-message-uuid"
+
+			outboundBi <- &transport.UMHMessage{
+				InstanceUUID: originalUUID,
+				Content:      "status-update",
+				Email:        "user@example.com",
+			}
+
+			mockDeps.authenticatedUUID = "" // Empty - authentication not complete
+
+			err := act.Execute(context.Background(), mockDeps)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(mockTrans.pushCallCount).To(Equal(1))
+			Expect(mockTrans.pushedMsgs).To(HaveLen(1))
+			// Original UUID should be preserved when authenticatedUUID is empty
+			Expect(mockTrans.pushedMsgs[0].InstanceUUID).To(Equal(originalUUID))
+		})
 	})
 })

--- a/umh-core/pkg/fsmv2/workers/transport/push/dependencies.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/dependencies.go
@@ -77,6 +77,10 @@ func (d *PushDependencies) RecordTypedError(errType httpTransport.ErrorType, ret
 	d.parentDeps.RecordTypedError(errType, retryAfter)
 }
 
+// RecordSuccess resets the child's error state. It intentionally does NOT
+// propagate to the parent tracker. The parent tracker is only reset by auth
+// success (authenticate.go). This prevents a push success from masking pull
+// errors (or vice versa) on the shared parent counter.
 func (d *PushDependencies) RecordSuccess() {
 	d.errorMu.Lock()
 	d.lastErrorType = 0

--- a/umh-core/pkg/fsmv2/workers/transport/push/dependencies.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/dependencies.go
@@ -61,6 +61,10 @@ func (d *PushDependencies) GetJWTToken() string {
 	return d.parentDeps.GetJWTToken()
 }
 
+func (d *PushDependencies) GetAuthenticatedUUID() string {
+	return d.parentDeps.GetAuthenticatedUUID()
+}
+
 func (d *PushDependencies) RecordTypedError(errType httpTransport.ErrorType, retryAfter time.Duration) {
 	d.parentDeps.RecordTypedError(errType, retryAfter)
 }

--- a/umh-core/pkg/fsmv2/workers/transport/push/dependencies.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/dependencies.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps/retry"
 	communicator_transport "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator/transport"
 	httpTransport "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator/transport/http"
 	transport_pkg "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport"
@@ -34,8 +35,10 @@ type PushDependencies struct {
 	*deps.BaseDependencies
 	parentDeps              *transport_pkg.TransportDependencies
 	pendingMessages         []*communicator_transport.UMHMessage
+	errorMu                 sync.RWMutex
 	pendingMu               sync.RWMutex
 	lastSeenResetGeneration uint64
+	lastErrorType           httpTransport.ErrorType
 }
 
 func NewPushDependencies(parentDeps *transport_pkg.TransportDependencies, identity deps.Identity, logger deps.FSMLogger, stateReader deps.StateReader) (*PushDependencies, error) {
@@ -66,23 +69,35 @@ func (d *PushDependencies) GetAuthenticatedUUID() string {
 }
 
 func (d *PushDependencies) RecordTypedError(errType httpTransport.ErrorType, retryAfter time.Duration) {
+	d.errorMu.Lock()
+	d.lastErrorType = errType
+	d.errorMu.Unlock()
+
+	d.RetryTracker().RecordError(retry.WithClass(errType.String()), retry.WithRetryAfter(retryAfter))
 	d.parentDeps.RecordTypedError(errType, retryAfter)
 }
 
 func (d *PushDependencies) RecordSuccess() {
-	d.parentDeps.RecordSuccess()
+	d.errorMu.Lock()
+	d.lastErrorType = 0
+	d.errorMu.Unlock()
+
+	d.RetryTracker().RecordSuccess()
 }
 
 func (d *PushDependencies) RecordError() {
+	d.RetryTracker().RecordError()
 	d.parentDeps.RecordError()
 }
 
 func (d *PushDependencies) GetConsecutiveErrors() int {
-	return d.parentDeps.GetConsecutiveErrors()
+	return d.RetryTracker().ConsecutiveErrors()
 }
 
 func (d *PushDependencies) GetLastErrorType() httpTransport.ErrorType {
-	return d.parentDeps.GetLastErrorType()
+	d.errorMu.RLock()
+	defer d.errorMu.RUnlock()
+	return d.lastErrorType
 }
 
 func (d *PushDependencies) StorePendingMessages(msgs []*communicator_transport.UMHMessage) {
@@ -137,15 +152,16 @@ func (d *PushDependencies) IsTokenValid() bool {
 }
 
 func (d *PushDependencies) GetLastRetryAfter() time.Duration {
-	return d.parentDeps.GetLastRetryAfter()
+	return d.RetryTracker().LastError().RetryAfter
 }
 
 func (d *PushDependencies) GetDegradedEnteredAt() time.Time {
-	return d.parentDeps.GetDegradedEnteredAt()
+	degradedSince, _ := d.RetryTracker().DegradedSince()
+	return degradedSince
 }
 
 func (d *PushDependencies) GetLastErrorAt() time.Time {
-	return d.parentDeps.GetLastErrorAt()
+	return d.RetryTracker().LastError().OccurredAt
 }
 
 func (d *PushDependencies) GetResetGeneration() uint64 {

--- a/umh-core/pkg/fsmv2/workers/transport/push/dependencies_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/dependencies_test.go
@@ -114,7 +114,7 @@ var _ = Describe("PushDependencies", func() {
 		})
 	})
 
-	Describe("Delegation to parent", func() {
+	Describe("Per-child error tracking", func() {
 		var d *push.PushDependencies
 
 		BeforeEach(func() {
@@ -323,16 +323,24 @@ var _ = Describe("PushDependencies", func() {
 	})
 
 	Describe("Cross-child isolation", func() {
-		It("push success does not mask pull errors", func() {
+		var (
+			pushDeps *push.PushDependencies
+			pullDeps *pull.PullDependencies
+		)
+
+		BeforeEach(func() {
 			pushIdentity := deps.Identity{ID: "push-id", WorkerType: "push"}
 			pullIdentity := deps.Identity{ID: "pull-id", WorkerType: "pull"}
 
-			pushDeps, err := push.NewPushDependencies(parentDeps, pushIdentity, logger, nil)
+			var err error
+			pushDeps, err = push.NewPushDependencies(parentDeps, pushIdentity, logger, nil)
 			Expect(err).NotTo(HaveOccurred())
 
-			pullDeps, err := pull.NewPullDependencies(parentDeps, pullIdentity, logger, nil)
+			pullDeps, err = pull.NewPullDependencies(parentDeps, pullIdentity, logger, nil)
 			Expect(err).NotTo(HaveOccurred())
+		})
 
+		It("push success does not mask pull errors", func() {
 			pullDeps.RecordError()
 			pullDeps.RecordError()
 			pullDeps.RecordError()
@@ -342,6 +350,18 @@ var _ = Describe("PushDependencies", func() {
 
 			Expect(pushDeps.GetConsecutiveErrors()).To(Equal(0))
 			Expect(pullDeps.GetConsecutiveErrors()).To(Equal(3))
+			Expect(parentDeps.GetConsecutiveErrors()).To(Equal(3))
+		})
+
+		It("pull success does not mask push errors", func() {
+			pushDeps.RecordError()
+			pushDeps.RecordError()
+			pushDeps.RecordError()
+
+			pullDeps.RecordSuccess()
+
+			Expect(pullDeps.GetConsecutiveErrors()).To(Equal(0))
+			Expect(pushDeps.GetConsecutiveErrors()).To(Equal(3))
 			Expect(parentDeps.GetConsecutiveErrors()).To(Equal(3))
 		})
 	})

--- a/umh-core/pkg/fsmv2/workers/transport/push/dependencies_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/dependencies_test.go
@@ -26,6 +26,7 @@ import (
 	communicator_transport "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator/transport"
 	httpTransport "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator/transport/http"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/pull"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/push"
 )
 
@@ -152,46 +153,81 @@ var _ = Describe("PushDependencies", func() {
 		})
 
 		Describe("RecordTypedError", func() {
-			It("should delegate to parent", func() {
+			It("should record on both child and parent", func() {
 				d.RecordTypedError(httpTransport.ErrorTypeBackendRateLimit, 30*time.Second)
-				Expect(parentDeps.GetLastErrorType()).To(Equal(httpTransport.ErrorTypeBackendRateLimit))
+				Expect(d.GetConsecutiveErrors()).To(Equal(1))
 				Expect(parentDeps.GetConsecutiveErrors()).To(Equal(1))
+				Expect(parentDeps.GetLastErrorType()).To(Equal(httpTransport.ErrorTypeBackendRateLimit))
 			})
 		})
 
 		Describe("RecordSuccess", func() {
-			It("should delegate to parent", func() {
+			It("should zero child errors but not parent errors", func() {
 				parentDeps.RecordError()
 				parentDeps.RecordError()
 				Expect(parentDeps.GetConsecutiveErrors()).To(Equal(2))
 
+				d.RecordError()
+				d.RecordError()
+				Expect(d.GetConsecutiveErrors()).To(Equal(2))
+				Expect(parentDeps.GetConsecutiveErrors()).To(Equal(4))
+
 				d.RecordSuccess()
-				Expect(parentDeps.GetConsecutiveErrors()).To(Equal(0))
+				Expect(d.GetConsecutiveErrors()).To(Equal(0))
+				Expect(parentDeps.GetConsecutiveErrors()).To(Equal(4))
 			})
 		})
 
 		Describe("RecordError", func() {
-			It("should delegate to parent", func() {
+			It("should record on both child and parent", func() {
 				d.RecordError()
 				d.RecordError()
+				Expect(d.GetConsecutiveErrors()).To(Equal(2))
 				Expect(parentDeps.GetConsecutiveErrors()).To(Equal(2))
 			})
 		})
 
 		Describe("GetConsecutiveErrors", func() {
-			It("should return parent consecutive errors", func() {
+			It("should read from child tracker, not parent", func() {
 				Expect(d.GetConsecutiveErrors()).To(Equal(0))
 				parentDeps.RecordError()
 				parentDeps.RecordError()
 				parentDeps.RecordError()
-				Expect(d.GetConsecutiveErrors()).To(Equal(3))
+				Expect(d.GetConsecutiveErrors()).To(Equal(0))
 			})
 		})
 
 		Describe("GetLastErrorType", func() {
-			It("should return parent last error type", func() {
-				parentDeps.RecordTypedError(httpTransport.ErrorTypeNetwork, 0)
+			It("should read from child field", func() {
+				d.RecordTypedError(httpTransport.ErrorTypeNetwork, 0)
 				Expect(d.GetLastErrorType()).To(Equal(httpTransport.ErrorTypeNetwork))
+				d.RecordSuccess()
+				Expect(d.GetLastErrorType()).To(Equal(httpTransport.ErrorType(0)))
+			})
+		})
+
+		Describe("GetDegradedEnteredAt", func() {
+			It("should read from child tracker", func() {
+				Expect(d.GetDegradedEnteredAt().IsZero()).To(BeTrue())
+				d.RecordError()
+				Expect(d.GetDegradedEnteredAt().IsZero()).To(BeFalse())
+				d.RecordSuccess()
+				Expect(d.GetDegradedEnteredAt().IsZero()).To(BeTrue())
+			})
+		})
+
+		Describe("GetLastErrorAt", func() {
+			It("should read from child tracker", func() {
+				before := time.Now()
+				d.RecordTypedError(httpTransport.ErrorTypeNetwork, 0)
+				Expect(d.GetLastErrorAt()).To(BeTemporally(">=", before))
+			})
+		})
+
+		Describe("GetLastRetryAfter", func() {
+			It("should read from child tracker", func() {
+				d.RecordTypedError(httpTransport.ErrorTypeBackendRateLimit, 30*time.Second)
+				Expect(d.GetLastRetryAfter()).To(Equal(30 * time.Second))
 			})
 		})
 	})
@@ -283,6 +319,30 @@ var _ = Describe("PushDependencies", func() {
 		It("should return true when token is valid and not near expiry", func() {
 			parentDeps.SetJWT("good-token", time.Now().Add(1*time.Hour))
 			Expect(d.IsTokenValid()).To(BeTrue())
+		})
+	})
+
+	Describe("Cross-child isolation", func() {
+		It("push success does not mask pull errors", func() {
+			pushIdentity := deps.Identity{ID: "push-id", WorkerType: "push"}
+			pullIdentity := deps.Identity{ID: "pull-id", WorkerType: "pull"}
+
+			pushDeps, err := push.NewPushDependencies(parentDeps, pushIdentity, logger, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			pullDeps, err := pull.NewPullDependencies(parentDeps, pullIdentity, logger, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			pullDeps.RecordError()
+			pullDeps.RecordError()
+			pullDeps.RecordError()
+			Expect(pullDeps.GetConsecutiveErrors()).To(Equal(3))
+
+			pushDeps.RecordSuccess()
+
+			Expect(pushDeps.GetConsecutiveErrors()).To(Equal(0))
+			Expect(pullDeps.GetConsecutiveErrors()).To(Equal(3))
+			Expect(parentDeps.GetConsecutiveErrors()).To(Equal(3))
 		})
 	})
 

--- a/umh-core/pkg/fsmv2/workers/transport/push/snapshot/snapshot.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/snapshot/snapshot.go
@@ -50,7 +50,7 @@ type PushDependencies interface {
 	GetResetGeneration() uint64
 	CheckAndClearOnReset() bool
 
-	// Backoff timing from parent error tracking
+	// Backoff timing from child's own error tracking
 	GetLastRetryAfter() time.Duration
 	GetDegradedEnteredAt() time.Time
 	GetLastErrorAt() time.Time

--- a/umh-core/pkg/fsmv2/workers/transport/push/snapshot/snapshot.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/snapshot/snapshot.go
@@ -30,6 +30,7 @@ type PushDependencies interface {
 	GetOutboundChan() <-chan *transport.UMHMessage
 	GetTransport() transport.Transport
 	GetJWTToken() string
+	GetAuthenticatedUUID() string
 	RecordTypedError(errType httpTransport.ErrorType, retryAfter time.Duration)
 	RecordSuccess()
 	RecordError()

--- a/umh-core/pkg/fsmv2/workers/transport/push/worker.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/worker.go
@@ -101,6 +101,37 @@ func (w *PushWorker) CollectObservedState(ctx context.Context) (fsmv2.ObservedSt
 	observed.DegradedEnteredAt = d.GetDegradedEnteredAt()
 	observed.LastErrorAt = d.GetLastErrorAt()
 
+	var prevWorkerMetrics deps.Metrics
+
+	stateReader := d.GetStateReader()
+	if stateReader != nil {
+		var prev snapshot.PushObservedState
+		if err := stateReader.LoadObservedTyped(ctx, d.GetWorkerType(), d.GetWorkerID(), &prev); err == nil {
+			prevWorkerMetrics = prev.Metrics.Worker
+		}
+	}
+
+	newWorkerMetrics := prevWorkerMetrics
+	if newWorkerMetrics.Counters == nil {
+		newWorkerMetrics.Counters = make(map[string]int64)
+	}
+
+	if newWorkerMetrics.Gauges == nil {
+		newWorkerMetrics.Gauges = make(map[string]float64)
+	}
+
+	tickMetrics := d.MetricsRecorder().Drain()
+
+	for name, delta := range tickMetrics.Counters {
+		newWorkerMetrics.Counters[name] += delta
+	}
+
+	for name, value := range tickMetrics.Gauges {
+		newWorkerMetrics.Gauges[name] = value
+	}
+
+	observed.Metrics.Worker = newWorkerMetrics
+
 	if fm := d.GetFrameworkState(); fm != nil {
 		observed.Metrics.Framework = *fm
 	}

--- a/umh-core/pkg/fsmv2/workers/transport/push/worker.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/worker.go
@@ -108,6 +108,8 @@ func (w *PushWorker) CollectObservedState(ctx context.Context) (fsmv2.ObservedSt
 		var prev snapshot.PushObservedState
 		if err := stateReader.LoadObservedTyped(ctx, d.GetWorkerType(), d.GetWorkerID(), &prev); err == nil {
 			prevWorkerMetrics = prev.Metrics.Worker
+		} else {
+			d.GetLogger().Debug("observed_state_load_failed", deps.Err(err))
 		}
 	}
 

--- a/umh-core/pkg/fsmv2/workers/transport/push/worker_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/worker_test.go
@@ -36,14 +36,14 @@ var _ fsmv2.Worker = (*push.PushWorker)(nil)
 var _ = Describe("PushWorker", func() {
 	var (
 		worker     *push.PushWorker
-		logger     deps.FSMLogger
-		identity   deps.Identity
+		logger     depspkg.FSMLogger
+		identity   depspkg.Identity
 		parentDeps *transport.TransportDependencies
 	)
 
 	BeforeEach(func() {
-		logger = deps.NewNopFSMLogger()
-		identity = deps.Identity{ID: "test-push", Name: "Test Push"}
+		logger = depspkg.NewNopFSMLogger()
+		identity = depspkg.Identity{ID: "test-push", Name: "Test Push"}
 		transport.SetChannelProvider(newTestChannelProvider())
 		parentDeps = createParentDeps(logger)
 	})

--- a/umh-core/pkg/fsmv2/workers/transport/push/worker_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/worker_test.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	fsmv2config "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/config"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
+	depspkg "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/factory"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/push"
@@ -159,6 +159,46 @@ var _ = Describe("PushWorker", func() {
 			typedObs, ok := observed.(snapshot.PushObservedState)
 			Expect(ok).To(BeTrue())
 			Expect(typedObs.Metrics).NotTo(BeNil())
+		})
+
+		It("should drain worker metrics from MetricsRecorder into ObservedState", func() {
+			d := worker.GetDependencies()
+			d.MetricsRecorder().IncrementCounter(depspkg.CounterMessagesPushed, 5)
+			d.MetricsRecorder().IncrementCounter(depspkg.CounterBytesPushed, 1024)
+			d.MetricsRecorder().SetGauge(depspkg.GaugeLastPushLatencyMs, 42.0)
+
+			ctx := context.Background()
+			observed, err := worker.CollectObservedState(ctx)
+
+			Expect(err).ToNot(HaveOccurred())
+			typedObs, ok := observed.(snapshot.PushObservedState)
+			Expect(ok).To(BeTrue())
+
+			Expect(typedObs.Metrics.Worker.Counters).NotTo(BeNil())
+			Expect(typedObs.Metrics.Worker.Counters["messages_pushed"]).To(Equal(int64(5)))
+			Expect(typedObs.Metrics.Worker.Counters["bytes_pushed"]).To(Equal(int64(1024)))
+
+			Expect(typedObs.Metrics.Worker.Gauges).NotTo(BeNil())
+			Expect(typedObs.Metrics.Worker.Gauges["last_push_latency_ms"]).To(Equal(42.0))
+		})
+
+		It("should drain metrics from recorder buffer on each tick", func() {
+			ctx := context.Background()
+
+			d := worker.GetDependencies()
+			d.MetricsRecorder().IncrementCounter(depspkg.CounterPushOps, 1)
+			observed1, err := worker.CollectObservedState(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			typedObs1, ok := observed1.(snapshot.PushObservedState)
+			Expect(ok).To(BeTrue())
+			Expect(typedObs1.Metrics.Worker.Counters["push_ops"]).To(Equal(int64(1)))
+
+			d.MetricsRecorder().IncrementCounter(depspkg.CounterPushOps, 2)
+			observed2, err := worker.CollectObservedState(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			typedObs2, ok := observed2.(snapshot.PushObservedState)
+			Expect(ok).To(BeTrue())
+			Expect(typedObs2.Metrics.Worker.Counters["push_ops"]).To(Equal(int64(2)))
 		})
 	})
 

--- a/umh-core/pkg/fsmv2/workers/transport/push/worker_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/worker_test.go
@@ -138,9 +138,9 @@ var _ = Describe("PushWorker", func() {
 			Expect(typedObs.HasValidToken).To(BeFalse())
 		})
 
-		It("should report consecutive errors from parent deps", func() {
-			parentDeps.RecordError()
-			parentDeps.RecordError()
+		It("should report consecutive errors from child deps", func() {
+			worker.GetDependencies().RecordError()
+			worker.GetDependencies().RecordError()
 
 			ctx := context.Background()
 			observed, err := worker.CollectObservedState(ctx)

--- a/umh-core/pkg/fsmv2/workers/transport/state/running.go
+++ b/umh-core/pkg/fsmv2/workers/transport/state/running.go
@@ -74,7 +74,8 @@ func ShouldProactivelyReauth(expiry time.Time, now time.Time) bool {
 	}
 
 	// Only consider tokens expiring within 24 hours
-	if expiry.Sub(now) > 24*time.Hour {
+	delta := expiry.Sub(now)
+	if delta <= 0 || delta > 24*time.Hour {
 		return false
 	}
 

--- a/umh-core/pkg/fsmv2/workers/transport/state/running.go
+++ b/umh-core/pkg/fsmv2/workers/transport/state/running.go
@@ -49,7 +49,7 @@ func (s *RunningState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	}
 
 	// Proactive night re-auth: if token would expire during business hours, re-auth at 3 AM
-	if shouldProactivelyReauth(snap.Observed.JWTExpiry, time.Now()) {
+	if ShouldProactivelyReauth(snap.Observed.JWTExpiry, time.Now()) {
 		return fsmv2.Result[any, any](&StartingState{}, fsmv2.SignalNone, nil,
 			fmt.Sprintf("proactive night re-auth: token expires at %s (business hours), re-authing now",
 				snap.Observed.JWTExpiry.Local().Format("15:04")))
@@ -64,10 +64,17 @@ func (s *RunningState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil, "All children healthy, transport running")
 }
 
-// shouldProactivelyReauth returns true if the token would expire during business
-// hours and it's currently the proactive re-auth hour (3 AM).
-func shouldProactivelyReauth(expiry time.Time, now time.Time) bool {
+// ShouldProactivelyReauth returns true if the token would expire during business
+// hours, within 24 hours, and it's currently the proactive re-auth hour (3 AM).
+// The 24-hour proximity check prevents unnecessary nightly re-auth for tokens
+// that expire weeks away.
+func ShouldProactivelyReauth(expiry time.Time, now time.Time) bool {
 	if expiry.IsZero() {
+		return false
+	}
+
+	// Only consider tokens expiring within 24 hours
+	if expiry.Sub(now) > 24*time.Hour {
 		return false
 	}
 

--- a/umh-core/pkg/fsmv2/workers/transport/state/state_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/state/state_test.go
@@ -297,6 +297,69 @@ var _ = Describe("TransportWorker States", func() {
 		})
 	})
 
+	Describe("ShouldProactivelyReauth", func() {
+		It("should return false for zero expiry", func() {
+			now := time.Date(2025, 2, 6, 3, 0, 0, 0, time.Local) // 3 AM
+			Expect(state.ShouldProactivelyReauth(time.Time{}, now)).To(BeFalse())
+		})
+
+		It("should return false when token expires more than 24 hours away", func() {
+			// 3 AM today
+			now := time.Date(2025, 2, 6, 3, 0, 0, 0, time.Local)
+			// Expiry at 10 AM in 30 days (business hours, but too far away)
+			expiry := time.Date(2025, 3, 8, 10, 0, 0, 0, time.Local)
+			Expect(state.ShouldProactivelyReauth(expiry, now)).To(BeFalse())
+		})
+
+		It("should return false when token expires outside business hours", func() {
+			// 3 AM today
+			now := time.Date(2025, 2, 6, 3, 0, 0, 0, time.Local)
+			// Expiry at 2 AM tomorrow (within 24h but outside business hours)
+			expiry := time.Date(2025, 2, 7, 2, 0, 0, 0, time.Local)
+			Expect(state.ShouldProactivelyReauth(expiry, now)).To(BeFalse())
+		})
+
+		It("should return false when not at 3 AM", func() {
+			// 10 AM today (not proactive re-auth hour)
+			now := time.Date(2025, 2, 6, 10, 0, 0, 0, time.Local)
+			// Expiry at 10 AM tomorrow (within 24h, during business hours)
+			expiry := time.Date(2025, 2, 7, 10, 0, 0, 0, time.Local)
+			Expect(state.ShouldProactivelyReauth(expiry, now)).To(BeFalse())
+		})
+
+		It("should return true when all conditions met: 3 AM, within 24h, business hours expiry", func() {
+			// 3 AM today
+			now := time.Date(2025, 2, 6, 3, 0, 0, 0, time.Local)
+			// Expiry at 10 AM today (within 24h, during business hours)
+			expiry := time.Date(2025, 2, 6, 10, 0, 0, 0, time.Local)
+			Expect(state.ShouldProactivelyReauth(expiry, now)).To(BeTrue())
+		})
+
+		It("should return true for edge case: expiry exactly at business hours start", func() {
+			// 3 AM today
+			now := time.Date(2025, 2, 6, 3, 0, 0, 0, time.Local)
+			// Expiry at 7 AM today (business hours start boundary)
+			expiry := time.Date(2025, 2, 6, 7, 0, 0, 0, time.Local)
+			Expect(state.ShouldProactivelyReauth(expiry, now)).To(BeTrue())
+		})
+
+		It("should return false for edge case: expiry at business hours end", func() {
+			// 3 AM today
+			now := time.Date(2025, 2, 6, 3, 0, 0, 0, time.Local)
+			// Expiry at 20:00 today (business hours end boundary - exclusive)
+			expiry := time.Date(2025, 2, 6, 20, 0, 0, 0, time.Local)
+			Expect(state.ShouldProactivelyReauth(expiry, now)).To(BeFalse())
+		})
+
+		It("should return true for expiry at 19:59 (just before end)", func() {
+			// 3 AM today
+			now := time.Date(2025, 2, 6, 3, 0, 0, 0, time.Local)
+			// Expiry at 19:59 today (still within business hours)
+			expiry := time.Date(2025, 2, 6, 19, 59, 0, 0, time.Local)
+			Expect(state.ShouldProactivelyReauth(expiry, now)).To(BeTrue())
+		})
+	})
+
 	Describe("DegradedState", func() {
 		var s *state.DegradedState
 


### PR DESCRIPTION
## Summary

- **CommunicatorWorker becomes a parent orchestrator** that spawns TransportWorker as a child FSM, replacing direct SyncAction dispatch with hierarchical worker pattern
- **Authentication removed from CommunicatorWorker** — goes Stopped → Syncing directly; TransportWorker handles all auth internally
- **SyncingState/RecoveringState simplified to child health monitoring** — `IsSyncHealthy()` reduced from 4 conditions (Authenticated, TokenExpired, ConsecutiveErrors, IsBackpressured) to `ChildrenUnhealthy == 0`
- **Deprecated files kept with type-level comments** (SyncAction, AuthenticateAction, ResetTransportAction, TryingToAuthenticateState) — deletion deferred to ENG-4265

### Architecture Change

```
BEFORE:                              AFTER:
CommunicatorWorker (leaf)            CommunicatorWorker (parent)
  └── SyncAction (push+pull)           └── TransportWorker (child)
                                            ├── PushWorker (grandchild)
                                            └── PullWorker (grandchild)
```

### Files Changed (18 files, +219/-1124)

| File | Change |
|------|--------|
| `communicator/snapshot/snapshot.go` | Add ChildrenSpecs, ChildSpecProvider, SetChildrenCounts; simplify IsSyncHealthy |
| `communicator/worker.go` | Add makeTransportChildSpec, populate ChildrenSpecs in DeriveDesiredState |
| `communicator/state/state_stopped.go` | Transition to SyncingState instead of TryingToAuthenticateState |
| `communicator/state/state_syncing.go` | Remove SyncAction + auth checks, add child health monitoring |
| `communicator/state/state_recovering.go` | Remove SyncAction + ResetTransport + backoff, simplify to health monitoring |
| `communicator/state/state_trying_to_authenticate.go` | Add deprecation comment (unreachable) |
| `communicator/action/{sync,authenticate,reset_transport}.go` | Add deprecation comments |
| `cmd/main.go` | Add transport.SetChannelProvider + blank imports for push/pull factories |
| `examples/communicator_scenario.go` | Add transport.SetChannelProvider for scenario tests |
| `*_test.go` (7 files) | Replace SyncAction/auth tests with child health monitoring tests |

### Edge Cases Handled

| Edge Case | Mitigation |
|-----------|------------|
| Shutdown cascade (4 levels) | 20s worst case (4 × 5s), scenario test timeout increased |
| Startup gap (3-5 ticks) | Messages buffered in channels + backend queues inbound |
| Syncing↔Recovering oscillation | Children's DegradedState backoff (2s+) prevents rapid parent oscillation |
| ChildrenUnhealthy == 0 at startup | Before TransportWorker created, stays in Syncing; children created next tick |

### Verification

- Communicator unit tests: ALL PASS
- Transport unit tests: ALL PASS
- Architecture tests: ALL PASS (38 passed)
- Scenario tests: ALL PASS (42 specs)
- golangci-lint: 0 issues
- betteralign: 0 issues

## Test plan

- [ ] Verify communicator unit tests pass: `go test ./pkg/fsmv2/workers/communicator/... -count=1`
- [ ] Verify transport unit tests pass: `go test ./pkg/fsmv2/workers/transport/... -count=1`
- [ ] Verify architecture tests pass: `go test ./pkg/fsmv2/ -count=1`
- [ ] Verify scenario tests pass: `go test ./pkg/fsmv2/examples/ -count=1 -timeout 600s`
- [ ] Verify lint clean: `golangci-lint run ./pkg/fsmv2/workers/communicator/... ./pkg/fsmv2/workers/transport/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Code Review

**Reviewed by**: eng-4260-ship team (2026-02-17)
**Result**: ✅ All fixes confirmed applied and DA-verified — ready for human review

### Confirmed Fixed

| Fix | Description | Location |
|-----|-------------|----------|
| **NEW-1** | Debug log for `LoadObservedTyped` errors in Push/Pull `CollectObservedState` | `push/worker.go` and `pull/worker.go` — debug-level log in `else` branch (DA spot-check confirmed) |

### Architecture Verified Correct
- **Per-child RetryTracker**: Each worker has independent tracker; asymmetric error propagation (child→parent UP, successes do NOT propagate) is intentional
- **`ParentMappedState` normalization**: `reconciliation.go:1173` applies `strings.ToLower()` before injecting into children — `ShouldBeRunning()` correctly returns true (not a bug)
- **CommunicatorWorker own RetryTracker**: Always 0 (nothing writes to it) — covered by TODO(ENG-4265)
- **Per-child error tracking CLAUDE.md**: Correctly documents per-child semantics

### Verified Correct (no action needed)
- FSMv2 architecture test compliance: all invariants pass across all 4 PRs
- 3-level supervision = 15-second graceful shutdown cascade: correct by design
- `CommunicatorWorker.StoppedState` missing `ShouldBeRunning()` guard — always-on by design (D10)

### Deferred (tracked in ENG-4342)
- Dual `ChannelProvider` singletons (`communicator` + `transport`) — footgun for test writers, consolidation ticket
- Stringly-typed coordination points (`"transport_deps"`, state name strings) — type-safety cleanup ticket
