### PR TITLE
ENG-4340: fix ShutdownRequestedProvider fail-safe (F2)

### DIFF
--- a/umh-core/pkg/fsmv2/supervisor/api.go
+++ b/umh-core/pkg/fsmv2/supervisor/api.go
@@ -202,7 +202,8 @@ func (s *Supervisor[TObserved, TDesired]) AddWorker(identity deps.Identity, work
 
 			var desired TDesired
 			if err := s.store.LoadDesiredTyped(ctx, s.workerType, identity.ID, &desired); err != nil {
-				return false
+				s.logger.Warnw("shutdown_requested_load_failed", "error", err, "worker_type", s.workerType, "identity", identity.ID)
+				return true
 			}
 
 			return desired.IsShutdownRequested()


### PR DESCRIPTION
## Summary

- **P0.18**: `ShutdownRequestedProvider` in the supervisor API returned `false` when `LoadDesiredTyped` failed, which is unsafe — it tells the framework the worker is NOT shutdown-requested, allowing it to keep running when it should be shutting down
- Changed to `return true` (fail-safe): a spurious shutdown is recoverable via reconciliation, but a missed shutdown can leave orphaned workers indefinitely
- Added warning log so the error is observable

This is a framework-level bug affecting ALL FSMv2 workers — any worker type that uses `ShutdownRequestedProvider` was vulnerable to missed shutdowns when the store had transient errors.

## Test plan

- [x] Verify `go build ./...` passes
- [x] Verify `go vet ./...` passes
- [x] Review that fail-safe direction is correct (shutdown > continue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)