### PR TITLE
chore(renovate): add specific pr-title prefix

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
+  "commitMessagePrefix": "[renovate]chore(deps):",
   "includePaths": ["umh-core/**"],
   "enabledManagers": ["dockerfile", "gomod"],
   "postUpdateOptions": ["gomodTidy", "gomodVendor"],


### PR DESCRIPTION
# Description:

Currently the issue is that renovate sets the PR's title to `fix(deps): update whatever`.
What we want to achieve here is a pattern like `[renovate]chore(deps): update whatever (major)`.

Therefore we need to set the `commitMessagePrefix` accordingly here.