### PR TITLE
ci: add scheduled GHCR image cleanup (dry-run)

### DIFF
--- a/.github/workflows/cleanup-ghcr.yml
+++ b/.github/workflows/cleanup-ghcr.yml
@@ -1,0 +1,40 @@
+# Copyright 2025 UMH Systems GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Cleanup GHCR Images
+
+on:
+  schedule:
+    - cron: "0 3 * * 0" # Weekly on Sunday at 3am UTC
+  workflow_dispatch: # Allow manual trigger
+
+jobs:
+  cleanup:
+    name: Delete old container images
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Cleanup old GHCR images
+        uses: dataaxiom/ghcr-cleanup-action@v1
+        with:
+          owner: united-manufacturing-hub
+          package: umh-core
+          exclude-tags: staging,main,v*
+          delete-tags: sha-*,gh-readonly-queue-*
+          older-than: 30 days
+          delete-untagged: true
+          delete-ghost-images: true
+          dry-run: true
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cleanup-ghcr.yml
+++ b/.github/workflows/cleanup-ghcr.yml
@@ -27,7 +27,7 @@ jobs:
       packages: write
     steps:
       - name: Cleanup old GHCR images
-        uses: dataaxiom/ghcr-cleanup-action@v1
+        uses: dataaxiom/ghcr-cleanup-action@cd0cdb900b5dbf3a6f2cc869f0dbb0b8211f50c4 # v1.0.16
         with:
           owner: united-manufacturing-hub
           package: umh-core


### PR DESCRIPTION
## Summary

- Adds a weekly GitHub Action (`cleanup-ghcr.yml`) using [`dataaxiom/ghcr-cleanup-action@v1`](https://github.com/dataaxiom/ghcr-cleanup-action) to clean up old container images from GHCR
- **Protects**: `staging`, `main`, and `v*` tags (kept forever)
- **Deletes**: `sha-*` and `gh-readonly-queue-*` tagged images older than 30 days, plus untagged/ghost images
- **Starts with `dry-run: true`** — logs what it would delete without actually deleting anything. A follow-up PR will set `dry-run: false` after verifying the output.

## Test plan

- [ ] Merge this PR
- [ ] Manually trigger the workflow from Actions tab (`workflow_dispatch`)
- [ ] Verify logs show correct filtering: `staging`/`main`/`v*` images are kept, old `sha-*`/`gh-readonly-queue-*` images are marked for deletion
- [ ] If GITHUB_TOKEN lacks org-level delete permissions, add a PAT with `write:packages` + `delete:packages`
- [ ] After verification, merge follow-up PR to set `dry-run: false`

Ref: ENG-4364

🤖 Generated with [Claude Code](https://claude.ai/code)