### PR TITLE
ci: enable GHCR cleanup and use Depot runner

### DIFF
--- a/.github/workflows/cleanup-ghcr.yml
+++ b/.github/workflows/cleanup-ghcr.yml
@@ -22,7 +22,7 @@ on:
 jobs:
   cleanup:
     name: Delete old container images
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     permissions:
       packages: write
     steps:
@@ -36,5 +36,5 @@ jobs:
           older-than: 30 days
           delete-untagged: true
           delete-ghost-images: true
-          dry-run: true
+          dry-run: false
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Disables `dry-run` to enable actual deletion of old GHCR images
- Switches runner from `ubuntu-latest` to `depot-ubuntu-24.04` to match other workflows

Follow-up to #2426 which added the workflow with dry-run enabled.

## Dry-run results

[Dry-run workflow log](https://github.com/united-manufacturing-hub/united-manufacturing-hub/actions/runs/21863691763/job/63099173190) — verified correct filtering:
- **3,616 multi-arch images** marked for deletion
- **10,762 total images** marked for deletion
- No `staging`, `main`, or `v*` tagged images in delete list
- Images "in use by another image" correctly skipped

## Test plan

- [x] Verify dry-run output from #2426 looked correct (no protected tags in delete list)
- [ ] After merge, manually trigger the workflow and confirm images are actually deleted
- [x] If `GITHUB_TOKEN` lacks delete permissions, add Admin access in package settings or switch to a PAT

Ref: ENG-4364

🤖 Generated with [Claude Code](https://claude.ai/code)