### PR TITLE
feat(fsmv2/supervisor): add panic recovery and timeout protection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,7 +119,7 @@ The United Manufacturing Hub (UMH) is an Industrial IoT platform for manufacturi
 
 ## Code Style Requirements
 
-1. **Do NOT add comments unless explicitly requested**
+1. **Comments**: Do NOT add inline comments unless explicitly requested. DO add godoc comments on exported functions/types and comments on non-obvious constants, following [Google Developer Documentation Style Guide](https://developers.google.com/style) (active voice, present tense, concise)
 2. **Prefer editing existing files over creating new ones**
 3. **Follow existing patterns in the codebase**
 4. **Struct field alignment**: Run `make betteralign-fix` (automated tool orders fields by decreasing size)

--- a/umh-core/pkg/fsmv2/MIGRATION.md
+++ b/umh-core/pkg/fsmv2/MIGRATION.md
@@ -339,7 +339,7 @@ func (m *MyFSM) beforeRunning(e *fsm.Event) {
     // Pre-condition check
     if !m.isHealthy() {
         e.Cancel()
-        m.logger.SentryWarn(deps.FeatureHealth, m.hierarchyPath, "Cannot enter running: unhealthy")
+        m.logger.SentryWarn(deps.FeatureFSMv2, m.hierarchyPath, "Cannot enter running: unhealthy")
         return
     }
 }

--- a/umh-core/pkg/fsmv2/supervisor/api.go
+++ b/umh-core/pkg/fsmv2/supervisor/api.go
@@ -788,6 +788,7 @@ type SupervisorDebugInfo struct {
 	Workers             []WorkerDebugInfo              `json:"workers"`
 	CollectedAtUnixNano int64                          `json:"collected_at_unix_nano"`
 	CircuitOpen         bool                           `json:"circuit_open"`
+	PanicCircuitOpen    bool                           `json:"panic_circuit_open"`
 }
 
 // GetDebugInfo returns introspection data for debugging and monitoring.
@@ -802,6 +803,7 @@ func (s *Supervisor[TObserved, TDesired]) GetDebugInfo() interface{} {
 		WorkerType:          s.workerType,
 		HierarchyPath:       s.GetHierarchyPathUnlocked(),
 		CircuitOpen:         s.circuitOpen.Load(),
+		PanicCircuitOpen:    s.panicCircuitOpen.Load(),
 		MappedParentState:   s.mappedParentState,
 		CollectedAtUnixNano: time.Now().UnixNano(),
 		Workers:             make([]WorkerDebugInfo, 0, len(s.workers)),

--- a/umh-core/pkg/fsmv2/supervisor/api.go
+++ b/umh-core/pkg/fsmv2/supervisor/api.go
@@ -523,17 +523,17 @@ func (s *Supervisor[TObserved, TDesired]) getMappedParentState() string {
 	return s.GetMappedParentState()
 }
 
-// isCircuitOpen returns true if the circuit breaker is open for this supervisor.
+// isCircuitOpen returns true if any circuit breaker is open for this supervisor.
 // Used by InfrastructureHealthChecker.CheckChildConsistency() to detect unhealthy children.
 func (s *Supervisor[TObserved, TDesired]) isCircuitOpen() bool {
-	return s.circuitOpen.Load()
+	return s.IsCircuitOpen()
 }
 
 // IsCircuitOpen implements SupervisorInterface.
-// Returns true if the circuit breaker is open (infrastructure failure detected).
-// Used by ChildInfo to report infrastructure status to parents.
+// Returns true if any circuit breaker is open (infrastructure failure or repeated panics).
+// Used by ChildInfo to report health status to parents.
 func (s *Supervisor[TObserved, TDesired]) IsCircuitOpen() bool {
-	return s.circuitOpen.Load()
+	return s.circuitOpen.Load() || s.panicCircuitOpen.Load()
 }
 
 // IsObservationStale implements SupervisorInterface.

--- a/umh-core/pkg/fsmv2/supervisor/child_shutdown_timeout_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/child_shutdown_timeout_test.go
@@ -1,0 +1,127 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package supervisor_test
+
+import (
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/supervisor"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+var _ = Describe("Child Shutdown Timeout", func() {
+	Describe("when child done channel never closes", func() {
+		It("should not block forever during Shutdown", func() {
+			observedLogs, logger := createChildShutdownObservedLogger()
+
+			store := supervisor.CreateTestTriangularStore()
+
+			s := supervisor.NewSupervisor[*supervisor.TestObservedState, *supervisor.TestDesiredState](supervisor.Config{
+				WorkerType:              "test",
+				Store:                   store,
+				Logger:                  logger,
+				TickInterval:            50 * time.Millisecond,
+				GracefulShutdownTimeout: 100 * time.Millisecond,
+				ChildShutdownTimeout:    200 * time.Millisecond,
+			})
+
+			child := supervisor.CreateTestSupervisorWithCircuitState(false)
+
+			stuckDone := make(chan struct{})
+			defer close(stuckDone)
+
+			s.TestSetChild("stuck-child", child, stuckDone)
+			s.TestMarkAsStarted()
+
+			shutdownDone := make(chan struct{})
+			go func() {
+				s.Shutdown()
+				close(shutdownDone)
+			}()
+
+			Eventually(shutdownDone, 2*time.Second).Should(BeClosed(),
+				"Shutdown should complete within timeout, not block forever")
+
+			timeoutLogs := filterChildShutdownLogs(observedLogs, "child_shutdown_timeout")
+			Expect(timeoutLogs).ToNot(BeEmpty(), "Expected child_shutdown_timeout log entry")
+
+			timeoutLog := timeoutLogs[0]
+			Expect(timeoutLog.ContextMap()).To(HaveKey("child_name"))
+			Expect(timeoutLog.ContextMap()["child_name"]).To(Equal("stuck-child"))
+		})
+
+		It("should proceed normally when child shuts down within timeout", func() {
+			_, logger := createChildShutdownObservedLogger()
+
+			store := supervisor.CreateTestTriangularStore()
+
+			s := supervisor.NewSupervisor[*supervisor.TestObservedState, *supervisor.TestDesiredState](supervisor.Config{
+				WorkerType:              "test",
+				Store:                   store,
+				Logger:                  logger,
+				TickInterval:            50 * time.Millisecond,
+				GracefulShutdownTimeout: 100 * time.Millisecond,
+				ChildShutdownTimeout:    1 * time.Second,
+			})
+
+			child := supervisor.CreateTestSupervisorWithCircuitState(false)
+
+			normalDone := make(chan struct{})
+
+			s.TestSetChild("normal-child", child, normalDone)
+			s.TestMarkAsStarted()
+
+			go func() {
+				time.Sleep(50 * time.Millisecond)
+				close(normalDone)
+			}()
+
+			shutdownDone := make(chan struct{})
+			go func() {
+				s.Shutdown()
+				close(shutdownDone)
+			}()
+
+			Eventually(shutdownDone, 2*time.Second).Should(BeClosed(),
+				"Shutdown should complete when child finishes normally")
+		})
+	})
+})
+
+func createChildShutdownObservedLogger() (*observer.ObservedLogs, deps.FSMLogger) {
+	core, logs := observer.New(zapcore.DebugLevel)
+	logger := deps.NewFSMLogger(zap.New(core).Sugar())
+
+	return logs, logger
+}
+
+func filterChildShutdownLogs(logs *observer.ObservedLogs, message string) []observer.LoggedEntry {
+	var filtered []observer.LoggedEntry
+
+	for _, entry := range logs.All() {
+		if strings.Contains(entry.Message, message) {
+			filtered = append(filtered, entry)
+		}
+	}
+
+	return filtered
+}

--- a/umh-core/pkg/fsmv2/supervisor/constants.go
+++ b/umh-core/pkg/fsmv2/supervisor/constants.go
@@ -52,4 +52,15 @@ const (
 
 	// DefaultGracefulRestartTimeout is how long to wait for graceful restart before force resetting.
 	DefaultGracefulRestartTimeout = 30 * time.Second
+
+	// DefaultChildShutdownTimeout is how long to wait for a child supervisor's done channel
+	// to close after calling Shutdown(). If exceeded, the parent logs a warning and proceeds.
+	DefaultChildShutdownTimeout = 30 * time.Second
+
+	// DefaultPanicEscalationWindow is the time window for counting tick panics.
+	DefaultPanicEscalationWindow = 5 * time.Minute
+
+	// DefaultMaxTickPanics is the maximum number of tick panics allowed within the escalation window
+	// before the panic circuit breaker opens.
+	DefaultMaxTickPanics = 3
 )

--- a/umh-core/pkg/fsmv2/supervisor/constants.go
+++ b/umh-core/pkg/fsmv2/supervisor/constants.go
@@ -27,7 +27,7 @@ const (
 	// DefaultCollectorTimeout is the default age threshold for detecting stale data requiring restart.
 	DefaultCollectorTimeout = 20 * time.Second
 
-	// DefaultMaxRestartAttempts is the default maximum number of collector restart attempts before panic.
+	// DefaultMaxRestartAttempts is the default maximum number of collector restart attempts before escalation to graceful shutdown.
 	DefaultMaxRestartAttempts = 3
 
 	// DefaultObservationInterval is the default interval between observation collection attempts.

--- a/umh-core/pkg/fsmv2/supervisor/doc.go
+++ b/umh-core/pkg/fsmv2/supervisor/doc.go
@@ -147,8 +147,8 @@
 // Freshness check skipped during shutdown (collectors already stopped).
 //
 // On timeout:
-//   - Restarts collector with exponential backoff
-//   - Max restart attempts: 3 (DefaultMaxCollectorRestartAttempts)
+//   - Restarts collector with linear backoff
+//   - Max restart attempts: 3 (DefaultMaxRestartAttempts)
 //   - Escalates to shutdown if max attempts exhausted
 //
 // States assume data is fresh except during shutdown.
@@ -250,8 +250,8 @@
 //
 // panicCircuitOpen (atomic.Bool):
 //   - Circuit breaker state (code bug detection)
-//   - Opens permanently after repeated tick panics within the escalation window
-//   - Unlike circuitOpen, never auto-clears (requires process restart)
+//   - Opens after repeated tick panics within the sliding window
+//   - Auto-resets when the sliding window drains (panics older than the window are forgotten)
 //   - No mutex needed for single boolean flag
 //
 // tickCount (atomic.Uint64):
@@ -262,7 +262,7 @@
 //
 // CollectObservedState():
 //   - Runs in separate goroutine per worker
-//   - Timeout: DefaultObservationInterval (500ms)
+//   - Timeout: DefaultObservationTimeout (2.2s)
 //   - Saves observation to database (database handles concurrency)
 //   - Does not modify supervisor state directly
 //

--- a/umh-core/pkg/fsmv2/supervisor/doc.go
+++ b/umh-core/pkg/fsmv2/supervisor/doc.go
@@ -245,6 +245,13 @@
 //
 // circuitOpen (atomic.Bool):
 //   - Circuit breaker state (infrastructure health)
+//   - Auto-clears when health checks pass
+//   - No mutex needed for single boolean flag
+//
+// panicCircuitOpen (atomic.Bool):
+//   - Circuit breaker state (code bug detection)
+//   - Opens permanently after repeated tick panics within the escalation window
+//   - Unlike circuitOpen, never auto-clears (requires process restart)
 //   - No mutex needed for single boolean flag
 //
 // tickCount (atomic.Uint64):

--- a/umh-core/pkg/fsmv2/supervisor/edge_cases_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/edge_cases_test.go
@@ -17,7 +17,6 @@ package supervisor_test
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sync/atomic"
 	"time"
 
@@ -638,7 +637,7 @@ func (a *alternateObservedState) GetObservedDesiredState() fsmv2.DesiredState {
 var _ = Describe("Type Safety (Invariant I16)", func() {
 	Describe("ObservedState type validation", func() {
 		Context("when worker returns wrong ObservedState type", func() {
-			It("should panic with clear message before calling state.Next()", func() {
+			It("should return error with clear message (panic recovered)", func() {
 				mockStore := newMockTriangularStore()
 
 				identity := mockIdentity()
@@ -679,25 +678,15 @@ var _ = Describe("Type Safety (Invariant I16)", func() {
 				}
 				mockStore.Observed["container"][identity.ID] = wrongTypeObs
 
-				var panicMessage string
-				func() {
-					defer func() {
-						if r := recover(); r != nil {
-							panicMessage = fmt.Sprintf("%v", r)
-						}
-					}()
-					_ = s.TestTick(context.Background())
-				}()
-
-				Expect(panicMessage).To(ContainSubstring("Invariant I16 violated"))
-				Expect(panicMessage).To(ContainSubstring("test-worker"))
-				Expect(panicMessage).To(ContainSubstring("alternateObservedState"))
-				Expect(panicMessage).To(ContainSubstring("TestObservedState"))
+				err = s.TestTick(context.Background())
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("tick panic"))
+				Expect(err.Error()).To(ContainSubstring("Invariant I16 violated"))
 			})
 		})
 
 		Context("when worker returns nil ObservedState", func() {
-			It("should panic with clear message before calling state.Next()", func() {
+			It("should return error with clear message (panic recovered)", func() {
 				mockStore := newMockTriangularStore()
 
 				identity := mockIdentity()
@@ -737,19 +726,10 @@ var _ = Describe("Type Safety (Invariant I16)", func() {
 				}
 				mockStore.Observed["container"][identity.ID] = nil
 
-				var panicMessage string
-				func() {
-					defer func() {
-						if r := recover(); r != nil {
-							panicMessage = fmt.Sprintf("%v", r)
-						}
-					}()
-					_ = s.TestTick(context.Background())
-				}()
-
-				Expect(panicMessage).To(ContainSubstring("Invariant I16 violated"))
-				Expect(panicMessage).To(ContainSubstring("nil ObservedState"))
-				Expect(panicMessage).To(ContainSubstring("test-worker"))
+				err = s.TestTick(context.Background())
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("tick panic"))
+				Expect(err.Error()).To(ContainSubstring("Invariant I16 violated"))
 			})
 		})
 

--- a/umh-core/pkg/fsmv2/supervisor/internal/collection/collector.go
+++ b/umh-core/pkg/fsmv2/supervisor/internal/collection/collector.go
@@ -491,25 +491,25 @@ func (c *Collector[TObserved]) collectAndSaveObservedState(ctx context.Context) 
 // handleCollectorPanic processes a recovered panic from collectAndSaveObservedState.
 // It classifies the panic, records metrics, and logs to Sentry. If the recovery handler
 // itself panics, that secondary panic is caught and logged separately.
-func (c *Collector[TObserved]) handleCollectorPanic(r interface{}) error {
+func (c *Collector[TObserved]) handleCollectorPanic(r interface{}) (err error) {
 	logger := c.config.Logger
 	hierarchyPath := c.config.Identity.HierarchyPath
 
 	defer func() {
 		if r2 := recover(); r2 != nil {
-			doubleErr := fmt.Errorf("collector panic (recovery handler also panicked: %v): %v", r2, r)
+			err = fmt.Errorf("collector panic (recovery handler also panicked: %v): %v", r2, r)
 
 			func() {
 				defer func() { recover() }() //nolint:errcheck // recover() return value is intentionally unused in safety net
 
-				logger.SentryError(deps.FeatureFSMv2, hierarchyPath, doubleErr, "collector_double_panic",
+				logger.SentryError(deps.FeatureFSMv2, hierarchyPath, err, "collector_double_panic",
 					deps.String("stack", string(debug.Stack())))
 			}()
 		}
 	}()
 
 	panicType, panicErr := panicutil.ClassifyPanic(r)
-	err := fmt.Errorf("collector panic: %w", panicErr)
+	err = fmt.Errorf("collector panic: %w", panicErr)
 
 	metrics.RecordPanicRecovery(hierarchyPath, panicType)
 

--- a/umh-core/pkg/fsmv2/supervisor/internal/collection/collector.go
+++ b/umh-core/pkg/fsmv2/supervisor/internal/collection/collector.go
@@ -351,6 +351,9 @@ func (c *Collector[TObserved]) observationLoop() {
 }
 
 func (c *Collector[TObserved]) collectAndSaveObservedState(ctx context.Context) (err error) {
+	logger := c.config.Logger
+	hierarchyPath := c.config.Identity.HierarchyPath
+
 	defer func() {
 		if r := recover(); r != nil {
 			defer func() {
@@ -358,7 +361,7 @@ func (c *Collector[TObserved]) collectAndSaveObservedState(ctx context.Context) 
 					err = fmt.Errorf("collector panic (recovery handler also panicked: %v): %v", r2, r)
 					func() {
 						defer func() { recover() }()
-						c.config.Logger.SentryError(deps.FeatureFSMv2, c.config.Identity.HierarchyPath, err, "collector_double_panic",
+						logger.SentryError(deps.FeatureFSMv2, hierarchyPath, err, "collector_double_panic",
 							deps.String("stack", string(debug.Stack())))
 					}()
 				}
@@ -367,10 +370,9 @@ func (c *Collector[TObserved]) collectAndSaveObservedState(ctx context.Context) 
 			panicType, panicErr := classifyPanic(r)
 			err = fmt.Errorf("collector panic: %w", panicErr)
 
-			hierarchyPath := c.config.Identity.HierarchyPath
 			metrics.RecordPanicRecovery(hierarchyPath, panicType)
 
-			c.config.Logger.SentryError(deps.FeatureFSMv2, hierarchyPath, err, "collector_panic",
+			logger.SentryError(deps.FeatureFSMv2, hierarchyPath, err, "collector_panic",
 				deps.Field{Key: "panic_value", Value: fmt.Sprintf("%v", r)},
 				deps.Field{Key: "panic_type", Value: panicType},
 				deps.Field{Key: "stack_trace", Value: string(debug.Stack())})
@@ -490,8 +492,6 @@ func (c *Collector[TObserved]) collectAndSaveObservedState(ctx context.Context) 
 	}
 
 	saveDuration := time.Since(saveStartTime)
-
-	hierarchyPath := c.config.Identity.HierarchyPath
 
 	metrics.RecordObservationSave(hierarchyPath, changed, saveDuration)
 	metrics.ExportWorkerMetrics(hierarchyPath, observed)

--- a/umh-core/pkg/fsmv2/supervisor/internal/collection/collector.go
+++ b/umh-core/pkg/fsmv2/supervisor/internal/collection/collector.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"runtime/debug"
 	"sync"
 	"time"
 
@@ -235,6 +236,9 @@ func (c *Collector[TObserved]) Stop(ctx context.Context) {
 	doneChan := c.goroutineDone
 	c.mu.Unlock()
 
+	stopTimer := time.NewTimer(5 * time.Second)
+	defer stopTimer.Stop()
+
 	select {
 	case <-doneChan:
 		c.config.Logger.Debug("collector_stopped",
@@ -242,7 +246,7 @@ func (c *Collector[TObserved]) Stop(ctx context.Context) {
 	case <-ctx.Done():
 		c.config.Logger.SentryWarn(deps.FeatureFSMv2, c.config.Identity.HierarchyPath, "collector_stopped",
 			deps.String("result", "context_cancelled"))
-	case <-time.After(5 * time.Second):
+	case <-stopTimer.C:
 		c.config.Logger.SentryWarn(deps.FeatureFSMv2, c.config.Identity.HierarchyPath, "collector_stopped",
 			deps.String("result", "timeout"))
 	}
@@ -346,7 +350,37 @@ func (c *Collector[TObserved]) observationLoop() {
 	}
 }
 
-func (c *Collector[TObserved]) collectAndSaveObservedState(ctx context.Context) error {
+func (c *Collector[TObserved]) collectAndSaveObservedState(ctx context.Context) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			var panicErr error
+
+			var panicType string
+
+			switch v := r.(type) {
+			case error:
+				panicErr = v
+				panicType = "error"
+			case string:
+				panicErr = errors.New(v)
+				panicType = "string"
+			default:
+				panicErr = fmt.Errorf("%v", r)
+				panicType = "unknown"
+			}
+
+			err = fmt.Errorf("collector panic: %w", panicErr)
+
+			hierarchyPath := c.config.Identity.HierarchyPath
+			metrics.RecordPanicRecovery(hierarchyPath, panicType)
+
+			c.config.Logger.SentryError(deps.FeatureFSMv2, hierarchyPath, err, "collector_panic",
+				deps.Field{Key: "panic_value", Value: fmt.Sprintf("%v", r)},
+				deps.Field{Key: "panic_type", Value: panicType},
+				deps.Field{Key: "stack_trace", Value: string(debug.Stack())})
+		}
+	}()
+
 	collectionStartTime := time.Now()
 	c.logTrace("observation_collection_starting",
 		deps.String("collection_start_time", collectionStartTime.Format(time.RFC3339Nano)))

--- a/umh-core/pkg/fsmv2/supervisor/internal/collection/collector.go
+++ b/umh-core/pkg/fsmv2/supervisor/internal/collection/collector.go
@@ -353,22 +353,18 @@ func (c *Collector[TObserved]) observationLoop() {
 func (c *Collector[TObserved]) collectAndSaveObservedState(ctx context.Context) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			var panicErr error
+			defer func() {
+				if r2 := recover(); r2 != nil {
+					err = fmt.Errorf("collector panic (recovery handler also panicked: %v): %v", r2, r)
+					func() {
+						defer func() { recover() }()
+						c.config.Logger.SentryError(deps.FeatureFSMv2, c.config.Identity.HierarchyPath, err, "collector_double_panic",
+							deps.String("stack", string(debug.Stack())))
+					}()
+				}
+			}()
 
-			var panicType string
-
-			switch v := r.(type) {
-			case error:
-				panicErr = v
-				panicType = "error"
-			case string:
-				panicErr = errors.New(v)
-				panicType = "string"
-			default:
-				panicErr = fmt.Errorf("%v", r)
-				panicType = "unknown"
-			}
-
+			panicType, panicErr := classifyPanic(r)
 			err = fmt.Errorf("collector panic: %w", panicErr)
 
 			hierarchyPath := c.config.Identity.HierarchyPath
@@ -453,8 +449,6 @@ func (c *Collector[TObserved]) collectAndSaveObservedState(ctx context.Context) 
 		}
 	}
 
-	// NOTE: ActionHistory injection was removed - collector must not modify ObservedState
-	// after CollectObservedState returns. Workers read deps.GetActionHistory() directly.
 	var observationTimestamp time.Time
 	if timestampProvider, ok := observed.(fsmv2.TimestampProvider); ok {
 		observationTimestamp = timestampProvider.GetTimestamp()
@@ -513,4 +507,17 @@ func (c *Collector[TObserved]) collectAndSaveObservedState(ctx context.Context) 
 	}
 
 	return nil
+}
+
+// classifyPanic converts a recovered panic value into a typed error and a classification string.
+// This is a local copy of the same logic in supervisor/panic_recovery.go to avoid circular imports.
+func classifyPanic(r interface{}) (panicType string, panicErr error) {
+	switch v := r.(type) {
+	case error:
+		return "error", v
+	case string:
+		return "string", errors.New(v)
+	default:
+		return "unknown", fmt.Errorf("%v", r)
+	}
 }

--- a/umh-core/pkg/fsmv2/supervisor/internal/collection/collector.go
+++ b/umh-core/pkg/fsmv2/supervisor/internal/collection/collector.go
@@ -25,6 +25,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/cse/storage"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/supervisor/internal/panicutil"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/supervisor/metrics"
 )
 
@@ -351,31 +352,9 @@ func (c *Collector[TObserved]) observationLoop() {
 }
 
 func (c *Collector[TObserved]) collectAndSaveObservedState(ctx context.Context) (err error) {
-	logger := c.config.Logger
-	hierarchyPath := c.config.Identity.HierarchyPath
-
 	defer func() {
 		if r := recover(); r != nil {
-			defer func() {
-				if r2 := recover(); r2 != nil {
-					err = fmt.Errorf("collector panic (recovery handler also panicked: %v): %v", r2, r)
-					func() {
-						defer func() { recover() }()
-						logger.SentryError(deps.FeatureFSMv2, hierarchyPath, err, "collector_double_panic",
-							deps.String("stack", string(debug.Stack())))
-					}()
-				}
-			}()
-
-			panicType, panicErr := classifyPanic(r)
-			err = fmt.Errorf("collector panic: %w", panicErr)
-
-			metrics.RecordPanicRecovery(hierarchyPath, panicType)
-
-			logger.SentryError(deps.FeatureFSMv2, hierarchyPath, err, "collector_panic",
-				deps.Field{Key: "panic_value", Value: fmt.Sprintf("%v", r)},
-				deps.Field{Key: "panic_type", Value: panicType},
-				deps.Field{Key: "stack_trace", Value: string(debug.Stack())})
+			err = c.handleCollectorPanic(r)
 		}
 	}()
 
@@ -493,8 +472,8 @@ func (c *Collector[TObserved]) collectAndSaveObservedState(ctx context.Context) 
 
 	saveDuration := time.Since(saveStartTime)
 
-	metrics.RecordObservationSave(hierarchyPath, changed, saveDuration)
-	metrics.ExportWorkerMetrics(hierarchyPath, observed)
+	metrics.RecordObservationSave(c.config.Identity.HierarchyPath, changed, saveDuration)
+	metrics.ExportWorkerMetrics(c.config.Identity.HierarchyPath, observed)
 
 	if changed {
 		c.logTrace("observation_saved",
@@ -509,15 +488,35 @@ func (c *Collector[TObserved]) collectAndSaveObservedState(ctx context.Context) 
 	return nil
 }
 
-// classifyPanic converts a recovered panic value into a typed error and a classification string.
-// This is a local copy of the same logic in supervisor/panic_recovery.go to avoid circular imports.
-func classifyPanic(r interface{}) (panicType string, panicErr error) {
-	switch v := r.(type) {
-	case error:
-		return "error", v
-	case string:
-		return "string", errors.New(v)
-	default:
-		return "unknown", fmt.Errorf("%v", r)
-	}
+// handleCollectorPanic processes a recovered panic from collectAndSaveObservedState.
+// It classifies the panic, records metrics, and logs to Sentry. If the recovery handler
+// itself panics, that secondary panic is caught and logged separately.
+func (c *Collector[TObserved]) handleCollectorPanic(r interface{}) error {
+	logger := c.config.Logger
+	hierarchyPath := c.config.Identity.HierarchyPath
+
+	defer func() {
+		if r2 := recover(); r2 != nil {
+			doubleErr := fmt.Errorf("collector panic (recovery handler also panicked: %v): %v", r2, r)
+
+			func() {
+				defer func() { recover() }() //nolint:errcheck // recover() return value is intentionally unused in safety net
+
+				logger.SentryError(deps.FeatureFSMv2, hierarchyPath, doubleErr, "collector_double_panic",
+					deps.String("stack", string(debug.Stack())))
+			}()
+		}
+	}()
+
+	panicType, panicErr := panicutil.ClassifyPanic(r)
+	err := fmt.Errorf("collector panic: %w", panicErr)
+
+	metrics.RecordPanicRecovery(hierarchyPath, panicType)
+
+	logger.SentryError(deps.FeatureFSMv2, hierarchyPath, err, "collector_panic",
+		deps.Field{Key: "panic_value", Value: fmt.Sprintf("%v", r)},
+		deps.Field{Key: "panic_type", Value: panicType},
+		deps.Field{Key: "stack_trace", Value: string(debug.Stack())})
+
+	return err
 }

--- a/umh-core/pkg/fsmv2/supervisor/internal/collection/collector_panic_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/internal/collection/collector_panic_test.go
@@ -1,0 +1,237 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collection_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/supervisor"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/supervisor/internal/collection"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+var _ = Describe("Collector Panic Recovery", func() {
+	Context("when CollectObservedState panics", func() {
+		It("should recover and continue the observation loop", func() {
+			var callCount atomic.Int32
+
+			worker := &supervisor.TestWorker{
+				CollectFunc: func(ctx context.Context) (fsmv2.ObservedState, error) {
+					count := callCount.Add(1)
+					if count == 1 {
+						panic("simulated collector panic")
+					}
+
+					return supervisor.CreateTestObservedStateWithID("test-worker"), nil
+				},
+			}
+
+			observedCore, observedLogs := observer.New(zapcore.DebugLevel)
+			logger := deps.NewFSMLogger(zap.New(observedCore).Sugar())
+
+			collector := collection.NewCollector[supervisor.TestObservedState](collection.CollectorConfig[supervisor.TestObservedState]{
+				Worker:              worker,
+				Identity:            supervisor.TestIdentity(),
+				Store:               supervisor.CreateTestTriangularStore(),
+				Logger:              logger,
+				ObservationInterval: 50 * time.Millisecond,
+				ObservationTimeout:  1 * time.Second,
+			})
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			err := collector.Start(ctx)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Wait for at least 2 collection cycles (first panics, second succeeds)
+			time.Sleep(200 * time.Millisecond)
+
+			// Collector should still be running after recovering from panic
+			Expect(collector.IsRunning()).To(BeTrue(),
+				"Collector should still be running after panic recovery")
+
+			// CollectFunc should have been called more than once (panic didn't kill the loop)
+			Expect(callCount.Load()).To(BeNumerically(">", 1),
+				"CollectFunc should be called multiple times after panic recovery")
+
+			// Verify panic was logged
+			panicLogs := filterCollectorLogs(observedLogs, "collector_panic")
+			Expect(panicLogs).ToNot(BeEmpty(), "Expected collector_panic log entry")
+
+			cancel()
+			time.Sleep(100 * time.Millisecond)
+			Expect(collector.IsRunning()).To(BeFalse())
+		})
+
+		It("should log stack trace when recovering from panic", func() {
+			var panicked atomic.Bool
+
+			worker := &supervisor.TestWorker{
+				CollectFunc: func(ctx context.Context) (fsmv2.ObservedState, error) {
+					if !panicked.Load() {
+						panicked.Store(true)
+						panic("panic with stack trace test")
+					}
+
+					return supervisor.CreateTestObservedStateWithID("test-worker"), nil
+				},
+			}
+
+			observedCore, observedLogs := observer.New(zapcore.DebugLevel)
+			logger := deps.NewFSMLogger(zap.New(observedCore).Sugar())
+
+			collector := collection.NewCollector[supervisor.TestObservedState](collection.CollectorConfig[supervisor.TestObservedState]{
+				Worker:              worker,
+				Identity:            supervisor.TestIdentity(),
+				Store:               supervisor.CreateTestTriangularStore(),
+				Logger:              logger,
+				ObservationInterval: 50 * time.Millisecond,
+				ObservationTimeout:  1 * time.Second,
+			})
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			err := collector.Start(ctx)
+			Expect(err).ToNot(HaveOccurred())
+
+			time.Sleep(200 * time.Millisecond)
+
+			panicLogs := filterCollectorLogs(observedLogs, "collector_panic")
+			Expect(panicLogs).ToNot(BeEmpty())
+
+			panicLog := panicLogs[0]
+			Expect(panicLog.ContextMap()).To(HaveKey("stack_trace"))
+			Expect(panicLog.ContextMap()).To(HaveKey("panic_value"))
+
+			cancel()
+			time.Sleep(100 * time.Millisecond)
+		})
+	})
+})
+
+var _ = Describe("Collector Panic Type Classification", func() {
+	It("should classify error-type panics with panic_type=error", func() {
+		var panicked atomic.Bool
+
+		worker := &supervisor.TestWorker{
+			CollectFunc: func(ctx context.Context) (fsmv2.ObservedState, error) {
+				if !panicked.Load() {
+					panicked.Store(true)
+					panic(errors.New("typed error panic"))
+				}
+
+				return supervisor.CreateTestObservedStateWithID("test-worker"), nil
+			},
+		}
+
+		observedCore, observedLogs := observer.New(zapcore.DebugLevel)
+		logger := deps.NewFSMLogger(zap.New(observedCore).Sugar())
+
+		collector := collection.NewCollector[supervisor.TestObservedState](collection.CollectorConfig[supervisor.TestObservedState]{
+			Worker:              worker,
+			Identity:            supervisor.TestIdentity(),
+			Store:               supervisor.CreateTestTriangularStore(),
+			Logger:              logger,
+			ObservationInterval: 50 * time.Millisecond,
+			ObservationTimeout:  1 * time.Second,
+		})
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		err := collector.Start(ctx)
+		Expect(err).ToNot(HaveOccurred())
+
+		time.Sleep(200 * time.Millisecond)
+
+		panicLogs := filterCollectorLogs(observedLogs, "collector_panic")
+		Expect(panicLogs).ToNot(BeEmpty())
+
+		panicLog := panicLogs[0]
+		Expect(panicLog.ContextMap()["panic_type"]).To(Equal("error"))
+
+		cancel()
+		time.Sleep(100 * time.Millisecond)
+	})
+
+	It("should classify non-string non-error panics with panic_type=unknown", func() {
+		var panicked atomic.Bool
+
+		worker := &supervisor.TestWorker{
+			CollectFunc: func(ctx context.Context) (fsmv2.ObservedState, error) {
+				if !panicked.Load() {
+					panicked.Store(true)
+					panic(42)
+				}
+
+				return supervisor.CreateTestObservedStateWithID("test-worker"), nil
+			},
+		}
+
+		observedCore, observedLogs := observer.New(zapcore.DebugLevel)
+		logger := deps.NewFSMLogger(zap.New(observedCore).Sugar())
+
+		collector := collection.NewCollector[supervisor.TestObservedState](collection.CollectorConfig[supervisor.TestObservedState]{
+			Worker:              worker,
+			Identity:            supervisor.TestIdentity(),
+			Store:               supervisor.CreateTestTriangularStore(),
+			Logger:              logger,
+			ObservationInterval: 50 * time.Millisecond,
+			ObservationTimeout:  1 * time.Second,
+		})
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		err := collector.Start(ctx)
+		Expect(err).ToNot(HaveOccurred())
+
+		time.Sleep(200 * time.Millisecond)
+
+		panicLogs := filterCollectorLogs(observedLogs, "collector_panic")
+		Expect(panicLogs).ToNot(BeEmpty())
+
+		panicLog := panicLogs[0]
+		Expect(panicLog.ContextMap()["panic_type"]).To(Equal("unknown"))
+
+		cancel()
+		time.Sleep(100 * time.Millisecond)
+	})
+})
+
+func filterCollectorLogs(logs *observer.ObservedLogs, message string) []observer.LoggedEntry {
+	var filtered []observer.LoggedEntry
+
+	for _, entry := range logs.All() {
+		if strings.Contains(entry.Message, message) {
+			filtered = append(filtered, entry)
+		}
+	}
+
+	return filtered
+}

--- a/umh-core/pkg/fsmv2/supervisor/internal/collection/collector_panic_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/internal/collection/collector_panic_test.go
@@ -224,6 +224,69 @@ var _ = Describe("Collector Panic Type Classification", func() {
 	})
 })
 
+var _ = Describe("Collector Double Panic", func() {
+	It("should recover when the recovery handler itself panics", func() {
+		var panicked atomic.Bool
+
+		worker := &supervisor.TestWorker{
+			CollectFunc: func(ctx context.Context) (fsmv2.ObservedState, error) {
+				if !panicked.Load() {
+					panicked.Store(true)
+					panic("trigger collector double panic")
+				}
+
+				return supervisor.CreateTestObservedStateWithID("test-worker"), nil
+			},
+		}
+
+		logger := &panicOnSentryErrorCollectorLogger{}
+
+		collector := collection.NewCollector[supervisor.TestObservedState](collection.CollectorConfig[supervisor.TestObservedState]{
+			Worker:              worker,
+			Identity:            supervisor.TestIdentity(),
+			Store:               supervisor.CreateTestTriangularStore(),
+			Logger:              logger,
+			ObservationInterval: 50 * time.Millisecond,
+			ObservationTimeout:  1 * time.Second,
+		})
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		err := collector.Start(ctx)
+		Expect(err).ToNot(HaveOccurred())
+
+		time.Sleep(200 * time.Millisecond)
+
+		Expect(collector.IsRunning()).To(BeTrue(),
+			"Collector should still be running after double panic recovery")
+
+		cancel()
+		time.Sleep(100 * time.Millisecond)
+		Expect(collector.IsRunning()).To(BeFalse())
+	})
+})
+
+// panicOnSentryErrorCollectorLogger panics on the first SentryError call only.
+// After the first call, subsequent SentryError calls are no-ops.
+// This tests the double-panic path inside collectAndSaveObservedState without
+// crashing observationLoop's error handler (which also calls SentryError).
+type panicOnSentryErrorCollectorLogger struct {
+	panicked atomic.Bool
+}
+
+func (p *panicOnSentryErrorCollectorLogger) Debug(msg string, fields ...deps.Field)     {}
+func (p *panicOnSentryErrorCollectorLogger) Info(msg string, fields ...deps.Field)       {}
+func (p *panicOnSentryErrorCollectorLogger) SentryWarn(_ deps.Feature, _ string, _ string, _ ...deps.Field) {
+}
+func (p *panicOnSentryErrorCollectorLogger) SentryError(_ deps.Feature, _ string, _ error, _ string, _ ...deps.Field) {
+	if !p.panicked.Load() {
+		p.panicked.Store(true)
+		panic("logger SentryError panicked in collector")
+	}
+}
+func (p *panicOnSentryErrorCollectorLogger) With(fields ...deps.Field) deps.FSMLogger { return p }
+
 func filterCollectorLogs(logs *observer.ObservedLogs, message string) []observer.LoggedEntry {
 	var filtered []observer.LoggedEntry
 

--- a/umh-core/pkg/fsmv2/supervisor/internal/collection/collector_panic_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/internal/collection/collector_panic_test.go
@@ -173,7 +173,7 @@ var _ = Describe("Collector Panic Type Classification", func() {
 		Expect(panicLogs).ToNot(BeEmpty())
 
 		panicLog := panicLogs[0]
-		Expect(panicLog.ContextMap()["panic_type"]).To(Equal("error"))
+		Expect(panicLog.ContextMap()["panic_type"]).To(Equal("error_panic"))
 
 		cancel()
 		time.Sleep(100 * time.Millisecond)
@@ -217,7 +217,7 @@ var _ = Describe("Collector Panic Type Classification", func() {
 		Expect(panicLogs).ToNot(BeEmpty())
 
 		panicLog := panicLogs[0]
-		Expect(panicLog.ContextMap()["panic_type"]).To(Equal("unknown"))
+		Expect(panicLog.ContextMap()["panic_type"]).To(Equal("unknown_panic"))
 
 		cancel()
 		time.Sleep(100 * time.Millisecond)

--- a/umh-core/pkg/fsmv2/supervisor/internal/collection/doc.go
+++ b/umh-core/pkg/fsmv2/supervisor/internal/collection/doc.go
@@ -72,7 +72,7 @@
 //
 // # Automatic restart with backoff
 //
-// The collector restarts automatically with exponential backoff for three reasons:
+// The collector restarts automatically with linear backoff for three reasons:
 //
 // 1. Transient failures: Network blips, temporary resource exhaustion, or
 // brief service outages self-heal without operator intervention.

--- a/umh-core/pkg/fsmv2/supervisor/internal/execution/action_executor.go
+++ b/umh-core/pkg/fsmv2/supervisor/internal/execution/action_executor.go
@@ -73,26 +73,16 @@ type actionWork struct {
 }
 
 func NewActionExecutor(workerCount int, supervisorID string, identity deps.Identity, logger deps.FSMLogger) *ActionExecutor {
-	if workerCount <= 0 {
-		workerCount = 10
-	}
-
-	return &ActionExecutor{
-		supervisorID:    supervisorID,
-		identity:        identity,
-		workerCount:     workerCount,
-		actionQueue:     make(chan actionWork, workerCount*2),
-		inProgress:      make(map[string]inProgressEntry),
-		timeouts:        make(map[string]time.Duration),
-		defaultTimeout:  30 * time.Second,
-		metricsInterval: 5 * time.Second,
-		logger:          logger,
-	}
+	return NewActionExecutorWithTimeout(workerCount, nil, supervisorID, identity, logger)
 }
 
 func NewActionExecutorWithTimeout(workerCount int, timeouts map[string]time.Duration, supervisorID string, identity deps.Identity, logger deps.FSMLogger) *ActionExecutor {
 	if workerCount <= 0 {
 		workerCount = 10
+	}
+
+	if timeouts == nil {
+		timeouts = make(map[string]time.Duration)
 	}
 
 	return &ActionExecutor{
@@ -191,11 +181,19 @@ func (ae *ActionExecutor) executeWorkWithRecovery(ctx context.Context, work acti
 		callback := ae.onActionComplete
 		ae.mu.Unlock()
 
-		if !generationMatch {
-			ae.logger.Debug("action_completion_discarded_stale_generation",
+		if !exists {
+			ae.logger.Info("action_completion_discarded_entry_missing",
 				deps.CorrelationID(work.actionID),
 				deps.ActionName(work.action.Name()),
 				deps.Field{Key: "work_generation", Value: work.generation})
+			return
+		}
+		if !generationMatch {
+			ae.logger.Info("action_completion_discarded_stale_generation",
+				deps.CorrelationID(work.actionID),
+				deps.ActionName(work.action.Name()),
+				deps.Field{Key: "work_generation", Value: work.generation},
+				deps.Field{Key: "current_generation", Value: entry.generation})
 			return
 		}
 
@@ -353,6 +351,7 @@ func (ae *ActionExecutor) metricsReporter(ctx context.Context) {
 			ae.mu.Lock()
 			queueSize := len(ae.actionQueue)
 			inProgressCount := len(ae.inProgress)
+			callback := ae.onActionComplete
 
 			now := time.Now()
 
@@ -399,6 +398,15 @@ func (ae *ActionExecutor) metricsReporter(ctx context.Context) {
 						deps.Field{Key: "action_name", Value: stuck.actionName},
 						deps.Field{Key: "elapsed_ms", Value: stuck.elapsedMs},
 						deps.Field{Key: "timeout_ms", Value: stuck.timeoutMs})
+
+					if callback != nil {
+						callback(deps.ActionResult{
+							Timestamp:  now,
+							ActionType: stuck.actionName,
+							ErrorMsg:   fmt.Sprintf("force-removed: stuck for %dms (timeout %dms)", stuck.elapsedMs, stuck.timeoutMs),
+							Latency:    time.Duration(stuck.elapsedMs) * time.Millisecond,
+						})
+					}
 				} else {
 					metrics.RecordStuckActionDetected(ae.identity.HierarchyPath, stuck.actionName)
 					ae.logger.SentryWarn(deps.FeatureFSMv2, ae.identity.HierarchyPath, "stuck_action_detected",

--- a/umh-core/pkg/fsmv2/supervisor/internal/execution/action_executor.go
+++ b/umh-core/pkg/fsmv2/supervisor/internal/execution/action_executor.go
@@ -32,6 +32,14 @@ const (
 	stuckActionDetectionMultiplier = 2
 	// stuckActionForceRemoveMultiplier defines when a stuck action is force-removed, allowing re-enqueue.
 	stuckActionForceRemoveMultiplier = 3
+	// defaultWorkerCount is the number of concurrent action workers when none is specified.
+	defaultWorkerCount = 10
+	// queueSizeMultiplier determines queue capacity as workerCount * multiplier.
+	queueSizeMultiplier = 2
+	// defaultActionTimeout is the per-action execution timeout when no override is configured.
+	defaultActionTimeout = 30 * time.Second
+	// defaultMetricsInterval is how often the metrics reporter checks for stuck actions.
+	defaultMetricsInterval = 5 * time.Second
 )
 
 type inProgressEntry struct {
@@ -72,13 +80,21 @@ type actionWork struct {
 	generation uint64
 }
 
+type stuckEntry struct {
+	actionID    string
+	actionName  string
+	elapsedMs   int64
+	timeoutMs   int64
+	forceRemove bool
+}
+
 func NewActionExecutor(workerCount int, supervisorID string, identity deps.Identity, logger deps.FSMLogger) *ActionExecutor {
 	return NewActionExecutorWithTimeout(workerCount, nil, supervisorID, identity, logger)
 }
 
 func NewActionExecutorWithTimeout(workerCount int, timeouts map[string]time.Duration, supervisorID string, identity deps.Identity, logger deps.FSMLogger) *ActionExecutor {
 	if workerCount <= 0 {
-		workerCount = 10
+		workerCount = defaultWorkerCount
 	}
 
 	if timeouts == nil {
@@ -89,11 +105,11 @@ func NewActionExecutorWithTimeout(workerCount int, timeouts map[string]time.Dura
 		supervisorID:    supervisorID,
 		identity:        identity,
 		workerCount:     workerCount,
-		actionQueue:     make(chan actionWork, workerCount*2),
+		actionQueue:     make(chan actionWork, workerCount*queueSizeMultiplier),
 		inProgress:      make(map[string]inProgressEntry),
 		timeouts:        timeouts,
-		defaultTimeout:  30 * time.Second,
-		metricsInterval: 5 * time.Second,
+		defaultTimeout:  defaultActionTimeout,
+		metricsInterval: defaultMetricsInterval,
 		logger:          logger,
 	}
 }
@@ -355,13 +371,6 @@ func (ae *ActionExecutor) metricsReporter(ctx context.Context) {
 
 			now := time.Now()
 
-			type stuckEntry struct {
-				actionID    string
-				actionName  string
-				elapsedMs   int64
-				timeoutMs   int64
-				forceRemove bool
-			}
 			var stuckActions []stuckEntry
 
 			for actionID, entry := range ae.inProgress {

--- a/umh-core/pkg/fsmv2/supervisor/internal/execution/action_executor.go
+++ b/umh-core/pkg/fsmv2/supervisor/internal/execution/action_executor.go
@@ -27,10 +27,25 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/supervisor/metrics"
 )
 
+const (
+	// stuckActionDetectionMultiplier defines when an in-progress action is considered stuck (elapsed > multiplier * timeout).
+	stuckActionDetectionMultiplier = 2
+	// stuckActionForceRemoveMultiplier defines when a stuck action is force-removed, allowing re-enqueue.
+	stuckActionForceRemoveMultiplier = 3
+)
+
+type inProgressEntry struct {
+	startTime     time.Time
+	actionName    string
+	timeout       time.Duration
+	generation    uint64
+	stuckReported bool
+}
+
 type ActionExecutor struct {
 	ctx              context.Context
 	actionQueue      chan actionWork
-	inProgress       map[string]bool
+	inProgress       map[string]inProgressEntry
 	cancel           context.CancelFunc
 	timeouts         map[string]time.Duration
 	metricsCancel    context.CancelFunc
@@ -42,16 +57,19 @@ type ActionExecutor struct {
 	metricsWg        sync.WaitGroup
 	workerCount      int
 	defaultTimeout   time.Duration
+	metricsInterval  time.Duration
+	nextGeneration   uint64
 	mu               sync.RWMutex
 	closeOnce        sync.Once
 	stopped          bool
 }
 
 type actionWork struct {
-	action   fsmv2.Action[any]
-	deps     any
-	actionID string
-	timeout  time.Duration
+	action     fsmv2.Action[any]
+	deps       any
+	actionID   string
+	timeout    time.Duration
+	generation uint64
 }
 
 func NewActionExecutor(workerCount int, supervisorID string, identity deps.Identity, logger deps.FSMLogger) *ActionExecutor {
@@ -60,14 +78,15 @@ func NewActionExecutor(workerCount int, supervisorID string, identity deps.Ident
 	}
 
 	return &ActionExecutor{
-		supervisorID:   supervisorID,
-		identity:       identity,
-		workerCount:    workerCount,
-		actionQueue:    make(chan actionWork, workerCount*2),
-		inProgress:     make(map[string]bool),
-		timeouts:       make(map[string]time.Duration),
-		defaultTimeout: 30 * time.Second,
-		logger:         logger,
+		supervisorID:    supervisorID,
+		identity:        identity,
+		workerCount:     workerCount,
+		actionQueue:     make(chan actionWork, workerCount*2),
+		inProgress:      make(map[string]inProgressEntry),
+		timeouts:        make(map[string]time.Duration),
+		defaultTimeout:  30 * time.Second,
+		metricsInterval: 5 * time.Second,
+		logger:          logger,
 	}
 }
 
@@ -77,14 +96,15 @@ func NewActionExecutorWithTimeout(workerCount int, timeouts map[string]time.Dura
 	}
 
 	return &ActionExecutor{
-		supervisorID:   supervisorID,
-		identity:       identity,
-		workerCount:    workerCount,
-		actionQueue:    make(chan actionWork, workerCount*2),
-		inProgress:     make(map[string]bool),
-		timeouts:       timeouts,
-		defaultTimeout: 30 * time.Second,
-		logger:         logger,
+		supervisorID:    supervisorID,
+		identity:        identity,
+		workerCount:     workerCount,
+		actionQueue:     make(chan actionWork, workerCount*2),
+		inProgress:      make(map[string]inProgressEntry),
+		timeouts:        timeouts,
+		defaultTimeout:  30 * time.Second,
+		metricsInterval: 5 * time.Second,
+		logger:          logger,
 	}
 }
 
@@ -150,7 +170,7 @@ func (ae *ActionExecutor) executeWorkWithRecovery(ctx context.Context, work acti
 
 	defer func() {
 		if r := recover(); r != nil {
-			err = errors.New("action panicked")
+			err = fmt.Errorf("action panicked: %v", r)
 			status = "panic"
 
 			ae.logger.SentryError(deps.FeatureFSMv2, ae.identity.HierarchyPath, err, "action_panic",
@@ -163,9 +183,21 @@ func (ae *ActionExecutor) executeWorkWithRecovery(ctx context.Context, work acti
 		}
 
 		ae.mu.Lock()
-		delete(ae.inProgress, work.actionID)
+		entry, exists := ae.inProgress[work.actionID]
+		generationMatch := exists && entry.generation == work.generation
+		if generationMatch {
+			delete(ae.inProgress, work.actionID)
+		}
 		callback := ae.onActionComplete
 		ae.mu.Unlock()
+
+		if !generationMatch {
+			ae.logger.Debug("action_completion_discarded_stale_generation",
+				deps.CorrelationID(work.actionID),
+				deps.ActionName(work.action.Name()),
+				deps.Field{Key: "work_generation", Value: work.generation})
+			return
+		}
 
 		duration := time.Since(startTime)
 
@@ -247,7 +279,7 @@ func (ae *ActionExecutor) EnqueueAction(actionID string, action fsmv2.Action[any
 		return errors.New("executor stopped")
 	}
 
-	if ae.inProgress[actionID] {
+	if _, exists := ae.inProgress[actionID]; exists {
 		ae.mu.Unlock()
 
 		ae.logger.SentryWarn(deps.FeatureFSMv2, ae.identity.HierarchyPath, "action_enqueue_rejected",
@@ -258,21 +290,29 @@ func (ae *ActionExecutor) EnqueueAction(actionID string, action fsmv2.Action[any
 		return errors.New("action already in progress")
 	}
 
-	ae.inProgress[actionID] = true
-
 	// Read timeout while still holding lock to prevent race with concurrent access
-	timeout, exists := ae.timeouts[actionID]
-	if !exists {
+	timeout, timeoutExists := ae.timeouts[actionID]
+	if !timeoutExists {
 		timeout = ae.defaultTimeout
 	}
 
+	ae.nextGeneration++
+	gen := ae.nextGeneration
+
+	ae.inProgress[actionID] = inProgressEntry{
+		startTime:  time.Now(),
+		actionName: action.Name(),
+		timeout:    timeout,
+		generation: gen,
+	}
 	ae.mu.Unlock()
 
 	work := actionWork{
-		actionID: actionID,
-		action:   action,
-		timeout:  timeout,
-		deps:     workerDeps,
+		actionID:   actionID,
+		action:     action,
+		timeout:    timeout,
+		deps:       workerDeps,
+		generation: gen,
 	}
 
 	select {
@@ -302,7 +342,7 @@ func (ae *ActionExecutor) EnqueueAction(actionID string, action fsmv2.Action[any
 func (ae *ActionExecutor) metricsReporter(ctx context.Context) {
 	defer ae.metricsWg.Done()
 
-	ticker := time.NewTicker(5 * time.Second)
+	ticker := time.NewTicker(ae.metricsInterval)
 	defer ticker.Stop()
 
 	for {
@@ -310,10 +350,64 @@ func (ae *ActionExecutor) metricsReporter(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			ae.mu.RLock()
+			ae.mu.Lock()
 			queueSize := len(ae.actionQueue)
 			inProgressCount := len(ae.inProgress)
-			ae.mu.RUnlock()
+
+			now := time.Now()
+
+			type stuckEntry struct {
+				actionID    string
+				actionName  string
+				elapsedMs   int64
+				timeoutMs   int64
+				forceRemove bool
+			}
+			var stuckActions []stuckEntry
+
+			for actionID, entry := range ae.inProgress {
+				elapsed := now.Sub(entry.startTime)
+
+				if elapsed > stuckActionForceRemoveMultiplier*entry.timeout {
+					delete(ae.inProgress, actionID)
+					stuckActions = append(stuckActions, stuckEntry{
+						actionID:    actionID,
+						actionName:  entry.actionName,
+						elapsedMs:   elapsed.Milliseconds(),
+						timeoutMs:   entry.timeout.Milliseconds(),
+						forceRemove: true,
+					})
+				} else if elapsed > stuckActionDetectionMultiplier*entry.timeout && !entry.stuckReported {
+					entry.stuckReported = true
+					ae.inProgress[actionID] = entry
+					stuckActions = append(stuckActions, stuckEntry{
+						actionID:   actionID,
+						actionName: entry.actionName,
+						elapsedMs:  elapsed.Milliseconds(),
+						timeoutMs:  entry.timeout.Milliseconds(),
+					})
+				}
+			}
+
+			ae.mu.Unlock()
+
+			for _, stuck := range stuckActions {
+				if stuck.forceRemove {
+					metrics.RecordStuckActionForceRemoved(ae.identity.HierarchyPath, stuck.actionName)
+					ae.logger.SentryError(deps.FeatureFSMv2, ae.identity.HierarchyPath, fmt.Errorf("action %s stuck for %dms (timeout %dms), force-removed", stuck.actionName, stuck.elapsedMs, stuck.timeoutMs), "stuck_action_force_removed",
+						deps.Field{Key: "action_id", Value: stuck.actionID},
+						deps.Field{Key: "action_name", Value: stuck.actionName},
+						deps.Field{Key: "elapsed_ms", Value: stuck.elapsedMs},
+						deps.Field{Key: "timeout_ms", Value: stuck.timeoutMs})
+				} else {
+					metrics.RecordStuckActionDetected(ae.identity.HierarchyPath, stuck.actionName)
+					ae.logger.SentryWarn(deps.FeatureFSMv2, ae.identity.HierarchyPath, "stuck_action_detected",
+						deps.Field{Key: "action_id", Value: stuck.actionID},
+						deps.Field{Key: "action_name", Value: stuck.actionName},
+						deps.Field{Key: "elapsed_ms", Value: stuck.elapsedMs},
+						deps.Field{Key: "timeout_ms", Value: stuck.timeoutMs})
+				}
+			}
 
 			metrics.RecordWorkerPoolQueueSize(ae.identity.HierarchyPath, queueSize)
 
@@ -328,7 +422,9 @@ func (ae *ActionExecutor) HasActionInProgress(actionID string) bool {
 	ae.mu.RLock()
 	defer ae.mu.RUnlock()
 
-	return ae.inProgress[actionID]
+	_, exists := ae.inProgress[actionID]
+
+	return exists
 }
 
 // GetActiveActionCount returns the number of actions currently in progress.

--- a/umh-core/pkg/fsmv2/supervisor/internal/execution/action_executor.go
+++ b/umh-core/pkg/fsmv2/supervisor/internal/execution/action_executor.go
@@ -190,10 +190,12 @@ func (ae *ActionExecutor) executeWorkWithRecovery(ctx context.Context, work acti
 
 		ae.mu.Lock()
 		entry, exists := ae.inProgress[work.actionID]
+
 		generationMatch := exists && entry.generation == work.generation
 		if generationMatch {
 			delete(ae.inProgress, work.actionID)
 		}
+
 		callback := ae.onActionComplete
 		ae.mu.Unlock()
 
@@ -202,14 +204,17 @@ func (ae *ActionExecutor) executeWorkWithRecovery(ctx context.Context, work acti
 				deps.CorrelationID(work.actionID),
 				deps.ActionName(work.action.Name()),
 				deps.Field{Key: "work_generation", Value: work.generation})
+
 			return
 		}
+
 		if !generationMatch {
 			ae.logger.Info("action_completion_discarded_stale_generation",
 				deps.CorrelationID(work.actionID),
 				deps.ActionName(work.action.Name()),
 				deps.Field{Key: "work_generation", Value: work.generation},
 				deps.Field{Key: "current_generation", Value: entry.generation})
+
 			return
 		}
 

--- a/umh-core/pkg/fsmv2/supervisor/internal/execution/action_executor.go
+++ b/umh-core/pkg/fsmv2/supervisor/internal/execution/action_executor.go
@@ -417,6 +417,7 @@ func (ae *ActionExecutor) metricsReporter(ctx context.Context) {
 						callback(deps.ActionResult{
 							Timestamp:  now,
 							ActionType: stuck.actionName,
+							Success:    false,
 							ErrorMsg:   fmt.Sprintf("force-removed: stuck for %dms (timeout %dms)", stuck.elapsedMs, stuck.timeoutMs),
 							Latency:    time.Duration(stuck.elapsedMs) * time.Millisecond,
 						})

--- a/umh-core/pkg/fsmv2/supervisor/internal/execution/action_executor_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/internal/execution/action_executor_test.go
@@ -671,6 +671,29 @@ var _ = Describe("ActionExecutor", func() {
 				"Normal action should complete after previous action panicked")
 		})
 
+		It("should invoke callback with failure after panic", func() {
+			callbackCh := make(chan deps.ActionResult, 1)
+			executor.SetOnActionComplete(func(result deps.ActionResult) {
+				callbackCh <- result
+			})
+
+			panicAction := &testAction{
+				execute: func(ctx context.Context) error {
+					panic("callback test panic")
+				},
+				name: "panic-callback-test",
+			}
+
+			err := executor.EnqueueAction("panic-callback", panicAction, nil)
+			Expect(err).ToNot(HaveOccurred())
+
+			var result deps.ActionResult
+			Eventually(callbackCh, 2*time.Second).Should(Receive(&result))
+			Expect(result.Success).To(BeFalse())
+			Expect(result.ErrorMsg).ToNot(BeEmpty())
+			Expect(result.ActionType).To(Equal("panic-callback-test"))
+		})
+
 		It("should handle multiple consecutive panics without crashing", func() {
 			for i := range 5 {
 				actionID := fmt.Sprintf("panic-action-%d", i)

--- a/umh-core/pkg/fsmv2/supervisor/internal/execution/stuck_action_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/internal/execution/stuck_action_test.go
@@ -56,6 +56,7 @@ var _ = Describe("Stuck Action Detection", func() {
 				name: "stuck-action",
 				execute: func(ctx context.Context) error {
 					<-blockChan
+
 					return nil
 				},
 			}
@@ -101,6 +102,7 @@ var _ = Describe("Stuck Action Detection", func() {
 				name: "fast-action",
 				execute: func(ctx context.Context) error {
 					time.Sleep(50 * time.Millisecond)
+
 					return nil
 				},
 			}
@@ -141,6 +143,7 @@ var _ = Describe("Stuck Action Force-Removal", func() {
 			name: "stuck-force",
 			execute: func(ctx context.Context) error {
 				<-blockChan
+
 				return nil
 			},
 		}
@@ -188,6 +191,7 @@ var _ = Describe("Stuck Action Force-Removal", func() {
 			name: "stuck-reenqueue",
 			execute: func(ctx context.Context) error {
 				<-blockChan
+
 				return nil
 			},
 		}
@@ -205,6 +209,7 @@ var _ = Describe("Stuck Action Force-Removal", func() {
 			name: "stuck-reenqueue",
 			execute: func(ctx context.Context) error {
 				completed <- true
+
 				return nil
 			},
 		}
@@ -242,6 +247,7 @@ var _ = Describe("Stuck Action Force-Removal", func() {
 			name: "orphan-cb",
 			execute: func(ctx context.Context) error {
 				<-releaseChan
+
 				return nil
 			},
 		}
@@ -286,6 +292,7 @@ var _ = Describe("Stuck Action Force-Removal", func() {
 			name: "orphan-del",
 			execute: func(ctx context.Context) error {
 				<-releaseChan
+
 				return nil
 			},
 		}
@@ -304,6 +311,7 @@ var _ = Describe("Stuck Action Force-Removal", func() {
 			name: "orphan-del",
 			execute: func(ctx context.Context) error {
 				<-blockChan
+
 				return nil
 			},
 		}
@@ -346,6 +354,7 @@ var _ = Describe("Stuck Action Deduplication", func() {
 			name: "stuck-dedup",
 			execute: func(ctx context.Context) error {
 				<-blockChan
+
 				return nil
 			},
 		}
@@ -387,6 +396,7 @@ var _ = Describe("Stuck Action Deduplication", func() {
 				name: id,
 				execute: func(ctx context.Context) error {
 					<-blockChan
+
 					return nil
 				},
 			}

--- a/umh-core/pkg/fsmv2/supervisor/internal/execution/stuck_action_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/internal/execution/stuck_action_test.go
@@ -1,0 +1,420 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package execution_test
+
+import (
+	"context"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/supervisor/internal/execution"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+var _ = Describe("Stuck Action Detection", func() {
+	Context("when an action ignores context cancellation and blocks beyond 2x timeout", func() {
+		It("should detect and log stuck action", func() {
+			observedCore, observedLogs := observer.New(zapcore.DebugLevel)
+			logger := deps.NewFSMLogger(zap.New(observedCore).Sugar())
+
+			identity := deps.Identity{ID: "test-worker", WorkerType: "test", HierarchyPath: "test/stuck"}
+
+			executor := execution.NewActionExecutorWithTimeout(2, map[string]time.Duration{
+				"stuck-action": 100 * time.Millisecond,
+			}, "test-supervisor", identity, logger)
+			executor.TestSetMetricsInterval(200 * time.Millisecond)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			executor.Start(ctx)
+			defer executor.Shutdown()
+
+			blockChan := make(chan struct{})
+			defer close(blockChan)
+
+			action := &testAction{
+				name: "stuck-action",
+				execute: func(ctx context.Context) error {
+					<-blockChan
+					return nil
+				},
+			}
+
+			err := executor.EnqueueAction("stuck-action", action, nil)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Wait for stuck detection:
+			// - Action timeout: 100ms
+			// - 2x threshold: 200ms
+			// - Metrics interval: 200ms
+			// So by ~400ms the first metrics check after 2x should fire
+			time.Sleep(600 * time.Millisecond)
+
+			stuckLogs := filterStuckActionLogs(observedLogs, "stuck_action_detected")
+			Expect(stuckLogs).ToNot(BeEmpty(), "Expected stuck_action_detected log entry")
+
+			stuckLog := stuckLogs[0]
+			Expect(stuckLog.ContextMap()).To(HaveKey("action_name"))
+			Expect(stuckLog.ContextMap()["action_name"]).To(Equal("stuck-action"))
+			Expect(stuckLog.ContextMap()).To(HaveKey("elapsed_ms"))
+			Expect(stuckLog.ContextMap()).To(HaveKey("timeout_ms"))
+		})
+
+		It("should not flag actions that complete within timeout", func() {
+			observedCore, observedLogs := observer.New(zapcore.DebugLevel)
+			logger := deps.NewFSMLogger(zap.New(observedCore).Sugar())
+
+			identity := deps.Identity{ID: "test-worker", WorkerType: "test", HierarchyPath: "test/normal"}
+
+			executor := execution.NewActionExecutorWithTimeout(2, map[string]time.Duration{
+				"fast-action": 1 * time.Second,
+			}, "test-supervisor", identity, logger)
+			executor.TestSetMetricsInterval(200 * time.Millisecond)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			executor.Start(ctx)
+			defer executor.Shutdown()
+
+			action := &testAction{
+				name: "fast-action",
+				execute: func(ctx context.Context) error {
+					time.Sleep(50 * time.Millisecond)
+					return nil
+				},
+			}
+
+			err := executor.EnqueueAction("fast-action", action, nil)
+			Expect(err).ToNot(HaveOccurred())
+
+			time.Sleep(500 * time.Millisecond)
+
+			stuckLogs := filterStuckActionLogs(observedLogs, "stuck_action_detected")
+			Expect(stuckLogs).To(BeEmpty(), "No stuck action logs expected for fast action")
+		})
+	})
+})
+
+var _ = Describe("Stuck Action Force-Removal", func() {
+	It("should force-remove stuck entry after 3x timeout", func() {
+		observedCore, observedLogs := observer.New(zapcore.DebugLevel)
+		logger := deps.NewFSMLogger(zap.New(observedCore).Sugar())
+
+		identity := deps.Identity{ID: "test-worker", WorkerType: "test", HierarchyPath: "test/force-remove"}
+
+		executor := execution.NewActionExecutorWithTimeout(2, map[string]time.Duration{
+			"stuck-force": 100 * time.Millisecond,
+		}, "test-supervisor", identity, logger)
+		executor.TestSetMetricsInterval(100 * time.Millisecond)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		executor.Start(ctx)
+		defer executor.Shutdown()
+
+		blockChan := make(chan struct{})
+		defer close(blockChan)
+
+		action := &testAction{
+			name: "stuck-force",
+			execute: func(ctx context.Context) error {
+				<-blockChan
+				return nil
+			},
+		}
+
+		err := executor.EnqueueAction("stuck-force", action, nil)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(executor.HasActionInProgress("stuck-force")).To(BeTrue())
+
+		// Wait for force-removal: 3x timeout = 300ms, plus metrics interval headroom
+		time.Sleep(600 * time.Millisecond)
+
+		Expect(executor.HasActionInProgress("stuck-force")).To(BeFalse(),
+			"Stuck entry should be force-removed after 3x timeout")
+
+		removedLogs := filterStuckActionLogs(observedLogs, "stuck_action_force_removed")
+		Expect(removedLogs).ToNot(BeEmpty(), "Expected stuck_action_force_removed log entry")
+		removedLog := removedLogs[0]
+		Expect(removedLog.ContextMap()).To(HaveKey("action_name"))
+		Expect(removedLog.ContextMap()).To(HaveKey("elapsed_ms"))
+		Expect(removedLog.ContextMap()).To(HaveKey("timeout_ms"))
+	})
+
+	It("should allow re-enqueue after force-removal", func() {
+		observedCore, _ := observer.New(zapcore.DebugLevel)
+		logger := deps.NewFSMLogger(zap.New(observedCore).Sugar())
+
+		identity := deps.Identity{ID: "test-worker", WorkerType: "test", HierarchyPath: "test/re-enqueue"}
+
+		executor := execution.NewActionExecutorWithTimeout(2, map[string]time.Duration{
+			"stuck-reenqueue": 100 * time.Millisecond,
+		}, "test-supervisor", identity, logger)
+		executor.TestSetMetricsInterval(100 * time.Millisecond)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		executor.Start(ctx)
+		defer executor.Shutdown()
+
+		blockChan := make(chan struct{})
+		defer close(blockChan)
+
+		action := &testAction{
+			name: "stuck-reenqueue",
+			execute: func(ctx context.Context) error {
+				<-blockChan
+				return nil
+			},
+		}
+
+		err := executor.EnqueueAction("stuck-reenqueue", action, nil)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Wait for force-removal
+		time.Sleep(600 * time.Millisecond)
+		Expect(executor.HasActionInProgress("stuck-reenqueue")).To(BeFalse())
+
+		// Re-enqueue should succeed
+		completed := make(chan bool, 1)
+		normalAction := &testAction{
+			name: "stuck-reenqueue",
+			execute: func(ctx context.Context) error {
+				completed <- true
+				return nil
+			},
+		}
+		err = executor.EnqueueAction("stuck-reenqueue", normalAction, nil)
+		Expect(err).ToNot(HaveOccurred())
+
+		Eventually(completed, 2*time.Second).Should(Receive())
+	})
+
+	It("should not invoke callback when orphaned goroutine finishes after force-removal", func() {
+		observedCore, _ := observer.New(zapcore.DebugLevel)
+		logger := deps.NewFSMLogger(zap.New(observedCore).Sugar())
+
+		identity := deps.Identity{ID: "test-worker", WorkerType: "test", HierarchyPath: "test/orphan-callback"}
+
+		executor := execution.NewActionExecutorWithTimeout(2, map[string]time.Duration{
+			"orphan-cb": 100 * time.Millisecond,
+		}, "test-supervisor", identity, logger)
+		executor.TestSetMetricsInterval(100 * time.Millisecond)
+
+		var callbackCount int32
+		executor.SetOnActionComplete(func(result deps.ActionResult) {
+			atomic.AddInt32(&callbackCount, 1)
+		})
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		executor.Start(ctx)
+		defer executor.Shutdown()
+
+		releaseChan := make(chan struct{})
+
+		action := &testAction{
+			name: "orphan-cb",
+			execute: func(ctx context.Context) error {
+				<-releaseChan
+				return nil
+			},
+		}
+
+		err := executor.EnqueueAction("orphan-cb", action, nil)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Wait for force-removal
+		time.Sleep(600 * time.Millisecond)
+		Expect(executor.HasActionInProgress("orphan-cb")).To(BeFalse())
+
+		// Release the orphaned goroutine
+		close(releaseChan)
+		time.Sleep(200 * time.Millisecond)
+
+		Expect(atomic.LoadInt32(&callbackCount)).To(Equal(int32(0)),
+			"Callback should NOT be invoked by orphaned goroutine after force-removal")
+	})
+
+	It("should not delete re-enqueued entry when orphaned goroutine finishes", func() {
+		observedCore, _ := observer.New(zapcore.DebugLevel)
+		logger := deps.NewFSMLogger(zap.New(observedCore).Sugar())
+
+		identity := deps.Identity{ID: "test-worker", WorkerType: "test", HierarchyPath: "test/orphan-delete"}
+
+		executor := execution.NewActionExecutorWithTimeout(2, map[string]time.Duration{
+			"orphan-del": 100 * time.Millisecond,
+		}, "test-supervisor", identity, logger)
+		executor.TestSetMetricsInterval(100 * time.Millisecond)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		executor.Start(ctx)
+		defer executor.Shutdown()
+
+		releaseChan := make(chan struct{})
+
+		stuckAction := &testAction{
+			name: "orphan-del",
+			execute: func(ctx context.Context) error {
+				<-releaseChan
+				return nil
+			},
+		}
+
+		err := executor.EnqueueAction("orphan-del", stuckAction, nil)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Wait for force-removal
+		time.Sleep(600 * time.Millisecond)
+		Expect(executor.HasActionInProgress("orphan-del")).To(BeFalse())
+
+		// Re-enqueue with a long-running action
+		blockChan := make(chan struct{})
+		defer close(blockChan)
+		newAction := &testAction{
+			name: "orphan-del",
+			execute: func(ctx context.Context) error {
+				<-blockChan
+				return nil
+			},
+		}
+		err = executor.EnqueueAction("orphan-del", newAction, nil)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(executor.HasActionInProgress("orphan-del")).To(BeTrue())
+
+		// Release the orphaned goroutine
+		close(releaseChan)
+		time.Sleep(200 * time.Millisecond)
+
+		// The re-enqueued entry should still be in progress (orphan didn't delete it)
+		Expect(executor.HasActionInProgress("orphan-del")).To(BeTrue(),
+			"Re-enqueued entry should NOT be deleted by orphaned goroutine")
+	})
+})
+
+var _ = Describe("Stuck Action Deduplication", func() {
+	It("should log stuck exactly once across multiple metrics ticks", func() {
+		observedCore, observedLogs := observer.New(zapcore.DebugLevel)
+		logger := deps.NewFSMLogger(zap.New(observedCore).Sugar())
+
+		identity := deps.Identity{ID: "test-worker", WorkerType: "test", HierarchyPath: "test/dedup"}
+
+		executor := execution.NewActionExecutorWithTimeout(2, map[string]time.Duration{
+			"stuck-dedup": 100 * time.Millisecond,
+		}, "test-supervisor", identity, logger)
+		executor.TestSetMetricsInterval(100 * time.Millisecond)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		executor.Start(ctx)
+		defer executor.Shutdown()
+
+		blockChan := make(chan struct{})
+		defer close(blockChan)
+
+		action := &testAction{
+			name: "stuck-dedup",
+			execute: func(ctx context.Context) error {
+				<-blockChan
+				return nil
+			},
+		}
+
+		err := executor.EnqueueAction("stuck-dedup", action, nil)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Wait for several metrics ticks after the stuck threshold (2x100ms=200ms)
+		// Metrics fires every 100ms, so after 800ms we'd have ~6 ticks past the threshold
+		time.Sleep(800 * time.Millisecond)
+
+		stuckLogs := filterStuckActionLogs(observedLogs, "stuck_action_detected")
+		Expect(stuckLogs).To(HaveLen(1), "Expected exactly 1 stuck_action_detected log, got %d", len(stuckLogs))
+	})
+
+	It("should report separately for different action IDs", func() {
+		observedCore, observedLogs := observer.New(zapcore.DebugLevel)
+		logger := deps.NewFSMLogger(zap.New(observedCore).Sugar())
+
+		identity := deps.Identity{ID: "test-worker", WorkerType: "test", HierarchyPath: "test/multi"}
+
+		executor := execution.NewActionExecutorWithTimeout(4, map[string]time.Duration{
+			"stuck-a": 100 * time.Millisecond,
+			"stuck-b": 100 * time.Millisecond,
+		}, "test-supervisor", identity, logger)
+		executor.TestSetMetricsInterval(100 * time.Millisecond)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		executor.Start(ctx)
+		defer executor.Shutdown()
+
+		blockChan := make(chan struct{})
+		defer close(blockChan)
+
+		for _, id := range []string{"stuck-a", "stuck-b"} {
+			action := &testAction{
+				name: id,
+				execute: func(ctx context.Context) error {
+					<-blockChan
+					return nil
+				},
+			}
+			err := executor.EnqueueAction(id, action, nil)
+			Expect(err).ToNot(HaveOccurred())
+		}
+
+		time.Sleep(800 * time.Millisecond)
+
+		stuckLogs := filterStuckActionLogs(observedLogs, "stuck_action_detected")
+		Expect(stuckLogs).To(HaveLen(2), "Expected exactly 2 stuck_action_detected logs (one per action)")
+
+		actionNames := map[string]bool{}
+		for _, log := range stuckLogs {
+			name, _ := log.ContextMap()["action_name"].(string)
+			actionNames[name] = true
+		}
+		Expect(actionNames).To(HaveKey("stuck-a"))
+		Expect(actionNames).To(HaveKey("stuck-b"))
+	})
+})
+
+func filterStuckActionLogs(logs *observer.ObservedLogs, message string) []observer.LoggedEntry {
+	var filtered []observer.LoggedEntry
+
+	for _, entry := range logs.All() {
+		if strings.Contains(entry.Message, message) {
+			filtered = append(filtered, entry)
+		}
+	}
+
+	return filtered
+}

--- a/umh-core/pkg/fsmv2/supervisor/internal/execution/stuck_action_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/internal/execution/stuck_action_test.go
@@ -404,11 +404,14 @@ var _ = Describe("Stuck Action Deduplication", func() {
 			Expect(err).ToNot(HaveOccurred())
 		}
 
-		time.Sleep(800 * time.Millisecond)
+		// Use Eventually instead of fixed sleep to avoid race between action
+		// enqueue (worker must pick up action and add to inProgress map) and
+		// the metrics tick that detects stuck actions.
+		Eventually(func() int {
+			return len(filterStuckActionLogs(observedLogs, "stuck_action_detected"))
+		}, 5*time.Second, 50*time.Millisecond).Should(Equal(2), "Expected exactly 2 stuck_action_detected logs (one per action)")
 
 		stuckLogs := filterStuckActionLogs(observedLogs, "stuck_action_detected")
-		Expect(stuckLogs).To(HaveLen(2), "Expected exactly 2 stuck_action_detected logs (one per action)")
-
 		actionNames := map[string]bool{}
 		for _, log := range stuckLogs {
 			name, _ := log.ContextMap()["action_name"].(string)

--- a/umh-core/pkg/fsmv2/supervisor/internal/execution/stuck_action_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/internal/execution/stuck_action_test.go
@@ -249,16 +249,18 @@ var _ = Describe("Stuck Action Force-Removal", func() {
 		err := executor.EnqueueAction("orphan-cb", action, nil)
 		Expect(err).ToNot(HaveOccurred())
 
-		// Wait for force-removal
+		// Wait for force-removal (metricsReporter fires callback for force-removed actions)
 		time.Sleep(600 * time.Millisecond)
 		Expect(executor.HasActionInProgress("orphan-cb")).To(BeFalse())
+		Expect(atomic.LoadInt32(&callbackCount)).To(Equal(int32(1)),
+			"Force-removal should invoke callback with failure result")
 
 		// Release the orphaned goroutine
 		close(releaseChan)
 		time.Sleep(200 * time.Millisecond)
 
-		Expect(atomic.LoadInt32(&callbackCount)).To(Equal(int32(0)),
-			"Callback should NOT be invoked by orphaned goroutine after force-removal")
+		Expect(atomic.LoadInt32(&callbackCount)).To(Equal(int32(1)),
+			"Orphaned goroutine should NOT invoke callback after force-removal")
 	})
 
 	It("should not delete re-enqueued entry when orphaned goroutine finishes", func() {

--- a/umh-core/pkg/fsmv2/supervisor/internal/execution/test_accessors.go
+++ b/umh-core/pkg/fsmv2/supervisor/internal/execution/test_accessors.go
@@ -1,0 +1,21 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package execution
+
+import "time"
+
+func (ae *ActionExecutor) TestSetMetricsInterval(d time.Duration) {
+	ae.metricsInterval = d
+}

--- a/umh-core/pkg/fsmv2/supervisor/internal/panicutil/classify.go
+++ b/umh-core/pkg/fsmv2/supervisor/internal/panicutil/classify.go
@@ -20,14 +20,20 @@ import (
 	"fmt"
 )
 
+const (
+	PanicTypeError   = "error_panic"
+	PanicTypeString  = "string_panic"
+	PanicTypeUnknown = "unknown_panic"
+)
+
 // ClassifyPanic converts a recovered panic value into a typed error and a classification string.
 func ClassifyPanic(r interface{}) (panicType string, panicErr error) {
 	switch v := r.(type) {
 	case error:
-		return "error", v
+		return PanicTypeError, v
 	case string:
-		return "string", errors.New(v)
+		return PanicTypeString, errors.New(v)
 	default:
-		return "unknown", fmt.Errorf("%v", r)
+		return PanicTypeUnknown, fmt.Errorf("%v", r)
 	}
 }

--- a/umh-core/pkg/fsmv2/supervisor/internal/panicutil/classify.go
+++ b/umh-core/pkg/fsmv2/supervisor/internal/panicutil/classify.go
@@ -1,0 +1,33 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package panicutil provides shared panic classification utilities for the supervisor hierarchy.
+package panicutil
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ClassifyPanic converts a recovered panic value into a typed error and a classification string.
+func ClassifyPanic(r interface{}) (panicType string, panicErr error) {
+	switch v := r.(type) {
+	case error:
+		return "error", v
+	case string:
+		return "string", errors.New(v)
+	default:
+		return "unknown", fmt.Errorf("%v", r)
+	}
+}

--- a/umh-core/pkg/fsmv2/supervisor/lifecycle.go
+++ b/umh-core/pkg/fsmv2/supervisor/lifecycle.go
@@ -223,13 +223,24 @@ func (s *Supervisor[TObserved, TDesired]) Shutdown() {
 
 			child.Shutdown()
 
-			// Wait for child supervisor to fully shut down
+			// Wait for child supervisor to fully shut down (with timeout)
 			if done, exists := childDoneChans[childName]; exists {
 				s.logger.Debug("waiting_child_shutdown",
 					deps.String("child_name", childName))
-				<-done
-				s.logger.Debug("child_shutdown_complete",
-					deps.String("child_name", childName))
+
+				shutdownTimer := time.NewTimer(s.childShutdownTimeout)
+				select {
+				case <-done:
+					shutdownTimer.Stop()
+					s.logger.Debug("child_shutdown_complete",
+						deps.String("child_name", childName))
+				case <-shutdownTimer.C:
+					metrics.RecordChildShutdownTimeout(s.GetHierarchyPath(), childName)
+
+					s.logger.SentryWarn(deps.FeatureFSMv2, s.GetHierarchyPath(), "child_shutdown_timeout",
+						deps.String("child_name", childName),
+						deps.Duration("timeout", s.childShutdownTimeout))
+				}
 			}
 
 			s.logTrace("lifecycle",
@@ -257,12 +268,14 @@ func (s *Supervisor[TObserved, TDesired]) Shutdown() {
 		// Wait for workers to complete graceful shutdown (with timeout)
 		gracefulTimeout := s.gracefulShutdownTimeout
 		ticker := time.NewTicker(100 * time.Millisecond)
-		timeoutCh := time.After(gracefulTimeout)
+		defer ticker.Stop()
+		gracefulTimer := time.NewTimer(gracefulTimeout)
+		defer gracefulTimer.Stop()
 
 	gracefulWaitLoop:
 		for {
 			select {
-			case <-timeoutCh:
+			case <-gracefulTimer.C:
 				s.mu.RLock()
 				remainingCount := len(s.workers)
 				s.mu.RUnlock()

--- a/umh-core/pkg/fsmv2/supervisor/lifecycle.go
+++ b/umh-core/pkg/fsmv2/supervisor/lifecycle.go
@@ -105,7 +105,7 @@ func (s *Supervisor[TObserved, TDesired]) StartAsChild(ctx context.Context) {
 }
 
 // tickLoop is the main FSM loop.
-// Calls Tick() which includes hierarchical composition (Phase 0) and worker state transitions.
+// Calls tick() which includes hierarchical composition (Phase 0) and worker state transitions.
 func (s *Supervisor[TObserved, TDesired]) tickLoop(ctx context.Context) {
 	s.logger.Debug("tick_loop_initializing")
 
@@ -653,6 +653,8 @@ func (s *Supervisor[TObserved, TDesired]) clearShutdownRequested(ctx context.Con
 		sr.SetShutdownRequested(false)
 	} else if sr, ok := any(&desired).(fsmv2.ShutdownRequestable); ok {
 		sr.SetShutdownRequested(false)
+	} else {
+		return fmt.Errorf("desired state type %T does not implement ShutdownRequestable", desired)
 	}
 
 	// Save back - need to convert to Document

--- a/umh-core/pkg/fsmv2/supervisor/lifecycle.go
+++ b/umh-core/pkg/fsmv2/supervisor/lifecycle.go
@@ -567,7 +567,7 @@ func (s *Supervisor[TObserved, TDesired]) handleWorkerRestart(ctx context.Contex
 	s.logger.Debug("worker_restart_new_created",
 		deps.HierarchyPath(identity.HierarchyPath))
 
-	// 4. Add new worker to supervisor (this also starts the collector if supervisor is running)
+	// 4. Add new worker to supervisor (registers worker in the workers map)
 	if err := s.AddWorker(identity, newWorker); err != nil {
 		return fmt.Errorf("failed to add new worker for restart: %w", err)
 	}

--- a/umh-core/pkg/fsmv2/supervisor/lifecycle.go
+++ b/umh-core/pkg/fsmv2/supervisor/lifecycle.go
@@ -258,8 +258,10 @@ func (s *Supervisor[TObserved, TDesired]) Shutdown() {
 
 		// Wait for workers to complete graceful shutdown (with timeout)
 		gracefulTimeout := s.gracefulShutdownTimeout
+
 		ticker := time.NewTicker(100 * time.Millisecond)
 		defer ticker.Stop()
+
 		gracefulTimer := time.NewTimer(gracefulTimeout)
 		defer gracefulTimer.Stop()
 
@@ -288,7 +290,6 @@ func (s *Supervisor[TObserved, TDesired]) Shutdown() {
 				}
 			}
 		}
-
 	}
 
 	// Phase 4: Cleanup executors and collectors.

--- a/umh-core/pkg/fsmv2/supervisor/lifecycle.go
+++ b/umh-core/pkg/fsmv2/supervisor/lifecycle.go
@@ -123,7 +123,13 @@ func (s *Supervisor[TObserved, TDesired]) tickLoop(ctx context.Context) {
 			return
 		case <-ticker.C:
 			if err := s.tick(ctx); err != nil {
-				s.logger.SentryError(deps.FeatureFSMv2, s.GetHierarchyPath(), err, "tick_error")
+				if errors.Is(err, ErrPanicCircuitOpen) || errors.Is(err, ErrInfraCircuitOpen) {
+					s.logger.Debug("tick_suppressed_circuit_open",
+						deps.HierarchyPath(s.GetHierarchyPath()),
+						deps.Err(err))
+				} else {
+					s.logger.SentryError(deps.FeatureFSMv2, s.GetHierarchyPath(), err, "tick_error")
+				}
 			}
 		}
 	}
@@ -228,10 +234,10 @@ func (s *Supervisor[TObserved, TDesired]) Shutdown() {
 				s.logger.Debug("waiting_child_shutdown",
 					deps.String("child_name", childName))
 
-				s.waitForChildDone(done, childName, s.GetHierarchyPath(), "shutdown")
-
-				s.logger.Debug("child_shutdown_complete",
-					deps.String("child_name", childName))
+				if s.waitForChildDone(done, childName, s.GetHierarchyPath(), "shutdown") {
+					s.logger.Debug("child_shutdown_complete",
+						deps.String("child_name", childName))
+				}
 			}
 
 			s.logTrace("lifecycle",
@@ -320,13 +326,15 @@ func (s *Supervisor[TObserved, TDesired]) Shutdown() {
 }
 
 // waitForChildDone waits for a child supervisor's done channel to close, with a timeout.
-// If the timeout fires, it records a metric and logs a warning. The hierarchyPath and
-// logContext parameters are used for metrics and log attribution.
-func (s *Supervisor[TObserved, TDesired]) waitForChildDone(done <-chan struct{}, childName, hierarchyPath, logContext string) {
+// Returns true if the child completed, false if the timeout fired.
+// The hierarchyPath and logContext parameters are used for metrics and log attribution.
+func (s *Supervisor[TObserved, TDesired]) waitForChildDone(done <-chan struct{}, childName, hierarchyPath, logContext string) bool {
 	shutdownTimer := time.NewTimer(s.childShutdownTimeout)
+	defer shutdownTimer.Stop()
+
 	select {
 	case <-done:
-		shutdownTimer.Stop()
+		return true
 	case <-shutdownTimer.C:
 		metrics.RecordChildShutdownTimeout(hierarchyPath, childName)
 
@@ -334,6 +342,8 @@ func (s *Supervisor[TObserved, TDesired]) waitForChildDone(done <-chan struct{},
 			deps.String("child_name", childName),
 			deps.Duration("timeout", s.childShutdownTimeout),
 			deps.String("context", logContext))
+
+		return false
 	}
 }
 
@@ -640,6 +650,8 @@ func (s *Supervisor[TObserved, TDesired]) clearShutdownRequested(ctx context.Con
 
 	// Clear shutdown flag via interface
 	if sr, ok := any(desired).(fsmv2.ShutdownRequestable); ok {
+		sr.SetShutdownRequested(false)
+	} else if sr, ok := any(&desired).(fsmv2.ShutdownRequestable); ok {
 		sr.SetShutdownRequested(false)
 	}
 

--- a/umh-core/pkg/fsmv2/supervisor/lifecycle.go
+++ b/umh-core/pkg/fsmv2/supervisor/lifecycle.go
@@ -228,19 +228,10 @@ func (s *Supervisor[TObserved, TDesired]) Shutdown() {
 				s.logger.Debug("waiting_child_shutdown",
 					deps.String("child_name", childName))
 
-				shutdownTimer := time.NewTimer(s.childShutdownTimeout)
-				select {
-				case <-done:
-					shutdownTimer.Stop()
-					s.logger.Debug("child_shutdown_complete",
-						deps.String("child_name", childName))
-				case <-shutdownTimer.C:
-					metrics.RecordChildShutdownTimeout(s.GetHierarchyPath(), childName)
+				s.waitForChildDone(done, childName, s.GetHierarchyPath(), "shutdown")
 
-					s.logger.SentryWarn(deps.FeatureFSMv2, s.GetHierarchyPath(), "child_shutdown_timeout",
-						deps.String("child_name", childName),
-						deps.Duration("timeout", s.childShutdownTimeout))
-				}
+				s.logger.Debug("child_shutdown_complete",
+					deps.String("child_name", childName))
 			}
 
 			s.logTrace("lifecycle",
@@ -298,7 +289,6 @@ func (s *Supervisor[TObserved, TDesired]) Shutdown() {
 			}
 		}
 
-		ticker.Stop()
 	}
 
 	// Phase 4: Cleanup executors and collectors.
@@ -326,6 +316,24 @@ func (s *Supervisor[TObserved, TDesired]) Shutdown() {
 
 	s.logTrace("lifecycle",
 		deps.String("lifecycle_event", "shutdown_complete"))
+}
+
+// waitForChildDone waits for a child supervisor's done channel to close, with a timeout.
+// If the timeout fires, it records a metric and logs a warning. The hierarchyPath and
+// logContext parameters are used for metrics and log attribution.
+func (s *Supervisor[TObserved, TDesired]) waitForChildDone(done <-chan struct{}, childName, hierarchyPath, logContext string) {
+	shutdownTimer := time.NewTimer(s.childShutdownTimeout)
+	select {
+	case <-done:
+		shutdownTimer.Stop()
+	case <-shutdownTimer.C:
+		metrics.RecordChildShutdownTimeout(hierarchyPath, childName)
+
+		s.logger.SentryWarn(deps.FeatureFSMv2, hierarchyPath, "child_shutdown_timeout",
+			deps.String("child_name", childName),
+			deps.Duration("timeout", s.childShutdownTimeout),
+			deps.String("context", logContext))
+	}
 }
 
 // startMetricsReporter starts a goroutine that periodically records hierarchy metrics.
@@ -496,15 +504,13 @@ func (s *Supervisor[TObserved, TDesired]) RequestShutdown(ctx context.Context, r
 // including any attempt counters, connection pools, or cached data in dependencies.
 //
 // Flow:
-//  1. Extract identity from existing worker (before removal)
-//  2. RemoveWorker - stops collector, executor, removes from registry
-//  3. Clear ShutdownRequested in storage (so new worker starts fresh)
-//  4. factory.NewWorkerByType - creates completely new worker instance
-//  5. AddWorker - registers new worker, starts collector
+//  1. RemoveWorker - stops collector, executor, removes from registry
+//  2. Clear ShutdownRequested in storage (so new worker starts fresh)
+//  3. factory.NewWorkerByType - creates completely new worker instance
+//  4. AddWorker - registers new worker
+//  5. Start collector and executor if supervisor is running
+//  6. Reset health counters for fresh start
 func (s *Supervisor[TObserved, TDesired]) handleWorkerRestart(ctx context.Context, workerID string) error {
-	// Extract identity and state under lock before removal.
-	// NOTE: We hold both s.mu and workerCtx.mu to prevent TOCTOU race when
-	// reading currentState - otherwise reconciliation could modify it concurrently.
 	s.mu.RLock()
 
 	workerCtx, exists := s.workers[workerID]
@@ -566,11 +572,7 @@ func (s *Supervisor[TObserved, TDesired]) handleWorkerRestart(ctx context.Contex
 		return fmt.Errorf("failed to add new worker for restart: %w", err)
 	}
 
-	// 5. Start the new worker's collector and executor if supervisor is already running.
-	// NOTE: We capture collector and executor under lock to prevent TOCTOU race.
-	// Between checking worker existence and starting collector/executor, another
-	// goroutine could remove the worker. By capturing the pointers under lock,
-	// we ensure we have valid references even if the worker is subsequently removed.
+	// 5. Start collector and executor if supervisor is running
 	if supervisorCtx, started := s.getStartedContext(); started {
 		s.mu.RLock()
 
@@ -603,9 +605,6 @@ func (s *Supervisor[TObserved, TDesired]) handleWorkerRestart(ctx context.Contex
 	s.collectorHealth.restartCount = 0
 	s.mu.Unlock()
 
-	// Get new state for logging.
-	// NOTE: We hold both s.mu and workerCtx.mu to prevent TOCTOU race when
-	// reading currentState - otherwise reconciliation could modify it concurrently.
 	s.mu.RLock()
 
 	newWorkerCtx := s.workers[workerID]

--- a/umh-core/pkg/fsmv2/supervisor/lifecycle_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/lifecycle_test.go
@@ -100,7 +100,7 @@ var _ = Describe("Supervisor Lifecycle", func() {
 
 	Describe("Tick state transition edge case", func() {
 		Context("when state violates invariant by switching state AND emitting action", func() {
-			It("should panic", func() {
+			It("should return error (panic recovered)", func() {
 				store := newMockTriangularStore()
 
 				nextState := &mockState{}
@@ -112,9 +112,9 @@ var _ = Describe("Supervisor Lifecycle", func() {
 
 				s := newSupervisorWithWorker(&mockWorker{initialState: initialState}, store, supervisor.CollectorHealthConfig{})
 
-				Expect(func() {
-					_ = s.TestTick(context.Background())
-				}).To(Panic())
+				err := s.TestTick(context.Background())
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("tick panic"))
 			})
 		})
 	})

--- a/umh-core/pkg/fsmv2/supervisor/metrics/metrics.go
+++ b/umh-core/pkg/fsmv2/supervisor/metrics/metrics.go
@@ -285,6 +285,46 @@ var (
 		},
 		[]string{"hierarchy_path", "changed"},
 	)
+
+	panicRecoveryTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "panic_recovery_total",
+			Help:      "Total number of panic recoveries in FSMv2 goroutines (tick loop, collector, etc.)",
+		},
+		[]string{"hierarchy_path", "panic_type"},
+	)
+
+	childShutdownTimeoutTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "child_shutdown_timeout_total",
+			Help:      "Total number of child supervisor shutdown timeouts",
+		},
+		[]string{"hierarchy_path", "child_name"},
+	)
+
+	stuckActionDetectedTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "stuck_action_detected_total",
+			Help:      "Total number of stuck action detections (action running > 2x timeout)",
+		},
+		[]string{"hierarchy_path", "action_name"},
+	)
+
+	stuckActionForceRemovedTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "stuck_action_force_removed_total",
+			Help:      "Total number of stuck actions force-removed from in-progress tracking (action running > 3x timeout)",
+		},
+		[]string{"hierarchy_path", "action_name"},
+	)
 )
 
 // RecordCircuitOpen records circuit breaker state.
@@ -403,6 +443,26 @@ func RecordStateDuration(hierarchyPath, state string, duration time.Duration) {
 // CleanupStateDuration removes state duration metric for a worker.
 func CleanupStateDuration(hierarchyPath, state string) {
 	stateDurationSeconds.DeleteLabelValues(hierarchyPath, state)
+}
+
+// RecordPanicRecovery records a panic recovery event in a supervisor goroutine.
+func RecordPanicRecovery(hierarchyPath, panicType string) {
+	panicRecoveryTotal.WithLabelValues(hierarchyPath, panicType).Inc()
+}
+
+// RecordChildShutdownTimeout records a child supervisor shutdown timeout event.
+func RecordChildShutdownTimeout(hierarchyPath, childName string) {
+	childShutdownTimeoutTotal.WithLabelValues(hierarchyPath, childName).Inc()
+}
+
+// RecordStuckActionDetected records detection of a stuck action (running > 2x timeout).
+func RecordStuckActionDetected(hierarchyPath, actionName string) {
+	stuckActionDetectedTotal.WithLabelValues(hierarchyPath, actionName).Inc()
+}
+
+// RecordStuckActionForceRemoved records force-removal of a stuck action (running > 3x timeout).
+func RecordStuckActionForceRemoved(hierarchyPath, actionName string) {
+	stuckActionForceRemovedTotal.WithLabelValues(hierarchyPath, actionName).Inc()
 }
 
 // WorkerMetricsExporter exports worker-specific metrics from ObservedState to Prometheus.

--- a/umh-core/pkg/fsmv2/supervisor/metrics/metrics.go
+++ b/umh-core/pkg/fsmv2/supervisor/metrics/metrics.go
@@ -325,6 +325,19 @@ var (
 		},
 		[]string{"hierarchy_path", "action_name"},
 	)
+
+	// stuckActionLeakedGoroutines tracks goroutines that continue running after force-removal.
+	// Force-removing a stuck action removes it from tracking but cannot cancel the goroutine
+	// (the context.WithTimeout has already expired). This gauge helps operators detect accumulating leaks.
+	stuckActionLeakedGoroutines = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "stuck_action_leaked_goroutines",
+			Help:      "Estimated goroutines leaked from force-removed stuck actions (cannot be cancelled after timeout expiry)",
+		},
+		[]string{"hierarchy_path"},
+	)
 )
 
 // RecordCircuitOpen records circuit breaker state.
@@ -463,6 +476,7 @@ func RecordStuckActionDetected(hierarchyPath, actionName string) {
 // RecordStuckActionForceRemoved records force-removal of a stuck action (running > 3x timeout).
 func RecordStuckActionForceRemoved(hierarchyPath, actionName string) {
 	stuckActionForceRemovedTotal.WithLabelValues(hierarchyPath, actionName).Inc()
+	stuckActionLeakedGoroutines.WithLabelValues(hierarchyPath).Inc()
 }
 
 // WorkerMetricsExporter exports worker-specific metrics from ObservedState to Prometheus.

--- a/umh-core/pkg/fsmv2/supervisor/panic_recovery.go
+++ b/umh-core/pkg/fsmv2/supervisor/panic_recovery.go
@@ -32,9 +32,11 @@ func newPanicRecovery(window time.Duration, maxPanics int) *panicRecovery {
 	if window <= 0 {
 		panic("panicRecovery: window must be positive")
 	}
+
 	if maxPanics <= 0 {
 		panic("panicRecovery: maxPanics must be positive")
 	}
+
 	return &panicRecovery{
 		window:    window,
 		maxPanics: maxPanics,
@@ -56,12 +58,14 @@ func (p *panicRecovery) RecordPanic() bool {
 // pruneExpired removes timestamps older than the window. Caller must hold p.mu.
 func (p *panicRecovery) pruneExpired(now time.Time) {
 	cutoff := now.Add(-p.window)
+
 	pruned := p.timestamps[:0]
 	for _, ts := range p.timestamps {
 		if ts.After(cutoff) {
 			pruned = append(pruned, ts)
 		}
 	}
+
 	p.timestamps = pruned
 }
 
@@ -69,11 +73,13 @@ func (p *panicRecovery) pruneExpired(now time.Time) {
 func (p *panicRecovery) countWithinWindow() int {
 	cutoff := time.Now().Add(-p.window)
 	count := 0
+
 	for _, ts := range p.timestamps {
 		if ts.After(cutoff) {
 			count++
 		}
 	}
+
 	return count
 }
 

--- a/umh-core/pkg/fsmv2/supervisor/panic_recovery.go
+++ b/umh-core/pkg/fsmv2/supervisor/panic_recovery.go
@@ -15,10 +15,10 @@
 package supervisor
 
 import (
-	"errors"
-	"fmt"
 	"sync"
 	"time"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/supervisor/internal/panicutil"
 )
 
 type panicRecovery struct {
@@ -91,16 +91,7 @@ func (p *panicRecovery) Reset() {
 	p.timestamps = nil
 }
 
-// classifyPanic converts a recovered panic value into a typed error and a classification string.
-// Used by the tick() panic recovery handler. The collector has a local copy
-// (internal/collection/collector.go) due to circular import constraints.
+// classifyPanic delegates to the shared panicutil.ClassifyPanic implementation.
 func classifyPanic(r interface{}) (panicType string, panicErr error) {
-	switch v := r.(type) {
-	case error:
-		return "error", v
-	case string:
-		return "string", errors.New(v)
-	default:
-		return "unknown", fmt.Errorf("%v", r)
-	}
+	return panicutil.ClassifyPanic(r)
 }

--- a/umh-core/pkg/fsmv2/supervisor/panic_recovery.go
+++ b/umh-core/pkg/fsmv2/supervisor/panic_recovery.go
@@ -15,6 +15,8 @@
 package supervisor
 
 import (
+	"errors"
+	"fmt"
 	"sync"
 	"time"
 )
@@ -80,4 +82,18 @@ func (p *panicRecovery) Reset() {
 	defer p.mu.Unlock()
 
 	p.timestamps = nil
+}
+
+// classifyPanic converts a recovered panic value into a typed error and a classification string.
+// Used by the tick() panic recovery handler. The collector has a local copy
+// (internal/collection/collector.go) due to circular import constraints.
+func classifyPanic(r interface{}) (panicType string, panicErr error) {
+	switch v := r.(type) {
+	case error:
+		return "error", v
+	case string:
+		return "string", errors.New(v)
+	default:
+		return "unknown", fmt.Errorf("%v", r)
+	}
 }

--- a/umh-core/pkg/fsmv2/supervisor/panic_recovery.go
+++ b/umh-core/pkg/fsmv2/supervisor/panic_recovery.go
@@ -48,7 +48,13 @@ func (p *panicRecovery) RecordPanic() bool {
 
 	now := time.Now()
 	p.timestamps = append(p.timestamps, now)
+	p.pruneExpired(now)
 
+	return len(p.timestamps) >= p.maxPanics
+}
+
+// pruneExpired removes timestamps older than the window. Caller must hold p.mu.
+func (p *panicRecovery) pruneExpired(now time.Time) {
 	cutoff := now.Add(-p.window)
 	pruned := p.timestamps[:0]
 	for _, ts := range p.timestamps {
@@ -57,24 +63,25 @@ func (p *panicRecovery) RecordPanic() bool {
 		}
 	}
 	p.timestamps = pruned
-
-	return len(p.timestamps) >= p.maxPanics
 }
 
-func (p *panicRecovery) PanicCount() int {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-
-	now := time.Now()
-	cutoff := now.Add(-p.window)
+// countWithinWindow returns the number of timestamps within the window. Caller must hold p.mu.
+func (p *panicRecovery) countWithinWindow() int {
+	cutoff := time.Now().Add(-p.window)
 	count := 0
 	for _, ts := range p.timestamps {
 		if ts.After(cutoff) {
 			count++
 		}
 	}
-
 	return count
+}
+
+func (p *panicRecovery) PanicCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	return p.countWithinWindow()
 }
 
 func (p *panicRecovery) Reset() {

--- a/umh-core/pkg/fsmv2/supervisor/panic_recovery.go
+++ b/umh-core/pkg/fsmv2/supervisor/panic_recovery.go
@@ -1,0 +1,83 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package supervisor
+
+import (
+	"sync"
+	"time"
+)
+
+type panicRecovery struct {
+	timestamps []time.Time
+	window     time.Duration
+	maxPanics  int
+	mu         sync.Mutex
+}
+
+func newPanicRecovery(window time.Duration, maxPanics int) *panicRecovery {
+	if window <= 0 {
+		panic("panicRecovery: window must be positive")
+	}
+	if maxPanics <= 0 {
+		panic("panicRecovery: maxPanics must be positive")
+	}
+	return &panicRecovery{
+		window:    window,
+		maxPanics: maxPanics,
+	}
+}
+
+// RecordPanic records a panic event and returns true if the escalation threshold has been reached.
+func (p *panicRecovery) RecordPanic() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	now := time.Now()
+	p.timestamps = append(p.timestamps, now)
+
+	cutoff := now.Add(-p.window)
+	pruned := p.timestamps[:0]
+	for _, ts := range p.timestamps {
+		if ts.After(cutoff) {
+			pruned = append(pruned, ts)
+		}
+	}
+	p.timestamps = pruned
+
+	return len(p.timestamps) >= p.maxPanics
+}
+
+func (p *panicRecovery) PanicCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	now := time.Now()
+	cutoff := now.Add(-p.window)
+	count := 0
+	for _, ts := range p.timestamps {
+		if ts.After(cutoff) {
+			count++
+		}
+	}
+
+	return count
+}
+
+func (p *panicRecovery) Reset() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.timestamps = nil
+}

--- a/umh-core/pkg/fsmv2/supervisor/panic_recovery.go
+++ b/umh-core/pkg/fsmv2/supervisor/panic_recovery.go
@@ -17,8 +17,6 @@ package supervisor
 import (
 	"sync"
 	"time"
-
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/supervisor/internal/panicutil"
 )
 
 type panicRecovery struct {
@@ -69,25 +67,13 @@ func (p *panicRecovery) pruneExpired(now time.Time) {
 	p.timestamps = pruned
 }
 
-// countWithinWindow returns the number of timestamps within the window. Caller must hold p.mu.
-func (p *panicRecovery) countWithinWindow() int {
-	cutoff := time.Now().Add(-p.window)
-	count := 0
-
-	for _, ts := range p.timestamps {
-		if ts.After(cutoff) {
-			count++
-		}
-	}
-
-	return count
-}
-
 func (p *panicRecovery) PanicCount() int {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	return p.countWithinWindow()
+	p.pruneExpired(time.Now())
+
+	return len(p.timestamps)
 }
 
 func (p *panicRecovery) Reset() {
@@ -97,7 +83,3 @@ func (p *panicRecovery) Reset() {
 	p.timestamps = nil
 }
 
-// classifyPanic delegates to the shared panicutil.ClassifyPanic implementation.
-func classifyPanic(r interface{}) (panicType string, panicErr error) {
-	return panicutil.ClassifyPanic(r)
-}

--- a/umh-core/pkg/fsmv2/supervisor/panic_recovery_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/panic_recovery_test.go
@@ -1,0 +1,509 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package supervisor_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/config"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/supervisor"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/supervisor/testutil"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+var _ = Describe("Tick Loop Panic Recovery", func() {
+	Describe("when tick() panics", func() {
+		Context("with a panicking worker state machine", func() {
+			It("should recover from panic and log the error", func() {
+				observedLogs, logger := createObservedLogger()
+
+				store := supervisor.CreateTestTriangularStore()
+
+				s := supervisor.NewSupervisor[*supervisor.TestObservedState, *supervisor.TestDesiredState](supervisor.Config{
+					WorkerType:              "test",
+					Store:                   store,
+					Logger:                  logger,
+					TickInterval:            50 * time.Millisecond,
+					GracefulShutdownTimeout: 100 * time.Millisecond,
+				})
+
+				identity := supervisor.TestIdentity()
+				worker := &panickingWorker{
+					panicOnTick:  true,
+					panicMessage: "simulated tick panic for testing",
+				}
+				err := s.AddWorker(identity, worker)
+				Expect(err).ToNot(HaveOccurred())
+				defer s.Shutdown()
+
+				ctx := context.Background()
+
+				// This should NOT panic (supervisor should recover) and return an error
+				err = s.TestTick(ctx)
+
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("tick panic"))
+
+				// Verify panic was logged with ErrorFields pattern
+				panicLogs := filterLogs(observedLogs, "tick_panic")
+				Expect(panicLogs).ToNot(BeEmpty(), "Expected tick_panic log entry")
+
+				panicLog := panicLogs[0]
+				Expect(panicLog.ContextMap()).To(HaveKey("error"))
+				Expect(panicLog.ContextMap()).To(HaveKey("stack_trace"))
+				Expect(panicLog.ContextMap()).To(HaveKey("feature"))
+				Expect(panicLog.ContextMap()["feature"]).To(Equal("reconciliation"))
+			})
+
+			It("should continue operating after recovering from panic", func() {
+				_, logger := createObservedLogger()
+
+				store := supervisor.CreateTestTriangularStore()
+
+				s := supervisor.NewSupervisor[*supervisor.TestObservedState, *supervisor.TestDesiredState](supervisor.Config{
+					WorkerType:              "test",
+					Store:                   store,
+					Logger:                  logger,
+					TickInterval:            50 * time.Millisecond,
+					GracefulShutdownTimeout: 100 * time.Millisecond,
+				})
+
+				identity := supervisor.TestIdentity()
+				worker := &panickingWorker{
+					panicOnTick:   true,
+					panicMessage:  "simulated tick panic",
+					panicOnlyOnce: true,
+				}
+				err := s.AddWorker(identity, worker)
+				Expect(err).ToNot(HaveOccurred())
+				defer s.Shutdown()
+
+				ctx := context.Background()
+
+				// First tick panics
+				err = s.TestTick(ctx)
+				Expect(err).To(HaveOccurred())
+
+				// Second tick should succeed (worker no longer panics)
+				err = s.TestTick(ctx)
+				Expect(err).ToNot(HaveOccurred(), "Second tick should succeed after panic recovery")
+			})
+
+			It("should log panic_type as 'string' for string panics", func() {
+				observedLogs, logger := createObservedLogger()
+
+				store := supervisor.CreateTestTriangularStore()
+
+				s := supervisor.NewSupervisor[*supervisor.TestObservedState, *supervisor.TestDesiredState](supervisor.Config{
+					WorkerType:              "test",
+					Store:                   store,
+					Logger:                  logger,
+					TickInterval:            50 * time.Millisecond,
+					GracefulShutdownTimeout: 100 * time.Millisecond,
+				})
+
+				identity := supervisor.TestIdentity()
+				worker := &panickingWorker{
+					panicOnTick:  true,
+					panicMessage: "string panic message",
+				}
+				err := s.AddWorker(identity, worker)
+				Expect(err).ToNot(HaveOccurred())
+				defer s.Shutdown()
+
+				err = s.TestTick(context.Background())
+				Expect(err).To(HaveOccurred())
+
+				panicLogs := filterLogs(observedLogs, "tick_panic")
+				Expect(panicLogs).ToNot(BeEmpty())
+				Expect(panicLogs[0].ContextMap()["panic_type"]).To(Equal("string"))
+			})
+
+			It("should log panic_type as 'error' and preserve error chain for error panics", func() {
+				observedLogs, logger := createObservedLogger()
+
+				store := supervisor.CreateTestTriangularStore()
+
+				s := supervisor.NewSupervisor[*supervisor.TestObservedState, *supervisor.TestDesiredState](supervisor.Config{
+					WorkerType:              "test",
+					Store:                   store,
+					Logger:                  logger,
+					TickInterval:            50 * time.Millisecond,
+					GracefulShutdownTimeout: 100 * time.Millisecond,
+				})
+
+				identity := supervisor.TestIdentity()
+				testErr := errors.New("wrapped error for testing")
+				worker := &panickingWorker{
+					panicOnTick:         true,
+					panicValue:          testErr,
+					useCustomPanicValue: true,
+				}
+				err := s.AddWorker(identity, worker)
+				Expect(err).ToNot(HaveOccurred())
+				defer s.Shutdown()
+
+				err = s.TestTick(context.Background())
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("tick panic"))
+				Expect(err.Error()).To(ContainSubstring("wrapped error for testing"))
+
+				// Verify error chain is preserved
+				Expect(errors.Is(err, testErr)).To(BeTrue(), "Error chain should be preserved")
+
+				panicLogs := filterLogs(observedLogs, "tick_panic")
+				Expect(panicLogs).ToNot(BeEmpty())
+				Expect(panicLogs[0].ContextMap()["panic_type"]).To(Equal("error"))
+			})
+
+			It("should handle panic(nil) gracefully", func() {
+				observedLogs, logger := createObservedLogger()
+
+				store := supervisor.CreateTestTriangularStore()
+
+				s := supervisor.NewSupervisor[*supervisor.TestObservedState, *supervisor.TestDesiredState](supervisor.Config{
+					WorkerType:              "test",
+					Store:                   store,
+					Logger:                  logger,
+					TickInterval:            50 * time.Millisecond,
+					GracefulShutdownTimeout: 100 * time.Millisecond,
+				})
+
+				identity := supervisor.TestIdentity()
+				worker := &panickingWorker{
+					panicOnTick:         true,
+					panicValue:          nil,
+					useCustomPanicValue: true,
+				}
+				err := s.AddWorker(identity, worker)
+				Expect(err).ToNot(HaveOccurred())
+				defer s.Shutdown()
+
+				err = s.TestTick(context.Background())
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("tick panic"))
+
+				panicLogs := filterLogs(observedLogs, "tick_panic")
+				Expect(panicLogs).ToNot(BeEmpty())
+				// In Go 1.21+, panic(nil) creates *runtime.PanicNilError which is an error type
+				Expect(panicLogs[0].ContextMap()["panic_type"]).To(Equal("error"))
+			})
+
+			It("should log panic_type as 'unknown' for non-error non-string panics", func() {
+				observedLogs, logger := createObservedLogger()
+
+				store := supervisor.CreateTestTriangularStore()
+
+				s := supervisor.NewSupervisor[*supervisor.TestObservedState, *supervisor.TestDesiredState](supervisor.Config{
+					WorkerType:              "test",
+					Store:                   store,
+					Logger:                  logger,
+					TickInterval:            50 * time.Millisecond,
+					GracefulShutdownTimeout: 100 * time.Millisecond,
+				})
+
+				identity := supervisor.TestIdentity()
+				worker := &panickingWorker{
+					panicOnTick:         true,
+					panicValue:          42,
+					useCustomPanicValue: true,
+				}
+				err := s.AddWorker(identity, worker)
+				Expect(err).ToNot(HaveOccurred())
+				defer s.Shutdown()
+
+				err = s.TestTick(context.Background())
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("tick panic"))
+				Expect(err.Error()).To(ContainSubstring("42"))
+
+				panicLogs := filterLogs(observedLogs, "tick_panic")
+				Expect(panicLogs).ToNot(BeEmpty())
+				Expect(panicLogs[0].ContextMap()["panic_type"]).To(Equal("unknown"))
+			})
+		})
+	})
+})
+
+var _ = Describe("Panic Recovery Unit Tests", func() {
+	Describe("panicRecovery sliding window", func() {
+		It("should not reach threshold after a single panic", func() {
+			tracker := supervisor.NewTestPanicRecoveryTracker(5*time.Minute, 3)
+
+			shouldEscalate := tracker.RecordPanic()
+			Expect(shouldEscalate).To(BeFalse())
+			Expect(tracker.PanicCount()).To(Equal(1))
+		})
+
+		It("should reach threshold after maxPanics within window", func() {
+			tracker := supervisor.NewTestPanicRecoveryTracker(5*time.Minute, 3)
+
+			Expect(tracker.RecordPanic()).To(BeFalse())
+			Expect(tracker.RecordPanic()).To(BeFalse())
+			shouldEscalate := tracker.RecordPanic()
+			Expect(shouldEscalate).To(BeTrue())
+			Expect(tracker.PanicCount()).To(Equal(3))
+		})
+
+		It("should prune panics outside the window", func() {
+			tracker := supervisor.NewTestPanicRecoveryTracker(100*time.Millisecond, 3)
+
+			tracker.RecordPanic()
+			tracker.RecordPanic()
+			Expect(tracker.PanicCount()).To(Equal(2))
+
+			time.Sleep(150 * time.Millisecond)
+
+			Expect(tracker.PanicCount()).To(Equal(0))
+
+			Expect(tracker.RecordPanic()).To(BeFalse())
+			Expect(tracker.PanicCount()).To(Equal(1))
+		})
+
+		It("should reset all recorded panics", func() {
+			tracker := supervisor.NewTestPanicRecoveryTracker(5*time.Minute, 3)
+
+			tracker.RecordPanic()
+			tracker.RecordPanic()
+			Expect(tracker.PanicCount()).To(Equal(2))
+
+			tracker.Reset()
+			Expect(tracker.PanicCount()).To(Equal(0))
+		})
+	})
+})
+
+var _ = Describe("Panic Escalation", func() {
+	Describe("tick panic circuit breaker", func() {
+		It("should not open circuit after a single panic", func() {
+			_, logger := createObservedLogger()
+			store := supervisor.CreateTestTriangularStore()
+
+			s := supervisor.NewSupervisor[*supervisor.TestObservedState, *supervisor.TestDesiredState](supervisor.Config{
+				WorkerType:              "test",
+				Store:                   store,
+				Logger:                  logger,
+				TickInterval:            50 * time.Millisecond,
+				GracefulShutdownTimeout: 100 * time.Millisecond,
+			})
+
+			identity := supervisor.TestIdentity()
+			worker := &panickingWorker{
+				panicOnTick:  true,
+				panicMessage: "escalation test panic",
+			}
+			err := s.AddWorker(identity, worker)
+			Expect(err).ToNot(HaveOccurred())
+			defer s.Shutdown()
+
+			ctx := context.Background()
+
+			err = s.TestTick(ctx)
+			Expect(err).To(HaveOccurred())
+
+			Expect(s.TestIsPanicCircuitOpen()).To(BeFalse(), "Single panic should not open circuit")
+		})
+
+		It("should open circuit after 3 panics within window", func() {
+			observedLogs, logger := createObservedLogger()
+			store := supervisor.CreateTestTriangularStore()
+
+			s := supervisor.NewSupervisor[*supervisor.TestObservedState, *supervisor.TestDesiredState](supervisor.Config{
+				WorkerType:              "test",
+				Store:                   store,
+				Logger:                  logger,
+				TickInterval:            50 * time.Millisecond,
+				GracefulShutdownTimeout: 100 * time.Millisecond,
+			})
+
+			identity := supervisor.TestIdentity()
+			worker := &panickingWorker{
+				panicOnTick:  true,
+				panicMessage: "escalation test panic",
+			}
+			err := s.AddWorker(identity, worker)
+			Expect(err).ToNot(HaveOccurred())
+			defer s.Shutdown()
+
+			ctx := context.Background()
+
+			for i := 0; i < 3; i++ {
+				err = s.TestTick(ctx)
+				Expect(err).To(HaveOccurred())
+			}
+
+			Expect(s.TestIsPanicCircuitOpen()).To(BeTrue(), "3 panics should open panic circuit")
+
+			circuitLogs := filterLogs(observedLogs, "panic_circuit_open")
+			Expect(circuitLogs).ToNot(BeEmpty(), "Expected panic_circuit_open log entry")
+			circuitLog := circuitLogs[0]
+			Expect(circuitLog.ContextMap()["feature"]).To(Equal("reconciliation"))
+			Expect(circuitLog.ContextMap()["panic_count"]).To(BeEquivalentTo(3))
+		})
+
+		It("should skip tick processing when panic circuit is open", func() {
+			_, logger := createObservedLogger()
+			store := supervisor.CreateTestTriangularStore()
+
+			s := supervisor.NewSupervisor[*supervisor.TestObservedState, *supervisor.TestDesiredState](supervisor.Config{
+				WorkerType:              "test",
+				Store:                   store,
+				Logger:                  logger,
+				TickInterval:            50 * time.Millisecond,
+				GracefulShutdownTimeout: 100 * time.Millisecond,
+			})
+
+			identity := supervisor.TestIdentity()
+			worker := &panickingWorker{
+				panicOnTick:  true,
+				panicMessage: "escalation test panic",
+			}
+			err := s.AddWorker(identity, worker)
+			Expect(err).ToNot(HaveOccurred())
+			defer s.Shutdown()
+
+			ctx := context.Background()
+
+			// Trigger 3 panics to open the circuit
+			for i := 0; i < 3; i++ {
+				err = s.TestTick(ctx)
+				Expect(err).To(HaveOccurred())
+			}
+
+			Expect(s.TestIsPanicCircuitOpen()).To(BeTrue())
+
+			// 4th tick should be skipped (no panic, no error)
+			err = s.TestTick(ctx)
+			Expect(err).ToNot(HaveOccurred(), "Tick should be skipped when panic circuit is open")
+		})
+
+		It("should report panic circuit via IsCircuitOpen()", func() {
+			_, logger := createObservedLogger()
+			store := supervisor.CreateTestTriangularStore()
+
+			s := supervisor.NewSupervisor[*supervisor.TestObservedState, *supervisor.TestDesiredState](supervisor.Config{
+				WorkerType:              "test",
+				Store:                   store,
+				Logger:                  logger,
+				TickInterval:            50 * time.Millisecond,
+				GracefulShutdownTimeout: 100 * time.Millisecond,
+			})
+
+			identity := supervisor.TestIdentity()
+			worker := &panickingWorker{
+				panicOnTick:  true,
+				panicMessage: "escalation test panic",
+			}
+			err := s.AddWorker(identity, worker)
+			Expect(err).ToNot(HaveOccurred())
+			defer s.Shutdown()
+
+			ctx := context.Background()
+
+			Expect(s.IsCircuitOpen()).To(BeFalse())
+
+			// Trigger 3 panics to open circuit
+			for i := 0; i < 3; i++ {
+				err = s.TestTick(ctx)
+				Expect(err).To(HaveOccurred())
+			}
+
+			Expect(s.IsCircuitOpen()).To(BeTrue(), "IsCircuitOpen should reflect panic circuit state")
+		})
+	})
+})
+
+// panickingWorker is a test worker that panics during state machine execution.
+// This simulates a bug in a worker's state machine that causes a panic.
+type panickingWorker struct {
+	panicOnTick         bool
+	panicMessage        string
+	panicValue          any
+	useCustomPanicValue bool
+	panicOnlyOnce       bool
+	panicTriggered      bool
+}
+
+func (w *panickingWorker) CollectObservedState(ctx context.Context) (fsmv2.ObservedState, error) {
+	return &testutil.ObservedState{
+		ID:          "panic-worker",
+		CollectedAt: time.Now(),
+		Desired:     &testutil.DesiredState{},
+	}, nil
+}
+
+func (w *panickingWorker) DeriveDesiredState(spec interface{}) (fsmv2.DesiredState, error) {
+	return &config.DesiredState{BaseDesiredState: config.BaseDesiredState{State: "running"}}, nil
+}
+
+func (w *panickingWorker) GetInitialState() fsmv2.State[any, any] {
+	return &panickingState{worker: w}
+}
+
+// panickingState is a state that panics when Next() is called.
+type panickingState struct {
+	worker *panickingWorker
+}
+
+func (s *panickingState) Next(snapshot any) fsmv2.NextResult[any, any] {
+	if s.worker.panicOnTick {
+		if s.worker.panicOnlyOnce && s.worker.panicTriggered {
+			return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil, "staying in state")
+		}
+
+		s.worker.panicTriggered = true
+
+		if s.worker.useCustomPanicValue {
+			panic(s.worker.panicValue)
+		}
+
+		panic(s.worker.panicMessage)
+	}
+
+	return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil, "staying in state")
+}
+
+func (s *panickingState) String() string { return "PanickingState" }
+
+func (s *panickingState) LifecyclePhase() config.LifecyclePhase { return config.PhaseRunningHealthy }
+
+func createObservedLogger() (*observer.ObservedLogs, deps.FSMLogger) {
+	core, logs := observer.New(zapcore.DebugLevel)
+	logger := deps.NewFSMLogger(zap.New(core).Sugar())
+
+	return logs, logger
+}
+
+func filterLogs(logs *observer.ObservedLogs, message string) []observer.LoggedEntry {
+	var filtered []observer.LoggedEntry
+
+	for _, entry := range logs.All() {
+		if strings.Contains(entry.Message, message) {
+			filtered = append(filtered, entry)
+		}
+	}
+
+	return filtered
+}

--- a/umh-core/pkg/fsmv2/supervisor/panic_recovery_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/panic_recovery_test.go
@@ -349,7 +349,7 @@ var _ = Describe("Panic Escalation", func() {
 
 			ctx := context.Background()
 
-			for i := 0; i < 3; i++ {
+			for range 3 {
 				err = s.TestTick(ctx)
 				Expect(err).To(HaveOccurred())
 			}
@@ -387,7 +387,7 @@ var _ = Describe("Panic Escalation", func() {
 			ctx := context.Background()
 
 			// Trigger 3 panics to open the circuit
-			for i := 0; i < 3; i++ {
+			for range 3 {
 				err = s.TestTick(ctx)
 				Expect(err).To(HaveOccurred())
 			}
@@ -425,7 +425,7 @@ var _ = Describe("Panic Escalation", func() {
 			Expect(s.IsCircuitOpen()).To(BeFalse())
 
 			// Trigger 3 panics to open circuit
-			for i := 0; i < 3; i++ {
+			for range 3 {
 				err = s.TestTick(ctx)
 				Expect(err).To(HaveOccurred())
 			}

--- a/umh-core/pkg/fsmv2/supervisor/panic_recovery_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/panic_recovery_test.go
@@ -74,7 +74,7 @@ var _ = Describe("Tick Loop Panic Recovery", func() {
 				Expect(panicLog.ContextMap()).To(HaveKey("error"))
 				Expect(panicLog.ContextMap()).To(HaveKey("stack_trace"))
 				Expect(panicLog.ContextMap()).To(HaveKey("feature"))
-				Expect(panicLog.ContextMap()["feature"]).To(Equal("reconciliation"))
+				Expect(panicLog.ContextMap()["feature"]).To(Equal("fsmv2"))
 			})
 
 			It("should continue operating after recovering from panic", func() {
@@ -359,7 +359,7 @@ var _ = Describe("Panic Escalation", func() {
 			circuitLogs := filterLogs(observedLogs, "panic_circuit_open")
 			Expect(circuitLogs).ToNot(BeEmpty(), "Expected panic_circuit_open log entry")
 			circuitLog := circuitLogs[0]
-			Expect(circuitLog.ContextMap()["feature"]).To(Equal("reconciliation"))
+			Expect(circuitLog.ContextMap()["feature"]).To(Equal("fsmv2"))
 			Expect(circuitLog.ContextMap()["panic_count"]).To(BeEquivalentTo(3))
 		})
 
@@ -434,6 +434,71 @@ var _ = Describe("Panic Escalation", func() {
 		})
 	})
 })
+
+var _ = Describe("Tick Double Panic", func() {
+	It("should recover when the recovery handler itself panics", func() {
+		logger := &panicOnSentryErrorLogger{}
+
+		store := supervisor.CreateTestTriangularStore()
+
+		s := supervisor.NewSupervisor[*supervisor.TestObservedState, *supervisor.TestDesiredState](supervisor.Config{
+			WorkerType:              "test",
+			Store:                   store,
+			Logger:                  logger,
+			TickInterval:            50 * time.Millisecond,
+			GracefulShutdownTimeout: 100 * time.Millisecond,
+		})
+
+		identity := supervisor.TestIdentity()
+		worker := &panickingWorker{
+			panicOnTick:  true,
+			panicMessage: "trigger double panic",
+		}
+		err := s.AddWorker(identity, worker)
+		Expect(err).ToNot(HaveOccurred())
+		defer s.Shutdown()
+
+		err = s.TestTick(context.Background())
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("recovery handler also panicked"))
+		Expect(s.TestIsPanicCircuitOpen()).To(BeTrue(), "Double panic should open panic circuit")
+	})
+})
+
+var _ = Describe("IsCircuitOpen Infra Path", func() {
+	It("should return true when infrastructure circuit is open", func() {
+		_, logger := createObservedLogger()
+		store := supervisor.CreateTestTriangularStore()
+
+		s := supervisor.NewSupervisor[*supervisor.TestObservedState, *supervisor.TestDesiredState](supervisor.Config{
+			WorkerType:              "test",
+			Store:                   store,
+			Logger:                  logger,
+			TickInterval:            50 * time.Millisecond,
+			GracefulShutdownTimeout: 100 * time.Millisecond,
+		})
+
+		Expect(s.IsCircuitOpen()).To(BeFalse())
+
+		s.TestSetCircuitOpen(true)
+		Expect(s.IsCircuitOpen()).To(BeTrue(), "IsCircuitOpen should reflect infra circuit state")
+		Expect(s.TestIsPanicCircuitOpen()).To(BeFalse(), "Panic circuit should remain closed")
+
+		s.TestSetCircuitOpen(false)
+		Expect(s.IsCircuitOpen()).To(BeFalse())
+	})
+})
+
+// panicOnSentryErrorLogger panics when SentryError is called, used to test double-panic recovery.
+type panicOnSentryErrorLogger struct{}
+
+func (p *panicOnSentryErrorLogger) Debug(msg string, fields ...deps.Field)                         {}
+func (p *panicOnSentryErrorLogger) Info(msg string, fields ...deps.Field)                          {}
+func (p *panicOnSentryErrorLogger) SentryWarn(_ deps.Feature, _ string, _ string, _ ...deps.Field) {}
+func (p *panicOnSentryErrorLogger) SentryError(_ deps.Feature, _ string, _ error, _ string, _ ...deps.Field) {
+	panic("logger SentryError panicked")
+}
+func (p *panicOnSentryErrorLogger) With(fields ...deps.Field) deps.FSMLogger { return p }
 
 // panickingWorker is a test worker that panics during state machine execution.
 // This simulates a bug in a worker's state machine that causes a panic.

--- a/umh-core/pkg/fsmv2/supervisor/panic_recovery_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/panic_recovery_test.go
@@ -394,9 +394,9 @@ var _ = Describe("Panic Escalation", func() {
 
 			Expect(s.TestIsPanicCircuitOpen()).To(BeTrue())
 
-			// 4th tick should be skipped (no panic, no error)
+			// 4th tick should return ErrPanicCircuitOpen (circuit is open, tick suppressed)
 			err = s.TestTick(ctx)
-			Expect(err).ToNot(HaveOccurred(), "Tick should be skipped when panic circuit is open")
+			Expect(err).To(MatchError(supervisor.ErrPanicCircuitOpen), "Tick should be suppressed when panic circuit is open")
 		})
 
 		It("should report panic circuit via IsCircuitOpen()", func() {

--- a/umh-core/pkg/fsmv2/supervisor/panic_recovery_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/panic_recovery_test.go
@@ -138,7 +138,7 @@ var _ = Describe("Tick Loop Panic Recovery", func() {
 
 				panicLogs := filterLogs(observedLogs, "tick_panic")
 				Expect(panicLogs).ToNot(BeEmpty())
-				Expect(panicLogs[0].ContextMap()["panic_type"]).To(Equal("string"))
+				Expect(panicLogs[0].ContextMap()["panic_type"]).To(Equal("string_panic"))
 			})
 
 			It("should log panic_type as 'error' and preserve error chain for error panics", func() {
@@ -175,7 +175,7 @@ var _ = Describe("Tick Loop Panic Recovery", func() {
 
 				panicLogs := filterLogs(observedLogs, "tick_panic")
 				Expect(panicLogs).ToNot(BeEmpty())
-				Expect(panicLogs[0].ContextMap()["panic_type"]).To(Equal("error"))
+				Expect(panicLogs[0].ContextMap()["panic_type"]).To(Equal("error_panic"))
 			})
 
 			It("should handle panic(nil) gracefully", func() {
@@ -208,7 +208,7 @@ var _ = Describe("Tick Loop Panic Recovery", func() {
 				panicLogs := filterLogs(observedLogs, "tick_panic")
 				Expect(panicLogs).ToNot(BeEmpty())
 				// In Go 1.21+, panic(nil) creates *runtime.PanicNilError which is an error type
-				Expect(panicLogs[0].ContextMap()["panic_type"]).To(Equal("error"))
+				Expect(panicLogs[0].ContextMap()["panic_type"]).To(Equal("error_panic"))
 			})
 
 			It("should log panic_type as 'unknown' for non-error non-string panics", func() {
@@ -241,7 +241,7 @@ var _ = Describe("Tick Loop Panic Recovery", func() {
 
 				panicLogs := filterLogs(observedLogs, "tick_panic")
 				Expect(panicLogs).ToNot(BeEmpty())
-				Expect(panicLogs[0].ContextMap()["panic_type"]).To(Equal("unknown"))
+				Expect(panicLogs[0].ContextMap()["panic_type"]).To(Equal("unknown_panic"))
 			})
 		})
 	})

--- a/umh-core/pkg/fsmv2/supervisor/reconciliation.go
+++ b/umh-core/pkg/fsmv2/supervisor/reconciliation.go
@@ -35,8 +35,12 @@ import (
 
 // ErrPanicCircuitOpen is returned when the tick is suppressed because the panic circuit breaker is open.
 // Returning an error (instead of nil) ensures the supervisor knows the worker is unhealthy
-// and continues ticking it, allowing the circuit breaker to auto-reset after the cooling period.
+// and continues ticking it, allowing the circuit breaker to auto-reset once the sliding window
+// of recent panics drains (panics older than the window are forgotten).
 var ErrPanicCircuitOpen = errors.New("panic circuit breaker open")
+
+// ErrInfraCircuitOpen is returned when the tick is suppressed because the infrastructure circuit breaker is open.
+var ErrInfraCircuitOpen = errors.New("infrastructure circuit breaker open")
 
 // factoryRegistryAdapter provides an adapter for config validation.
 type factoryRegistryAdapter struct{}
@@ -545,6 +549,7 @@ func (s *Supervisor[TObserved, TDesired]) tick(ctx context.Context) (err error) 
 		}
 	}()
 
+	// tick() is called from a single goroutine (tickLoop or parent's tick). No concurrent ticks occur.
 	if s.panicCircuitOpen.Load() {
 		if s.panicTracker.PanicCount() == 0 {
 			s.panicCircuitOpen.Store(false)
@@ -627,7 +632,7 @@ func (s *Supervisor[TObserved, TDesired]) tick(ctx context.Context) (err error) 
 			}
 		}
 
-		return nil
+		return ErrInfraCircuitOpen
 	}
 
 	if s.circuitOpen.Load() {
@@ -1044,7 +1049,12 @@ func (s *Supervisor[TObserved, TDesired]) processSignal(ctx context.Context, wor
 		// Capture terminal state (e.g., "Stopped") before shutdown
 		if workerCtx.collector.IsRunning() {
 			collectCtx, cancel := context.WithTimeout(ctx, s.collectorHealth.observationTimeout)
-			_ = workerCtx.collector.CollectFinalObservation(collectCtx)
+
+			if err := workerCtx.collector.CollectFinalObservation(collectCtx); err != nil {
+				s.logger.Debug("final_observation_failed",
+					deps.Err(err),
+					deps.HierarchyPath(workerCtx.identity.HierarchyPath))
+			}
 
 			cancel()
 		}

--- a/umh-core/pkg/fsmv2/supervisor/reconciliation.go
+++ b/umh-core/pkg/fsmv2/supervisor/reconciliation.go
@@ -334,10 +334,6 @@ func (s *Supervisor[TObserved, TDesired]) tickWorker(ctx context.Context, worker
 		return nil
 	}
 
-	// NOTE: FrameworkMetrics injection is now handled automatically by the Collector
-	// via FrameworkMetricsProvider callback. See collector.go collectAndSaveObservedState().
-	// The provider is set up in api.go AddWorker() when creating the CollectorConfig.
-
 	result := currentState.Next(*snapshot)
 
 	hasAction := result.Action != nil
@@ -525,29 +521,26 @@ func (s *Supervisor[TObserved, TDesired]) tickWorker(ctx context.Context, worker
 // PHASE 2: Async Action Execution
 //   - State machine evaluates transitions and enqueues actions when needed
 //   - Actions execute in global worker pool (non-blocking)
-//   - Timeouts and retries handled automatically by ActionExecutor
+//   - Timeouts enforced by ActionExecutor; retries via tick-based re-evaluation
 //
 // PERFORMANCE: The complete tick loop is non-blocking and completes in <10ms,
 // making it safe to call at high frequency (100Hz+) without impacting system performance.
 func (s *Supervisor[TObserved, TDesired]) tick(ctx context.Context) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			var panicErr error
+			defer func() {
+				if r2 := recover(); r2 != nil {
+					err = fmt.Errorf("tick panic (recovery handler also panicked: %v): %v", r2, r)
+					s.panicCircuitOpen.Store(true)
+					func() {
+						defer func() { recover() }()
+						s.logger.SentryError(deps.FeatureFSMv2, "unknown", err, "tick_double_panic",
+							deps.String("stack", string(debug.Stack())))
+					}()
+				}
+			}()
 
-			var panicType string
-
-			switch v := r.(type) {
-			case error:
-				panicErr = v
-				panicType = "error"
-			case string:
-				panicErr = errors.New(v)
-				panicType = "string"
-			default:
-				panicErr = fmt.Errorf("%v", r)
-				panicType = "unknown"
-			}
-
+			panicType, panicErr := classifyPanic(r)
 			err = fmt.Errorf("tick panic: %w", panicErr)
 
 			hierarchyPath := s.GetHierarchyPathUnlocked()
@@ -569,6 +562,8 @@ func (s *Supervisor[TObserved, TDesired]) tick(ctx context.Context) (err error) 
 	}()
 
 	if s.panicCircuitOpen.Load() {
+		s.logger.Debug("tick_suppressed_panic_circuit_open",
+			deps.HierarchyPath(s.GetHierarchyPathUnlocked()))
 		return nil
 	}
 
@@ -1037,9 +1032,6 @@ func (s *Supervisor[TObserved, TDesired]) processSignal(ctx context.Context, wor
 
 		s.mu.Unlock()
 
-		// TODO: Use context-aware RequestGracefulShutdown instead of immediate Shutdown
-		_ = ctx
-
 		for name, child := range childrenToCleanup {
 			s.logger.Debug("child_supervisor_shutdown",
 				deps.String("child_name", name),
@@ -1048,18 +1040,7 @@ func (s *Supervisor[TObserved, TDesired]) processSignal(ctx context.Context, wor
 
 			// Wait for child supervisor to fully stop (with timeout)
 			if done, exists := doneChannels[name]; exists {
-				shutdownTimer := time.NewTimer(s.childShutdownTimeout)
-				select {
-				case <-done:
-					shutdownTimer.Stop()
-				case <-shutdownTimer.C:
-					metrics.RecordChildShutdownTimeout(s.GetHierarchyPath(), name)
-
-					s.logger.SentryWarn(deps.FeatureFSMv2, s.GetHierarchyPath(), "child_shutdown_timeout",
-						deps.String("child_name", name),
-						deps.Duration("timeout", s.childShutdownTimeout),
-						deps.String("context", "worker_removal_cleanup"))
-				}
+				s.waitForChildDone(done, name, s.GetHierarchyPath(), "worker_removal_cleanup")
 			}
 
 			// Remove from parent's children map (requires lock)
@@ -1374,8 +1355,6 @@ func (s *Supervisor[TObserved, TDesired]) logHeartbeat() {
 
 	s.mu.RUnlock()
 
-	activeActions := 0
-
 	s.logger.Info("supervisor_heartbeat",
 		deps.HierarchyPath(s.GetHierarchyPathUnlocked()),
 		deps.Any("tick", atomic.LoadUint64(&s.tickCount)),
@@ -1383,7 +1362,7 @@ func (s *Supervisor[TObserved, TDesired]) logHeartbeat() {
 		deps.Int("children", childCount),
 		deps.Any("worker_states", workerStates),
 		deps.Any("worker_reasons", workerReasons),
-		deps.Int("active_actions", activeActions))
+		deps.Int("active_actions", s.actionExecutor.GetActiveActionCount()))
 }
 
 func (s *Supervisor[TObserved, TDesired]) getRecoveryStatus() string {
@@ -1638,19 +1617,7 @@ func (s *Supervisor[TObserved, TDesired]) reconcileChildren(specs []config.Child
 			child.Shutdown()
 
 			if done, exists := s.childDoneChans[name]; exists {
-				shutdownTimer := time.NewTimer(s.childShutdownTimeout)
-				select {
-				case <-done:
-					shutdownTimer.Stop()
-				case <-shutdownTimer.C:
-					metrics.RecordChildShutdownTimeout(s.GetHierarchyPathUnlocked(), name)
-
-					s.logger.SentryWarn(deps.FeatureFSMv2, s.GetHierarchyPathUnlocked(), "child_shutdown_timeout",
-						deps.String("child_name", name),
-						deps.Duration("timeout", s.childShutdownTimeout),
-						deps.String("context", "reconcile_children"))
-				}
-
+				s.waitForChildDone(done, name, s.GetHierarchyPathUnlocked(), "reconcile_children")
 				delete(s.childDoneChans, name)
 			}
 

--- a/umh-core/pkg/fsmv2/supervisor/reconciliation.go
+++ b/umh-core/pkg/fsmv2/supervisor/reconciliation.go
@@ -33,6 +33,11 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/persistence"
 )
 
+// ErrPanicCircuitOpen is returned when the tick is suppressed because the panic circuit breaker is open.
+// Returning an error (instead of nil) ensures the supervisor knows the worker is unhealthy
+// and continues ticking it, allowing the circuit breaker to auto-reset after the cooling period.
+var ErrPanicCircuitOpen = errors.New("panic circuit breaker open")
+
 // factoryRegistryAdapter provides an adapter for config validation.
 type factoryRegistryAdapter struct{}
 
@@ -539,9 +544,15 @@ func (s *Supervisor[TObserved, TDesired]) tick(ctx context.Context) (err error) 
 	}()
 
 	if s.panicCircuitOpen.Load() {
-		s.logger.Debug("tick_suppressed_panic_circuit_open",
-			deps.HierarchyPath(s.GetHierarchyPathUnlocked()))
-		return nil
+		if s.panicTracker.PanicCount() == 0 {
+			s.panicCircuitOpen.Store(false)
+			s.logger.SentryWarn(deps.FeatureFSMv2, s.GetHierarchyPathUnlocked(), "panic_circuit_auto_reset",
+				deps.WorkerType(s.workerType))
+		} else {
+			s.logger.Debug("tick_suppressed_panic_circuit_open",
+				deps.HierarchyPath(s.GetHierarchyPathUnlocked()))
+			return ErrPanicCircuitOpen
+		}
 	}
 
 	tickCount := atomic.AddUint64(&s.tickCount, 1)

--- a/umh-core/pkg/fsmv2/supervisor/reconciliation.go
+++ b/umh-core/pkg/fsmv2/supervisor/reconciliation.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"runtime/debug"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -528,7 +529,49 @@ func (s *Supervisor[TObserved, TDesired]) tickWorker(ctx context.Context, worker
 //
 // PERFORMANCE: The complete tick loop is non-blocking and completes in <10ms,
 // making it safe to call at high frequency (100Hz+) without impacting system performance.
-func (s *Supervisor[TObserved, TDesired]) tick(ctx context.Context) error {
+func (s *Supervisor[TObserved, TDesired]) tick(ctx context.Context) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			var panicErr error
+
+			var panicType string
+
+			switch v := r.(type) {
+			case error:
+				panicErr = v
+				panicType = "error"
+			case string:
+				panicErr = errors.New(v)
+				panicType = "string"
+			default:
+				panicErr = fmt.Errorf("%v", r)
+				panicType = "unknown"
+			}
+
+			err = fmt.Errorf("tick panic: %w", panicErr)
+
+			hierarchyPath := s.GetHierarchyPathUnlocked()
+			metrics.RecordPanicRecovery(hierarchyPath, panicType)
+
+			s.logger.SentryError(deps.FeatureFSMv2, hierarchyPath, err, "tick_panic",
+				deps.WorkerType(s.workerType),
+				deps.Field{Key: "panic_type", Value: panicType},
+				deps.Field{Key: "stack_trace", Value: string(debug.Stack())})
+
+			if s.panicTracker.RecordPanic() {
+				s.panicCircuitOpen.Store(true)
+				panicCount := s.panicTracker.PanicCount()
+				s.logger.SentryError(deps.FeatureFSMv2, hierarchyPath, fmt.Errorf("tick panic circuit breaker opens after %d panics", panicCount), "panic_circuit_open",
+					deps.WorkerType(s.workerType),
+					deps.Field{Key: "panic_count", Value: panicCount})
+			}
+		}
+	}()
+
+	if s.panicCircuitOpen.Load() {
+		return nil
+	}
+
 	tickCount := atomic.AddUint64(&s.tickCount, 1)
 	if tickCount%heartbeatTickInterval == 0 {
 		s.logHeartbeat()
@@ -1003,9 +1046,20 @@ func (s *Supervisor[TObserved, TDesired]) processSignal(ctx context.Context, wor
 				deps.String("context", "post_graceful_cleanup"))
 			child.Shutdown()
 
-			// Wait for child supervisor to fully stop
+			// Wait for child supervisor to fully stop (with timeout)
 			if done, exists := doneChannels[name]; exists {
-				<-done
+				shutdownTimer := time.NewTimer(s.childShutdownTimeout)
+				select {
+				case <-done:
+					shutdownTimer.Stop()
+				case <-shutdownTimer.C:
+					metrics.RecordChildShutdownTimeout(s.GetHierarchyPath(), name)
+
+					s.logger.SentryWarn(deps.FeatureFSMv2, s.GetHierarchyPath(), "child_shutdown_timeout",
+						deps.String("child_name", name),
+						deps.Duration("timeout", s.childShutdownTimeout),
+						deps.String("context", "worker_removal_cleanup"))
+				}
 			}
 
 			// Remove from parent's children map (requires lock)
@@ -1419,6 +1473,8 @@ func (s *Supervisor[TObserved, TDesired]) reconcileChildren(specs []config.Child
 				Logger:                  s.baseLogger, // Important: Use un-enriched logger to prevent duplicate "worker" fields
 				TickInterval:            s.tickInterval,
 				GracefulShutdownTimeout: s.gracefulShutdownTimeout,
+				ChildShutdownTimeout:    s.childShutdownTimeout,
+				EnableTraceLogging:      s.enableTraceLogging,
 				Dependencies:            mergedDeps,
 			}
 
@@ -1582,7 +1638,19 @@ func (s *Supervisor[TObserved, TDesired]) reconcileChildren(specs []config.Child
 			child.Shutdown()
 
 			if done, exists := s.childDoneChans[name]; exists {
-				<-done
+				shutdownTimer := time.NewTimer(s.childShutdownTimeout)
+				select {
+				case <-done:
+					shutdownTimer.Stop()
+				case <-shutdownTimer.C:
+					metrics.RecordChildShutdownTimeout(s.GetHierarchyPathUnlocked(), name)
+
+					s.logger.SentryWarn(deps.FeatureFSMv2, s.GetHierarchyPathUnlocked(), "child_shutdown_timeout",
+						deps.String("child_name", name),
+						deps.Duration("timeout", s.childShutdownTimeout),
+						deps.String("context", "reconcile_children"))
+				}
+
 				delete(s.childDoneChans, name)
 			}
 

--- a/umh-core/pkg/fsmv2/supervisor/reconciliation.go
+++ b/umh-core/pkg/fsmv2/supervisor/reconciliation.go
@@ -166,27 +166,12 @@ func (s *Supervisor[TObserved, TDesired]) tickWorker(ctx context.Context, worker
 	currentStateForPhase := workerCtx.currentState
 	workerCtx.mu.RUnlock()
 
-	var (
-		lifecyclePhase    config.LifecyclePhase
-		observedStateName string
-	)
-
 	if currentStateForPhase != nil {
-		lifecyclePhase = currentStateForPhase.LifecyclePhase()
-		// Construct observed state name: phase.Prefix() + lowercase(state.String())
-		suffix := strings.ToLower(currentStateForPhase.String())
+		phase := currentStateForPhase.LifecyclePhase()
 
-		prefix := lifecyclePhase.Prefix()
-		if lifecyclePhase == config.PhaseStopped {
-			observedStateName = prefix // "stopped" has no suffix
-		} else {
-			observedStateName = prefix + suffix
-		}
-
-		// Cache both the observed state name and lifecycle phase
 		workerCtx.mu.Lock()
-		workerCtx.lastObservedStateName = observedStateName
-		workerCtx.lastLifecyclePhase = lifecyclePhase
+		workerCtx.lastObservedStateName = buildObservedStateName(phase, currentStateForPhase)
+		workerCtx.lastLifecyclePhase = phase
 		workerCtx.mu.Unlock()
 	}
 
@@ -440,15 +425,7 @@ func (s *Supervisor[TObserved, TDesired]) tickWorker(ctx context.Context, worker
 		// Parent supervisors call GetLifecyclePhase() which returns lastLifecyclePhase.
 		// If we update this before the transition, parent sees stale health status.
 		newPhase := result.State.LifecyclePhase()
-		newSuffix := strings.ToLower(result.State.String())
-
-		newPrefix := newPhase.Prefix()
-		if newPhase == config.PhaseStopped {
-			workerCtx.lastObservedStateName = newPrefix // "stopped" has no suffix
-		} else {
-			workerCtx.lastObservedStateName = newPrefix + newSuffix
-		}
-
+		workerCtx.lastObservedStateName = buildObservedStateName(newPhase, result.State)
 		workerCtx.lastLifecyclePhase = newPhase
 
 		workerCtx.mu.Unlock()
@@ -1160,6 +1137,16 @@ func (s *Supervisor[TObserved, TDesired]) checkRestartTimeouts(ctx context.Conte
 	}
 }
 
+// buildObservedStateName constructs the observed state name from a lifecycle phase and state string.
+// Format: phase.Prefix() + lowercase(state.String()), except PhaseStopped which has no suffix.
+func buildObservedStateName(phase config.LifecyclePhase, state fsmv2.State[any, any]) string {
+	prefix := phase.Prefix()
+	if phase == config.PhaseStopped {
+		return prefix
+	}
+	return prefix + strings.ToLower(state.String())
+}
+
 // getString extracts a string value from a document map with a default fallback.
 func getString(doc interface{}, key string, defaultValue string) string {
 	if doc == nil {
@@ -1299,34 +1286,29 @@ func (s *Supervisor[TObserved, TDesired]) checkDataFreshness(snapshot *fsmv2.Sna
 	isShuttingDown := !s.started.Load()
 
 	if s.freshnessChecker.IsTimeout(snapshot) {
-		if isShuttingDown {
-			s.logger.Debug("data_timeout_during_shutdown",
-				deps.Duration("age", age),
-				deps.Duration("threshold", s.collectorHealth.timeout))
-		} else {
-			s.logger.SentryWarn(deps.FeatureFSMv2, snapshot.Identity.HierarchyPath, "data_timeout",
-				deps.Duration("age", age),
-				deps.Duration("threshold", s.collectorHealth.timeout))
-		}
-
+		s.logFreshnessWarning(isShuttingDown, snapshot.Identity.HierarchyPath, "data_timeout", age, s.collectorHealth.timeout)
 		return false
 	}
 
 	if !s.freshnessChecker.Check(snapshot) {
-		if isShuttingDown {
-			s.logger.Debug("data_stale_during_shutdown",
-				deps.Duration("age", age),
-				deps.Duration("threshold", s.collectorHealth.staleThreshold))
-		} else {
-			s.logger.SentryWarn(deps.FeatureFSMv2, snapshot.Identity.HierarchyPath, "data_stale",
-				deps.Duration("age", age),
-				deps.Duration("threshold", s.collectorHealth.staleThreshold))
-		}
-
+		s.logFreshnessWarning(isShuttingDown, snapshot.Identity.HierarchyPath, "data_stale", age, s.collectorHealth.staleThreshold)
 		return false
 	}
 
 	return true
+}
+
+// logFreshnessWarning logs a data freshness issue at DEBUG during shutdown (expected) or SentryWarn otherwise.
+func (s *Supervisor[TObserved, TDesired]) logFreshnessWarning(isShuttingDown bool, hierarchyPath, msg string, age, threshold time.Duration) {
+	if isShuttingDown {
+		s.logger.Debug(msg+"_during_shutdown",
+			deps.Duration("age", age),
+			deps.Duration("threshold", threshold))
+	} else {
+		s.logger.SentryWarn(deps.FeatureFSMv2, hierarchyPath, msg,
+			deps.Duration("age", age),
+			deps.Duration("threshold", threshold))
+	}
 }
 
 func (s *Supervisor[TObserved, TDesired]) logHeartbeat() {

--- a/umh-core/pkg/fsmv2/supervisor/reconciliation.go
+++ b/umh-core/pkg/fsmv2/supervisor/reconciliation.go
@@ -29,6 +29,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/config"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/factory"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/supervisor/internal/panicutil"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/supervisor/metrics"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/persistence"
 )
@@ -528,7 +529,7 @@ func (s *Supervisor[TObserved, TDesired]) tick(ctx context.Context) (err error) 
 				}
 			}()
 
-			panicType, panicErr := classifyPanic(r)
+			panicType, panicErr := panicutil.ClassifyPanic(r)
 			err = fmt.Errorf("tick panic: %w", panicErr)
 
 			hierarchyPath := s.GetHierarchyPathUnlocked()

--- a/umh-core/pkg/fsmv2/supervisor/reconciliation.go
+++ b/umh-core/pkg/fsmv2/supervisor/reconciliation.go
@@ -536,7 +536,7 @@ func (s *Supervisor[TObserved, TDesired]) tick(ctx context.Context) (err error) 
 			if s.panicTracker.RecordPanic() {
 				s.panicCircuitOpen.Store(true)
 				panicCount := s.panicTracker.PanicCount()
-				s.logger.SentryError(deps.FeatureFSMv2, hierarchyPath, fmt.Errorf("tick panic circuit breaker opens after %d panics", panicCount), "panic_circuit_open",
+				s.logger.SentryWarn(deps.FeatureFSMv2, hierarchyPath, "panic_circuit_open",
 					deps.WorkerType(s.workerType),
 					deps.Field{Key: "panic_count", Value: panicCount})
 			}

--- a/umh-core/pkg/fsmv2/supervisor/reconciliation.go
+++ b/umh-core/pkg/fsmv2/supervisor/reconciliation.go
@@ -513,9 +513,11 @@ func (s *Supervisor[TObserved, TDesired]) tick(ctx context.Context) (err error) 
 			defer func() {
 				if r2 := recover(); r2 != nil {
 					err = fmt.Errorf("tick panic (recovery handler also panicked: %v): %v", r2, r)
+
 					s.panicCircuitOpen.Store(true)
 					func() {
-						defer func() { recover() }()
+						defer func() { _ = recover() }()
+
 						s.logger.SentryError(deps.FeatureFSMv2, "unknown", err, "tick_double_panic",
 							deps.String("stack", string(debug.Stack())))
 					}()
@@ -551,6 +553,7 @@ func (s *Supervisor[TObserved, TDesired]) tick(ctx context.Context) (err error) 
 		} else {
 			s.logger.Debug("tick_suppressed_panic_circuit_open",
 				deps.HierarchyPath(s.GetHierarchyPathUnlocked()))
+
 			return ErrPanicCircuitOpen
 		}
 	}
@@ -1155,6 +1158,7 @@ func buildObservedStateName(phase config.LifecyclePhase, state fsmv2.State[any, 
 	if phase == config.PhaseStopped {
 		return prefix
 	}
+
 	return prefix + strings.ToLower(state.String())
 }
 
@@ -1298,11 +1302,13 @@ func (s *Supervisor[TObserved, TDesired]) checkDataFreshness(snapshot *fsmv2.Sna
 
 	if s.freshnessChecker.IsTimeout(snapshot) {
 		s.logFreshnessWarning(isShuttingDown, snapshot.Identity.HierarchyPath, "data_timeout", age, s.collectorHealth.timeout)
+
 		return false
 	}
 
 	if !s.freshnessChecker.Check(snapshot) {
 		s.logFreshnessWarning(isShuttingDown, snapshot.Identity.HierarchyPath, "data_stale", age, s.collectorHealth.staleThreshold)
+
 		return false
 	}
 

--- a/umh-core/pkg/fsmv2/supervisor/supervisor.go
+++ b/umh-core/pkg/fsmv2/supervisor/supervisor.go
@@ -158,6 +158,7 @@ type Supervisor[TObserved fsmv2.ObservedState, TDesired fsmv2.DesiredState] stru
 	restartRequestedAt map[string]time.Time
 	globalVars         map[string]any
 	healthChecker      *InfrastructureHealthChecker
+	panicTracker       *panicRecovery
 	actionExecutor     *execution.ActionExecutor
 	ctxCancel          context.CancelFunc
 	// ctxMu Protects ctx and ctxCancel to prevent TOCTOU races during shutdown.
@@ -185,7 +186,9 @@ type Supervisor[TObserved fsmv2.ObservedState, TDesired fsmv2.DesiredState] stru
 	tickCount                uint64
 	gracefulShutdownTimeout  time.Duration
 	metricsReportInterval    time.Duration
+	childShutdownTimeout     time.Duration
 	circuitOpen              atomic.Bool
+	panicCircuitOpen         atomic.Bool
 	started                  atomic.Bool
 	enableTraceLogging       bool
 }
@@ -256,6 +259,11 @@ func NewSupervisor[TObserved fsmv2.ObservedState, TDesired fsmv2.DesiredState](c
 		metricsReportInterval = DefaultMetricsReportInterval
 	}
 
+	childShutdownTimeout := cfg.ChildShutdownTimeout
+	if childShutdownTimeout == 0 {
+		childShutdownTimeout = DefaultChildShutdownTimeout
+	}
+
 	return &Supervisor[TObserved, TDesired]{
 		workerType:         cfg.WorkerType,
 		workers:            make(map[string]*WorkerContext[TObserved, TDesired]),
@@ -275,6 +283,7 @@ func NewSupervisor[TObserved fsmv2.ObservedState, TDesired fsmv2.DesiredState](c
 		createdAt:          time.Now(),
 		parentID:           "",
 		healthChecker:      NewInfrastructureHealthChecker(DefaultMaxInfraRecoveryAttempts, DefaultRecoveryAttemptWindow),
+		panicTracker:       newPanicRecovery(DefaultPanicEscalationWindow, DefaultMaxTickPanics),
 		actionExecutor:     execution.NewActionExecutor(10, cfg.WorkerType, deps.Identity{WorkerType: cfg.WorkerType}, cfg.Logger),
 		collectorHealth: CollectorHealth{
 			observationTimeout: observationTimeout,
@@ -287,6 +296,7 @@ func NewSupervisor[TObserved fsmv2.ObservedState, TDesired fsmv2.DesiredState](c
 		enableTraceLogging:      cfg.EnableTraceLogging,
 		gracefulShutdownTimeout: gracefulShutdownTimeout,
 		metricsReportInterval:   metricsReportInterval,
+		childShutdownTimeout:    childShutdownTimeout,
 		deps:                    cfg.Dependencies,
 		validatedSpecHashes:     make(map[string]string),
 	}

--- a/umh-core/pkg/fsmv2/supervisor/test_accessors.go
+++ b/umh-core/pkg/fsmv2/supervisor/test_accessors.go
@@ -21,6 +21,27 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/config"
 )
 
+// TestSetChild injects a child supervisor and done channel for testing. DO NOT USE in production code.
+func (s *Supervisor[TObserved, TDesired]) TestSetChild(name string, child SupervisorInterface, done <-chan struct{}) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.children[name] = child
+	s.childDoneChans[name] = done
+}
+
+// TestMarkAsStarted sets the supervisor as started with a valid context. DO NOT USE in production code.
+func (s *Supervisor[TObserved, TDesired]) TestMarkAsStarted() {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	s.ctxMu.Lock()
+	s.ctx = ctx
+	s.ctxCancel = cancel
+	s.ctxMu.Unlock()
+
+	s.started.Store(true)
+}
+
 // TestTick exposes tick() for testing. DO NOT USE in production code.
 func (s *Supervisor[TObserved, TDesired]) TestTick(ctx context.Context) error {
 	return s.tick(ctx)
@@ -103,6 +124,36 @@ func (s *Supervisor[TObserved, TDesired]) TestSetLastRestart(t time.Time) {
 	s.collectorHealth.lastRestart = t
 }
 
+// TestIsPanicCircuitOpen returns true if the panic circuit breaker is open. DO NOT USE in production code.
+func (s *Supervisor[TObserved, TDesired]) TestIsPanicCircuitOpen() bool {
+	return s.panicCircuitOpen.Load()
+}
+
+// TestPanicRecoveryTracker wraps panicRecovery for unit testing. DO NOT USE in production code.
+type TestPanicRecoveryTracker struct {
+	pr *panicRecovery
+}
+
+// NewTestPanicRecoveryTracker creates a panicRecovery tracker for testing. DO NOT USE in production code.
+func NewTestPanicRecoveryTracker(window time.Duration, maxPanics int) *TestPanicRecoveryTracker {
+	return &TestPanicRecoveryTracker{pr: newPanicRecovery(window, maxPanics)}
+}
+
+// RecordPanic records a panic and returns true if the escalation threshold has been reached.
+func (t *TestPanicRecoveryTracker) RecordPanic() bool {
+	return t.pr.RecordPanic()
+}
+
+// PanicCount returns the number of panics within the window.
+func (t *TestPanicRecoveryTracker) PanicCount() int {
+	return t.pr.PanicCount()
+}
+
+// Reset clears all recorded panics.
+func (t *TestPanicRecoveryTracker) Reset() {
+	t.pr.Reset()
+}
+
 // TestIsPendingRemoval checks if a child is in the pendingRemoval map. DO NOT USE in production code.
 func (s *Supervisor[TObserved, TDesired]) TestIsPendingRemoval(childName string) bool {
 	s.mu.RLock()
@@ -111,7 +162,7 @@ func (s *Supervisor[TObserved, TDesired]) TestIsPendingRemoval(childName string)
 	return s.pendingRemoval[childName]
 }
 
-// TestSetPendingRemoval marks a child as pending removal for testing. DO NOT USE in production code.
+// TestSetPendingRemovalFlag marks a child as pending removal for testing. DO NOT USE in production code.
 func (s *Supervisor[TObserved, TDesired]) TestSetPendingRemovalFlag(childName string, value bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/umh-core/pkg/fsmv2/supervisor/test_accessors.go
+++ b/umh-core/pkg/fsmv2/supervisor/test_accessors.go
@@ -129,6 +129,11 @@ func (s *Supervisor[TObserved, TDesired]) TestIsPanicCircuitOpen() bool {
 	return s.panicCircuitOpen.Load()
 }
 
+// TestSetCircuitOpen sets the infrastructure circuit breaker state for testing. DO NOT USE in production code.
+func (s *Supervisor[TObserved, TDesired]) TestSetCircuitOpen(open bool) {
+	s.circuitOpen.Store(open)
+}
+
 // TestPanicRecoveryTracker wraps panicRecovery for unit testing. DO NOT USE in production code.
 type TestPanicRecoveryTracker struct {
 	pr *panicRecovery

--- a/umh-core/pkg/fsmv2/supervisor/tick_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/tick_test.go
@@ -100,7 +100,7 @@ var _ = Describe("Tick with Data Freshness", func() {
 	})
 
 	Context("when ObservedState is nil (Invariant I16)", func() {
-		It("should panic with clear error message about nil ObservedState", func() {
+		It("should return error with clear message (panic recovered)", func() {
 			identity := mockIdentity()
 			worker := &mockWorker{
 				initialState: initialState,
@@ -125,9 +125,10 @@ var _ = Describe("Tick with Data Freshness", func() {
 				StaleThreshold: 10 * time.Second,
 			})
 
-			Expect(func() {
-				_ = s.TestTick(context.Background())
-			}).Should(PanicWith(MatchRegexp("Invariant I16 violated.*nil ObservedState")))
+			err := s.TestTick(context.Background())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("tick panic"))
+			Expect(err.Error()).To(ContainSubstring("Invariant I16 violated"))
 		})
 	})
 })

--- a/umh-core/pkg/fsmv2/supervisor/types.go
+++ b/umh-core/pkg/fsmv2/supervisor/types.go
@@ -96,7 +96,8 @@ type SupervisorInterface interface {
 	// Used by ChildInfo to report infrastructure status to parents.
 	IsObservationStale() bool
 	// IsCircuitOpen returns true if the circuit breaker is open for this supervisor.
-	// When open, it indicates infrastructure failure (child consistency check failed).
+	// When open, it indicates infrastructure failure (child consistency check failed)
+	// or repeated tick panics (code bug triggered the panic circuit breaker).
 	// Used by ChildInfo to report infrastructure status to parents.
 	IsCircuitOpen() bool
 	// TestGetUserSpec returns the current userSpec for testing. DO NOT USE in production code.

--- a/umh-core/pkg/fsmv2/supervisor/types.go
+++ b/umh-core/pkg/fsmv2/supervisor/types.go
@@ -188,14 +188,14 @@ type CollectorHealthConfig struct {
 	StaleThreshold time.Duration
 
 	// Timeout is how old observation data can be before collector is considered broken.
-	// When exceeded, supervisor triggers collector restart with exponential backoff.
+	// When exceeded, supervisor triggers collector restart with linear backoff.
 	// Should be significantly larger than StaleThreshold to avoid restart thrashing.
 	// Default: 20 seconds (see DefaultCollectorTimeout in constants.go)
 	Timeout time.Duration
 
 	// MaxRestartAttempts is the maximum number of collector restart attempts.
 	// After this many failed restarts, supervisor escalates to graceful FSM shutdown.
-	// Each restart uses exponential backoff: attempt N waits N*2 seconds.
+	// Each restart uses linear backoff: attempt N waits (N+1)*2 seconds.
 	// Default: 3 attempts (see DefaultMaxRestartAttempts in constants.go)
 	MaxRestartAttempts int
 }

--- a/umh-core/pkg/fsmv2/supervisor/types.go
+++ b/umh-core/pkg/fsmv2/supervisor/types.go
@@ -245,6 +245,11 @@ type Config struct {
 	// Optional - defaults to 10 seconds (see DefaultMetricsReportInterval).
 	MetricsReportInterval time.Duration
 
+	// ChildShutdownTimeout is how long to wait for a child supervisor's done channel
+	// to close after calling Shutdown(). If exceeded, the parent logs a warning and proceeds.
+	// Optional - defaults to 30 seconds.
+	ChildShutdownTimeout time.Duration
+
 	// EnableTraceLogging enables verbose lifecycle event logging (mutex locks, tick events, etc.)
 	// Optional - defaults to false. Set ENABLE_TRACE_LOGGING=true for deep debugging.
 	// When false, these high-frequency internal logs are suppressed to improve signal-to-noise ratio.

--- a/umh-core/pkg/fsmv2/supervisor/types.go
+++ b/umh-core/pkg/fsmv2/supervisor/types.go
@@ -179,7 +179,7 @@ type CollectorHealthConfig struct {
 	// ObservationTimeout is the maximum time allowed for a single observation operation.
 	// If an observation takes longer than this, it is cancelled and considered failed.
 	// Must be less than StaleThreshold to ensure observation failures don't trigger stale detection.
-	// Default: ~1.3 seconds (see DefaultObservationTimeout in constants.go)
+	// Default: 2.2 seconds (see DefaultObservationTimeout in constants.go)
 	ObservationTimeout time.Duration
 
 	// StaleThreshold is how old observation data can be before FSM pauses.


### PR DESCRIPTION
> **Note:** This is a re-target of [PR #2404](https://github.com/united-manufacturing-hub/united-manufacturing-hub/pull/2404), which was accidentally merged into `eng-4226` instead of `staging`. That merge was reverted. The code is identical and was already reviewed/approved. See #2404 for full review history.

## Summary

Adds comprehensive panic recovery and timeout protection to all FSMv2 supervisor goroutines, preventing supervisor crashes and indefinite hangs.

- **Tick loop panic recovery** with circuit breaker (3 panics in 5-min window → permanent open)
- **Collector panic recovery** with restart-on-panic
- **Child shutdown timeout** (30s) preventing parent hangs
- **Stuck action detection** with force-removal after 3x timeout
- **Infrastructure circuit breaker** with auto-reset when sliding window expires

### Key design decisions
- Two separate circuit breakers: `panicCircuitOpen` (code bugs, permanent until window expires) vs `circuitOpen` (infra, auto-clears)
- Generation counter pattern prevents orphaned goroutines from corrupting re-enqueued entries
- Circuit-open errors suppressed from Sentry (logged at Debug level) to prevent event flooding

### Code review findings addressed
- 16 findings fixed from 9-agent code review (bug fixes, doc fixes, code quality)
- 24 findings deferred to ENG-4342 (post-rollout improvements)
- 1 finding (RequestShutdown API contract) split to ENG-4378

## Test plan

- [x] 228+ supervisor specs pass with `-race` (4 full runs)
- [x] New test suites: `panic_recovery_test.go` (574 lines), `child_shutdown_timeout_test.go`, `collector_panic_test.go`, `stuck_action_test.go`
- [x] `golangci-lint run --fix` clean
- [x] `go vet` clean
- [ ] CI passes

## Linear

Closes ENG-4289

🤖 Generated with [Claude Code](https://claude.com/claude-code)