### PR TITLE
fix: sync workflow dry-run fails to checkout private repo

### DIFF
--- a/.github/workflows/sync-changelog.yml
+++ b/.github/workflows/sync-changelog.yml
@@ -60,7 +60,6 @@ jobs:
           path: umh-core
 
       - name: Generate GitHub App token
-        if: github.event.inputs.dry_run != 'true'
         id: app-token
         uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2
         with:
@@ -72,7 +71,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: united-manufacturing-hub/changelog.umh.app
-          token: ${{ github.event.inputs.dry_run == 'true' && github.token || steps.app-token.outputs.token }}
+          token: ${{ steps.app-token.outputs.token }}
           path: changelog-app
 
       - name: Setup Node.js

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,6 +132,17 @@ The United Manufacturing Hub (UMH) is an Industrial IoT platform for manufacturi
 
 **No code change without corresponding documentation updates.** Every code modification must include relevant documentation changes in the same PR. See `docs/` directory for user-facing documentation.
 
+### Changelog
+
+Every PR with user-visible changes must add an entry to `umh-core/CHANGELOG.md` under the current (topmost) version section. Use the `/changelog-entry` skill to generate entries in the correct format.
+
+- **Format**: `- **Bold title** - Description in problem-solution format`
+- **Categories** (in order): `### Breaking Changes`, `### New Features`, `### Improvements`, `### Fixes`
+- **No entry needed** for: CI/CD changes, refactoring, test-only changes, documentation-only changes
+- **Never create a new version section** — only add to the existing topmost `## [X.Y.Z]` section
+- On tag push, a sync workflow automatically creates entries in changelog.umh.app from CHANGELOG.md
+- When creating a GitHub Release, copy the version's content from CHANGELOG.md as the release body. Include a link to the changelog.umh.app entry at the bottom: `See https://changelog.umh.app/changelog/<date>-umh-core-<version>`
+
 ## Support & Troubleshooting Workflows
 
 This section covers umh-core-specific troubleshooting workflows. For universal team processes (Linear/Sentry integration, ticket routing), see `/Users/jeremytheocharis/Documents/git/troubleshooting/CLAUDE.md`.


### PR DESCRIPTION
## Summary

- The dry-run mode of the sync-changelog workflow fails because `changelog.umh.app` is a private repo
- The workflow was skipping GitHub App token generation in dry-run mode and falling back to `github.token`, which only has access to the current repo
- The App token is now always generated — dry-run mode only skips PR creation, not repo access

## Evidence

Failed run: https://github.com/united-manufacturing-hub/united-manufacturing-hub/actions/runs/22102290499

```
Not Found - https://docs.github.com/rest/repos/repos#get-a-repository
```

## Test plan

- [ ] Re-run dry-run after merge: `gh workflow run sync-changelog.yml -f dry_run=true -f version=v0.44.7`
- [ ] Verify the sync script runs and shows generated output

🤖 Generated with [Claude Code](https://claude.com/claude-code)