### PR TITLE
feat: add config.yaml backup versioning to prevent data loss

### DIFF
--- a/umh-core/pkg/config/manager.go
+++ b/umh-core/pkg/config/manager.go
@@ -22,7 +22,9 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"sort"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -531,6 +533,9 @@ func (m *FileConfigManager) writeConfig(ctx context.Context, config FullConfig) 
 		return ctx.Err()
 	}
 
+	// Create backup before writing (best-effort)
+	m.createConfigBackup(ctx)
+
 	// Create the directory if it doesn't exist
 	dir := filepath.Dir(m.configPath)
 	if err := m.fsService.EnsureDirectory(ctx, dir); err != nil {
@@ -570,6 +575,82 @@ func (m *FileConfigManager) writeConfig(ctx context.Context, config FullConfig) 
 	m.logger.Infof("Successfully wrote config to %s", m.configPath)
 
 	return nil
+}
+
+// createConfigBackup creates a timestamped backup of the current config before writing.
+// This is best-effort - failures are logged but don't prevent the main write operation.
+// Must be called while holding the write lock (mutexReadOrWrite).
+func (m *FileConfigManager) createConfigBackup(ctx context.Context) {
+	exists, err := m.fsService.FileExists(ctx, m.configPath)
+	if err != nil || !exists {
+		return
+	}
+
+	data, err := m.fsService.ReadFile(ctx, m.configPath)
+	if err != nil {
+		m.logger.Warnf("Failed to read config for backup: %v", err)
+		return
+	}
+
+	if err := m.fsService.EnsureDirectory(ctx, constants.ConfigBackupDir); err != nil {
+		m.logger.Warnf("Failed to create backup directory: %v", err)
+		return
+	}
+
+	timestamp := time.Now().Unix()
+	backupPath := filepath.Join(constants.ConfigBackupDir, fmt.Sprintf("%d.yaml", timestamp))
+	if err := m.fsService.WriteFile(ctx, backupPath, data, 0644); err != nil {
+		m.logger.Warnf("Failed to write config backup: %v", err)
+		return
+	}
+
+	m.logger.Debugf("Created config backup at %s", backupPath)
+
+	m.cleanupOldBackups(ctx)
+}
+
+// cleanupOldBackups removes old backups, keeping only the most recent entries.
+// Best-effort - failures are logged but don't affect other operations.
+func (m *FileConfigManager) cleanupOldBackups(ctx context.Context) {
+	entries, err := m.fsService.ReadDir(ctx, constants.ConfigBackupDir)
+	if err != nil {
+		return
+	}
+
+	type backupFile struct {
+		timestamp int64
+		path      string
+	}
+	var backups []backupFile
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".yaml") {
+			continue
+		}
+		timestampStr := strings.TrimSuffix(entry.Name(), ".yaml")
+		timestamp, err := strconv.ParseInt(timestampStr, 10, 64)
+		if err != nil {
+			continue
+		}
+		backups = append(backups, backupFile{
+			timestamp: timestamp,
+			path:      filepath.Join(constants.ConfigBackupDir, entry.Name()),
+		})
+	}
+
+	if len(backups) <= constants.ConfigBackupMaxEntries {
+		return
+	}
+
+	sort.Slice(backups, func(i, j int) bool {
+		return backups[i].timestamp > backups[j].timestamp
+	})
+
+	for i := constants.ConfigBackupMaxEntries; i < len(backups); i++ {
+		if err := m.fsService.Remove(ctx, backups[i].path); err != nil {
+			m.logger.Warnf("Failed to remove old backup %s: %v", backups[i].path, err)
+		}
+	}
 }
 
 func (m *FileConfigManager) WithConfigPath(configPath string) *FileConfigManager {
@@ -1077,6 +1158,9 @@ func (m *FileConfigManager) WriteYAMLConfigFromString(ctx context.Context, confi
 			}
 		}
 	}
+
+	// Create backup before writing (best-effort)
+	m.createConfigBackup(ctx)
 
 	// Create the directory if it doesn't exist
 	dir := filepath.Dir(m.configPath)

--- a/umh-core/pkg/config/manager_test.go
+++ b/umh-core/pkg/config/manager_test.go
@@ -833,4 +833,181 @@ agent:
 			})
 		})
 	})
+
+	Describe("Config Backup", func() {
+		var (
+			configContent    = "agent:\n  metricsPort: 8080\n"
+			writtenBackups   map[string][]byte
+			removedFiles     []string
+			fileExistsResult bool
+		)
+
+		BeforeEach(func() {
+			writtenBackups = make(map[string][]byte)
+			removedFiles = nil
+			fileExistsResult = true
+
+			mockFS.WithFileExistsFunc(func(ctx context.Context, path string) (bool, error) {
+				if path == DefaultConfigPath {
+					return fileExistsResult, nil
+				}
+				return false, nil
+			})
+
+			mockFS.WithReadFileFunc(func(ctx context.Context, path string) ([]byte, error) {
+				if path == DefaultConfigPath {
+					return []byte(configContent), nil
+				}
+				return nil, errors.New("file not found")
+			})
+
+			mockFS.WithEnsureDirectoryFunc(func(ctx context.Context, path string) error {
+				return nil
+			})
+
+			mockFS.WithWriteFileFunc(func(ctx context.Context, path string, data []byte, perm os.FileMode) error {
+				if strings.HasPrefix(path, constants.ConfigBackupDir) {
+					writtenBackups[path] = data
+				}
+				return nil
+			})
+
+			mockFS.WithStatFunc(func(ctx context.Context, path string) (os.FileInfo, error) {
+				return mockFS.NewMockFileInfo(filepath.Base(path), 100, 0644, time.Now(), false), nil
+			})
+
+			mockFS.WithRemoveFunc(func(ctx context.Context, path string) error {
+				removedFiles = append(removedFiles, path)
+				return nil
+			})
+		})
+
+		Context("createConfigBackup", func() {
+			It("should create backup when config exists", func() {
+				configManager.createConfigBackup(ctx)
+
+				Expect(writtenBackups).To(HaveLen(1))
+				for path, content := range writtenBackups {
+					Expect(path).To(HavePrefix(constants.ConfigBackupDir))
+					Expect(path).To(HaveSuffix(".yaml"))
+					Expect(content).To(Equal([]byte(configContent)))
+				}
+			})
+
+			It("should not create backup when config does not exist", func() {
+				fileExistsResult = false
+
+				configManager.createConfigBackup(ctx)
+
+				Expect(writtenBackups).To(BeEmpty())
+			})
+
+			It("should not fail when backup directory creation fails", func() {
+				mockFS.WithEnsureDirectoryFunc(func(ctx context.Context, path string) error {
+					if path == constants.ConfigBackupDir {
+						return errors.New("failed to create directory")
+					}
+					return nil
+				})
+
+				// Should not panic
+				configManager.createConfigBackup(ctx)
+				Expect(writtenBackups).To(BeEmpty())
+			})
+
+			It("should not fail when backup write fails", func() {
+				mockFS.WithWriteFileFunc(func(ctx context.Context, path string, data []byte, perm os.FileMode) error {
+					if strings.HasPrefix(path, constants.ConfigBackupDir) {
+						return errors.New("failed to write backup")
+					}
+					return nil
+				})
+
+				// Should not panic
+				configManager.createConfigBackup(ctx)
+			})
+		})
+
+		Context("cleanupOldBackups", func() {
+			It("should not remove files when under limit", func() {
+				mockFS.WithReadDirFunc(func(ctx context.Context, path string) ([]os.DirEntry, error) {
+					if path == constants.ConfigBackupDir {
+						return []os.DirEntry{
+							&mockDirEntry{name: "1000000001.yaml", isDir: false},
+							&mockDirEntry{name: "1000000002.yaml", isDir: false},
+						}, nil
+					}
+					return nil, nil
+				})
+
+				configManager.cleanupOldBackups(ctx)
+
+				Expect(removedFiles).To(BeEmpty())
+			})
+
+			It("should remove oldest files when over limit", func() {
+				var entries []os.DirEntry
+				// Create 102 backup entries (2 over limit)
+				for i := 0; i < 102; i++ {
+					entries = append(entries, &mockDirEntry{
+						name:  fmt.Sprintf("%d.yaml", 1000000000+i),
+						isDir: false,
+					})
+				}
+
+				mockFS.WithReadDirFunc(func(ctx context.Context, path string) ([]os.DirEntry, error) {
+					if path == constants.ConfigBackupDir {
+						return entries, nil
+					}
+					return nil, nil
+				})
+
+				configManager.cleanupOldBackups(ctx)
+
+				// Should remove 2 oldest files (timestamps 1000000000 and 1000000001)
+				Expect(removedFiles).To(HaveLen(2))
+				Expect(removedFiles).To(ContainElement(filepath.Join(constants.ConfigBackupDir, "1000000000.yaml")))
+				Expect(removedFiles).To(ContainElement(filepath.Join(constants.ConfigBackupDir, "1000000001.yaml")))
+			})
+
+			It("should ignore directories and non-yaml files", func() {
+				mockFS.WithReadDirFunc(func(ctx context.Context, path string) ([]os.DirEntry, error) {
+					if path == constants.ConfigBackupDir {
+						return []os.DirEntry{
+							&mockDirEntry{name: "subdir", isDir: true},
+							&mockDirEntry{name: "1000000001.yaml", isDir: false},
+							&mockDirEntry{name: "readme.txt", isDir: false},
+							&mockDirEntry{name: "invalid-name.yaml", isDir: false},
+						}, nil
+					}
+					return nil, nil
+				})
+
+				configManager.cleanupOldBackups(ctx)
+
+				Expect(removedFiles).To(BeEmpty())
+			})
+
+			It("should handle ReadDir failure gracefully", func() {
+				mockFS.WithReadDirFunc(func(ctx context.Context, path string) ([]os.DirEntry, error) {
+					return nil, errors.New("directory not found")
+				})
+
+				// Should not panic
+				configManager.cleanupOldBackups(ctx)
+				Expect(removedFiles).To(BeEmpty())
+			})
+		})
+	})
 })
+
+// mockDirEntry is a test helper implementing os.DirEntry
+type mockDirEntry struct {
+	name  string
+	isDir bool
+}
+
+func (m *mockDirEntry) Name() string               { return m.name }
+func (m *mockDirEntry) IsDir() bool                { return m.isDir }
+func (m *mockDirEntry) Type() os.FileMode          { return 0 }
+func (m *mockDirEntry) Info() (os.FileInfo, error) { return nil, nil }

--- a/umh-core/pkg/constants/config.go
+++ b/umh-core/pkg/constants/config.go
@@ -28,4 +28,10 @@ const (
 	// It is more a safety net to prevent a single reader from blocking the config file
 	// The actual number does not really matter, it should be "high enough".
 	AmountReadersForConfigFile = 100
+
+	// ConfigBackupDir is the directory where config backups are stored.
+	ConfigBackupDir = "/data/config-backups"
+
+	// ConfigBackupMaxEntries is the maximum number of backup files to retain.
+	ConfigBackupMaxEntries = 100
 )


### PR DESCRIPTION
Add automatic timestamped backups of config.yaml before every write operation. Backups are stored in /data/config-backups/ with unix timestamp filenames. Keeps last 100 backups to bound storage usage.

Key changes:
- Add createConfigBackup() to create timestamped backup before writes
- Add cleanupOldBackups() to remove old backups beyond 100 limit
- Modify writeConfig() and WriteYAMLConfigFromString() to call backup
- Add constants ConfigBackupDir and ConfigBackupMaxEntries
- Add unit tests for backup and cleanup functionality

Backup is best-effort: failures are logged but don't block main writes. This addresses customer data loss incidents where config.yaml was overwritten with no recovery option.

Slack: https://umh-app.slack.com/archives/C07D3S5ESHM/p1771415761017189?thread_ts=1771398686.818119&cid=C07D3S5ESHM

https://claude.ai/code/session_018sb7inQyVWfZtPhEK4JVsK

Fixes
VE-235
ENG-4398 (sub-issue)
ENG-4399 (sub-issue)