### PR TITLE
fix(persistence): reduce delta retention from 24h to 1h

### DIFF
--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [0.44.9]
 
+### Fixes
+
+- **Reduced memory usage for FSMv2 preview instances** - The memory cleanup routine introduced in v0.44.8 retained state history for 24 hours, which still allowed hundreds of thousands of entries to accumulate in RAM on busy systems before being cleaned up. The retention window is now 1 hour, reducing steady-state memory by roughly 95%. Requires `USE_FSMV2_MEMORY_CLEANUP=true`.
+
 ## [0.44.8]
 
 If you enabled the FSMv2 communicator preview (introduced in v0.44.5), this release fixes three issues that could cause your instance to use a lot of memory, go offline, or restart unexpectedly. We strongly recommend upgrading.

--- a/umh-core/pkg/fsmv2/workers/persistence/worker.go
+++ b/umh-core/pkg/fsmv2/workers/persistence/worker.go
@@ -34,7 +34,7 @@ import (
 
 const (
 	DefaultCompactionInterval  = 5 * time.Minute
-	DefaultRetentionWindow     = 24 * time.Hour
+	DefaultRetentionWindow     = 1 * time.Hour
 	DefaultMaintenanceInterval = 7 * 24 * time.Hour
 )
 


### PR DESCRIPTION
## Summary

- Reduces `DefaultRetentionWindow` from 24 hours to 1 hour in the persistence worker
- At ~10 deltas/sec from the communicator sync loop, 24h retention accumulates ~860K deltas in RAM
- 1h retention cuts steady-state memory by ~95% while preserving enough history for diagnostics

Only affects instances with `USE_FSMV2_MEMORY_CLEANUP=true` enabled (FSMv2 preview).

## Test plan

- [ ] Verify persistence worker tests still pass (`go test ./pkg/fsmv2/workers/persistence/...`)
- [ ] Deploy and monitor memory stabilization over 24h

## Changelog Entry

**Component:** umh-core
**Type:** Fix

### Reduced memory usage for FSMv2 preview instances

The memory cleanup routine introduced in v0.44.8 retained state history for 24 hours, which still allowed hundreds of thousands of entries to accumulate in RAM on busy systems before being cleaned up. The retention window is now 1 hour, reducing steady-state memory by roughly 95%. Requires `USE_FSMV2_MEMORY_CLEANUP=true`.

Fixes ENG-4408


🤖 Generated with [Claude Code](https://claude.com/claude-code)