### PR TITLE
fix: add 60s startup sleep to rate-limit Sentry flooding (ENG-4369)

### DIFF
--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - **Reduced container memory by up to 30%** - Previously, internal timing metrics grew continuously in memory the longer your instance ran, consuming over 500 MB on busy systems with many bridges and data flows. These metrics now use fixed-size histogram buckets that no longer grow with uptime, reducing steady-state container memory by roughly 30%
 
+### Fixes
+
+- **Fixed rapid container restarts consuming excessive resources when config.yaml is invalid** -- Previously, a missing or broken config caused the container to restart hundreds of times per minute. The container now waits 60 seconds between retries and deduplicates error reports, reducing resource usage and giving you time to diagnose the issue before the next restart
+
 ## [0.44.10]
 
 This release simplifies S7 addressing and fixes three edge cases in the Management Console editor and S7 data type handling.

--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -1,14 +1,16 @@
 # Changelog
 
+## [0.44.12]
+
+### Fixes
+
+- **Fixed rapid container restarts when config.yaml is missing or invalid** -- the container previously restarted hundreds of times per minute and now waits 60 seconds before retrying, giving you time to fix the configuration
+
 ## [0.44.11]
 
 ### Improvements
 
 - **Reduced container memory by up to 30%** - Previously, internal timing metrics grew continuously in memory the longer your instance ran, consuming over 500 MB on busy systems with many bridges and data flows. These metrics now use fixed-size histogram buckets that no longer grow with uptime, reducing steady-state container memory by roughly 30%
-
-### Fixes
-
-- **Fixed rapid container restarts consuming excessive resources when config.yaml is invalid** -- Previously, a missing or broken config caused the container to restart hundreds of times per minute. The container now waits 60 seconds between retries and deduplicates error reports, reducing resource usage and giving you time to diagnose the issue before the next restart
 
 ## [0.44.10]
 

--- a/umh-core/cmd/main.go
+++ b/umh-core/cmd/main.go
@@ -90,6 +90,9 @@ func main() {
 	configManager, err := config.NewFileConfigManagerWithBackoff()
 	if err != nil {
 		sentry.ReportIssuef(sentry.IssueTypeFatal, log, "Failed to create config manager: %w", err)
+		log.Errorf("Sleeping 60s before exit to rate-limit restart loop (ENG-4369)")
+		sentry.Flush(5 * time.Second)
+		time.Sleep(60 * time.Second)
 		cancel()
 
 		return
@@ -110,6 +113,9 @@ func main() {
 	configData, err := config.LoadConfigWithEnvOverrides(ctx, configManager, log)
 	if err != nil {
 		sentry.ReportIssuef(sentry.IssueTypeFatal, log, "Failed to load config: %w", err)
+		log.Errorf("Sleeping 60s before exit to rate-limit restart loop (ENG-4369)")
+		sentry.Flush(5 * time.Second)
+		time.Sleep(60 * time.Second)
 
 		return
 	}
@@ -142,6 +148,9 @@ func main() {
 	// This is particularly important when using /tmp/umh-core/services (the default)
 	if err := ensureS6RepositoryDirectory(log); err != nil {
 		sentry.ReportIssuef(sentry.IssueTypeFatal, log, "Failed to ensure S6 repository directory: %w", err)
+		log.Errorf("Sleeping 60s before exit to rate-limit restart loop (ENG-4369)")
+		sentry.Flush(5 * time.Second)
+		time.Sleep(60 * time.Second)
 
 		return
 	}


### PR DESCRIPTION
## Problem

When config loading fails at startup (e.g., missing `/data/config.yaml`, broken filesystem permissions), umh-core exits and S6 restarts it in milliseconds. This creates a crash loop that floods Sentry with thousands of duplicate fatal events.

**Observed impact**: UMH-CORE-1MT — 12K events from 7 instances, all identical crash-loop noise.

## Solution

Add `sentry.Flush(5s) + time.Sleep(60s)` before `return` on all 3 fatal startup paths:

1. `NewFileConfigManagerWithBackoff` fails
2. `LoadConfigWithEnvOverrides` fails  
3. `ensureS6RepositoryDirectory` fails

The `sentry.Flush` ensures the fatal event reaches Sentry **before** the sleep. The 60s sleep then rate-limits restarts from ~100/minute down to ~1/minute, reducing duplicate event volume by ~99x.

## Notes

- This is a stacked PR on top of `config-sentry-logging` (PR #2443)
- Path 1 preserves the existing `cancel()` call — sleep is inserted before it
- Linear: [ENG-4369](https://linear.app/united-manufacturing-hub/issue/ENG-4369)
- Sentry: UMH-CORE-1MT

🤖 Generated with [Claude Code](https://claude.com/claude-code)