### PR TITLE
fix: skip SentryWarn for ErrNotFound on first startup

### DIFF
--- a/umh-core/pkg/fsmv2/workers/persistence/dependencies.go
+++ b/umh-core/pkg/fsmv2/workers/persistence/dependencies.go
@@ -103,7 +103,7 @@ func (d *PersistenceDependencies) SetObservedStateLoaded() {
 	d.observedStateLoaded = true
 }
 
-func (d *PersistenceDependencies) GetObservedStateLoaded() bool {
+func (d *PersistenceDependencies) IsObservedStateLoaded() bool {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 

--- a/umh-core/pkg/fsmv2/workers/persistence/dependencies.go
+++ b/umh-core/pkg/fsmv2/workers/persistence/dependencies.go
@@ -27,11 +27,11 @@ import (
 type PersistenceDependencies struct {
 	*deps.BaseDependencies
 
-	mu                  sync.RWMutex
 	lastCompactionAt    time.Time
 	lastMaintenanceAt   time.Time
 	store               storage.TriangularStoreInterface
 	scheduler           deps.Scheduler
+	mu                  sync.RWMutex
 	observedStateLoaded bool
 }
 

--- a/umh-core/pkg/fsmv2/workers/persistence/dependencies.go
+++ b/umh-core/pkg/fsmv2/workers/persistence/dependencies.go
@@ -27,12 +27,12 @@ import (
 type PersistenceDependencies struct {
 	*deps.BaseDependencies
 
-	store               storage.TriangularStoreInterface
-	scheduler           deps.Scheduler
+	mu                  sync.RWMutex
 	lastCompactionAt    time.Time
 	lastMaintenanceAt   time.Time
+	store               storage.TriangularStoreInterface
+	scheduler           deps.Scheduler
 	observedStateLoaded bool
-	mu                  sync.RWMutex
 }
 
 var _ snapshot.PersistenceDependencies = (*PersistenceDependencies)(nil)
@@ -96,6 +96,8 @@ func (d *PersistenceDependencies) GetLastMaintenanceAt() time.Time {
 	return d.lastMaintenanceAt
 }
 
+// SetObservedStateLoaded marks that observed state was successfully loaded at least once.
+// It is safe for concurrent use.
 func (d *PersistenceDependencies) SetObservedStateLoaded() {
 	d.mu.Lock()
 	defer d.mu.Unlock()
@@ -103,6 +105,8 @@ func (d *PersistenceDependencies) SetObservedStateLoaded() {
 	d.observedStateLoaded = true
 }
 
+// IsObservedStateLoaded reports whether observed state was successfully loaded at least once.
+// It is safe for concurrent use.
 func (d *PersistenceDependencies) IsObservedStateLoaded() bool {
 	d.mu.RLock()
 	defer d.mu.RUnlock()

--- a/umh-core/pkg/fsmv2/workers/persistence/dependencies.go
+++ b/umh-core/pkg/fsmv2/workers/persistence/dependencies.go
@@ -27,11 +27,12 @@ import (
 type PersistenceDependencies struct {
 	*deps.BaseDependencies
 
-	store             storage.TriangularStoreInterface
-	scheduler         deps.Scheduler
-	lastCompactionAt  time.Time
-	lastMaintenanceAt time.Time
-	mu                sync.RWMutex
+	store               storage.TriangularStoreInterface
+	scheduler           deps.Scheduler
+	lastCompactionAt    time.Time
+	lastMaintenanceAt   time.Time
+	observedStateLoaded bool
+	mu                  sync.RWMutex
 }
 
 var _ snapshot.PersistenceDependencies = (*PersistenceDependencies)(nil)
@@ -93,4 +94,18 @@ func (d *PersistenceDependencies) GetLastMaintenanceAt() time.Time {
 	defer d.mu.RUnlock()
 
 	return d.lastMaintenanceAt
+}
+
+func (d *PersistenceDependencies) SetObservedStateLoaded() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.observedStateLoaded = true
+}
+
+func (d *PersistenceDependencies) GetObservedStateLoaded() bool {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	return d.observedStateLoaded
 }

--- a/umh-core/pkg/fsmv2/workers/persistence/worker.go
+++ b/umh-core/pkg/fsmv2/workers/persistence/worker.go
@@ -83,7 +83,11 @@ func (w *PersistenceWorker) CollectObservedState(ctx context.Context) (fsmv2.Obs
 	if stateReader != nil {
 		if err := stateReader.LoadObservedTyped(ctx, d.GetWorkerType(), d.GetWorkerID(), &prev); err == nil {
 			prevWorkerMetrics = prev.Metrics.Worker
-		} else if !errors.Is(err, persistencepkg.ErrNotFound) {
+
+			d.SetObservedStateLoaded()
+		} else if errors.Is(err, persistencepkg.ErrNotFound) && !d.GetObservedStateLoaded() {
+			// ErrNotFound is expected before state has been persisted for the first time
+		} else {
 			d.GetLogger().SentryWarn(deps.FeaturePersistence, d.GetHierarchyPath(), "previous_observed_load_failed",
 				deps.Err(err),
 				deps.String("worker_type", d.GetWorkerType()),

--- a/umh-core/pkg/fsmv2/workers/persistence/worker.go
+++ b/umh-core/pkg/fsmv2/workers/persistence/worker.go
@@ -85,8 +85,9 @@ func (w *PersistenceWorker) CollectObservedState(ctx context.Context) (fsmv2.Obs
 			prevWorkerMetrics = prev.Metrics.Worker
 
 			d.SetObservedStateLoaded()
-		} else if errors.Is(err, persistencepkg.ErrNotFound) && !d.GetObservedStateLoaded() {
+		} else if errors.Is(err, persistencepkg.ErrNotFound) && !d.IsObservedStateLoaded() {
 			// ErrNotFound is expected before state has been persisted for the first time
+			d.GetLogger().Debug("no previous observed state found, using zero-value defaults")
 		} else {
 			d.GetLogger().SentryWarn(deps.FeaturePersistence, d.GetHierarchyPath(), "previous_observed_load_failed",
 				deps.Err(err),

--- a/umh-core/pkg/fsmv2/workers/persistence/worker.go
+++ b/umh-core/pkg/fsmv2/workers/persistence/worker.go
@@ -16,6 +16,7 @@ package persistence
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -30,6 +31,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/supervisor"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/persistence/snapshot"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/persistence/state"
+	persistencepkg "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/persistence"
 )
 
 const (
@@ -81,7 +83,7 @@ func (w *PersistenceWorker) CollectObservedState(ctx context.Context) (fsmv2.Obs
 	if stateReader != nil {
 		if err := stateReader.LoadObservedTyped(ctx, d.GetWorkerType(), d.GetWorkerID(), &prev); err == nil {
 			prevWorkerMetrics = prev.Metrics.Worker
-		} else {
+		} else if !errors.Is(err, persistencepkg.ErrNotFound) {
 			d.GetLogger().SentryWarn(deps.FeaturePersistence, d.GetHierarchyPath(), "previous_observed_load_failed",
 				deps.Err(err),
 				deps.String("worker_type", d.GetWorkerType()),

--- a/umh-core/pkg/fsmv2/workers/persistence/worker.go
+++ b/umh-core/pkg/fsmv2/workers/persistence/worker.go
@@ -86,7 +86,6 @@ func (w *PersistenceWorker) CollectObservedState(ctx context.Context) (fsmv2.Obs
 
 			d.SetObservedStateLoaded()
 		} else if errors.Is(err, persistencepkg.ErrNotFound) && !d.IsObservedStateLoaded() {
-			// ErrNotFound is expected before state has been persisted for the first time
 			d.GetLogger().Debug("no previous observed state found, using zero-value defaults")
 		} else {
 			d.GetLogger().SentryWarn(deps.FeaturePersistence, d.GetHierarchyPath(), "previous_observed_load_failed",


### PR DESCRIPTION
## Summary

- Fixes `previous_observed_load_failed` SentryWarn firing on every first startup when no persisted state exists yet (Sentry UMH-CORE-223)
- Tracks whether observed state has been loaded via `observedStateLoaded` flag on `PersistenceDependencies` — `ErrNotFound` is only suppressed before the first successful load
- If persisted state disappears after a successful load, SentryWarn still fires (detects data loss)
- Adds DEBUG log on first-run suppression path for observability

## Test plan

- [x] `go test ./pkg/fsmv2/workers/persistence/... -v -count=1` — 15/15 PASS
- [x] `go test ./pkg/fsmv2/... -run "Architecture" -v` — all PASS
- [x] `golangci-lint run ./pkg/fsmv2/workers/persistence/...` — 0 issues
- [x] `go vet ./pkg/fsmv2/workers/persistence/...` — clean
- [x] No focused specs

Closes ENG-4419

🤖 Generated with [Claude Code](https://claude.com/claude-code)