### PR TITLE
feat: replace SummaryVec with HistogramVec for reconcile metrics

### DIFF
--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -6,7 +6,7 @@ This release simplifies S7 addressing and fixes three edge cases in the Manageme
 
 ### Improvements
 
-- **Reduced container memory by up to 30%** - Previously, internal timing metrics grew continuously in memory the longer your instance ran, consuming over 500 MB on busy systems with many bridges and data flows. These metrics now use fixed-size counters that stay constant regardless of uptime or component count, reducing steady-state container memory by roughly 30%
+- **Reduced container memory by up to 30%** - Previously, internal timing metrics grew continuously in memory the longer your instance ran, consuming over 500 MB on busy systems with many bridges and data flows. These metrics now use fixed-size histogram buckets that no longer grow with uptime, reducing steady-state container memory by roughly 30%
 
 - **Simplified S7 address format for non-Data Block memory areas** - Previously, S7 addresses for PE, PA, MK, C, and T areas required a block number that served no function. You can now write `PE.X0.0` instead of `PE0.X0.0`. The old format still works but logs a deprecation warning and will be removed in a future version. Data Block addresses (`DB1.DW20`) are unchanged
 

--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -6,7 +6,7 @@ This release simplifies S7 addressing and fixes three edge cases in the Manageme
 
 ### Improvements
 
-- **Reduced memory usage for reconcile metrics** - Previously, reconcile timing used Prometheus SummaryVec which accumulated quantile data in memory, consuming up to 569 MB of heap on busy instances. Now uses HistogramVec with fixed buckets, reducing heap usage by ~75% and container memory by ~65%
+- **Reduced container memory by up to 30%** - Previously, internal timing metrics grew continuously in memory the longer your instance ran, consuming over 500 MB on busy systems with many bridges and data flows. These metrics now use fixed-size counters that stay constant regardless of uptime or component count, reducing steady-state container memory by roughly 30%
 
 - **Simplified S7 address format for non-Data Block memory areas** - Previously, S7 addresses for PE, PA, MK, C, and T areas required a block number that served no function. You can now write `PE.X0.0` instead of `PE0.X0.0`. The old format still works but logs a deprecation warning and will be removed in a future version. Data Block addresses (`DB1.DW20`) are unchanged
 

--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -6,6 +6,8 @@ This release simplifies S7 addressing and fixes three edge cases in the Manageme
 
 ### Improvements
 
+- **Reduced memory usage for reconcile metrics** - Previously, reconcile timing used Prometheus SummaryVec which accumulated quantile data in memory, consuming up to 569 MB of heap on busy instances. Now uses HistogramVec with fixed buckets, reducing heap usage by ~75% and container memory by ~65%
+
 - **Simplified S7 address format for non-Data Block memory areas** - Previously, S7 addresses for PE, PA, MK, C, and T areas required a block number that served no function. You can now write `PE.X0.0` instead of `PE0.X0.0`. The old format still works but logs a deprecation warning and will be removed in a future version. Data Block addresses (`DB1.DW20`) are unchanged
 
 ### Fixes

--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -1,12 +1,16 @@
 # Changelog
 
+## [0.44.11]
+
+### Improvements
+
+- **Reduced container memory by up to 30%** - Previously, internal timing metrics grew continuously in memory the longer your instance ran, consuming over 500 MB on busy systems with many bridges and data flows. These metrics now use fixed-size histogram buckets that no longer grow with uptime, reducing steady-state container memory by roughly 30%
+
 ## [0.44.10]
 
 This release simplifies S7 addressing and fixes three edge cases in the Management Console editor and S7 data type handling.
 
 ### Improvements
-
-- **Reduced container memory by up to 30%** - Previously, internal timing metrics grew continuously in memory the longer your instance ran, consuming over 500 MB on busy systems with many bridges and data flows. These metrics now use fixed-size histogram buckets that no longer grow with uptime, reducing steady-state container memory by roughly 30%
 
 - **Simplified S7 address format for non-Data Block memory areas** - Previously, S7 addresses for PE, PA, MK, C, and T areas required a block number that served no function. You can now write `PE.X0.0` instead of `PE0.X0.0`. The old format still works but logs a deprecation warning and will be removed in a future version. Data Block addresses (`DB1.DW20`) are unchanged
 

--- a/umh-core/integration/metrics_parsing.go
+++ b/umh-core/integration/metrics_parsing.go
@@ -219,7 +219,7 @@ func checkWhetherMetricsHealthy(body string, enforceP99ReconcileTime bool, enfor
 		errors = append(errors, err)
 	}
 
-	if err := displayReconcileTimeQuantiles(body); err != nil {
+	if err := displayReconcileTimeHistogram(body); err != nil {
 		errors = append(errors, err)
 	}
 
@@ -291,8 +291,8 @@ func checkErrorCounters(body string) error {
 	return nil
 }
 
-// displayReconcileTimeQuantiles displays the reconcile time histogram bucket distribution for the control loop.
-func displayReconcileTimeQuantiles(body string) error {
+// displayReconcileTimeHistogram displays the reconcile time histogram bucket distribution for the control loop.
+func displayReconcileTimeHistogram(body string) error {
 	GinkgoWriter.Println("\nControl loop reconcile time histogram buckets:")
 
 	buckets := []string{"1", "2", "5", "10", "20", "50", "90", "100", "200", "500", "1000", "+Inf"}

--- a/umh-core/integration/metrics_parsing.go
+++ b/umh-core/integration/metrics_parsing.go
@@ -52,24 +52,21 @@ func parseMetricValue(metricsBody, metricName string) (float64, bool) {
 	return 0, false
 }
 
-// parseSummaryQuantile scans the metrics for a summary line, e.g.:
+// parseHistogramBucket scans the metrics for a histogram bucket line, e.g.:
 //
-//	metricName{component="control_loop",instance="main",quantile="0.99"}  12
+//	metricName_bucket{component="control_loop",instance="main",le="90"}  450
 //
-// We'll look for lines that start with metricName and contain 'quantile="<quantile>"'
-// (and optionally we can also filter by component=..., instance=..., if needed).
-func parseSummaryQuantile(metricsBody, metricName, quantile, component, instance string) (float64, bool) {
-	// Build a regex that matches the line with specific labels including component and instance
-	// For example:
-	//   umh_core_reconcile_duration_milliseconds{component="control_loop",instance="main",quantile="0.99"}  31
-	pattern := fmt.Sprintf(`^%s\{[^}]*component="%s"[^}]*instance="%s"[^}]*quantile="%s"[^}]*\}\s+([0-9.+-eE]+)$`,
-		regexp.QuoteMeta(metricName), regexp.QuoteMeta(component), regexp.QuoteMeta(instance), regexp.QuoteMeta(quantile))
+// Returns the cumulative count for the given bucket boundary.
+func parseHistogramBucket(metricsBody, metricName, le, component, instance string) (float64, bool) {
+	bucketMetric := metricName + "_bucket"
+	pattern := fmt.Sprintf(`^%s\{[^}]*component="%s"[^}]*instance="%s"[^}]*le="%s"[^}]*\}\s+([0-9.+-eE]+)$`,
+		regexp.QuoteMeta(bucketMetric), regexp.QuoteMeta(component), regexp.QuoteMeta(instance), regexp.QuoteMeta(le))
 
 	re := regexp.MustCompile(pattern)
 
 	lines := strings.Split(metricsBody, "\n")
 	for _, line := range lines {
-		if strings.Contains(line, metricName) && strings.Contains(line, quantile) {
+		if strings.Contains(line, bucketMetric) && strings.Contains(line, fmt.Sprintf(`le="%s"`, le)) {
 			if match := re.FindStringSubmatch(line); match != nil {
 				valStr := match[1]
 
@@ -82,10 +79,10 @@ func parseSummaryQuantile(metricsBody, metricName, quantile, component, instance
 	}
 
 	// If no match, dump all relevant lines for debugging
-	GinkgoWriter.Println("No exact match found. Relevant lines:")
+	GinkgoWriter.Println("No exact match found. Relevant bucket lines:")
 
 	for _, line := range lines {
-		if strings.Contains(line, metricName) && strings.Contains(line, "quantile=\"0.99\"") {
+		if strings.Contains(line, bucketMetric) && strings.Contains(line, fmt.Sprintf(`component="%s"`, component)) {
 			GinkgoWriter.Printf("  %s\n", line)
 		}
 	}
@@ -93,25 +90,44 @@ func parseSummaryQuantile(metricsBody, metricName, quantile, component, instance
 	return 0, false
 }
 
-// printAllReconcileDurations prints all reconcile duration p99 metrics that are over a threshold.
-func printAllReconcileDurations(metricsBody string, thresholdMs float64) {
+// parseHistogramCount scans the metrics for a histogram _count line, e.g.:
+//
+//	metricName_count{component="control_loop",instance="main"}  500
+func parseHistogramCount(metricsBody, metricName, component, instance string) (float64, bool) {
+	countMetric := metricName + "_count"
+	pattern := fmt.Sprintf(`^%s\{[^}]*component="%s"[^}]*instance="%s"[^}]*\}\s+([0-9.+-eE]+)$`,
+		regexp.QuoteMeta(countMetric), regexp.QuoteMeta(component), regexp.QuoteMeta(instance))
+
+	re := regexp.MustCompile(pattern)
+
+	lines := strings.Split(metricsBody, "\n")
+	for _, line := range lines {
+		if strings.Contains(line, countMetric) {
+			if match := re.FindStringSubmatch(line); match != nil {
+				valStr := match[1]
+
+				f, err := strconv.ParseFloat(valStr, 64)
+				if err == nil {
+					return f, true
+				}
+			}
+		}
+	}
+
+	return 0, false
+}
+
+// printAllReconcileDurations prints all reconcile duration histogram bucket data for debugging.
+func printAllReconcileDurations(metricsBody string, _ float64) {
 	lines := strings.Split(metricsBody, "\n")
 
-	GinkgoWriter.Printf("\nReconcile p99 durations over %.1f ms:\n", thresholdMs)
+	GinkgoWriter.Printf("\nReconcile duration histogram buckets:\n")
 
 	for _, line := range lines {
-		if strings.Contains(line, "umh_core_reconcile_duration_milliseconds") && strings.Contains(line, `quantile="0.99"`) {
-			fields := strings.Fields(line)
-			if len(fields) < 2 {
-				continue
-			}
-
-			valStr := fields[len(fields)-1]
-
-			val, err := strconv.ParseFloat(valStr, 64)
-			if err == nil && val > thresholdMs {
-				GinkgoWriter.Printf("  %s\n", line)
-			}
+		if strings.Contains(line, "umh_core_reconcile_duration_milliseconds_bucket") ||
+			strings.Contains(line, "umh_core_reconcile_duration_milliseconds_count") ||
+			strings.Contains(line, "umh_core_reconcile_duration_milliseconds_sum") {
+			GinkgoWriter.Printf("  %s\n", line)
 		}
 	}
 }
@@ -206,47 +222,62 @@ func checkErrorCounters(body string) error {
 	return nil
 }
 
-// displayReconcileTimeQuantiles displays the reconcile time quantiles for the control loop.
+// displayReconcileTimeQuantiles displays the reconcile time histogram bucket distribution for the control loop.
 func displayReconcileTimeQuantiles(body string) error {
-	GinkgoWriter.Println("\nControl loop reconcile time quantiles:")
+	GinkgoWriter.Println("\nControl loop reconcile time histogram buckets:")
 
-	quantiles := []string{"0.5", "0.9", "0.95", "0.99"}
-	for _, q := range quantiles {
-		val, found := parseSummaryQuantile(body,
-			"umh_core_reconcile_duration_milliseconds", q, "control_loop", "main")
+	buckets := []string{"1", "2", "5", "10", "20", "50", "90", "100", "200", "500", "1000", "+Inf"}
+	for _, b := range buckets {
+		val, found := parseHistogramBucket(body,
+			"umh_core_reconcile_duration_milliseconds", b, "control_loop", "main")
 		if found {
-			GinkgoWriter.Printf("  %s quantile: %.2f ms\n", q, val)
+			GinkgoWriter.Printf("  le=%s: %.0f\n", b, val)
 		} else {
-			GinkgoWriter.Printf("  %s quantile: not found\n", q)
+			GinkgoWriter.Printf("  le=%s: not found\n", b)
 		}
+	}
+
+	count, found := parseHistogramCount(body, "umh_core_reconcile_duration_milliseconds", "control_loop", "main")
+	if found {
+		GinkgoWriter.Printf("  count: %.0f\n", count)
 	}
 
 	return nil
 }
 
-// checkReconcileTimeThresholds checks the reconcile time thresholds based on configuration.
+// checkReconcileTimeThresholds checks reconcile time thresholds using histogram bucket ratios.
+// For p99 enforcement: verifies that >=99% of observations fall within the le="90" bucket.
+// For p95 enforcement: verifies that >=95% of observations fall within the le="90" bucket.
 func checkReconcileTimeThresholds(body string, enforceP99ReconcileTime bool, enforceP95ReconcileTime bool) error {
-	if enforceP99ReconcileTime {
-		// Enforce the 99th percentile threshold
-		recon99, found := parseSummaryQuantile(body,
-			"umh_core_reconcile_duration_milliseconds", "0.99", "control_loop", "main")
-		if !found {
-			return errors.New("expected to find 0.99 quantile for control_loop's reconcile time")
-		}
+	if !enforceP99ReconcileTime && !enforceP95ReconcileTime {
+		return nil
+	}
 
-		if recon99 > maxReconcileTime99th {
-			return fmt.Errorf("99th percentile reconcile time (%.2f ms) exceeded %.1f ms", recon99, maxReconcileTime99th)
+	// Use the bucket boundary matching our threshold (90ms)
+	thresholdBucket := fmt.Sprintf("%g", maxReconcileTime99th)
+	bucketCount, foundBucket := parseHistogramBucket(body,
+		"umh_core_reconcile_duration_milliseconds", thresholdBucket, "control_loop", "main")
+
+	totalCount, foundCount := parseHistogramCount(body,
+		"umh_core_reconcile_duration_milliseconds", "control_loop", "main")
+
+	if !foundBucket || !foundCount {
+		return fmt.Errorf("expected to find histogram bucket le=%s and count for control_loop's reconcile time", thresholdBucket)
+	}
+
+	if totalCount == 0 {
+		return errors.New("histogram count is zero for control_loop's reconcile time")
+	}
+
+	ratio := bucketCount / totalCount
+
+	if enforceP99ReconcileTime {
+		if ratio < 0.99 {
+			return fmt.Errorf("less than 99%% of reconciliations completed within %.0f ms (%.1f%% did)", maxReconcileTime99th, ratio*100)
 		}
 	} else if enforceP95ReconcileTime {
-		// Enforce the 95th percentile threshold
-		recon95, found := parseSummaryQuantile(body,
-			"umh_core_reconcile_duration_milliseconds", "0.95", "control_loop", "main")
-		if !found {
-			return errors.New("expected to find 0.95 quantile for control_loop's reconcile time")
-		}
-
-		if recon95 > maxReconcileTime99th { // For now this uses the same limit as the 99th percentile
-			return fmt.Errorf("95th percentile reconcile time (%.2f ms) exceeded %.1f ms", recon95, maxReconcileTime99th)
+		if ratio < 0.95 {
+			return fmt.Errorf("less than 95%% of reconciliations completed within %.0f ms (%.1f%% did)", maxReconcileTime99th, ratio*100)
 		}
 	}
 

--- a/umh-core/integration/metrics_parsing.go
+++ b/umh-core/integration/metrics_parsing.go
@@ -57,7 +57,8 @@ func parseMetricValue(metricsBody, metricName string) (float64, bool) {
 //	metricName_bucket{component="control_loop",instance="main",le="90"}  450
 //
 // Returns the cumulative count for the given bucket boundary.
-func parseHistogramBucket(metricsBody, metricName, le, component, instance string) (float64, bool) {
+// When verbose is true, prints debug output on miss (use for targeted diagnostics).
+func parseHistogramBucket(metricsBody, metricName, le, component, instance string, verbose ...bool) (float64, bool) {
 	bucketMetric := metricName + "_bucket"
 	pattern := fmt.Sprintf(`^%s\{[^}]*component="%s"[^}]*instance="%s"[^}]*le="%s"[^}]*\}\s+([0-9.+-eE]+)$`,
 		regexp.QuoteMeta(bucketMetric), regexp.QuoteMeta(component), regexp.QuoteMeta(instance), regexp.QuoteMeta(le))
@@ -78,12 +79,14 @@ func parseHistogramBucket(metricsBody, metricName, le, component, instance strin
 		}
 	}
 
-	// If no match, dump all relevant lines for debugging
-	GinkgoWriter.Println("No exact match found. Relevant bucket lines:")
+	// Only dump debug output when explicitly requested
+	if len(verbose) > 0 && verbose[0] {
+		GinkgoWriter.Println("No exact match found. Relevant bucket lines:")
 
-	for _, line := range lines {
-		if strings.Contains(line, bucketMetric) && strings.Contains(line, fmt.Sprintf(`component="%s"`, component)) {
-			GinkgoWriter.Printf("  %s\n", line)
+		for _, line := range lines {
+			if strings.Contains(line, bucketMetric) && strings.Contains(line, fmt.Sprintf(`component="%s"`, component)) {
+				GinkgoWriter.Printf("  %s\n", line)
+			}
 		}
 	}
 
@@ -117,19 +120,85 @@ func parseHistogramCount(metricsBody, metricName, component, instance string) (f
 	return 0, false
 }
 
-// printAllReconcileDurations prints all reconcile duration histogram bucket data for debugging.
-func printAllReconcileDurations(metricsBody string) {
+// printSlowReconcileComponents prints reconcile duration data only for components where
+// less than 95% of observations fall within the 90ms bucket, indicating potential issues.
+// This avoids flooding JUnit XML with thousands of lines of debug output from healthy components.
+func printSlowReconcileComponents(metricsBody string, thresholdBucket string) {
 	lines := strings.Split(metricsBody, "\n")
 
-	GinkgoWriter.Printf("\nReconcile duration histogram buckets:\n")
+	// Extract unique component/instance pairs from _count lines
+	type componentKey struct {
+		component string
+		instance  string
+	}
+
+	var slow []componentKey
+
+	countMetric := "umh_core_reconcile_duration_milliseconds_count"
+	bucketMetric := "umh_core_reconcile_duration_milliseconds_bucket"
 
 	for _, line := range lines {
-		if strings.Contains(line, "umh_core_reconcile_duration_milliseconds_bucket") ||
-			strings.Contains(line, "umh_core_reconcile_duration_milliseconds_count") ||
-			strings.Contains(line, "umh_core_reconcile_duration_milliseconds_sum") {
-			GinkgoWriter.Printf("  %s\n", line)
+		if !strings.Contains(line, countMetric) {
+			continue
+		}
+
+		component := extractLabel(line, "component")
+		instance := extractLabel(line, "instance")
+		if component == "" || instance == "" {
+			continue
+		}
+
+		total, foundTotal := parseHistogramCount(metricsBody, "umh_core_reconcile_duration_milliseconds", component, instance)
+		if !foundTotal || total == 0 {
+			continue
+		}
+
+		bucket, foundBucket := parseHistogramBucket(metricsBody, "umh_core_reconcile_duration_milliseconds", thresholdBucket, component, instance)
+		if !foundBucket {
+			continue
+		}
+
+		if bucket/total < 0.95 {
+			slow = append(slow, componentKey{component, instance})
 		}
 	}
+
+	if len(slow) == 0 {
+		return
+	}
+
+	GinkgoWriter.Printf("\nSlow reconcile components (>5%% above %sms):\n", thresholdBucket)
+
+	for _, k := range slow {
+		GinkgoWriter.Printf("  %s/%s:\n", k.component, k.instance)
+
+		for _, line := range lines {
+			if (strings.Contains(line, bucketMetric) ||
+				strings.Contains(line, countMetric) ||
+				strings.Contains(line, "umh_core_reconcile_duration_milliseconds_sum")) &&
+				strings.Contains(line, fmt.Sprintf(`component="%s"`, k.component)) &&
+				strings.Contains(line, fmt.Sprintf(`instance="%s"`, k.instance)) {
+				GinkgoWriter.Printf("    %s\n", line)
+			}
+		}
+	}
+}
+
+// extractLabel extracts a label value from a Prometheus metric line.
+func extractLabel(line, label string) string {
+	prefix := label + `="`
+	idx := strings.Index(line, prefix)
+	if idx < 0 {
+		return ""
+	}
+
+	start := idx + len(prefix)
+	end := strings.Index(line[start:], `"`)
+	if end < 0 {
+		return ""
+	}
+
+	return line[start : start+end]
 }
 
 // checkWhetherMetricsHealthy checks that the metrics are healthy and returns an error if they are not.
@@ -154,8 +223,8 @@ func checkWhetherMetricsHealthy(body string, enforceP99ReconcileTime bool, enfor
 		errors = append(errors, err)
 	}
 
-	// Print all reconcile durations over threshold for debugging
-	printAllReconcileDurations(body)
+	// Print only slow reconcile components for debugging
+	printSlowReconcileComponents(body, fmt.Sprintf("%g", maxReconcileTime99th))
 
 	if err := checkReconcileTimeThresholds(body, enforceP99ReconcileTime, enforceP95ReconcileTime); err != nil {
 		errors = append(errors, err)
@@ -229,7 +298,7 @@ func displayReconcileTimeQuantiles(body string) error {
 	buckets := []string{"1", "2", "5", "10", "20", "50", "90", "100", "200", "500", "1000", "+Inf"}
 	for _, b := range buckets {
 		val, found := parseHistogramBucket(body,
-			"umh_core_reconcile_duration_milliseconds", b, "control_loop", "main")
+			"umh_core_reconcile_duration_milliseconds", b, "control_loop", "main", true)
 		if found {
 			GinkgoWriter.Printf("  le=%s: %.0f\n", b, val)
 		} else {
@@ -256,7 +325,7 @@ func checkReconcileTimeThresholds(body string, enforceP99ReconcileTime bool, enf
 	// Use the bucket boundary matching our threshold (90ms)
 	thresholdBucket := fmt.Sprintf("%g", maxReconcileTime99th)
 	bucketCount, foundBucket := parseHistogramBucket(body,
-		"umh_core_reconcile_duration_milliseconds", thresholdBucket, "control_loop", "main")
+		"umh_core_reconcile_duration_milliseconds", thresholdBucket, "control_loop", "main", true)
 
 	totalCount, foundCount := parseHistogramCount(body,
 		"umh_core_reconcile_duration_milliseconds", "control_loop", "main")

--- a/umh-core/integration/metrics_parsing.go
+++ b/umh-core/integration/metrics_parsing.go
@@ -118,7 +118,7 @@ func parseHistogramCount(metricsBody, metricName, component, instance string) (f
 }
 
 // printAllReconcileDurations prints all reconcile duration histogram bucket data for debugging.
-func printAllReconcileDurations(metricsBody string, _ float64) {
+func printAllReconcileDurations(metricsBody string) {
 	lines := strings.Split(metricsBody, "\n")
 
 	GinkgoWriter.Printf("\nReconcile duration histogram buckets:\n")
@@ -155,7 +155,7 @@ func checkWhetherMetricsHealthy(body string, enforceP99ReconcileTime bool, enfor
 	}
 
 	// Print all reconcile durations over threshold for debugging
-	printAllReconcileDurations(body, 20.0)
+	printAllReconcileDurations(body)
 
 	if err := checkReconcileTimeThresholds(body, enforceP99ReconcileTime, enforceP95ReconcileTime); err != nil {
 		errors = append(errors, err)

--- a/umh-core/integration/metrics_parsing_test.go
+++ b/umh-core/integration/metrics_parsing_test.go
@@ -208,14 +208,15 @@ umh_core_reconcile_starved_total_seconds 3`
 
 		It("should pass with healthy metrics", func() {
 			// Modify metrics to be healthy: no errors, no starved seconds, and >=99% within 90ms.
-			// Change le="90" bucket from 95 to 100 so ratio is 100/100 = 100% (passes p99).
+			// Change le="90" bucket from 95 to 99 so ratio is 99/100 = 99% (passes p99).
+			// Using 99 (not 100) to maintain cumulative histogram ordering: le="90" <= le="100" (both 99).
 			healthyMetrics := strings.ReplaceAll(testMetrics, "umh_core_errors_total{component=\"s6_instance\",instance=\"golden-service\"} 3",
 				"umh_core_errors_total{component=\"s6_instance\",instance=\"golden-service\"} 0")
 			healthyMetrics = strings.ReplaceAll(healthyMetrics, "umh_core_reconcile_starved_total_seconds 3",
 				"umh_core_reconcile_starved_total_seconds 0")
 			healthyMetrics = strings.ReplaceAll(healthyMetrics,
 				"umh_core_reconcile_duration_milliseconds_bucket{component=\"control_loop\",instance=\"main\",le=\"90\"} 95",
-				"umh_core_reconcile_duration_milliseconds_bucket{component=\"control_loop\",instance=\"main\",le=\"90\"} 100")
+				"umh_core_reconcile_duration_milliseconds_bucket{component=\"control_loop\",instance=\"main\",le=\"90\"} 99")
 
 			metricsErrors := checkWhetherMetricsHealthy(healthyMetrics, true, true)
 			Expect(metricsErrors).To(BeEmpty(), "Should not have any failures with healthy metrics")

--- a/umh-core/integration/metrics_parsing_test.go
+++ b/umh-core/integration/metrics_parsing_test.go
@@ -133,6 +133,18 @@ umh_core_reconcile_starved_total_seconds 3`
 				"umh_core_reconcile_duration_milliseconds", "90", "non_existent", "component")
 			Expect(found).To(BeFalse(), "Should not find a non-existent component")
 		})
+
+		It("should return false for a non-existent bucket boundary", func() {
+			_, found := parseHistogramBucket(testMetrics,
+				"umh_core_reconcile_duration_milliseconds", "999", "control_loop", "main")
+			Expect(found).To(BeFalse(), "Should not find le=999 bucket")
+		})
+
+		It("should return false for empty metrics string", func() {
+			_, found := parseHistogramBucket("",
+				"umh_core_reconcile_duration_milliseconds", "90", "control_loop", "main")
+			Expect(found).To(BeFalse(), "Should not find anything in empty metrics")
+		})
 	})
 
 	Describe("parseHistogramCount", Label("integration"), func() {
@@ -146,6 +158,12 @@ umh_core_reconcile_starved_total_seconds 3`
 				"umh_core_reconcile_duration_milliseconds", "base_fsm_manager", "S6ManagerCore")
 			Expect(found).To(BeTrue(), "Should find the count for base_fsm_manager/S6ManagerCore")
 			Expect(s6Count).To(BeNumerically("==", 50), "Should parse the S6 manager count correctly")
+		})
+
+		It("should return false when _count metric is missing", func() {
+			_, found := parseHistogramCount(testMetrics,
+				"umh_core_reconcile_duration_milliseconds", "non_existent", "instance")
+			Expect(found).To(BeFalse(), "Should not find count for non-existent component")
 		})
 	})
 
@@ -224,6 +242,18 @@ umh_core_reconcile_starved_total_seconds 3`
 				}
 			}
 			Expect(foundReconcileTimeError).To(BeTrue(), "Should have caught the reconcile time error")
+		})
+	})
+
+	Describe("checkReconcileTimeThresholds", Label("integration"), func() {
+		It("should return error when total count is zero", func() {
+			zeroCountMetrics := strings.ReplaceAll(testMetrics,
+				"umh_core_reconcile_duration_milliseconds_count{component=\"control_loop\",instance=\"main\"} 100",
+				"umh_core_reconcile_duration_milliseconds_count{component=\"control_loop\",instance=\"main\"} 0")
+
+			err := checkReconcileTimeThresholds(zeroCountMetrics, true, false)
+			Expect(err).To(HaveOccurred(), "Should return error when count is zero")
+			Expect(err.Error()).To(ContainSubstring("zero"), "Error should mention zero count")
 		})
 	})
 })

--- a/umh-core/integration/metrics_parsing_test.go
+++ b/umh-core/integration/metrics_parsing_test.go
@@ -28,7 +28,6 @@
 package integration_test
 
 import (
-	"strconv"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -41,6 +40,9 @@ var _ = Describe("Metrics Parsing", Label("metrics_parsing"), func() {
 
 	BeforeEach(func() {
 		// This is our test metrics data with various violations
+		// Uses histogram format (buckets) instead of summary (quantiles).
+		// The control_loop/main has 100 total observations: 95 under 90ms, 99 under 100ms, 1 over 1000ms.
+		// The base_fsm_manager/S6ManagerCore has 50 total observations all under 1ms.
 		testMetrics = `# HELP go_memstats_alloc_bytes Number of bytes allocated in heap and currently in use.
 # TYPE go_memstats_alloc_bytes gauge
 go_memstats_alloc_bytes 3.05356e+06
@@ -54,15 +56,35 @@ umh_core_errors_total{component="s6_instance",instance="golden-service"} 3
 umh_core_errors_total{component="s6_instance",instance="sleepy"} 0
 umh_core_errors_total{component="s6_manager",instance="Core"} 0
 # HELP umh_core_reconcile_duration_milliseconds Time taken to reconcile (in milliseconds)
-# TYPE umh_core_reconcile_duration_milliseconds summary
-umh_core_reconcile_duration_milliseconds{component="base_fsm_manager",instance="S6ManagerCore",quantile="0.5"} 0
-umh_core_reconcile_duration_milliseconds{component="base_fsm_manager",instance="S6ManagerCore",quantile="0.9"} 0
-umh_core_reconcile_duration_milliseconds{component="base_fsm_manager",instance="S6ManagerCore",quantile="0.95"} 0
-umh_core_reconcile_duration_milliseconds{component="base_fsm_manager",instance="S6ManagerCore",quantile="0.99"} 0
-umh_core_reconcile_duration_milliseconds{component="control_loop",instance="main",quantile="0.5"} 1
-umh_core_reconcile_duration_milliseconds{component="control_loop",instance="main",quantile="0.9"} 1
-umh_core_reconcile_duration_milliseconds{component="control_loop",instance="main",quantile="0.95"} 2
-umh_core_reconcile_duration_milliseconds{component="control_loop",instance="main",quantile="0.99"} 16
+# TYPE umh_core_reconcile_duration_milliseconds histogram
+umh_core_reconcile_duration_milliseconds_bucket{component="base_fsm_manager",instance="S6ManagerCore",le="1"} 50
+umh_core_reconcile_duration_milliseconds_bucket{component="base_fsm_manager",instance="S6ManagerCore",le="2"} 50
+umh_core_reconcile_duration_milliseconds_bucket{component="base_fsm_manager",instance="S6ManagerCore",le="5"} 50
+umh_core_reconcile_duration_milliseconds_bucket{component="base_fsm_manager",instance="S6ManagerCore",le="10"} 50
+umh_core_reconcile_duration_milliseconds_bucket{component="base_fsm_manager",instance="S6ManagerCore",le="20"} 50
+umh_core_reconcile_duration_milliseconds_bucket{component="base_fsm_manager",instance="S6ManagerCore",le="50"} 50
+umh_core_reconcile_duration_milliseconds_bucket{component="base_fsm_manager",instance="S6ManagerCore",le="90"} 50
+umh_core_reconcile_duration_milliseconds_bucket{component="base_fsm_manager",instance="S6ManagerCore",le="100"} 50
+umh_core_reconcile_duration_milliseconds_bucket{component="base_fsm_manager",instance="S6ManagerCore",le="200"} 50
+umh_core_reconcile_duration_milliseconds_bucket{component="base_fsm_manager",instance="S6ManagerCore",le="500"} 50
+umh_core_reconcile_duration_milliseconds_bucket{component="base_fsm_manager",instance="S6ManagerCore",le="1000"} 50
+umh_core_reconcile_duration_milliseconds_bucket{component="base_fsm_manager",instance="S6ManagerCore",le="+Inf"} 50
+umh_core_reconcile_duration_milliseconds_sum{component="base_fsm_manager",instance="S6ManagerCore"} 10
+umh_core_reconcile_duration_milliseconds_count{component="base_fsm_manager",instance="S6ManagerCore"} 50
+umh_core_reconcile_duration_milliseconds_bucket{component="control_loop",instance="main",le="1"} 60
+umh_core_reconcile_duration_milliseconds_bucket{component="control_loop",instance="main",le="2"} 75
+umh_core_reconcile_duration_milliseconds_bucket{component="control_loop",instance="main",le="5"} 85
+umh_core_reconcile_duration_milliseconds_bucket{component="control_loop",instance="main",le="10"} 90
+umh_core_reconcile_duration_milliseconds_bucket{component="control_loop",instance="main",le="20"} 93
+umh_core_reconcile_duration_milliseconds_bucket{component="control_loop",instance="main",le="50"} 95
+umh_core_reconcile_duration_milliseconds_bucket{component="control_loop",instance="main",le="90"} 95
+umh_core_reconcile_duration_milliseconds_bucket{component="control_loop",instance="main",le="100"} 99
+umh_core_reconcile_duration_milliseconds_bucket{component="control_loop",instance="main",le="200"} 99
+umh_core_reconcile_duration_milliseconds_bucket{component="control_loop",instance="main",le="500"} 99
+umh_core_reconcile_duration_milliseconds_bucket{component="control_loop",instance="main",le="1000"} 99
+umh_core_reconcile_duration_milliseconds_bucket{component="control_loop",instance="main",le="+Inf"} 100
+umh_core_reconcile_duration_milliseconds_sum{component="control_loop",instance="main"} 450
+umh_core_reconcile_duration_milliseconds_count{component="control_loop",instance="main"} 100
 # HELP umh_core_reconcile_starved_total_seconds Total seconds the reconcile loop was starved
 # TYPE umh_core_reconcile_starved_total_seconds counter
 umh_core_reconcile_starved_total_seconds 3`
@@ -86,30 +108,44 @@ umh_core_reconcile_starved_total_seconds 3`
 		})
 	})
 
-	Describe("parseSummaryQuantile", Label("integration"), func() {
-		It("should parse quantile metrics correctly when filtering by component and instance", func() {
-			// Test finding the 99th percentile for control_loop/main
-			p99, found := parseSummaryQuantile(testMetrics,
-				"umh_core_reconcile_duration_milliseconds", "0.99", "control_loop", "main")
-			Expect(found).To(BeTrue(), "Should find the 0.99 quantile for control_loop/main")
-			Expect(p99).To(BeNumerically("==", 16), "Should parse the 99th percentile correctly")
+	Describe("parseHistogramBucket", Label("integration"), func() {
+		It("should parse histogram bucket metrics correctly when filtering by component and instance", func() {
+			// Test finding the le="90" bucket for control_loop/main (95 of 100 observations)
+			bucket90, found := parseHistogramBucket(testMetrics,
+				"umh_core_reconcile_duration_milliseconds", "90", "control_loop", "main")
+			Expect(found).To(BeTrue(), "Should find the le=90 bucket for control_loop/main")
+			Expect(bucket90).To(BeNumerically("==", 95), "Should parse the le=90 bucket correctly")
 
-			// Test finding the 95th percentile for control_loop/main
-			p95, found := parseSummaryQuantile(testMetrics,
-				"umh_core_reconcile_duration_milliseconds", "0.95", "control_loop", "main")
-			Expect(found).To(BeTrue(), "Should find the 0.95 quantile for control_loop/main")
-			Expect(p95).To(BeNumerically("==", 2), "Should parse the 95th percentile correctly")
+			// Test finding the le="100" bucket for control_loop/main (99 of 100 observations)
+			bucket100, found := parseHistogramBucket(testMetrics,
+				"umh_core_reconcile_duration_milliseconds", "100", "control_loop", "main")
+			Expect(found).To(BeTrue(), "Should find the le=100 bucket for control_loop/main")
+			Expect(bucket100).To(BeNumerically("==", 99), "Should parse the le=100 bucket correctly")
 
-			// Test finding a metric for a different component
-			p99s6, found := parseSummaryQuantile(testMetrics,
-				"umh_core_reconcile_duration_milliseconds", "0.99", "base_fsm_manager", "S6ManagerCore")
-			Expect(found).To(BeTrue(), "Should find the 0.99 quantile for base_fsm_manager/S6ManagerCore")
-			Expect(p99s6).To(BeNumerically("==", 0), "Should parse the S6 manager 99th percentile correctly")
+			// Test finding a bucket for a different component (all 50 observations under 1ms)
+			s6Bucket, found := parseHistogramBucket(testMetrics,
+				"umh_core_reconcile_duration_milliseconds", "1", "base_fsm_manager", "S6ManagerCore")
+			Expect(found).To(BeTrue(), "Should find the le=1 bucket for base_fsm_manager/S6ManagerCore")
+			Expect(s6Bucket).To(BeNumerically("==", 50), "Should parse the S6 manager le=1 bucket correctly")
 
 			// Test a non-existent component/instance
-			_, found = parseSummaryQuantile(testMetrics,
-				"umh_core_reconcile_duration_milliseconds", "0.99", "non_existent", "component")
+			_, found = parseHistogramBucket(testMetrics,
+				"umh_core_reconcile_duration_milliseconds", "90", "non_existent", "component")
 			Expect(found).To(BeFalse(), "Should not find a non-existent component")
+		})
+	})
+
+	Describe("parseHistogramCount", Label("integration"), func() {
+		It("should parse histogram count correctly", func() {
+			count, found := parseHistogramCount(testMetrics,
+				"umh_core_reconcile_duration_milliseconds", "control_loop", "main")
+			Expect(found).To(BeTrue(), "Should find the count for control_loop/main")
+			Expect(count).To(BeNumerically("==", 100), "Should parse the count correctly")
+
+			s6Count, found := parseHistogramCount(testMetrics,
+				"umh_core_reconcile_duration_milliseconds", "base_fsm_manager", "S6ManagerCore")
+			Expect(found).To(BeTrue(), "Should find the count for base_fsm_manager/S6ManagerCore")
+			Expect(s6Count).To(BeNumerically("==", 50), "Should parse the S6 manager count correctly")
 		})
 	})
 
@@ -153,26 +189,27 @@ umh_core_reconcile_starved_total_seconds 3`
 		})
 
 		It("should pass with healthy metrics", func() {
-			// Modify metrics to be healthy (no errors, no starved seconds, p99 under threshold)
+			// Modify metrics to be healthy: no errors, no starved seconds, and >=99% within 90ms.
+			// Change le="90" bucket from 95 to 100 so ratio is 100/100 = 100% (passes p99).
 			healthyMetrics := strings.ReplaceAll(testMetrics, "umh_core_errors_total{component=\"s6_instance\",instance=\"golden-service\"} 3",
 				"umh_core_errors_total{component=\"s6_instance\",instance=\"golden-service\"} 0")
 			healthyMetrics = strings.ReplaceAll(healthyMetrics, "umh_core_reconcile_starved_total_seconds 3",
 				"umh_core_reconcile_starved_total_seconds 0")
+			healthyMetrics = strings.ReplaceAll(healthyMetrics,
+				"umh_core_reconcile_duration_milliseconds_bucket{component=\"control_loop\",instance=\"main\",le=\"90\"} 95",
+				"umh_core_reconcile_duration_milliseconds_bucket{component=\"control_loop\",instance=\"main\",le=\"90\"} 100")
 
 			metricsErrors := checkWhetherMetricsHealthy(healthyMetrics, true, true)
 			Expect(metricsErrors).To(BeEmpty(), "Should not have any failures with healthy metrics")
 		})
 
 		It("should fail when p99 reconcile time exceeds max", func() {
-			// Using the non-error metrics but changing the reconcile time to exceed the threshold
+			// Modify metrics to have no errors/starved seconds but too many observations above 90ms.
+			// The default fixture has le="90" = 95 out of 100 = 95%, which fails the 99% threshold.
 			noErrorMetrics := strings.ReplaceAll(testMetrics, "umh_core_errors_total{component=\"s6_instance\",instance=\"golden-service\"} 3",
 				"umh_core_errors_total{component=\"s6_instance\",instance=\"golden-service\"} 0")
-			noErrorStarvedMetrics := strings.ReplaceAll(noErrorMetrics, "umh_core_reconcile_starved_total_seconds 3",
+			highReconcileMetrics := strings.ReplaceAll(noErrorMetrics, "umh_core_reconcile_starved_total_seconds 3",
 				"umh_core_reconcile_starved_total_seconds 0")
-
-			highReconcileMetrics := strings.ReplaceAll(noErrorStarvedMetrics,
-				"umh_core_reconcile_duration_milliseconds{component=\"control_loop\",instance=\"main\",quantile=\"0.99\"} 16",
-				"umh_core_reconcile_duration_milliseconds{component=\"control_loop\",instance=\"main\",quantile=\"0.99\"} "+strconv.FormatFloat(maxReconcileTime99th+1, 'f', -1, 64))
 
 			metricsErrors := checkWhetherMetricsHealthy(highReconcileMetrics, true, true)
 			Expect(metricsErrors).NotTo(BeEmpty(), "Should have detected high reconcile time")
@@ -180,7 +217,7 @@ umh_core_reconcile_starved_total_seconds 3`
 			// Check that we caught the reconcile time issue
 			foundReconcileTimeError := false
 			for _, failure := range metricsErrors {
-				if strings.Contains(failure.Error(), "reconcile time") && strings.Contains(failure.Error(), strconv.FormatFloat(maxReconcileTime99th, 'f', -1, 64)) {
+				if strings.Contains(failure.Error(), "reconciliations completed within") {
 					foundReconcileTimeError = true
 
 					break

--- a/umh-core/pkg/metrics/metrics.go
+++ b/umh-core/pkg/metrics/metrics.go
@@ -86,18 +86,13 @@ var (
 	)
 
 	// Reconcile timing.
-	reconcileTime = promauto.NewSummaryVec(
-		prometheus.SummaryOpts{
+	reconcileTime = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
 			Namespace: namespace,
 			Subsystem: subsystem,
 			Name:      "reconcile_duration_milliseconds",
 			Help:      "Time taken to reconcile (in milliseconds)",
-			Objectives: map[float64]float64{
-				0.5:  0.01, // 50th percentile with 1% error
-				0.9:  0.01, // 90th percentile with 1% error
-				0.95: 0.01, // 95th percentile with 1% error
-				0.99: 0.01, // 99th percentile with 1% error
-			},
+			Buckets:   []float64{1, 2, 5, 10, 20, 50, 90, 100, 200, 500, 1000},
 		},
 		[]string{"component", "instance"},
 	)


### PR DESCRIPTION
## Summary

Replace `promauto.NewSummaryVec` with `promauto.NewHistogramVec` for reconcile duration metrics. SummaryVec maintains sorted sliding-window quantile streams per label combination that grow unboundedly — with ~200-400 unique `{component, instance}` pairs, this consumed **521 MB of heap (64.7% of total)**. HistogramVec uses fixed-size bucket arrays costing only **3 MB** (174x improvement).

### Verified Results (Two Independent Experiment Runs)

| Metric | Baseline (SummaryVec) | Fix (HistogramVec) | Range Across Runs |
|--------|----------------------|-------------------|-------------------|
| **Go heap (pprof)** | 569–805 MB | 140–287 MB | **-64% to -75%** |
| **SummaryVec in heap** | 521 MB (64.7%) | 0 MB | **-100% (confirmed both runs)** |
| **HistogramVec cost** | 0 MB | 3 MB (1.2%) | 174x improvement |
| **Container memory** | 3.8–3.85 GB | 1.35–2.65 GB | **-31% to -65%** |
| **CPU** | 371–373% | 339–379% | **-9% to +2%** |

**Key finding**: Heap reduction is consistent (~64%) across both runs. Container memory and CPU vary with measurement timing — the 31% memory / +2% CPU from the revalidation run (15 min warmup, steady state) are the conservative, reproducible figures. The -65% memory / -9% CPU from the first run captured a transient favorable state early in warmup.

### What works
- SummaryVec quantile buffers fully eliminated (521 MB → 0 MB, confirmed by pprof in both runs)
- Heap stays bounded — HistogramVec uses fixed-size arrays, no growth with label cardinality
- Zero call site changes (`.Observe()` API identical), zero behavioral changes
- FSMv2 state identical between baseline and fix

### What doesn't improve
- **CPU**: +2% regression at steady state from 6.5x more frequent GC cycles on smaller heap. SummaryVec quantile computation was <0.5% of CPU — removing it doesn't save meaningful CPU. The first run's -9% was measured before GC overhead accumulated.
- **Container RSS varies**: 31-65% depending on Redpanda state, benthos worker count, and MADV_FREE page reclamation timing. Go heap (64%) is the authoritative metric.

### Data quality notes from revalidation
- Baseline Prometheus metrics file was accidentally captured from fix container (wrong port) — does not affect heap profiles or docker stats
- High-res CPU tracked s6-svscan (PID 1), not umh-core Go binary — nmap oscillation confirmed unaffected via pprof instead

## Files Changed

1. `pkg/metrics/metrics.go` — SummaryVec → HistogramVec (5-line change)
2. `integration/metrics_parsing.go` — summary quantile parser → histogram bucket parser
3. `integration/metrics_parsing_test.go` — updated test fixtures

## Risk

- **Low**: Zero behavioral changes, zero call site changes
- **Note**: Breaks external Prometheus/Grafana queries using `quantile="..."` labels (need to update to `le="..."` bucket queries)
- **CPU trade-off**: +2% from increased GC frequency — acceptable for eliminating unbounded memory growth

## Test plan

- [x] EXP-1 first run: 82 S6 services, 15 min warmup, heap/memory/CPU captured
- [x] EXP-1 revalidation: 77 S6 services, 15 min warmup, full A/B with pprof + docker stats + Prometheus
- [x] Integration tests pass (metrics_parsing_test.go updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)