### PR TITLE
Parallelize unit test suite execution in CI

### DIFF
--- a/umh-core/Makefile
+++ b/umh-core/Makefile
@@ -317,10 +317,12 @@ test: vet-nilaway-lint-betteralign
 unit-test: vet-nilaway-lint-betteralign
 ifeq ($(CI), true)
 	gotestsum --junitfile unit-test-report.xml -- -race -tags=test -count=1 -failfast \
-		-ginkgo.label-filter='$(UNIT_LABEL_FILTER)' ./cmd/... ./internal/... ./pkg/... ./test/...
+		./cmd/... ./internal/... ./pkg/... ./test/... \
+		-args -ginkgo.label-filter='$(UNIT_LABEL_FILTER)'
 else
 	go test -race -tags=test -count=1 -failfast \
-		-ginkgo.label-filter='$(UNIT_LABEL_FILTER)' ./cmd/... ./internal/... ./pkg/... ./test/...
+		./cmd/... ./internal/... ./pkg/... ./test/... \
+		-args -ginkgo.label-filter='$(UNIT_LABEL_FILTER)'
 endif
 
 unit-test-fail-slow: vet-nilaway-lint-betteralign

--- a/umh-core/Makefile
+++ b/umh-core/Makefile
@@ -60,6 +60,7 @@ NILAWAY_VERSION = v0.0.0-20260213150243-937701de96c7
 LEFTHOOK_VERSION = v1.13.2
 GOLANGCI_LINT_VERSION = v2.5.0
 BETTERALIGN_VERSION = v0.7.1
+GOTESTSUM_VERSION = v1.13.0
 DLV_VERSION = v1.25.1
 
 # Default values for build arguments
@@ -89,6 +90,7 @@ install:
 	go install github.com/evilmartians/lefthook@$(LEFTHOOK_VERSION)
 	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 	go install github.com/dkorunic/betteralign/cmd/betteralign@$(BETTERALIGN_VERSION)
+	go install gotest.tools/gotestsum@$(GOTESTSUM_VERSION)
 
 download-docker-binaries:
 	@mkdir -p .docker-cache/s6-overlay .docker-cache/benthos .docker-cache/redpanda
@@ -224,6 +226,8 @@ else
     INTEGRATION_REPORT_FLAG :=
 endif
 
+UNIT_LABEL_FILTER := !integration && !redpanda-extended && !tls && !live
+
 build:
 build-pprof:       EXTRA_ARGS := --build-arg PPROF=true
 build-debug:       EXTRA_ARGS := --build-arg DEBUG=true
@@ -311,10 +315,16 @@ test: vet-nilaway-lint-betteralign
 	go test -race -v -tags=test ./...
 
 unit-test: vet-nilaway-lint-betteralign
-	go run github.com/onsi/ginkgo/v2/ginkgo -r --tags=test --race --label-filter='!integration && !redpanda-extended && !tls && !live' --fail-fast $(UNIT_REPORT_FLAG) ./...
+ifeq ($(CI), true)
+	GINKGO_LABEL_FILTER='$(UNIT_LABEL_FILTER)' \
+	gotestsum --junitfile unit-test-report.xml -- -race -tags=test -count=1 -failfast ./...
+else
+	GINKGO_LABEL_FILTER='$(UNIT_LABEL_FILTER)' \
+	go test -race -tags=test -count=1 -failfast ./...
+endif
 
 unit-test-fail-slow: vet-nilaway-lint-betteralign
-	go run github.com/onsi/ginkgo/v2/ginkgo -r --tags=test --race --label-filter='!integration && !redpanda-extended && !tls && !live' ./...
+	go run github.com/onsi/ginkgo/v2/ginkgo -r --tags=test --race --label-filter='$(UNIT_LABEL_FILTER)' ./...
 
 benchmark:
 	@echo "Running benchmarks..."

--- a/umh-core/Makefile
+++ b/umh-core/Makefile
@@ -316,11 +316,11 @@ test: vet-nilaway-lint-betteralign
 
 unit-test: vet-nilaway-lint-betteralign
 ifeq ($(CI), true)
-	GINKGO_LABEL_FILTER='$(UNIT_LABEL_FILTER)' \
-	gotestsum --junitfile unit-test-report.xml -- -race -tags=test -count=1 -failfast ./...
+	gotestsum --junitfile unit-test-report.xml -- -race -tags=test -count=1 -failfast \
+		-ginkgo.label-filter='$(UNIT_LABEL_FILTER)' ./cmd/... ./internal/... ./pkg/... ./test/...
 else
-	GINKGO_LABEL_FILTER='$(UNIT_LABEL_FILTER)' \
-	go test -race -tags=test -count=1 -failfast ./...
+	go test -race -tags=test -count=1 -failfast \
+		-ginkgo.label-filter='$(UNIT_LABEL_FILTER)' ./cmd/... ./internal/... ./pkg/... ./test/...
 endif
 
 unit-test-fail-slow: vet-nilaway-lint-betteralign

--- a/umh-core/Makefile
+++ b/umh-core/Makefile
@@ -219,14 +219,14 @@ endef
 
 # Check for CI, add junit report if in CI
 ifeq ($(CI), true)
-    UNIT_REPORT_FLAG := --junit-report=unit-test-report.xml
     INTEGRATION_REPORT_FLAG := --junit-report=integration-test-report.xml -ldflags="-X 'github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/version.AppVersion=$(VERSION)'"
 else
-    UNIT_REPORT_FLAG :=
     INTEGRATION_REPORT_FLAG :=
 endif
 
 UNIT_LABEL_FILTER := !integration && !redpanda-extended && !tls && !live
+# Explicit list: excludes integration/ (requires Docker; has its own make target)
+UNIT_TEST_PKGS := ./cmd/... ./internal/... ./pkg/... ./test/...
 
 build:
 build-pprof:       EXTRA_ARGS := --build-arg PPROF=true
@@ -316,15 +316,16 @@ test: vet-nilaway-lint-betteralign
 
 unit-test: vet-nilaway-lint-betteralign
 ifeq ($(CI), true)
-	gotestsum --junitfile unit-test-report.xml -- -race -tags=test -count=1 -failfast \
-		./cmd/... ./internal/... ./pkg/... ./test/... \
+	gotestsum --junitfile unit-test-report.xml -- -race -v -tags=test -count=1 -failfast \
+		$(UNIT_TEST_PKGS) \
 		-args -ginkgo.label-filter='$(UNIT_LABEL_FILTER)'
 else
-	go test -race -tags=test -count=1 -failfast \
-		./cmd/... ./internal/... ./pkg/... ./test/... \
+	go test -race -v -tags=test -count=1 -failfast \
+		$(UNIT_TEST_PKGS) \
 		-args -ginkgo.label-filter='$(UNIT_LABEL_FILTER)'
 endif
 
+# Sequential fallback using ginkgo directly (no fail-fast, full failure report, covers ./...)
 unit-test-fail-slow: vet-nilaway-lint-betteralign
 	go run github.com/onsi/ginkgo/v2/ginkgo -r --tags=test --race --label-filter='$(UNIT_LABEL_FILTER)' ./...
 


### PR DESCRIPTION
## Summary

Switches the `unit-test` Makefile target from sequential `ginkgo -r` to parallel `go test ./...` + `gotestsum` (for JUnit XML in CI).

**Result: ~23 min → ~16 min (~30% faster)**

### Changes

- Add `gotestsum` as a dev tool (standard in Kubernetes, Terraform)
- Extract `UNIT_LABEL_FILTER` variable to deduplicate label filter across targets
- Replace `unit-test` with `go test` (packages run in parallel via GOMAXPROCS)
- In CI: use `gotestsum` for JUnit XML output; locally: plain `go test`
- Pass label filter via `-args -ginkgo.label-filter=...` (correct Ginkgo v2 approach for `go test`)
- Exclude `integration/` from unit test packages (needs Docker, has own CI job)
- Keep `unit-test-fail-slow` on ginkgo (sequential, easier to debug) with shared variable

### Key learnings

- `GINKGO_LABEL_FILTER` env var does NOT exist in Ginkgo v2 — must use `-ginkgo.label-filter` flag
- `-ginkgo.label-filter` must be passed via `-args` (after packages) for `go test` to forward it correctly
- The bottleneck is the Examples suite (6.9 min) — wall time can't be less than the longest package

### CI results

| Package | Time | Notes |
|---------|------|-------|
| pkg/fsmv2/examples | 414s | Bottleneck |
| pkg/fsmv2/supervisor | 283s | |
| pkg/fsmv2/config | 275s | |
| pkg/fsmv2/integration | 137s | (fsmv2 unit tests, not top-level) |
| 120 other packages | <33s each | |
| **Total** | **124 packages, 0 failures** | **~16 min wall time** |

## Test plan

- [x] `make -n unit-test` shows correct command (non-CI path)
- [x] `CI=true make -n unit-test` shows gotestsum with JUnit output
- [x] `make -n unit-test-fail-slow` uses shared `UNIT_LABEL_FILTER` variable
- [x] CI unit tests pass (124 packages, 0 failures)
- [x] Label filter works: HTTP package runs 2/36 specs (34 live/tls skipped)
- [x] Top-level `integration/` excluded from test packages
- [x] JUnit XML uploaded as artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)