### PR TITLE
docs(changelog): add FSMv2 communicator parallel transport entry

### DIFF
--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -14,6 +14,10 @@ This release simplifies S7 addressing and fixes three edge cases in the Manageme
 - **Fixed false "required" warnings in the Management Console editor** - Fields with children that already have default values were incorrectly marked as required when editing bridge configurations -- they are now correctly treated as optional
 - **Fixed deprecated fields not shown as deprecated in the editor** - Fields marked as deprecated in bridge plugin definitions were not flagged in the Management Console editor -- they now correctly appear as deprecated
 
+### Preview: FSMv2 Communicator
+
+- **Fixed instance appearing offline when the long-poll connection drops** -- Status updates and incoming commands now use independent connections, so a connection dropped by an enterprise proxy or firewall no longer prevents the instance from sending heartbeats. Requires `USE_FSMV2_TRANSPORT=true`
+
 ## [0.44.9]
 
 This release adds config backup as an opt-in preview and includes stability fixes for FSMv2 communicator preview users. All changes require feature flags -- if you haven't enabled any preview features, this release does not affect you.


### PR DESCRIPTION
## Summary

- Adds changelog entry for PR #2414 (ENG-4264: Wire TransportWorker into CommunicatorWorker)
- Entry goes under `### Preview: FSMv2 Communicator` in `[0.44.10]`
- Describes the fix: independent Push/Pull connections so an enterprise proxy dropping the long-poll no longer blocks heartbeats

## Test plan

- [ ] Verify entry appears correctly in `[0.44.10]` section
- [ ] Verify no trailing periods, no forbidden words, no internal names exposed
- [ ] Verify `Requires USE_FSMV2_TRANSPORT=true` suffix present

🤖 Generated with [Claude Code](https://claude.com/claude-code)