### PR TITLE
ci: reject PRs that modify released CHANGELOG sections

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -129,8 +129,9 @@ jobs:
 
           CHANGELOG="umh-core/CHANGELOG.md"
 
-          # Find the latest stable tag (vX.Y.Z, no pre-release suffixes)
-          LATEST_TAG=$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+          # Find the latest stable tag (vX.Y.Z, no pre-release suffixes).
+          # "|| true" prevents set -e from aborting when grep finds no matches.
+          LATEST_TAG=$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || true)
 
           if [[ -z "$LATEST_TAG" ]]; then
             echo "::warning::No stable tags found — skipping released-section guard"
@@ -141,8 +142,8 @@ jobs:
 
           HEADER="## [${LATEST_TAG#v}]"
 
-          # Find the header line in the current CHANGELOG (fixed-string match)
-          LINE_NUM=$(grep -Fn "$HEADER" "$CHANGELOG" | head -1 | cut -d: -f1)
+          # Find the header line in the current CHANGELOG (fixed-string match; || true for set -e safety)
+          LINE_NUM=$(grep -Fn "$HEADER" "$CHANGELOG" | head -1 | cut -d: -f1 || true)
 
           if [[ -z "$LINE_NUM" ]]; then
             echo "::warning::Header '$HEADER' not found in current $CHANGELOG — skipping guard"
@@ -160,8 +161,8 @@ jobs:
             exit 0
           }
 
-          # Find the same header in the tag version (fixed-string match)
-          TAG_LINE_NUM=$(printf '%s\n' "$TAG_FILE" | grep -Fn "$HEADER" | head -1 | cut -d: -f1)
+          # Find the same header in the tag version (fixed-string match; || true for set -e safety)
+          TAG_LINE_NUM=$(printf '%s\n' "$TAG_FILE" | grep -Fn "$HEADER" | head -1 | cut -d: -f1 || true)
 
           if [[ -z "$TAG_LINE_NUM" ]]; then
             echo "::warning::Header '$HEADER' not found in $LATEST_TAG:$CHANGELOG — skipping guard"

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -95,6 +95,8 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.changelog == 'true' }}
     runs-on: depot-ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       # Check out THIS repo (fetch-depth: 0 fetches all tags + history, needed by
       # the changelog guard for "git tag --list --sort=-version:refname" and "git show TAG:path")
@@ -130,7 +132,7 @@ jobs:
           CHANGELOG="umh-core/CHANGELOG.md"
 
           # Find the latest stable tag (vX.Y.Z, no pre-release suffixes).
-          # "|| true" prevents set -e from aborting when grep finds no matches.
+          # "|| true" keeps the script alive if git tag itself fails (e.g. no git history yet).
           LATEST_TAG=$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || true)
 
           if [[ -z "$LATEST_TAG" ]]; then
@@ -142,7 +144,8 @@ jobs:
 
           HEADER="## [${LATEST_TAG#v}]"
 
-          # Find the header line in the current CHANGELOG (fixed-string match; || true for set -e safety)
+          # Find the header line in the current CHANGELOG (-F = fixed-string to avoid bracket metacharacters, -n = emit line numbers for cut)
+          # "|| true": grep exits 1 on no match which would abort the script under set -euo pipefail
           LINE_NUM=$(grep -Fn "$HEADER" "$CHANGELOG" | head -1 | cut -d: -f1 || true)
 
           if [[ -z "$LINE_NUM" ]]; then
@@ -155,13 +158,13 @@ jobs:
           # Extract the released tail (from the header line to EOF)
           CURRENT_TAIL=$(tail -n +"$LINE_NUM" "$CHANGELOG")
 
-          # Get the same file from the tag commit
-          TAG_FILE=$(git show "$LATEST_TAG:$CHANGELOG" 2>/dev/null) || {
-            echo "::warning::Could not read $CHANGELOG from $LATEST_TAG — skipping guard"
+          # Get the same file from the tag commit (2>&1 captures error into variable for the warning)
+          if ! TAG_FILE=$(git show "$LATEST_TAG:$CHANGELOG" 2>&1); then
+            echo "::warning::Could not read $CHANGELOG from $LATEST_TAG (git: $TAG_FILE) — skipping guard"
             exit 0
-          }
+          fi
 
-          # Find the same header in the tag version (fixed-string match; || true for set -e safety)
+          # Find the same header in the tag version (-F = fixed-string, -n = line numbers; || true for set -e safety)
           TAG_LINE_NUM=$(printf '%s\n' "$TAG_FILE" | grep -Fn "$HEADER" | head -1 | cut -d: -f1 || true)
 
           if [[ -z "$TAG_LINE_NUM" ]]; then
@@ -172,12 +175,19 @@ jobs:
           # Extract the released tail from the tag
           TAG_TAIL=$(printf '%s\n' "$TAG_FILE" | tail -n +"$TAG_LINE_NUM")
 
-          # Compare — use printf '%s' (no trailing newline) so diff is not thrown off by newline differences at EOF
+          # Compare — use printf '%s' (no trailing newline) so diff is not thrown off by newline differences at EOF.
+          # Capture exit code separately: 0=identical, 1=differences, 2=error. Treat 2 as a hard failure.
+          DIFF_EXIT=0
           DIFF_OUTPUT=$(diff --unified \
             --label "released ($LATEST_TAG)" \
             --label "current (PR)" \
             <(printf '%s' "$TAG_TAIL") \
-            <(printf '%s' "$CURRENT_TAIL")) || true
+            <(printf '%s' "$CURRENT_TAIL")) || DIFF_EXIT=$?
+
+          if [[ "$DIFF_EXIT" -gt 1 ]]; then
+            echo "::error::diff failed unexpectedly (exit $DIFF_EXIT)"
+            exit 1
+          fi
 
           if [[ -n "$DIFF_OUTPUT" ]]; then
             echo "::group::Diff of released sections"

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -132,8 +132,9 @@ jobs:
           CHANGELOG="umh-core/CHANGELOG.md"
 
           # Find the latest stable tag (vX.Y.Z, no pre-release suffixes).
-          # "|| true" keeps the script alive if git tag itself fails (e.g. no git history yet).
-          # Note: set -e alone would not abort a $() assignment; pipefail is the actual hazard here.
+          # "|| true": grep exits 1 when no tag matches the stable pattern, which would abort
+          # the script under set -euo pipefail (pipefail propagates grep's exit 1 even though
+          # head -1 exits 0 after reading empty input).
           LATEST_TAG=$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || true)
 
           if [[ -z "$LATEST_TAG" ]]; then

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -149,8 +149,10 @@ jobs:
           LINE_NUM=$(grep -Fn "$HEADER" "$CHANGELOG" | head -1 | cut -d: -f1 || true)
 
           if [[ -z "$LINE_NUM" ]]; then
-            echo "::warning::Header '$HEADER' not found in current $CHANGELOG — skipping guard"
-            exit 0
+            echo "::error::Header '$HEADER' not found in current $CHANGELOG"
+            echo "The released version section was deleted or renamed. If this is intentional,"
+            echo "add the 'skip-changelog-guard' label to bypass this check."
+            exit 1
           fi
 
           echo "Found '$HEADER' at line $LINE_NUM"

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -96,8 +96,10 @@ jobs:
     if: ${{ needs.changes.outputs.changelog == 'true' }}
     runs-on: depot-ubuntu-24.04
     steps:
-      # Check out THIS repo
+      # Check out THIS repo (fetch-depth: 0 needed for git show TAG:path)
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
       # Generate token for cross-repo access
       - name: Generate GitHub App token
         id: app-token
@@ -115,6 +117,75 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "20"
+      - name: Check released sections are unmodified
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-changelog-guard') }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          CHANGELOG="umh-core/CHANGELOG.md"
+
+          # Find the latest stable tag (vX.Y.Z, no pre-release suffixes)
+          LATEST_TAG=$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+
+          if [[ -z "$LATEST_TAG" ]]; then
+            echo "::warning::No stable tags found — skipping released-section guard"
+            exit 0
+          fi
+
+          echo "Latest tag: $LATEST_TAG"
+
+          # Extract version number (v0.44.10 -> 0.44.10)
+          VERSION="${LATEST_TAG#v}"
+          HEADER="## [$VERSION]"
+
+          # Find the header line in the current CHANGELOG (fixed-string match)
+          LINE_NUM=$(grep -Fn "$HEADER" "$CHANGELOG" | head -1 | cut -d: -f1)
+
+          if [[ -z "$LINE_NUM" ]]; then
+            echo "::warning::Header '$HEADER' not found in current $CHANGELOG — skipping guard"
+            exit 0
+          fi
+
+          echo "Found '$HEADER' at line $LINE_NUM"
+
+          # Extract the released tail (from the header line to EOF)
+          CURRENT_TAIL=$(tail -n +"$LINE_NUM" "$CHANGELOG")
+
+          # Get the same file from the tag commit
+          TAG_FILE=$(git show "$LATEST_TAG:$CHANGELOG" 2>/dev/null) || {
+            echo "::warning::Could not read $CHANGELOG from $LATEST_TAG — skipping guard"
+            exit 0
+          }
+
+          # Find the same header in the tag version (fixed-string match)
+          TAG_LINE_NUM=$(printf '%s\n' "$TAG_FILE" | grep -Fn "$HEADER" | head -1 | cut -d: -f1)
+
+          if [[ -z "$TAG_LINE_NUM" ]]; then
+            echo "::warning::Header '$HEADER' not found in $LATEST_TAG:$CHANGELOG — skipping guard"
+            exit 0
+          fi
+
+          # Extract the released tail from the tag
+          TAG_TAIL=$(printf '%s\n' "$TAG_FILE" | tail -n +"$TAG_LINE_NUM")
+
+          # Compare — use printf '%s' to avoid trailing newline false positives
+          if ! diff --unified \
+            <(printf '%s' "$TAG_TAIL") \
+            <(printf '%s' "$CURRENT_TAIL"); then
+            echo ""
+            echo "::error::Released CHANGELOG sections have been modified!"
+            echo ""
+            echo "The content below '${HEADER}' differs from what was tagged in ${LATEST_TAG}."
+            echo "This usually happens when a rebase resolves CHANGELOG.md merge conflicts"
+            echo "and accidentally moves entries into an already-released version section."
+            echo ""
+            echo "To fix: move your entries above '${HEADER}' (into the current unreleased section)."
+            echo "To bypass: add the 'skip-changelog-guard' label to this PR."
+            exit 1
+          fi
+
+          echo "Released sections match $LATEST_TAG — OK"
       - name: Validate CHANGELOG.md
         run: npx tsx changelog-scripts/.github/scripts/validate-changelog.ts --format version --changelog-path umh-core/CHANGELOG.md
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -96,7 +96,8 @@ jobs:
     if: ${{ needs.changes.outputs.changelog == 'true' }}
     runs-on: depot-ubuntu-24.04
     steps:
-      # Check out THIS repo (fetch-depth: 0 needed for git show TAG:path)
+      # Check out THIS repo (fetch-depth: 0 fetches all tags + history, needed by
+      # the changelog guard for "git tag --list --sort=-version:refname" and "git show TAG:path")
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
@@ -170,10 +171,17 @@ jobs:
           # Extract the released tail from the tag
           TAG_TAIL=$(printf '%s\n' "$TAG_FILE" | tail -n +"$TAG_LINE_NUM")
 
-          # Compare — use printf '%s' to avoid trailing newline false positives
-          if ! diff --unified \
+          # Compare — use printf '%s' (no trailing newline) so diff is not thrown off by newline differences at EOF
+          DIFF_OUTPUT=$(diff --unified \
+            --label "released ($LATEST_TAG)" \
+            --label "current (PR)" \
             <(printf '%s' "$TAG_TAIL") \
-            <(printf '%s' "$CURRENT_TAIL"); then
+            <(printf '%s' "$CURRENT_TAIL")) || true
+
+          if [[ -n "$DIFF_OUTPUT" ]]; then
+            echo "::group::Diff of released sections"
+            echo "$DIFF_OUTPUT"
+            echo "::endgroup::"
             echo ""
             echo "::error::Released CHANGELOG sections have been modified!"
             echo ""

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -118,7 +118,10 @@ jobs:
         with:
           node-version: "20"
       - name: Check released sections are unmodified
-        if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-changelog-guard') }}
+        if: >-
+          ${{ github.event_name != 'merge_group'
+              && github.event_name != 'workflow_dispatch'
+              && !contains(github.event.pull_request.labels.*.name, 'skip-changelog-guard') }}
         shell: bash
         run: |
           set -euo pipefail
@@ -135,9 +138,7 @@ jobs:
 
           echo "Latest tag: $LATEST_TAG"
 
-          # Extract version number (v0.44.10 -> 0.44.10)
-          VERSION="${LATEST_TAG#v}"
-          HEADER="## [$VERSION]"
+          HEADER="## [${LATEST_TAG#v}]"
 
           # Find the header line in the current CHANGELOG (fixed-string match)
           LINE_NUM=$(grep -Fn "$HEADER" "$CHANGELOG" | head -1 | cut -d: -f1)

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -133,6 +133,7 @@ jobs:
 
           # Find the latest stable tag (vX.Y.Z, no pre-release suffixes).
           # "|| true" keeps the script alive if git tag itself fails (e.g. no git history yet).
+          # Note: set -e alone would not abort a $() assignment; pipefail is the actual hazard here.
           LATEST_TAG=$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || true)
 
           if [[ -z "$LATEST_TAG" ]]; then
@@ -202,8 +203,8 @@ jobs:
             echo "This usually happens when a rebase resolves CHANGELOG.md merge conflicts"
             echo "and accidentally moves entries into an already-released version section."
             echo ""
-            echo "To fix: move your entries above '${HEADER}' (into the current unreleased section)."
-            echo "To bypass: add the 'skip-changelog-guard' label to this PR."
+            echo "To fix: move your entries above '${HEADER}' (under the next unreleased version header)."
+            echo "To bypass: add the 'skip-changelog-guard' label to this PR (maintainers only)."
             exit 1
           fi
 


### PR DESCRIPTION
## Summary

Three times on PR #2447 alone: CHANGELOG.md merge conflicts during rebase silently moved new entries under the already-released `## [0.44.10]` section. The existing `validate-changelog` job only checks format, not content integrity. This adds an automated guard that catches it.

### What happened

When rebasing onto staging, git's conflict markers land inside CHANGELOG.md. Resolving them by hand (or via AI) can accidentally place new entries below the released version header instead of above it. The TypeScript format validator has no concept of "this section was already shipped."

### How it works

A single new bash step ("tail match") in the `validate-changelog` job:

1. Finds the latest stable tag (`v0.44.10`)
2. Extracts everything from `## [0.44.10]` to EOF in the PR's CHANGELOG ("released tail")
3. Extracts the same tail from `git show v0.44.10:umh-core/CHANGELOG.md`
4. Diffs them — any difference = CI failure with an actionable error message and collapsible diff

This catches edits anywhere in released sections, including older versions like 0.44.9, since the tail includes everything below the latest tagged header.

### Why inline bash (not extending the TS validator)

The check needs `git show TAG:path` which requires repo-local tag access. The TS validator is format-focused and shared via changelog.umh.app. Keeping this as inline bash matches the existing pattern (`update-github-release.yml` already does shell-based CHANGELOG parsing).

### Reuse in other repos

Portable to ManagementConsole and benthos-umh — change `CHANGELOG="umh-core/CHANGELOG.md"` to the respective path. Could be extracted into a reusable composite action later if needed.

### Known limitations

**Merge queue**: The guard is intentionally skipped on `merge_group` events because `github.event.pull_request` is null there (label bypass would silently break). This means the guard runs on every PR push — which is when the human is actively looking at CI — but not on the final merge queue run. A bad rebase in the merge queue itself would not be caught. In practice, the merge queue uses the same commit that already passed the guard on the PR branch, making a new violation at that stage very unlikely.

**Link references at file bottom**: If the changelog format ever adds reference-style links at the bottom (standard keep-a-changelog practice), those would trigger the guard. Add the `skip-changelog-guard` label in that case, or let a maintainer bypass.

**`fetch-depth: 0`**: Full history is fetched on every changelog PR so `git tag --list --sort=-version:refname` and `git show TAG:path` work. A targeted single-tag fetch would be cheaper but more complex to implement correctly. Accepted tradeoff.

**Bypass (maintainers only)**: The `skip-changelog-guard` label bypasses the check. Only repository members with triage access can add labels — external contributors who hit a false positive should ask a maintainer to apply it.

### Changes

One file, two edits to `.github/workflows/pull-request.yml`:

1. `fetch-depth: 0` + `permissions: contents: read` on `validate-changelog`
2. New step "Check released sections are unmodified" between `setup-node` and "Validate CHANGELOG.md"

## Test plan

- [x] Guard passes on unmodified CHANGELOG
- [x] Guard fails with clear diff when bad entry inserted under released section
- [x] No trailing-newline false positive (`printf '%s'` strips trailing newline)
- [x] Scenario A (no tags): `::warning::` + exit 0 ✓
- [x] Scenario C (header not in tag): `::warning::` + exit 0 ✓
- [x] Scenario D (diff exit 2): `::error::` + exit 1 ✓
- [x] Merge-group fix: guard correctly skips on `merge_group`/`workflow_dispatch`
- [x] `|| true` on all grep pipelines prevents pipefail-triggered abort
- [ ] CI runs the new step on this PR (happy path, guard passes trivially)

Closes ENG-4525

🤖 Generated with [Claude Code](https://claude.com/claude-code)
