### PR TITLE
fix(mem): cgroup memory reading

### DIFF
--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - **Fixed rapid container restarts when config.yaml is missing or invalid** -- the container previously restarted hundreds of times per minute and now waits 60 seconds before retrying, giving you time to fix the configuration
+- **Fixed container memory metrics showing host values instead of container limits** -- memory monitoring read host-level values even inside containers, while CPU monitoring already used cgroup-aware values. Memory metrics now read cgroup v2 limits and usage, so dashboards show correct container memory utilization
 
 ## [0.44.11]
 

--- a/umh-core/pkg/service/container_monitor/cgroup_memory.go
+++ b/umh-core/pkg/service/container_monitor/cgroup_memory.go
@@ -46,6 +46,9 @@ func ParseMemoryMax(data []byte) (limitBytes int64, unlimited bool, err error) {
 	if err != nil {
 		return 0, false, fmt.Errorf("failed to parse memory.max value %q: %w", s, err)
 	}
+	if limitBytes < 0 {
+		return 0, false, fmt.Errorf("negative memory.max value %q", s)
+	}
 
 	return limitBytes, false, nil
 }
@@ -61,6 +64,9 @@ func ParseMemoryCurrent(data []byte) (currentBytes int64, err error) {
 	currentBytes, err = strconv.ParseInt(s, 10, 64)
 	if err != nil {
 		return 0, fmt.Errorf("failed to parse memory.current value %q: %w", s, err)
+	}
+	if currentBytes < 0 {
+		return 0, fmt.Errorf("negative memory.current value %q", s)
 	}
 
 	return currentBytes, nil

--- a/umh-core/pkg/service/container_monitor/cgroup_memory.go
+++ b/umh-core/pkg/service/container_monitor/cgroup_memory.go
@@ -16,6 +16,7 @@ package container_monitor
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -34,7 +35,7 @@ type MemoryCgroupInfo struct {
 func ParseMemoryMax(data []byte) (limitBytes int64, unlimited bool, err error) {
 	s := strings.TrimSpace(string(data))
 	if s == "" {
-		return 0, false, fmt.Errorf("empty memory.max data")
+		return 0, false, errors.New("empty memory.max data")
 	}
 
 	if s == "max" {
@@ -54,7 +55,7 @@ func ParseMemoryMax(data []byte) (limitBytes int64, unlimited bool, err error) {
 func ParseMemoryCurrent(data []byte) (currentBytes int64, err error) {
 	s := strings.TrimSpace(string(data))
 	if s == "" {
-		return 0, fmt.Errorf("empty memory.current data")
+		return 0, errors.New("empty memory.current data")
 	}
 
 	currentBytes, err = strconv.ParseInt(s, 10, 64)

--- a/umh-core/pkg/service/container_monitor/cgroup_memory.go
+++ b/umh-core/pkg/service/container_monitor/cgroup_memory.go
@@ -1,0 +1,98 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package container_monitor
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// MemoryCgroupInfo contains cgroup v2 memory metrics.
+type MemoryCgroupInfo struct {
+	LimitBytes   int64 // Memory limit in bytes from memory.max
+	CurrentBytes int64 // Current memory usage in bytes from memory.current
+	Unlimited    bool  // True if memory.max is "max" (no limit set)
+}
+
+// ParseMemoryMax parses the memory.max file content.
+// Returns the limit in bytes, whether the limit is unlimited ("max"), and any error.
+func ParseMemoryMax(data []byte) (limitBytes int64, unlimited bool, err error) {
+	s := strings.TrimSpace(string(data))
+	if s == "" {
+		return 0, false, fmt.Errorf("empty memory.max data")
+	}
+
+	if s == "max" {
+		return 0, true, nil
+	}
+
+	limitBytes, err = strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return 0, false, fmt.Errorf("failed to parse memory.max value %q: %w", s, err)
+	}
+
+	return limitBytes, false, nil
+}
+
+// ParseMemoryCurrent parses the memory.current file content.
+// Returns the current memory usage in bytes.
+func ParseMemoryCurrent(data []byte) (currentBytes int64, err error) {
+	s := strings.TrimSpace(string(data))
+	if s == "" {
+		return 0, fmt.Errorf("empty memory.current data")
+	}
+
+	currentBytes, err = strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse memory.current value %q: %w", s, err)
+	}
+
+	return currentBytes, nil
+}
+
+// getCgroupMemoryInfo reads cgroup v2 memory limits and current usage.
+func (c *ContainerMonitorService) getCgroupMemoryInfo(ctx context.Context) (*MemoryCgroupInfo, error) {
+	info := &MemoryCgroupInfo{}
+
+	memMaxData, err := os.ReadFile("/sys/fs/cgroup/memory.max")
+	if err != nil {
+		return nil, fmt.Errorf("failed to read memory.max: %w", err)
+	}
+
+	limitBytes, unlimited, err := ParseMemoryMax(memMaxData)
+	if err != nil {
+		return nil, err
+	}
+
+	info.LimitBytes = limitBytes
+	info.Unlimited = unlimited
+
+	memCurrentData, err := os.ReadFile("/sys/fs/cgroup/memory.current")
+	if err != nil {
+		return nil, fmt.Errorf("failed to read memory.current: %w", err)
+	}
+
+	currentBytes, err := ParseMemoryCurrent(memCurrentData)
+	if err != nil {
+		return nil, err
+	}
+
+	info.CurrentBytes = currentBytes
+
+	return info, nil
+}

--- a/umh-core/pkg/service/container_monitor/cgroup_memory.go
+++ b/umh-core/pkg/service/container_monitor/cgroup_memory.go
@@ -76,6 +76,9 @@ func ParseMemoryCurrent(data []byte) (currentBytes int64, err error) {
 func (c *ContainerMonitorService) getCgroupMemoryInfo(ctx context.Context) (*MemoryCgroupInfo, error) {
 	info := &MemoryCgroupInfo{}
 
+	// TODO: ENG-4555 - use the filesystem service abstraction (c.fs.ReadFile) instead of os.ReadFile
+	// for proper context propagation and testability (same as cgroup_cpu.go)
+
 	memMaxData, err := os.ReadFile("/sys/fs/cgroup/memory.max")
 	if err != nil {
 		return nil, fmt.Errorf("failed to read memory.max: %w", err)

--- a/umh-core/pkg/service/container_monitor/cgroup_memory.go
+++ b/umh-core/pkg/service/container_monitor/cgroup_memory.go
@@ -30,9 +30,9 @@ type MemoryCgroupInfo struct {
 	Unlimited    bool  // True if memory.max is "max" (no limit set)
 }
 
-// ParseMemoryMax parses the memory.max file content.
+// parseMemoryMax parses the memory.max file content.
 // Returns the limit in bytes, whether the limit is unlimited ("max"), and any error.
-func ParseMemoryMax(data []byte) (limitBytes int64, unlimited bool, err error) {
+func parseMemoryMax(data []byte) (limitBytes int64, unlimited bool, err error) {
 	s := strings.TrimSpace(string(data))
 	if s == "" {
 		return 0, false, errors.New("empty memory.max data")
@@ -53,9 +53,9 @@ func ParseMemoryMax(data []byte) (limitBytes int64, unlimited bool, err error) {
 	return limitBytes, false, nil
 }
 
-// ParseMemoryCurrent parses the memory.current file content.
+// parseMemoryCurrent parses the memory.current file content.
 // Returns the current memory usage in bytes.
-func ParseMemoryCurrent(data []byte) (currentBytes int64, err error) {
+func parseMemoryCurrent(data []byte) (currentBytes int64, err error) {
 	s := strings.TrimSpace(string(data))
 	if s == "" {
 		return 0, errors.New("empty memory.current data")
@@ -84,7 +84,7 @@ func (c *ContainerMonitorService) getCgroupMemoryInfo(ctx context.Context) (*Mem
 		return nil, fmt.Errorf("failed to read memory.max: %w", err)
 	}
 
-	limitBytes, unlimited, err := ParseMemoryMax(memMaxData)
+	limitBytes, unlimited, err := parseMemoryMax(memMaxData)
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +97,7 @@ func (c *ContainerMonitorService) getCgroupMemoryInfo(ctx context.Context) (*Mem
 		return nil, fmt.Errorf("failed to read memory.current: %w", err)
 	}
 
-	currentBytes, err := ParseMemoryCurrent(memCurrentData)
+	currentBytes, err := parseMemoryCurrent(memCurrentData)
 	if err != nil {
 		return nil, err
 	}

--- a/umh-core/pkg/service/container_monitor/cgroup_memory_test.go
+++ b/umh-core/pkg/service/container_monitor/cgroup_memory_test.go
@@ -1,0 +1,106 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package container_monitor_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/container_monitor"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/filesystem"
+)
+
+var _ = Describe("Cgroup Memory", func() {
+	Describe("Fallback behavior", func() {
+		It("should return valid memory metrics even when cgroup files are unavailable", func() {
+			// On macOS and non-container Linux, /sys/fs/cgroup/memory.max does not exist.
+			// getMemoryMetrics() should fall back to gopsutil host-level values.
+			mockFS := filesystem.NewMockFileSystem()
+			service := container_monitor.NewContainerMonitorServiceWithPath(mockFS, GinkgoT().TempDir())
+
+			status, err := service.GetStatus(context.Background())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(status.Memory).ToNot(BeNil())
+			Expect(status.Memory.CGroupTotalBytes).To(BeNumerically(">", 0))
+			Expect(status.Memory.CGroupUsedBytes).To(BeNumerically(">", 0))
+		})
+	})
+
+	Describe("ParseMemoryMax", func() {
+		It("should parse a numeric memory limit", func() {
+			data := []byte("8589934592\n") // 8 GiB
+			limit, unlimited, err := container_monitor.ParseMemoryMax(data)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(unlimited).To(BeFalse())
+			Expect(limit).To(Equal(int64(8589934592)))
+		})
+
+		It("should handle 'max' as unlimited", func() {
+			data := []byte("max\n")
+			_, unlimited, err := container_monitor.ParseMemoryMax(data)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(unlimited).To(BeTrue())
+		})
+
+		It("should handle value without trailing newline", func() {
+			data := []byte("4294967296")
+			limit, unlimited, err := container_monitor.ParseMemoryMax(data)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(unlimited).To(BeFalse())
+			Expect(limit).To(Equal(int64(4294967296)))
+		})
+
+		It("should return error for empty data", func() {
+			data := []byte("")
+			_, _, err := container_monitor.ParseMemoryMax(data)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should return error for non-numeric data", func() {
+			data := []byte("notanumber\n")
+			_, _, err := container_monitor.ParseMemoryMax(data)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("ParseMemoryCurrent", func() {
+		It("should parse current memory usage", func() {
+			data := []byte("2147483648\n") // 2 GiB
+			current, err := container_monitor.ParseMemoryCurrent(data)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(current).To(Equal(int64(2147483648)))
+		})
+
+		It("should handle value without trailing newline", func() {
+			data := []byte("1073741824")
+			current, err := container_monitor.ParseMemoryCurrent(data)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(current).To(Equal(int64(1073741824)))
+		})
+
+		It("should return error for empty data", func() {
+			data := []byte("")
+			_, err := container_monitor.ParseMemoryCurrent(data)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should return error for non-numeric data", func() {
+			data := []byte("abc\n")
+			_, err := container_monitor.ParseMemoryCurrent(data)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})

--- a/umh-core/pkg/service/container_monitor/cgroup_memory_test.go
+++ b/umh-core/pkg/service/container_monitor/cgroup_memory_test.go
@@ -12,14 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package container_monitor_test
+package container_monitor
 
 import (
 	"context"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/container_monitor"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/filesystem"
 )
 
@@ -29,7 +28,7 @@ var _ = Describe("Cgroup Memory", func() {
 			// On macOS and non-container Linux, /sys/fs/cgroup/memory.max does not exist.
 			// getMemoryMetrics() should fall back to gopsutil host-level values.
 			mockFS := filesystem.NewMockFileSystem()
-			service := container_monitor.NewContainerMonitorServiceWithPath(mockFS, GinkgoT().TempDir())
+			service := NewContainerMonitorServiceWithPath(mockFS, GinkgoT().TempDir())
 
 			status, err := service.GetStatus(context.Background())
 			Expect(err).ToNot(HaveOccurred())
@@ -39,10 +38,10 @@ var _ = Describe("Cgroup Memory", func() {
 		})
 	})
 
-	Describe("ParseMemoryMax", func() {
+	Describe("parseMemoryMax", func() {
 		It("should parse a numeric memory limit", func() {
 			data := []byte("8589934592\n") // 8 GiB
-			limit, unlimited, err := container_monitor.ParseMemoryMax(data)
+			limit, unlimited, err := parseMemoryMax(data)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(unlimited).To(BeFalse())
 			Expect(limit).To(Equal(int64(8589934592)))
@@ -50,14 +49,14 @@ var _ = Describe("Cgroup Memory", func() {
 
 		It("should handle 'max' as unlimited", func() {
 			data := []byte("max\n")
-			_, unlimited, err := container_monitor.ParseMemoryMax(data)
+			_, unlimited, err := parseMemoryMax(data)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(unlimited).To(BeTrue())
 		})
 
 		It("should handle value without trailing newline", func() {
 			data := []byte("4294967296")
-			limit, unlimited, err := container_monitor.ParseMemoryMax(data)
+			limit, unlimited, err := parseMemoryMax(data)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(unlimited).To(BeFalse())
 			Expect(limit).To(Equal(int64(4294967296)))
@@ -65,53 +64,53 @@ var _ = Describe("Cgroup Memory", func() {
 
 		It("should return error for empty data", func() {
 			data := []byte("")
-			_, _, err := container_monitor.ParseMemoryMax(data)
+			_, _, err := parseMemoryMax(data)
 			Expect(err).To(HaveOccurred())
 		})
 
 		It("should return error for non-numeric data", func() {
 			data := []byte("notanumber\n")
-			_, _, err := container_monitor.ParseMemoryMax(data)
+			_, _, err := parseMemoryMax(data)
 			Expect(err).To(HaveOccurred())
 		})
 
 		It("should return error for negative values", func() {
 			data := []byte("-1\n")
-			_, _, err := container_monitor.ParseMemoryMax(data)
+			_, _, err := parseMemoryMax(data)
 			Expect(err).To(HaveOccurred())
 		})
 	})
 
-	Describe("ParseMemoryCurrent", func() {
+	Describe("parseMemoryCurrent", func() {
 		It("should parse current memory usage", func() {
 			data := []byte("2147483648\n") // 2 GiB
-			current, err := container_monitor.ParseMemoryCurrent(data)
+			current, err := parseMemoryCurrent(data)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(current).To(Equal(int64(2147483648)))
 		})
 
 		It("should handle value without trailing newline", func() {
 			data := []byte("1073741824")
-			current, err := container_monitor.ParseMemoryCurrent(data)
+			current, err := parseMemoryCurrent(data)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(current).To(Equal(int64(1073741824)))
 		})
 
 		It("should return error for empty data", func() {
 			data := []byte("")
-			_, err := container_monitor.ParseMemoryCurrent(data)
+			_, err := parseMemoryCurrent(data)
 			Expect(err).To(HaveOccurred())
 		})
 
 		It("should return error for non-numeric data", func() {
 			data := []byte("abc\n")
-			_, err := container_monitor.ParseMemoryCurrent(data)
+			_, err := parseMemoryCurrent(data)
 			Expect(err).To(HaveOccurred())
 		})
 
 		It("should return error for negative values", func() {
 			data := []byte("-100\n")
-			_, err := container_monitor.ParseMemoryCurrent(data)
+			_, err := parseMemoryCurrent(data)
 			Expect(err).To(HaveOccurred())
 		})
 	})

--- a/umh-core/pkg/service/container_monitor/cgroup_memory_test.go
+++ b/umh-core/pkg/service/container_monitor/cgroup_memory_test.go
@@ -74,6 +74,12 @@ var _ = Describe("Cgroup Memory", func() {
 			_, _, err := container_monitor.ParseMemoryMax(data)
 			Expect(err).To(HaveOccurred())
 		})
+
+		It("should return error for negative values", func() {
+			data := []byte("-1\n")
+			_, _, err := container_monitor.ParseMemoryMax(data)
+			Expect(err).To(HaveOccurred())
+		})
 	})
 
 	Describe("ParseMemoryCurrent", func() {
@@ -99,6 +105,12 @@ var _ = Describe("Cgroup Memory", func() {
 
 		It("should return error for non-numeric data", func() {
 			data := []byte("abc\n")
+			_, err := container_monitor.ParseMemoryCurrent(data)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should return error for negative values", func() {
+			data := []byte("-100\n")
 			_, err := container_monitor.ParseMemoryCurrent(data)
 			Expect(err).To(HaveOccurred())
 		})

--- a/umh-core/pkg/service/container_monitor/container_monitor.go
+++ b/umh-core/pkg/service/container_monitor/container_monitor.go
@@ -349,13 +349,15 @@ func (c *ContainerMonitorService) getMemoryMetrics(ctx context.Context) (*models
 	usedBytes := vmStat.Used
 	totalBytes := vmStat.Total
 
-	// Try cgroup values — prefer container-aware limits over host values
+	// Try cgroup values: prefer container-aware limits over host values
 	cgroupInfo, cgroupErr := c.getCgroupMemoryInfo(ctx)
 	if cgroupErr == nil {
 		usedBytes = uint64(cgroupInfo.CurrentBytes)
 		if !cgroupInfo.Unlimited && cgroupInfo.LimitBytes > 0 {
 			totalBytes = uint64(cgroupInfo.LimitBytes)
 		}
+	} else {
+		c.logger.Debugf("cgroup memory info unavailable, using host values: %v", cgroupErr)
 	}
 
 	// Default to Active health

--- a/umh-core/pkg/service/container_monitor/container_monitor.go
+++ b/umh-core/pkg/service/container_monitor/container_monitor.go
@@ -351,9 +351,11 @@ func (c *ContainerMonitorService) getMemoryMetrics(ctx context.Context) (*models
 
 	// Try cgroup values — prefer container-aware limits over host values
 	cgroupInfo, cgroupErr := c.getCgroupMemoryInfo(ctx)
-	if cgroupErr == nil && !cgroupInfo.Unlimited {
+	if cgroupErr == nil {
 		usedBytes = uint64(cgroupInfo.CurrentBytes)
-		totalBytes = uint64(cgroupInfo.LimitBytes)
+		if !cgroupInfo.Unlimited && cgroupInfo.LimitBytes > 0 {
+			totalBytes = uint64(cgroupInfo.LimitBytes)
+		}
 	}
 
 	// Default to Active health

--- a/umh-core/pkg/service/container_monitor/container_monitor.go
+++ b/umh-core/pkg/service/container_monitor/container_monitor.go
@@ -338,8 +338,8 @@ func (c *ContainerMonitorService) getRawCPUMetrics(ctx context.Context) (usageMC
 	return usageMCores, coreCount, usagePercent, nil
 }
 
-// getMemoryMetrics collects memory metrics using gopsutil.
-// By default, this returns host-level usage, not cgroup-limited usage.
+// getMemoryMetrics collects memory metrics, preferring cgroup values when available.
+// Falls back to host-level gopsutil values in non-container environments.
 func (c *ContainerMonitorService) getMemoryMetrics(ctx context.Context) (*models.Memory, error) {
 	vmStat, err := mem.VirtualMemoryWithContext(ctx)
 	if err != nil {
@@ -348,6 +348,13 @@ func (c *ContainerMonitorService) getMemoryMetrics(ctx context.Context) (*models
 
 	usedBytes := vmStat.Used
 	totalBytes := vmStat.Total
+
+	// Try cgroup values — prefer container-aware limits over host values
+	cgroupInfo, cgroupErr := c.getCgroupMemoryInfo(ctx)
+	if cgroupErr == nil && !cgroupInfo.Unlimited {
+		usedBytes = uint64(cgroupInfo.CurrentBytes)
+		totalBytes = uint64(cgroupInfo.LimitBytes)
+	}
 
 	// Default to Active health
 	category := models.Active

--- a/umh-core/pkg/service/container_monitor/container_monitor.go
+++ b/umh-core/pkg/service/container_monitor/container_monitor.go
@@ -354,6 +354,8 @@ func (c *ContainerMonitorService) getMemoryMetrics(ctx context.Context) (*models
 	if cgroupErr == nil {
 		usedBytes = uint64(cgroupInfo.CurrentBytes)
 		if !cgroupInfo.Unlimited && cgroupInfo.LimitBytes > 0 {
+			// Only override totalBytes when a cgroup limit is set.
+			// When unlimited, keep host total (same approach as CPU with unlimited quota).
 			totalBytes = uint64(cgroupInfo.LimitBytes)
 		}
 	} else {


### PR DESCRIPTION
Fixes ENG-4471

# Description
This PR fixes memory metrics reporting host-level values instead of container cgroup
limits.

### Previous Issue
`getMemoryMetrics()` used `gopsutil`'s `mem.VirtualMemoryWithContext()`, which reads `/proc/meminfo` — host-level memry. The struct fields `CGroupUsedBytes` / `CGroupTotalBytes` were populated with host values. On a 32 GB VM with an 8 GB k3s pod imit, it showed 31.4 GiB total, causing the 80% memory threshold to trigger against host RAM instead of the pod limt, wrongly blocking bridge creation.

### Solution
Added `cgroup_memory.go` (same pattern as existing for cpu) that reads:
- `/sys/fs/cgroup/memory.max` → cgroup memory limit (`"max"` = unlimited)
- `/sys/fs/cgroup/memory.current` → current container memory usage

`getMemoryMetrics()` now prefers cgroup values when available and falls back to `gopsutil` host values in non-container environments (macOS, bare metal).