### PR TITLE
feat: proper docker layers, docker go cache and dockerignore

### DIFF
--- a/umh-core/.dockerignore
+++ b/umh-core/.dockerignore
@@ -8,3 +8,19 @@ tmp/
 data/
 
 metrics.txt
+
+# Git metadata
+.git
+.gitignore
+.gitattributes
+
+# Documentation and non-code assets
+docs/
+examples/
+changelog-images/
+*.md
+*.txt
+
+# Test files (not needed for the binary)
+**/*_test.go
+tools/

--- a/umh-core/.dockerignore
+++ b/umh-core/.dockerignore
@@ -24,3 +24,5 @@ changelog-images/
 # Test files (not needed for the binary)
 **/*_test.go
 tools/
+integration/
+test/

--- a/umh-core/Dockerfile
+++ b/umh-core/Dockerfile
@@ -96,7 +96,6 @@ RUN echo "GOOS: ${GOOS:-$(go env GOOS)}, GOARCH: ${GOARCH:-$(go env GOARCH)}"
 RUN echo "Go version: $(go version)"
 # CGO_ENABLED=1 is needed for the race detector to work
 RUN --mount=type=cache,target=/root/.cache/go-build \
-    --mount=type=cache,target=/go/pkg/mod \
     if [ "$DEBUG" = "true" ]; then \
     CGO_ENABLED=1 go build \
     -race \

--- a/umh-core/Dockerfile
+++ b/umh-core/Dockerfile
@@ -83,14 +83,21 @@ WORKDIR /go/src/github.com/united-manufacturing-hub/united-manufacturing-hub
 # Set app version with a default value - can be overridden at build time
 ARG APP_VERSION=MUST_BE_SET_BY_MAKEFILE
 RUN apk add --no-cache gcc musl-dev
-# Copy go.mod first for better caching
-COPY ./go.mod ./umh-core/
 WORKDIR /go/src/github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core
-COPY . .
+# Copy dependency manifests first — only invalidated when deps change
+COPY ./go.mod ./go.sum ./
+# Copy vendored dependencies — invalidated only when vendor/ changes
+COPY ./vendor ./vendor
+# Copy source code — most frequently changing layer
+COPY ./cmd ./cmd
+COPY ./pkg ./pkg
+COPY ./internal ./internal
 RUN echo "GOOS: ${GOOS:-$(go env GOOS)}, GOARCH: ${GOARCH:-$(go env GOARCH)}"
 RUN echo "Go version: $(go version)"
 # CGO_ENABLED=1 is needed for the race detector to work
-RUN if [ "$DEBUG" = "true" ]; then \
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg/mod \
+    if [ "$DEBUG" = "true" ]; then \
     CGO_ENABLED=1 go build \
     -race \
     -gcflags="all=-N -l" \


### PR DESCRIPTION
This PR speeds up recurring docker builds on my machine from **~21 sec** to **~7 sec**

What changes:
- Ignore more stuff in `.dockerignore` (probably most helpful for `depot` builds)
- Use better layer caching 
- Persist the `go build` cache using docker mount caches