### PR TITLE
feat(fsmv2): extract failurerate.Tracker package (1/4)

### DIFF
--- a/umh-core/pkg/fsmv2/deps/retry/failurerate/doc.go
+++ b/umh-core/pkg/fsmv2/deps/retry/failurerate/doc.go
@@ -1,0 +1,60 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package failurerate tracks the failure rate of the last N outcomes using a
+// fixed-size circular buffer. The caller records each outcome as success or
+// failure; the [Tracker] computes the rolling failure rate and fires a one-shot
+// escalation when the rate crosses a configurable threshold.
+//
+// # Transient and Persistent Errors
+//
+// Transport errors fall into two categories:
+//
+//   - Transient errors self-resolve without human intervention: network timeouts,
+//     DNS failures, HTTP 5xx responses, rate limits, and full channels. These
+//     appear as ErrorTypeNetwork, ErrorTypeServerError, ErrorTypeChannelFull, and
+//     ErrorTypeBackendRateLimit in [communicator/transport/http].
+//
+//   - Persistent errors require human intervention: invalid tokens, deleted
+//     instances, proxy blocks, and Cloudflare challenges. These appear as
+//     ErrorTypeInvalidToken, ErrorTypeInstanceDeleted, ErrorTypeProxyBlock, and
+//     ErrorTypeCloudflareChallenge.
+//
+// The action layer suppresses Sentry alerts for transient errors (they fire
+// metrics and update DegradedState instead). Persistent errors still fire
+// SentryError immediately.
+//
+// # Escalation Lifecycle
+//
+// When transient errors dominate — the failure rate exceeds the configured
+// threshold over the rolling window — the Tracker fires a one-shot escalation.
+// The caller (typically push or pull dependencies) fires a SentryWarn to alert
+// operators. After enough successes bring the rate below the threshold, the
+// Tracker rearms and can fire again on the next crossing.
+//
+// # Why a Rolling Window
+//
+// A timer-based approach (escalate when degraded longer than N minutes) has a
+// blind spot: a single success in a 99% failure pattern resets the timer
+// completely (ENG-4565). The rolling window tracks rate, not duration. A single
+// success shifts the window from 100/100 failures to 99/100 — the rate barely
+// changes, and escalation holds.
+//
+// # Integration
+//
+// Error classification lives in [communicator/transport/http] (ErrorType and
+// IsTransient). Transient suppression lives in the pull and push action files.
+// Rate tracking lives in this package. Push and pull dependencies each hold a
+// *[Tracker] and call [Tracker.RecordOutcome] on every error or success.
+package failurerate

--- a/umh-core/pkg/fsmv2/deps/retry/failurerate/failurerate.go
+++ b/umh-core/pkg/fsmv2/deps/retry/failurerate/failurerate.go
@@ -43,14 +43,14 @@ type Config struct {
 // Tracker is safe for concurrent use.
 type Tracker struct {
 	mu       sync.RWMutex
-	outcomes []bool // circular buffer: true = success, false = failure
-	head     int    // next write position
-	count    int    // total recorded outcomes (capped at WindowSize)
-	failures int    // running failure count within the window
+	outcomes []bool  // circular buffer: true = success, false = failure
+	cfg      Config  // immutable after construction
+	head     int     // next write position
+	count    int     // total recorded outcomes (capped at WindowSize)
+	failures int     // running failure count within the window
 	// escalated tracks the one-shot state: true after the failure rate
 	// first crosses the threshold, false after it drops back below.
 	escalated bool
-	cfg       Config
 }
 
 // New creates a Tracker with the given configuration. The circular buffer

--- a/umh-core/pkg/fsmv2/deps/retry/failurerate/failurerate.go
+++ b/umh-core/pkg/fsmv2/deps/retry/failurerate/failurerate.go
@@ -1,0 +1,150 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package failurerate
+
+import "sync"
+
+// Config controls the Tracker's window size, escalation threshold, and
+// minimum sample count.
+type Config struct {
+	// WindowSize is the number of outcomes the circular buffer retains.
+	// Older outcomes are evicted when the buffer is full.
+	// Example: 6000 ≈ 10 minutes at one outcome per 100 ms tick.
+	WindowSize int
+
+	// Threshold is the failure rate (0.0–1.0) that triggers escalation.
+	// Example: 0.9 means 90 % failures.
+	Threshold float64
+
+	// MinSamples is the minimum number of recorded outcomes before the
+	// Tracker can escalate. This prevents spurious alerts during startup.
+	MinSamples int
+}
+
+// Tracker tracks the failure rate of the last N outcomes using a fixed-size
+// circular buffer. Call [RecordOutcome] with true (success) or false (failure);
+// the Tracker computes the rolling failure rate and detects threshold crossings.
+//
+// Tracker is safe for concurrent use.
+type Tracker struct {
+	mu       sync.RWMutex
+	outcomes []bool // circular buffer: true = success, false = failure
+	head     int    // next write position
+	count    int    // total recorded outcomes (capped at WindowSize)
+	failures int    // running failure count within the window
+	// escalated tracks the one-shot state: true after the failure rate
+	// first crosses the threshold, false after it drops back below.
+	escalated bool
+	cfg       Config
+}
+
+// New creates a Tracker with the given configuration. The circular buffer
+// is pre-allocated to cfg.WindowSize.
+func New(cfg Config) *Tracker {
+	return &Tracker{
+		outcomes: make([]bool, cfg.WindowSize),
+		cfg:      cfg,
+	}
+}
+
+// RecordOutcome records a success (true) or failure (false) and updates the
+// rolling window. It returns true exactly once when the failure rate first
+// crosses the escalation threshold (one-shot). After the rate drops below
+// the threshold, the one-shot rearms and can fire again on the next crossing.
+func (t *Tracker) RecordOutcome(success bool) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	// Evict the oldest outcome if the buffer is full.
+	if t.count == t.cfg.WindowSize {
+		evicted := t.outcomes[t.head]
+		if !evicted {
+			t.failures--
+		}
+	} else {
+		t.count++
+	}
+
+	// Write the new outcome.
+	t.outcomes[t.head] = success
+	if !success {
+		t.failures++
+	}
+	t.head = (t.head + 1) % t.cfg.WindowSize
+
+	// Check escalation transition.
+	if t.count < t.cfg.MinSamples {
+		return false
+	}
+
+	rate := float64(t.failures) / float64(t.count)
+	aboveThreshold := rate >= t.cfg.Threshold
+
+	if aboveThreshold && !t.escalated {
+		t.escalated = true
+		return true // one-shot: first crossing
+	}
+	if !aboveThreshold && t.escalated {
+		t.escalated = false // rearm for next crossing
+	}
+
+	return false
+}
+
+// FailureRate returns the current failure rate (0.0–1.0).
+// It returns 0.0 if fewer than [Config.MinSamples] outcomes have been recorded.
+func (t *Tracker) FailureRate() float64 {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	if t.count < t.cfg.MinSamples {
+		return 0.0
+	}
+	return float64(t.failures) / float64(t.count)
+}
+
+// IsEscalated reports whether the failure rate exceeds the threshold and at
+// least [Config.MinSamples] outcomes have been recorded.
+func (t *Tracker) IsEscalated() bool {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	return t.escalated
+}
+
+// Reset clears all recorded outcomes. Use this when the transport is
+// recreated from scratch and historical data is no longer relevant.
+func (t *Tracker) Reset() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.head = 0
+	t.count = 0
+	t.failures = 0
+	t.escalated = false
+	// Re-zero the buffer to avoid stale data on wraparound.
+	for i := range t.outcomes {
+		t.outcomes[i] = false
+	}
+}
+
+// SetEscalatedForTest sets the escalated flag directly. This is only for
+// use in external test packages that need to set up specific escalation states.
+func (t *Tracker) SetEscalatedForTest(v bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.escalated = v
+}

--- a/umh-core/pkg/fsmv2/deps/retry/failurerate/failurerate.go
+++ b/umh-core/pkg/fsmv2/deps/retry/failurerate/failurerate.go
@@ -24,7 +24,7 @@ import (
 type Config struct {
 	// WindowSize is the number of outcomes the circular buffer retains.
 	// Older outcomes are evicted when the buffer is full.
-	// Example: 6000 ≈ 10 minutes at one outcome per 100 ms tick.
+	// Example: 600 ≈ 10 minutes at one outcome per 1 second tick.
 	WindowSize int
 
 	// Threshold is the failure rate (0.0–1.0) that triggers escalation.

--- a/umh-core/pkg/fsmv2/deps/retry/failurerate/failurerate.go
+++ b/umh-core/pkg/fsmv2/deps/retry/failurerate/failurerate.go
@@ -42,12 +42,12 @@ type Config struct {
 //
 // Tracker is safe for concurrent use.
 type Tracker struct {
-	mu       sync.RWMutex
 	outcomes []bool  // circular buffer: true = success, false = failure
 	cfg      Config  // immutable after construction
-	head     int     // next write position
-	count    int     // total recorded outcomes (capped at WindowSize)
-	failures int     // running failure count within the window
+	mu       sync.RWMutex
+	head     int // next write position
+	count    int // total recorded outcomes (capped at WindowSize)
+	failures int // running failure count within the window
 	// escalated tracks the one-shot state: true after the failure rate
 	// first crosses the threshold, false after it drops back below.
 	escalated bool

--- a/umh-core/pkg/fsmv2/deps/retry/failurerate/failurerate.go
+++ b/umh-core/pkg/fsmv2/deps/retry/failurerate/failurerate.go
@@ -14,7 +14,10 @@
 
 package failurerate
 
-import "sync"
+import (
+	"fmt"
+	"sync"
+)
 
 // Config controls the Tracker's window size, escalation threshold, and
 // minimum sample count.
@@ -51,8 +54,19 @@ type Tracker struct {
 }
 
 // New creates a Tracker with the given configuration. The circular buffer
-// is pre-allocated to cfg.WindowSize.
+// is pre-allocated to cfg.WindowSize. New panics if the configuration is
+// invalid (WindowSize <= 0, Threshold out of (0,1], or MinSamples > WindowSize).
 func New(cfg Config) *Tracker {
+	if cfg.WindowSize <= 0 {
+		panic(fmt.Sprintf("failurerate: WindowSize must be > 0, got %d", cfg.WindowSize))
+	}
+	if cfg.Threshold <= 0.0 || cfg.Threshold > 1.0 {
+		panic(fmt.Sprintf("failurerate: Threshold must be in (0.0, 1.0], got %f", cfg.Threshold))
+	}
+	if cfg.MinSamples < 0 || cfg.MinSamples > cfg.WindowSize {
+		panic(fmt.Sprintf("failurerate: MinSamples must be in [0, WindowSize], got %d (WindowSize=%d)", cfg.MinSamples, cfg.WindowSize))
+	}
+
 	return &Tracker{
 		outcomes: make([]bool, cfg.WindowSize),
 		cfg:      cfg,
@@ -109,7 +123,7 @@ func (t *Tracker) FailureRate() float64 {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 
-	if t.count < t.cfg.MinSamples {
+	if t.count == 0 || t.count < t.cfg.MinSamples {
 		return 0.0
 	}
 	return float64(t.failures) / float64(t.count)
@@ -134,10 +148,6 @@ func (t *Tracker) Reset() {
 	t.count = 0
 	t.failures = 0
 	t.escalated = false
-	// Re-zero the buffer to avoid stale data on wraparound.
-	for i := range t.outcomes {
-		t.outcomes[i] = false
-	}
 }
 
 // SetEscalatedForTest sets the escalated flag directly. This is only for

--- a/umh-core/pkg/fsmv2/deps/retry/failurerate/failurerate.go
+++ b/umh-core/pkg/fsmv2/deps/retry/failurerate/failurerate.go
@@ -16,6 +16,7 @@ package failurerate
 
 import (
 	"fmt"
+	"math"
 	"sync"
 )
 
@@ -55,12 +56,13 @@ type Tracker struct {
 
 // New creates a Tracker with the given configuration. The circular buffer
 // is pre-allocated to cfg.WindowSize. New panics if the configuration is
-// invalid (WindowSize <= 0, Threshold out of (0,1], or MinSamples > WindowSize).
+// invalid (WindowSize <= 0, Threshold out of (0,1] or NaN, MinSamples < 0,
+// or MinSamples > WindowSize).
 func New(cfg Config) *Tracker {
 	if cfg.WindowSize <= 0 {
 		panic(fmt.Sprintf("failurerate: WindowSize must be > 0, got %d", cfg.WindowSize))
 	}
-	if cfg.Threshold <= 0.0 || cfg.Threshold > 1.0 {
+	if math.IsNaN(cfg.Threshold) || cfg.Threshold <= 0.0 || cfg.Threshold > 1.0 {
 		panic(fmt.Sprintf("failurerate: Threshold must be in (0.0, 1.0], got %f", cfg.Threshold))
 	}
 	if cfg.MinSamples < 0 || cfg.MinSamples > cfg.WindowSize {

--- a/umh-core/pkg/fsmv2/deps/retry/failurerate/failurerate_suite_test.go
+++ b/umh-core/pkg/fsmv2/deps/retry/failurerate/failurerate_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package failurerate_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestFailurerate(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Failurerate Suite")
+}

--- a/umh-core/pkg/fsmv2/deps/retry/failurerate/failurerate_test.go
+++ b/umh-core/pkg/fsmv2/deps/retry/failurerate/failurerate_test.go
@@ -1,0 +1,299 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package failurerate_test
+
+import (
+	"sync"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps/retry/failurerate"
+)
+
+var _ = Describe("Failure Rate Tracker", func() {
+	var tracker *failurerate.Tracker
+
+	// Standard config for most tests: window of 100, 90% threshold, 10 min samples.
+	defaultCfg := failurerate.Config{
+		WindowSize: 100,
+		Threshold:  0.9,
+		MinSamples: 10,
+	}
+
+	BeforeEach(func() {
+		tracker = failurerate.New(defaultCfg)
+	})
+
+	Describe("RecordOutcome()", func() {
+		It("should increase failure rate as failures are recorded", func() {
+			for range 50 {
+				tracker.RecordOutcome(false)
+			}
+			Expect(tracker.FailureRate()).To(BeNumerically("==", 1.0))
+		})
+
+		It("should decrease failure rate when successes are recorded", func() {
+			// Fill with 20 failures
+			for range 20 {
+				tracker.RecordOutcome(false)
+			}
+			Expect(tracker.FailureRate()).To(BeNumerically("==", 1.0))
+
+			// Add 20 successes — rate should drop to 0.5
+			for range 20 {
+				tracker.RecordOutcome(true)
+			}
+			Expect(tracker.FailureRate()).To(BeNumerically("~", 0.5, 0.01))
+		})
+
+		It("should evict oldest outcomes when window is full", func() {
+			// Fill the entire window (100) with failures
+			for range 100 {
+				tracker.RecordOutcome(false)
+			}
+			Expect(tracker.FailureRate()).To(BeNumerically("==", 1.0))
+
+			// Now record 50 successes — oldest 50 failures are evicted
+			for range 50 {
+				tracker.RecordOutcome(true)
+			}
+			// Window now: 50 failures + 50 successes = 50% failure rate
+			Expect(tracker.FailureRate()).To(BeNumerically("~", 0.5, 0.01))
+		})
+
+		It("should fire escalation at threshold crossing", func() {
+			// Record enough failures to cross 90% threshold with min 10 samples.
+			// 10 failures out of 10 = 100% > 90% threshold.
+			for i := range 10 {
+				fired := tracker.RecordOutcome(false)
+				if i < 9 {
+					Expect(fired).To(BeFalse(), "should not fire before MinSamples at i=%d", i)
+				} else {
+					Expect(fired).To(BeTrue(), "should fire at MinSamples when rate exceeds threshold")
+				}
+			}
+		})
+
+		It("should be one-shot: second call does not fire again", func() {
+			// Cross threshold
+			for range 10 {
+				tracker.RecordOutcome(false)
+			}
+			// Already fired on the 10th call above, subsequent should NOT fire
+			fired := tracker.RecordOutcome(false)
+			Expect(fired).To(BeFalse(), "should not fire twice without rearm")
+		})
+
+		It("should rearm after recovery and fire again on next crossing", func() {
+			// Cross threshold (fires on 10th)
+			for range 10 {
+				tracker.RecordOutcome(false)
+			}
+			Expect(tracker.IsEscalated()).To(BeTrue())
+
+			// Add enough successes to drop below threshold.
+			// Current: 10 failures out of 10. Need rate < 0.9.
+			// Adding 2 successes: 10 failures out of 12 = 83% < 90%
+			tracker.RecordOutcome(true)
+			tracker.RecordOutcome(true)
+			Expect(tracker.IsEscalated()).To(BeFalse(), "should de-escalate after recovery")
+
+			// Now cross threshold again — should fire again
+			// Fill with failures until we cross 90% again
+			var firedAgain bool
+			for range 20 {
+				if tracker.RecordOutcome(false) {
+					firedAgain = true
+					break
+				}
+			}
+			Expect(firedAgain).To(BeTrue(), "should fire again after rearm")
+		})
+
+		It("should not escalate before MinSamples even at 100% failure rate", func() {
+			cfg := failurerate.Config{
+				WindowSize: 100,
+				Threshold:  0.9,
+				MinSamples: 50,
+			}
+			t := failurerate.New(cfg)
+
+			for range 49 {
+				fired := t.RecordOutcome(false)
+				Expect(fired).To(BeFalse(), "should not fire before MinSamples")
+			}
+			Expect(t.FailureRate()).To(BeNumerically("==", 0.0),
+				"FailureRate should return 0.0 below MinSamples")
+
+			// The 50th outcome should fire
+			fired := t.RecordOutcome(false)
+			Expect(fired).To(BeTrue(), "should fire at MinSamples")
+		})
+	})
+
+	Describe("FailureRate()", func() {
+		It("should return 0.0 when no outcomes are recorded", func() {
+			Expect(tracker.FailureRate()).To(BeNumerically("==", 0.0))
+		})
+
+		It("should return 0.0 below MinSamples", func() {
+			for range 9 {
+				tracker.RecordOutcome(false)
+			}
+			Expect(tracker.FailureRate()).To(BeNumerically("==", 0.0))
+		})
+
+		It("should return correct rate at MinSamples", func() {
+			// 7 failures + 3 successes = 70%
+			for range 7 {
+				tracker.RecordOutcome(false)
+			}
+			for range 3 {
+				tracker.RecordOutcome(true)
+			}
+			Expect(tracker.FailureRate()).To(BeNumerically("~", 0.7, 0.01))
+		})
+	})
+
+	Describe("IsEscalated()", func() {
+		It("should return false initially", func() {
+			Expect(tracker.IsEscalated()).To(BeFalse())
+		})
+
+		It("should return true after threshold crossing", func() {
+			for range 10 {
+				tracker.RecordOutcome(false)
+			}
+			Expect(tracker.IsEscalated()).To(BeTrue())
+		})
+
+		It("should return false after recovery", func() {
+			for range 10 {
+				tracker.RecordOutcome(false)
+			}
+			// Recover
+			tracker.RecordOutcome(true)
+			tracker.RecordOutcome(true)
+			Expect(tracker.IsEscalated()).To(BeFalse())
+		})
+	})
+
+	Describe("Reset()", func() {
+		It("should clear all state", func() {
+			for range 50 {
+				tracker.RecordOutcome(false)
+			}
+			Expect(tracker.IsEscalated()).To(BeTrue())
+			Expect(tracker.FailureRate()).To(BeNumerically(">", 0))
+
+			tracker.Reset()
+
+			Expect(tracker.IsEscalated()).To(BeFalse())
+			Expect(tracker.FailureRate()).To(BeNumerically("==", 0.0))
+
+			// Should be able to escalate again after reset
+			for range 10 {
+				tracker.RecordOutcome(false)
+			}
+			Expect(tracker.IsEscalated()).To(BeTrue())
+		})
+	})
+
+	Describe("SetEscalatedForTest()", func() {
+		It("should set escalated flag directly", func() {
+			Expect(tracker.IsEscalated()).To(BeFalse())
+
+			tracker.SetEscalatedForTest(true)
+			Expect(tracker.IsEscalated()).To(BeTrue())
+
+			tracker.SetEscalatedForTest(false)
+			Expect(tracker.IsEscalated()).To(BeFalse())
+		})
+	})
+
+	Describe("Thread Safety", func() {
+		It("should handle concurrent RecordOutcome calls without panic", func() {
+			const goroutines = 10
+			const iterations = 100
+
+			var wg sync.WaitGroup
+			wg.Add(goroutines * 3)
+
+			// Concurrent failures
+			for range goroutines {
+				go func() {
+					defer wg.Done()
+					for range iterations {
+						tracker.RecordOutcome(false)
+					}
+				}()
+			}
+
+			// Concurrent successes
+			for range goroutines {
+				go func() {
+					defer wg.Done()
+					for range iterations {
+						tracker.RecordOutcome(true)
+					}
+				}()
+			}
+
+			// Concurrent reads
+			for range goroutines {
+				go func() {
+					defer wg.Done()
+					for range iterations {
+						_ = tracker.FailureRate()
+						_ = tracker.IsEscalated()
+					}
+				}()
+			}
+
+			wg.Wait()
+			// If we get here without deadlock or panic, the test passes
+		})
+	})
+
+	Describe("Circular Buffer Wraparound", func() {
+		It("should correctly maintain failure count through multiple wraparounds", func() {
+			cfg := failurerate.Config{
+				WindowSize: 10,
+				Threshold:  0.9,
+				MinSamples: 5,
+			}
+			t := failurerate.New(cfg)
+
+			// Fill with 10 failures (full window)
+			for range 10 {
+				t.RecordOutcome(false)
+			}
+			Expect(t.FailureRate()).To(BeNumerically("==", 1.0))
+
+			// Wrap around: add 10 successes — evicts all 10 failures
+			for range 10 {
+				t.RecordOutcome(true)
+			}
+			Expect(t.FailureRate()).To(BeNumerically("==", 0.0))
+
+			// Wrap again: add 5 failures — now 5 failures + 5 successes
+			for range 5 {
+				t.RecordOutcome(false)
+			}
+			Expect(t.FailureRate()).To(BeNumerically("~", 0.5, 0.01))
+		})
+	})
+})

--- a/umh-core/pkg/fsmv2/deps/retry/failurerate/failurerate_test.go
+++ b/umh-core/pkg/fsmv2/deps/retry/failurerate/failurerate_test.go
@@ -15,6 +15,7 @@
 package failurerate_test
 
 import (
+	"math"
 	"sync"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -317,6 +318,12 @@ var _ = Describe("Failure Rate Tracker", func() {
 		It("should panic on Threshold > 1.0", func() {
 			Expect(func() {
 				failurerate.New(failurerate.Config{WindowSize: 100, Threshold: 1.5, MinSamples: 10})
+			}).To(Panic())
+		})
+
+		It("should panic on NaN Threshold", func() {
+			Expect(func() {
+				failurerate.New(failurerate.Config{WindowSize: 100, Threshold: math.NaN(), MinSamples: 10})
 			}).To(Panic())
 		})
 

--- a/umh-core/pkg/fsmv2/deps/retry/failurerate/failurerate_test.go
+++ b/umh-core/pkg/fsmv2/deps/retry/failurerate/failurerate_test.go
@@ -123,6 +123,23 @@ var _ = Describe("Failure Rate Tracker", func() {
 			Expect(firedAgain).To(BeTrue(), "should fire again after rearm")
 		})
 
+		It("should fire escalation at exact threshold boundary (rate == threshold)", func() {
+			// 9 failures + 1 success = 90% rate == 0.9 threshold — should fire (>= comparator)
+			cfg := failurerate.Config{
+				WindowSize: 100,
+				Threshold:  0.9,
+				MinSamples: 10,
+			}
+			t := failurerate.New(cfg)
+
+			for range 9 {
+				t.RecordOutcome(false)
+			}
+			t.RecordOutcome(true)
+			// 9/10 = 0.9 == threshold — should have fired on the 10th outcome
+			Expect(t.IsEscalated()).To(BeTrue(), "should escalate when rate exactly equals threshold")
+		})
+
 		It("should not escalate before MinSamples even at 100% failure rate", func() {
 			cfg := failurerate.Config{
 				WindowSize: 100,
@@ -225,12 +242,12 @@ var _ = Describe("Failure Rate Tracker", func() {
 	})
 
 	Describe("Thread Safety", func() {
-		It("should handle concurrent RecordOutcome calls without panic", func() {
+		It("should handle concurrent RecordOutcome and Reset calls without panic", func() {
 			const goroutines = 10
 			const iterations = 100
 
 			var wg sync.WaitGroup
-			wg.Add(goroutines * 3)
+			wg.Add(goroutines * 4)
 
 			// Concurrent failures
 			for range goroutines {
@@ -263,8 +280,62 @@ var _ = Describe("Failure Rate Tracker", func() {
 				}()
 			}
 
+			// Concurrent resets
+			for range goroutines {
+				go func() {
+					defer wg.Done()
+					for range iterations {
+						tracker.Reset()
+					}
+				}()
+			}
+
 			wg.Wait()
 			// If we get here without deadlock or panic, the test passes
+		})
+	})
+
+	Describe("Config Validation", func() {
+		It("should panic on WindowSize=0", func() {
+			Expect(func() {
+				failurerate.New(failurerate.Config{WindowSize: 0, Threshold: 0.9, MinSamples: 0})
+			}).To(Panic())
+		})
+
+		It("should panic on negative WindowSize", func() {
+			Expect(func() {
+				failurerate.New(failurerate.Config{WindowSize: -1, Threshold: 0.9, MinSamples: 0})
+			}).To(Panic())
+		})
+
+		It("should panic on Threshold=0", func() {
+			Expect(func() {
+				failurerate.New(failurerate.Config{WindowSize: 100, Threshold: 0.0, MinSamples: 10})
+			}).To(Panic())
+		})
+
+		It("should panic on Threshold > 1.0", func() {
+			Expect(func() {
+				failurerate.New(failurerate.Config{WindowSize: 100, Threshold: 1.5, MinSamples: 10})
+			}).To(Panic())
+		})
+
+		It("should panic on MinSamples > WindowSize", func() {
+			Expect(func() {
+				failurerate.New(failurerate.Config{WindowSize: 10, Threshold: 0.9, MinSamples: 20})
+			}).To(Panic())
+		})
+
+		It("should not panic on valid edge configs", func() {
+			// Threshold=1.0 is valid (only 100% failure escalates)
+			Expect(func() {
+				failurerate.New(failurerate.Config{WindowSize: 1, Threshold: 1.0, MinSamples: 0})
+			}).NotTo(Panic())
+
+			// MinSamples=0 is valid (no startup protection)
+			Expect(func() {
+				failurerate.New(failurerate.Config{WindowSize: 100, Threshold: 0.5, MinSamples: 0})
+			}).NotTo(Panic())
 		})
 	})
 


### PR DESCRIPTION
Transient transport errors (network timeouts, HTTP 5xx, rate limits) should not fire SentryError immediately. But if they persist, we need to know. This package tracks the rolling failure rate and signals when transient errors cross from noise to sustained problem.

PR #2462 already fixed this, but reviewing it required understanding 7 files across 4 packages with duplicated escalation logic in push and pull. We closed it and split into 4 PRs:
- **PR 1** (this): Shared `failurerate.Tracker` package
- **PR 2** (#2466): Wire into push/pull dependencies
- **PR 2.5** (#2468): Restructure error handling in push/pull to make PR 3's diff trivial
- **PR 3** (#2467): Add `IsTransient()`, suppress transient errors from SentryError

The package uses a rolling window over the last N outcomes. If push fails for 5 minutes, succeeds once, then fails for another 5 minutes, the window still sees ~99% failure and keeps the alert. One brief success doesn't reset anything.

FYI: the closed PR #2462 used a simpler timer-based approach where any single success would reset the escalation timer entirely.

**Test plan:**
- [x] 24 Ginkgo specs pass with `-race`
- [x] `go build`, `go vet` clean

---
**Stack**: #2465 (this) → #2466 → #2468 → #2467 | ENG-4450