### PR TITLE
feat(fsmv2): wire failurerate.Tracker into push/pull deps (2/4)

### DIFF
--- a/umh-core/pkg/fsmv2/deps/retry/failurerate/doc.go
+++ b/umh-core/pkg/fsmv2/deps/retry/failurerate/doc.go
@@ -27,14 +27,15 @@
 //   - Persistent errors require human intervention: invalid tokens, deleted
 //     instances, proxy blocks, and Cloudflare challenges.
 //
-// The intended integration (wired in subsequent PRs) suppresses Sentry alerts
-// for transient errors while still updating metrics and DegradedState.
-// Persistent errors continue to fire SentryError immediately.
+// All error types (transient and persistent) feed the rolling window.
+// Persistent errors also fire SentryError immediately. The downstream
+// suppression logic (wired in subsequent PRs) suppresses SentryError for
+// transient errors while still updating metrics and DegradedState.
 //
 // # Escalation Lifecycle
 //
-// When transient errors dominate and the failure rate exceeds the configured
-// threshold over the rolling window, the Tracker fires a one-shot escalation.
+// When the failure rate exceeds the configured threshold over the rolling
+// window, the Tracker fires a one-shot escalation.
 // The caller fires a SentryWarn to alert operators. After enough successes
 // bring the rate below the threshold, the Tracker rearms and can fire again
 // on the next crossing.
@@ -51,6 +52,6 @@
 //
 // Error classification lives in the communicator/transport/http package
 // (ErrorType constants). Rate tracking lives in this package. Push and pull
-// dependencies will each hold a *[Tracker] and call [Tracker.RecordOutcome]
+// dependencies each hold a *[Tracker] and call [Tracker.RecordOutcome]
 // on every error or success.
 package failurerate

--- a/umh-core/pkg/fsmv2/deps/retry/failurerate/doc.go
+++ b/umh-core/pkg/fsmv2/deps/retry/failurerate/doc.go
@@ -22,26 +22,22 @@
 // Transport errors fall into two categories:
 //
 //   - Transient errors self-resolve without human intervention: network timeouts,
-//     DNS failures, HTTP 5xx responses, rate limits, and full channels. These
-//     appear as ErrorTypeNetwork, ErrorTypeServerError, ErrorTypeChannelFull, and
-//     ErrorTypeBackendRateLimit in [communicator/transport/http].
+//     DNS failures, HTTP 5xx responses, rate limits, and full channels.
 //
 //   - Persistent errors require human intervention: invalid tokens, deleted
-//     instances, proxy blocks, and Cloudflare challenges. These appear as
-//     ErrorTypeInvalidToken, ErrorTypeInstanceDeleted, ErrorTypeProxyBlock, and
-//     ErrorTypeCloudflareChallenge.
+//     instances, proxy blocks, and Cloudflare challenges.
 //
-// The action layer suppresses Sentry alerts for transient errors (they fire
-// metrics and update DegradedState instead). Persistent errors still fire
-// SentryError immediately.
+// The intended integration (wired in subsequent PRs) suppresses Sentry alerts
+// for transient errors while still updating metrics and DegradedState.
+// Persistent errors continue to fire SentryError immediately.
 //
 // # Escalation Lifecycle
 //
-// When transient errors dominate — the failure rate exceeds the configured
-// threshold over the rolling window — the Tracker fires a one-shot escalation.
-// The caller (typically push or pull dependencies) fires a SentryWarn to alert
-// operators. After enough successes bring the rate below the threshold, the
-// Tracker rearms and can fire again on the next crossing.
+// When transient errors dominate and the failure rate exceeds the configured
+// threshold over the rolling window, the Tracker fires a one-shot escalation.
+// The caller fires a SentryWarn to alert operators. After enough successes
+// bring the rate below the threshold, the Tracker rearms and can fire again
+// on the next crossing.
 //
 // # Why a Rolling Window
 //
@@ -53,8 +49,8 @@
 //
 // # Integration
 //
-// Error classification lives in [communicator/transport/http] (ErrorType and
-// IsTransient). Transient suppression lives in the pull and push action files.
-// Rate tracking lives in this package. Push and pull dependencies each hold a
-// *[Tracker] and call [Tracker.RecordOutcome] on every error or success.
+// Error classification lives in the communicator/transport/http package
+// (ErrorType constants). Rate tracking lives in this package. Push and pull
+// dependencies will each hold a *[Tracker] and call [Tracker.RecordOutcome]
+// on every error or success.
 package failurerate

--- a/umh-core/pkg/fsmv2/deps/retry/failurerate/failurerate.go
+++ b/umh-core/pkg/fsmv2/deps/retry/failurerate/failurerate.go
@@ -37,8 +37,9 @@ type Config struct {
 }
 
 // Tracker tracks the failure rate of the last N outcomes using a fixed-size
-// circular buffer. Call [RecordOutcome] with true (success) or false (failure);
-// the Tracker computes the rolling failure rate and detects threshold crossings.
+// circular buffer. Call [Tracker.RecordOutcome] with true (success) or false
+// (failure); the Tracker computes the rolling failure rate and detects
+// threshold crossings.
 //
 // Tracker is safe for concurrent use.
 type Tracker struct {
@@ -129,8 +130,8 @@ func (t *Tracker) FailureRate() float64 {
 	return float64(t.failures) / float64(t.count)
 }
 
-// IsEscalated reports whether the failure rate exceeds the threshold and at
-// least [Config.MinSamples] outcomes have been recorded.
+// IsEscalated reports whether the failure rate meets or exceeds the threshold
+// and at least [Config.MinSamples] outcomes have been recorded.
 func (t *Tracker) IsEscalated() bool {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
@@ -138,7 +139,7 @@ func (t *Tracker) IsEscalated() bool {
 	return t.escalated
 }
 
-// Reset clears all recorded outcomes. Use this when the transport is
+// Reset clears all recorded outcomes. Use this when the tracked entity is
 // recreated from scratch and historical data is no longer relevant.
 func (t *Tracker) Reset() {
 	t.mu.Lock()

--- a/umh-core/pkg/fsmv2/workers/transport/dependencies.go
+++ b/umh-core/pkg/fsmv2/workers/transport/dependencies.go
@@ -21,9 +21,20 @@ import (
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps/retry"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps/retry/failurerate"
 	communicator_transport "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator/transport"
 	httpTransport "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator/transport/http"
 )
+
+// ChildFailureRateConfig is the shared failurerate.Config for push and pull
+// child workers. WindowSize=600 at the 1-second production tick rate covers
+// roughly 10 minutes. Threshold=0.9 triggers escalation at 90% failure rate.
+// MinSamples=100 suppresses spurious alerts during startup.
+var ChildFailureRateConfig = failurerate.Config{
+	WindowSize: 600,
+	Threshold:  0.9,
+	MinSamples: 100,
+}
 
 // ChannelProvider interface and singleton functions are defined in channel_provider.go
 

--- a/umh-core/pkg/fsmv2/workers/transport/pull/dependencies.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/dependencies.go
@@ -60,7 +60,7 @@ func NewPullDependencies(parentDeps *transport_pkg.TransportDependencies, identi
 		BaseDependencies: deps.NewBaseDependencies(logger, stateReader, identity),
 		parentDeps:       parentDeps,
 		failureRate: failurerate.New(failurerate.Config{
-			WindowSize: 6000,
+			WindowSize: 600,
 			Threshold:  0.9,
 			MinSamples: 100,
 		}),

--- a/umh-core/pkg/fsmv2/workers/transport/pull/dependencies.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/dependencies.go
@@ -59,11 +59,7 @@ func NewPullDependencies(parentDeps *transport_pkg.TransportDependencies, identi
 	return &PullDependencies{
 		BaseDependencies: deps.NewBaseDependencies(logger, stateReader, identity),
 		parentDeps:       parentDeps,
-		failureRate: failurerate.New(failurerate.Config{
-			WindowSize: 600,
-			Threshold:  0.9,
-			MinSamples: 100,
-		}),
+		failureRate: failurerate.New(transport_pkg.ChildFailureRateConfig),
 	}, nil
 }
 
@@ -247,8 +243,8 @@ func (d *PullDependencies) CheckAndClearOnReset() bool {
 	return changed
 }
 
-// IsPersistentFailureEscalated reports whether the failure rate exceeds the
-// escalation threshold over the rolling window.
+// IsPersistentFailureEscalated reports whether the failure rate meets or exceeds
+// the escalation threshold over the rolling window.
 func (d *PullDependencies) IsPersistentFailureEscalated() bool {
 	return d.failureRate.IsEscalated()
 }

--- a/umh-core/pkg/fsmv2/workers/transport/pull/dependencies.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/dependencies.go
@@ -110,7 +110,10 @@ func (d *PullDependencies) RecordSuccess() {
 func (d *PullDependencies) RecordError() {
 	d.RetryTracker().RecordError()
 	d.parentDeps.RecordError()
-	d.failureRate.RecordOutcome(false)
+	if d.failureRate.RecordOutcome(false) {
+		d.BaseDependencies.GetLogger().SentryWarn(deps.FeatureCommunicator, d.GetHierarchyPath(), "persistent_pull_failure",
+			deps.Float64("failure_rate", d.failureRate.FailureRate()))
+	}
 }
 
 func (d *PullDependencies) GetConsecutiveErrors() int {

--- a/umh-core/pkg/fsmv2/workers/transport/pull/dependencies.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/dependencies.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps/retry"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps/retry/failurerate"
 	communicator_transport "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator/transport"
 	httpTransport "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator/transport/http"
 	transport_pkg "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport"
@@ -39,6 +40,7 @@ var _ snapshot.PullDependencies = (*PullDependencies)(nil)
 type PullDependencies struct {
 	*deps.BaseDependencies
 	parentDeps              *transport_pkg.TransportDependencies
+	failureRate             *failurerate.Tracker
 	pendingMessages         []*communicator_transport.UMHMessage
 	errorMu                 sync.RWMutex
 	pendingMu               sync.RWMutex
@@ -57,6 +59,11 @@ func NewPullDependencies(parentDeps *transport_pkg.TransportDependencies, identi
 	return &PullDependencies{
 		BaseDependencies: deps.NewBaseDependencies(logger, stateReader, identity),
 		parentDeps:       parentDeps,
+		failureRate: failurerate.New(failurerate.Config{
+			WindowSize: 6000,
+			Threshold:  0.9,
+			MinSamples: 100,
+		}),
 	}, nil
 }
 
@@ -83,6 +90,12 @@ func (d *PullDependencies) RecordTypedError(errType httpTransport.ErrorType, ret
 
 	d.RetryTracker().RecordError(retry.WithClass(errType.String()), retry.WithRetryAfter(retryAfter))
 	d.parentDeps.RecordTypedError(errType, retryAfter)
+
+	if d.failureRate.RecordOutcome(false) {
+		d.BaseDependencies.GetLogger().SentryWarn(deps.FeatureCommunicator, d.GetHierarchyPath(), "persistent_pull_failure",
+			deps.String("error_type", errType.String()),
+			deps.Float64("failure_rate", d.failureRate.FailureRate()))
+	}
 }
 
 // RecordSuccess resets the child's error state. It intentionally does NOT
@@ -95,11 +108,13 @@ func (d *PullDependencies) RecordSuccess() {
 	d.errorMu.Unlock()
 
 	d.RetryTracker().RecordSuccess()
+	d.failureRate.RecordOutcome(true)
 }
 
 func (d *PullDependencies) RecordError() {
 	d.RetryTracker().RecordError()
 	d.parentDeps.RecordError()
+	d.failureRate.RecordOutcome(false)
 }
 
 func (d *PullDependencies) GetConsecutiveErrors() int {
@@ -225,7 +240,20 @@ func (d *PullDependencies) CheckAndClearOnReset() bool {
 		d.backpressureMu.Lock()
 		d.backpressured = false
 		d.backpressureMu.Unlock()
+
+		d.failureRate.Reset()
 	}
 
 	return changed
+}
+
+// IsPersistentFailureEscalated reports whether the failure rate exceeds the
+// escalation threshold over the rolling window.
+func (d *PullDependencies) IsPersistentFailureEscalated() bool {
+	return d.failureRate.IsEscalated()
+}
+
+// SetPersistentFailureEscalatedForTest sets the escalation flag directly for tests.
+func (d *PullDependencies) SetPersistentFailureEscalatedForTest(v bool) {
+	d.failureRate.SetEscalatedForTest(v)
 }

--- a/umh-core/pkg/fsmv2/workers/transport/push/dependencies.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/dependencies.go
@@ -52,7 +52,7 @@ func NewPushDependencies(parentDeps *transport_pkg.TransportDependencies, identi
 		BaseDependencies: deps.NewBaseDependencies(logger, stateReader, identity),
 		parentDeps:       parentDeps,
 		failureRate: failurerate.New(failurerate.Config{
-			WindowSize: 6000,
+			WindowSize: 600,
 			Threshold:  0.9,
 			MinSamples: 100,
 		}),

--- a/umh-core/pkg/fsmv2/workers/transport/push/dependencies.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/dependencies.go
@@ -102,7 +102,10 @@ func (d *PushDependencies) RecordSuccess() {
 func (d *PushDependencies) RecordError() {
 	d.RetryTracker().RecordError()
 	d.parentDeps.RecordError()
-	d.failureRate.RecordOutcome(false)
+	if d.failureRate.RecordOutcome(false) {
+		d.BaseDependencies.GetLogger().SentryWarn(deps.FeatureCommunicator, d.GetHierarchyPath(), "persistent_push_failure",
+			deps.Float64("failure_rate", d.failureRate.FailureRate()))
+	}
 }
 
 func (d *PushDependencies) GetConsecutiveErrors() int {

--- a/umh-core/pkg/fsmv2/workers/transport/push/dependencies.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/dependencies.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps/retry"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps/retry/failurerate"
 	communicator_transport "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator/transport"
 	httpTransport "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator/transport/http"
 	transport_pkg "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport"
@@ -34,6 +35,7 @@ var _ snapshot.PushDependencies = (*PushDependencies)(nil)
 type PushDependencies struct {
 	*deps.BaseDependencies
 	parentDeps              *transport_pkg.TransportDependencies
+	failureRate             *failurerate.Tracker
 	pendingMessages         []*communicator_transport.UMHMessage
 	errorMu                 sync.RWMutex
 	pendingMu               sync.RWMutex
@@ -49,6 +51,11 @@ func NewPushDependencies(parentDeps *transport_pkg.TransportDependencies, identi
 	return &PushDependencies{
 		BaseDependencies: deps.NewBaseDependencies(logger, stateReader, identity),
 		parentDeps:       parentDeps,
+		failureRate: failurerate.New(failurerate.Config{
+			WindowSize: 6000,
+			Threshold:  0.9,
+			MinSamples: 100,
+		}),
 	}, nil
 }
 
@@ -75,6 +82,12 @@ func (d *PushDependencies) RecordTypedError(errType httpTransport.ErrorType, ret
 
 	d.RetryTracker().RecordError(retry.WithClass(errType.String()), retry.WithRetryAfter(retryAfter))
 	d.parentDeps.RecordTypedError(errType, retryAfter)
+
+	if d.failureRate.RecordOutcome(false) {
+		d.BaseDependencies.GetLogger().SentryWarn(deps.FeatureCommunicator, d.GetHierarchyPath(), "persistent_push_failure",
+			deps.String("error_type", errType.String()),
+			deps.Float64("failure_rate", d.failureRate.FailureRate()))
+	}
 }
 
 // RecordSuccess resets the child's error state. It intentionally does NOT
@@ -87,11 +100,13 @@ func (d *PushDependencies) RecordSuccess() {
 	d.errorMu.Unlock()
 
 	d.RetryTracker().RecordSuccess()
+	d.failureRate.RecordOutcome(true)
 }
 
 func (d *PushDependencies) RecordError() {
 	d.RetryTracker().RecordError()
 	d.parentDeps.RecordError()
+	d.failureRate.RecordOutcome(false)
 }
 
 func (d *PushDependencies) GetConsecutiveErrors() int {
@@ -183,9 +198,21 @@ func (d *PushDependencies) CheckAndClearOnReset() bool {
 	if currentGen != d.lastSeenResetGeneration {
 		d.pendingMessages = nil
 		d.lastSeenResetGeneration = currentGen
+		d.failureRate.Reset()
 
 		return true
 	}
 
 	return false
+}
+
+// IsPersistentFailureEscalated reports whether the failure rate exceeds the
+// escalation threshold over the rolling window.
+func (d *PushDependencies) IsPersistentFailureEscalated() bool {
+	return d.failureRate.IsEscalated()
+}
+
+// SetPersistentFailureEscalatedForTest sets the escalation flag directly for tests.
+func (d *PushDependencies) SetPersistentFailureEscalatedForTest(v bool) {
+	d.failureRate.SetEscalatedForTest(v)
 }

--- a/umh-core/pkg/fsmv2/workers/transport/push/dependencies.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/dependencies.go
@@ -51,11 +51,7 @@ func NewPushDependencies(parentDeps *transport_pkg.TransportDependencies, identi
 	return &PushDependencies{
 		BaseDependencies: deps.NewBaseDependencies(logger, stateReader, identity),
 		parentDeps:       parentDeps,
-		failureRate: failurerate.New(failurerate.Config{
-			WindowSize: 600,
-			Threshold:  0.9,
-			MinSamples: 100,
-		}),
+		failureRate: failurerate.New(transport_pkg.ChildFailureRateConfig),
 	}, nil
 }
 
@@ -188,26 +184,30 @@ func (d *PushDependencies) GetResetGeneration() uint64 {
 }
 
 // CheckAndClearOnReset checks if parent has done a transport reset.
-// If resetGeneration changed, clears all pending messages and returns true.
+// If resetGeneration changed, clears all pending messages, resets the failure
+// rate tracker, and returns true.
 func (d *PushDependencies) CheckAndClearOnReset() bool {
 	currentGen := d.parentDeps.GetResetGeneration()
 
 	d.pendingMu.Lock()
-	defer d.pendingMu.Unlock()
 
-	if currentGen != d.lastSeenResetGeneration {
+	changed := currentGen != d.lastSeenResetGeneration
+	if changed {
 		d.pendingMessages = nil
 		d.lastSeenResetGeneration = currentGen
-		d.failureRate.Reset()
-
-		return true
 	}
 
-	return false
+	d.pendingMu.Unlock()
+
+	if changed {
+		d.failureRate.Reset()
+	}
+
+	return changed
 }
 
-// IsPersistentFailureEscalated reports whether the failure rate exceeds the
-// escalation threshold over the rolling window.
+// IsPersistentFailureEscalated reports whether the failure rate meets or exceeds
+// the escalation threshold over the rolling window.
 func (d *PushDependencies) IsPersistentFailureEscalated() bool {
 	return d.failureRate.IsEscalated()
 }


### PR DESCRIPTION
Adds `failurerate.Tracker` to push and pull dependencies. Existing `RetryTracker` is untouched — both coexist. RetryTracker handles backoff and DegradedState. failurerate.Tracker handles "should we alert Sentry about sustained failures?"

Also includes doc/comment fixes from PR 1 review.

**Test plan:**
- [x] All transport tests pass
- [x] `go build`, `go vet` clean

---
**Stack**: #2465 → #2466 (this) → #2468 → #2467 | ENG-4450