### PR TITLE
feat(fsmv2): suppress transient transport errors from SentryError (4/4)

### DIFF
--- a/umh-core/pkg/fsmv2/deps/retry/failurerate/doc.go
+++ b/umh-core/pkg/fsmv2/deps/retry/failurerate/doc.go
@@ -17,33 +17,29 @@
 // failure; the [Tracker] computes the rolling failure rate and fires a one-shot
 // escalation when the rate crosses a configurable threshold.
 //
-// # Problem
+// # Why This Exists
 //
-// Transport push and pull workers each need to detect sustained failure
-// patterns and alert operators via Sentry. Without a shared abstraction,
-// each worker would implement its own escalation infrastructure: a mutex,
-// a flag, a threshold check, and a timer or counter. This duplication is
-// error-prone and makes the escalation behavior hard to review, test, and
-// reason about across workers.
+// Transient transport errors (network timeouts, HTTP 5xx, rate limits) should
+// not fire SentryError immediately. They self-resolve. But if they persist
+// continuously at a high rate, something is genuinely wrong (server issue,
+// broken network path) and needs attention. This package provides the filter:
+// it tracks the rolling failure rate and signals when transient errors cross
+// from "expected noise" to "sustained problem."
 //
-// The naive approach — escalate when degraded longer than N minutes — has a
-// known blind spot (ENG-4565): a single success in a 99% failure pattern
-// resets the timer completely. The system never escalates even though it is
-// failing 99% of the time.
+// [Tracker.RecordOutcome] returns true exactly once when the failure rate
+// first crosses the threshold. Callers (push/pull dependencies) use this
+// signal to fire a one-shot SentryWarn.
+//
+// Persistent errors (invalid tokens, deleted instances, proxy blocks) are not
+// tracked here. They fire SentryError immediately and always require human
+// intervention.
 //
 // # Design
 //
-// The Tracker uses a fixed-size circular buffer to compute a rolling failure
-// rate. A single success shifts the window from 100/100 failures to 99/100.
-// The rate barely changes, and escalation holds.
-//
-// A rolling window was chosen over an exponentially weighted moving average
-// (EWMA) because the window provides exact, bounded semantics: "90% of the
-// last 6000 outcomes failed" is easy to reason about and configure. EWMA
-// gives a fuzzy decay where the effective window size depends on the smoothing
-// factor, making threshold tuning less intuitive. The circular buffer also
-// makes tests fully deterministic (no time dependency, no floating-point
-// drift from repeated multiplication).
+// The Tracker uses a fixed-size circular buffer over the last N outcomes.
+// If push fails for 5 minutes, succeeds once, then fails for another
+// 5 minutes, the window still sees ~99% failure and keeps the alert. One
+// brief success doesn't reset anything.
 //
 // The window size is outcome-count-based, not time-based. At a 100 ms tick
 // rate, WindowSize=6000 covers roughly 10 minutes. Under backoff the
@@ -62,9 +58,9 @@
 //     instances, proxy blocks, and Cloudflare challenges.
 //
 // All error types (transient and persistent) feed the rolling window.
-// Persistent errors also fire SentryError immediately. The downstream
-// suppression logic (wired in subsequent PRs) suppresses SentryError for
-// transient errors while still updating metrics and DegradedState.
+// Persistent errors also fire SentryError immediately. The suppression
+// logic suppresses SentryError for transient errors while still updating
+// metrics and DegradedState.
 //
 // # Escalation Lifecycle
 //
@@ -84,10 +80,10 @@
 //
 // # Integration
 //
-// Error classification lives in the communicator/transport/http package
-// (ErrorType constants). Rate tracking lives in this package. Push and pull
-// dependencies each hold a *[Tracker] and call [Tracker.RecordOutcome]
-// after every real HTTP operation (success or failure). Idle ticks — where
-// no HTTP request was made — must NOT record an outcome, as this would
-// dilute the failure rate with phantom data.
+// Error classification (ErrorType, IsTransient) lives in the
+// communicator/transport/http package. Rate tracking lives in this package.
+// Push and pull dependencies each hold a *[Tracker] and call
+// [Tracker.RecordOutcome] after every real HTTP operation (success or
+// failure). Idle ticks — where no HTTP request was made — must NOT record
+// an outcome, as this would dilute the failure rate with phantom data.
 package failurerate

--- a/umh-core/pkg/fsmv2/deps/retry/failurerate/doc.go
+++ b/umh-core/pkg/fsmv2/deps/retry/failurerate/doc.go
@@ -17,12 +17,46 @@
 // failure; the [Tracker] computes the rolling failure rate and fires a one-shot
 // escalation when the rate crosses a configurable threshold.
 //
+// # Problem
+//
+// Transport push and pull workers each need to detect sustained failure
+// patterns and alert operators via Sentry. Without a shared abstraction,
+// each worker would implement its own escalation infrastructure: a mutex,
+// a flag, a threshold check, and a timer or counter. This duplication is
+// error-prone and makes the escalation behavior hard to review, test, and
+// reason about across workers.
+//
+// The naive approach — escalate when degraded longer than N minutes — has a
+// known blind spot (ENG-4565): a single success in a 99% failure pattern
+// resets the timer completely. The system never escalates even though it is
+// failing 99% of the time.
+//
+// # Design
+//
+// The Tracker uses a fixed-size circular buffer to compute a rolling failure
+// rate. A single success shifts the window from 100/100 failures to 99/100.
+// The rate barely changes, and escalation holds.
+//
+// A rolling window was chosen over an exponentially weighted moving average
+// (EWMA) because the window provides exact, bounded semantics: "90% of the
+// last 6000 outcomes failed" is easy to reason about and configure. EWMA
+// gives a fuzzy decay where the effective window size depends on the smoothing
+// factor, making threshold tuning less intuitive. The circular buffer also
+// makes tests fully deterministic (no time dependency, no floating-point
+// drift from repeated multiplication).
+//
+// The window size is outcome-count-based, not time-based. At a 100 ms tick
+// rate, WindowSize=6000 covers roughly 10 minutes. Under backoff the
+// effective duration stretches because fewer outcomes are recorded per unit
+// of time.
+//
 // # Transient and Persistent Errors
 //
 // Transport errors fall into two categories:
 //
-//   - Transient errors self-resolve without human intervention: network timeouts,
-//     DNS failures, HTTP 5xx responses, rate limits, and full channels.
+//   - Transient errors self-resolve without human intervention: network
+//     timeouts, DNS failures, HTTP 5xx responses, rate limits, and full
+//     channels.
 //
 //   - Persistent errors require human intervention: invalid tokens, deleted
 //     instances, proxy blocks, and Cloudflare challenges.

--- a/umh-core/pkg/fsmv2/deps/retry/failurerate/doc.go
+++ b/umh-core/pkg/fsmv2/deps/retry/failurerate/doc.go
@@ -30,9 +30,9 @@
 // first crosses the threshold. Callers (push/pull dependencies) use this
 // signal to fire a one-shot SentryWarn.
 //
-// Persistent errors (invalid tokens, deleted instances, proxy blocks) are not
-// tracked here. They fire SentryError immediately and always require human
-// intervention.
+// Persistent errors (invalid tokens, deleted instances, proxy blocks) also
+// feed the rolling window but fire SentryError immediately and always
+// require human intervention.
 //
 // # Design
 //
@@ -41,10 +41,10 @@
 // 5 minutes, the window still sees ~99% failure and keeps the alert. One
 // brief success doesn't reset anything.
 //
-// The window size is outcome-count-based, not time-based. At a 100 ms tick
-// rate, WindowSize=6000 covers roughly 10 minutes. Under backoff the
-// effective duration stretches because fewer outcomes are recorded per unit
-// of time.
+// The window size is outcome-count-based, not time-based. At the production
+// default of 1 second per tick, WindowSize=600 covers roughly 10 minutes.
+// Under backoff the effective duration stretches because fewer outcomes are
+// recorded per unit of time.
 //
 // # Transient and Persistent Errors
 //

--- a/umh-core/pkg/fsmv2/deps/retry/failurerate/failurerate.go
+++ b/umh-core/pkg/fsmv2/deps/retry/failurerate/failurerate.go
@@ -118,8 +118,8 @@ func (t *Tracker) RecordOutcome(success bool) bool {
 	return false
 }
 
-// FailureRate returns the current failure rate (0.0–1.0).
-// It returns 0.0 if fewer than [Config.MinSamples] outcomes have been recorded.
+// FailureRate returns the current failure rate (0.0–1.0). It returns 0.0 if
+// no outcomes have been recorded or if fewer than [Config.MinSamples] have.
 func (t *Tracker) FailureRate() float64 {
 	t.mu.RLock()
 	defer t.mu.RUnlock()

--- a/umh-core/pkg/fsmv2/deps/retry/failurerate/failurerate.go
+++ b/umh-core/pkg/fsmv2/deps/retry/failurerate/failurerate.go
@@ -44,14 +44,12 @@ type Config struct {
 //
 // Tracker is safe for concurrent use.
 type Tracker struct {
-	outcomes []bool  // circular buffer: true = success, false = failure
-	cfg      Config  // immutable after construction
-	mu       sync.RWMutex
-	head     int // next write position
-	count    int // total recorded outcomes (capped at WindowSize)
-	failures int // running failure count within the window
-	// escalated tracks the one-shot state: true after the failure rate
-	// first crosses the threshold, false after it drops back below.
+	outcomes  []bool
+	cfg       Config
+	mu        sync.RWMutex
+	head      int
+	count     int
+	failures  int
 	escalated bool
 }
 

--- a/umh-core/pkg/fsmv2/deps/retry/failurerate/failurerate.go
+++ b/umh-core/pkg/fsmv2/deps/retry/failurerate/failurerate.go
@@ -44,12 +44,14 @@ type Config struct {
 //
 // Tracker is safe for concurrent use.
 type Tracker struct {
-	outcomes  []bool
-	cfg       Config
-	mu        sync.RWMutex
-	head      int
-	count     int
-	failures  int
+	outcomes []bool  // circular buffer: true = success, false = failure
+	cfg      Config  // immutable after construction
+	mu       sync.RWMutex
+	head     int // next write position
+	count    int // total recorded outcomes (capped at WindowSize)
+	failures int // running failure count within the window
+	// escalated tracks the one-shot state: true after the failure rate
+	// first crosses the threshold, false after it drops back below.
 	escalated bool
 }
 
@@ -118,8 +120,8 @@ func (t *Tracker) RecordOutcome(success bool) bool {
 	return false
 }
 
-// FailureRate returns the current failure rate (0.0–1.0). It returns 0.0 if
-// no outcomes have been recorded or if fewer than [Config.MinSamples] have.
+// FailureRate returns the current failure rate (0.0–1.0).
+// It returns 0.0 if fewer than [Config.MinSamples] outcomes have been recorded.
 func (t *Tracker) FailureRate() float64 {
 	t.mu.RLock()
 	defer t.mu.RUnlock()

--- a/umh-core/pkg/fsmv2/workers/communicator/transport/http/error_helpers_test.go
+++ b/umh-core/pkg/fsmv2/workers/communicator/transport/http/error_helpers_test.go
@@ -50,11 +50,11 @@ var _ = Describe("ExtractErrorType", func() {
 		Expect(retryAfter).To(BeZero())
 	})
 
-	It("defaults to ErrorTypeNetwork for non-TransportError", func() {
+	It("defaults to ErrorTypeUnknown for non-TransportError", func() {
 		plainErr := errors.New("connection refused")
 
 		errType, retryAfter := httpTransport.ExtractErrorType(plainErr)
-		Expect(errType).To(Equal(httpTransport.ErrorTypeNetwork))
+		Expect(errType).To(Equal(httpTransport.ErrorTypeUnknown))
 		Expect(retryAfter).To(BeZero())
 	})
 })

--- a/umh-core/pkg/fsmv2/workers/communicator/transport/http/error_helpers_test.go
+++ b/umh-core/pkg/fsmv2/workers/communicator/transport/http/error_helpers_test.go
@@ -15,6 +15,7 @@
 package transport_test
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -27,7 +28,7 @@ import (
 
 var _ = Describe("ExtractErrorType", func() {
 	It("extracts type and RetryAfter from a TransportError", func() {
-		inner := fmt.Errorf("rate limited")
+		inner := errors.New("rate limited")
 		transportErr := httpTransport.NewTransportErrorForTest(
 			httpTransport.ErrorTypeBackendRateLimit, 429, "rate limited", 30*time.Second, inner,
 		)
@@ -38,7 +39,7 @@ var _ = Describe("ExtractErrorType", func() {
 	})
 
 	It("extracts type from a wrapped TransportError", func() {
-		inner := fmt.Errorf("server error")
+		inner := errors.New("server error")
 		transportErr := httpTransport.NewTransportErrorForTest(
 			httpTransport.ErrorTypeServerError, 500, "server error", 0, inner,
 		)
@@ -50,7 +51,7 @@ var _ = Describe("ExtractErrorType", func() {
 	})
 
 	It("defaults to ErrorTypeNetwork for non-TransportError", func() {
-		plainErr := fmt.Errorf("connection refused")
+		plainErr := errors.New("connection refused")
 
 		errType, retryAfter := httpTransport.ExtractErrorType(plainErr)
 		Expect(errType).To(Equal(httpTransport.ErrorTypeNetwork))

--- a/umh-core/pkg/fsmv2/workers/communicator/transport/http/error_helpers_test.go
+++ b/umh-core/pkg/fsmv2/workers/communicator/transport/http/error_helpers_test.go
@@ -1,0 +1,80 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package transport_test
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	depspkg "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
+	httpTransport "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator/transport/http"
+)
+
+var _ = Describe("ExtractErrorType", func() {
+	It("extracts type and RetryAfter from a TransportError", func() {
+		inner := fmt.Errorf("rate limited")
+		transportErr := httpTransport.NewTransportErrorForTest(
+			httpTransport.ErrorTypeBackendRateLimit, 429, "rate limited", 30*time.Second, inner,
+		)
+
+		errType, retryAfter := httpTransport.ExtractErrorType(transportErr)
+		Expect(errType).To(Equal(httpTransport.ErrorTypeBackendRateLimit))
+		Expect(retryAfter).To(Equal(30 * time.Second))
+	})
+
+	It("extracts type from a wrapped TransportError", func() {
+		inner := fmt.Errorf("server error")
+		transportErr := httpTransport.NewTransportErrorForTest(
+			httpTransport.ErrorTypeServerError, 500, "server error", 0, inner,
+		)
+		wrapped := fmt.Errorf("operation failed: %w", transportErr)
+
+		errType, retryAfter := httpTransport.ExtractErrorType(wrapped)
+		Expect(errType).To(Equal(httpTransport.ErrorTypeServerError))
+		Expect(retryAfter).To(BeZero())
+	})
+
+	It("defaults to ErrorTypeNetwork for non-TransportError", func() {
+		plainErr := fmt.Errorf("connection refused")
+
+		errType, retryAfter := httpTransport.ExtractErrorType(plainErr)
+		Expect(errType).To(Equal(httpTransport.ErrorTypeNetwork))
+		Expect(retryAfter).To(BeZero())
+	})
+})
+
+var _ = Describe("CounterForErrorType", func() {
+	DescribeTable("maps each ErrorType to its Prometheus counter",
+		func(errType httpTransport.ErrorType, expected depspkg.CounterName) {
+			Expect(httpTransport.CounterForErrorType(errType)).To(Equal(expected))
+		},
+		Entry("CloudflareChallenge", httpTransport.ErrorTypeCloudflareChallenge, depspkg.CounterCloudflareErrorsTotal),
+		Entry("BackendRateLimit", httpTransport.ErrorTypeBackendRateLimit, depspkg.CounterBackendRateLimitErrorsTotal),
+		Entry("InvalidToken", httpTransport.ErrorTypeInvalidToken, depspkg.CounterAuthFailuresTotal),
+		Entry("InstanceDeleted", httpTransport.ErrorTypeInstanceDeleted, depspkg.CounterInstanceDeletedTotal),
+		Entry("ServerError", httpTransport.ErrorTypeServerError, depspkg.CounterServerErrorsTotal),
+		Entry("ProxyBlock", httpTransport.ErrorTypeProxyBlock, depspkg.CounterProxyBlockErrorsTotal),
+		Entry("Network", httpTransport.ErrorTypeNetwork, depspkg.CounterNetworkErrorsTotal),
+		Entry("Unknown defaults to network", httpTransport.ErrorTypeUnknown, depspkg.CounterNetworkErrorsTotal),
+	)
+
+	It("defaults to network counter for out-of-range ErrorType", func() {
+		outOfRange := httpTransport.ErrorType(999)
+		Expect(httpTransport.CounterForErrorType(outOfRange)).To(Equal(depspkg.CounterNetworkErrorsTotal))
+	})
+})

--- a/umh-core/pkg/fsmv2/workers/communicator/transport/http/export_test.go
+++ b/umh-core/pkg/fsmv2/workers/communicator/transport/http/export_test.go
@@ -1,0 +1,29 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package transport
+
+import "time"
+
+// NewTransportErrorForTest creates a TransportError with explicit fields for testing.
+// This is an internal test helper (export_test.go is only compiled during testing).
+func NewTransportErrorForTest(errType ErrorType, statusCode int, message string, retryAfter time.Duration, inner error) *TransportError {
+	return &TransportError{
+		Type:       errType,
+		StatusCode: statusCode,
+		Message:    message,
+		RetryAfter: retryAfter,
+		Err:        inner,
+	}
+}

--- a/umh-core/pkg/fsmv2/workers/communicator/transport/http/http.go
+++ b/umh-core/pkg/fsmv2/workers/communicator/transport/http/http.go
@@ -40,33 +40,57 @@ const (
 	LongPollingBuffer = 1 * time.Second
 )
 
-// ErrorType classifies HTTP errors for intelligent backoff strategies.
+// ErrorType classifies transport-layer HTTP errors into categories that
+// determine how the system responds. Each type maps to a Prometheus counter
+// (via [CounterForErrorType]) and a transient/persistent classification
+// (via [IsTransient]) that controls whether the error propagates to the FSM
+// or is silently absorbed.
 type ErrorType int
 
 const (
 	// ErrorTypeUnknown represents an unclassified error.
 	ErrorTypeUnknown ErrorType = iota
 	// ErrorTypeCloudflareChallenge represents Cloudflare challenge page (429 + HTML "Just a moment").
+	// Persistent: requires network path change or Cloudflare allowlisting.
 	ErrorTypeCloudflareChallenge
 	// ErrorTypeBackendRateLimit represents backend rate limiting (429 + JSON + Retry-After).
+	// Transient: self-resolves after the rate limit window expires.
 	ErrorTypeBackendRateLimit
 	// ErrorTypeInvalidToken represents authentication failure (401/403).
+	// Persistent: requires re-authentication by the parent worker.
 	ErrorTypeInvalidToken
 	// ErrorTypeInstanceDeleted represents instance not found (404).
+	// Persistent: requires instance re-registration or human intervention.
 	ErrorTypeInstanceDeleted
 	// ErrorTypeServerError represents server-side errors (5xx).
+	// Transient: backend recovers on its own.
 	ErrorTypeServerError
 	// ErrorTypeProxyBlock represents proxy block pages (Zscaler, BlueCoat, etc.).
+	// Persistent: requires proxy configuration change.
 	ErrorTypeProxyBlock
-	// ErrorTypeNetwork represents network/connection errors.
+	// ErrorTypeNetwork represents network/connection errors (DNS, TCP, TLS).
+	// Transient: network path recovers on its own.
 	ErrorTypeNetwork
 	// ErrorTypeChannelFull represents inbound channel capacity exceeded.
-	// Not a transport error per se, but uses same classification for backoff.
+	// Transient: resolves as the consumer drains the channel.
+	// Not a transport error per se, but uses the same classification for backoff.
 	ErrorTypeChannelFull
 )
 
-// IsTransient reports whether the error type represents a transient condition
-// that typically self-resolves without human intervention.
+// IsTransient reports whether the error type represents a condition that
+// typically self-resolves without human intervention.
+//
+// Transient: Network, ServerError, ChannelFull, BackendRateLimit.
+// Persistent: everything else (InvalidToken, InstanceDeleted, ProxyBlock,
+// CloudflareChallenge, Unknown).
+//
+// The classification controls error propagation in push and pull actions:
+//   - Transient errors are suppressed (action returns nil). Metrics and
+//     DegradedState are still updated. The [failurerate.Tracker] monitors
+//     the rolling failure rate; if transient errors dominate the window,
+//     it fires a one-shot SentryWarn escalation.
+//   - Persistent errors propagate to the FSM as errors, triggering state
+//     transitions (recovering, re-authentication) and firing SentryError.
 func (e ErrorType) IsTransient() bool {
 	switch e {
 	case ErrorTypeNetwork, ErrorTypeServerError, ErrorTypeChannelFull, ErrorTypeBackendRateLimit:

--- a/umh-core/pkg/fsmv2/workers/communicator/transport/http/http.go
+++ b/umh-core/pkg/fsmv2/workers/communicator/transport/http/http.go
@@ -155,15 +155,16 @@ func (e *TransportError) Is(target error) bool {
 }
 
 // ExtractErrorType unwraps a *TransportError from err and returns its ErrorType
-// and RetryAfter duration. If err does not wrap a *TransportError, it defaults
-// to ErrorTypeNetwork with zero retry delay.
+// and RetryAfter duration. If err does not wrap a *TransportError, it returns
+// ErrorTypeUnknown — a persistent type that propagates to the FSM and fires
+// SentryError, ensuring unclassified errors are never silently suppressed.
 func ExtractErrorType(err error) (ErrorType, time.Duration) {
 	var transportErr *TransportError
 	if errors.As(err, &transportErr) {
 		return transportErr.Type, transportErr.RetryAfter
 	}
 
-	return ErrorTypeNetwork, 0
+	return ErrorTypeUnknown, 0
 }
 
 // CounterForErrorType maps an ErrorType to its corresponding Prometheus counter.

--- a/umh-core/pkg/fsmv2/workers/communicator/transport/http/http.go
+++ b/umh-core/pkg/fsmv2/workers/communicator/transport/http/http.go
@@ -44,7 +44,7 @@ const (
 // determine how the system responds. Each type maps to a Prometheus counter
 // (via [CounterForErrorType]) and a transient/persistent classification
 // (via [IsTransient]) that controls whether the error propagates to the FSM
-// or is silently absorbed.
+// or is suppressed at the action layer (metrics are still recorded).
 type ErrorType int
 
 const (
@@ -86,7 +86,7 @@ const (
 //
 // The classification controls error propagation in push and pull actions:
 //   - Transient errors are suppressed (action returns nil). Metrics and
-//     DegradedState are still updated. The [failurerate.Tracker] monitors
+//     DegradedState are still updated. The failurerate.Tracker monitors
 //     the rolling failure rate; if transient errors dominate the window,
 //     it fires a one-shot SentryWarn escalation.
 //   - Persistent errors propagate to the FSM as errors, triggering state

--- a/umh-core/pkg/fsmv2/workers/communicator/transport/http/http.go
+++ b/umh-core/pkg/fsmv2/workers/communicator/transport/http/http.go
@@ -65,6 +65,17 @@ const (
 	ErrorTypeChannelFull
 )
 
+// IsTransient reports whether the error type represents a transient condition
+// that typically self-resolves without human intervention.
+func (e ErrorType) IsTransient() bool {
+	switch e {
+	case ErrorTypeNetwork, ErrorTypeServerError, ErrorTypeChannelFull, ErrorTypeBackendRateLimit:
+		return true
+	default:
+		return false
+	}
+}
+
 // String returns a human-readable name for the error type.
 func (e ErrorType) String() string {
 	switch e {

--- a/umh-core/pkg/fsmv2/workers/communicator/transport/http/http_suite_test.go
+++ b/umh-core/pkg/fsmv2/workers/communicator/transport/http/http_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package transport_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestHTTPTransport(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "HTTP Transport Suite")
+}

--- a/umh-core/pkg/fsmv2/workers/communicator/transport/http/is_transient_test.go
+++ b/umh-core/pkg/fsmv2/workers/communicator/transport/http/is_transient_test.go
@@ -1,0 +1,39 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package transport_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	httpTransport "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator/transport/http"
+)
+
+var _ = Describe("IsTransient", func() {
+	DescribeTable("classifies all ErrorType values",
+		func(errType httpTransport.ErrorType, expected bool) {
+			Expect(errType.IsTransient()).To(Equal(expected))
+		},
+		Entry("Unknown is persistent", httpTransport.ErrorTypeUnknown, false),
+		Entry("CloudflareChallenge is persistent", httpTransport.ErrorTypeCloudflareChallenge, false),
+		Entry("InvalidToken is persistent", httpTransport.ErrorTypeInvalidToken, false),
+		Entry("InstanceDeleted is persistent", httpTransport.ErrorTypeInstanceDeleted, false),
+		Entry("ProxyBlock is persistent", httpTransport.ErrorTypeProxyBlock, false),
+		Entry("Network is transient", httpTransport.ErrorTypeNetwork, true),
+		Entry("ServerError is transient", httpTransport.ErrorTypeServerError, true),
+		Entry("ChannelFull is transient", httpTransport.ErrorTypeChannelFull, true),
+		Entry("BackendRateLimit is transient", httpTransport.ErrorTypeBackendRateLimit, true),
+	)
+})

--- a/umh-core/pkg/fsmv2/workers/transport/pull/action/pull.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/action/pull.go
@@ -158,6 +158,10 @@ func (a *PullAction) Execute(ctx context.Context, depsAny any) error {
 		metrics.IncrementCounter(depspkg.CounterPullFailures, 1)
 		metrics.SetGauge(depspkg.GaugeLastPullLatencyMs, float64(pullLatency.Milliseconds()))
 
+		if errType.IsTransient() {
+			return nil
+		}
+
 		return fmt.Errorf("pull failed: %w", err)
 	}
 

--- a/umh-core/pkg/fsmv2/workers/transport/pull/action/pull.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/action/pull.go
@@ -158,6 +158,10 @@ func (a *PullAction) Execute(ctx context.Context, depsAny any) error {
 		metrics.IncrementCounter(depspkg.CounterPullFailures, 1)
 		metrics.SetGauge(depspkg.GaugeLastPullLatencyMs, float64(pullLatency.Milliseconds()))
 
+		if ctx.Err() != nil {
+			return fmt.Errorf("pull failed (context canceled): %w", ctx.Err())
+		}
+
 		if errType.IsTransient() {
 			return nil
 		}

--- a/umh-core/pkg/fsmv2/workers/transport/pull/action/pull_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/action/pull_test.go
@@ -294,14 +294,15 @@ var _ = Describe("PullAction", func() {
 	})
 
 	Describe("Failed pull with non-TransportError", func() {
-		It("should default to ErrorTypeNetwork and suppress as transient", func() {
+		It("should default to ErrorTypeUnknown and propagate as persistent", func() {
 			mockTrans.pullErr = errors.New("connection refused")
 
 			err := act.Execute(context.Background(), mockDeps)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("pull failed"))
 
 			Expect(mockDeps.recordTypedErrorCalls).To(HaveLen(1))
-			Expect(mockDeps.recordTypedErrorCalls[0].errType).To(Equal(httpTransport.ErrorTypeNetwork))
+			Expect(mockDeps.recordTypedErrorCalls[0].errType).To(Equal(httpTransport.ErrorTypeUnknown))
 			Expect(mockDeps.recordTypedErrorCalls[0].retryAfter).To(Equal(time.Duration(0)))
 
 			drained := mockDeps.metricsRecorder.Drain()

--- a/umh-core/pkg/fsmv2/workers/transport/pull/action/pull_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/action/pull_test.go
@@ -261,7 +261,7 @@ var _ = Describe("PullAction", func() {
 	})
 
 	Describe("Failed pull with TransportError", func() {
-		It("should record typed error and increment failure counter", func() {
+		It("should record typed error and suppress transient errors", func() {
 			mockTrans.pullErr = &httpTransport.TransportError{
 				Type:       httpTransport.ErrorTypeServerError,
 				Message:    "HTTP 500: server_error",
@@ -269,8 +269,7 @@ var _ = Describe("PullAction", func() {
 			}
 
 			err := act.Execute(context.Background(), mockDeps)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("pull failed"))
+			Expect(err).NotTo(HaveOccurred())
 
 			Expect(mockDeps.recordTypedErrorCalls).To(HaveLen(1))
 			Expect(mockDeps.recordTypedErrorCalls[0].errType).To(Equal(httpTransport.ErrorTypeServerError))
@@ -281,15 +280,25 @@ var _ = Describe("PullAction", func() {
 			Expect(drained.Counters[string(deps.CounterPullFailures)]).To(Equal(int64(1)))
 			Expect(drained.Counters[string(deps.CounterServerErrorsTotal)]).To(Equal(int64(1)))
 		})
-	})
 
-	Describe("Failed pull with non-TransportError", func() {
-		It("should default to ErrorTypeNetwork", func() {
-			mockTrans.pullErr = errors.New("connection refused")
+		It("should propagate persistent errors", func() {
+			mockTrans.pullErr = &httpTransport.TransportError{
+				Type:    httpTransport.ErrorTypeInstanceDeleted,
+				Message: "HTTP 404: instance_deleted",
+			}
 
 			err := act.Execute(context.Background(), mockDeps)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("pull failed"))
+		})
+	})
+
+	Describe("Failed pull with non-TransportError", func() {
+		It("should default to ErrorTypeNetwork and suppress as transient", func() {
+			mockTrans.pullErr = errors.New("connection refused")
+
+			err := act.Execute(context.Background(), mockDeps)
+			Expect(err).NotTo(HaveOccurred())
 
 			Expect(mockDeps.recordTypedErrorCalls).To(HaveLen(1))
 			Expect(mockDeps.recordTypedErrorCalls[0].errType).To(Equal(httpTransport.ErrorTypeNetwork))

--- a/umh-core/pkg/fsmv2/workers/transport/push/action/push.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/action/push.go
@@ -223,13 +223,13 @@ func (a *PushAction) retryPending(ctx context.Context, t transport.Transport, pu
 	return nil, nil
 }
 
-// isRecoverableByParent returns true for error types where the message itself is
-// valid but delivery failed due to an external condition. These messages are
-// preserved in the pending buffer for retry rather than dropped.
+// isRecoverableByParent returns true for persistent error types where the
+// message is valid but delivery failed due to an external condition requiring
+// parent action (re-authentication, transport reset). Messages are preserved
+// in the pending buffer for retry rather than dropped.
 //
-// Covers both infrastructure errors (network, server, rate limit) and
-// access errors (auth, cloudflare, proxy) that resolve via parent actions
-// (re-authentication, transport reset) or child-level backoff.
+// Transient errors (network, server, rate limit, channel full) are handled
+// before this function by IsTransient() in retryPending and never reach here.
 func isRecoverableByParent(errType httpTransport.ErrorType) bool {
 	switch errType {
 	case httpTransport.ErrorTypeNetwork,

--- a/umh-core/pkg/fsmv2/workers/transport/push/action/push.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/action/push.go
@@ -126,6 +126,10 @@ drainLoop:
 		metrics.SetGauge(depspkg.GaugeLastPushLatencyMs, float64(pushLatency.Milliseconds()))
 		metrics.SetGauge(depspkg.GaugePendingMessages, float64(pushDeps.PendingMessageCount()))
 
+		if ctx.Err() != nil {
+			return fmt.Errorf("push failed (context canceled): %w", ctx.Err())
+		}
+
 		if errType.IsTransient() {
 			return nil
 		}
@@ -228,14 +232,11 @@ func (a *PushAction) retryPending(ctx context.Context, t transport.Transport, pu
 // parent action (re-authentication, transport reset). Messages are preserved
 // in the pending buffer for retry rather than dropped.
 //
-// Transient errors (network, server, rate limit, channel full) are handled
-// before this function by IsTransient() in retryPending and never reach here.
+// Only persistent types reach here — transient errors (network, server, rate
+// limit, channel full) are intercepted by IsTransient() earlier in retryPending.
 func isRecoverableByParent(errType httpTransport.ErrorType) bool {
 	switch errType {
-	case httpTransport.ErrorTypeNetwork,
-		httpTransport.ErrorTypeServerError,
-		httpTransport.ErrorTypeCloudflareChallenge,
-		httpTransport.ErrorTypeBackendRateLimit,
+	case httpTransport.ErrorTypeCloudflareChallenge,
 		httpTransport.ErrorTypeInvalidToken,
 		httpTransport.ErrorTypeProxyBlock:
 		return true

--- a/umh-core/pkg/fsmv2/workers/transport/push/action/push.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/action/push.go
@@ -126,6 +126,10 @@ drainLoop:
 		metrics.SetGauge(depspkg.GaugeLastPushLatencyMs, float64(pushLatency.Milliseconds()))
 		metrics.SetGauge(depspkg.GaugePendingMessages, float64(pushDeps.PendingMessageCount()))
 
+		if errType.IsTransient() {
+			return nil
+		}
+
 		return fmt.Errorf("push failed: %w", err)
 	}
 
@@ -191,6 +195,10 @@ func (a *PushAction) retryPending(ctx context.Context, t transport.Transport, pu
 
 			if ctx.Err() != nil {
 				return pending[i:], fmt.Errorf("context canceled during retry: %w", ctx.Err())
+			}
+
+			if errType.IsTransient() {
+				return pending[i:], nil
 			}
 
 			if isRecoverableByParent(errType) {

--- a/umh-core/pkg/fsmv2/workers/transport/push/action/push_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/action/push_test.go
@@ -240,7 +240,7 @@ var _ = Describe("PushAction", func() {
 	})
 
 	Describe("Failed push with TransportError", func() {
-		It("should record typed error and increment failure counter", func() {
+		It("should record typed error and suppress transient errors", func() {
 			outboundBi <- &transport.UMHMessage{Content: "msg1"}
 			mockTrans.pushErr = &httpTransport.TransportError{
 				Type:       httpTransport.ErrorTypeServerError,
@@ -249,8 +249,7 @@ var _ = Describe("PushAction", func() {
 			}
 
 			err := act.Execute(context.Background(), mockDeps)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("push failed"))
+			Expect(err).NotTo(HaveOccurred())
 
 			Expect(mockDeps.recordTypedErrorCalls).To(HaveLen(1))
 			Expect(mockDeps.recordTypedErrorCalls[0].errType).To(Equal(httpTransport.ErrorTypeServerError))
@@ -261,16 +260,27 @@ var _ = Describe("PushAction", func() {
 			Expect(drained.Counters[string(deps.CounterPushFailures)]).To(Equal(int64(1)))
 			Expect(drained.Counters[string(deps.CounterServerErrorsTotal)]).To(Equal(int64(1)))
 		})
-	})
 
-	Describe("Failed push with non-TransportError", func() {
-		It("should default to ErrorTypeNetwork", func() {
+		It("should propagate persistent errors", func() {
 			outboundBi <- &transport.UMHMessage{Content: "msg1"}
-			mockTrans.pushErr = errors.New("connection refused")
+			mockTrans.pushErr = &httpTransport.TransportError{
+				Type:    httpTransport.ErrorTypeInstanceDeleted,
+				Message: "HTTP 404: instance_deleted",
+			}
 
 			err := act.Execute(context.Background(), mockDeps)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("push failed"))
+		})
+	})
+
+	Describe("Failed push with non-TransportError", func() {
+		It("should default to ErrorTypeNetwork and suppress as transient", func() {
+			outboundBi <- &transport.UMHMessage{Content: "msg1"}
+			mockTrans.pushErr = errors.New("connection refused")
+
+			err := act.Execute(context.Background(), mockDeps)
+			Expect(err).NotTo(HaveOccurred())
 
 			Expect(mockDeps.recordTypedErrorCalls).To(HaveLen(1))
 			Expect(mockDeps.recordTypedErrorCalls[0].errType).To(Equal(httpTransport.ErrorTypeNetwork))
@@ -361,7 +371,7 @@ var _ = Describe("PushAction", func() {
 			mockTrans.pushErr = errors.New("network error")
 
 			err := act.Execute(context.Background(), mockDeps)
-			Expect(err).To(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 
 			Expect(mockDeps.PendingMessageCount()).To(Equal(2))
 		})
@@ -413,7 +423,7 @@ var _ = Describe("PushAction", func() {
 			Expect(drained.Counters[string(deps.CounterMessagesDropped)]).To(Equal(int64(1)))
 		})
 
-		It("should stop pending retry on infrastructure error and keep remaining", func() {
+		It("should suppress transient error during pending retry", func() {
 			mockDeps.pendingMessages = []*transport.UMHMessage{
 				{Content: "msg1"},
 				{Content: "msg2"},
@@ -427,6 +437,32 @@ var _ = Describe("PushAction", func() {
 					return &httpTransport.TransportError{
 						Type:    httpTransport.ErrorTypeNetwork,
 						Message: "connection refused",
+					}
+				}
+
+				return nil
+			}
+
+			err := act.Execute(context.Background(), mockDeps)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(mockDeps.PendingMessageCount()).To(Equal(0))
+		})
+
+		It("should propagate persistent error during pending retry and keep remaining", func() {
+			mockDeps.pendingMessages = []*transport.UMHMessage{
+				{Content: "msg1"},
+				{Content: "msg2"},
+				{Content: "msg3"},
+			}
+
+			callCount := 0
+			mockTrans.pushFunc = func(_ context.Context, _ string, msgs []*transport.UMHMessage) error {
+				callCount++
+				if callCount == 2 {
+					return &httpTransport.TransportError{
+						Type:    httpTransport.ErrorTypeInvalidToken,
+						Message: "HTTP 401: invalid_token",
 					}
 				}
 

--- a/umh-core/pkg/fsmv2/workers/transport/push/action/push_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/action/push_test.go
@@ -275,15 +275,16 @@ var _ = Describe("PushAction", func() {
 	})
 
 	Describe("Failed push with non-TransportError", func() {
-		It("should default to ErrorTypeNetwork and suppress as transient", func() {
+		It("should default to ErrorTypeUnknown and propagate as persistent", func() {
 			outboundBi <- &transport.UMHMessage{Content: "msg1"}
 			mockTrans.pushErr = errors.New("connection refused")
 
 			err := act.Execute(context.Background(), mockDeps)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("push failed"))
 
 			Expect(mockDeps.recordTypedErrorCalls).To(HaveLen(1))
-			Expect(mockDeps.recordTypedErrorCalls[0].errType).To(Equal(httpTransport.ErrorTypeNetwork))
+			Expect(mockDeps.recordTypedErrorCalls[0].errType).To(Equal(httpTransport.ErrorTypeUnknown))
 			Expect(mockDeps.recordTypedErrorCalls[0].retryAfter).To(Equal(time.Duration(0)))
 
 			drained := mockDeps.metricsRecorder.Drain()
@@ -371,7 +372,7 @@ var _ = Describe("PushAction", func() {
 			mockTrans.pushErr = errors.New("network error")
 
 			err := act.Execute(context.Background(), mockDeps)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).To(HaveOccurred())
 
 			Expect(mockDeps.PendingMessageCount()).To(Equal(2))
 		})

--- a/umh-core/pkg/fsmv2/workers/transport/push/action/push_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/action/push_test.go
@@ -423,7 +423,7 @@ var _ = Describe("PushAction", func() {
 			Expect(drained.Counters[string(deps.CounterMessagesDropped)]).To(Equal(int64(1)))
 		})
 
-		It("should suppress transient error during pending retry", func() {
+		It("should suppress transient error during pending retry and retain remaining messages", func() {
 			mockDeps.pendingMessages = []*transport.UMHMessage{
 				{Content: "msg1"},
 				{Content: "msg2"},
@@ -446,7 +446,7 @@ var _ = Describe("PushAction", func() {
 			err := act.Execute(context.Background(), mockDeps)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(mockDeps.PendingMessageCount()).To(Equal(0))
+			Expect(mockDeps.PendingMessageCount()).To(Equal(2), "msg2 (failed) and msg3 (unattempted) should be retained for retry")
 		})
 
 		It("should propagate persistent error during pending retry and keep remaining", func() {


### PR DESCRIPTION
The behavior change. Transient transport errors no longer fire SentryError. They still record to metrics and DegradedState, but the action returns nil instead of an error. If they persist above 90% failure rate over ~10 minutes, a one-shot SentryWarn fires.

Persistent errors (invalid tokens, deleted instances, proxy blocks) still fire SentryError immediately.

PR 2.5 (#2468) restructured the error handling in push/pull so this diff is small: just `if errType.IsTransient() { return nil }` in 3 places.

**Resolves**: ENG-4432, ENG-4446, ENG-4455, ENG-4560, ENG-4561

**Test plan:**
- [x] Transient errors return nil, persistent errors propagate
- [x] Pending messages retained on transient retry failure
- [x] All transport tests pass

---
**Stack**: #2465 → #2466 → #2468 → #2467 (this) | ENG-4450