### PR TITLE
fix: pass --title from GitHub release to sync-changelog

### DIFF
--- a/.github/workflows/sync-changelog.yml
+++ b/.github/workflows/sync-changelog.yml
@@ -29,6 +29,10 @@ on:
         description: 'Version to sync (e.g., v0.44.8). Required for workflow_dispatch.'
         required: false
         type: string
+      title:
+        description: 'Title for the changelog entry (5-10 words). If omitted for push triggers, fetched from the GitHub release.'
+        required: false
+        type: string
 
 jobs:
   sync:
@@ -53,6 +57,25 @@ jobs:
             fi
             echo "version=$INPUT_VERSION" >> $GITHUB_OUTPUT
           fi
+
+      - name: Get release title
+        id: release-title
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ github.ref_name }}
+          INPUT_TITLE: ${{ github.event.inputs.title }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          if [ -n "$INPUT_TITLE" ]; then
+            title="$INPUT_TITLE"
+          elif [ "$EVENT_NAME" = "push" ]; then
+            title=$(gh release view "$TAG_NAME" --json name --jq '.name' 2>/dev/null || echo "")
+          fi
+          if [ -z "$title" ]; then
+            echo "Error: No title found. Create a GitHub release with a descriptive title, or pass --title via workflow_dispatch."
+            exit 1
+          fi
+          echo "title=$title" >> $GITHUB_OUTPUT
 
       - name: Checkout umh-core
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -87,10 +110,12 @@ jobs:
         working-directory: changelog-app
         env:
           SYNC_VERSION: ${{ steps.version.outputs.version }}
+          SYNC_TITLE: ${{ steps.release-title.outputs.title }}
         run: |
           npx tsx .github/scripts/sync-changelog.ts \
             --repo umh-core \
             --version "$SYNC_VERSION" \
+            --title "$SYNC_TITLE" \
             --changelog-path ../umh-core/umh-core/CHANGELOG.md \
             --images-path ../umh-core/umh-core/changelog-images \
             --output-path public/changelog/entries

--- a/.github/workflows/update-github-release.yml
+++ b/.github/workflows/update-github-release.yml
@@ -60,8 +60,8 @@ jobs:
 
           # IMPORTANT: Slug generation must match sync-changelog.ts generateSlug()
           # in the changelog.umh.app repo. If that function changes, update this too.
-          # Extract first bold title (mirrors sync-changelog.ts extractTitle)
-          TITLE=$(grep -m1 -oP '(?<=\*\*).+?(?=\*\*)' /tmp/release-body.md || echo "")
+          # Fetch title from GitHub release (single source of truth, matches sync-changelog.yml)
+          TITLE=$(gh release view "$VERSION" --json name --jq '.name' 2>/dev/null || echo "")
 
           if [ -n "$TITLE" ]; then
             # Generate slug (mirrors sync-changelog.ts generateSlug)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,7 @@ Every PR with user-visible changes must add an entry to `umh-core/CHANGELOG.md` 
 - **Never create a new version section** — only add to the existing topmost `## [X.Y.Z]` section
 - **No trailing periods** on bullet points
 - On tag push, a sync workflow automatically creates entries in changelog.umh.app from CHANGELOG.md
+- **Release titles**: When creating a GitHub release, use a descriptive title (5-10 words, e.g., "Modbus Per-Slave Address Mapping") — this becomes the changelog.umh.app entry title
 - GitHub Release notes are automatically populated from CHANGELOG.md by the `update-github-release.yml` workflow (runs on tag push). The job extracts the version's section, transforms headers for standalone display, and appends a changelog.umh.app link. You can still edit the Release body manually after if needed.
 
 ## Support & Troubleshooting Workflows

--- a/umh-core/pkg/fsmv2/deps/retry/failurerate/doc.go
+++ b/umh-core/pkg/fsmv2/deps/retry/failurerate/doc.go
@@ -1,0 +1,60 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package failurerate tracks the failure rate of the last N outcomes using a
+// fixed-size circular buffer. The caller records each outcome as success or
+// failure; the [Tracker] computes the rolling failure rate and fires a one-shot
+// escalation when the rate crosses a configurable threshold.
+//
+// # Transient and Persistent Errors
+//
+// Transport errors fall into two categories:
+//
+//   - Transient errors self-resolve without human intervention: network timeouts,
+//     DNS failures, HTTP 5xx responses, rate limits, and full channels. These
+//     appear as ErrorTypeNetwork, ErrorTypeServerError, ErrorTypeChannelFull, and
+//     ErrorTypeBackendRateLimit in [communicator/transport/http].
+//
+//   - Persistent errors require human intervention: invalid tokens, deleted
+//     instances, proxy blocks, and Cloudflare challenges. These appear as
+//     ErrorTypeInvalidToken, ErrorTypeInstanceDeleted, ErrorTypeProxyBlock, and
+//     ErrorTypeCloudflareChallenge.
+//
+// The action layer suppresses Sentry alerts for transient errors (they fire
+// metrics and update DegradedState instead). Persistent errors still fire
+// SentryError immediately.
+//
+// # Escalation Lifecycle
+//
+// When transient errors dominate — the failure rate exceeds the configured
+// threshold over the rolling window — the Tracker fires a one-shot escalation.
+// The caller (typically push or pull dependencies) fires a SentryWarn to alert
+// operators. After enough successes bring the rate below the threshold, the
+// Tracker rearms and can fire again on the next crossing.
+//
+// # Why a Rolling Window
+//
+// A timer-based approach (escalate when degraded longer than N minutes) has a
+// blind spot: a single success in a 99% failure pattern resets the timer
+// completely (ENG-4565). The rolling window tracks rate, not duration. A single
+// success shifts the window from 100/100 failures to 99/100 — the rate barely
+// changes, and escalation holds.
+//
+// # Integration
+//
+// Error classification lives in [communicator/transport/http] (ErrorType and
+// IsTransient). Transient suppression lives in the pull and push action files.
+// Rate tracking lives in this package. Push and pull dependencies each hold a
+// *[Tracker] and call [Tracker.RecordOutcome] on every error or success.
+package failurerate

--- a/umh-core/pkg/fsmv2/deps/retry/failurerate/doc.go
+++ b/umh-core/pkg/fsmv2/deps/retry/failurerate/doc.go
@@ -27,14 +27,15 @@
 //   - Persistent errors require human intervention: invalid tokens, deleted
 //     instances, proxy blocks, and Cloudflare challenges.
 //
-// The intended integration (wired in subsequent PRs) suppresses Sentry alerts
-// for transient errors while still updating metrics and DegradedState.
-// Persistent errors continue to fire SentryError immediately.
+// All error types (transient and persistent) feed the rolling window.
+// Persistent errors also fire SentryError immediately. The downstream
+// suppression logic (wired in subsequent PRs) suppresses SentryError for
+// transient errors while still updating metrics and DegradedState.
 //
 // # Escalation Lifecycle
 //
-// When transient errors dominate and the failure rate exceeds the configured
-// threshold over the rolling window, the Tracker fires a one-shot escalation.
+// When the failure rate exceeds the configured threshold over the rolling
+// window, the Tracker fires a one-shot escalation.
 // The caller fires a SentryWarn to alert operators. After enough successes
 // bring the rate below the threshold, the Tracker rearms and can fire again
 // on the next crossing.
@@ -51,6 +52,6 @@
 //
 // Error classification lives in the communicator/transport/http package
 // (ErrorType constants). Rate tracking lives in this package. Push and pull
-// dependencies will each hold a *[Tracker] and call [Tracker.RecordOutcome]
+// dependencies each hold a *[Tracker] and call [Tracker.RecordOutcome]
 // on every error or success.
 package failurerate

--- a/umh-core/pkg/fsmv2/deps/retry/failurerate/doc.go
+++ b/umh-core/pkg/fsmv2/deps/retry/failurerate/doc.go
@@ -22,26 +22,22 @@
 // Transport errors fall into two categories:
 //
 //   - Transient errors self-resolve without human intervention: network timeouts,
-//     DNS failures, HTTP 5xx responses, rate limits, and full channels. These
-//     appear as ErrorTypeNetwork, ErrorTypeServerError, ErrorTypeChannelFull, and
-//     ErrorTypeBackendRateLimit in [communicator/transport/http].
+//     DNS failures, HTTP 5xx responses, rate limits, and full channels.
 //
 //   - Persistent errors require human intervention: invalid tokens, deleted
-//     instances, proxy blocks, and Cloudflare challenges. These appear as
-//     ErrorTypeInvalidToken, ErrorTypeInstanceDeleted, ErrorTypeProxyBlock, and
-//     ErrorTypeCloudflareChallenge.
+//     instances, proxy blocks, and Cloudflare challenges.
 //
-// The action layer suppresses Sentry alerts for transient errors (they fire
-// metrics and update DegradedState instead). Persistent errors still fire
-// SentryError immediately.
+// The intended integration (wired in subsequent PRs) suppresses Sentry alerts
+// for transient errors while still updating metrics and DegradedState.
+// Persistent errors continue to fire SentryError immediately.
 //
 // # Escalation Lifecycle
 //
-// When transient errors dominate — the failure rate exceeds the configured
-// threshold over the rolling window — the Tracker fires a one-shot escalation.
-// The caller (typically push or pull dependencies) fires a SentryWarn to alert
-// operators. After enough successes bring the rate below the threshold, the
-// Tracker rearms and can fire again on the next crossing.
+// When transient errors dominate and the failure rate exceeds the configured
+// threshold over the rolling window, the Tracker fires a one-shot escalation.
+// The caller fires a SentryWarn to alert operators. After enough successes
+// bring the rate below the threshold, the Tracker rearms and can fire again
+// on the next crossing.
 //
 // # Why a Rolling Window
 //
@@ -53,8 +49,8 @@
 //
 // # Integration
 //
-// Error classification lives in [communicator/transport/http] (ErrorType and
-// IsTransient). Transient suppression lives in the pull and push action files.
-// Rate tracking lives in this package. Push and pull dependencies each hold a
-// *[Tracker] and call [Tracker.RecordOutcome] on every error or success.
+// Error classification lives in the communicator/transport/http package
+// (ErrorType constants). Rate tracking lives in this package. Push and pull
+// dependencies will each hold a *[Tracker] and call [Tracker.RecordOutcome]
+// on every error or success.
 package failurerate

--- a/umh-core/pkg/fsmv2/deps/retry/failurerate/failurerate.go
+++ b/umh-core/pkg/fsmv2/deps/retry/failurerate/failurerate.go
@@ -43,14 +43,14 @@ type Config struct {
 // Tracker is safe for concurrent use.
 type Tracker struct {
 	mu       sync.RWMutex
-	outcomes []bool // circular buffer: true = success, false = failure
-	head     int    // next write position
-	count    int    // total recorded outcomes (capped at WindowSize)
-	failures int    // running failure count within the window
+	outcomes []bool  // circular buffer: true = success, false = failure
+	cfg      Config  // immutable after construction
+	head     int     // next write position
+	count    int     // total recorded outcomes (capped at WindowSize)
+	failures int     // running failure count within the window
 	// escalated tracks the one-shot state: true after the failure rate
 	// first crosses the threshold, false after it drops back below.
 	escalated bool
-	cfg       Config
 }
 
 // New creates a Tracker with the given configuration. The circular buffer

--- a/umh-core/pkg/fsmv2/deps/retry/failurerate/failurerate.go
+++ b/umh-core/pkg/fsmv2/deps/retry/failurerate/failurerate.go
@@ -37,8 +37,9 @@ type Config struct {
 }
 
 // Tracker tracks the failure rate of the last N outcomes using a fixed-size
-// circular buffer. Call [RecordOutcome] with true (success) or false (failure);
-// the Tracker computes the rolling failure rate and detects threshold crossings.
+// circular buffer. Call [Tracker.RecordOutcome] with true (success) or false
+// (failure); the Tracker computes the rolling failure rate and detects
+// threshold crossings.
 //
 // Tracker is safe for concurrent use.
 type Tracker struct {
@@ -129,8 +130,8 @@ func (t *Tracker) FailureRate() float64 {
 	return float64(t.failures) / float64(t.count)
 }
 
-// IsEscalated reports whether the failure rate exceeds the threshold and at
-// least [Config.MinSamples] outcomes have been recorded.
+// IsEscalated reports whether the failure rate meets or exceeds the threshold
+// and at least [Config.MinSamples] outcomes have been recorded.
 func (t *Tracker) IsEscalated() bool {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
@@ -138,7 +139,7 @@ func (t *Tracker) IsEscalated() bool {
 	return t.escalated
 }
 
-// Reset clears all recorded outcomes. Use this when the transport is
+// Reset clears all recorded outcomes. Use this when the tracked entity is
 // recreated from scratch and historical data is no longer relevant.
 func (t *Tracker) Reset() {
 	t.mu.Lock()

--- a/umh-core/pkg/fsmv2/deps/retry/failurerate/failurerate.go
+++ b/umh-core/pkg/fsmv2/deps/retry/failurerate/failurerate.go
@@ -1,0 +1,150 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package failurerate
+
+import "sync"
+
+// Config controls the Tracker's window size, escalation threshold, and
+// minimum sample count.
+type Config struct {
+	// WindowSize is the number of outcomes the circular buffer retains.
+	// Older outcomes are evicted when the buffer is full.
+	// Example: 6000 ≈ 10 minutes at one outcome per 100 ms tick.
+	WindowSize int
+
+	// Threshold is the failure rate (0.0–1.0) that triggers escalation.
+	// Example: 0.9 means 90 % failures.
+	Threshold float64
+
+	// MinSamples is the minimum number of recorded outcomes before the
+	// Tracker can escalate. This prevents spurious alerts during startup.
+	MinSamples int
+}
+
+// Tracker tracks the failure rate of the last N outcomes using a fixed-size
+// circular buffer. Call [RecordOutcome] with true (success) or false (failure);
+// the Tracker computes the rolling failure rate and detects threshold crossings.
+//
+// Tracker is safe for concurrent use.
+type Tracker struct {
+	mu       sync.RWMutex
+	outcomes []bool // circular buffer: true = success, false = failure
+	head     int    // next write position
+	count    int    // total recorded outcomes (capped at WindowSize)
+	failures int    // running failure count within the window
+	// escalated tracks the one-shot state: true after the failure rate
+	// first crosses the threshold, false after it drops back below.
+	escalated bool
+	cfg       Config
+}
+
+// New creates a Tracker with the given configuration. The circular buffer
+// is pre-allocated to cfg.WindowSize.
+func New(cfg Config) *Tracker {
+	return &Tracker{
+		outcomes: make([]bool, cfg.WindowSize),
+		cfg:      cfg,
+	}
+}
+
+// RecordOutcome records a success (true) or failure (false) and updates the
+// rolling window. It returns true exactly once when the failure rate first
+// crosses the escalation threshold (one-shot). After the rate drops below
+// the threshold, the one-shot rearms and can fire again on the next crossing.
+func (t *Tracker) RecordOutcome(success bool) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	// Evict the oldest outcome if the buffer is full.
+	if t.count == t.cfg.WindowSize {
+		evicted := t.outcomes[t.head]
+		if !evicted {
+			t.failures--
+		}
+	} else {
+		t.count++
+	}
+
+	// Write the new outcome.
+	t.outcomes[t.head] = success
+	if !success {
+		t.failures++
+	}
+	t.head = (t.head + 1) % t.cfg.WindowSize
+
+	// Check escalation transition.
+	if t.count < t.cfg.MinSamples {
+		return false
+	}
+
+	rate := float64(t.failures) / float64(t.count)
+	aboveThreshold := rate >= t.cfg.Threshold
+
+	if aboveThreshold && !t.escalated {
+		t.escalated = true
+		return true // one-shot: first crossing
+	}
+	if !aboveThreshold && t.escalated {
+		t.escalated = false // rearm for next crossing
+	}
+
+	return false
+}
+
+// FailureRate returns the current failure rate (0.0–1.0).
+// It returns 0.0 if fewer than [Config.MinSamples] outcomes have been recorded.
+func (t *Tracker) FailureRate() float64 {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	if t.count < t.cfg.MinSamples {
+		return 0.0
+	}
+	return float64(t.failures) / float64(t.count)
+}
+
+// IsEscalated reports whether the failure rate exceeds the threshold and at
+// least [Config.MinSamples] outcomes have been recorded.
+func (t *Tracker) IsEscalated() bool {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	return t.escalated
+}
+
+// Reset clears all recorded outcomes. Use this when the transport is
+// recreated from scratch and historical data is no longer relevant.
+func (t *Tracker) Reset() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.head = 0
+	t.count = 0
+	t.failures = 0
+	t.escalated = false
+	// Re-zero the buffer to avoid stale data on wraparound.
+	for i := range t.outcomes {
+		t.outcomes[i] = false
+	}
+}
+
+// SetEscalatedForTest sets the escalated flag directly. This is only for
+// use in external test packages that need to set up specific escalation states.
+func (t *Tracker) SetEscalatedForTest(v bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.escalated = v
+}

--- a/umh-core/pkg/fsmv2/deps/retry/failurerate/failurerate.go
+++ b/umh-core/pkg/fsmv2/deps/retry/failurerate/failurerate.go
@@ -24,7 +24,7 @@ import (
 type Config struct {
 	// WindowSize is the number of outcomes the circular buffer retains.
 	// Older outcomes are evicted when the buffer is full.
-	// Example: 6000 ≈ 10 minutes at one outcome per 100 ms tick.
+	// Example: 600 ≈ 10 minutes at one outcome per 1 second tick.
 	WindowSize int
 
 	// Threshold is the failure rate (0.0–1.0) that triggers escalation.

--- a/umh-core/pkg/fsmv2/deps/retry/failurerate/failurerate.go
+++ b/umh-core/pkg/fsmv2/deps/retry/failurerate/failurerate.go
@@ -42,12 +42,12 @@ type Config struct {
 //
 // Tracker is safe for concurrent use.
 type Tracker struct {
-	mu       sync.RWMutex
 	outcomes []bool  // circular buffer: true = success, false = failure
 	cfg      Config  // immutable after construction
-	head     int     // next write position
-	count    int     // total recorded outcomes (capped at WindowSize)
-	failures int     // running failure count within the window
+	mu       sync.RWMutex
+	head     int // next write position
+	count    int // total recorded outcomes (capped at WindowSize)
+	failures int // running failure count within the window
 	// escalated tracks the one-shot state: true after the failure rate
 	// first crosses the threshold, false after it drops back below.
 	escalated bool

--- a/umh-core/pkg/fsmv2/deps/retry/failurerate/failurerate.go
+++ b/umh-core/pkg/fsmv2/deps/retry/failurerate/failurerate.go
@@ -14,7 +14,10 @@
 
 package failurerate
 
-import "sync"
+import (
+	"fmt"
+	"sync"
+)
 
 // Config controls the Tracker's window size, escalation threshold, and
 // minimum sample count.
@@ -51,8 +54,19 @@ type Tracker struct {
 }
 
 // New creates a Tracker with the given configuration. The circular buffer
-// is pre-allocated to cfg.WindowSize.
+// is pre-allocated to cfg.WindowSize. New panics if the configuration is
+// invalid (WindowSize <= 0, Threshold out of (0,1], or MinSamples > WindowSize).
 func New(cfg Config) *Tracker {
+	if cfg.WindowSize <= 0 {
+		panic(fmt.Sprintf("failurerate: WindowSize must be > 0, got %d", cfg.WindowSize))
+	}
+	if cfg.Threshold <= 0.0 || cfg.Threshold > 1.0 {
+		panic(fmt.Sprintf("failurerate: Threshold must be in (0.0, 1.0], got %f", cfg.Threshold))
+	}
+	if cfg.MinSamples < 0 || cfg.MinSamples > cfg.WindowSize {
+		panic(fmt.Sprintf("failurerate: MinSamples must be in [0, WindowSize], got %d (WindowSize=%d)", cfg.MinSamples, cfg.WindowSize))
+	}
+
 	return &Tracker{
 		outcomes: make([]bool, cfg.WindowSize),
 		cfg:      cfg,
@@ -109,7 +123,7 @@ func (t *Tracker) FailureRate() float64 {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 
-	if t.count < t.cfg.MinSamples {
+	if t.count == 0 || t.count < t.cfg.MinSamples {
 		return 0.0
 	}
 	return float64(t.failures) / float64(t.count)
@@ -134,10 +148,6 @@ func (t *Tracker) Reset() {
 	t.count = 0
 	t.failures = 0
 	t.escalated = false
-	// Re-zero the buffer to avoid stale data on wraparound.
-	for i := range t.outcomes {
-		t.outcomes[i] = false
-	}
 }
 
 // SetEscalatedForTest sets the escalated flag directly. This is only for

--- a/umh-core/pkg/fsmv2/deps/retry/failurerate/failurerate_suite_test.go
+++ b/umh-core/pkg/fsmv2/deps/retry/failurerate/failurerate_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package failurerate_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestFailurerate(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Failurerate Suite")
+}

--- a/umh-core/pkg/fsmv2/deps/retry/failurerate/failurerate_test.go
+++ b/umh-core/pkg/fsmv2/deps/retry/failurerate/failurerate_test.go
@@ -1,0 +1,299 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package failurerate_test
+
+import (
+	"sync"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps/retry/failurerate"
+)
+
+var _ = Describe("Failure Rate Tracker", func() {
+	var tracker *failurerate.Tracker
+
+	// Standard config for most tests: window of 100, 90% threshold, 10 min samples.
+	defaultCfg := failurerate.Config{
+		WindowSize: 100,
+		Threshold:  0.9,
+		MinSamples: 10,
+	}
+
+	BeforeEach(func() {
+		tracker = failurerate.New(defaultCfg)
+	})
+
+	Describe("RecordOutcome()", func() {
+		It("should increase failure rate as failures are recorded", func() {
+			for range 50 {
+				tracker.RecordOutcome(false)
+			}
+			Expect(tracker.FailureRate()).To(BeNumerically("==", 1.0))
+		})
+
+		It("should decrease failure rate when successes are recorded", func() {
+			// Fill with 20 failures
+			for range 20 {
+				tracker.RecordOutcome(false)
+			}
+			Expect(tracker.FailureRate()).To(BeNumerically("==", 1.0))
+
+			// Add 20 successes — rate should drop to 0.5
+			for range 20 {
+				tracker.RecordOutcome(true)
+			}
+			Expect(tracker.FailureRate()).To(BeNumerically("~", 0.5, 0.01))
+		})
+
+		It("should evict oldest outcomes when window is full", func() {
+			// Fill the entire window (100) with failures
+			for range 100 {
+				tracker.RecordOutcome(false)
+			}
+			Expect(tracker.FailureRate()).To(BeNumerically("==", 1.0))
+
+			// Now record 50 successes — oldest 50 failures are evicted
+			for range 50 {
+				tracker.RecordOutcome(true)
+			}
+			// Window now: 50 failures + 50 successes = 50% failure rate
+			Expect(tracker.FailureRate()).To(BeNumerically("~", 0.5, 0.01))
+		})
+
+		It("should fire escalation at threshold crossing", func() {
+			// Record enough failures to cross 90% threshold with min 10 samples.
+			// 10 failures out of 10 = 100% > 90% threshold.
+			for i := range 10 {
+				fired := tracker.RecordOutcome(false)
+				if i < 9 {
+					Expect(fired).To(BeFalse(), "should not fire before MinSamples at i=%d", i)
+				} else {
+					Expect(fired).To(BeTrue(), "should fire at MinSamples when rate exceeds threshold")
+				}
+			}
+		})
+
+		It("should be one-shot: second call does not fire again", func() {
+			// Cross threshold
+			for range 10 {
+				tracker.RecordOutcome(false)
+			}
+			// Already fired on the 10th call above, subsequent should NOT fire
+			fired := tracker.RecordOutcome(false)
+			Expect(fired).To(BeFalse(), "should not fire twice without rearm")
+		})
+
+		It("should rearm after recovery and fire again on next crossing", func() {
+			// Cross threshold (fires on 10th)
+			for range 10 {
+				tracker.RecordOutcome(false)
+			}
+			Expect(tracker.IsEscalated()).To(BeTrue())
+
+			// Add enough successes to drop below threshold.
+			// Current: 10 failures out of 10. Need rate < 0.9.
+			// Adding 2 successes: 10 failures out of 12 = 83% < 90%
+			tracker.RecordOutcome(true)
+			tracker.RecordOutcome(true)
+			Expect(tracker.IsEscalated()).To(BeFalse(), "should de-escalate after recovery")
+
+			// Now cross threshold again — should fire again
+			// Fill with failures until we cross 90% again
+			var firedAgain bool
+			for range 20 {
+				if tracker.RecordOutcome(false) {
+					firedAgain = true
+					break
+				}
+			}
+			Expect(firedAgain).To(BeTrue(), "should fire again after rearm")
+		})
+
+		It("should not escalate before MinSamples even at 100% failure rate", func() {
+			cfg := failurerate.Config{
+				WindowSize: 100,
+				Threshold:  0.9,
+				MinSamples: 50,
+			}
+			t := failurerate.New(cfg)
+
+			for range 49 {
+				fired := t.RecordOutcome(false)
+				Expect(fired).To(BeFalse(), "should not fire before MinSamples")
+			}
+			Expect(t.FailureRate()).To(BeNumerically("==", 0.0),
+				"FailureRate should return 0.0 below MinSamples")
+
+			// The 50th outcome should fire
+			fired := t.RecordOutcome(false)
+			Expect(fired).To(BeTrue(), "should fire at MinSamples")
+		})
+	})
+
+	Describe("FailureRate()", func() {
+		It("should return 0.0 when no outcomes are recorded", func() {
+			Expect(tracker.FailureRate()).To(BeNumerically("==", 0.0))
+		})
+
+		It("should return 0.0 below MinSamples", func() {
+			for range 9 {
+				tracker.RecordOutcome(false)
+			}
+			Expect(tracker.FailureRate()).To(BeNumerically("==", 0.0))
+		})
+
+		It("should return correct rate at MinSamples", func() {
+			// 7 failures + 3 successes = 70%
+			for range 7 {
+				tracker.RecordOutcome(false)
+			}
+			for range 3 {
+				tracker.RecordOutcome(true)
+			}
+			Expect(tracker.FailureRate()).To(BeNumerically("~", 0.7, 0.01))
+		})
+	})
+
+	Describe("IsEscalated()", func() {
+		It("should return false initially", func() {
+			Expect(tracker.IsEscalated()).To(BeFalse())
+		})
+
+		It("should return true after threshold crossing", func() {
+			for range 10 {
+				tracker.RecordOutcome(false)
+			}
+			Expect(tracker.IsEscalated()).To(BeTrue())
+		})
+
+		It("should return false after recovery", func() {
+			for range 10 {
+				tracker.RecordOutcome(false)
+			}
+			// Recover
+			tracker.RecordOutcome(true)
+			tracker.RecordOutcome(true)
+			Expect(tracker.IsEscalated()).To(BeFalse())
+		})
+	})
+
+	Describe("Reset()", func() {
+		It("should clear all state", func() {
+			for range 50 {
+				tracker.RecordOutcome(false)
+			}
+			Expect(tracker.IsEscalated()).To(BeTrue())
+			Expect(tracker.FailureRate()).To(BeNumerically(">", 0))
+
+			tracker.Reset()
+
+			Expect(tracker.IsEscalated()).To(BeFalse())
+			Expect(tracker.FailureRate()).To(BeNumerically("==", 0.0))
+
+			// Should be able to escalate again after reset
+			for range 10 {
+				tracker.RecordOutcome(false)
+			}
+			Expect(tracker.IsEscalated()).To(BeTrue())
+		})
+	})
+
+	Describe("SetEscalatedForTest()", func() {
+		It("should set escalated flag directly", func() {
+			Expect(tracker.IsEscalated()).To(BeFalse())
+
+			tracker.SetEscalatedForTest(true)
+			Expect(tracker.IsEscalated()).To(BeTrue())
+
+			tracker.SetEscalatedForTest(false)
+			Expect(tracker.IsEscalated()).To(BeFalse())
+		})
+	})
+
+	Describe("Thread Safety", func() {
+		It("should handle concurrent RecordOutcome calls without panic", func() {
+			const goroutines = 10
+			const iterations = 100
+
+			var wg sync.WaitGroup
+			wg.Add(goroutines * 3)
+
+			// Concurrent failures
+			for range goroutines {
+				go func() {
+					defer wg.Done()
+					for range iterations {
+						tracker.RecordOutcome(false)
+					}
+				}()
+			}
+
+			// Concurrent successes
+			for range goroutines {
+				go func() {
+					defer wg.Done()
+					for range iterations {
+						tracker.RecordOutcome(true)
+					}
+				}()
+			}
+
+			// Concurrent reads
+			for range goroutines {
+				go func() {
+					defer wg.Done()
+					for range iterations {
+						_ = tracker.FailureRate()
+						_ = tracker.IsEscalated()
+					}
+				}()
+			}
+
+			wg.Wait()
+			// If we get here without deadlock or panic, the test passes
+		})
+	})
+
+	Describe("Circular Buffer Wraparound", func() {
+		It("should correctly maintain failure count through multiple wraparounds", func() {
+			cfg := failurerate.Config{
+				WindowSize: 10,
+				Threshold:  0.9,
+				MinSamples: 5,
+			}
+			t := failurerate.New(cfg)
+
+			// Fill with 10 failures (full window)
+			for range 10 {
+				t.RecordOutcome(false)
+			}
+			Expect(t.FailureRate()).To(BeNumerically("==", 1.0))
+
+			// Wrap around: add 10 successes — evicts all 10 failures
+			for range 10 {
+				t.RecordOutcome(true)
+			}
+			Expect(t.FailureRate()).To(BeNumerically("==", 0.0))
+
+			// Wrap again: add 5 failures — now 5 failures + 5 successes
+			for range 5 {
+				t.RecordOutcome(false)
+			}
+			Expect(t.FailureRate()).To(BeNumerically("~", 0.5, 0.01))
+		})
+	})
+})

--- a/umh-core/pkg/fsmv2/deps/retry/failurerate/failurerate_test.go
+++ b/umh-core/pkg/fsmv2/deps/retry/failurerate/failurerate_test.go
@@ -123,6 +123,23 @@ var _ = Describe("Failure Rate Tracker", func() {
 			Expect(firedAgain).To(BeTrue(), "should fire again after rearm")
 		})
 
+		It("should fire escalation at exact threshold boundary (rate == threshold)", func() {
+			// 9 failures + 1 success = 90% rate == 0.9 threshold — should fire (>= comparator)
+			cfg := failurerate.Config{
+				WindowSize: 100,
+				Threshold:  0.9,
+				MinSamples: 10,
+			}
+			t := failurerate.New(cfg)
+
+			for range 9 {
+				t.RecordOutcome(false)
+			}
+			t.RecordOutcome(true)
+			// 9/10 = 0.9 == threshold — should have fired on the 10th outcome
+			Expect(t.IsEscalated()).To(BeTrue(), "should escalate when rate exactly equals threshold")
+		})
+
 		It("should not escalate before MinSamples even at 100% failure rate", func() {
 			cfg := failurerate.Config{
 				WindowSize: 100,
@@ -225,12 +242,12 @@ var _ = Describe("Failure Rate Tracker", func() {
 	})
 
 	Describe("Thread Safety", func() {
-		It("should handle concurrent RecordOutcome calls without panic", func() {
+		It("should handle concurrent RecordOutcome and Reset calls without panic", func() {
 			const goroutines = 10
 			const iterations = 100
 
 			var wg sync.WaitGroup
-			wg.Add(goroutines * 3)
+			wg.Add(goroutines * 4)
 
 			// Concurrent failures
 			for range goroutines {
@@ -263,8 +280,62 @@ var _ = Describe("Failure Rate Tracker", func() {
 				}()
 			}
 
+			// Concurrent resets
+			for range goroutines {
+				go func() {
+					defer wg.Done()
+					for range iterations {
+						tracker.Reset()
+					}
+				}()
+			}
+
 			wg.Wait()
 			// If we get here without deadlock or panic, the test passes
+		})
+	})
+
+	Describe("Config Validation", func() {
+		It("should panic on WindowSize=0", func() {
+			Expect(func() {
+				failurerate.New(failurerate.Config{WindowSize: 0, Threshold: 0.9, MinSamples: 0})
+			}).To(Panic())
+		})
+
+		It("should panic on negative WindowSize", func() {
+			Expect(func() {
+				failurerate.New(failurerate.Config{WindowSize: -1, Threshold: 0.9, MinSamples: 0})
+			}).To(Panic())
+		})
+
+		It("should panic on Threshold=0", func() {
+			Expect(func() {
+				failurerate.New(failurerate.Config{WindowSize: 100, Threshold: 0.0, MinSamples: 10})
+			}).To(Panic())
+		})
+
+		It("should panic on Threshold > 1.0", func() {
+			Expect(func() {
+				failurerate.New(failurerate.Config{WindowSize: 100, Threshold: 1.5, MinSamples: 10})
+			}).To(Panic())
+		})
+
+		It("should panic on MinSamples > WindowSize", func() {
+			Expect(func() {
+				failurerate.New(failurerate.Config{WindowSize: 10, Threshold: 0.9, MinSamples: 20})
+			}).To(Panic())
+		})
+
+		It("should not panic on valid edge configs", func() {
+			// Threshold=1.0 is valid (only 100% failure escalates)
+			Expect(func() {
+				failurerate.New(failurerate.Config{WindowSize: 1, Threshold: 1.0, MinSamples: 0})
+			}).NotTo(Panic())
+
+			// MinSamples=0 is valid (no startup protection)
+			Expect(func() {
+				failurerate.New(failurerate.Config{WindowSize: 100, Threshold: 0.5, MinSamples: 0})
+			}).NotTo(Panic())
 		})
 	})
 

--- a/umh-core/pkg/fsmv2/workers/communicator/action/authenticate.go
+++ b/umh-core/pkg/fsmv2/workers/communicator/action/authenticate.go
@@ -135,7 +135,7 @@ func (a *AuthenticateAction) Execute(ctx context.Context, depsAny any) error {
 		var transportErr *httpTransport.TransportError
 		if errors.As(err, &transportErr) {
 			deps.RecordTypedError(transportErr.Type, transportErr.RetryAfter)
-			deps.MetricsRecorder().IncrementCounter(counterForErrorType(transportErr.Type), 1)
+			deps.MetricsRecorder().IncrementCounter(httpTransport.CounterForErrorType(transportErr.Type), 1)
 		} else {
 			deps.RecordTypedError(httpTransport.ErrorTypeNetwork, 0)
 			deps.MetricsRecorder().IncrementCounter(depspkg.CounterNetworkErrorsTotal, 1)
@@ -166,30 +166,6 @@ func (a *AuthenticateAction) Execute(ctx context.Context, depsAny any) error {
 	}
 
 	return nil
-}
-
-// counterForErrorType maps ErrorType to Prometheus counter.
-func counterForErrorType(t httpTransport.ErrorType) depspkg.CounterName {
-	switch t {
-	case httpTransport.ErrorTypeCloudflareChallenge:
-		return depspkg.CounterCloudflareErrorsTotal
-	case httpTransport.ErrorTypeBackendRateLimit:
-		return depspkg.CounterBackendRateLimitErrorsTotal
-	case httpTransport.ErrorTypeInvalidToken:
-		return depspkg.CounterAuthFailuresTotal
-	case httpTransport.ErrorTypeInstanceDeleted:
-		return depspkg.CounterInstanceDeletedTotal
-	case httpTransport.ErrorTypeServerError:
-		return depspkg.CounterServerErrorsTotal
-	case httpTransport.ErrorTypeProxyBlock:
-		return depspkg.CounterProxyBlockErrorsTotal
-	case httpTransport.ErrorTypeNetwork:
-		return depspkg.CounterNetworkErrorsTotal
-	case httpTransport.ErrorTypeUnknown:
-		return depspkg.CounterNetworkErrorsTotal
-	default:
-		return depspkg.CounterNetworkErrorsTotal
-	}
 }
 
 func (a *AuthenticateAction) Name() string {

--- a/umh-core/pkg/fsmv2/workers/communicator/action/sync.go
+++ b/umh-core/pkg/fsmv2/workers/communicator/action/sync.go
@@ -137,7 +137,7 @@ func (a *SyncAction) Execute(ctx context.Context, depsAny any) error {
 			var transportErr *httpTransport.TransportError
 			if errors.As(err, &transportErr) {
 				deps.RecordTypedError(transportErr.Type, transportErr.RetryAfter)
-				deps.MetricsRecorder().IncrementCounter(counterForErrorType(transportErr.Type), 1)
+				deps.MetricsRecorder().IncrementCounter(httpTransport.CounterForErrorType(transportErr.Type), 1)
 			} else {
 				deps.RecordTypedError(httpTransport.ErrorTypeNetwork, 0)
 				deps.MetricsRecorder().IncrementCounter(depspkg.CounterNetworkErrorsTotal, 1)
@@ -220,7 +220,7 @@ func (a *SyncAction) Execute(ctx context.Context, depsAny any) error {
 			var transportErr *httpTransport.TransportError
 			if errors.As(err, &transportErr) {
 				deps.RecordTypedError(transportErr.Type, transportErr.RetryAfter)
-				deps.MetricsRecorder().IncrementCounter(counterForErrorType(transportErr.Type), 1)
+				deps.MetricsRecorder().IncrementCounter(httpTransport.CounterForErrorType(transportErr.Type), 1)
 			} else {
 				deps.RecordTypedError(httpTransport.ErrorTypeNetwork, 0)
 				deps.MetricsRecorder().IncrementCounter(depspkg.CounterNetworkErrorsTotal, 1)

--- a/umh-core/pkg/fsmv2/workers/communicator/transport/http/http.go
+++ b/umh-core/pkg/fsmv2/workers/communicator/transport/http/http.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/communicator/pkg/hash"
+	depspkg "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator/transport"
 )
 
@@ -128,6 +129,31 @@ func ExtractErrorType(err error) (ErrorType, time.Duration) {
 	}
 
 	return ErrorTypeNetwork, 0
+}
+
+// CounterForErrorType maps an ErrorType to its corresponding Prometheus counter.
+// Unknown and unrecognized types default to CounterNetworkErrorsTotal.
+func CounterForErrorType(t ErrorType) depspkg.CounterName {
+	switch t {
+	case ErrorTypeCloudflareChallenge:
+		return depspkg.CounterCloudflareErrorsTotal
+	case ErrorTypeBackendRateLimit:
+		return depspkg.CounterBackendRateLimitErrorsTotal
+	case ErrorTypeInvalidToken:
+		return depspkg.CounterAuthFailuresTotal
+	case ErrorTypeInstanceDeleted:
+		return depspkg.CounterInstanceDeletedTotal
+	case ErrorTypeServerError:
+		return depspkg.CounterServerErrorsTotal
+	case ErrorTypeProxyBlock:
+		return depspkg.CounterProxyBlockErrorsTotal
+	case ErrorTypeNetwork:
+		return depspkg.CounterNetworkErrorsTotal
+	case ErrorTypeUnknown:
+		return depspkg.CounterNetworkErrorsTotal
+	default:
+		return depspkg.CounterNetworkErrorsTotal
+	}
 }
 
 // isCloudflareChallenge detects Cloudflare challenge pages via headers and body content.

--- a/umh-core/pkg/fsmv2/workers/communicator/transport/http/http.go
+++ b/umh-core/pkg/fsmv2/workers/communicator/transport/http/http.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -115,6 +116,18 @@ func (e *TransportError) Is(target error) bool {
 	}
 
 	return e.Type == t.Type
+}
+
+// ExtractErrorType unwraps a *TransportError from err and returns its ErrorType
+// and RetryAfter duration. If err does not wrap a *TransportError, it defaults
+// to ErrorTypeNetwork with zero retry delay.
+func ExtractErrorType(err error) (ErrorType, time.Duration) {
+	var transportErr *TransportError
+	if errors.As(err, &transportErr) {
+		return transportErr.Type, transportErr.RetryAfter
+	}
+
+	return ErrorTypeNetwork, 0
 }
 
 // isCloudflareChallenge detects Cloudflare challenge pages via headers and body content.

--- a/umh-core/pkg/fsmv2/workers/transport/action/authenticate.go
+++ b/umh-core/pkg/fsmv2/workers/transport/action/authenticate.go
@@ -100,7 +100,7 @@ func (a *AuthenticateAction) Execute(ctx context.Context, depsAny any) error {
 		var transportErr *httpTransport.TransportError
 		if errors.As(err, &transportErr) {
 			deps.RecordTypedError(transportErr.Type, transportErr.RetryAfter)
-			deps.MetricsRecorder().IncrementCounter(counterForErrorType(transportErr.Type), 1)
+			deps.MetricsRecorder().IncrementCounter(httpTransport.CounterForErrorType(transportErr.Type), 1)
 			deps.GetLogger().SentryWarn(depspkg.FeatureCommunicator, deps.GetHierarchyPath(), "authentication_failed",
 				depspkg.Err(err), depspkg.String("errorType", transportErr.Type.String()))
 		} else {
@@ -135,29 +135,6 @@ func (a *AuthenticateAction) Execute(ctx context.Context, depsAny any) error {
 	}
 
 	return nil
-}
-
-func counterForErrorType(t httpTransport.ErrorType) depspkg.CounterName {
-	switch t {
-	case httpTransport.ErrorTypeCloudflareChallenge:
-		return depspkg.CounterCloudflareErrorsTotal
-	case httpTransport.ErrorTypeBackendRateLimit:
-		return depspkg.CounterBackendRateLimitErrorsTotal
-	case httpTransport.ErrorTypeInvalidToken:
-		return depspkg.CounterAuthFailuresTotal
-	case httpTransport.ErrorTypeInstanceDeleted:
-		return depspkg.CounterInstanceDeletedTotal
-	case httpTransport.ErrorTypeServerError:
-		return depspkg.CounterServerErrorsTotal
-	case httpTransport.ErrorTypeProxyBlock:
-		return depspkg.CounterProxyBlockErrorsTotal
-	case httpTransport.ErrorTypeNetwork:
-		return depspkg.CounterNetworkErrorsTotal
-	case httpTransport.ErrorTypeUnknown:
-		return depspkg.CounterNetworkErrorsTotal
-	default:
-		return depspkg.CounterNetworkErrorsTotal
-	}
 }
 
 func (a *AuthenticateAction) Name() string {

--- a/umh-core/pkg/fsmv2/workers/transport/dependencies.go
+++ b/umh-core/pkg/fsmv2/workers/transport/dependencies.go
@@ -21,9 +21,20 @@ import (
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps/retry"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps/retry/failurerate"
 	communicator_transport "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator/transport"
 	httpTransport "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator/transport/http"
 )
+
+// ChildFailureRateConfig is the shared failurerate.Config for push and pull
+// child workers. WindowSize=600 at the 1-second production tick rate covers
+// roughly 10 minutes. Threshold=0.9 triggers escalation at 90% failure rate.
+// MinSamples=100 suppresses spurious alerts during startup.
+var ChildFailureRateConfig = failurerate.Config{
+	WindowSize: 600,
+	Threshold:  0.9,
+	MinSamples: 100,
+}
 
 // ChannelProvider interface and singleton functions are defined in channel_provider.go
 

--- a/umh-core/pkg/fsmv2/workers/transport/pull/action/pull.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/action/pull.go
@@ -150,14 +150,9 @@ func (a *PullAction) Execute(ctx context.Context, depsAny any) error {
 	pullLatency := time.Since(pullStart)
 
 	if err != nil {
-		var transportErr *httpTransport.TransportError
-		if errors.As(err, &transportErr) {
-			pullDeps.RecordTypedError(transportErr.Type, transportErr.RetryAfter)
-			metrics.IncrementCounter(counterForErrorType(transportErr.Type), 1)
-		} else {
-			pullDeps.RecordTypedError(httpTransport.ErrorTypeNetwork, 0)
-			metrics.IncrementCounter(depspkg.CounterNetworkErrorsTotal, 1)
-		}
+		errType, retryAfter := httpTransport.ExtractErrorType(err)
+		pullDeps.RecordTypedError(errType, retryAfter)
+		metrics.IncrementCounter(counterForErrorType(errType), 1)
 
 		metrics.IncrementCounter(depspkg.CounterPullOps, 1)
 		metrics.IncrementCounter(depspkg.CounterPullFailures, 1)

--- a/umh-core/pkg/fsmv2/workers/transport/pull/action/pull.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/action/pull.go
@@ -152,7 +152,7 @@ func (a *PullAction) Execute(ctx context.Context, depsAny any) error {
 	if err != nil {
 		errType, retryAfter := httpTransport.ExtractErrorType(err)
 		pullDeps.RecordTypedError(errType, retryAfter)
-		metrics.IncrementCounter(counterForErrorType(errType), 1)
+		metrics.IncrementCounter(httpTransport.CounterForErrorType(errType), 1)
 
 		metrics.IncrementCounter(depspkg.CounterPullOps, 1)
 		metrics.IncrementCounter(depspkg.CounterPullFailures, 1)
@@ -229,29 +229,6 @@ func (a *PullAction) String() string {
 // Name returns the action name for FSM registration.
 func (a *PullAction) Name() string {
 	return PullActionName
-}
-
-func counterForErrorType(t httpTransport.ErrorType) depspkg.CounterName {
-	switch t {
-	case httpTransport.ErrorTypeCloudflareChallenge:
-		return depspkg.CounterCloudflareErrorsTotal
-	case httpTransport.ErrorTypeBackendRateLimit:
-		return depspkg.CounterBackendRateLimitErrorsTotal
-	case httpTransport.ErrorTypeInvalidToken:
-		return depspkg.CounterAuthFailuresTotal
-	case httpTransport.ErrorTypeInstanceDeleted:
-		return depspkg.CounterInstanceDeletedTotal
-	case httpTransport.ErrorTypeServerError:
-		return depspkg.CounterServerErrorsTotal
-	case httpTransport.ErrorTypeProxyBlock:
-		return depspkg.CounterProxyBlockErrorsTotal
-	case httpTransport.ErrorTypeNetwork:
-		return depspkg.CounterNetworkErrorsTotal
-	case httpTransport.ErrorTypeUnknown:
-		return depspkg.CounterNetworkErrorsTotal
-	default:
-		return depspkg.CounterNetworkErrorsTotal
-	}
 }
 
 // Backpressure thresholds for inbound channel capacity management.

--- a/umh-core/pkg/fsmv2/workers/transport/pull/dependencies.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/dependencies.go
@@ -60,7 +60,7 @@ func NewPullDependencies(parentDeps *transport_pkg.TransportDependencies, identi
 		BaseDependencies: deps.NewBaseDependencies(logger, stateReader, identity),
 		parentDeps:       parentDeps,
 		failureRate: failurerate.New(failurerate.Config{
-			WindowSize: 6000,
+			WindowSize: 600,
 			Threshold:  0.9,
 			MinSamples: 100,
 		}),

--- a/umh-core/pkg/fsmv2/workers/transport/pull/dependencies.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/dependencies.go
@@ -59,11 +59,7 @@ func NewPullDependencies(parentDeps *transport_pkg.TransportDependencies, identi
 	return &PullDependencies{
 		BaseDependencies: deps.NewBaseDependencies(logger, stateReader, identity),
 		parentDeps:       parentDeps,
-		failureRate: failurerate.New(failurerate.Config{
-			WindowSize: 600,
-			Threshold:  0.9,
-			MinSamples: 100,
-		}),
+		failureRate: failurerate.New(transport_pkg.ChildFailureRateConfig),
 	}, nil
 }
 
@@ -247,8 +243,8 @@ func (d *PullDependencies) CheckAndClearOnReset() bool {
 	return changed
 }
 
-// IsPersistentFailureEscalated reports whether the failure rate exceeds the
-// escalation threshold over the rolling window.
+// IsPersistentFailureEscalated reports whether the failure rate meets or exceeds
+// the escalation threshold over the rolling window.
 func (d *PullDependencies) IsPersistentFailureEscalated() bool {
 	return d.failureRate.IsEscalated()
 }

--- a/umh-core/pkg/fsmv2/workers/transport/pull/dependencies.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/dependencies.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps/retry"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps/retry/failurerate"
 	communicator_transport "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator/transport"
 	httpTransport "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator/transport/http"
 	transport_pkg "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport"
@@ -39,6 +40,7 @@ var _ snapshot.PullDependencies = (*PullDependencies)(nil)
 type PullDependencies struct {
 	*deps.BaseDependencies
 	parentDeps              *transport_pkg.TransportDependencies
+	failureRate             *failurerate.Tracker
 	pendingMessages         []*communicator_transport.UMHMessage
 	errorMu                 sync.RWMutex
 	pendingMu               sync.RWMutex
@@ -57,6 +59,11 @@ func NewPullDependencies(parentDeps *transport_pkg.TransportDependencies, identi
 	return &PullDependencies{
 		BaseDependencies: deps.NewBaseDependencies(logger, stateReader, identity),
 		parentDeps:       parentDeps,
+		failureRate: failurerate.New(failurerate.Config{
+			WindowSize: 6000,
+			Threshold:  0.9,
+			MinSamples: 100,
+		}),
 	}, nil
 }
 
@@ -83,6 +90,12 @@ func (d *PullDependencies) RecordTypedError(errType httpTransport.ErrorType, ret
 
 	d.RetryTracker().RecordError(retry.WithClass(errType.String()), retry.WithRetryAfter(retryAfter))
 	d.parentDeps.RecordTypedError(errType, retryAfter)
+
+	if d.failureRate.RecordOutcome(false) {
+		d.BaseDependencies.GetLogger().SentryWarn(deps.FeatureCommunicator, d.GetHierarchyPath(), "persistent_pull_failure",
+			deps.String("error_type", errType.String()),
+			deps.Float64("failure_rate", d.failureRate.FailureRate()))
+	}
 }
 
 // RecordSuccess resets the child's error state. It intentionally does NOT
@@ -95,11 +108,13 @@ func (d *PullDependencies) RecordSuccess() {
 	d.errorMu.Unlock()
 
 	d.RetryTracker().RecordSuccess()
+	d.failureRate.RecordOutcome(true)
 }
 
 func (d *PullDependencies) RecordError() {
 	d.RetryTracker().RecordError()
 	d.parentDeps.RecordError()
+	d.failureRate.RecordOutcome(false)
 }
 
 func (d *PullDependencies) GetConsecutiveErrors() int {
@@ -225,7 +240,20 @@ func (d *PullDependencies) CheckAndClearOnReset() bool {
 		d.backpressureMu.Lock()
 		d.backpressured = false
 		d.backpressureMu.Unlock()
+
+		d.failureRate.Reset()
 	}
 
 	return changed
+}
+
+// IsPersistentFailureEscalated reports whether the failure rate exceeds the
+// escalation threshold over the rolling window.
+func (d *PullDependencies) IsPersistentFailureEscalated() bool {
+	return d.failureRate.IsEscalated()
+}
+
+// SetPersistentFailureEscalatedForTest sets the escalation flag directly for tests.
+func (d *PullDependencies) SetPersistentFailureEscalatedForTest(v bool) {
+	d.failureRate.SetEscalatedForTest(v)
 }

--- a/umh-core/pkg/fsmv2/workers/transport/pull/state/state_degraded.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/state/state_degraded.go
@@ -36,7 +36,7 @@ func (s *DegradedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.Observed.IsStopRequired() {
 		return fsmv2.Result[any, any](&StoppingState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: shutdown=%t, parentState=%s", snap.Desired.IsShutdownRequested(), snap.Desired.ParentMappedState))
+			fmt.Sprintf("stop required: shutdown=%t, parentState=%s", snap.Desired.IsShutdownRequested(), snap.Observed.ParentMappedState))
 	}
 
 	if snap.Observed.ConsecutiveErrors == 0 && snap.Observed.PendingMessageCount < pendingDegradedThreshold {

--- a/umh-core/pkg/fsmv2/workers/transport/pull/state/state_running.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/state/state_running.go
@@ -43,7 +43,7 @@ func (s *RunningState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.Observed.IsStopRequired() {
 		return fsmv2.Result[any, any](&StoppingState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: shutdown=%t, parentState=%s", snap.Desired.IsShutdownRequested(), snap.Desired.ParentMappedState))
+			fmt.Sprintf("stop required: shutdown=%t, parentState=%s", snap.Desired.IsShutdownRequested(), snap.Observed.ParentMappedState))
 	}
 
 	if snap.Observed.ConsecutiveErrors >= errorDegradedThreshold {

--- a/umh-core/pkg/fsmv2/workers/transport/pull/state/state_stopping.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/state/state_stopping.go
@@ -30,13 +30,10 @@ type StoppingState struct {
 func (s *StoppingState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := helpers.ConvertSnapshot[snapshot.PullObservedState, *snapshot.PullDesiredState](snapAny)
 
-	if snap.Observed.IsStopRequired() {
-		return fsmv2.Result[any, any](&StoppedState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: shutdown=%t, parentState=%s", snap.Desired.IsShutdownRequested(), snap.Desired.ParentMappedState))
-	}
-
-	return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil,
-		fmt.Sprintf("stopping, waiting for stop condition: shutdown=%t, parentState=%s", snap.Desired.IsShutdownRequested(), snap.Desired.ParentMappedState))
+	// Unconditional transition to Stopped. The decision to stop was already made
+	// on entry to StoppingState. StoppedState handles recovery via ShouldBeRunning().
+	return fsmv2.Result[any, any](&StoppedState{}, fsmv2.SignalNone, nil,
+		fmt.Sprintf("stop complete: shutdown=%t, parentState=%s", snap.Observed.IsShutdownRequested(), snap.Observed.ParentMappedState))
 }
 
 func (s *StoppingState) String() string {

--- a/umh-core/pkg/fsmv2/workers/transport/pull/state/state_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/state/state_test.go
@@ -358,12 +358,30 @@ var _ = Describe("StoppingState", func() {
 		Expect(result.State).To(BeAssignableToTypeOf(&state.StoppedState{}))
 	})
 
-	It("should stay in Stopping when stop condition not yet met", func() {
+	It("should transition to Stopped unconditionally (ENG-4608)", func() {
 		snap := makeSnapshot(config.DesiredStateRunning, false, 0, true, true)
 		result := s.Next(snap)
-		Expect(result.State).To(BeAssignableToTypeOf(&state.StoppingState{}))
+		Expect(result.State).To(BeAssignableToTypeOf(&state.StoppedState{}))
 		Expect(result.Signal).To(Equal(fsmv2.SignalNone))
-		Expect(result.Reason).To(ContainSubstring("stopping"))
+		Expect(result.Reason).To(ContainSubstring("stop complete"))
+	})
+
+	It("ENG-4608: should not get stuck when parent recovers from Starting to Running", func() {
+		// Reproduction: transport parent temporarily enters Starting for token refresh,
+		// which maps to "stopped" for children. Pull enters Stopping. Parent returns to
+		// Running, but pull was permanently stuck in Stopping because IsStopRequired()
+		// returned false (parent is Running again, shutdown not requested).
+		// Fix: StoppingState always transitions to Stopped. StoppedState handles recovery.
+		snap := makeSnapshot(config.DesiredStateRunning, false, 0, true, true)
+		result := s.Next(snap)
+		Expect(result.State).To(BeAssignableToTypeOf(&state.StoppedState{}),
+			"StoppingState must not get stuck when parent recovers to Running")
+
+		// Verify that StoppedState recovers to Running
+		stopped := &state.StoppedState{}
+		result = stopped.Next(snap)
+		Expect(result.State).To(BeAssignableToTypeOf(&state.RunningState{}),
+			"StoppedState should recover to Running when ShouldBeRunning is true")
 	})
 
 	It("should return a valid String()", func() {

--- a/umh-core/pkg/fsmv2/workers/transport/push/action/push.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/action/push.go
@@ -158,13 +158,15 @@ drainLoop:
 // and we need per-message error handling to isolate poison messages.
 //
 // For each message the error cascade is:
-//  1. Context canceled → return remaining messages with cancellation error.
-//  2. Recoverable by parent (auth failure, proxy block, etc.) → return
+//  1. Context canceled (pre-push) → return remaining messages immediately.
+//  2. Push fails, context expired during push → return remaining with
+//     cancellation error.
+//  3. Recoverable by parent (auth failure, proxy block, etc.) → return
 //     remaining messages with error so the parent triggers re-authentication
 //     or transport reset.
-//  3. Poison message (unrecoverable) → log SentryWarn, drop the message,
+//  4. Poison message (unrecoverable) → log SentryWarn, drop the message,
 //     continue to next.
-//  4. Success → record metrics, continue.
+//  5. Success → record metrics, continue.
 //
 // Returns (nil, nil) when all messages are sent successfully. Otherwise
 // returns the unsent tail of pending so the caller can buffer them for

--- a/umh-core/pkg/fsmv2/workers/transport/push/action/push.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/action/push.go
@@ -119,14 +119,9 @@ drainLoop:
 
 		pushDeps.StorePendingMessages(messagesToPush)
 
-		var transportErr *httpTransport.TransportError
-		if errors.As(err, &transportErr) {
-			pushDeps.RecordTypedError(transportErr.Type, transportErr.RetryAfter)
-			metrics.IncrementCounter(counterForErrorType(transportErr.Type), 1)
-		} else {
-			pushDeps.RecordTypedError(httpTransport.ErrorTypeNetwork, 0)
-			metrics.IncrementCounter(depspkg.CounterNetworkErrorsTotal, 1)
-		}
+		errType, retryAfter := httpTransport.ExtractErrorType(err)
+		pushDeps.RecordTypedError(errType, retryAfter)
+		metrics.IncrementCounter(counterForErrorType(errType), 1)
 
 		metrics.IncrementCounter(depspkg.CounterPushOps, 1)
 		metrics.IncrementCounter(depspkg.CounterPushFailures, 1)
@@ -174,29 +169,25 @@ func (a *PushAction) retryPending(ctx context.Context, t transport.Transport, pu
 		}
 
 		if err := t.Push(ctx, jwtToken, []*transport.UMHMessage{msg}); err != nil {
-			var transportErr *httpTransport.TransportError
+			errType, retryAfter := httpTransport.ExtractErrorType(err)
+			pushDeps.RecordTypedError(errType, retryAfter)
+			metrics.IncrementCounter(counterForErrorType(errType), 1)
 
-			if errors.As(err, &transportErr) {
-				pushDeps.RecordTypedError(transportErr.Type, transportErr.RetryAfter)
-				metrics.IncrementCounter(counterForErrorType(transportErr.Type), 1)
-
-				if isRecoverableByParent(transportErr.Type) {
-					return pending[i:], fmt.Errorf("pending retry failed (recoverable by parent): %w", err)
-				}
-
-				pushDeps.GetLogger().SentryWarn(depspkg.FeatureCommunicator, pushDeps.GetHierarchyPath(), "dropping_poison_message",
-					depspkg.String("errorType", transportErr.Type.String()),
-					depspkg.Err(transportErr),
-					depspkg.Int("remaining", len(pending)-i-1))
-				metrics.IncrementCounter(depspkg.CounterMessagesDropped, 1)
-
-				continue
+			if ctx.Err() != nil {
+				return pending[i:], fmt.Errorf("context canceled during retry: %w", ctx.Err())
 			}
 
-			pushDeps.RecordTypedError(httpTransport.ErrorTypeNetwork, 0)
-			metrics.IncrementCounter(depspkg.CounterNetworkErrorsTotal, 1)
+			if isRecoverableByParent(errType) {
+				return pending[i:], fmt.Errorf("pending retry failed (recoverable by parent): %w", err)
+			}
 
-			return pending[i:], fmt.Errorf("pending retry failed: %w", err)
+			pushDeps.GetLogger().SentryWarn(depspkg.FeatureCommunicator, pushDeps.GetHierarchyPath(), "dropping_poison_message",
+				depspkg.String("errorType", errType.String()),
+				depspkg.Err(err),
+				depspkg.Int("remaining", len(pending)-i-1))
+			metrics.IncrementCounter(depspkg.CounterMessagesDropped, 1)
+
+			continue
 		}
 
 		pushDeps.RecordSuccess()
@@ -234,11 +225,13 @@ func counterForErrorType(t httpTransport.ErrorType) depspkg.CounterName {
 	}
 }
 
-// isRecoverableByParent returns true for error types where the message should be
-// preserved in the pending buffer rather than dropped. These are transient errors
-// (network, server, auth, rate limit, proxy) where the message itself is valid.
-// Recovery happens via parent actions (re-authentication, transport reset) or
-// child-level backoff (rate limit delay), not by discarding the message.
+// isRecoverableByParent returns true for error types where the message itself is
+// valid but delivery failed due to an external condition. These messages are
+// preserved in the pending buffer for retry rather than dropped.
+//
+// Covers both infrastructure errors (network, server, rate limit) and
+// access errors (auth, cloudflare, proxy) that resolve via parent actions
+// (re-authentication, transport reset) or child-level backoff.
 func isRecoverableByParent(errType httpTransport.ErrorType) bool {
 	switch errType {
 	case httpTransport.ErrorTypeNetwork,

--- a/umh-core/pkg/fsmv2/workers/transport/push/action/push.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/action/push.go
@@ -153,6 +153,22 @@ drainLoop:
 	return nil
 }
 
+// retryPending sends previously failed messages one at a time. Messages are
+// sent individually (not batched) because a prior batch push already failed,
+// and we need per-message error handling to isolate poison messages.
+//
+// For each message the error cascade is:
+//  1. Context canceled → return remaining messages with cancellation error.
+//  2. Recoverable by parent (auth failure, proxy block, etc.) → return
+//     remaining messages with error so the parent triggers re-authentication
+//     or transport reset.
+//  3. Poison message (unrecoverable) → log SentryWarn, drop the message,
+//     continue to next.
+//  4. Success → record metrics, continue.
+//
+// Returns (nil, nil) when all messages are sent successfully. Otherwise
+// returns the unsent tail of pending so the caller can buffer them for
+// the next tick.
 func (a *PushAction) retryPending(ctx context.Context, t transport.Transport, pushDeps snapshot.PushDependencies, pending []*transport.UMHMessage, metrics *depspkg.MetricsRecorder) ([]*transport.UMHMessage, error) {
 	jwtToken := pushDeps.GetJWTToken()
 	authenticatedUUID := pushDeps.GetAuthenticatedUUID()

--- a/umh-core/pkg/fsmv2/workers/transport/push/action/push.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/action/push.go
@@ -121,7 +121,7 @@ drainLoop:
 
 		errType, retryAfter := httpTransport.ExtractErrorType(err)
 		pushDeps.RecordTypedError(errType, retryAfter)
-		metrics.IncrementCounter(counterForErrorType(errType), 1)
+		metrics.IncrementCounter(httpTransport.CounterForErrorType(errType), 1)
 
 		metrics.IncrementCounter(depspkg.CounterPushOps, 1)
 		metrics.IncrementCounter(depspkg.CounterPushFailures, 1)
@@ -171,7 +171,7 @@ func (a *PushAction) retryPending(ctx context.Context, t transport.Transport, pu
 		if err := t.Push(ctx, jwtToken, []*transport.UMHMessage{msg}); err != nil {
 			errType, retryAfter := httpTransport.ExtractErrorType(err)
 			pushDeps.RecordTypedError(errType, retryAfter)
-			metrics.IncrementCounter(counterForErrorType(errType), 1)
+			metrics.IncrementCounter(httpTransport.CounterForErrorType(errType), 1)
 
 			if ctx.Err() != nil {
 				return pending[i:], fmt.Errorf("context canceled during retry: %w", ctx.Err())
@@ -197,32 +197,6 @@ func (a *PushAction) retryPending(ctx context.Context, t transport.Transport, pu
 	}
 
 	return nil, nil
-}
-
-func counterForErrorType(t httpTransport.ErrorType) depspkg.CounterName {
-	switch t {
-	case httpTransport.ErrorTypeCloudflareChallenge:
-		return depspkg.CounterCloudflareErrorsTotal
-	case httpTransport.ErrorTypeBackendRateLimit:
-		return depspkg.CounterBackendRateLimitErrorsTotal
-	case httpTransport.ErrorTypeInvalidToken:
-		return depspkg.CounterAuthFailuresTotal
-	// ErrorTypeInstanceDeleted: reachable via HTTP 404 from classifyError().
-	// Rare in practice (push endpoint uses session auth, not instance lookup),
-	// but kept for correct metric attribution if backend returns 404.
-	case httpTransport.ErrorTypeInstanceDeleted:
-		return depspkg.CounterInstanceDeletedTotal
-	case httpTransport.ErrorTypeServerError:
-		return depspkg.CounterServerErrorsTotal
-	case httpTransport.ErrorTypeProxyBlock:
-		return depspkg.CounterProxyBlockErrorsTotal
-	case httpTransport.ErrorTypeNetwork:
-		return depspkg.CounterNetworkErrorsTotal
-	case httpTransport.ErrorTypeUnknown:
-		return depspkg.CounterNetworkErrorsTotal
-	default:
-		return depspkg.CounterNetworkErrorsTotal
-	}
 }
 
 // isRecoverableByParent returns true for error types where the message itself is

--- a/umh-core/pkg/fsmv2/workers/transport/push/dependencies.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/dependencies.go
@@ -52,7 +52,7 @@ func NewPushDependencies(parentDeps *transport_pkg.TransportDependencies, identi
 		BaseDependencies: deps.NewBaseDependencies(logger, stateReader, identity),
 		parentDeps:       parentDeps,
 		failureRate: failurerate.New(failurerate.Config{
-			WindowSize: 6000,
+			WindowSize: 600,
 			Threshold:  0.9,
 			MinSamples: 100,
 		}),

--- a/umh-core/pkg/fsmv2/workers/transport/push/dependencies.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/dependencies.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps/retry"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps/retry/failurerate"
 	communicator_transport "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator/transport"
 	httpTransport "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator/transport/http"
 	transport_pkg "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport"
@@ -34,6 +35,7 @@ var _ snapshot.PushDependencies = (*PushDependencies)(nil)
 type PushDependencies struct {
 	*deps.BaseDependencies
 	parentDeps              *transport_pkg.TransportDependencies
+	failureRate             *failurerate.Tracker
 	pendingMessages         []*communicator_transport.UMHMessage
 	errorMu                 sync.RWMutex
 	pendingMu               sync.RWMutex
@@ -49,6 +51,11 @@ func NewPushDependencies(parentDeps *transport_pkg.TransportDependencies, identi
 	return &PushDependencies{
 		BaseDependencies: deps.NewBaseDependencies(logger, stateReader, identity),
 		parentDeps:       parentDeps,
+		failureRate: failurerate.New(failurerate.Config{
+			WindowSize: 6000,
+			Threshold:  0.9,
+			MinSamples: 100,
+		}),
 	}, nil
 }
 
@@ -75,6 +82,12 @@ func (d *PushDependencies) RecordTypedError(errType httpTransport.ErrorType, ret
 
 	d.RetryTracker().RecordError(retry.WithClass(errType.String()), retry.WithRetryAfter(retryAfter))
 	d.parentDeps.RecordTypedError(errType, retryAfter)
+
+	if d.failureRate.RecordOutcome(false) {
+		d.BaseDependencies.GetLogger().SentryWarn(deps.FeatureCommunicator, d.GetHierarchyPath(), "persistent_push_failure",
+			deps.String("error_type", errType.String()),
+			deps.Float64("failure_rate", d.failureRate.FailureRate()))
+	}
 }
 
 // RecordSuccess resets the child's error state. It intentionally does NOT
@@ -87,11 +100,13 @@ func (d *PushDependencies) RecordSuccess() {
 	d.errorMu.Unlock()
 
 	d.RetryTracker().RecordSuccess()
+	d.failureRate.RecordOutcome(true)
 }
 
 func (d *PushDependencies) RecordError() {
 	d.RetryTracker().RecordError()
 	d.parentDeps.RecordError()
+	d.failureRate.RecordOutcome(false)
 }
 
 func (d *PushDependencies) GetConsecutiveErrors() int {
@@ -183,9 +198,21 @@ func (d *PushDependencies) CheckAndClearOnReset() bool {
 	if currentGen != d.lastSeenResetGeneration {
 		d.pendingMessages = nil
 		d.lastSeenResetGeneration = currentGen
+		d.failureRate.Reset()
 
 		return true
 	}
 
 	return false
+}
+
+// IsPersistentFailureEscalated reports whether the failure rate exceeds the
+// escalation threshold over the rolling window.
+func (d *PushDependencies) IsPersistentFailureEscalated() bool {
+	return d.failureRate.IsEscalated()
+}
+
+// SetPersistentFailureEscalatedForTest sets the escalation flag directly for tests.
+func (d *PushDependencies) SetPersistentFailureEscalatedForTest(v bool) {
+	d.failureRate.SetEscalatedForTest(v)
 }

--- a/umh-core/pkg/fsmv2/workers/transport/push/dependencies.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/dependencies.go
@@ -51,11 +51,7 @@ func NewPushDependencies(parentDeps *transport_pkg.TransportDependencies, identi
 	return &PushDependencies{
 		BaseDependencies: deps.NewBaseDependencies(logger, stateReader, identity),
 		parentDeps:       parentDeps,
-		failureRate: failurerate.New(failurerate.Config{
-			WindowSize: 600,
-			Threshold:  0.9,
-			MinSamples: 100,
-		}),
+		failureRate: failurerate.New(transport_pkg.ChildFailureRateConfig),
 	}, nil
 }
 
@@ -188,26 +184,30 @@ func (d *PushDependencies) GetResetGeneration() uint64 {
 }
 
 // CheckAndClearOnReset checks if parent has done a transport reset.
-// If resetGeneration changed, clears all pending messages and returns true.
+// If resetGeneration changed, clears all pending messages, resets the failure
+// rate tracker, and returns true.
 func (d *PushDependencies) CheckAndClearOnReset() bool {
 	currentGen := d.parentDeps.GetResetGeneration()
 
 	d.pendingMu.Lock()
-	defer d.pendingMu.Unlock()
 
-	if currentGen != d.lastSeenResetGeneration {
+	changed := currentGen != d.lastSeenResetGeneration
+	if changed {
 		d.pendingMessages = nil
 		d.lastSeenResetGeneration = currentGen
-		d.failureRate.Reset()
-
-		return true
 	}
 
-	return false
+	d.pendingMu.Unlock()
+
+	if changed {
+		d.failureRate.Reset()
+	}
+
+	return changed
 }
 
-// IsPersistentFailureEscalated reports whether the failure rate exceeds the
-// escalation threshold over the rolling window.
+// IsPersistentFailureEscalated reports whether the failure rate meets or exceeds
+// the escalation threshold over the rolling window.
 func (d *PushDependencies) IsPersistentFailureEscalated() bool {
 	return d.failureRate.IsEscalated()
 }

--- a/umh-core/pkg/fsmv2/workers/transport/push/state/state_degraded.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/state/state_degraded.go
@@ -35,7 +35,7 @@ func (s *DegradedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.Observed.IsStopRequired() {
 		return fsmv2.Result[any, any](&StoppingState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: shutdown=%t, parentState=%s", snap.Desired.IsShutdownRequested(), snap.Desired.ParentMappedState))
+			fmt.Sprintf("stop required: shutdown=%t, parentState=%s", snap.Desired.IsShutdownRequested(), snap.Observed.ParentMappedState))
 	}
 
 	if snap.Observed.ConsecutiveErrors == 0 {

--- a/umh-core/pkg/fsmv2/workers/transport/push/state/state_running.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/state/state_running.go
@@ -35,7 +35,7 @@ func (s *RunningState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.Observed.IsStopRequired() {
 		return fsmv2.Result[any, any](&StoppingState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: shutdown=%t, parentState=%s", snap.Desired.IsShutdownRequested(), snap.Desired.ParentMappedState))
+			fmt.Sprintf("stop required: shutdown=%t, parentState=%s", snap.Desired.IsShutdownRequested(), snap.Observed.ParentMappedState))
 	}
 
 	if snap.Observed.ConsecutiveErrors >= 3 {

--- a/umh-core/pkg/fsmv2/workers/transport/push/state/state_stopping.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/state/state_stopping.go
@@ -30,13 +30,10 @@ type StoppingState struct {
 func (s *StoppingState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := helpers.ConvertSnapshot[snapshot.PushObservedState, *snapshot.PushDesiredState](snapAny)
 
-	if snap.Observed.IsStopRequired() {
-		return fsmv2.Result[any, any](&StoppedState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: shutdown=%t, parentState=%s", snap.Desired.IsShutdownRequested(), snap.Desired.ParentMappedState))
-	}
-
-	return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil,
-		fmt.Sprintf("stopping, waiting for stop condition: shutdown=%t, parentState=%s", snap.Desired.IsShutdownRequested(), snap.Desired.ParentMappedState))
+	// Unconditional transition to Stopped. The decision to stop was already made
+	// on entry to StoppingState. StoppedState handles recovery via ShouldBeRunning().
+	return fsmv2.Result[any, any](&StoppedState{}, fsmv2.SignalNone, nil,
+		fmt.Sprintf("stop complete: shutdown=%t, parentState=%s", snap.Observed.IsShutdownRequested(), snap.Observed.ParentMappedState))
 }
 
 func (s *StoppingState) String() string {

--- a/umh-core/pkg/fsmv2/workers/transport/push/state/state_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/state/state_test.go
@@ -333,12 +333,30 @@ var _ = Describe("StoppingState", func() {
 		Expect(result.State).To(BeAssignableToTypeOf(&state.StoppedState{}))
 	})
 
-	It("should stay in Stopping when stop condition not yet met", func() {
+	It("should transition to Stopped unconditionally (ENG-4608)", func() {
 		snap := makeSnapshot(config.DesiredStateRunning, false, 0, true, true)
 		result := s.Next(snap)
-		Expect(result.State).To(BeAssignableToTypeOf(&state.StoppingState{}))
+		Expect(result.State).To(BeAssignableToTypeOf(&state.StoppedState{}))
 		Expect(result.Signal).To(Equal(fsmv2.SignalNone))
-		Expect(result.Reason).To(ContainSubstring("stopping"))
+		Expect(result.Reason).To(ContainSubstring("stop complete"))
+	})
+
+	It("ENG-4608: should not get stuck when parent recovers from Starting to Running", func() {
+		// Reproduction: transport parent temporarily enters Starting for token refresh,
+		// which maps to "stopped" for children. Push enters Stopping. Parent returns to
+		// Running, but push was permanently stuck in Stopping because IsStopRequired()
+		// returned false (parent is Running again, shutdown not requested).
+		// Fix: StoppingState always transitions to Stopped. StoppedState handles recovery.
+		snap := makeSnapshot(config.DesiredStateRunning, false, 0, true, true)
+		result := s.Next(snap)
+		Expect(result.State).To(BeAssignableToTypeOf(&state.StoppedState{}),
+			"StoppingState must not get stuck when parent recovers to Running")
+
+		// Verify that StoppedState recovers to Running
+		stopped := &state.StoppedState{}
+		result = stopped.Next(snap)
+		Expect(result.State).To(BeAssignableToTypeOf(&state.RunningState{}),
+			"StoppedState should recover to Running when ShouldBeRunning is true")
 	})
 
 	It("should return a valid String()", func() {

--- a/umh-core/pkg/fsmv2/workers/transport/state/state_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/state/state_test.go
@@ -474,20 +474,20 @@ var _ = Describe("TransportWorker States", func() {
 			Expect(result.State).To(BeAssignableToTypeOf(&state.StoppedState{}))
 		})
 
-		It("should stay Stopping when children still running", func() {
+		It("should transition to Stopped unconditionally even with children still running (ENG-4608)", func() {
 			snap := makeSnapshot(true, config.DesiredStateStopped, "", time.Time{}, 1, 0)
 			result := s.Next(snap)
 
 			Expect(result.Signal).To(Equal(fsmv2.SignalNone))
-			Expect(result.State).To(BeAssignableToTypeOf(&state.StoppingState{}))
+			Expect(result.State).To(BeAssignableToTypeOf(&state.StoppedState{}))
 		})
 
-		It("should stay Stopping when children unhealthy but not stopped", func() {
+		It("should transition to Stopped unconditionally even with unhealthy children (ENG-4608)", func() {
 			snap := makeSnapshot(true, config.DesiredStateStopped, "", time.Time{}, 0, 1)
 			result := s.Next(snap)
 
 			Expect(result.Signal).To(Equal(fsmv2.SignalNone))
-			Expect(result.State).To(BeAssignableToTypeOf(&state.StoppingState{}))
+			Expect(result.State).To(BeAssignableToTypeOf(&state.StoppedState{}))
 		})
 	})
 

--- a/umh-core/pkg/fsmv2/workers/transport/state/stopping.go
+++ b/umh-core/pkg/fsmv2/workers/transport/state/stopping.go
@@ -15,6 +15,8 @@
 package state
 
 import (
+	"fmt"
+
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/internal/helpers"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/snapshot"
@@ -33,12 +35,13 @@ func (s *StoppingState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	if snap.Desired.IsShutdownRequested() { //nolint:staticcheck // architecture invariant: shutdown check must be first conditional
 	}
 
-	// All children must be stopped before transitioning to Stopped
-	if snap.Observed.ChildrenHealthy == 0 && snap.Observed.ChildrenUnhealthy == 0 {
-		return fsmv2.Result[any, any](&StoppedState{}, fsmv2.SignalNone, nil, "All children stopped, transitioning to Stopped")
-	}
-
-	return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil, "Gracefully stopping all children")
+	// Unconditional transition to Stopped. The decision to stop was already made
+	// on entry to StoppingState. The supervisor handles child teardown independently.
+	// Previously, waiting for ChildrenHealthy==0 && ChildrenUnhealthy==0 caused a
+	// cascade deadlock when children were stuck in Stopping (ENG-4608).
+	return fsmv2.Result[any, any](&StoppedState{}, fsmv2.SignalNone, nil,
+		fmt.Sprintf("stop complete: children healthy=%d, unhealthy=%d",
+			snap.Observed.ChildrenHealthy, snap.Observed.ChildrenUnhealthy))
 }
 
 // String returns the state name derived from the type.


### PR DESCRIPTION
## Summary
- `sync-changelog.yml`: fetches GitHub release title via `gh release view`, passes as `--title`
- `update-github-release.yml`: replaces inline bold-bullet grep with `gh release view` for slug generation
- CLAUDE.md: added release title guidance for changelog.umh.app entries

**Part of a 3-repo fix** for the "Untitled" changelog entry bug. See changelog.umh.app PR for the script changes.

## Test plan
- [ ] Verify workflow YAML is valid (CI)
- [ ] Next umh-core release: create GitHub release with descriptive title, verify sync + release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)