### PR TITLE
fix: pass --title from GitHub release to sync-changelog

### DIFF
--- a/.github/workflows/sync-changelog.yml
+++ b/.github/workflows/sync-changelog.yml
@@ -29,6 +29,10 @@ on:
         description: 'Version to sync (e.g., v0.44.8). Required for workflow_dispatch.'
         required: false
         type: string
+      title:
+        description: 'Title for the changelog entry (5-10 words). If omitted for push triggers, fetched from the GitHub release.'
+        required: false
+        type: string
 
 jobs:
   sync:
@@ -53,6 +57,30 @@ jobs:
             fi
             echo "version=$INPUT_VERSION" >> $GITHUB_OUTPUT
           fi
+
+      - name: Get release title
+        id: release-title
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ github.ref_name }}
+          INPUT_TITLE: ${{ github.event.inputs.title }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          if [ -n "$INPUT_TITLE" ]; then
+            title="$INPUT_TITLE"
+          elif [ "$EVENT_NAME" = "push" ]; then
+            raw=$(gh release view "$TAG_NAME" --json name --jq '.name' 2>/dev/null || echo "")
+            # Strip version prefix: "v0.44.12 - Title" → "Title"
+            title=$(echo "$raw" | sed -E 's/^v?[0-9]+\.[0-9]+\.[0-9]+[[:space:]]*-[[:space:]]*//')
+            if [ "$title" = "$raw" ]; then
+              title="$raw"
+            fi
+          fi
+          if [ -z "$title" ]; then
+            echo "Error: No title found. Create a GitHub release with format 'v0.44.12 - Descriptive Title', or pass --title via workflow_dispatch."
+            exit 1
+          fi
+          echo "title=$title" >> $GITHUB_OUTPUT
 
       - name: Checkout umh-core
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -87,10 +115,12 @@ jobs:
         working-directory: changelog-app
         env:
           SYNC_VERSION: ${{ steps.version.outputs.version }}
+          SYNC_TITLE: ${{ steps.release-title.outputs.title }}
         run: |
           npx tsx .github/scripts/sync-changelog.ts \
             --repo umh-core \
             --version "$SYNC_VERSION" \
+            --title "$SYNC_TITLE" \
             --changelog-path ../umh-core/umh-core/CHANGELOG.md \
             --images-path ../umh-core/umh-core/changelog-images \
             --output-path public/changelog/entries

--- a/.github/workflows/update-github-release.yml
+++ b/.github/workflows/update-github-release.yml
@@ -64,7 +64,6 @@ jobs:
           # Fetch title from GitHub release (e.g., "v0.44.12 - Modbus Mapping" -> "Modbus Mapping")
           RAW_TITLE=$(gh release view "$VERSION" --json name --jq '.name' 2>/dev/null || echo "")
           TITLE=$(echo "$RAW_TITLE" | sed -E 's/^v?[0-9]+\.[0-9]+\.[0-9]+[[:space:]]*-[[:space:]]*//')
-          if [ "$TITLE" = "$RAW_TITLE" ]; then TITLE=""; fi
 
           if [ -n "$TITLE" ]; then
             # Generate slug (mirrors sync-changelog.ts generateSlug)

--- a/.github/workflows/update-github-release.yml
+++ b/.github/workflows/update-github-release.yml
@@ -45,6 +45,7 @@ jobs:
         id: changelog
         env:
           VERSION: ${{ inputs.version || github.ref_name }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           SEMVER="${VERSION#v}"
@@ -60,8 +61,10 @@ jobs:
 
           # IMPORTANT: Slug generation must match sync-changelog.ts generateSlug()
           # in the changelog.umh.app repo. If that function changes, update this too.
-          # Extract first bold title (mirrors sync-changelog.ts extractTitle)
-          TITLE=$(grep -m1 -oP '(?<=\*\*).+?(?=\*\*)' /tmp/release-body.md || echo "")
+          # Fetch title from GitHub release (e.g., "v0.44.12 - Modbus Mapping" -> "Modbus Mapping")
+          RAW_TITLE=$(gh release view "$VERSION" --json name --jq '.name' 2>/dev/null || echo "")
+          TITLE=$(echo "$RAW_TITLE" | sed -E 's/^v?[0-9]+\.[0-9]+\.[0-9]+[[:space:]]*-[[:space:]]*//')
+          if [ "$TITLE" = "$RAW_TITLE" ]; then TITLE=""; fi
 
           if [ -n "$TITLE" ]; then
             # Generate slug (mirrors sync-changelog.ts generateSlug)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,7 @@ Every PR with user-visible changes must add an entry to `umh-core/CHANGELOG.md` 
 - **Never create a new version section** — only add to the existing topmost `## [X.Y.Z]` section
 - **No trailing periods** on bullet points
 - On tag push, a sync workflow automatically creates entries in changelog.umh.app from CHANGELOG.md
+- **Release titles**: Use format `vX.Y.Z - Short Descriptive Title` (e.g., `v0.44.12 - Modbus Per-Slave Address Mapping`). The part after the dash becomes the changelog.umh.app entry title.
 - GitHub Release notes are automatically populated from CHANGELOG.md by the `update-github-release.yml` workflow (runs on tag push). The job extracts the version's section, transforms headers for standalone display, and appends a changelog.umh.app link. You can still edit the Release body manually after if needed.
 
 ## Support & Troubleshooting Workflows


### PR DESCRIPTION
## Summary
- `sync-changelog.yml`: fetches GitHub release title via `gh release view`, passes as `--title`
- `update-github-release.yml`: replaces inline bold-bullet grep with `gh release view` for slug generation
- CLAUDE.md: added release title guidance for changelog.umh.app entries

**Part of a 3-repo fix** for the "Untitled" changelog entry bug. See changelog.umh.app PR #43 (merged) for the script changes.

## Test plan
- [ ] Verify workflow YAML is valid (CI)
- [ ] Next umh-core release: create GitHub release with descriptive title, verify sync + release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)