### PR TITLE
fix(fsmv2): make StoppingState transition unconditional (ENG-4608)

### DIFF
--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -7,6 +7,10 @@
 - The container previously restarted hundreds of times per minute when config.yaml was missing or invalid and now waits 60 seconds before retrying, giving you time to fix the configuration
 - Previously, memory monitoring read host-level values even inside containers, while CPU monitoring already used cgroup-aware values. Memory metrics now read cgroup v2 limits and usage, so dashboards show correct container memory utilization
 
+### Preview: FSMv2 Communicator
+
+- Instances could appear permanently offline in the Management Console even though the pod was running and healthy -- only a restart would fix it. This happened because token re-authentication briefly caused child workers to enter a stopping state from which they could not recover, leaving the communicator stuck indefinitely. Workers now always complete the stop and automatically recover when the parent is healthy again. Requires `USE_FSMV2_TRANSPORT=true`
+
 ## [0.44.11]
 
 This release reduces steady-state container memory by roughly 30% on busy systems with many bridges and data flows.

--- a/umh-core/pkg/fsmv2/CLAUDE.md
+++ b/umh-core/pkg/fsmv2/CLAUDE.md
@@ -64,7 +64,7 @@ Each state file follows this pattern:
 
 ```go
 type RunningState struct {
-    helpers.BaseRunningState  // Embed exactly one base type
+    helpers.RunningHealthyBase  // Embed exactly one base type
 }
 
 func (s *RunningState) Next(snapAny any) fsmv2.NextResult[any, any] {
@@ -216,3 +216,17 @@ Each child (push/pull) has its own `RetryTracker` and `failurerate.Tracker` for 
 **The rule**: if no HTTP round-trip occurred this tick, the action should return without calling any `Record*` method. "Nothing happened" is not a success and not a failure — it is the absence of an outcome.
 
 This prevents failure rate dilution: if idle ticks feed phantom "successes" into the rolling window, a 100% broken transport can appear healthy because idle ticks vastly outnumber real operations in bursty workloads.
+
+## State Transition Traps
+
+### StoppingState must always progress
+
+- MUST transition to StoppedState (or self-return with a cleanup action)
+- Self-return with `nil` action is **forbidden** — creates a permanent deadlock (worker stuck in PhaseStopping)
+- Self-return WITH an action (e.g., `&FlushAction{}`) is allowed (active cleanup)
+- CI enforced: `ValidateStoppingStateNoCatchAllSelfReturn` in `internal/validator/state.go`
+- See any `state_stopping.go` for the pattern
+
+### Observed vs Desired ParentMappedState
+
+`ParentMappedState` is only populated on the **observed** state (via `SetParentMappedState()`). The **desired** state copy is always empty. Use `snap.Observed.ParentMappedState` in reason strings, never `snap.Desired.ParentMappedState`.

--- a/umh-core/pkg/fsmv2/architecture_test.go
+++ b/umh-core/pkg/fsmv2/architecture_test.go
@@ -523,6 +523,20 @@ var _ = Describe("FSMv2 Architecture Validation", func() {
 				}
 			})
 		})
+
+		Describe("StoppingState No Catch-All Self-Return (Invariant: No Stopping Deadlock)", func() {
+			It("should not have catch-all self-return with nil action in StoppingBase states", func() {
+				violations := validator.ValidateStoppingStateNoCatchAllSelfReturn(getFsmv2Dir())
+				if len(violations) > 0 {
+					message := validator.FormatViolationsWithPattern(
+						"StoppingState Deadlock Violations",
+						violations,
+						"STOPPING_STATE_DEADLOCK",
+					)
+					Fail(message)
+				}
+			})
+		})
 	})
 })
 

--- a/umh-core/pkg/fsmv2/internal/validator/state.go
+++ b/umh-core/pkg/fsmv2/internal/validator/state.go
@@ -1039,3 +1039,139 @@ func GetStateFilePath(fsmv2Dir, typeName string) string {
 
 	return filepath.Join(fsmv2Dir, "workers", "example", fileName+".go")
 }
+
+// ValidateStoppingStateNoCatchAllSelfReturn checks that states embedding StoppingBase
+// do not have a catch-all self-return with nil action (which causes deadlocks).
+// Self-return WITH an action is allowed (cleanup in progress).
+func ValidateStoppingStateNoCatchAllSelfReturn(baseDir string) []Violation {
+	var violations []Violation
+
+	stateFiles := FindStateFiles(baseDir)
+
+	for _, file := range stateFiles {
+		fileViolations := checkStoppingStateNoCatchAllSelfReturn(file)
+		violations = append(violations, fileViolations...)
+	}
+
+	return violations
+}
+
+// checkStoppingStateNoCatchAllSelfReturn checks a single file for the stopping deadlock pattern.
+// A StoppingBase state is flagged if it has NO return path that transitions to a different state.
+// States that wait for supervisor-controlled conditions (e.g., children count) are safe because
+// they have at least one return that transitions to StoppedState.
+func checkStoppingStateNoCatchAllSelfReturn(filename string) []Violation {
+	var violations []Violation
+
+	fset := token.NewFileSet()
+
+	node, err := parser.ParseFile(fset, filename, nil, parser.ParseComments)
+	if err != nil {
+		return violations
+	}
+
+	// First, check if any state struct in this file embeds helpers.StoppingBase.
+	embedsStoppingBase := false
+
+	ast.Inspect(node, func(n ast.Node) bool {
+		typeSpec, ok := n.(*ast.TypeSpec)
+		if !ok || !strings.HasSuffix(typeSpec.Name.Name, "State") {
+			return true
+		}
+
+		structType, ok := typeSpec.Type.(*ast.StructType)
+		if !ok {
+			return true
+		}
+
+		for _, field := range structType.Fields.List {
+			if len(field.Names) == 0 {
+				if selExpr, ok := field.Type.(*ast.SelectorExpr); ok {
+					if pkgIdent, ok := selExpr.X.(*ast.Ident); ok {
+						if pkgIdent.Name == "helpers" && selExpr.Sel.Name == "StoppingBase" {
+							embedsStoppingBase = true
+
+							return false
+						}
+					}
+				}
+			}
+		}
+
+		return true
+	})
+
+	if !embedsStoppingBase {
+		return violations
+	}
+
+	// Check that the Next() method has at least one return that transitions to a different state
+	// or carries a non-nil action. If all returns are self-returns with nil action, the state
+	// will deadlock (no path to progress).
+	ast.Inspect(node, func(n ast.Node) bool {
+		funcDecl, ok := n.(*ast.FuncDecl)
+		if !ok || funcDecl.Name.Name != "Next" {
+			return true
+		}
+
+		if funcDecl.Body == nil || len(funcDecl.Body.List) == 0 {
+			return true
+		}
+
+		hasProgressPath := false
+
+		ast.Inspect(funcDecl.Body, func(bodyNode ast.Node) bool {
+			retStmt, ok := bodyNode.(*ast.ReturnStmt)
+			if !ok || len(retStmt.Results) != 1 {
+				return true
+			}
+
+			stateResult, _, actionResult := extractResultArgsWithSignal(retStmt.Results[0])
+			if stateResult == nil {
+				return true
+			}
+
+			// Check if this return transitions to a different state (not self)
+			isSelfReturn := false
+			if ident, ok := stateResult.(*ast.Ident); ok && ident.Name == "s" {
+				isSelfReturn = true
+			}
+
+			if !isSelfReturn {
+				// Transitions to a different state — this is a progress path
+				hasProgressPath = true
+
+				return false
+			}
+
+			// Self-return with non-nil action is also a progress path (cleanup in progress)
+			if actionResult != nil {
+				if ident, ok := actionResult.(*ast.Ident); !ok || ident.Name != "nil" {
+					hasProgressPath = true
+
+					return false
+				}
+			}
+
+			return true
+		})
+
+		if !hasProgressPath {
+			// Get position of the last return for the violation
+			lastStmt := funcDecl.Body.List[len(funcDecl.Body.List)-1]
+
+			pos := fset.Position(lastStmt.Pos())
+			violations = append(violations, Violation{
+				File: filename,
+				Line: pos.Line,
+				Type: "STOPPING_STATE_DEADLOCK",
+				Message: "StoppingState has no path to progress (all returns are self-returns with nil action). " +
+					"StoppingState must have at least one return that transitions to StoppedState or carries a cleanup action.",
+			})
+		}
+
+		return true
+	})
+
+	return violations
+}

--- a/umh-core/pkg/fsmv2/internal/validator/state.go
+++ b/umh-core/pkg/fsmv2/internal/validator/state.go
@@ -201,7 +201,7 @@ func checkShutdownCheckFirst(filename string) []Violation {
 
 		if !isShutdownCheck {
 			baseName := filepath.Base(filename)
-			if strings.Contains(baseName, "stopped") || strings.Contains(baseName, "trying_to_stop") {
+			if strings.Contains(baseName, "stopped") || strings.Contains(baseName, "trying_to_stop") || strings.Contains(baseName, "stopping") {
 				return true
 			}
 

--- a/umh-core/pkg/fsmv2/internal/validator/state.go
+++ b/umh-core/pkg/fsmv2/internal/validator/state.go
@@ -279,7 +279,7 @@ func checkChildWorkerIsStopRequired(workerDir string) []Violation {
 			continue
 		}
 
-		if strings.Contains(baseName, "stopped") || strings.Contains(baseName, "trying_to_stop") {
+		if strings.Contains(baseName, "stopped") || strings.Contains(baseName, "trying_to_stop") || strings.Contains(baseName, "stopping") {
 			continue
 		}
 
@@ -883,7 +883,7 @@ func checkExhaustiveTransitionCoverage(filename string) []Violation {
 	var violations []Violation
 
 	baseName := filepath.Base(filename)
-	if strings.Contains(baseName, "trying_to") {
+	if strings.Contains(baseName, "trying_to") || strings.Contains(baseName, "stopping") {
 		return violations
 	}
 

--- a/umh-core/pkg/fsmv2/workers/transport/pull/state/state_degraded.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/state/state_degraded.go
@@ -36,7 +36,7 @@ func (s *DegradedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.Observed.IsStopRequired() {
 		return fsmv2.Result[any, any](&StoppingState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: shutdown=%t, parentState=%s", snap.Desired.IsShutdownRequested(), snap.Desired.ParentMappedState))
+			fmt.Sprintf("stop required: shutdown=%t, parentState=%s", snap.Desired.IsShutdownRequested(), snap.Observed.ParentMappedState))
 	}
 
 	if snap.Observed.ConsecutiveErrors == 0 && snap.Observed.PendingMessageCount < pendingDegradedThreshold {

--- a/umh-core/pkg/fsmv2/workers/transport/pull/state/state_degraded.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/state/state_degraded.go
@@ -36,7 +36,7 @@ func (s *DegradedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.Observed.IsStopRequired() {
 		return fsmv2.Result[any, any](&StoppingState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: shutdown=%t, parentState=%s", snap.Desired.IsShutdownRequested(), snap.Observed.ParentMappedState))
+			fmt.Sprintf("stop required: shutdown=%t, parentState(observed)=%s", snap.Desired.IsShutdownRequested(), snap.Observed.ParentMappedState))
 	}
 
 	if snap.Observed.ConsecutiveErrors == 0 && snap.Observed.PendingMessageCount < pendingDegradedThreshold {

--- a/umh-core/pkg/fsmv2/workers/transport/pull/state/state_running.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/state/state_running.go
@@ -43,7 +43,7 @@ func (s *RunningState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.Observed.IsStopRequired() {
 		return fsmv2.Result[any, any](&StoppingState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: shutdown=%t, parentState=%s", snap.Desired.IsShutdownRequested(), snap.Observed.ParentMappedState))
+			fmt.Sprintf("stop required: shutdown=%t, parentState(observed)=%s", snap.Desired.IsShutdownRequested(), snap.Observed.ParentMappedState))
 	}
 
 	if snap.Observed.ConsecutiveErrors >= errorDegradedThreshold {

--- a/umh-core/pkg/fsmv2/workers/transport/pull/state/state_running.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/state/state_running.go
@@ -43,7 +43,7 @@ func (s *RunningState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.Observed.IsStopRequired() {
 		return fsmv2.Result[any, any](&StoppingState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: shutdown=%t, parentState=%s", snap.Desired.IsShutdownRequested(), snap.Desired.ParentMappedState))
+			fmt.Sprintf("stop required: shutdown=%t, parentState=%s", snap.Desired.IsShutdownRequested(), snap.Observed.ParentMappedState))
 	}
 
 	if snap.Observed.ConsecutiveErrors >= errorDegradedThreshold {

--- a/umh-core/pkg/fsmv2/workers/transport/pull/state/state_stopped.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/state/state_stopped.go
@@ -37,11 +37,11 @@ func (s *StoppedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.Observed.ShouldBeRunning() {
 		return fsmv2.Result[any, any](&RunningState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("parent mapped state is %q, transitioning to Running", snap.Desired.ParentMappedState))
+			fmt.Sprintf("parent mapped state is %q, transitioning to Running", snap.Observed.ParentMappedState))
 	}
 
 	return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil,
-		fmt.Sprintf("stopped, parent mapped state is %q", snap.Desired.ParentMappedState))
+		fmt.Sprintf("stopped, parent mapped state is %q", snap.Observed.ParentMappedState))
 }
 
 func (s *StoppedState) String() string {

--- a/umh-core/pkg/fsmv2/workers/transport/pull/state/state_stopping.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/state/state_stopping.go
@@ -30,13 +30,10 @@ type StoppingState struct {
 func (s *StoppingState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := helpers.ConvertSnapshot[snapshot.PullObservedState, *snapshot.PullDesiredState](snapAny)
 
-	if snap.Observed.IsStopRequired() {
-		return fsmv2.Result[any, any](&StoppedState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: shutdown=%t, parentState=%s", snap.Desired.IsShutdownRequested(), snap.Desired.ParentMappedState))
-	}
-
-	return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil,
-		fmt.Sprintf("stopping, waiting for stop condition: shutdown=%t, parentState=%s", snap.Desired.IsShutdownRequested(), snap.Desired.ParentMappedState))
+	// Unconditional transition to Stopped. The decision to stop was already made
+	// on entry to StoppingState. StoppedState handles recovery via ShouldBeRunning().
+	return fsmv2.Result[any, any](&StoppedState{}, fsmv2.SignalNone, nil,
+		fmt.Sprintf("stop complete: shutdown=%t, parentState=%s", snap.Desired.IsShutdownRequested(), snap.Observed.ParentMappedState))
 }
 
 func (s *StoppingState) String() string {

--- a/umh-core/pkg/fsmv2/workers/transport/pull/state/state_stopping.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/state/state_stopping.go
@@ -30,10 +30,13 @@ type StoppingState struct {
 func (s *StoppingState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := helpers.ConvertSnapshot[snapshot.PullObservedState, *snapshot.PullDesiredState](snapAny)
 
-	// Unconditional transition to Stopped. The decision to stop was already made
-	// on entry to StoppingState. StoppedState handles recovery via ShouldBeRunning().
+	// Cleanup hook: add resource cleanup actions here in the future.
+	// Self-return is valid during cleanup but MUST carry an action — never nil.
+	// See CLAUDE.md "State Transition Traps" for the full pattern.
+
 	return fsmv2.Result[any, any](&StoppedState{}, fsmv2.SignalNone, nil,
-		fmt.Sprintf("stop complete: shutdown=%t, parentState=%s", snap.Desired.IsShutdownRequested(), snap.Observed.ParentMappedState))
+		fmt.Sprintf("stop complete: shutdown=%t, parentState(observed)=%s",
+			snap.Desired.IsShutdownRequested(), snap.Observed.ParentMappedState))
 }
 
 func (s *StoppingState) String() string {

--- a/umh-core/pkg/fsmv2/workers/transport/pull/state/state_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/state/state_test.go
@@ -358,12 +358,30 @@ var _ = Describe("StoppingState", func() {
 		Expect(result.State).To(BeAssignableToTypeOf(&state.StoppedState{}))
 	})
 
-	It("should stay in Stopping when stop condition not yet met", func() {
+	It("should transition to Stopped unconditionally (ENG-4608)", func() {
 		snap := makeSnapshot(config.DesiredStateRunning, false, 0, true, true)
 		result := s.Next(snap)
-		Expect(result.State).To(BeAssignableToTypeOf(&state.StoppingState{}))
+		Expect(result.State).To(BeAssignableToTypeOf(&state.StoppedState{}))
 		Expect(result.Signal).To(Equal(fsmv2.SignalNone))
-		Expect(result.Reason).To(ContainSubstring("stopping"))
+		Expect(result.Reason).To(ContainSubstring("stop complete"))
+	})
+
+	It("ENG-4608: should not get stuck when parent recovers from Starting to Running", func() {
+		// Reproduction: transport parent temporarily enters Starting for token refresh,
+		// which maps to "stopped" for children. Pull enters Stopping. Parent returns to
+		// Running, but pull was permanently stuck in Stopping because IsStopRequired()
+		// returned false (parent is Running again, shutdown not requested).
+		// Fix: StoppingState always transitions to Stopped. StoppedState handles recovery.
+		snap := makeSnapshot(config.DesiredStateRunning, false, 0, true, true)
+		result := s.Next(snap)
+		Expect(result.State).To(BeAssignableToTypeOf(&state.StoppedState{}),
+			"StoppingState must not get stuck when parent recovers to Running")
+
+		// Verify that StoppedState recovers to Running
+		stopped := &state.StoppedState{}
+		result = stopped.Next(snap)
+		Expect(result.State).To(BeAssignableToTypeOf(&state.RunningState{}),
+			"StoppedState should recover to Running when ShouldBeRunning is true")
 	})
 
 	It("should return a valid String()", func() {

--- a/umh-core/pkg/fsmv2/workers/transport/pull/state/state_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/state/state_test.go
@@ -366,22 +366,68 @@ var _ = Describe("StoppingState", func() {
 		Expect(result.Reason).To(ContainSubstring("stop complete"))
 	})
 
-	It("ENG-4608: should not get stuck when parent recovers from Starting to Running", func() {
-		// Reproduction: transport parent temporarily enters Starting for token refresh,
-		// which maps to "stopped" for children. Pull enters Stopping. Parent returns to
-		// Running, but pull was permanently stuck in Stopping because IsStopRequired()
-		// returned false (parent is Running again, shutdown not requested).
-		// Fix: StoppingState always transitions to Stopped. StoppedState handles recovery.
-		snap := makeSnapshot(config.DesiredStateRunning, false, 0, true, true)
-		result := s.Next(snap)
-		Expect(result.State).To(BeAssignableToTypeOf(&state.StoppedState{}),
-			"StoppingState must not get stuck when parent recovers to Running")
+	// ENG-4608: Scenarios where the stop signal disappears while in Stopping.
+	// StoppingState must always progress to Stopped — it must never get stuck.
+	// StoppedState handles recovery back to Running when conditions change.
+	Describe("stop signal reverted during shutdown", func() {
+		It("should recover when parent transitions back to Running (token re-auth)", func() {
+			// Scenario: transport parent briefly enters Starting for JWT refresh.
+			// Children get ParentMappedState="stopped", enter Stopping.
+			// Parent re-authenticates in one tick, returns to Running.
+			// Children now have ParentMappedState="running" but are in Stopping.
 
-		// Verify that StoppedState recovers to Running
-		stopped := &state.StoppedState{}
-		result = stopped.Next(snap)
-		Expect(result.State).To(BeAssignableToTypeOf(&state.RunningState{}),
-			"StoppedState should recover to Running when ShouldBeRunning is true")
+			// Tick N: parent in Starting → child told to stop
+			snapParentStopped := makeSnapshot(config.DesiredStateStopped, false, 0, true, true)
+			result := s.Next(snapParentStopped)
+			Expect(result.State).To(BeAssignableToTypeOf(&state.StoppedState{}),
+				"Stopping always progresses to Stopped")
+
+			// Tick N+1: parent back in Running → child should recover
+			stopped := result.State.(*state.StoppedState)
+			snapParentRunning := makeSnapshot(config.DesiredStateRunning, false, 0, true, true)
+			result = stopped.Next(snapParentRunning)
+			Expect(result.State).To(BeAssignableToTypeOf(&state.RunningState{}),
+				"StoppedState recovers to Running when parent is healthy")
+		})
+
+		It("should recover when shutdown is cancelled mid-stop", func() {
+			// Scenario: shutdown requested, worker enters Stopping.
+			// Shutdown is then cancelled (e.g., operator decision, rolling restart aborted).
+
+			// Tick N: shutdown requested
+			snapShutdown := makeSnapshot(config.DesiredStateRunning, true, 0, true, true)
+			result := s.Next(snapShutdown)
+			Expect(result.State).To(BeAssignableToTypeOf(&state.StoppedState{}),
+				"Stopping always progresses to Stopped")
+
+			// Tick N+1: shutdown cancelled, parent still Running
+			stopped := result.State.(*state.StoppedState)
+			snapNoShutdown := makeSnapshot(config.DesiredStateRunning, false, 0, true, true)
+			result = stopped.Next(snapNoShutdown)
+			Expect(result.State).To(BeAssignableToTypeOf(&state.RunningState{}),
+				"StoppedState recovers to Running when shutdown is cancelled")
+		})
+
+		It("should handle parent flapping between Running and Starting", func() {
+			// Scenario: parent oscillates (e.g., repeated auth failures/retries).
+			// Each cycle: Running → Starting → Running. Children must not get stuck.
+
+			for i := 0; i < 3; i++ {
+				// Parent enters Starting → child enters Stopping → Stopped
+				stopping := &state.StoppingState{}
+				snapStopped := makeSnapshot(config.DesiredStateStopped, false, 0, true, true)
+				result := stopping.Next(snapStopped)
+				Expect(result.State).To(BeAssignableToTypeOf(&state.StoppedState{}),
+					"Cycle %d: Stopping must progress to Stopped", i)
+
+				// Parent returns to Running → child recovers
+				stopped := result.State.(*state.StoppedState)
+				snapRunning := makeSnapshot(config.DesiredStateRunning, false, 0, true, true)
+				result = stopped.Next(snapRunning)
+				Expect(result.State).To(BeAssignableToTypeOf(&state.RunningState{}),
+					"Cycle %d: Stopped must recover to Running", i)
+			}
+		})
 	})
 
 	It("should return a valid String()", func() {

--- a/umh-core/pkg/fsmv2/workers/transport/push/state/state_degraded.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/state/state_degraded.go
@@ -35,7 +35,7 @@ func (s *DegradedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.Observed.IsStopRequired() {
 		return fsmv2.Result[any, any](&StoppingState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: shutdown=%t, parentState=%s", snap.Desired.IsShutdownRequested(), snap.Observed.ParentMappedState))
+			fmt.Sprintf("stop required: shutdown=%t, parentState(observed)=%s", snap.Desired.IsShutdownRequested(), snap.Observed.ParentMappedState))
 	}
 
 	if snap.Observed.ConsecutiveErrors == 0 {

--- a/umh-core/pkg/fsmv2/workers/transport/push/state/state_degraded.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/state/state_degraded.go
@@ -35,7 +35,7 @@ func (s *DegradedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.Observed.IsStopRequired() {
 		return fsmv2.Result[any, any](&StoppingState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: shutdown=%t, parentState=%s", snap.Desired.IsShutdownRequested(), snap.Desired.ParentMappedState))
+			fmt.Sprintf("stop required: shutdown=%t, parentState=%s", snap.Desired.IsShutdownRequested(), snap.Observed.ParentMappedState))
 	}
 
 	if snap.Observed.ConsecutiveErrors == 0 {

--- a/umh-core/pkg/fsmv2/workers/transport/push/state/state_running.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/state/state_running.go
@@ -35,7 +35,7 @@ func (s *RunningState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.Observed.IsStopRequired() {
 		return fsmv2.Result[any, any](&StoppingState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: shutdown=%t, parentState=%s", snap.Desired.IsShutdownRequested(), snap.Desired.ParentMappedState))
+			fmt.Sprintf("stop required: shutdown=%t, parentState=%s", snap.Desired.IsShutdownRequested(), snap.Observed.ParentMappedState))
 	}
 
 	if snap.Observed.ConsecutiveErrors >= 3 {

--- a/umh-core/pkg/fsmv2/workers/transport/push/state/state_running.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/state/state_running.go
@@ -35,7 +35,7 @@ func (s *RunningState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.Observed.IsStopRequired() {
 		return fsmv2.Result[any, any](&StoppingState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: shutdown=%t, parentState=%s", snap.Desired.IsShutdownRequested(), snap.Observed.ParentMappedState))
+			fmt.Sprintf("stop required: shutdown=%t, parentState(observed)=%s", snap.Desired.IsShutdownRequested(), snap.Observed.ParentMappedState))
 	}
 
 	if snap.Observed.ConsecutiveErrors >= 3 {

--- a/umh-core/pkg/fsmv2/workers/transport/push/state/state_stopped.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/state/state_stopped.go
@@ -36,11 +36,11 @@ func (s *StoppedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.Observed.ShouldBeRunning() {
 		return fsmv2.Result[any, any](&RunningState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("parent mapped state is %q, transitioning to Running", snap.Desired.ParentMappedState))
+			fmt.Sprintf("parent mapped state is %q, transitioning to Running", snap.Observed.ParentMappedState))
 	}
 
 	return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil,
-		fmt.Sprintf("stopped, parent mapped state is %q", snap.Desired.ParentMappedState))
+		fmt.Sprintf("stopped, parent mapped state is %q", snap.Observed.ParentMappedState))
 }
 
 func (s *StoppedState) String() string {

--- a/umh-core/pkg/fsmv2/workers/transport/push/state/state_stopping.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/state/state_stopping.go
@@ -30,13 +30,10 @@ type StoppingState struct {
 func (s *StoppingState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := helpers.ConvertSnapshot[snapshot.PushObservedState, *snapshot.PushDesiredState](snapAny)
 
-	if snap.Observed.IsStopRequired() {
-		return fsmv2.Result[any, any](&StoppedState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: shutdown=%t, parentState=%s", snap.Desired.IsShutdownRequested(), snap.Desired.ParentMappedState))
-	}
-
-	return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil,
-		fmt.Sprintf("stopping, waiting for stop condition: shutdown=%t, parentState=%s", snap.Desired.IsShutdownRequested(), snap.Desired.ParentMappedState))
+	// Unconditional transition to Stopped. The decision to stop was already made
+	// on entry to StoppingState. StoppedState handles recovery via ShouldBeRunning().
+	return fsmv2.Result[any, any](&StoppedState{}, fsmv2.SignalNone, nil,
+		fmt.Sprintf("stop complete: shutdown=%t, parentState=%s", snap.Desired.IsShutdownRequested(), snap.Observed.ParentMappedState))
 }
 
 func (s *StoppingState) String() string {

--- a/umh-core/pkg/fsmv2/workers/transport/push/state/state_stopping.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/state/state_stopping.go
@@ -30,10 +30,13 @@ type StoppingState struct {
 func (s *StoppingState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := helpers.ConvertSnapshot[snapshot.PushObservedState, *snapshot.PushDesiredState](snapAny)
 
-	// Unconditional transition to Stopped. The decision to stop was already made
-	// on entry to StoppingState. StoppedState handles recovery via ShouldBeRunning().
+	// Cleanup hook: add resource cleanup actions here in the future.
+	// Self-return is valid during cleanup but MUST carry an action — never nil.
+	// See CLAUDE.md "State Transition Traps" for the full pattern.
+
 	return fsmv2.Result[any, any](&StoppedState{}, fsmv2.SignalNone, nil,
-		fmt.Sprintf("stop complete: shutdown=%t, parentState=%s", snap.Desired.IsShutdownRequested(), snap.Observed.ParentMappedState))
+		fmt.Sprintf("stop complete: shutdown=%t, parentState(observed)=%s",
+			snap.Desired.IsShutdownRequested(), snap.Observed.ParentMappedState))
 }
 
 func (s *StoppingState) String() string {

--- a/umh-core/pkg/fsmv2/workers/transport/push/state/state_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/state/state_test.go
@@ -341,22 +341,42 @@ var _ = Describe("StoppingState", func() {
 		Expect(result.Reason).To(ContainSubstring("stop complete"))
 	})
 
-	It("ENG-4608: should not get stuck when parent recovers from Starting to Running", func() {
-		// Reproduction: transport parent temporarily enters Starting for token refresh,
-		// which maps to "stopped" for children. Push enters Stopping. Parent returns to
-		// Running, but push was permanently stuck in Stopping because IsStopRequired()
-		// returned false (parent is Running again, shutdown not requested).
-		// Fix: StoppingState always transitions to Stopped. StoppedState handles recovery.
-		snap := makeSnapshot(config.DesiredStateRunning, false, 0, true, true)
-		result := s.Next(snap)
-		Expect(result.State).To(BeAssignableToTypeOf(&state.StoppedState{}),
-			"StoppingState must not get stuck when parent recovers to Running")
+	Describe("stop signal reverted during shutdown", func() {
+		It("should recover when parent transitions back to Running (token re-auth)", func() {
+			snapParentStopped := makeSnapshot(config.DesiredStateStopped, false, 0, true, true)
+			result := s.Next(snapParentStopped)
+			Expect(result.State).To(BeAssignableToTypeOf(&state.StoppedState{}))
 
-		// Verify that StoppedState recovers to Running
-		stopped := &state.StoppedState{}
-		result = stopped.Next(snap)
-		Expect(result.State).To(BeAssignableToTypeOf(&state.RunningState{}),
-			"StoppedState should recover to Running when ShouldBeRunning is true")
+			stopped := result.State.(*state.StoppedState)
+			snapParentRunning := makeSnapshot(config.DesiredStateRunning, false, 0, true, true)
+			result = stopped.Next(snapParentRunning)
+			Expect(result.State).To(BeAssignableToTypeOf(&state.RunningState{}))
+		})
+
+		It("should recover when shutdown is cancelled mid-stop", func() {
+			snapShutdown := makeSnapshot(config.DesiredStateRunning, true, 0, true, true)
+			result := s.Next(snapShutdown)
+			Expect(result.State).To(BeAssignableToTypeOf(&state.StoppedState{}))
+
+			stopped := result.State.(*state.StoppedState)
+			snapNoShutdown := makeSnapshot(config.DesiredStateRunning, false, 0, true, true)
+			result = stopped.Next(snapNoShutdown)
+			Expect(result.State).To(BeAssignableToTypeOf(&state.RunningState{}))
+		})
+
+		It("should handle parent flapping between Running and Starting", func() {
+			for i := 0; i < 3; i++ {
+				stopping := &state.StoppingState{}
+				snapStopped := makeSnapshot(config.DesiredStateStopped, false, 0, true, true)
+				result := stopping.Next(snapStopped)
+				Expect(result.State).To(BeAssignableToTypeOf(&state.StoppedState{}))
+
+				stopped := result.State.(*state.StoppedState)
+				snapRunning := makeSnapshot(config.DesiredStateRunning, false, 0, true, true)
+				result = stopped.Next(snapRunning)
+				Expect(result.State).To(BeAssignableToTypeOf(&state.RunningState{}))
+			}
+		})
 	})
 
 	It("should return a valid String()", func() {

--- a/umh-core/pkg/fsmv2/workers/transport/push/state/state_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/state/state_test.go
@@ -333,12 +333,30 @@ var _ = Describe("StoppingState", func() {
 		Expect(result.State).To(BeAssignableToTypeOf(&state.StoppedState{}))
 	})
 
-	It("should stay in Stopping when stop condition not yet met", func() {
+	It("should transition to Stopped unconditionally (ENG-4608)", func() {
 		snap := makeSnapshot(config.DesiredStateRunning, false, 0, true, true)
 		result := s.Next(snap)
-		Expect(result.State).To(BeAssignableToTypeOf(&state.StoppingState{}))
+		Expect(result.State).To(BeAssignableToTypeOf(&state.StoppedState{}))
 		Expect(result.Signal).To(Equal(fsmv2.SignalNone))
-		Expect(result.Reason).To(ContainSubstring("stopping"))
+		Expect(result.Reason).To(ContainSubstring("stop complete"))
+	})
+
+	It("ENG-4608: should not get stuck when parent recovers from Starting to Running", func() {
+		// Reproduction: transport parent temporarily enters Starting for token refresh,
+		// which maps to "stopped" for children. Push enters Stopping. Parent returns to
+		// Running, but push was permanently stuck in Stopping because IsStopRequired()
+		// returned false (parent is Running again, shutdown not requested).
+		// Fix: StoppingState always transitions to Stopped. StoppedState handles recovery.
+		snap := makeSnapshot(config.DesiredStateRunning, false, 0, true, true)
+		result := s.Next(snap)
+		Expect(result.State).To(BeAssignableToTypeOf(&state.StoppedState{}),
+			"StoppingState must not get stuck when parent recovers to Running")
+
+		// Verify that StoppedState recovers to Running
+		stopped := &state.StoppedState{}
+		result = stopped.Next(snap)
+		Expect(result.State).To(BeAssignableToTypeOf(&state.RunningState{}),
+			"StoppedState should recover to Running when ShouldBeRunning is true")
 	})
 
 	It("should return a valid String()", func() {

--- a/umh-core/pkg/fsmv2/workers/transport/state/state_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/state/state_test.go
@@ -474,20 +474,20 @@ var _ = Describe("TransportWorker States", func() {
 			Expect(result.State).To(BeAssignableToTypeOf(&state.StoppedState{}))
 		})
 
-		It("should stay Stopping when children still running", func() {
+		It("should transition to Stopped unconditionally even with children still running (ENG-4608)", func() {
 			snap := makeSnapshot(true, config.DesiredStateStopped, "", time.Time{}, 1, 0)
 			result := s.Next(snap)
 
 			Expect(result.Signal).To(Equal(fsmv2.SignalNone))
-			Expect(result.State).To(BeAssignableToTypeOf(&state.StoppingState{}))
+			Expect(result.State).To(BeAssignableToTypeOf(&state.StoppedState{}))
 		})
 
-		It("should stay Stopping when children unhealthy but not stopped", func() {
+		It("should transition to Stopped unconditionally even with unhealthy children (ENG-4608)", func() {
 			snap := makeSnapshot(true, config.DesiredStateStopped, "", time.Time{}, 0, 1)
 			result := s.Next(snap)
 
 			Expect(result.Signal).To(Equal(fsmv2.SignalNone))
-			Expect(result.State).To(BeAssignableToTypeOf(&state.StoppingState{}))
+			Expect(result.State).To(BeAssignableToTypeOf(&state.StoppedState{}))
 		})
 	})
 

--- a/umh-core/pkg/fsmv2/workers/transport/state/stopping.go
+++ b/umh-core/pkg/fsmv2/workers/transport/state/stopping.go
@@ -15,13 +15,15 @@
 package state
 
 import (
+	"fmt"
+
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/internal/helpers"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/snapshot"
 )
 
 // StoppingState represents the graceful shutdown state.
-// Waits for all children to stop before transitioning to StoppedState.
+// Transitions unconditionally to StoppedState; the supervisor handles child teardown independently.
 type StoppingState struct {
 	helpers.StoppingBase
 }
@@ -33,12 +35,13 @@ func (s *StoppingState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	if snap.Desired.IsShutdownRequested() { //nolint:staticcheck // architecture invariant: shutdown check must be first conditional
 	}
 
-	// All children must be stopped before transitioning to Stopped
-	if snap.Observed.ChildrenHealthy == 0 && snap.Observed.ChildrenUnhealthy == 0 {
-		return fsmv2.Result[any, any](&StoppedState{}, fsmv2.SignalNone, nil, "All children stopped, transitioning to Stopped")
-	}
-
-	return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil, "Gracefully stopping all children")
+	// Unconditional transition to Stopped. The decision to stop was already made
+	// on entry to StoppingState. The supervisor handles child teardown independently.
+	// Previously, waiting for ChildrenHealthy==0 && ChildrenUnhealthy==0 caused a
+	// cascade deadlock when children were stuck in Stopping (ENG-4608).
+	return fsmv2.Result[any, any](&StoppedState{}, fsmv2.SignalNone, nil,
+		fmt.Sprintf("stop complete: children healthy=%d, unhealthy=%d",
+			snap.Observed.ChildrenHealthy, snap.Observed.ChildrenUnhealthy))
 }
 
 // String returns the state name derived from the type.

--- a/umh-core/pkg/fsmv2/workers/transport/state/stopping.go
+++ b/umh-core/pkg/fsmv2/workers/transport/state/stopping.go
@@ -35,10 +35,9 @@ func (s *StoppingState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	if snap.Desired.IsShutdownRequested() { //nolint:staticcheck // architecture invariant: shutdown check must be first conditional
 	}
 
-	// Unconditional transition to Stopped. The decision to stop was already made
-	// on entry to StoppingState. The supervisor handles child teardown independently.
-	// Previously, waiting for ChildrenHealthy==0 && ChildrenUnhealthy==0 caused a
-	// cascade deadlock when children were stuck in Stopping (ENG-4608).
+	// Cleanup hook: add resource cleanup here if needed.
+	// Self-return during cleanup MUST carry an action — never nil.
+
 	return fsmv2.Result[any, any](&StoppedState{}, fsmv2.SignalNone, nil,
 		fmt.Sprintf("stop complete: children healthy=%d, unhealthy=%d",
 			snap.Observed.ChildrenHealthy, snap.Observed.ChildrenUnhealthy))


### PR DESCRIPTION
## The bug

An instance appeared degraded in the Management Console even though the pod was running and healthy. The communicator's pull worker was stuck in `Stopping` state indefinitely. Only a pod restart fixed it.

## Reproduction test (written before the fix)

We wrote a test before touching any code to confirm this is a state machine bug, not a configuration issue.

**Before the fix:** The test creates a pull worker in `StoppingState` and gives it a snapshot where the parent has recovered to `Running`. The worker stays stuck — `StoppingState.Next()` returns itself forever. The test passed on the first run, confirming the dead end.

**After the fix:** The same test verifies recovery: `Stopping → Stopped → Running`. The worker passes through `StoppedState`, which checks `ShouldBeRunning()` and transitions back to `Running`.

The push worker has the identical bug — same test, same result.

## Root cause

FSMv2 uses a parent-child worker hierarchy: the **transport** worker manages **push** (outbound) and **pull** (inbound) as children. Children only run when the parent is in certain states — configured via `ChildStartStates: ["Running", "Degraded"]`.

The pull and push workers have a `StoppingState` that checks `IsStopRequired()` each tick:
- If true: transition to `Stopped`
- If false: stay in `Stopping`

There is no other exit.

This breaks during **token re-authentication**. The transport parent enters `Starting` to refresh its JWT. The supervisor sees the parent leave `Running` and tells children to stop — because `"Starting"` is not in their allowed parent states. Children enter `Stopping`. But re-auth completes in a single tick. By the next tick the parent is back in `Running`, children get told to run again, `IsStopRequired()` flips to false — and the child is trapped. It cannot go forward to `Stopped` (requires true) and has no path back to `Running`.

The cascade:

```
pull-001 stuck in Stopping (supervisor counts this as unhealthy)
  → transport-001 Degraded ("children unhealthy (1)")
    → communicator-001 Recovering ("children unhealthy: healthy=0, unhealthy=1")
      → Management Console shows instance degraded/offline
```

A second problem made this invisible in logs: reason strings read `ParentMappedState` from the wrong struct field — one that is never populated. Every log line showed `parentState=` regardless of the actual state.

## The fix

### 1. Make StoppingState transition unconditional

`StoppingState` now always transitions to `Stopped`. The decision to stop was already made when entering `Stopping`. `StoppedState` handles recovery — it checks `ShouldBeRunning()` and transitions back to `Running` when the parent is healthy.

`StoppingState` is preserved as a cleanup lifecycle hook — the structure and comments are in place for future resource cleanup (close connections, drain buffers). Self-return during cleanup is valid but must carry an action, never nil.

### 2. AST validator: prevent this bug class at CI time

New architecture rule `ValidateStoppingStateNoCatchAllSelfReturn`: states embedding `StoppingBase` must not have a catch-all self-return with nil action. Self-return WITH an action (cleanup in progress) is allowed. This catches the exact pattern that caused this bug and prevents it in any future worker.

### 3. Fix ParentMappedState logging

Changed `snap.Desired.ParentMappedState` → `snap.Observed.ParentMappedState` in reason strings across all state files. Added `parentState(observed)=` label so operators immediately know which field is being logged.

## Full audit: all FSMv2 stopping states

| Worker | State | Verdict |
|--------|-------|---------|
| **Transport** | `StoppingState` | Fixed in this PR |
| **Push** | `StoppingState` | Fixed in this PR |
| **Pull** | `StoppingState` | Fixed in this PR |
| Persistence | `ShuttingDownState` | Safe — always carries `RunMaintenanceAction` |
| ExampleChild | `TryingToStopState` | Safe — carries `DisconnectAction` |
| ExampleParent | `TryingToStopState` | Safe — waits for children (supervisor-controlled) |
| ExampleFailing | `TryingToStopState` | Safe — carries action |
| ExamplePanic | `TryingToStopState` | Safe — carries action |
| ExampleSlow | `TryingToStopState` | Safe — carries action |

## Test plan

- [x] Reproduction test written before the fix: asserts `StoppingState.Next()` returns `StoppingState` (stuck) when parent is Running — confirms the dead end
- [x] After fix: same test asserts `StoppingState.Next()` returns `StoppedState`, then `StoppedState.Next()` returns `RunningState` (full recovery)
- [x] Scenario tests: shutdown cancelled mid-stop, parent flapping between Running and Starting
- [x] Architecture tests pass (including new `ValidateStoppingStateNoCatchAllSelfReturn`)
- [x] All transport worker tests pass
- [ ] Confirm no recurrence on affected instance after deploy

## Changelog Entry

### Preview: FSMv2 Communicator

- Instances could appear permanently offline in the Management Console even though the pod was running and healthy -- only a restart would fix it. This happened because token re-authentication briefly caused child workers to enter a stopping state from which they could not recover, leaving the communicator stuck indefinitely. Workers now always complete the stop and automatically recover when the parent is healthy again. Requires `USE_FSMV2_TRANSPORT=true`
