### PR TITLE
docs: add GitBook editing reference to docs/CLAUDE.md

### DIFF
--- a/umh-core/docs/CLAUDE.md
+++ b/umh-core/docs/CLAUDE.md
@@ -1,5 +1,19 @@
 # Documentation Guidelines
 
-## GitBook Navigation
+Full GitBook editing reference (syntax, blocks, variables): <https://gitbook.com/docs/skill.md>
 
-When adding new documentation pages, you must add them to `SUMMARY.md` for them to appear in GitBook navigation.
+## File Structure
+
+```
+docs/
+  .gitbook.yaml    # Space config (root, structure, redirects)
+  SUMMARY.md       # Navigation — all pages MUST be listed here
+  README.md        # Homepage
+```
+
+## Rules
+
+- Every new page must be added to `SUMMARY.md`
+- Do not reference the same file twice in `SUMMARY.md`
+- Always close custom block tags (`{% endtabs %}`, `{% endhint %}`, etc.)
+- Keep file paths consistent between `SUMMARY.md` and actual locations

--- a/umh-core/docs/CLAUDE.md
+++ b/umh-core/docs/CLAUDE.md
@@ -4,7 +4,7 @@ Full GitBook editing reference (syntax, blocks, variables): <https://gitbook.com
 
 ## File Structure
 
-```
+```text
 docs/
   .gitbook.yaml    # Space config (root, structure, redirects)
   SUMMARY.md       # Navigation — all pages MUST be listed here


### PR DESCRIPTION
## Summary

- Links GitBook's editing skill (`https://gitbook.com/docs/skill.md`) in `umh-core/docs/CLAUDE.md`
- Adds file structure overview and UMH-specific documentation rules
- Enables both Claude Code (inline context) and CodeRabbit (fetchable URL) to know GitBook syntax when editing docs

Found while reviewing [ENG-4239](https://linear.app/united-manufacturing-hub/issue/ENG-4239) (GitBook embedding workstream).

Closes [ENG-4629](https://linear.app/united-manufacturing-hub/issue/ENG-4629)

## Test plan

- [ ] Verify `https://gitbook.com/docs/skill.md` resolves correctly
- [ ] Confirm no content from skill.md is duplicated in CLAUDE.md


🤖 Generated with [Claude Code](https://claude.com/claude-code)