### PR TITLE
ci: enforce changelog entry requirement in PRs

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -93,18 +93,36 @@ jobs:
 
   validate-changelog:
     needs: changes
-    if: ${{ needs.changes.outputs.changelog == 'true' }}
+    if: ${{ needs.changes.outputs.changelog == 'true' || needs.changes.outputs.code == 'true' }}
     runs-on: depot-ubuntu-24.04
     permissions:
       contents: read
     steps:
+      # workflow_dispatch has no PR context — labels are unavailable
+      - name: Require CHANGELOG.md for code changes
+        if: >-
+          ${{ github.event_name != 'merge_group'
+              && github.event_name != 'workflow_dispatch'
+              && needs.changes.outputs.code == 'true'
+              && needs.changes.outputs.changelog != 'true'
+              && !contains(github.event.pull_request.labels.*.name, 'skip-changelog-guard') }}
+        run: |
+          echo "::error::No changes to umh-core/CHANGELOG.md detected."
+          echo ""
+          echo "This PR modifies code but doesn't include a changelog entry."
+          echo "Add an entry under the topmost version section (e.g. ## [X.Y.Z]) in umh-core/CHANGELOG.md,"
+          echo "or add the 'skip-changelog-guard' label if not needed (CI, refactoring, tests-only)"
+          echo "and re-run this check."
+          exit 1
       # Check out THIS repo (fetch-depth: 0 fetches all tags + history, needed by
       # the changelog guard for "git tag --list --sort=-version:refname" and "git show TAG:path")
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        if: ${{ needs.changes.outputs.changelog == 'true' }}
         with:
           fetch-depth: 0
       # Generate token for cross-repo access
       - name: Generate GitHub App token
+        if: ${{ needs.changes.outputs.changelog == 'true' }}
         id: app-token
         uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2
         with:
@@ -113,16 +131,19 @@ jobs:
           repositories: changelog.umh.app
       # Check out the changelog.umh.app repo
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        if: ${{ needs.changes.outputs.changelog == 'true' }}
         with:
           repository: united-manufacturing-hub/changelog.umh.app
           token: ${{ steps.app-token.outputs.token }}
           path: changelog-scripts
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        if: ${{ needs.changes.outputs.changelog == 'true' }}
         with:
           node-version: "20"
       - name: Check released sections are unmodified
         if: >-
-          ${{ github.event_name != 'merge_group'
+          ${{ needs.changes.outputs.changelog == 'true'
+              && github.event_name != 'merge_group'
               && github.event_name != 'workflow_dispatch'
               && !contains(github.event.pull_request.labels.*.name, 'skip-changelog-guard') }}
         shell: bash
@@ -211,6 +232,7 @@ jobs:
 
           echo "Released sections match $LATEST_TAG — OK"
       - name: Validate CHANGELOG.md
+        if: ${{ needs.changes.outputs.changelog == 'true' }}
         run: npx tsx changelog-scripts/.github/scripts/validate-changelog.ts --format version --changelog-path umh-core/CHANGELOG.md
 
   # Gather results from all required steps

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -94,7 +94,8 @@ jobs:
   require-changelog-entry:
     needs: changes
     if: ${{ needs.changes.outputs.code == 'true' }}
-    runs-on: depot-ubuntu-24.04
+    # Use GH runner for fast startup, does not need Depot
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -91,19 +91,18 @@ jobs:
             docker pull ghcr.io/united-manufacturing-hub/umh-core:sha-${{ steps.short-sha.outputs.SHORT_SHA }}
             ```
 
-  validate-changelog:
+  require-changelog-entry:
     needs: changes
-    if: ${{ needs.changes.outputs.changelog == 'true' || needs.changes.outputs.code == 'true' }}
+    if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: depot-ubuntu-24.04
     permissions:
       contents: read
     steps:
-      # workflow_dispatch has no PR context — labels are unavailable
+      # merge_group: already validated at PR level; workflow_dispatch: no PR context (labels unavailable)
       - name: Require CHANGELOG.md for code changes
         if: >-
           ${{ github.event_name != 'merge_group'
               && github.event_name != 'workflow_dispatch'
-              && needs.changes.outputs.code == 'true'
               && needs.changes.outputs.changelog != 'true'
               && !contains(github.event.pull_request.labels.*.name, 'skip-changelog-guard') }}
         run: |
@@ -111,18 +110,26 @@ jobs:
           echo ""
           echo "This PR modifies code but doesn't include a changelog entry."
           echo "Add an entry under the topmost version section (e.g. ## [X.Y.Z]) in umh-core/CHANGELOG.md,"
-          echo "or add the 'skip-changelog-guard' label if not needed (CI, refactoring, tests-only)"
-          echo "and re-run this check."
+          echo "or add the 'skip-changelog-guard' label if not needed (CI/CD, refactoring, or test-only changes)"
+          echo "and push a commit to re-trigger CI."
+          echo ""
+          echo "See CLAUDE.md > Changelog for entry format and guidelines."
           exit 1
+
+  validate-changelog:
+    needs: changes
+    if: ${{ needs.changes.outputs.changelog == 'true' }}
+    runs-on: depot-ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
       # Check out THIS repo (fetch-depth: 0 fetches all tags + history, needed by
       # the changelog guard for "git tag --list --sort=-version:refname" and "git show TAG:path")
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        if: ${{ needs.changes.outputs.changelog == 'true' }}
         with:
           fetch-depth: 0
       # Generate token for cross-repo access
       - name: Generate GitHub App token
-        if: ${{ needs.changes.outputs.changelog == 'true' }}
         id: app-token
         uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2
         with:
@@ -131,19 +138,16 @@ jobs:
           repositories: changelog.umh.app
       # Check out the changelog.umh.app repo
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        if: ${{ needs.changes.outputs.changelog == 'true' }}
         with:
           repository: united-manufacturing-hub/changelog.umh.app
           token: ${{ steps.app-token.outputs.token }}
           path: changelog-scripts
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
-        if: ${{ needs.changes.outputs.changelog == 'true' }}
         with:
           node-version: "20"
       - name: Check released sections are unmodified
         if: >-
-          ${{ needs.changes.outputs.changelog == 'true'
-              && github.event_name != 'merge_group'
+          ${{ github.event_name != 'merge_group'
               && github.event_name != 'workflow_dispatch'
               && !contains(github.event.pull_request.labels.*.name, 'skip-changelog-guard') }}
         shell: bash
@@ -232,7 +236,6 @@ jobs:
 
           echo "Released sections match $LATEST_TAG — OK"
       - name: Validate CHANGELOG.md
-        if: ${{ needs.changes.outputs.changelog == 'true' }}
         run: npx tsx changelog-scripts/.github/scripts/validate-changelog.ts --format version --changelog-path umh-core/CHANGELOG.md
 
   # Gather results from all required steps
@@ -240,7 +243,7 @@ jobs:
   required-checks:
     name: Required Checks
     runs-on: ubuntu-latest # Use GH runner for fast startup, does not need Depot
-    needs: [go-analysis, tests, build, license-eye-header, validate-changelog]
+    needs: [go-analysis, tests, build, license-eye-header, require-changelog-entry, validate-changelog]
     if: always()
     steps:
       - run: echo '${{ toJSON(needs) }}' | jq -e 'to_entries | all(.value.result == "success" or .value.result == "skipped")'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,6 +143,7 @@ Every PR with user-visible changes must add an entry to `umh-core/CHANGELOG.md` 
 - **No trailing periods** on bullet points
 - On tag push, a sync workflow automatically creates entries in changelog.umh.app from CHANGELOG.md
 - GitHub Release notes are automatically populated from CHANGELOG.md by the `update-github-release.yml` workflow (runs on tag push). The job extracts the version's section, transforms headers for standalone display, and appends a changelog.umh.app link. You can still edit the Release body manually after if needed.
+- **CI enforcement**: PRs with code changes must modify CHANGELOG.md, or CI will fail. Add the `skip-changelog-guard` label to bypass (for CI/CD, refactoring, or test-only changes).
 
 ## Support & Troubleshooting Workflows
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
+  "labels": ["skip-changelog-guard"],
   "commitMessagePrefix": "[renovate]chore(deps):",
   "includePaths": ["umh-core/**"],
   "enabledManagers": ["dockerfile", "gomod"],


### PR DESCRIPTION
## Summary

From today's Eng Weekly "what's slowing us down?" brainstorm. Developers keep forgetting changelog entries, which turns release day into 1+ hours of hunting down what changed. Fix: make changelog entries required by default, with `skip-changelog-guard` as the escape hatch. Part of Changelog M4 (validation).

- New `require-changelog-entry` job fails CI when code changes don't include a `umh-core/CHANGELOG.md` update
- `validate-changelog` is untouched, still only runs when CHANGELOG.md changes
- Renovate config auto-applies the `skip-changelog-guard` label
- CLAUDE.md documents the rule

The new job only fires on code changes. If CHANGELOG.md was also modified, the check passes and `validate-changelog` runs format checks as usual. The `skip-changelog-guard` label bypasses the requirement. `merge_group` and `workflow_dispatch` events skip the check (no PR context).

## Test plan

- [ ] PR with code change but no CHANGELOG.md entry should fail
- [ ] Adding `skip-changelog-guard` label should make it pass
- [ ] Adding a CHANGELOG.md entry (no label) should pass with format validation
- [ ] Existing PRs with changelog entries still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)