### PR TITLE
feat(fsmv2): pass DesiredState to CollectObservedState (ENG-4638)

### DIFF
--- a/umh-core/pkg/fsmv2/api.go
+++ b/umh-core/pkg/fsmv2/api.go
@@ -186,7 +186,11 @@ func Result[TSnapshot any, TDeps any](
 // not by a method on this interface.
 type Worker interface {
 	// CollectObservedState monitors the actual system state.
-	CollectObservedState(ctx context.Context) (ObservedState, error)
+	// The desired parameter provides the current desired state so observation-based
+	// workers can access configuration (target IP, port, etc.) without workarounds.
+	// The supervisor guarantees desired is always non-nil; collection is skipped
+	// until a desired state exists in the store.
+	CollectObservedState(ctx context.Context, desired DesiredState) (ObservedState, error)
 
 	// DeriveDesiredState derives the target state from user configuration (spec).
 	DeriveDesiredState(spec interface{}) (DesiredState, error)

--- a/umh-core/pkg/fsmv2/examples/helloworld.go
+++ b/umh-core/pkg/fsmv2/examples/helloworld.go
@@ -18,10 +18,10 @@ package examples
 //
 // Demonstrates both I/O patterns:
 //   - Action: SayHelloAction writes to in-memory deps
-//   - Observation: CollectObservedState reads the mood file path from disk
+//   - Observation: CollectObservedState reads the mood file from disk
 //
-// The mood file path is configured via DesiredState (moodFilePath).
-// When omitted, mood checking is skipped entirely (backwards compatible).
+// Set the mood file path via the moodFilePath field in the scenario config.
+// When omitted, mood checking is skipped.
 //
 // Interactive demo:
 //

--- a/umh-core/pkg/fsmv2/examples/helloworld.go
+++ b/umh-core/pkg/fsmv2/examples/helloworld.go
@@ -18,7 +18,10 @@ package examples
 //
 // Demonstrates both I/O patterns:
 //   - Action: SayHelloAction writes to in-memory deps
-//   - Observation: CollectObservedState reads /tmp/helloworld-mood from disk
+//   - Observation: CollectObservedState reads the mood file path from disk
+//
+// The mood file path is configured via DesiredState (moodFilePath).
+// When omitted, mood checking is skipped entirely (backwards compatible).
 //
 // Interactive demo:
 //
@@ -27,7 +30,7 @@ package examples
 //	rm /tmp/helloworld-mood               # → Running
 var HelloworldScenario = Scenario{
 	Name:        "helloworld",
-	Description: "Minimal worker: says hello, reads mood from /tmp/helloworld-mood",
+	Description: "Minimal worker: says hello, reads mood from configurable file path",
 	YAMLConfig: `
 children:
   - name: "hello-1"
@@ -35,5 +38,6 @@ children:
     userSpec:
       config: |
         state: running
+        moodFilePath: /tmp/helloworld-mood
 `,
 }

--- a/umh-core/pkg/fsmv2/factory/worker_factory_test.go
+++ b/umh-core/pkg/fsmv2/factory/worker_factory_test.go
@@ -33,7 +33,7 @@ type mockWorker struct {
 	identity deps.Identity
 }
 
-func (m *mockWorker) CollectObservedState(ctx context.Context) (fsmv2.ObservedState, error) {
+func (m *mockWorker) CollectObservedState(ctx context.Context, _ fsmv2.DesiredState) (fsmv2.ObservedState, error) {
 	return nil, nil
 }
 

--- a/umh-core/pkg/fsmv2/internal/validator/registry.go
+++ b/umh-core/pkg/fsmv2/internal/validator/registry.go
@@ -226,7 +226,7 @@ WHY: Collection runs with a timeout. Without context cancellation handling, the
 method blocks until I/O completes (network timeout, disk read) even after the
 context is cancelled. This delays shutdown and can cause timeouts to cascade.
 Early exit on ctx.Done() enables responsive shutdown.`,
-		CorrectCode: `func (w *Worker) CollectObservedState(ctx context.Context) (ObservedState, error) {
+		CorrectCode: `func (w *Worker) CollectObservedState(ctx context.Context, _ DesiredState) (ObservedState, error) {
     select {
     case <-ctx.Done():
         return nil, ctx.Err()  // Early exit
@@ -319,12 +319,12 @@ More importantly, Go interfaces work differently with pointer vs value
 receivers - inconsistent receiver types cause subtle interface satisfaction
 bugs where methods "disappear" depending on how the type is used.`,
 		CorrectCode: `// Correct: pointer receiver
-func (w *MyWorker) CollectObservedState(ctx context.Context) (ObservedState, error) {
+func (w *MyWorker) CollectObservedState(ctx context.Context, _ DesiredState) (ObservedState, error) {
     return w.doCollection(ctx)
 }
 
 // WRONG: value receiver loses state
-func (w MyWorker) CollectObservedState(ctx context.Context) (ObservedState, error) {
+func (w MyWorker) CollectObservedState(ctx context.Context, _ DesiredState) (ObservedState, error) {
     return w.doCollection(ctx)  // Changes to w are lost!
 }`,
 		ReferenceFile: "example-child/worker.go",

--- a/umh-core/pkg/fsmv2/supervisor/api.go
+++ b/umh-core/pkg/fsmv2/supervisor/api.go
@@ -66,13 +66,8 @@ func (s *Supervisor[TObserved, TDesired]) AddWorker(identity deps.Identity, work
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	observed, err := worker.CollectObservedState(ctx)
-	if err != nil {
-		s.logger.SentryError(deps.FeatureFSMv2, identity.HierarchyPath, err, "worker_add_collect_observed_failed")
-
-		return fmt.Errorf("failed to collect initial observed state: %w", err)
-	}
-
+	// Derive desired state first so we can pass it to CollectObservedState.
+	// Workers are guaranteed a non-nil desired state parameter.
 	initialDesired, err := worker.DeriveDesiredState(nil)
 	if err != nil {
 		s.logger.SentryError(deps.FeatureFSMv2, identity.HierarchyPath, err, "worker_add_derive_desired_failed")
@@ -84,6 +79,13 @@ func (s *Supervisor[TObserved, TDesired]) AddWorker(identity deps.Identity, work
 		s.logger.SentryError(deps.FeatureFSMv2, identity.HierarchyPath, valErr, "worker_add_validate_desired_failed")
 
 		return fmt.Errorf("failed to derive initial desired state: %w", valErr)
+	}
+
+	observed, err := worker.CollectObservedState(ctx, initialDesired)
+	if err != nil {
+		s.logger.SentryError(deps.FeatureFSMv2, identity.HierarchyPath, err, "worker_add_collect_observed_failed")
+
+		return fmt.Errorf("failed to collect initial observed state: %w", err)
 	}
 
 	identityDoc := persistence.Document{
@@ -286,6 +288,19 @@ func (s *Supervisor[TObserved, TDesired]) AddWorker(identity deps.Identity, work
 					setter.SetActionHistory(history)
 				}
 			}
+		},
+		DesiredStateProvider: func() fsmv2.DesiredState {
+			ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+			defer cancel()
+
+			var desired TDesired
+			if err := s.store.LoadDesiredTyped(ctx, s.workerType, identity.ID, &desired); err != nil {
+				s.logger.SentryWarn(deps.FeatureFSMv2, identity.HierarchyPath, "desired_state_load_failed",
+					deps.Err(err))
+				return nil
+			}
+
+			return desired
 		},
 	})
 

--- a/umh-core/pkg/fsmv2/supervisor/benchmark_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/benchmark_test.go
@@ -147,7 +147,7 @@ type slowCollectWorker struct {
 	observed     *mockObservedState
 }
 
-func (w *slowCollectWorker) CollectObservedState(ctx context.Context) (fsmv2.ObservedState, error) {
+func (w *slowCollectWorker) CollectObservedState(ctx context.Context, _ fsmv2.DesiredState) (fsmv2.ObservedState, error) {
 	// Simulate slow collection (e.g., network timeout, slow database query)
 	select {
 	case <-time.After(w.collectDelay):
@@ -298,7 +298,7 @@ type observationLatencyWorker struct {
 	observed      *mockObservedState
 }
 
-func (w *observationLatencyWorker) CollectObservedState(ctx context.Context) (fsmv2.ObservedState, error) {
+func (w *observationLatencyWorker) CollectObservedState(ctx context.Context, _ fsmv2.DesiredState) (fsmv2.ObservedState, error) {
 	w.mu.Lock()
 	w.lastCollected = time.Now()
 	w.observed.CollectedAt = w.lastCollected

--- a/umh-core/pkg/fsmv2/supervisor/childspec_validation_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/childspec_validation_test.go
@@ -591,7 +591,7 @@ type validChildSpecMockWorker struct {
 	childSpecs   []config.ChildSpec
 }
 
-func (m *validChildSpecMockWorker) CollectObservedState(_ context.Context) (fsmv2.ObservedState, error) {
+func (m *validChildSpecMockWorker) CollectObservedState(_ context.Context, _ fsmv2.DesiredState) (fsmv2.ObservedState, error) {
 	return &mockObservedState{
 		doc: persistence.Document{
 			"id": m.identity.ID,
@@ -620,7 +620,7 @@ type trackedCallOrderMockWorker struct {
 	callTracker  *[]string
 }
 
-func (m *trackedCallOrderMockWorker) CollectObservedState(_ context.Context) (fsmv2.ObservedState, error) {
+func (m *trackedCallOrderMockWorker) CollectObservedState(_ context.Context, _ fsmv2.DesiredState) (fsmv2.ObservedState, error) {
 	return &mockObservedState{
 		doc: persistence.Document{
 			"id": m.identity.ID,

--- a/umh-core/pkg/fsmv2/supervisor/hierarchical_tick_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/hierarchical_tick_test.go
@@ -61,7 +61,7 @@ type hierarchicalWorker struct {
 	observed      *mockObservedState
 }
 
-func (h *hierarchicalWorker) CollectObservedState(ctx context.Context) (fsmv2.ObservedState, error) {
+func (h *hierarchicalWorker) CollectObservedState(ctx context.Context, _ fsmv2.DesiredState) (fsmv2.ObservedState, error) {
 	return h.observed, nil
 }
 

--- a/umh-core/pkg/fsmv2/supervisor/incremental_validation_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/incremental_validation_test.go
@@ -326,7 +326,7 @@ type incrementalValidationMockWorker struct {
 	childSpecs   []config.ChildSpec
 }
 
-func (m *incrementalValidationMockWorker) CollectObservedState(_ context.Context) (fsmv2.ObservedState, error) {
+func (m *incrementalValidationMockWorker) CollectObservedState(_ context.Context, _ fsmv2.DesiredState) (fsmv2.ObservedState, error) {
 	return &mockObservedState{
 		doc: persistence.Document{
 			"id": m.identity.ID,
@@ -352,7 +352,7 @@ type dynamicChildSpecMockWorker struct {
 	childSpecs   []config.ChildSpec
 }
 
-func (m *dynamicChildSpecMockWorker) CollectObservedState(_ context.Context) (fsmv2.ObservedState, error) {
+func (m *dynamicChildSpecMockWorker) CollectObservedState(_ context.Context, _ fsmv2.DesiredState) (fsmv2.ObservedState, error) {
 	return &mockObservedState{
 		doc: persistence.Document{
 			"id": m.identity.ID,

--- a/umh-core/pkg/fsmv2/supervisor/internal/collection/collector.go
+++ b/umh-core/pkg/fsmv2/supervisor/internal/collection/collector.go
@@ -78,7 +78,13 @@ type CollectorConfig[TObserved any] struct {
 	// Workers then access via deps.GetActionHistory() and assign to their ObservedState.
 	// This follows the same pattern as FrameworkMetricsSetter.
 	ActionHistorySetter func([]deps.ActionResult)
-	Identity            deps.Identity
+	// DesiredStateProvider returns the current desired state from the CSE store.
+	// Called BEFORE CollectObservedState so workers can access configuration
+	// (target IP, port, etc.) without workarounds. If nil is returned (desired
+	// state not yet saved), collection is skipped entirely — workers are
+	// guaranteed to always receive a non-nil desired state.
+	DesiredStateProvider func() fsmv2.DesiredState
+	Identity             deps.Identity
 	ObservationInterval time.Duration
 	ObservationTimeout  time.Duration
 	EnableTraceLogging  bool // Whether to emit verbose per-collection logs
@@ -374,7 +380,21 @@ func (c *Collector[TObserved]) collectAndSaveObservedState(ctx context.Context) 
 		c.config.ActionHistorySetter(actionHistory)
 	}
 
-	observed, err := c.config.Worker.CollectObservedState(ctx)
+	// Load desired state to pass to CollectObservedState.
+	// Skip collection entirely if no desired state exists yet — the supervisor
+	// guarantees workers always receive a non-nil desired state.
+	var desired fsmv2.DesiredState
+	if c.config.DesiredStateProvider != nil {
+		desired = c.config.DesiredStateProvider()
+	}
+
+	if desired == nil {
+		c.logTrace("collector_skipped_no_desired_state")
+
+		return nil
+	}
+
+	observed, err := c.config.Worker.CollectObservedState(ctx, desired)
 	if err != nil {
 		c.config.Logger.Debug("collector_collect_failed",
 			deps.Err(err))

--- a/umh-core/pkg/fsmv2/supervisor/internal/collection/collector_panic_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/internal/collection/collector_panic_test.go
@@ -57,6 +57,9 @@ var _ = Describe("Collector Panic Recovery", func() {
 				Identity:            supervisor.TestIdentity(),
 				Store:               supervisor.CreateTestTriangularStore(),
 				Logger:              logger,
+				DesiredStateProvider: func() fsmv2.DesiredState {
+					return &supervisor.TestDesiredState{State: "running"}
+				},
 				ObservationInterval: 50 * time.Millisecond,
 				ObservationTimeout:  1 * time.Second,
 			})
@@ -109,6 +112,9 @@ var _ = Describe("Collector Panic Recovery", func() {
 				Identity:            supervisor.TestIdentity(),
 				Store:               supervisor.CreateTestTriangularStore(),
 				Logger:              logger,
+				DesiredStateProvider: func() fsmv2.DesiredState {
+					return &supervisor.TestDesiredState{State: "running"}
+				},
 				ObservationInterval: 50 * time.Millisecond,
 				ObservationTimeout:  1 * time.Second,
 			})
@@ -157,6 +163,9 @@ var _ = Describe("Collector Panic Type Classification", func() {
 			Identity:            supervisor.TestIdentity(),
 			Store:               supervisor.CreateTestTriangularStore(),
 			Logger:              logger,
+			DesiredStateProvider: func() fsmv2.DesiredState {
+				return &supervisor.TestDesiredState{State: "running"}
+			},
 			ObservationInterval: 50 * time.Millisecond,
 			ObservationTimeout:  1 * time.Second,
 		})
@@ -201,6 +210,9 @@ var _ = Describe("Collector Panic Type Classification", func() {
 			Identity:            supervisor.TestIdentity(),
 			Store:               supervisor.CreateTestTriangularStore(),
 			Logger:              logger,
+			DesiredStateProvider: func() fsmv2.DesiredState {
+				return &supervisor.TestDesiredState{State: "running"}
+			},
 			ObservationInterval: 50 * time.Millisecond,
 			ObservationTimeout:  1 * time.Second,
 		})
@@ -246,6 +258,9 @@ var _ = Describe("Collector Double Panic", func() {
 			Identity:            supervisor.TestIdentity(),
 			Store:               supervisor.CreateTestTriangularStore(),
 			Logger:              logger,
+			DesiredStateProvider: func() fsmv2.DesiredState {
+				return &supervisor.TestDesiredState{State: "running"}
+			},
 			ObservationInterval: 50 * time.Millisecond,
 			ObservationTimeout:  1 * time.Second,
 		})

--- a/umh-core/pkg/fsmv2/supervisor/panic_recovery_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/panic_recovery_test.go
@@ -511,7 +511,7 @@ type panickingWorker struct {
 	panicTriggered      bool
 }
 
-func (w *panickingWorker) CollectObservedState(ctx context.Context) (fsmv2.ObservedState, error) {
+func (w *panickingWorker) CollectObservedState(ctx context.Context, _ fsmv2.DesiredState) (fsmv2.ObservedState, error) {
 	return &testutil.ObservedState{
 		ID:          "panic-worker",
 		CollectedAt: time.Now(),

--- a/umh-core/pkg/fsmv2/supervisor/supervisor_suite_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/supervisor_suite_test.go
@@ -138,7 +138,7 @@ type mockWorker struct {
 	requestShutdownFunc func() // Callback for when RequestShutdown is called
 }
 
-func (m *mockWorker) CollectObservedState(ctx context.Context) (fsmv2.ObservedState, error) {
+func (m *mockWorker) CollectObservedState(ctx context.Context, _ fsmv2.DesiredState) (fsmv2.ObservedState, error) {
 	if m.collectFunc != nil {
 		return m.collectFunc(ctx)
 	}

--- a/umh-core/pkg/fsmv2/supervisor/supervisor_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/supervisor_test.go
@@ -84,7 +84,7 @@ type internalMockWorker struct {
 	observed     persistence.Document
 }
 
-func (m *internalMockWorker) CollectObservedState(_ context.Context) (fsmv2.ObservedState, error) {
+func (m *internalMockWorker) CollectObservedState(_ context.Context, _ fsmv2.DesiredState) (fsmv2.ObservedState, error) {
 	return &mockObservedState{
 		doc:       m.observed,
 		timestamp: time.Now(),
@@ -163,7 +163,7 @@ type internalMockWorkerWithChildren struct {
 	childrenSpecs []config.ChildSpec
 }
 
-func (m *internalMockWorkerWithChildren) CollectObservedState(_ context.Context) (fsmv2.ObservedState, error) {
+func (m *internalMockWorkerWithChildren) CollectObservedState(_ context.Context, _ fsmv2.DesiredState) (fsmv2.ObservedState, error) {
 	return &mockObservedState{
 		doc:       m.observed,
 		timestamp: time.Now(),

--- a/umh-core/pkg/fsmv2/supervisor/testing_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/testing_test.go
@@ -140,7 +140,7 @@ var _ = Describe("Testing Helpers", func() {
 				WorkerType: "s6",
 			}
 
-			observed, err := worker.CollectObservedState(ctx)
+			observed, err := worker.CollectObservedState(ctx, nil)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(observed).ToNot(BeNil())
 		})
@@ -160,7 +160,7 @@ var _ = Describe("Testing Helpers", func() {
 				WorkerType: "s6",
 			}
 
-			observed, err := worker.CollectObservedState(ctx)
+			observed, err := worker.CollectObservedState(ctx, nil)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(observed).To(Equal(customObserved))
 		})
@@ -174,7 +174,7 @@ var _ = Describe("Testing Helpers", func() {
 				},
 			}
 
-			observed, err := oldWorker.CollectObservedState(ctx)
+			observed, err := oldWorker.CollectObservedState(ctx, nil)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(observed).ToNot(BeNil())
 		})

--- a/umh-core/pkg/fsmv2/supervisor/testutil/helpers.go
+++ b/umh-core/pkg/fsmv2/supervisor/testutil/helpers.go
@@ -70,7 +70,7 @@ type Worker struct {
 	CollectFunc  func(ctx context.Context) (fsmv2.ObservedState, error)
 }
 
-func (m *Worker) CollectObservedState(ctx context.Context) (fsmv2.ObservedState, error) {
+func (m *Worker) CollectObservedState(ctx context.Context, _ fsmv2.DesiredState) (fsmv2.ObservedState, error) {
 	if m.CollectFunc != nil {
 		return m.CollectFunc(ctx)
 	}
@@ -107,7 +107,7 @@ type WorkerWithType struct {
 	WorkerType string
 }
 
-func (m *WorkerWithType) CollectObservedState(ctx context.Context) (fsmv2.ObservedState, error) {
+func (m *WorkerWithType) CollectObservedState(ctx context.Context, _ fsmv2.DesiredState) (fsmv2.ObservedState, error) {
 	if m.CollectFunc != nil {
 		return m.CollectFunc(ctx)
 	}

--- a/umh-core/pkg/fsmv2/supervisor/testutil/helpers_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/testutil/helpers_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Testutil Helpers", func() {
 			worker := &testutil.Worker{}
 			ctx := context.Background()
 
-			observed, err := worker.CollectObservedState(ctx)
+			observed, err := worker.CollectObservedState(ctx, nil)
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(observed).NotTo(BeNil())
@@ -70,7 +70,7 @@ var _ = Describe("Testutil Helpers", func() {
 			}
 			ctx := context.Background()
 
-			observed, err := worker.CollectObservedState(ctx)
+			observed, err := worker.CollectObservedState(ctx, nil)
 
 			Expect(err).NotTo(HaveOccurred())
 

--- a/umh-core/pkg/fsmv2/supervisor/variable_injection_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/variable_injection_test.go
@@ -37,7 +37,7 @@ type TestWorker struct {
 	deriveDesiredStateFunc func(spec config.UserSpec) (fsmv2.DesiredState, error)
 }
 
-func (t *TestWorker) CollectObservedState(ctx context.Context) (fsmv2.ObservedState, error) {
+func (t *TestWorker) CollectObservedState(ctx context.Context, _ fsmv2.DesiredState) (fsmv2.ObservedState, error) {
 	return &TestObservedState{
 		ID:          t.identity.ID,
 		CollectedAt: time.Now(),

--- a/umh-core/pkg/fsmv2/workers/application/worker.go
+++ b/umh-core/pkg/fsmv2/workers/application/worker.go
@@ -59,7 +59,7 @@ func NewApplicationWorker(id, name string) *ApplicationWorker {
 }
 
 // CollectObservedState returns the current observed state of the application supervisor.
-func (w *ApplicationWorker) CollectObservedState(ctx context.Context) (fsmv2.ObservedState, error) {
+func (w *ApplicationWorker) CollectObservedState(ctx context.Context, _ fsmv2.DesiredState) (fsmv2.ObservedState, error) {
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()

--- a/umh-core/pkg/fsmv2/workers/application/worker_test.go
+++ b/umh-core/pkg/fsmv2/workers/application/worker_test.go
@@ -39,7 +39,7 @@ var _ = Describe("ApplicationWorker", func() {
 	Describe("CollectObservedState", func() {
 		It("should return observed state with timestamp", func() {
 			ctx := context.Background()
-			obs, err := worker.CollectObservedState(ctx)
+			obs, err := worker.CollectObservedState(ctx, nil)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(obs).NotTo(BeNil())
 
@@ -51,7 +51,7 @@ var _ = Describe("ApplicationWorker", func() {
 
 		It("should return observed state with timestamp", func() {
 			ctx := context.Background()
-			obs, err := worker.CollectObservedState(ctx)
+			obs, err := worker.CollectObservedState(ctx, nil)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(obs).NotTo(BeNil())
 
@@ -65,7 +65,7 @@ var _ = Describe("ApplicationWorker", func() {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel() // Cancel immediately.
 
-			_, err := worker.CollectObservedState(ctx)
+			_, err := worker.CollectObservedState(ctx, nil)
 			Expect(err).To(Equal(context.Canceled))
 		})
 	})
@@ -198,7 +198,7 @@ children:
 		It("should return recent timestamp", func() {
 			ctx := context.Background()
 			before := time.Now()
-			obs, err := worker.CollectObservedState(ctx)
+			obs, err := worker.CollectObservedState(ctx, nil)
 			after := time.Now()
 
 			Expect(err).ToNot(HaveOccurred())

--- a/umh-core/pkg/fsmv2/workers/communicator/worker.go
+++ b/umh-core/pkg/fsmv2/workers/communicator/worker.go
@@ -105,7 +105,7 @@ func NewCommunicatorWorker(
 // CommunicatorObservedState. These are now tracked by TransportWorker.
 
 // CollectObservedState returns the current observed state of the communicator.
-func (w *CommunicatorWorker) CollectObservedState(ctx context.Context) (fsmv2.ObservedState, error) {
+func (w *CommunicatorWorker) CollectObservedState(ctx context.Context, _ fsmv2.DesiredState) (fsmv2.ObservedState, error) {
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()

--- a/umh-core/pkg/fsmv2/workers/communicator/worker_test.go
+++ b/umh-core/pkg/fsmv2/workers/communicator/worker_test.go
@@ -261,7 +261,7 @@ state: "running"
 
 	Describe("CollectObservedState", func() {
 		It("should return observed state with CollectedAt timestamp", func() {
-			observed, err := worker.CollectObservedState(ctx)
+			observed, err := worker.CollectObservedState(ctx, nil)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(observed).NotTo(BeNil())
 
@@ -274,7 +274,7 @@ state: "running"
 			expectedToken := "test-jwt-token-12345"
 			deps.SetJWT(expectedToken, time.Now().Add(1*time.Hour))
 
-			observed, err := worker.CollectObservedState(ctx)
+			observed, err := worker.CollectObservedState(ctx, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			communicatorObserved := observed.(snapshot.CommunicatorObservedState)
@@ -286,7 +286,7 @@ state: "running"
 			expectedExpiry := time.Now().Add(2 * time.Hour).Truncate(time.Second)
 			deps.SetJWT("some-token", expectedExpiry)
 
-			observed, err := worker.CollectObservedState(ctx)
+			observed, err := worker.CollectObservedState(ctx, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			communicatorObserved := observed.(snapshot.CommunicatorObservedState)
@@ -301,7 +301,7 @@ state: "running"
 			}
 			deps.SetPulledMessages(expectedMessages)
 
-			observed, err := worker.CollectObservedState(ctx)
+			observed, err := worker.CollectObservedState(ctx, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			communicatorObserved := observed.(snapshot.CommunicatorObservedState)
@@ -316,7 +316,7 @@ state: "running"
 			deps.RecordError()
 			deps.RecordError()
 
-			observed, err := worker.CollectObservedState(ctx)
+			observed, err := worker.CollectObservedState(ctx, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			communicatorObserved := observed.(snapshot.CommunicatorObservedState)
@@ -327,7 +327,7 @@ state: "running"
 			deps := worker.GetDependencies()
 			deps.SetJWT("valid-token", time.Now().Add(1*time.Hour))
 
-			observed, err := worker.CollectObservedState(ctx)
+			observed, err := worker.CollectObservedState(ctx, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			communicatorObserved := observed.(snapshot.CommunicatorObservedState)
@@ -335,7 +335,7 @@ state: "running"
 		})
 
 		It("should set Authenticated to false when JWT token is empty", func() {
-			observed, err := worker.CollectObservedState(ctx)
+			observed, err := worker.CollectObservedState(ctx, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			communicatorObserved := observed.(snapshot.CommunicatorObservedState)
@@ -364,7 +364,7 @@ state: "running"
 
 			// Helper to collect observed state and save it (simulates collector)
 			collectAndSave := func(tc *metricsTestContext) snapshot.CommunicatorObservedState {
-				observed, err := tc.worker.CollectObservedState(ctx)
+				observed, err := tc.worker.CollectObservedState(ctx, nil)
 				Expect(err).NotTo(HaveOccurred())
 				communicatorObserved := observed.(snapshot.CommunicatorObservedState)
 				// Simulate collector saving observed state
@@ -380,7 +380,7 @@ state: "running"
 				deps.MetricsRecorder().IncrementCounter(depspkg.CounterMessagesPulled, 5)
 				deps.MetricsRecorder().SetGauge(depspkg.GaugeLastPullLatencyMs, 100.0)
 
-				observed, err := worker.CollectObservedState(ctx)
+				observed, err := worker.CollectObservedState(ctx, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				communicatorObserved := observed.(snapshot.CommunicatorObservedState)
@@ -397,7 +397,7 @@ state: "running"
 				deps.MetricsRecorder().IncrementCounter(depspkg.CounterPullFailures, 1)
 				deps.MetricsRecorder().SetGauge(depspkg.GaugeLastPullLatencyMs, 50.0)
 
-				observed, err := worker.CollectObservedState(ctx)
+				observed, err := worker.CollectObservedState(ctx, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				communicatorObserved := observed.(snapshot.CommunicatorObservedState)
@@ -415,7 +415,7 @@ state: "running"
 				deps.MetricsRecorder().IncrementCounter(depspkg.CounterMessagesPushed, 3)
 				deps.MetricsRecorder().SetGauge(depspkg.GaugeLastPushLatencyMs, 200.0)
 
-				observed, err := worker.CollectObservedState(ctx)
+				observed, err := worker.CollectObservedState(ctx, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				communicatorObserved := observed.(snapshot.CommunicatorObservedState)
@@ -432,7 +432,7 @@ state: "running"
 				deps.MetricsRecorder().IncrementCounter(depspkg.CounterPushFailures, 1)
 				deps.MetricsRecorder().SetGauge(depspkg.GaugeLastPushLatencyMs, 150.0)
 
-				observed, err := worker.CollectObservedState(ctx)
+				observed, err := worker.CollectObservedState(ctx, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				communicatorObserved := observed.(snapshot.CommunicatorObservedState)
@@ -522,7 +522,7 @@ state: "running"
 				expectedUUID := "backend-authenticated-uuid-12345"
 				deps.SetAuthenticatedUUID(expectedUUID)
 
-				observed, err := worker.CollectObservedState(ctx)
+				observed, err := worker.CollectObservedState(ctx, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				communicatorObserved := observed.(snapshot.CommunicatorObservedState)
@@ -530,7 +530,7 @@ state: "running"
 			})
 
 			It("should return empty string when no UUID has been set", func() {
-				observed, err := worker.CollectObservedState(ctx)
+				observed, err := worker.CollectObservedState(ctx, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				communicatorObserved := observed.(snapshot.CommunicatorObservedState)
@@ -542,7 +542,7 @@ state: "running"
 				deps.SetAuthenticatedUUID("first-uuid")
 				deps.SetAuthenticatedUUID("second-uuid-after-reauth")
 
-				observed, err := worker.CollectObservedState(ctx)
+				observed, err := worker.CollectObservedState(ctx, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				communicatorObserved := observed.(snapshot.CommunicatorObservedState)

--- a/umh-core/pkg/fsmv2/workers/example/examplechild/worker.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplechild/worker.go
@@ -80,7 +80,7 @@ func NewChildWorker(
 }
 
 // CollectObservedState returns the current observed state of the child worker.
-func (w *ChildWorker) CollectObservedState(ctx context.Context) (fsmv2.ObservedState, error) {
+func (w *ChildWorker) CollectObservedState(ctx context.Context, _ fsmv2.DesiredState) (fsmv2.ObservedState, error) {
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()

--- a/umh-core/pkg/fsmv2/workers/example/examplechild/worker_test.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplechild/worker_test.go
@@ -60,7 +60,7 @@ var _ = Describe("ChildWorker", func() {
 			worker, err := example_child.NewChildWorker(identity, mockPool, logger, nil)
 			Expect(err).NotTo(HaveOccurred())
 
-			observed, err := worker.CollectObservedState(context.Background())
+			observed, err := worker.CollectObservedState(context.Background(), nil)
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(observed).NotTo(BeNil())

--- a/umh-core/pkg/fsmv2/workers/example/examplefailing/worker.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplefailing/worker.go
@@ -80,7 +80,7 @@ func NewFailingWorker(
 }
 
 // CollectObservedState returns the current observed state of the failing worker.
-func (w *FailingWorker) CollectObservedState(ctx context.Context) (fsmv2.ObservedState, error) {
+func (w *FailingWorker) CollectObservedState(ctx context.Context, _ fsmv2.DesiredState) (fsmv2.ObservedState, error) {
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()

--- a/umh-core/pkg/fsmv2/workers/example/examplepanic/worker.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplepanic/worker.go
@@ -69,7 +69,7 @@ func NewExamplepanicWorker(
 	}, nil
 }
 
-func (w *ExamplepanicWorker) CollectObservedState(ctx context.Context) (fsmv2.ObservedState, error) {
+func (w *ExamplepanicWorker) CollectObservedState(ctx context.Context, _ fsmv2.DesiredState) (fsmv2.ObservedState, error) {
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()

--- a/umh-core/pkg/fsmv2/workers/example/exampleparent/worker.go
+++ b/umh-core/pkg/fsmv2/workers/example/exampleparent/worker.go
@@ -67,7 +67,7 @@ func NewParentWorker(
 }
 
 // CollectObservedState returns the current observed state of the parent worker.
-func (w *ParentWorker) CollectObservedState(ctx context.Context) (fsmv2.ObservedState, error) {
+func (w *ParentWorker) CollectObservedState(ctx context.Context, _ fsmv2.DesiredState) (fsmv2.ObservedState, error) {
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()

--- a/umh-core/pkg/fsmv2/workers/example/exampleparent/worker_test.go
+++ b/umh-core/pkg/fsmv2/workers/example/exampleparent/worker_test.go
@@ -55,7 +55,7 @@ var _ = Describe("ParentWorker", func() {
 
 	Describe("CollectObservedState", func() {
 		It("should return observed state with timestamp", func() {
-			observed, err := worker.CollectObservedState(context.Background())
+			observed, err := worker.CollectObservedState(context.Background(), nil)
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(observed).NotTo(BeNil())

--- a/umh-core/pkg/fsmv2/workers/example/exampleslow/worker.go
+++ b/umh-core/pkg/fsmv2/workers/example/exampleslow/worker.go
@@ -69,7 +69,7 @@ func NewExampleslowWorker(
 	}, nil
 }
 
-func (w *ExampleslowWorker) CollectObservedState(ctx context.Context) (fsmv2.ObservedState, error) {
+func (w *ExampleslowWorker) CollectObservedState(ctx context.Context, _ fsmv2.DesiredState) (fsmv2.ObservedState, error) {
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()

--- a/umh-core/pkg/fsmv2/workers/example/helloworld/README.md
+++ b/umh-core/pkg/fsmv2/workers/example/helloworld/README.md
@@ -27,14 +27,24 @@ _ "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm
 
 | Control loop role | Helloworld implementation |
 |-------------------|--------------------------|
-| **Sensor** (`CollectObservedState`) | Reads `deps.HasSaidHello()` + reads `/tmp/helloworld-mood` from disk |
+| **Sensor** (`CollectObservedState`) | Reads `deps.HasSaidHello()` + reads mood file from `DesiredState.MoodFilePath` |
 | **Controller** (`State.Next()`) | Checks shutdown → checks hello said → checks mood → decides |
 | **Actuator** (Actions) | `SayHelloAction` logs a greeting and sets `deps.HelloSaid` |
 
 See the parent [README's control loop section](../../../README.md#the-control-loop) for the general pattern.
 
+The mood file path is configurable via `moodFilePath` in the worker's YAML config.
+When omitted, mood checking is skipped entirely (backwards compatible).
+
+```yaml
+# Scenario config example
+config: |
+  state: running
+  moodFilePath: /tmp/helloworld-mood
+```
+
 ```bash
-# Demo: observation-driven transitions
+# Demo: observation-driven transitions (assuming moodFilePath: /tmp/helloworld-mood)
 echo "happy" > /tmp/helloworld-mood   # stays Running
 echo "sad" > /tmp/helloworld-mood     # → Degraded
 rm /tmp/helloworld-mood               # → Running (no mood file = fine)
@@ -133,7 +143,8 @@ Run the helloworld scenario:
 ```bash
 go run pkg/fsmv2/cmd/runner/main.go --scenario=helloworld --duration=5s
 
-# Interactive mood demo (in a separate terminal while the scenario is running):
+# Interactive mood demo (in a separate terminal while the scenario is running).
+# The scenario configures moodFilePath: /tmp/helloworld-mood by default.
 echo "sad" > /tmp/helloworld-mood     # watch the worker transition to Degraded
 echo "happy" > /tmp/helloworld-mood   # back to Running
 rm /tmp/helloworld-mood               # stays Running (no mood file = fine)

--- a/umh-core/pkg/fsmv2/workers/example/helloworld/README.md
+++ b/umh-core/pkg/fsmv2/workers/example/helloworld/README.md
@@ -13,13 +13,13 @@ _ "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm
 ## State Machine
 
 ```text
-┌──────────┐    ShouldBeRunning()    ┌──────────────────┐    HelloSaid    ┌─────────┐
-│ stopped  │ ──────────────────────▶ │ trying_to_start  │ ─────────────▶ │ running │
-└──────────┘                         └──────────────────┘                └─────────┘
-     ▲                                        │                    mood="sad" │ ▲ mood!="sad"
-     │        IsShutdownRequested()           │                              ▼ │
-     │                                        │                        ┌──────────┐
-     └────────────────────────────────────────┴────────────────────────┤ degraded │
+┌──────────┐   !IsShutdownRequested()  ┌──────────────────┐   HelloSaid   ┌─────────┐
+│ stopped  │ ────────────────────────▶ │ trying_to_start  │ ────────────▶ │ running │
+└──────────┘                           └──────────────────┘              └─────────┘
+     ▲                                          │                  mood="sad" │ ▲ mood!="sad"
+     │         IsShutdownRequested()            │                            ▼ │
+     │                                          │                      ┌──────────┐
+     └──────────────────────────────────────────┴──────────────────────┤ degraded │
                                                                        └──────────┘
 ```
 
@@ -34,7 +34,7 @@ _ "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm
 See the parent [README's control loop section](../../../README.md#the-control-loop) for the general pattern.
 
 The mood file path is configurable via `moodFilePath` in the worker's YAML config.
-When omitted, mood checking is skipped entirely (backwards compatible).
+When omitted, mood checking is skipped.
 
 ```yaml
 # Scenario config example
@@ -54,7 +54,7 @@ rm /tmp/helloworld-mood               # → Running (no mood file = fine)
 
 ```text
 helloworld/
-├── README.md           # This file - start here!
+├── README.md           # Overview and step-by-step guide
 ├── worker.go           # Main worker implementation (3 required methods)
 ├── dependencies.go     # Action dependencies and state storage
 ├── userspec.go         # User configuration parsing
@@ -66,12 +66,12 @@ helloworld/
 │   ├── running.go      # Running state - worker is active
 │   └── degraded.go     # Degraded state - mood file says "sad"
 └── action/
-    └── say_hello.go    # Action that transitions to running
+    └── say_hello.go    # Action that logs a greeting and sets HelloSaid=true
 ```
 
-## Critical Naming Convention
+## Naming Convention
 
-**GOTCHA**: The folder name determines the type prefix. The worker type is derived
+The folder name determines the type prefix. The worker type is derived
 from `{TypePrefix}ObservedState` by lowercasing `{TypePrefix}`.
 
 | Folder Name | Type Prefix | Example Type |
@@ -79,7 +79,7 @@ from `{TypePrefix}ObservedState` by lowercasing `{TypePrefix}`.
 | `helloworld` | `Helloworld` | `HelloworldObservedState` |
 | `examplechild` | `Examplechild` | `ExamplechildObservedState` |
 
-**NOT**: `HelloWorldObservedState` (two capitals would derive to `helloworld` but
+**Incorrect**: `HelloWorldObservedState` (two capitals would derive to `helloworld` but
 the type name wouldn't match the folder convention).
 
 ## Creating a New Worker (Step by Step)
@@ -93,7 +93,7 @@ mkdir -p pkg/fsmv2/workers/yourworker/{snapshot,state,action}
 ### 2. Define snapshot types (`snapshot/snapshot.go`)
 
 ```go
-// CRITICAL: Type name must be {FolderName}ObservedState with EXACT capitalization
+// Type name must be {FolderName}ObservedState with matching capitalization
 type YourworkerObservedState struct {
     CollectedAt time.Time `json:"collected_at"`
     deps.MetricsEmbedder `json:",inline"`  // Required for metrics
@@ -143,8 +143,8 @@ Run the helloworld scenario:
 ```bash
 go run pkg/fsmv2/cmd/runner/main.go --scenario=helloworld --duration=5s
 
-# Interactive mood demo (in a separate terminal while the scenario is running).
-# The scenario configures moodFilePath: /tmp/helloworld-mood by default.
+# Interactive mood demo. Run these in a separate terminal while the scenario runs.
+# These commands use the path from moodFilePath in the scenario YAML.
 echo "sad" > /tmp/helloworld-mood     # watch the worker transition to Degraded
 echo "happy" > /tmp/helloworld-mood   # back to Running
 rm /tmp/helloworld-mood               # stays Running (no mood file = fine)

--- a/umh-core/pkg/fsmv2/workers/example/helloworld/action/say_hello.go
+++ b/umh-core/pkg/fsmv2/workers/example/helloworld/action/say_hello.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package action contains the actions for the helloworld worker.
+// Package action defines the actions for the helloworld worker.
 package action
 
 import (
@@ -21,18 +21,12 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/helloworld/snapshot"
 )
 
+// SayHelloActionName is the name used for logging and metrics.
 const SayHelloActionName = "say_hello"
 
 // SayHelloAction prints a greeting and marks hello as said.
 //
-// ACTION PATTERN:
-//   - Check context cancellation first
-//   - Check if action is already done (IDEMPOTENCY)
-//   - Perform the action
-//   - Update dependencies state
-//
-// IDEMPOTENCY: Actions must be safe to call multiple times.
-// The state machine may retry actions, so always check if already done.
+// The state machine retries actions, so check if already done.
 type SayHelloAction struct{}
 
 // Execute performs the say hello action.
@@ -47,7 +41,7 @@ func (a *SayHelloAction) Execute(ctx context.Context, depsAny any) error {
 	deps := depsAny.(snapshot.HelloworldDependencies)
 	logger := deps.ActionLogger(SayHelloActionName)
 
-	// 2. Check if already done (IDEMPOTENCY)
+	// 2. Check if already done (idempotency)
 	if deps.HasSaidHello() {
 		logger.Debug("already_said_hello")
 
@@ -63,7 +57,8 @@ func (a *SayHelloAction) Execute(ctx context.Context, depsAny any) error {
 	return nil
 }
 
-// String returns the action name for logging.
+// String returns the action name for logging (implements fmt.Stringer).
+// Both String and Name are required: String for fmt.Stringer, Name for the action interface.
 func (a *SayHelloAction) String() string {
 	return SayHelloActionName
 }

--- a/umh-core/pkg/fsmv2/workers/example/helloworld/dependencies.go
+++ b/umh-core/pkg/fsmv2/workers/example/helloworld/dependencies.go
@@ -20,7 +20,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
 )
 
-// HelloworldDependencies provides resources needed by worker actions.
+// HelloworldDependencies holds mutable state shared between actions and CollectObservedState.
 //
 // Actions interact with external systems (databases, APIs, hardware) through
 // dependencies. The dependencies struct stores state that actions modify
@@ -39,7 +39,6 @@ type HelloworldDependencies struct {
 func NewHelloworldDependencies(logger deps.FSMLogger, stateReader deps.StateReader, identity deps.Identity) *HelloworldDependencies {
 	return &HelloworldDependencies{
 		BaseDependencies: deps.NewBaseDependencies(logger, stateReader, identity),
-		helloSaid:        false,
 	}
 }
 

--- a/umh-core/pkg/fsmv2/workers/example/helloworld/snapshot/snapshot.go
+++ b/umh-core/pkg/fsmv2/workers/example/helloworld/snapshot/snapshot.go
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package snapshot defines the state types for the helloworld worker.
+// Package snapshot defines the observed and desired state types for the helloworld worker.
 //
-// NAMING CONVENTION: Types must be named {FolderName}ObservedState and
+// Naming convention: Types must be named {FolderName}ObservedState and
 // {FolderName}DesiredState where FolderName is the parent directory name
 // with only the first letter capitalized.
 //
@@ -31,7 +31,7 @@ import (
 )
 
 // HelloworldDependencies defines the interface for accessing worker dependencies.
-// Defined here to avoid import cycles between snapshot and the main package.
+// This interface lives here (not in the main package) to avoid import cycles.
 type HelloworldDependencies interface {
 	deps.Dependencies
 	SetHelloSaid(said bool)
@@ -42,17 +42,17 @@ type HelloworldDependencies interface {
 // Embed BaseDesiredState to get standard fields like ShutdownRequested.
 type HelloworldDesiredState struct {
 
-	// MoodFilePath is the path to an external file whose contents set the worker's mood.
-	// When empty, mood checking is skipped (backwards compatible).
+	// MoodFilePath is the path to the mood file whose contents set the worker's mood.
+	// When empty, mood checking is skipped.
 	MoodFilePath string `json:"moodFilePath,omitempty"`
 	config.BaseDesiredState
 }
 
 // HelloworldObservedState represents the current observed state of the worker.
-// This is collected by CollectObservedState() and persisted to the triangular store.
+// CollectObservedState collects it each tick, and the supervisor persists it to the triangular store.
 //
-// REQUIRED: Embed deps.MetricsEmbedder to enable metrics collection.
-// REQUIRED: Embed HelloworldDesiredState with json:",inline" for architecture tests.
+// Embeds deps.MetricsEmbedder to enable metrics collection (required by supervisor).
+// Embeds HelloworldDesiredState with json:",inline" (required by architecture_test.go).
 type HelloworldObservedState struct {
 	// CollectedAt is when this observation was taken
 	CollectedAt time.Time `json:"collected_at"`
@@ -60,19 +60,17 @@ type HelloworldObservedState struct {
 	// State is the current FSM state name (set by supervisor)
 	State string `json:"state"`
 
-	// Mood is read from the external file at DesiredState.MoodFilePath by CollectObservedState.
-	// When MoodFilePath is empty, this field stays empty. Demonstrates real blocking I/O.
+	// Mood is read from the mood file at DesiredState.MoodFilePath by CollectObservedState.
+	// When MoodFilePath is empty, this field stays empty.
 	Mood string `json:"mood,omitempty"`
 
 	// LastActionResults contains action history (managed by supervisor)
 	LastActionResults []deps.ActionResult `json:"last_action_results,omitempty"`
 
-	// HelloworldDesiredState embedded for state consistency
-	// REQUIRED: Architecture tests verify this pattern
+	// Embeds HelloworldDesiredState to enable state consistency (required by architecture_test.go).
 	HelloworldDesiredState `json:",inline"`
 
-	// MetricsEmbedder provides framework and worker metrics
-	// REQUIRED: Without this, metrics won't be collected
+	// Embeds MetricsEmbedder to enable metrics collection (required by supervisor).
 	deps.MetricsEmbedder `json:",inline"`
 
 	// HelloSaid tracks whether the SayHelloAction has been executed

--- a/umh-core/pkg/fsmv2/workers/example/helloworld/snapshot/snapshot.go
+++ b/umh-core/pkg/fsmv2/workers/example/helloworld/snapshot/snapshot.go
@@ -41,6 +41,10 @@ type HelloworldDependencies interface {
 // HelloworldDesiredState represents the target configuration for the worker.
 // Embed BaseDesiredState to get standard fields like ShutdownRequested.
 type HelloworldDesiredState struct {
+
+	// MoodFilePath is the path to an external file whose contents set the worker's mood.
+	// When empty, mood checking is skipped (backwards compatible).
+	MoodFilePath string `json:"moodFilePath,omitempty"`
 	config.BaseDesiredState
 }
 
@@ -56,8 +60,8 @@ type HelloworldObservedState struct {
 	// State is the current FSM state name (set by supervisor)
 	State string `json:"state"`
 
-	// Mood is read from an external file (/tmp/helloworld-mood) by CollectObservedState.
-	// Demonstrates real blocking I/O in observation collection.
+	// Mood is read from the external file at DesiredState.MoodFilePath by CollectObservedState.
+	// When MoodFilePath is empty, this field stays empty. Demonstrates real blocking I/O.
 	Mood string `json:"mood,omitempty"`
 
 	// LastActionResults contains action history (managed by supervisor)

--- a/umh-core/pkg/fsmv2/workers/example/helloworld/state/degraded.go
+++ b/umh-core/pkg/fsmv2/workers/example/helloworld/state/degraded.go
@@ -21,19 +21,13 @@ import (
 )
 
 // DegradedState represents the worker running but impaired.
-// Entered when the external mood file contains "sad".
+// Entered when the mood file contains "sad".
 // Transitions back to RunningState when the mood changes.
 type DegradedState struct {
 	helpers.RunningDegradedBase
 }
 
 // Next implements state transition logic for DegradedState.
-//
-// DEGRADED STATE PATTERN:
-//   - Check shutdown first
-//   - Check if the condition that caused degradation has cleared
-//   - If cleared, transition back to running
-//   - Otherwise stay degraded
 func (s *DegradedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := helpers.ConvertSnapshot[snapshot.HelloworldObservedState, *snapshot.HelloworldDesiredState](snapAny)
 

--- a/umh-core/pkg/fsmv2/workers/example/helloworld/state/running.go
+++ b/umh-core/pkg/fsmv2/workers/example/helloworld/state/running.go
@@ -27,11 +27,6 @@ type RunningState struct {
 }
 
 // Next implements state transition logic for RunningState.
-//
-// RUNNING STATE PATTERN:
-//   - Check shutdown first (transition to stopped)
-//   - Check observed mood from external file
-//   - Otherwise stay in running state
 func (s *RunningState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := helpers.ConvertSnapshot[snapshot.HelloworldObservedState, *snapshot.HelloworldDesiredState](snapAny)
 
@@ -40,7 +35,7 @@ func (s *RunningState) Next(snapAny any) fsmv2.NextResult[any, any] {
 		return fsmv2.Result[any, any](&StoppedState{}, fsmv2.SignalNone, nil, "Shutdown requested, transitioning to stopped")
 	}
 
-	// 2. Check mood from external observation (file read in CollectObservedState)
+	// 2. Check mood from mood file (read in CollectObservedState)
 	if snap.Observed.Mood == "sad" {
 		return fsmv2.Result[any, any](&DegradedState{}, fsmv2.SignalNone, nil, "Mood is sad, transitioning to degraded")
 	}

--- a/umh-core/pkg/fsmv2/workers/example/helloworld/state/state_degraded_test.go
+++ b/umh-core/pkg/fsmv2/workers/example/helloworld/state/state_degraded_test.go
@@ -25,30 +25,58 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/helloworld/state"
 )
 
-var _ = Describe("StoppedState", func() {
+var _ = Describe("DegradedState", func() {
 	var (
-		stateObj *state.StoppedState
+		stateObj *state.DegradedState
 		snap     fsmv2.Snapshot
 	)
 
 	BeforeEach(func() {
-		stateObj = &state.StoppedState{}
+		stateObj = &state.DegradedState{}
 	})
 
 	Describe("Next", func() {
-		Context("when shutdown is not requested", func() {
+		Context("when mood is still sad", func() {
 			BeforeEach(func() {
 				snap = fsmv2.Snapshot{
 					Identity: deps.Identity{ID: "test", Name: "test", WorkerType: "helloworld"},
-					Observed: snapshot.HelloworldObservedState{},
+					Observed: snapshot.HelloworldObservedState{Mood: "sad", HelloSaid: true},
 					Desired:  &snapshot.HelloworldDesiredState{},
 				}
 			})
 
-			It("should transition to TryingToStartState", func() {
+			It("should stay in DegradedState", func() {
 				result := stateObj.Next(snap)
 
-				Expect(result.State).To(BeAssignableToTypeOf(&state.TryingToStartState{}))
+				Expect(result.State).To(BeAssignableToTypeOf(&state.DegradedState{}))
+			})
+
+			It("should not signal anything", func() {
+				result := stateObj.Next(snap)
+
+				Expect(result.Signal).To(Equal(fsmv2.SignalNone))
+			})
+
+			It("should not return an action", func() {
+				result := stateObj.Next(snap)
+
+				Expect(result.Action).To(BeNil())
+			})
+		})
+
+		Context("when mood has recovered", func() {
+			BeforeEach(func() {
+				snap = fsmv2.Snapshot{
+					Identity: deps.Identity{ID: "test", Name: "test", WorkerType: "helloworld"},
+					Observed: snapshot.HelloworldObservedState{Mood: "happy", HelloSaid: true},
+					Desired:  &snapshot.HelloworldDesiredState{},
+				}
+			})
+
+			It("should transition to RunningState", func() {
+				result := stateObj.Next(snap)
+
+				Expect(result.State).To(BeAssignableToTypeOf(&state.RunningState{}))
 			})
 
 			It("should not signal anything", func() {
@@ -68,23 +96,23 @@ var _ = Describe("StoppedState", func() {
 			BeforeEach(func() {
 				snap = fsmv2.Snapshot{
 					Identity: deps.Identity{ID: "test", Name: "test", WorkerType: "helloworld"},
-					Observed: snapshot.HelloworldObservedState{},
+					Observed: snapshot.HelloworldObservedState{Mood: "sad", HelloSaid: true},
 					Desired: &snapshot.HelloworldDesiredState{
 						BaseDesiredState: config.BaseDesiredState{ShutdownRequested: true},
 					},
 				}
 			})
 
-			It("should stay in StoppedState", func() {
+			It("should transition to StoppedState", func() {
 				result := stateObj.Next(snap)
 
 				Expect(result.State).To(BeAssignableToTypeOf(&state.StoppedState{}))
 			})
 
-			It("should signal needs removal", func() {
+			It("should not signal anything", func() {
 				result := stateObj.Next(snap)
 
-				Expect(result.Signal).To(Equal(fsmv2.SignalNeedsRemoval))
+				Expect(result.Signal).To(Equal(fsmv2.SignalNone))
 			})
 
 			It("should not return an action", func() {
@@ -97,55 +125,53 @@ var _ = Describe("StoppedState", func() {
 
 	Describe("String", func() {
 		It("should return the state name", func() {
-			Expect(stateObj.String()).To(Equal("Stopped"))
+			Expect(stateObj.String()).To(Equal("Degraded"))
 		})
 	})
 })
 
-var _ = Describe("StoppedState Transitions", func() {
-	var stateObj *state.StoppedState
+var _ = Describe("DegradedState Transitions", func() {
+	var stateObj *state.DegradedState
 
 	BeforeEach(func() {
-		stateObj = &state.StoppedState{}
+		stateObj = &state.DegradedState{}
 	})
 
-	Describe("Stopped -> TryingToStartState", func() {
-		It("should transition with default desired state", func() {
+	Describe("Degraded -> RunningState", func() {
+		It("should transition when mood is no longer sad", func() {
 			snap := fsmv2.Snapshot{
 				Identity: deps.Identity{ID: "test", Name: "test", WorkerType: "helloworld"},
-				Observed: snapshot.HelloworldObservedState{},
+				Observed: snapshot.HelloworldObservedState{Mood: "happy", HelloSaid: true},
 				Desired:  &snapshot.HelloworldDesiredState{},
 			}
 
 			result := stateObj.Next(snap)
 
-			Expect(result.State).To(BeAssignableToTypeOf(&state.TryingToStartState{}))
+			Expect(result.State).To(BeAssignableToTypeOf(&state.RunningState{}))
 			Expect(result.Signal).To(Equal(fsmv2.SignalNone))
 			Expect(result.Action).To(BeNil())
 		})
 
-		It("should transition with explicit shutdown=false", func() {
+		It("should transition when mood file is absent (empty mood)", func() {
 			snap := fsmv2.Snapshot{
-				Identity: deps.Identity{ID: "hello-1", Name: "helloworld", WorkerType: "helloworld"},
-				Observed: snapshot.HelloworldObservedState{},
-				Desired: &snapshot.HelloworldDesiredState{
-					BaseDesiredState: config.BaseDesiredState{ShutdownRequested: false},
-				},
+				Identity: deps.Identity{ID: "test", Name: "test", WorkerType: "helloworld"},
+				Observed: snapshot.HelloworldObservedState{Mood: "", HelloSaid: true},
+				Desired:  &snapshot.HelloworldDesiredState{},
 			}
 
 			result := stateObj.Next(snap)
 
-			Expect(result.State).To(BeAssignableToTypeOf(&state.TryingToStartState{}))
+			Expect(result.State).To(BeAssignableToTypeOf(&state.RunningState{}))
 			Expect(result.Signal).To(Equal(fsmv2.SignalNone))
 			Expect(result.Action).To(BeNil())
 		})
 	})
 
-	Describe("Stopped -> SignalNeedsRemoval", func() {
-		It("should signal removal when shutdown is requested", func() {
+	Describe("Degraded -> StoppedState", func() {
+		It("should transition on shutdown request", func() {
 			snap := fsmv2.Snapshot{
 				Identity: deps.Identity{ID: "test", Name: "test", WorkerType: "helloworld"},
-				Observed: snapshot.HelloworldObservedState{},
+				Observed: snapshot.HelloworldObservedState{Mood: "sad", HelloSaid: true},
 				Desired: &snapshot.HelloworldDesiredState{
 					BaseDesiredState: config.BaseDesiredState{ShutdownRequested: true},
 				},
@@ -154,16 +180,14 @@ var _ = Describe("StoppedState Transitions", func() {
 			result := stateObj.Next(snap)
 
 			Expect(result.State).To(BeAssignableToTypeOf(&state.StoppedState{}))
-			Expect(result.Signal).To(Equal(fsmv2.SignalNeedsRemoval))
+			Expect(result.Signal).To(Equal(fsmv2.SignalNone))
 			Expect(result.Action).To(BeNil())
 		})
 
-		It("should signal removal even with HelloSaid=true", func() {
+		It("should shutdown even if mood has recovered", func() {
 			snap := fsmv2.Snapshot{
-				Identity: deps.Identity{ID: "hello-shutdown", Name: "helloworld", WorkerType: "helloworld"},
-				Observed: snapshot.HelloworldObservedState{
-					HelloSaid: true,
-				},
+				Identity: deps.Identity{ID: "test", Name: "test", WorkerType: "helloworld"},
+				Observed: snapshot.HelloworldObservedState{Mood: "happy", HelloSaid: true},
 				Desired: &snapshot.HelloworldDesiredState{
 					BaseDesiredState: config.BaseDesiredState{ShutdownRequested: true},
 				},
@@ -172,7 +196,23 @@ var _ = Describe("StoppedState Transitions", func() {
 			result := stateObj.Next(snap)
 
 			Expect(result.State).To(BeAssignableToTypeOf(&state.StoppedState{}))
-			Expect(result.Signal).To(Equal(fsmv2.SignalNeedsRemoval))
+			Expect(result.Signal).To(Equal(fsmv2.SignalNone))
+			Expect(result.Action).To(BeNil())
+		})
+	})
+
+	Describe("Degraded -> Stay", func() {
+		It("should stay degraded when mood is still sad", func() {
+			snap := fsmv2.Snapshot{
+				Identity: deps.Identity{ID: "test", Name: "test", WorkerType: "helloworld"},
+				Observed: snapshot.HelloworldObservedState{Mood: "sad", HelloSaid: true},
+				Desired:  &snapshot.HelloworldDesiredState{},
+			}
+
+			result := stateObj.Next(snap)
+
+			Expect(result.State).To(BeAssignableToTypeOf(&state.DegradedState{}))
+			Expect(result.Signal).To(Equal(fsmv2.SignalNone))
 			Expect(result.Action).To(BeNil())
 		})
 	})

--- a/umh-core/pkg/fsmv2/workers/example/helloworld/state/stopped.go
+++ b/umh-core/pkg/fsmv2/workers/example/helloworld/state/stopped.go
@@ -12,13 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package state contains the FSM states for the helloworld worker.
+// Package state defines the FSM states for the helloworld worker.
 //
-// State Machine:
+// State machine:
 //
 //	stopped -> trying_to_start -> running
-//	   ^                            |
-//	   └────── (shutdown) ──────────┘
+//	   ^                |        mood="sad" | ^ mood!="sad"
+//	   |                |                   v |
+//	   |                |               degraded
+//	   └── (shutdown) ──┴──────────────────┘
 package state
 
 import (
@@ -34,33 +36,20 @@ type StoppedState struct {
 }
 
 // Next implements the state transition logic.
-//
-// STATE MACHINE PATTERN:
-//  1. Check shutdown FIRST - always honor shutdown requests
-//  2. Check conditions for transitioning to other states
-//  3. If no transition, stay in current state
-//
-// Returns:
-//   - NextResult containing next state, signal, action, and reason
 func (s *StoppedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := helpers.ConvertSnapshot[snapshot.HelloworldObservedState, *snapshot.HelloworldDesiredState](snapAny)
 
-	// 1. ALWAYS check shutdown first
+	// 1. Check shutdown first
 	if snap.Desired.IsShutdownRequested() {
 		return fsmv2.Result[any, any](s, fsmv2.SignalNeedsRemoval, nil, "Shutdown requested, signaling removal")
 	}
 
-	// 2. Check if we should start running
-	if !snap.Desired.IsShutdownRequested() {
-		return fsmv2.Result[any, any](&TryingToStartState{}, fsmv2.SignalNone, nil, "Starting worker")
-	}
-
-	// 3. Stay in stopped state
-	return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil, "Worker is stopped, waiting to start")
+	// 2. Start running
+	return fsmv2.Result[any, any](&TryingToStartState{}, fsmv2.SignalNone, nil, "Starting worker")
 }
 
 // String returns the state name for logging and metrics.
-// Use helpers.DeriveStateName to get consistent snake_case naming.
+// Use helpers.DeriveStateName to get consistent naming.
 func (s *StoppedState) String() string {
 	return helpers.DeriveStateName(s)
 }

--- a/umh-core/pkg/fsmv2/workers/example/helloworld/state/trying_to_start.go
+++ b/umh-core/pkg/fsmv2/workers/example/helloworld/state/trying_to_start.go
@@ -28,16 +28,10 @@ type TryingToStartState struct {
 }
 
 // Next implements state transition logic for TryingToStartState.
-//
-// TRANSITIONAL STATE PATTERN:
-//   - Check shutdown first
-//   - Check if the action we need has completed (observe the effect)
-//   - If completed, transition to next state
-//   - If not completed, emit the action and stay in this state
 func (s *TryingToStartState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := helpers.ConvertSnapshot[snapshot.HelloworldObservedState, *snapshot.HelloworldDesiredState](snapAny)
 
-	// 1. ALWAYS check shutdown first
+	// 1. Check shutdown first
 	if snap.Desired.IsShutdownRequested() {
 		return fsmv2.Result[any, any](&StoppedState{}, fsmv2.SignalNone, nil, "Shutdown requested, transitioning to stopped")
 	}

--- a/umh-core/pkg/fsmv2/workers/example/helloworld/userspec.go
+++ b/umh-core/pkg/fsmv2/workers/example/helloworld/userspec.go
@@ -29,6 +29,6 @@ import (
 type HelloworldUserSpec struct {
 	config.BaseUserSpec // Provides State field with GetState() defaulting to "running"
 
-	// MoodFilePath is the path to an external file whose contents set the worker's mood.
+	// MoodFilePath is the path to the mood file whose contents set the worker's mood.
 	MoodFilePath string `json:"moodFilePath" yaml:"moodFilePath"`
 }

--- a/umh-core/pkg/fsmv2/workers/example/helloworld/userspec.go
+++ b/umh-core/pkg/fsmv2/workers/example/helloworld/userspec.go
@@ -25,10 +25,10 @@ import (
 //
 //	config: |
 //	  state: running
-//	  message: "Hello, {{ .Name }}!"
+//	  moodFilePath: /tmp/helloworld-mood
 type HelloworldUserSpec struct {
 	config.BaseUserSpec // Provides State field with GetState() defaulting to "running"
 
-	// Message is the optional greeting message (can use template variables)
-	Message string `json:"message" yaml:"message"`
+	// MoodFilePath is the path to an external file whose contents set the worker's mood.
+	MoodFilePath string `json:"moodFilePath" yaml:"moodFilePath"`
 }

--- a/umh-core/pkg/fsmv2/workers/example/helloworld/worker.go
+++ b/umh-core/pkg/fsmv2/workers/example/helloworld/worker.go
@@ -101,7 +101,7 @@ func NewHelloworldWorker(
 //   - Read external state via blocking I/O (file, network, etc.)
 //   - Copy framework metrics if available
 //   - Return the observed state
-func (w *HelloworldWorker) CollectObservedState(ctx context.Context, _ fsmv2.DesiredState) (fsmv2.ObservedState, error) {
+func (w *HelloworldWorker) CollectObservedState(ctx context.Context, desired fsmv2.DesiredState) (fsmv2.ObservedState, error) {
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()
@@ -123,28 +123,25 @@ func (w *HelloworldWorker) CollectObservedState(ctx context.Context, _ fsmv2.Des
 	// Include action history for debugging
 	observed.LastActionResults = deps.GetActionHistory()
 
-	// Observation: read mood from external file (blocking disk I/O).
-	// This demonstrates why CollectObservedState runs in a background goroutine —
-	// file reads block, and on network mounts or slow storage (common in factories),
-	// this can take seconds. The supervisor ensures slow reads never block the tick loop.
-	if data, err := os.ReadFile("/tmp/helloworld-mood"); err == nil {
+	// Observation: read mood from the file configured in DesiredState.
+	// This is blocking disk I/O, which is why CollectObservedState runs in a
+	// background goroutine. The supervisor ensures slow reads never block the tick loop.
+	d := desired.(*snapshot.HelloworldDesiredState)
+	if data, err := os.ReadFile(d.MoodFilePath); err == nil {
 		observed.Mood = strings.TrimSpace(string(data))
 	}
 
 	return observed, nil
 }
 
-// DeriveDesiredState determines what state the worker should be in.
+// DeriveDesiredState parses UserSpec.Config YAML into typed HelloworldDesiredState.
 //
-// This method parses user configuration (from scenarios or external config)
-// and returns the desired state. The supervisor compares this with observed
-// state to drive transitions.
-//
-// For simple workers, this just returns "running" as the desired state.
+// Uses config.ParseUserSpec instead of config.DeriveLeafState because
+// DeriveLeafState returns a generic config.DesiredState that loses
+// worker-specific fields like MoodFilePath. ParseUserSpec returns the
+// full typed struct so custom fields flow through to CollectObservedState.
 func (w *HelloworldWorker) DeriveDesiredState(spec interface{}) (fsmv2.DesiredState, error) {
 	if spec == nil {
-		// Default: desired state is running
-		// Return the registered type (*snapshot.HelloworldDesiredState) to avoid type assertion failures
 		return &snapshot.HelloworldDesiredState{
 			BaseDesiredState: config.BaseDesiredState{State: config.DesiredStateRunning},
 		}, nil
@@ -155,26 +152,20 @@ func (w *HelloworldWorker) DeriveDesiredState(spec interface{}) (fsmv2.DesiredSt
 		return nil, fmt.Errorf("invalid spec type: expected UserSpec, got %T", spec)
 	}
 
-	// Render any template variables in the config
 	renderedConfig, err := config.RenderConfigTemplate(userSpec.Config, userSpec.Variables)
 	if err != nil {
 		return nil, fmt.Errorf("template rendering failed: %w", err)
 	}
 
-	renderedSpec := config.UserSpec{
-		Config:    renderedConfig,
-		Variables: userSpec.Variables,
-	}
-
-	// Parse into typed config and derive desired state
-	desired, err := config.DeriveLeafState[HelloworldUserSpec](renderedSpec)
+	renderedSpec := config.UserSpec{Config: renderedConfig, Variables: userSpec.Variables}
+	hwSpec, err := config.ParseUserSpec[HelloworldUserSpec](renderedSpec)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("config parse failed: %w", err)
 	}
 
-	// Return the registered type (*snapshot.HelloworldDesiredState) to avoid type assertion failures
 	return &snapshot.HelloworldDesiredState{
-		BaseDesiredState: desired.BaseDesiredState,
+		BaseDesiredState: config.BaseDesiredState{State: hwSpec.GetState()},
+		MoodFilePath:     hwSpec.MoodFilePath,
 	}, nil
 }
 

--- a/umh-core/pkg/fsmv2/workers/example/helloworld/worker.go
+++ b/umh-core/pkg/fsmv2/workers/example/helloworld/worker.go
@@ -12,17 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package hello_world provides a minimal FSMv2 worker example.
+// Package hello_world implements a minimal FSMv2 worker that demonstrates
+// the three required Worker interface methods, factory registration,
+// state transitions, and action execution.
 //
-// This is the simplest possible worker implementation demonstrating:
-//   - The 3 required Worker interface methods
-//   - Factory registration pattern
-//   - State machine transitions
-//   - Action execution
+// Use this as a template when creating new workers. See README.md for the step-by-step guide.
 //
-// Use this as a template when creating new workers. See README.md for details.
-//
-// NAMING CONVENTION: The package name uses underscore (hello_world) but the
+// Naming convention: The package name uses underscore (hello_world) but the
 // folder name is "helloworld". The type prefix must be "Helloworld" (one capital)
 // to derive correctly as worker type "helloworld".
 package hello_world
@@ -48,7 +44,7 @@ import (
 
 // HelloworldWorker implements the FSMv2 Worker interface.
 //
-// Workers are the core building blocks of FSMv2. Each worker:
+// A worker is the core building block of FSMv2. Each worker:
 //   - Collects its current observed state (CollectObservedState)
 //   - Derives what state it should be in (DeriveDesiredState)
 //   - Provides an initial state (GetInitialState)
@@ -89,18 +85,11 @@ func NewHelloworldWorker(
 	}, nil
 }
 
-// CollectObservedState returns the current observed state.
+// CollectObservedState collects and returns the current observed state.
 //
 // This method is called by the supervisor each tick to collect what the
 // worker currently observes about itself. The observed state is then
 // passed to the current FSM state's Next() method.
-//
-// IMPLEMENTATION PATTERN:
-//   - Check context cancellation first
-//   - Read state from dependencies (what actions have set)
-//   - Read external state via blocking I/O (file, network, etc.)
-//   - Copy framework metrics if available
-//   - Return the observed state
 func (w *HelloworldWorker) CollectObservedState(ctx context.Context, desired fsmv2.DesiredState) (fsmv2.ObservedState, error) {
 	select {
 	case <-ctx.Done():
@@ -123,12 +112,13 @@ func (w *HelloworldWorker) CollectObservedState(ctx context.Context, desired fsm
 	// Include action history for debugging
 	observed.LastActionResults = deps.GetActionHistory()
 
-	// Observation: read mood from the file configured in DesiredState.
+	// Read the mood file at DesiredState.MoodFilePath.
 	// This is blocking disk I/O, which is why CollectObservedState runs in a
 	// background goroutine. The supervisor ensures slow reads never block the tick loop.
-	d := desired.(*snapshot.HelloworldDesiredState)
-	if data, err := os.ReadFile(d.MoodFilePath); err == nil {
-		observed.Mood = strings.TrimSpace(string(data))
+	if d, ok := desired.(*snapshot.HelloworldDesiredState); ok && d.MoodFilePath != "" {
+		if data, err := os.ReadFile(d.MoodFilePath); err == nil {
+			observed.Mood = strings.TrimSpace(string(data))
+		}
 	}
 
 	return observed, nil
@@ -136,8 +126,8 @@ func (w *HelloworldWorker) CollectObservedState(ctx context.Context, desired fsm
 
 // DeriveDesiredState parses UserSpec.Config YAML into typed HelloworldDesiredState.
 //
-// Uses config.ParseUserSpec instead of config.DeriveLeafState because
-// DeriveLeafState returns a generic config.DesiredState that loses
+// Uses config.ParseUserSpec instead of config.DeriveLeafState.
+// DeriveLeafState returns a generic config.DesiredState that drops
 // worker-specific fields like MoodFilePath. ParseUserSpec returns the
 // full typed struct so custom fields flow through to CollectObservedState.
 func (w *HelloworldWorker) DeriveDesiredState(spec interface{}) (fsmv2.DesiredState, error) {
@@ -171,16 +161,15 @@ func (w *HelloworldWorker) DeriveDesiredState(spec interface{}) (fsmv2.DesiredSt
 
 // GetInitialState returns the state the FSM should start in.
 //
-// All workers start in some initial state. For most workers this is
-// a "stopped" state that waits for the desired state to request running.
+// All workers start in StoppedState. It waits for the desired state
+// to request running before transitioning.
 func (w *HelloworldWorker) GetInitialState() fsmv2.State[any, any] {
 	return &state.StoppedState{}
 }
 
-// init registers the worker with the factory.
+// init registers the worker with the factory so the supervisor can discover it.
 //
-// CRITICAL: Without this init() function, the worker won't be discoverable
-// by the supervisor. The factory uses the type parameters to:
+// The factory uses the type parameters to:
 //   - Match incoming worker specs to the correct worker type
 //   - Create worker instances with proper typing
 //   - Create typed supervisors for the worker

--- a/umh-core/pkg/fsmv2/workers/example/helloworld/worker.go
+++ b/umh-core/pkg/fsmv2/workers/example/helloworld/worker.go
@@ -101,7 +101,7 @@ func NewHelloworldWorker(
 //   - Read external state via blocking I/O (file, network, etc.)
 //   - Copy framework metrics if available
 //   - Return the observed state
-func (w *HelloworldWorker) CollectObservedState(ctx context.Context) (fsmv2.ObservedState, error) {
+func (w *HelloworldWorker) CollectObservedState(ctx context.Context, _ fsmv2.DesiredState) (fsmv2.ObservedState, error) {
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()

--- a/umh-core/pkg/fsmv2/workers/example/helloworld/worker_test.go
+++ b/umh-core/pkg/fsmv2/workers/example/helloworld/worker_test.go
@@ -66,7 +66,7 @@ var _ = Describe("HelloworldWorker", func() {
 		})
 
 		It("should collect initial state with HelloSaid=false", func() {
-			obs, err := worker.CollectObservedState(context.Background())
+			obs, err := worker.CollectObservedState(context.Background(), nil)
 
 			Expect(err).NotTo(HaveOccurred())
 			typedObs, ok := obs.(snapshot.HelloworldObservedState)
@@ -78,7 +78,7 @@ var _ = Describe("HelloworldWorker", func() {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 
-			obs, err := worker.CollectObservedState(ctx)
+			obs, err := worker.CollectObservedState(ctx, nil)
 
 			Expect(err).To(Equal(context.Canceled))
 			Expect(obs).To(BeNil())

--- a/umh-core/pkg/fsmv2/workers/persistence/worker.go
+++ b/umh-core/pkg/fsmv2/workers/persistence/worker.go
@@ -66,7 +66,7 @@ func NewPersistenceWorker(
 	}, nil
 }
 
-func (w *PersistenceWorker) CollectObservedState(ctx context.Context) (fsmv2.ObservedState, error) {
+func (w *PersistenceWorker) CollectObservedState(ctx context.Context, _ fsmv2.DesiredState) (fsmv2.ObservedState, error) {
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()

--- a/umh-core/pkg/fsmv2/workers/persistence/worker_test.go
+++ b/umh-core/pkg/fsmv2/workers/persistence/worker_test.go
@@ -60,7 +60,7 @@ var _ = Describe("PersistenceWorker", func() {
 			worker, err := persistence.NewPersistenceWorker(identity, store, logger, nil)
 			Expect(err).NotTo(HaveOccurred())
 
-			observed, err := worker.CollectObservedState(context.Background())
+			observed, err := worker.CollectObservedState(context.Background(), nil)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(observed).NotTo(BeNil())
 
@@ -76,7 +76,7 @@ var _ = Describe("PersistenceWorker", func() {
 			cancelledCtx, cancel := context.WithCancel(context.Background())
 			cancel()
 
-			_, err = worker.CollectObservedState(cancelledCtx)
+			_, err = worker.CollectObservedState(cancelledCtx, nil)
 			Expect(err).To(Equal(context.Canceled))
 		})
 
@@ -90,7 +90,7 @@ var _ = Describe("PersistenceWorker", func() {
 					{Success: false, ActionType: "CompactDeltas", Timestamp: time.Now()},
 				})
 
-				observed, err := worker.CollectObservedState(context.Background())
+				observed, err := worker.CollectObservedState(context.Background(), nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				obs := observed.(snapshot.PersistenceObservedState)
@@ -108,7 +108,7 @@ var _ = Describe("PersistenceWorker", func() {
 					{Success: true, ActionType: "CompactDeltas", Timestamp: time.Now()},
 				})
 
-				observed, err := worker.CollectObservedState(context.Background())
+				observed, err := worker.CollectObservedState(context.Background(), nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				obs := observed.(snapshot.PersistenceObservedState)
@@ -124,7 +124,7 @@ var _ = Describe("PersistenceWorker", func() {
 					{Success: false, ActionType: "CompactDeltas", Timestamp: time.Now()},
 				})
 
-				observed1, err := worker.CollectObservedState(context.Background())
+				observed1, err := worker.CollectObservedState(context.Background(), nil)
 				Expect(err).NotTo(HaveOccurred())
 				obs1 := observed1.(snapshot.PersistenceObservedState)
 				Expect(obs1.ConsecutiveActionErrors).To(Equal(1))
@@ -134,7 +134,7 @@ var _ = Describe("PersistenceWorker", func() {
 				// won't persist across ticks in this unit test. This test verifies the
 				// within-tick computation: empty action history preserves previous count.
 				d.SetActionHistory(nil)
-				observed2, err := worker.CollectObservedState(context.Background())
+				observed2, err := worker.CollectObservedState(context.Background(), nil)
 				Expect(err).NotTo(HaveOccurred())
 				obs2 := observed2.(snapshot.PersistenceObservedState)
 				// Without stateReader, prev.ConsecutiveActionErrors is 0 and empty results
@@ -152,7 +152,7 @@ var _ = Describe("PersistenceWorker", func() {
 			d.SetLastCompactionAt(now)
 			d.SetLastMaintenanceAt(now.Add(-time.Hour))
 
-			observed, err := worker.CollectObservedState(context.Background())
+			observed, err := worker.CollectObservedState(context.Background(), nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			obs := observed.(snapshot.PersistenceObservedState)

--- a/umh-core/pkg/fsmv2/workers/transport/pull/worker.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/worker.go
@@ -79,7 +79,7 @@ func NewPullWorker(
 
 // CollectObservedState snapshots the current pull worker state.
 // Handles context cancellation at entry as required by architecture tests.
-func (w *PullWorker) CollectObservedState(ctx context.Context) (fsmv2.ObservedState, error) {
+func (w *PullWorker) CollectObservedState(ctx context.Context, _ fsmv2.DesiredState) (fsmv2.ObservedState, error) {
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()

--- a/umh-core/pkg/fsmv2/workers/transport/pull/worker_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/worker_test.go
@@ -86,7 +86,7 @@ var _ = Describe("PullWorker", func() {
 
 		It("should return valid observed state with timestamp", func() {
 			ctx := context.Background()
-			observed, err := worker.CollectObservedState(ctx)
+			observed, err := worker.CollectObservedState(ctx, nil)
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(observed).NotTo(BeNil())
@@ -97,7 +97,7 @@ var _ = Describe("PullWorker", func() {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 
-			_, err := worker.CollectObservedState(ctx)
+			_, err := worker.CollectObservedState(ctx, nil)
 
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(Equal(context.Canceled))
@@ -105,7 +105,7 @@ var _ = Describe("PullWorker", func() {
 
 		It("should report transport availability from parent deps", func() {
 			ctx := context.Background()
-			observed, err := worker.CollectObservedState(ctx)
+			observed, err := worker.CollectObservedState(ctx, nil)
 
 			Expect(err).ToNot(HaveOccurred())
 			typedObs, ok := observed.(snapshot.PullObservedState)
@@ -117,7 +117,7 @@ var _ = Describe("PullWorker", func() {
 			parentDeps.SetJWT("test-token", time.Now().Add(time.Hour))
 
 			ctx := context.Background()
-			observed, err := worker.CollectObservedState(ctx)
+			observed, err := worker.CollectObservedState(ctx, nil)
 
 			Expect(err).ToNot(HaveOccurred())
 			typedObs, ok := observed.(snapshot.PullObservedState)
@@ -130,7 +130,7 @@ var _ = Describe("PullWorker", func() {
 			worker.GetDependencies().RecordError()
 
 			ctx := context.Background()
-			observed, err := worker.CollectObservedState(ctx)
+			observed, err := worker.CollectObservedState(ctx, nil)
 
 			Expect(err).ToNot(HaveOccurred())
 			typedObs, ok := observed.(snapshot.PullObservedState)
@@ -140,7 +140,7 @@ var _ = Describe("PullWorker", func() {
 
 		It("should report pending message count", func() {
 			ctx := context.Background()
-			observed, err := worker.CollectObservedState(ctx)
+			observed, err := worker.CollectObservedState(ctx, nil)
 
 			Expect(err).ToNot(HaveOccurred())
 			typedObs, ok := observed.(snapshot.PullObservedState)
@@ -150,7 +150,7 @@ var _ = Describe("PullWorker", func() {
 
 		It("should report backpressure state", func() {
 			ctx := context.Background()
-			observed, err := worker.CollectObservedState(ctx)
+			observed, err := worker.CollectObservedState(ctx, nil)
 
 			Expect(err).ToNot(HaveOccurred())
 			typedObs, ok := observed.(snapshot.PullObservedState)
@@ -160,7 +160,7 @@ var _ = Describe("PullWorker", func() {
 
 		It("should include framework metrics", func() {
 			ctx := context.Background()
-			observed, err := worker.CollectObservedState(ctx)
+			observed, err := worker.CollectObservedState(ctx, nil)
 
 			Expect(err).ToNot(HaveOccurred())
 			typedObs, ok := observed.(snapshot.PullObservedState)
@@ -175,7 +175,7 @@ var _ = Describe("PullWorker", func() {
 			d.MetricsRecorder().SetGauge(depspkg.GaugeLastPullLatencyMs, 35.0)
 
 			ctx := context.Background()
-			observed, err := worker.CollectObservedState(ctx)
+			observed, err := worker.CollectObservedState(ctx, nil)
 
 			Expect(err).ToNot(HaveOccurred())
 			typedObs, ok := observed.(snapshot.PullObservedState)
@@ -194,14 +194,14 @@ var _ = Describe("PullWorker", func() {
 
 			d := worker.GetDependencies()
 			d.MetricsRecorder().IncrementCounter(depspkg.CounterPullOps, 1)
-			observed1, err := worker.CollectObservedState(ctx)
+			observed1, err := worker.CollectObservedState(ctx, nil)
 			Expect(err).ToNot(HaveOccurred())
 			typedObs1, ok := observed1.(snapshot.PullObservedState)
 			Expect(ok).To(BeTrue())
 			Expect(typedObs1.Metrics.Worker.Counters["pull_ops"]).To(Equal(int64(1)))
 
 			d.MetricsRecorder().IncrementCounter(depspkg.CounterPullOps, 2)
-			observed2, err := worker.CollectObservedState(ctx)
+			observed2, err := worker.CollectObservedState(ctx, nil)
 			Expect(err).ToNot(HaveOccurred())
 			typedObs2, ok := observed2.(snapshot.PullObservedState)
 			Expect(ok).To(BeTrue())

--- a/umh-core/pkg/fsmv2/workers/transport/push/worker.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/worker.go
@@ -79,7 +79,7 @@ func NewPushWorker(
 
 // CollectObservedState snapshots the current push worker state.
 // Handles context cancellation at entry as required by architecture tests.
-func (w *PushWorker) CollectObservedState(ctx context.Context) (fsmv2.ObservedState, error) {
+func (w *PushWorker) CollectObservedState(ctx context.Context, _ fsmv2.DesiredState) (fsmv2.ObservedState, error) {
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()

--- a/umh-core/pkg/fsmv2/workers/transport/push/worker_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/worker_test.go
@@ -87,7 +87,7 @@ var _ = Describe("PushWorker", func() {
 
 		It("should return valid observed state with timestamp", func() {
 			ctx := context.Background()
-			observed, err := worker.CollectObservedState(ctx)
+			observed, err := worker.CollectObservedState(ctx, nil)
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(observed).NotTo(BeNil())
@@ -98,7 +98,7 @@ var _ = Describe("PushWorker", func() {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 
-			_, err := worker.CollectObservedState(ctx)
+			_, err := worker.CollectObservedState(ctx, nil)
 
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(Equal(context.Canceled))
@@ -106,7 +106,7 @@ var _ = Describe("PushWorker", func() {
 
 		It("should report transport availability from parent deps", func() {
 			ctx := context.Background()
-			observed, err := worker.CollectObservedState(ctx)
+			observed, err := worker.CollectObservedState(ctx, nil)
 
 			Expect(err).ToNot(HaveOccurred())
 			typedObs, ok := observed.(snapshot.PushObservedState)
@@ -118,7 +118,7 @@ var _ = Describe("PushWorker", func() {
 			parentDeps.SetJWT("test-token", time.Now().Add(time.Hour))
 
 			ctx := context.Background()
-			observed, err := worker.CollectObservedState(ctx)
+			observed, err := worker.CollectObservedState(ctx, nil)
 
 			Expect(err).ToNot(HaveOccurred())
 			typedObs, ok := observed.(snapshot.PushObservedState)
@@ -130,7 +130,7 @@ var _ = Describe("PushWorker", func() {
 			parentDeps.SetJWT("expired-token", time.Now().Add(-1*time.Hour))
 
 			ctx := context.Background()
-			observed, err := worker.CollectObservedState(ctx)
+			observed, err := worker.CollectObservedState(ctx, nil)
 
 			Expect(err).ToNot(HaveOccurred())
 			typedObs, ok := observed.(snapshot.PushObservedState)
@@ -143,7 +143,7 @@ var _ = Describe("PushWorker", func() {
 			worker.GetDependencies().RecordError()
 
 			ctx := context.Background()
-			observed, err := worker.CollectObservedState(ctx)
+			observed, err := worker.CollectObservedState(ctx, nil)
 
 			Expect(err).ToNot(HaveOccurred())
 			typedObs, ok := observed.(snapshot.PushObservedState)
@@ -153,7 +153,7 @@ var _ = Describe("PushWorker", func() {
 
 		It("should include framework metrics", func() {
 			ctx := context.Background()
-			observed, err := worker.CollectObservedState(ctx)
+			observed, err := worker.CollectObservedState(ctx, nil)
 
 			Expect(err).ToNot(HaveOccurred())
 			typedObs, ok := observed.(snapshot.PushObservedState)
@@ -168,7 +168,7 @@ var _ = Describe("PushWorker", func() {
 			d.MetricsRecorder().SetGauge(depspkg.GaugeLastPushLatencyMs, 42.0)
 
 			ctx := context.Background()
-			observed, err := worker.CollectObservedState(ctx)
+			observed, err := worker.CollectObservedState(ctx, nil)
 
 			Expect(err).ToNot(HaveOccurred())
 			typedObs, ok := observed.(snapshot.PushObservedState)
@@ -187,14 +187,14 @@ var _ = Describe("PushWorker", func() {
 
 			d := worker.GetDependencies()
 			d.MetricsRecorder().IncrementCounter(depspkg.CounterPushOps, 1)
-			observed1, err := worker.CollectObservedState(ctx)
+			observed1, err := worker.CollectObservedState(ctx, nil)
 			Expect(err).ToNot(HaveOccurred())
 			typedObs1, ok := observed1.(snapshot.PushObservedState)
 			Expect(ok).To(BeTrue())
 			Expect(typedObs1.Metrics.Worker.Counters["push_ops"]).To(Equal(int64(1)))
 
 			d.MetricsRecorder().IncrementCounter(depspkg.CounterPushOps, 2)
-			observed2, err := worker.CollectObservedState(ctx)
+			observed2, err := worker.CollectObservedState(ctx, nil)
 			Expect(err).ToNot(HaveOccurred())
 			typedObs2, ok := observed2.(snapshot.PushObservedState)
 			Expect(ok).To(BeTrue())

--- a/umh-core/pkg/fsmv2/workers/transport/worker.go
+++ b/umh-core/pkg/fsmv2/workers/transport/worker.go
@@ -109,7 +109,7 @@ func NewTransportWorker(
 
 // CollectObservedState returns the current observed state of the transport worker.
 // Handles context cancellation at entry as required by architecture tests.
-func (w *TransportWorker) CollectObservedState(ctx context.Context) (fsmv2.ObservedState, error) {
+func (w *TransportWorker) CollectObservedState(ctx context.Context, _ fsmv2.DesiredState) (fsmv2.ObservedState, error) {
 	// Context cancellation check at entry (architecture requirement)
 	select {
 	case <-ctx.Done():

--- a/umh-core/pkg/fsmv2/workers/transport/worker_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/worker_test.go
@@ -86,7 +86,7 @@ var _ = Describe("TransportWorker", func() {
 
 		It("should return observed state with timestamp", func() {
 			ctx := context.Background()
-			observed, err := worker.CollectObservedState(ctx)
+			observed, err := worker.CollectObservedState(ctx, nil)
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(observed).NotTo(BeNil())
@@ -97,7 +97,7 @@ var _ = Describe("TransportWorker", func() {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel() // Cancel immediately
 
-			_, err := worker.CollectObservedState(ctx)
+			_, err := worker.CollectObservedState(ctx, nil)
 
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(Equal(context.Canceled))
@@ -105,7 +105,7 @@ var _ = Describe("TransportWorker", func() {
 
 		It("should call GetFrameworkState from dependencies", func() {
 			ctx := context.Background()
-			observed, err := worker.CollectObservedState(ctx)
+			observed, err := worker.CollectObservedState(ctx, nil)
 
 			Expect(err).ToNot(HaveOccurred())
 			// The observed state should have metrics container
@@ -116,7 +116,7 @@ var _ = Describe("TransportWorker", func() {
 
 		It("should call GetActionHistory from dependencies", func() {
 			ctx := context.Background()
-			observed, err := worker.CollectObservedState(ctx)
+			observed, err := worker.CollectObservedState(ctx, nil)
 
 			Expect(err).ToNot(HaveOccurred())
 			// The observed state should have last action results (even if empty)
@@ -389,7 +389,7 @@ authToken: "test-token"`,
 			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 			defer cancel()
 
-			_, err = worker.CollectObservedState(ctx)
+			_, err = worker.CollectObservedState(ctx, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			_, err = worker.DeriveDesiredState(nil)


### PR DESCRIPTION
## Summary

- Adds `desired DesiredState` parameter to the `CollectObservedState` interface
- Updates all 12 worker implementations (accept and ignore the new parameter)
- 37 files, 140 insertions, 101 deletions. One-time migration.

## The problem

`CollectObservedState` can't access configuration. For a worker that replaces the FSMv1 nmap/connection stack with a TCP reachability check, the implementation looks like this:

```go
func (w *Worker) CollectObservedState(ctx context.Context) (ObservedState, error) {
    // I need to dial target:port... but where do I get target and port?
    // DesiredState has them, but I can't see DesiredState here.
}
```

Actions can read `snap.Desired` in `State.Next()` and carry config on their struct. The sensor can't. So config-dependent I/O gets routed through Actions instead: emit a `ConfigureAction` that copies IP/port to Dependencies, wait a tick, then read from Dependencies. That's startup latency and boilerplate for every config field.

Most new workers need config-dependent observation. The FSMv1-to-FSMv2 migration alone has several (the nmap/connection stack, protocol converter health checks), and each one hits this same workaround.

## The fix

```go
// Before
CollectObservedState(ctx context.Context) (ObservedState, error)

// After
CollectObservedState(ctx context.Context, desired DesiredState) (ObservedState, error)
```

The supervisor loads DesiredState from the store and passes it before each collection call. Existing workers accept the parameter as `_`. Zero behavior change.

## Validation

In the documentation stress test described in the base PR (#2482), 5 implementation attempts on the old interface all placed `net.DialTimeout` inside an Action. After this interface change, the agent placed it in `CollectObservedState` and read host/port from `desired`. Full methodology and artifacts are in the base PR.

N=1, so take it accordingly. More runs planned.

## Design concerns

Three things that came up:

1. **Observation/intent boundary**: Already porous. Every `ObservedState` embeds `DesiredState` via `json:",inline"`, and `GetObservedDesiredState()` pairs them at the snapshot level. The coupling is in the data model already, this just makes the code honest about it.

2. **Goroutine safety**: Passing desired to the sensor means each observation records which config was in effect when it ran. Same pattern as `ShutdownRequestedProvider`.

3. **Slippery slope** (developers using `desired` for policy decisions in collectors): We can guard against this with architecture tests that detect calls to `desired.GetState()` or `desired.IsShutdownRequested()` inside `CollectObservedState`.

Outstanding work:
- [ ] Architecture test guard against policy methods in `CollectObservedState`
- [ ] `doc.go` update documenting permitted vs prohibited uses
- [ ] Migration guide for updating worker implementations

## Stacking

This PR sits on top of #2482, which rewrites the FSMv2 README to teach the sensor/controller/actuator framing that motivates this interface change. The base PR fixes the docs, this one fixes the interface.

## Test plan

- [x] `go build ./pkg/fsmv2/...` -- clean
- [x] `go test ./pkg/fsmv2/ -v -count=1` -- 39/39 architecture tests pass
- [x] Full test suite: 54/54 pass
- [ ] Address outstanding design concern items above