### PR TITLE
Fix: cpu throttle ratio

### DIFF
--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixes
 
+- CPU health stayed Degraded permanently after any brief throttle event because the ratio used cumulative counters since pod start. Now uses a sliding window, so health recovers when throttling stops
 - ADS symbol downloads failed in certain configurations -- bumped ADS plugin to v1.0.8 which fixes the issue
 
 ### Preview: FSMv2 Communicator

--- a/umh-core/pkg/constants/container.go
+++ b/umh-core/pkg/constants/container.go
@@ -49,4 +49,9 @@ const (
 	// CPUThrottleRatioThreshold defines when CPU throttling is considered significant.
 	// If more than 5% of periods are throttled, the CPU is considered throttled.
 	CPUThrottleRatioThreshold = 0.05
+
+	// CPUThrottleWindow defines the sliding window duration for throttle ratio calculation.
+	// At the 5% threshold, a 5-second window requires ~250ms of sustained throttling
+	// (2-3 CFS periods) before flagging degraded, filtering out transient spikes.
+	CPUThrottleWindow = 5 * time.Second
 )

--- a/umh-core/pkg/constants/container.go
+++ b/umh-core/pkg/constants/container.go
@@ -51,7 +51,7 @@ const (
 	CPUThrottleRatioThreshold = 0.05
 
 	// CPUThrottleWindow defines the sliding window duration for throttle ratio calculation.
-	// At the 5% threshold, a 5-second window requires ~250ms of sustained throttling
-	// (2-3 CFS periods) before flagging degraded, filtering out transient spikes.
-	CPUThrottleWindow = 5 * time.Second
+	// 60 seconds aligns with Prometheus/K8s rate windows for counter-derived metrics
+	// and avoids rapid Degraded/Active flips during bursty throttle events.
+	CPUThrottleWindow = 60 * time.Second
 )

--- a/umh-core/pkg/models/status_message.go
+++ b/umh-core/pkg/models/status_message.go
@@ -126,7 +126,7 @@ type CPU struct {
 	CoreCount      int     `json:"coreCount"`      // Number of CPU cores
 	// Cgroup-specific fields for container resource limits
 	CgroupCores   float64 `json:"cgroupCores,omitempty"`   // CPU quota from cgroup (e.g., 2.0 = 2 cores)
-	ThrottleRatio float64 `json:"throttleRatio,omitempty"` // Ratio of time throttled (0.0-1.0)
+	ThrottleRatio float64 `json:"throttleRatio,omitempty"` // Ratio of throttled periods (0.0-1.0)
 	IsThrottled   bool    `json:"isThrottled,omitempty"`   // True if recently throttled
 }
 

--- a/umh-core/pkg/service/container_monitor/cgroup_cpu.go
+++ b/umh-core/pkg/service/container_monitor/cgroup_cpu.go
@@ -21,7 +21,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants"
 )
 
 // CPUCgroupInfo contains cgroup v2 CPU metrics including throttling information.
@@ -137,13 +136,6 @@ func (c *ContainerMonitorService) getCgroupCPUInfo(ctx context.Context) (*CPUCgr
 	info.NrPeriods = nrPeriods
 	info.NrThrottled = nrThrottled
 	info.ThrottledUsec = throttledUsec
-
-	// Calculate throttle ratio
-	if info.NrPeriods > 0 {
-		info.ThrottleRatio = float64(info.NrThrottled) / float64(info.NrPeriods)
-		// Consider throttled if throttle ratio exceeds threshold
-		info.IsThrottled = info.ThrottleRatio > constants.CPUThrottleRatioThreshold
-	}
 
 	return info, nil
 }

--- a/umh-core/pkg/service/container_monitor/container_monitor.go
+++ b/umh-core/pkg/service/container_monitor/container_monitor.go
@@ -76,6 +76,7 @@ type ContainerMonitorService struct {
 	architecture      models.ContainerArchitecture //nolint:unused // will be used in the future
 	dataPath          string                       // Path to check for disk metrics and HWID file
 	throttleSnapshots []cgroupSnapshot             // Sliding window of cgroup counter snapshots
+	wasThrottled      bool                         // Previous throttle state for transition logging
 }
 
 // NewContainerMonitorService creates a new container monitor service instance.
@@ -290,10 +291,11 @@ func (c *ContainerMonitorService) getCPUMetrics(ctx context.Context) (*models.CP
 		message = "CPU utilization warning"
 	}
 
-	// Log throttling warnings
-	if isThrottled && cgroupInfo != nil {
+	// Log only on false→true transition to avoid flooding stdout
+	if isThrottled && !c.wasThrottled && cgroupInfo != nil {
 		c.logger.Warnf("CPU throttling detected: %.1f%% of periods throttled", cgroupInfo.ThrottleRatio*100)
 	}
+	c.wasThrottled = isThrottled
 
 	cpuStat := &models.CPU{
 		Health: &models.Health{

--- a/umh-core/pkg/service/container_monitor/container_monitor.go
+++ b/umh-core/pkg/service/container_monitor/container_monitor.go
@@ -59,15 +59,23 @@ type Service interface {
 	GetStatus(ctx context.Context) (*ServiceInfo, error)
 }
 
+// cgroupSnapshot stores cgroup CPU counters at a point in time for sliding window calculation.
+type cgroupSnapshot struct {
+	timestamp   time.Time
+	nrPeriods   int64
+	nrThrottled int64
+}
+
 // ContainerMonitorService implements the Service interface.
 type ContainerMonitorService struct {
-	fs              filesystem.Service
-	logger          *zap.SugaredLogger
-	instanceName    string
-	lastCollectedAt time.Time
-	hwid            string
-	architecture    models.ContainerArchitecture //nolint:unused // will be used in the future
-	dataPath        string                       // Path to check for disk metrics and HWID file
+	fs                filesystem.Service
+	logger            *zap.SugaredLogger
+	instanceName      string
+	lastCollectedAt   time.Time
+	hwid              string
+	architecture      models.ContainerArchitecture //nolint:unused // will be used in the future
+	dataPath          string                       // Path to check for disk metrics and HWID file
+	throttleSnapshots []cgroupSnapshot             // Sliding window of cgroup counter snapshots
 }
 
 // NewContainerMonitorService creates a new container monitor service instance.
@@ -259,8 +267,15 @@ func (c *ContainerMonitorService) getCPUMetrics(ctx context.Context) (*models.CP
 	category := models.Active
 	message := "CPU utilization normal"
 
-	// Check for throttling - only if cgroupInfo is not nil
-	isThrottled := cgroupErr == nil && cgroupInfo != nil && cgroupInfo.IsThrottled
+	// Compute windowed throttle ratio (replaces cumulative ratio from cgroup)
+	var windowedRatio float64
+	var isThrottled bool
+	if cgroupErr == nil && cgroupInfo != nil {
+		windowedRatio, isThrottled = c.updateThrottleWindow(cgroupInfo)
+		// Override the cumulative values with windowed values
+		cgroupInfo.ThrottleRatio = windowedRatio
+		cgroupInfo.IsThrottled = isThrottled
+	}
 
 	if usagePercent >= constants.CPUHighThresholdPercent || isThrottled {
 		category = models.Degraded
@@ -299,6 +314,65 @@ func (c *ContainerMonitorService) getCPUMetrics(ctx context.Context) (*models.CP
 	}
 
 	return cpuStat, nil
+}
+
+// updateThrottleWindow appends a cgroup snapshot and computes the throttle ratio
+// over a sliding window defined by constants.CPUThrottleWindow.
+// Returns (0.0, false) when there is insufficient data, nil input, or counter reset.
+func (c *ContainerMonitorService) updateThrottleWindow(cgroupInfo *CPUCgroupInfo) (ratio float64, isThrottled bool) {
+	// Guard: nil input or zero periods (cpu.stat unreadable)
+	if cgroupInfo == nil || cgroupInfo.NrPeriods <= 0 {
+		return 0.0, false
+	}
+
+	now := time.Now()
+
+	// Detect counter reset: if new counters are lower than the newest snapshot,
+	// the cgroup was recreated (pod rescheduled). Clear buffer and start fresh.
+	if len(c.throttleSnapshots) > 0 {
+		newest := c.throttleSnapshots[len(c.throttleSnapshots)-1]
+		if cgroupInfo.NrPeriods < newest.nrPeriods || cgroupInfo.NrThrottled < newest.nrThrottled {
+			c.throttleSnapshots = nil
+		}
+	}
+
+	// Append current snapshot
+	c.throttleSnapshots = append(c.throttleSnapshots, cgroupSnapshot{
+		timestamp:   now,
+		nrPeriods:   cgroupInfo.NrPeriods,
+		nrThrottled: cgroupInfo.NrThrottled,
+	})
+
+	// Prune entries older than the window
+	cutoff := now.Add(-constants.CPUThrottleWindow)
+	pruneIdx := 0
+	for pruneIdx < len(c.throttleSnapshots) && c.throttleSnapshots[pruneIdx].timestamp.Before(cutoff) {
+		pruneIdx++
+	}
+	if pruneIdx > 0 {
+		c.throttleSnapshots = c.throttleSnapshots[pruneIdx:]
+	}
+
+	// Need at least 2 snapshots for a delta
+	if len(c.throttleSnapshots) < 2 {
+		return 0.0, false
+	}
+
+	// Compute delta between newest and oldest snapshot in window
+	oldest := c.throttleSnapshots[0]
+	current := c.throttleSnapshots[len(c.throttleSnapshots)-1]
+
+	deltaPeriods := current.nrPeriods - oldest.nrPeriods
+	deltaThrottled := current.nrThrottled - oldest.nrThrottled
+
+	if deltaPeriods <= 0 {
+		return 0.0, false
+	}
+
+	ratio = float64(deltaThrottled) / float64(deltaPeriods)
+	isThrottled = ratio > constants.CPUThrottleRatioThreshold
+
+	return ratio, isThrottled
 }
 
 func (c *ContainerMonitorService) getRawCPUMetrics(ctx context.Context) (usageMCores float64, coreCount int, usagePercent float64, err error) {

--- a/umh-core/pkg/service/container_monitor/throttle_window_test.go
+++ b/umh-core/pkg/service/container_monitor/throttle_window_test.go
@@ -1,0 +1,196 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package container_monitor
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/filesystem"
+)
+
+func newThrottleTestService() *ContainerMonitorService {
+	return NewContainerMonitorServiceWithPath(filesystem.NewMockFileSystem(), "/tmp/test")
+}
+
+var _ = Describe("updateThrottleWindow", func() {
+	var svc *ContainerMonitorService
+
+	BeforeEach(func() {
+		svc = newThrottleTestService()
+	})
+
+	Context("on first read", func() {
+		It("should return zero ratio and not throttled", func() {
+			ratio, isThrottled := svc.updateThrottleWindow(&CPUCgroupInfo{
+				NrPeriods:   1000,
+				NrThrottled: 50,
+			})
+
+			Expect(ratio).To(Equal(0.0), "expected ratio 0.0 on first read")
+			Expect(isThrottled).To(BeFalse(), "expected isThrottled=false on first read")
+		})
+	})
+
+	Context("delta calculation", func() {
+		It("should compute the correct throttle ratio from deltas", func() {
+			now := time.Now()
+			svc.throttleSnapshots = []cgroupSnapshot{
+				{timestamp: now.Add(-1 * time.Second), nrPeriods: 1000, nrThrottled: 50},
+			}
+
+			ratio, isThrottled := svc.updateThrottleWindow(&CPUCgroupInfo{
+				NrPeriods:   1010,
+				NrThrottled: 55,
+			})
+
+			expectedRatio := 5.0 / 10.0
+			Expect(ratio).To(Equal(expectedRatio))
+			Expect(isThrottled).To(BeTrue(), "expected isThrottled=true for 50%% ratio")
+		})
+	})
+
+	Context("no throttling", func() {
+		It("should return zero ratio when no new throttling occurred", func() {
+			now := time.Now()
+			svc.throttleSnapshots = []cgroupSnapshot{
+				{timestamp: now.Add(-1 * time.Second), nrPeriods: 1000, nrThrottled: 50},
+			}
+
+			ratio, isThrottled := svc.updateThrottleWindow(&CPUCgroupInfo{
+				NrPeriods:   1010,
+				NrThrottled: 50,
+			})
+
+			Expect(ratio).To(Equal(0.0))
+			Expect(isThrottled).To(BeFalse())
+		})
+	})
+
+	Context("counter reset", func() {
+		It("should clear snapshots and return zero on counter reset", func() {
+			now := time.Now()
+			svc.throttleSnapshots = []cgroupSnapshot{
+				{timestamp: now.Add(-1 * time.Second), nrPeriods: 100000, nrThrottled: 5000},
+			}
+
+			ratio, isThrottled := svc.updateThrottleWindow(&CPUCgroupInfo{
+				NrPeriods:   100,
+				NrThrottled: 5,
+			})
+
+			Expect(ratio).To(Equal(0.0))
+			Expect(isThrottled).To(BeFalse())
+			Expect(svc.throttleSnapshots).To(HaveLen(1))
+		})
+	})
+
+	Context("nil cgroup info", func() {
+		It("should return zero ratio for nil input", func() {
+			ratio, isThrottled := svc.updateThrottleWindow(nil)
+
+			Expect(ratio).To(Equal(0.0))
+			Expect(isThrottled).To(BeFalse())
+		})
+	})
+
+	Context("zero periods", func() {
+		It("should return zero ratio and not store snapshot", func() {
+			ratio, isThrottled := svc.updateThrottleWindow(&CPUCgroupInfo{
+				NrPeriods:   0,
+				NrThrottled: 0,
+			})
+
+			Expect(ratio).To(Equal(0.0))
+			Expect(isThrottled).To(BeFalse())
+			Expect(svc.throttleSnapshots).To(HaveLen(0))
+		})
+	})
+
+	Context("pruning old entries", func() {
+		It("should remove entries older than the throttle window", func() {
+			now := time.Now()
+			svc.throttleSnapshots = []cgroupSnapshot{
+				{timestamp: now.Add(-10 * time.Second), nrPeriods: 500, nrThrottled: 25},
+				{timestamp: now.Add(-8 * time.Second), nrPeriods: 600, nrThrottled: 30},
+				{timestamp: now.Add(-3 * time.Second), nrPeriods: 900, nrThrottled: 45},
+			}
+
+			svc.updateThrottleWindow(&CPUCgroupInfo{
+				NrPeriods:   1000,
+				NrThrottled: 50,
+			})
+
+			Expect(svc.throttleSnapshots).To(HaveLen(2))
+		})
+	})
+
+	Context("below threshold", func() {
+		It("should not flag as throttled when ratio is below threshold", func() {
+			now := time.Now()
+			svc.throttleSnapshots = []cgroupSnapshot{
+				{timestamp: now.Add(-1 * time.Second), nrPeriods: 1000, nrThrottled: 50},
+			}
+
+			ratio, isThrottled := svc.updateThrottleWindow(&CPUCgroupInfo{
+				NrPeriods:   1100,
+				NrThrottled: 51,
+			})
+
+			expectedRatio := 1.0 / 100.0
+			Expect(ratio).To(Equal(expectedRatio))
+			Expect(isThrottled).To(BeFalse(), "expected isThrottled=false for ratio below threshold (%f < %f)", ratio, constants.CPUThrottleRatioThreshold)
+		})
+	})
+
+	Context("throttle then recover", func() {
+		It("should show throttling while window contains throttled data, then recover", func() {
+			now := time.Now()
+
+			// Phase 1: Window contains throttled data from the past
+			svc.throttleSnapshots = []cgroupSnapshot{
+				{timestamp: now.Add(-4 * time.Second), nrPeriods: 1000, nrThrottled: 50},
+				{timestamp: now.Add(-3 * time.Second), nrPeriods: 1010, nrThrottled: 58},
+				{timestamp: now.Add(-2 * time.Second), nrPeriods: 1020, nrThrottled: 65},
+			}
+
+			// Phase 2: New read with no throttling
+			ratio, isThrottled := svc.updateThrottleWindow(&CPUCgroupInfo{
+				NrPeriods:   1030,
+				NrThrottled: 65,
+			})
+
+			// Window: 30 periods, 15 throttled = 50%
+			expectedRatio := 15.0 / 30.0
+			Expect(ratio).To(Equal(expectedRatio))
+			Expect(isThrottled).To(BeTrue(), "expected isThrottled=true while window still contains throttled data")
+
+			// Phase 3: Old throttled entries fall out of window
+			svc.throttleSnapshots = []cgroupSnapshot{
+				{timestamp: now.Add(-1 * time.Second), nrPeriods: 1030, nrThrottled: 65},
+			}
+
+			ratio, isThrottled = svc.updateThrottleWindow(&CPUCgroupInfo{
+				NrPeriods:   1040,
+				NrThrottled: 65,
+			})
+
+			Expect(ratio).To(Equal(0.0))
+			Expect(isThrottled).To(BeFalse(), "expected isThrottled=false after throttling stopped and window slid past")
+		})
+	})
+})

--- a/umh-core/pkg/service/container_monitor/throttle_window_test.go
+++ b/umh-core/pkg/service/container_monitor/throttle_window_test.go
@@ -125,9 +125,9 @@ var _ = Describe("updateThrottleWindow", func() {
 		It("should remove entries older than the throttle window", func() {
 			now := time.Now()
 			svc.throttleSnapshots = []cgroupSnapshot{
-				{timestamp: now.Add(-10 * time.Second), nrPeriods: 500, nrThrottled: 25},
-				{timestamp: now.Add(-8 * time.Second), nrPeriods: 600, nrThrottled: 30},
-				{timestamp: now.Add(-3 * time.Second), nrPeriods: 900, nrThrottled: 45},
+				{timestamp: now.Add(-120 * time.Second), nrPeriods: 500, nrThrottled: 25},
+				{timestamp: now.Add(-90 * time.Second), nrPeriods: 600, nrThrottled: 30},
+				{timestamp: now.Add(-30 * time.Second), nrPeriods: 900, nrThrottled: 45},
 			}
 
 			svc.updateThrottleWindow(&CPUCgroupInfo{


### PR DESCRIPTION
# Description

- CPU throttle ratio was calculated from cumulative cgroup counters, causing permanent Degraded status after any brief throttle event
- Now uses a 5-second sliding window reflecting recent behavior, allowing recovery to Active when throttling stops

Fixes ENG-4470