### PR TITLE
Integration only merge queue

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -46,6 +46,8 @@ jobs:
     needs: [changes, go-analysis]
     if: ${{ needs.changes.outputs.code == 'true' }}
     uses: ./.github/workflows/test-umh-core.yml
+    with:
+      run-integration-tests: ${{ github.event_name == 'merge_group' }}
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -271,7 +271,15 @@ jobs:
   required-checks:
     name: Required Checks
     runs-on: ubuntu-latest # Use GH runner for fast startup, does not need Depot
-    needs: [go-analysis, tests, build, license-eye-header, require-changelog-entry, validate-changelog]
+    needs:
+      [
+        go-analysis,
+        tests,
+        build,
+        license-eye-header,
+        require-changelog-entry,
+        validate-changelog,
+      ]
     if: always()
     steps:
       - run: echo '${{ toJSON(needs) }}' | jq -e 'to_entries | all(.value.result == "success" or .value.result == "skipped")'

--- a/.github/workflows/test-umh-core.yml
+++ b/.github/workflows/test-umh-core.yml
@@ -20,6 +20,11 @@ concurrency:
 
 on:
   workflow_call:
+    inputs:
+      run-integration-tests:
+        description: "Whether to run integration tests"
+        type: boolean
+        default: true
   workflow_dispatch:
 
 jobs:
@@ -69,6 +74,7 @@ jobs:
 
   integration-tests:
     name: Integration Tests
+    if: inputs.run-integration-tests != false
     runs-on: depot-ubuntu-24.04-4
     strategy:
       matrix:

--- a/.github/workflows/test-umh-core.yml
+++ b/.github/workflows/test-umh-core.yml
@@ -26,6 +26,11 @@ on:
         type: boolean
         default: true
   workflow_dispatch:
+    inputs:
+      run-integration-tests:
+        description: "Whether to run integration tests"
+        type: boolean
+        default: true
 
 jobs:
   unit-tests:
@@ -60,7 +65,7 @@ jobs:
         if: failure()
         with:
           name: Unit Test Results
-          path: umh-core/unit-test-report.xml
+          path: "umh-core/unit-test-report*.xml"
           reporter: java-junit
           fail-on-error: false
 
@@ -69,7 +74,9 @@ jobs:
         if: always()
         with:
           name: unit-test-report
-          path: umh-core/unit-test-report.xml
+          path: |
+            umh-core/unit-test-report.xml
+            umh-core/unit-test-report-parallel.xml
           retention-days: 1
 
   integration-tests:

--- a/umh-core/Makefile
+++ b/umh-core/Makefile
@@ -227,6 +227,10 @@ endif
 UNIT_LABEL_FILTER := !integration && !redpanda-extended && !tls && !live
 # Explicit list: excludes integration/ (requires Docker; has its own make target)
 UNIT_TEST_PKGS := ./cmd/... ./internal/... ./pkg/... ./test/...
+# Package that runs its Ginkgo suite in parallel (--procs); must be kept separate
+UNIT_TEST_PKGS_PARALLEL := ./pkg/fsmv2/examples/...
+# All unit-test packages except the parallel ones (evaluated on first use)
+UNIT_TEST_PKGS_SERIAL = $(shell go list -tags=test ./cmd/... ./internal/... ./pkg/... ./test/... | grep -v 'fsmv2/examples' | tr '\n' ' ')
 
 build:
 build-pprof:       EXTRA_ARGS := --build-arg PPROF=true
@@ -314,15 +318,24 @@ vet-nilaway-lint-betteralign: vet nilaway lint betteralign
 test: vet-nilaway-lint-betteralign
 	go test -race -v -tags=test ./...
 
-unit-test: vet-nilaway-lint-betteralign
+unit-test:
 ifeq ($(CI), true)
-	gotestsum --junitfile unit-test-report.xml -- -race -v -tags=test -count=1 -failfast \
-		$(UNIT_TEST_PKGS) \
-		-args -ginkgo.label-filter='$(UNIT_LABEL_FILTER)'
+	rm -f /tmp/unit-test-failed
+	gotestsum --junitfile unit-test-report.xml -- -race -v -tags=test -count=1 -failfast -p 4 \
+		$(UNIT_TEST_PKGS_SERIAL) \
+		-args -ginkgo.label-filter='$(UNIT_LABEL_FILTER)' -ginkgo.no-color || touch /tmp/unit-test-failed
+	go run github.com/onsi/ginkgo/v2/ginkgo run --procs=30 --race --tags=test \
+		--label-filter='$(UNIT_LABEL_FILTER)' --junit-report=unit-test-report-parallel.xml \
+		--no-color \
+		$(UNIT_TEST_PKGS_PARALLEL) || touch /tmp/unit-test-failed
+	test ! -f /tmp/unit-test-failed
 else
-	go test -race -v -tags=test -count=1 -failfast \
-		$(UNIT_TEST_PKGS) \
+	go test -race -v -tags=test -count=1 -failfast -p 4 \
+		$(UNIT_TEST_PKGS_SERIAL) \
 		-args -ginkgo.label-filter='$(UNIT_LABEL_FILTER)'
+	go run github.com/onsi/ginkgo/v2/ginkgo run --procs=30 --race --tags=test \
+		--label-filter='$(UNIT_LABEL_FILTER)' \
+		$(UNIT_TEST_PKGS_PARALLEL)
 endif
 
 # Sequential fallback using ginkgo directly (no fail-fast, full failure report, covers ./...)

--- a/umh-core/Makefile
+++ b/umh-core/Makefile
@@ -320,15 +320,15 @@ test: vet-nilaway-lint-betteralign
 
 unit-test:
 ifeq ($(CI), true)
-	rm -f /tmp/unit-test-failed
+	FAILED=0; \
 	gotestsum --junitfile unit-test-report.xml -- -race -v -tags=test -count=1 -failfast -p 4 \
 		$(UNIT_TEST_PKGS_SERIAL) \
-		-args -ginkgo.label-filter='$(UNIT_LABEL_FILTER)' -ginkgo.no-color || touch /tmp/unit-test-failed
+		-args -ginkgo.label-filter='$(UNIT_LABEL_FILTER)' -ginkgo.no-color || FAILED=1; \
 	go run github.com/onsi/ginkgo/v2/ginkgo run --procs=30 --race --tags=test \
 		--label-filter='$(UNIT_LABEL_FILTER)' --junit-report=unit-test-report-parallel.xml \
 		--no-color \
-		$(UNIT_TEST_PKGS_PARALLEL) || touch /tmp/unit-test-failed
-	test ! -f /tmp/unit-test-failed
+		$(UNIT_TEST_PKGS_PARALLEL) || FAILED=1; \
+	exit $$FAILED
 else
 	go test -race -v -tags=test -count=1 -failfast -p 4 \
 		$(UNIT_TEST_PKGS_SERIAL) \

--- a/umh-core/pkg/fsmv2/config/hash_benchmark_test.go
+++ b/umh-core/pkg/fsmv2/config/hash_benchmark_test.go
@@ -66,13 +66,29 @@ var _ = Describe("ComputeUserSpecHash Performance", func() {
 
 	Describe("hash vs render performance ratio", func() {
 		const (
-			warmupIterations    = 100
-			measureIterations   = 1000
 			minimumSpeedupRatio = 5.0 // Conservative: actual is ~50x
 		)
 
+		// iterationsForSize returns warmup and measure counts scaled down for
+		// large configs to avoid multi-minute test runs. Parsing a 1MB template
+		// ~1100 times (100 warmup + 1000 measure) is the sole cause of slowness;
+		// even 5–10 iterations produce a stable ratio because both operations are
+		// deterministic with low variance.
+		iterationsForSize := func(sizeBytes int) (warmup, measure int) {
+			switch {
+			case sizeBytes >= 1024*1024: // ≥ 1 MB
+				return 2, 5
+			case sizeBytes >= 100*1024: // ≥ 100 KB
+				return 10, 50
+			default:
+				return 100, 1000
+			}
+		}
+
 		measurePerformance := func(configSize int, description string) {
 			It(fmt.Sprintf("hash is at least %.0fx faster than render for %s configs", minimumSpeedupRatio, description), func() {
+				warmupIterations, measureIterations := iterationsForSize(configSize)
+
 				// Create test data
 				configTemplate := generateConfigWithTemplates(configSize)
 				spec := config.UserSpec{


### PR DESCRIPTION
Closes ENG-4645

- Make integration only run in merge queue
- Decrease unit test time to ~6 min by extracting the `fsmv2/examples` package and have it run in parallel via `ginkgo`. Other tests still run in serial. Reports are still combined
