### PR TITLE
docs(fsmv2): rewrite README with control loop framing (ENG-4634)

### DIFF
--- a/umh-core/pkg/fsmv2/README.md
+++ b/umh-core/pkg/fsmv2/README.md
@@ -487,7 +487,7 @@ go run pkg/fsmv2/cmd/runner/main.go --scenario=simple --duration=10s
 go run pkg/fsmv2/cmd/runner/main.go --scenario=communicator --log-level=debug
 ```
 
-Built-in scenarios: `simple`, `failing`, `panic`, `cascade`, `timeout`, `communicator`
+Built-in scenarios: `helloworld`, `simple`, `failing`, `panic`, `slow`, `cascade`, `timeout`, `configerror`, `inheritance`, `communicator`, `concurrent`, `persistence`
 
 ### Unit tests
 

--- a/umh-core/pkg/fsmv2/README.md
+++ b/umh-core/pkg/fsmv2/README.md
@@ -11,7 +11,8 @@ Type-safe state machine framework for managing worker lifecycles with compile-ti
 ```bash
 # Run the existing examples
 go run pkg/fsmv2/cmd/runner/main.go --list          # List all scenarios
-go run pkg/fsmv2/cmd/runner/main.go --scenario=simple --duration=5s
+go run pkg/fsmv2/cmd/runner/main.go --scenario=helloworld --duration=5s  # Minimal single worker
+go run pkg/fsmv2/cmd/runner/main.go --scenario=simple --duration=5s      # Parent with 2 children
 ```
 
 ### Creating a New Worker
@@ -40,12 +41,40 @@ workers/myworker/
 
 ---
 
+## Modeling your worker
+
+FSMv2 runs the same control loop as a PLC or a room thermostat: observe the process, compare to the desired state, actuate, repeat. Your worker maps to three parts of that loop.
+
+### The control loop
+
+- **`CollectObservedState` is the sensor.** Read the world: check if an action completed, query a service, measure a connection. Read-only I/O. Example: helloworld reads `deps.HasSaidHello()` to see if the greeting was logged (`worker.go:115`).
+- **`State.Next()` is the controller.** Pure logic, no I/O. It compares observed state to desired state and decides: change state, or emit an action. Example: helloworld's `RunningState` checks shutdown, then checks the observed mood (`state/running.go:35`).
+- **Actions are the actuator.** Change the world: write files, send HTTP requests, authenticate. Always idempotent. Example: helloworld's `SayHelloAction` logs a greeting and sets a flag; the communicator's `AuthenticateAction` gets a JWT token.
+
+Sensor reads from Dependencies; actuator changes the external world and writes results back through Dependencies. The controller touches neither.
+
+### Lifecycle phases
+
+Each state embeds a base type that tells the supervisor which phase the control loop is in:
+
+- `helpers.StoppedBase` — loop is off, no observation or actuation happening
+- `helpers.StartingBase` — first observations arriving, actuator not yet confirmed working
+- `helpers.RunningHealthyBase` — loop running, health checks passing
+- `helpers.RunningDegradedBase` — loop running, but health checks failing (sensor sees a problem the actuator cannot fully fix)
+- `helpers.StoppingBase` — actuator shutting down gracefully, loop winding down
+
+See `internal/helpers/base_states.go` for the source. Example: helloworld's `RunningState` embeds `helpers.RunningHealthyBase` (`state/running.go:26`).
+
+Your states handle process deviations: is the port open? Is the sync working? Is the token expired? The supervisor handles instrumentation failures: stale observations, collector crashes, action panics, timeouts. You don't write states for those. In control loop terms, your controller handles the process. The supervisor is the watchdog that monitors the instruments.
+
+---
+
 ## How it works
 
 FSMv2 is a **state machine supervisor**:
 
 1. **You define** States (decision logic) and Actions (I/O operations)
-2. **Supervisor runs a loop**: Observe → Compare → Decide → Act → Repeat (~4µs per worker per tick)
+2. **Supervisor runs the control loop** [described above](#the-control-loop): observe, compare, actuate, repeat (~4µs per worker per tick)
 3. **State transitions happen** when observations change, NOT when actions complete
 
 ```text
@@ -66,8 +95,7 @@ FSMv2 solves problems from UMH Classic (Kubernetes-based) and FSMv1:
 | AI couldn't help (would "freestyle and break things") | Clean patterns AI can understand and generate |
 | Pod states don't reflect actual health | Explicit states: `running`, `degraded` (with reason), `stopped` |
 
-FSMv2 implements the same control loop pattern as Kubernetes controllers and PLCs:
-Desired state → Compare → Actuate → Observe → Repeat.
+FSMv2 implements the same [observe → compare → actuate](#the-control-loop) pattern as Kubernetes controllers and PLCs.
 
 ### For FSMv1 developers
 
@@ -104,31 +132,28 @@ type Worker interface {
 
 ### States: pure functions with Next()
 
-States are concrete Go types (not strings). Each state implements `Next()`:
+States are concrete Go types (not strings). Each state implements `Next()`, which returns a `NextResult` via `fsmv2.Result()`:
 
 ```go
-// States are empty structs - behavior only
-type StoppedState struct{}
-type TryingToStartState struct{}
-type RunningState struct{}
+// States embed a lifecycle base and implement Next()
+type StoppedState struct{ helpers.StoppedBase }
+type TryingToStartState struct{ helpers.StartingBase }
+type RunningState struct{ helpers.RunningHealthyBase }
 
-// Next() returns: (nextState, signal, action)
-func (s TryingToStartState) Next(snapshot fsmv2.Snapshot) (fsmv2.State, fsmv2.Signal, fsmv2.Action) {
-    // Type assertions are safe here - each worker defines its own concrete types
-    // and the supervisor guarantees type consistency within a worker
-    desired := snapshot.Desired.(DesiredState)
-    observed := snapshot.Observed.(ObservedState)
+// Next() returns a NextResult containing: state, signal, action, reason
+func (s *TryingToStartState) Next(snapAny any) fsmv2.NextResult[any, any] {
+    snap := helpers.ConvertSnapshot[ObservedState, *DesiredState](snapAny)
 
     // ALWAYS check shutdown first
-    if desired.IsShutdownRequested() {
-        return StoppedState{}, fsmv2.SignalNone, nil
+    if snap.Desired.IsShutdownRequested() {
+        return fsmv2.Result[any, any](&StoppedState{}, fsmv2.SignalNone, nil, "Shutdown requested")
     }
     // Check observation - did the process start?
-    if observed.IsRunning {
-        return RunningState{}, fsmv2.SignalNone, nil  // Transition based on observation
+    if snap.Observed.IsRunning {
+        return fsmv2.Result[any, any](&RunningState{}, fsmv2.SignalNone, nil, "Process is running")
     }
     // Not running yet - emit action to start it
-    return s, fsmv2.SignalNone, &StartAction{}  // Stay in same state, emit action
+    return fsmv2.Result[any, any](s, fsmv2.SignalNone, &StartAction{}, "Starting process")
 }
 ```
 
@@ -138,23 +163,19 @@ State transitions happen when observed state changes, NOT when actions complete.
 
 Return EITHER a state change OR an action from `Next()`, not both. See [State XOR action rule](#state-xor-action-rule).
 
-### State names and reasons (required methods)
+### State names
 
-Every state must implement two additional methods for observability:
+Every state must implement `String()` for logging and metrics. Use `helpers.DeriveStateName()` to derive the name automatically — it strips the `State` suffix and preserves casing:
 
 ```go
-// String() returns the state name for logging and metrics
-func (s TryingToStartState) String() string {
-    return "trying_to_start"
-}
-
-// Reason() provides human-readable context about the state
-func (s DegradedState) Reason() string {
-    return "degraded: 5 consecutive sync errors, retrying with backoff"
+func (s *TryingToStartState) String() string {
+    return helpers.DeriveStateName(s)  // returns "TryingToStart"
 }
 ```
 
-**Naming convention**: Use lowercase, underscore-separated names (`stopped`, `trying_to_connect`, `running`, `degraded`).
+**Naming convention**: `DeriveStateName` produces PascalCase names (`RunningState` → `"Running"`, `TryingToStartState` → `"TryingToStart"`, `StoppedState` → `"Stopped"`).
+
+Reason strings are the 4th argument to `fsmv2.Result()` in `Next()`, not a separate method. See the `Next()` example above.
 
 ### Signals
 
@@ -191,11 +212,11 @@ func (a *StartProcessAction) Name() string { return "StartProcess" }
 
 ### I/O isolation rule
 
-| Component | Can Do I/O | Purpose |
-|-----------|------------|---------|
+| Component | I/O | Purpose |
+|-----------|-----|---------|
 | States | NO (pure functions) | Decide next state + action |
-| Actions | YES (idempotent) | Perform HTTP, file, network I/O |
-| Worker | NO (read-only) | Collect observations |
+| Actions | WRITE (idempotent) | Change the world: HTTP, file, network I/O |
+| Worker | READ (query system state) | Collect observations from dependencies and state store |
 
 ### State XOR action rule
 
@@ -499,16 +520,16 @@ ginkgo run --focus="Architecture" -v ./pkg/fsmv2/
 
 ```go
 It("should transition to Running when process is observed", func() {
-    snapshot := fsmv2.Snapshot{
-        Observed: &MyObservedState{IsRunning: true},
-        Desired:  &MyDesiredState{},
-    }
-    state := TryingToStartState{}
-    nextState, signal, action := state.Next(snapshot)
+    snap := helpers.BuildTestSnapshot(
+        MyObservedState{IsRunning: true},
+        &MyDesiredState{},
+    )
+    state := &TryingToStartState{}
+    result := state.Next(snap)
 
-    Expect(nextState).To(BeAssignableToTypeOf(RunningState{}))
-    Expect(signal).To(Equal(fsmv2.SignalNone))
-    Expect(action).To(BeNil())
+    Expect(result.State).To(BeAssignableToTypeOf(&RunningState{}))
+    Expect(result.Signal).To(Equal(fsmv2.SignalNone))
+    Expect(result.Action).To(BeNil())
 })
 ```
 

--- a/umh-core/pkg/fsmv2/examples/helloworld.go
+++ b/umh-core/pkg/fsmv2/examples/helloworld.go
@@ -1,0 +1,39 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package examples
+
+// HelloworldScenario runs a single helloworld worker.
+//
+// Demonstrates both I/O patterns:
+//   - Action: SayHelloAction writes to in-memory deps
+//   - Observation: CollectObservedState reads /tmp/helloworld-mood from disk
+//
+// Interactive demo:
+//
+//	echo "happy" > /tmp/helloworld-mood   # stays Running
+//	echo "sad" > /tmp/helloworld-mood     # → Degraded
+//	rm /tmp/helloworld-mood               # → Running
+var HelloworldScenario = Scenario{
+	Name:        "helloworld",
+	Description: "Minimal worker: says hello, reads mood from /tmp/helloworld-mood",
+	YAMLConfig: `
+children:
+  - name: "hello-1"
+    workerType: "helloworld"
+    userSpec:
+      config: |
+        state: running
+`,
+}

--- a/umh-core/pkg/fsmv2/examples/scenario.go
+++ b/umh-core/pkg/fsmv2/examples/scenario.go
@@ -177,6 +177,7 @@ type Scenario struct {
 // Registry contains all available scenarios.
 // Add new scenarios here to make them available in both tests and CLI.
 var Registry = map[string]Scenario{
+	"helloworld":   HelloworldScenario,
 	"simple":       SimpleScenario,
 	"failing":      FailingScenario,
 	"panic":        PanicScenario,

--- a/umh-core/pkg/fsmv2/workers/example/helloworld/README.md
+++ b/umh-core/pkg/fsmv2/workers/example/helloworld/README.md
@@ -16,9 +16,28 @@ _ "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm
 ┌──────────┐    ShouldBeRunning()    ┌──────────────────┐    HelloSaid    ┌─────────┐
 │ stopped  │ ──────────────────────▶ │ trying_to_start  │ ─────────────▶ │ running │
 └──────────┘                         └──────────────────┘                └─────────┘
-     ▲                                        │                              │
-     │        IsShutdownRequested()           │                              │
-     └────────────────────────────────────────┴──────────────────────────────┘
+     ▲                                        │                    mood="sad" │ ▲ mood!="sad"
+     │        IsShutdownRequested()           │                              ▼ │
+     │                                        │                        ┌──────────┐
+     └────────────────────────────────────────┴────────────────────────┤ degraded │
+                                                                       └──────────┘
+```
+
+### Control loop mapping
+
+| Control loop role | Helloworld implementation |
+|-------------------|--------------------------|
+| **Sensor** (`CollectObservedState`) | Reads `deps.HasSaidHello()` + reads `/tmp/helloworld-mood` from disk |
+| **Controller** (`State.Next()`) | Checks shutdown → checks hello said → checks mood → decides |
+| **Actuator** (Actions) | `SayHelloAction` logs a greeting and sets `deps.HelloSaid` |
+
+See the parent [README's control loop section](../../../README.md#the-control-loop) for the general pattern.
+
+```bash
+# Demo: observation-driven transitions
+echo "happy" > /tmp/helloworld-mood   # stays Running
+echo "sad" > /tmp/helloworld-mood     # → Degraded
+rm /tmp/helloworld-mood               # → Running (no mood file = fine)
 ```
 
 ## File Structure
@@ -34,7 +53,8 @@ helloworld/
 ├── state/
 │   ├── stopped.go      # Initial state - waiting to start
 │   ├── trying_to_start.go  # Transitional state - emits action
-│   └── running.go      # Running state - worker is active
+│   ├── running.go      # Running state - worker is active
+│   └── degraded.go     # Degraded state - mood file says "sad"
 └── action/
     └── say_hello.go    # Action that transitions to running
 ```
@@ -109,9 +129,14 @@ func init() {
 
 ## Testing
 
-Run the hello world scenario:
+Run the helloworld scenario:
 ```bash
 go run pkg/fsmv2/cmd/runner/main.go --scenario=helloworld --duration=5s
+
+# Interactive mood demo (in a separate terminal while the scenario is running):
+echo "sad" > /tmp/helloworld-mood     # watch the worker transition to Degraded
+echo "happy" > /tmp/helloworld-mood   # back to Running
+rm /tmp/helloworld-mood               # stays Running (no mood file = fine)
 ```
 
 ## Common Mistakes

--- a/umh-core/pkg/fsmv2/workers/example/helloworld/snapshot/snapshot.go
+++ b/umh-core/pkg/fsmv2/workers/example/helloworld/snapshot/snapshot.go
@@ -69,6 +69,10 @@ type HelloworldObservedState struct {
 
 	// HelloSaid tracks whether the SayHelloAction has been executed
 	HelloSaid bool `json:"hello_said"`
+
+	// Mood is read from an external file (/tmp/helloworld-mood) by CollectObservedState.
+	// Demonstrates real blocking I/O in observation collection.
+	Mood string `json:"mood,omitempty"`
 }
 
 // GetTimestamp returns when this observation was collected.

--- a/umh-core/pkg/fsmv2/workers/example/helloworld/snapshot/snapshot.go
+++ b/umh-core/pkg/fsmv2/workers/example/helloworld/snapshot/snapshot.go
@@ -53,11 +53,15 @@ type HelloworldObservedState struct {
 	// CollectedAt is when this observation was taken
 	CollectedAt time.Time `json:"collected_at"`
 
-	// LastActionResults contains action history (managed by supervisor)
-	LastActionResults []deps.ActionResult `json:"last_action_results,omitempty"`
-
 	// State is the current FSM state name (set by supervisor)
 	State string `json:"state"`
+
+	// Mood is read from an external file (/tmp/helloworld-mood) by CollectObservedState.
+	// Demonstrates real blocking I/O in observation collection.
+	Mood string `json:"mood,omitempty"`
+
+	// LastActionResults contains action history (managed by supervisor)
+	LastActionResults []deps.ActionResult `json:"last_action_results,omitempty"`
 
 	// HelloworldDesiredState embedded for state consistency
 	// REQUIRED: Architecture tests verify this pattern
@@ -69,10 +73,6 @@ type HelloworldObservedState struct {
 
 	// HelloSaid tracks whether the SayHelloAction has been executed
 	HelloSaid bool `json:"hello_said"`
-
-	// Mood is read from an external file (/tmp/helloworld-mood) by CollectObservedState.
-	// Demonstrates real blocking I/O in observation collection.
-	Mood string `json:"mood,omitempty"`
 }
 
 // GetTimestamp returns when this observation was collected.

--- a/umh-core/pkg/fsmv2/workers/example/helloworld/state/degraded.go
+++ b/umh-core/pkg/fsmv2/workers/example/helloworld/state/degraded.go
@@ -20,36 +20,38 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/helloworld/snapshot"
 )
 
-// RunningState represents the worker actively running.
-// This is the steady state - worker stays here until shutdown.
-type RunningState struct {
-	helpers.RunningHealthyBase
+// DegradedState represents the worker running but impaired.
+// Entered when the external mood file contains "sad".
+// Transitions back to RunningState when the mood changes.
+type DegradedState struct {
+	helpers.RunningDegradedBase
 }
 
-// Next implements state transition logic for RunningState.
+// Next implements state transition logic for DegradedState.
 //
-// RUNNING STATE PATTERN:
-//   - Check shutdown first (transition to stopped)
-//   - Check observed mood from external file
-//   - Otherwise stay in running state
-func (s *RunningState) Next(snapAny any) fsmv2.NextResult[any, any] {
+// DEGRADED STATE PATTERN:
+//   - Check shutdown first
+//   - Check if the condition that caused degradation has cleared
+//   - If cleared, transition back to running
+//   - Otherwise stay degraded
+func (s *DegradedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := helpers.ConvertSnapshot[snapshot.HelloworldObservedState, *snapshot.HelloworldDesiredState](snapAny)
 
-	// 1. Check shutdown - transition back to stopped
+	// 1. Check shutdown
 	if snap.Desired.IsShutdownRequested() {
 		return fsmv2.Result[any, any](&StoppedState{}, fsmv2.SignalNone, nil, "Shutdown requested, transitioning to stopped")
 	}
 
-	// 2. Check mood from external observation (file read in CollectObservedState)
-	if snap.Observed.Mood == "sad" {
-		return fsmv2.Result[any, any](&DegradedState{}, fsmv2.SignalNone, nil, "Mood is sad, transitioning to degraded")
+	// 2. Check if mood has recovered (no longer "sad")
+	if snap.Observed.Mood != "sad" {
+		return fsmv2.Result[any, any](&RunningState{}, fsmv2.SignalNone, nil, "Mood recovered, transitioning to running")
 	}
 
-	// 3. Stay in running state
-	return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil, "Worker is running and has said hello")
+	// 3. Stay degraded
+	return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil, "Mood is still sad")
 }
 
 // String returns the state name for logging and metrics.
-func (s *RunningState) String() string {
+func (s *DegradedState) String() string {
 	return helpers.DeriveStateName(s)
 }

--- a/umh-core/pkg/fsmv2/workers/example/helloworld/worker.go
+++ b/umh-core/pkg/fsmv2/workers/example/helloworld/worker.go
@@ -31,6 +31,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/cse/storage"
@@ -96,6 +98,7 @@ func NewHelloworldWorker(
 // IMPLEMENTATION PATTERN:
 //   - Check context cancellation first
 //   - Read state from dependencies (what actions have set)
+//   - Read external state via blocking I/O (file, network, etc.)
 //   - Copy framework metrics if available
 //   - Return the observed state
 func (w *HelloworldWorker) CollectObservedState(ctx context.Context) (fsmv2.ObservedState, error) {
@@ -119,6 +122,14 @@ func (w *HelloworldWorker) CollectObservedState(ctx context.Context) (fsmv2.Obse
 
 	// Include action history for debugging
 	observed.LastActionResults = deps.GetActionHistory()
+
+	// Observation: read mood from external file (blocking disk I/O).
+	// This demonstrates why CollectObservedState runs in a background goroutine —
+	// file reads block, and on network mounts or slow storage (common in factories),
+	// this can take seconds. The supervisor ensures slow reads never block the tick loop.
+	if data, err := os.ReadFile("/tmp/helloworld-mood"); err == nil {
+		observed.Mood = strings.TrimSpace(string(data))
+	}
 
 	return observed, nil
 }


### PR DESCRIPTION
## Summary

- Adds "Modeling your worker" section that teaches when to use observations vs actions (sensor/controller/actuator framing)
- Updates all code examples to match the actual API (`fsmv2.Result[]`, pointer receivers, reason strings)
- Extends helloworld with DegradedState and a standalone scenario
- Fixes stale type names and jargon in CLAUDE.md and README

## The problem

The FSMv1 nmap/connection stack is two layers (Nmap FSM + Connection FSM, ~800 lines) that should collapse into one FSMv2 worker (~200 lines) using `net.DialTimeout`. The workshop spec even asks the right question: "Is checking whether a TCP port is open an action or an observation?"

We stress-tested the docs by giving AI agents this migration task. Every agent knew that `CollectObservedState` is the right place for `net.DialTimeout`. When asked directly, they said so. But when implementing, all of them put the TCP dial inside an Action.

The docs weren't factually wrong. Every API was correctly documented. But the README never told you how to decide which component to use. Without that, developers default to whatever pattern has the most examples, which is Actions.

This is half the problem. The other half, that `CollectObservedState` can't access configuration like target IP/port, is in the stacked PR #2479 which adds `desired DesiredState` as a parameter to `CollectObservedState`.

## The experiment

We ran 5 implementation attempts on the old interface with varying levels of guidance (full spec, outline only, direct question). All 5 placed `net.DialTimeout` inside an Action.

After both changes (this README rewrite + the interface change in PR #2479), one agent immediately placed the dial in `CollectObservedState` and read host/port from the `desired` parameter. So: 5 failures on the old setup, 1 success on the new. N=1, so take it accordingly. We plan more runs.

## What changed

New "Modeling your worker" section:
- `CollectObservedState` = sensor (read the world)
- `State.Next()` = controller (pure logic, no I/O)
- Actions = actuator (change the world)

The control loop was previously described in three places with different terminology. Now there's one description and the other two reference it.

Helloworld is now a teaching example:
- DegradedState shows observation-driven transitions (Running to Degraded based on mood file)
- Standalone `--scenario=helloworld` for quick experimentation
- Control loop mapping table in the helloworld README

Code examples updated to the actual API: pointer receivers, `fsmv2.Result[]`, `helpers.ConvertSnapshot`, `helpers.DeriveStateName` (PascalCase). The I/O isolation table now says READ/WRITE instead of YES/NO, which is clearer.

README: "safety system" changed to "watchdog" (avoids SIS regulatory connotation), "error signal" changed to "health checks". CLAUDE.md: `BaseRunningState` changed to `RunningHealthyBase`.

## Stacking

Base of a 2-PR stack. PR #2479 sits on top and adds `desired DesiredState` to `CollectObservedState`, giving the sensor access to configuration. This PR fixes the docs, PR #2479 fixes the interface.

## Test plan

- [x] `go build ./pkg/fsmv2/...`
- [x] `go test ./pkg/fsmv2/ -v -count=1` -- 40 of 41 architecture tests pass (1 skipped)
- [x] `make betteralign` -- clean
- [x] `--scenario=helloworld` runs: Stopped -> TryingToStart -> Running
- [ ] Re-run agent experiment with updated README only (no interface change) to isolate the documentation improvement
