### PR TITLE
fix(fsmv2): suppress redundant Sentry noise from auth failures (ENG-4576)

### DIFF
--- a/umh-core/pkg/fsmv2/workers/transport/action/authenticate.go
+++ b/umh-core/pkg/fsmv2/workers/transport/action/authenticate.go
@@ -38,7 +38,7 @@ const (
 // Idempotent: safe to retry on failure, multiple calls won't create multiple tokens.
 // Creates transport on first execution if not present.
 //
-// Returns nil on classified TransportError (tracked via RecordTypedError for snapshot-based backoff).
+// Returns nil on classified TransportError (tracked via deps for snapshot-based backoff).
 // Returns error on context cancellation, invalid dependency type, or non-TransportError
 // (programming bugs that must propagate to the executor).
 //
@@ -106,8 +106,10 @@ func (a *AuthenticateAction) Execute(ctx context.Context, depsAny any) error {
 		}
 
 		// Only suppress classified TransportErrors. Non-TransportErrors are programming
-		// bugs that must propagate to the executor for SentryError. Same pattern as
-		// push/pull actions (ENG-4450).
+		// bugs that must propagate to the executor for SentryError.
+		// Note: unlike push/pull (which only suppress transient errors), auth suppresses
+		// ALL classified TransportErrors because persistent auth errors are handled via
+		// snapshot-based state transitions (AuthFailedState), not error propagation.
 		var transportErr *httpTransport.TransportError
 		if !errors.As(err, &transportErr) {
 			return err
@@ -128,7 +130,7 @@ func (a *AuthenticateAction) Execute(ctx context.Context, depsAny any) error {
 		// and LastErrorType from the snapshot for backoff decisions (StartingState.Next()).
 		// Returning nil suppresses the executor's SentryError("action_failed"), which is
 		// appropriate because auth failures are expected business errors, not programming
-		// errors. Same pattern as pull/push transient error suppression (ENG-4450).
+		// errors.
 		return nil
 	}
 

--- a/umh-core/pkg/fsmv2/workers/transport/action/authenticate.go
+++ b/umh-core/pkg/fsmv2/workers/transport/action/authenticate.go
@@ -39,8 +39,8 @@ const (
 // Creates transport on first execution if not present.
 //
 // Returns nil on classified TransportError (tracked via RecordTypedError for snapshot-based backoff).
-// Returns error on context cancellation, invalid dependency type, or unclassified errors
-// (ErrorTypeUnknown), which are programming errors that must propagate to the executor.
+// Returns error on context cancellation, invalid dependency type, or non-TransportError
+// (programming bugs that must propagate to the executor).
 //
 // Architecture compliance:
 //   - Struct fields are read-only config (no mutable state) - Stateless Actions
@@ -105,14 +105,15 @@ func (a *AuthenticateAction) Execute(ctx context.Context, depsAny any) error {
 			return fmt.Errorf("authentication failed (context canceled): %w", ctx.Err())
 		}
 
-		errType, retryAfter := httpTransport.ExtractErrorType(err)
-
-		// Non-TransportErrors (ErrorTypeUnknown) are programming errors.
-		// Let them propagate to the executor for SentryError.
-		if errType == httpTransport.ErrorTypeUnknown {
+		// Only suppress classified TransportErrors. Non-TransportErrors are programming
+		// bugs that must propagate to the executor for SentryError. Same pattern as
+		// push/pull actions (ENG-4450).
+		var transportErr *httpTransport.TransportError
+		if !errors.As(err, &transportErr) {
 			return err
 		}
 
+		errType, retryAfter := transportErr.Type, transportErr.RetryAfter
 		deps.RecordTypedError(errType, retryAfter)
 		deps.MetricsRecorder().IncrementCounter(httpTransport.CounterForErrorType(errType), 1)
 

--- a/umh-core/pkg/fsmv2/workers/transport/action/authenticate.go
+++ b/umh-core/pkg/fsmv2/workers/transport/action/authenticate.go
@@ -17,6 +17,7 @@ package action
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	depspkg "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
@@ -37,7 +38,9 @@ const (
 // Idempotent: safe to retry on failure, multiple calls won't create multiple tokens.
 // Creates transport on first execution if not present.
 //
-// Returns error on network failure, invalid credentials (non-200), or malformed response.
+// Returns nil on classified TransportError (tracked via RecordTypedError for snapshot-based backoff).
+// Returns error on context cancellation, invalid dependency type, or unclassified errors
+// (ErrorTypeUnknown), which are programming errors that must propagate to the executor.
 //
 // Architecture compliance:
 //   - Struct fields are read-only config (no mutable state) - Stateless Actions
@@ -97,20 +100,35 @@ func (a *AuthenticateAction) Execute(ctx context.Context, depsAny any) error {
 
 	authResp, err := deps.GetTransport().Authenticate(ctx, authReq)
 	if err != nil {
-		var transportErr *httpTransport.TransportError
-		if errors.As(err, &transportErr) {
-			deps.RecordTypedError(transportErr.Type, transportErr.RetryAfter)
-			deps.MetricsRecorder().IncrementCounter(httpTransport.CounterForErrorType(transportErr.Type), 1)
-			deps.GetLogger().SentryWarn(depspkg.FeatureCommunicator, deps.GetHierarchyPath(), "authentication_failed",
-				depspkg.Err(err), depspkg.String("errorType", transportErr.Type.String()))
-		} else {
-			deps.RecordTypedError(httpTransport.ErrorTypeNetwork, 0)
-			deps.MetricsRecorder().IncrementCounter(depspkg.CounterNetworkErrorsTotal, 1)
-			deps.GetLogger().SentryWarn(depspkg.FeatureCommunicator, deps.GetHierarchyPath(), "authentication_failed",
-				depspkg.Err(err))
+		// Context cancellation propagates immediately for shutdown.
+		if ctx.Err() != nil {
+			return fmt.Errorf("authentication failed (context canceled): %w", ctx.Err())
 		}
 
-		return err
+		errType, retryAfter := httpTransport.ExtractErrorType(err)
+
+		// Non-TransportErrors (ErrorTypeUnknown) are programming errors.
+		// Let them propagate to the executor for SentryError.
+		if errType == httpTransport.ErrorTypeUnknown {
+			return err
+		}
+
+		deps.RecordTypedError(errType, retryAfter)
+		deps.MetricsRecorder().IncrementCounter(httpTransport.CounterForErrorType(errType), 1)
+
+		// First-occurrence SentryWarn: alert once per failure episode, not on every retry.
+		// Resets when RecordSuccess() clears consecutiveErrors to 0.
+		if deps.GetConsecutiveErrors() == 1 {
+			deps.GetLogger().SentryWarn(depspkg.FeatureCommunicator, deps.GetHierarchyPath(), "authentication_failed",
+				depspkg.Err(err), depspkg.String("errorType", errType.String()))
+		}
+
+		// Return nil for classified TransportErrors. The state machine reads ConsecutiveErrors
+		// and LastErrorType from the snapshot for backoff decisions (StartingState.Next()).
+		// Returning nil suppresses the executor's SentryError("action_failed"), which is
+		// appropriate because auth failures are expected business errors, not programming
+		// errors. Same pattern as pull/push transient error suppression (ENG-4450).
+		return nil
 	}
 
 	deps.RecordSuccess()

--- a/umh-core/pkg/fsmv2/workers/transport/action/authenticate_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/action/authenticate_test.go
@@ -199,10 +199,13 @@ var _ = Describe("AuthenticateAction", func() {
 			ctx := context.Background()
 			beforeExec := time.Now()
 
-			// Use a failing auth to test timestamp recording (success clears it)
-			mockTransp.authError = errors.New("auth failed")
+			// Use a classified TransportError to test timestamp recording
+			mockTransp.authError = &httpTransport.TransportError{
+				Type:    httpTransport.ErrorTypeNetwork,
+				Message: "connection refused",
+			}
 			err := act.Execute(ctx, dependencies)
-			Expect(err).To(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 
 			afterExec := time.Now()
 			attemptTime := dependencies.GetLastAuthAttemptAt()
@@ -213,7 +216,7 @@ var _ = Describe("AuthenticateAction", func() {
 			mockTransp.authError = nil
 		})
 
-		It("should record typed error on transport failure", func() {
+		It("should suppress auth errors and still record typed error", func() {
 			ctx := context.Background()
 			mockTransp.authError = &httpTransport.TransportError{
 				Type:       httpTransport.ErrorTypeBackendRateLimit,
@@ -222,15 +225,27 @@ var _ = Describe("AuthenticateAction", func() {
 			}
 
 			err := act.Execute(ctx, dependencies)
-			Expect(err).To(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 
 			Expect(dependencies.GetLastErrorType()).To(Equal(httpTransport.ErrorTypeBackendRateLimit))
 		})
 
+		It("should propagate unclassified errors (ErrorTypeUnknown)", func() {
+			ctx := context.Background()
+			mockTransp.authError = errors.New("unexpected programming error")
+
+			err := act.Execute(ctx, dependencies)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("unexpected programming error"))
+		})
+
 		It("should record success and reset error state on successful auth", func() {
 			ctx := context.Background()
-			// First, simulate an error to set error state
-			mockTransp.authError = errors.New("temporary error")
+			// First, simulate a classified error to set error state
+			mockTransp.authError = &httpTransport.TransportError{
+				Type:    httpTransport.ErrorTypeNetwork,
+				Message: "connection refused",
+			}
 			_ = act.Execute(ctx, dependencies)
 			Expect(dependencies.GetConsecutiveErrors()).To(BeNumerically(">", 0))
 
@@ -257,10 +272,80 @@ var _ = Describe("AuthenticateAction", func() {
 			}
 
 			err := act.Execute(ctx, dependencies)
-			Expect(err).To(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 
 			// Metrics are recorded via MetricsRecorder, which is tested separately
-			// This test verifies the action returns error as expected
+			// This test verifies the action suppresses auth errors
+		})
+	})
+
+	Describe("Auth Error Suppression", func() {
+		It("should suppress persistent auth errors (InvalidToken)", func() {
+			ctx := context.Background()
+			mockTransp.authError = &httpTransport.TransportError{
+				Type:    httpTransport.ErrorTypeInvalidToken,
+				Message: "invalid credentials",
+			}
+
+			err := act.Execute(ctx, dependencies)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(dependencies.GetLastErrorType()).To(Equal(httpTransport.ErrorTypeInvalidToken))
+			Expect(dependencies.GetConsecutiveErrors()).To(Equal(1))
+		})
+
+		It("should suppress persistent auth errors (InstanceDeleted)", func() {
+			ctx := context.Background()
+			mockTransp.authError = &httpTransport.TransportError{
+				Type:    httpTransport.ErrorTypeInstanceDeleted,
+				Message: "instance not found",
+			}
+
+			err := act.Execute(ctx, dependencies)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(dependencies.GetLastErrorType()).To(Equal(httpTransport.ErrorTypeInstanceDeleted))
+			Expect(dependencies.GetConsecutiveErrors()).To(Equal(1))
+		})
+
+		It("should fire SentryWarn on first occurrence only", func() {
+			ctx := context.Background()
+			mockTransp.authError = &httpTransport.TransportError{
+				Type:    httpTransport.ErrorTypeNetwork,
+				Message: "connection refused",
+			}
+
+			// First failure: consecutiveErrors goes 0 -> 1
+			err := act.Execute(ctx, dependencies)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dependencies.GetConsecutiveErrors()).To(Equal(1))
+
+			// Second failure: consecutiveErrors goes 1 -> 2
+			err = act.Execute(ctx, dependencies)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dependencies.GetConsecutiveErrors()).To(Equal(2))
+
+			// SentryWarn is called via NopFSMLogger which discards output.
+			// The behavior is verified by checking that consecutiveErrors
+			// increments correctly (the guard condition for SentryWarn).
+		})
+
+		It("should propagate context cancellation", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			mockTransp.authError = &httpTransport.TransportError{
+				Type:    httpTransport.ErrorTypeNetwork,
+				Message: "connection refused",
+			}
+
+			// Cancel context after transport is set up but the mock returns error
+			// We need to NOT cancel before Execute (that's tested in Context Cancellation above)
+			// Instead, simulate: transport returns error AND context is cancelled
+			cancel()
+
+			// Even though auth fails, context cancellation should propagate
+			err := act.Execute(ctx, dependencies)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("context"))
 		})
 	})
 })

--- a/umh-core/pkg/fsmv2/workers/transport/action/authenticate_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/action/authenticate_test.go
@@ -17,6 +17,7 @@ package action_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -230,13 +231,41 @@ var _ = Describe("AuthenticateAction", func() {
 			Expect(dependencies.GetLastErrorType()).To(Equal(httpTransport.ErrorTypeBackendRateLimit))
 		})
 
-		It("should propagate unclassified errors (ErrorTypeUnknown)", func() {
+		It("should propagate non-TransportError (programming bug)", func() {
 			ctx := context.Background()
 			mockTransp.authError = errors.New("unexpected programming error")
 
 			err := act.Execute(ctx, dependencies)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("unexpected programming error"))
+		})
+
+		It("should suppress TransportError with ErrorTypeUnknown (operational error)", func() {
+			ctx := context.Background()
+			// ErrorTypeUnknown TransportErrors represent operational issues (e.g., JSON decode
+			// failure from relay, unrecognized HTTP status). They ARE TransportErrors and should
+			// be tracked and suppressed, unlike plain errors.
+			mockTransp.authError = &httpTransport.TransportError{
+				Type:    httpTransport.ErrorTypeUnknown,
+				Message: "failed to decode auth response",
+			}
+
+			err := act.Execute(ctx, dependencies)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dependencies.GetConsecutiveErrors()).To(Equal(1))
+		})
+
+		It("should suppress wrapped TransportError via errors.As unwrapping", func() {
+			ctx := context.Background()
+			innerErr := &httpTransport.TransportError{
+				Type:    httpTransport.ErrorTypeNetwork,
+				Message: "connection refused",
+			}
+			mockTransp.authError = fmt.Errorf("auth request failed: %w", innerErr)
+
+			err := act.Execute(ctx, dependencies)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dependencies.GetLastErrorType()).To(Equal(httpTransport.ErrorTypeNetwork))
 		})
 
 		It("should record success and reset error state on successful auth", func() {

--- a/umh-core/pkg/fsmv2/workers/transport/action/authenticate_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/action/authenticate_test.go
@@ -372,6 +372,8 @@ var _ = Describe("AuthenticateAction", func() {
 			err := act.Execute(ctx, dependencies)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("context canceled"))
+			// Verify RecordTypedError was NOT called (ctx.Err() short-circuits before recording)
+			Expect(dependencies.GetConsecutiveErrors()).To(Equal(0))
 		})
 	})
 })

--- a/umh-core/pkg/fsmv2/workers/transport/action/authenticate_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/action/authenticate_test.go
@@ -339,24 +339,34 @@ var _ = Describe("AuthenticateAction", func() {
 
 		It("should fire SentryWarn on first occurrence only", func() {
 			ctx := context.Background()
+			spy := &spyLogger{FSMLogger: deps.NewNopFSMLogger()}
+			identity := deps.Identity{ID: "test-spy", WorkerType: "transport"}
+			spyDeps := transportpkg.NewTransportDependencies(mockTransp, spy, nil, identity)
+
 			mockTransp.authError = &httpTransport.TransportError{
 				Type:    httpTransport.ErrorTypeNetwork,
 				Message: "connection refused",
 			}
 
-			// First failure: consecutiveErrors goes 0 -> 1
-			err := act.Execute(ctx, dependencies)
+			// First failure: consecutiveErrors 0 -> 1, SentryWarn fires
+			err := act.Execute(ctx, spyDeps)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(dependencies.GetConsecutiveErrors()).To(Equal(1))
+			Expect(spyDeps.GetConsecutiveErrors()).To(Equal(1))
 
-			// Second failure: consecutiveErrors goes 1 -> 2
-			err = act.Execute(ctx, dependencies)
+			// Second failure: consecutiveErrors 1 -> 2, SentryWarn does NOT fire
+			err = act.Execute(ctx, spyDeps)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(dependencies.GetConsecutiveErrors()).To(Equal(2))
+			Expect(spyDeps.GetConsecutiveErrors()).To(Equal(2))
 
-			// SentryWarn is called via NopFSMLogger which discards output.
-			// The behavior is verified by checking that consecutiveErrors
-			// increments correctly (the guard condition for SentryWarn).
+			// Third failure: consecutiveErrors 2 -> 3, SentryWarn does NOT fire
+			err = act.Execute(ctx, spyDeps)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(spyDeps.GetConsecutiveErrors()).To(Equal(3))
+
+			// SentryWarn was called exactly once (on first failure)
+			Expect(spy.sentryWarnCount).To(Equal(1))
+			Expect(spy.sentryWarnMsgs).To(HaveLen(1))
+			Expect(spy.sentryWarnMsgs[0]).To(Equal("authentication_failed"))
 		})
 
 		It("should propagate context cancellation during Authenticate", func() {
@@ -412,3 +422,18 @@ func (m *mockTransport) Close() {
 
 func (m *mockTransport) Reset() {
 }
+
+// spyLogger wraps NopFSMLogger to count SentryWarn calls.
+// Test-local: only used by "should fire SentryWarn on first occurrence only".
+type spyLogger struct {
+	deps.FSMLogger
+	sentryWarnCount int
+	sentryWarnMsgs  []string
+}
+
+func (s *spyLogger) SentryWarn(_ deps.Feature, _ string, msg string, _ ...deps.Field) {
+	s.sentryWarnCount++
+	s.sentryWarnMsgs = append(s.sentryWarnMsgs, msg)
+}
+
+func (s *spyLogger) With(_ ...deps.Field) deps.FSMLogger { return s }

--- a/umh-core/pkg/fsmv2/workers/transport/action/authenticate_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/action/authenticate_test.go
@@ -25,8 +25,8 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator/transport"
 	httpTransport "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator/transport/http"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/action"
 	transportpkg "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/action"
 )
 
 var _ = Describe("AuthenticateAction", func() {
@@ -330,34 +330,36 @@ var _ = Describe("AuthenticateAction", func() {
 			// increments correctly (the guard condition for SentryWarn).
 		})
 
-		It("should propagate context cancellation", func() {
+		It("should propagate context cancellation during Authenticate", func() {
 			ctx, cancel := context.WithCancel(context.Background())
+			// Cancel inside Authenticate() to exercise the post-Authenticate ctx.Err() branch,
+			// not the top-of-method guard (which is tested in "Context Cancellation" above).
+			mockTransp.cancelDuringAuth = cancel
 			mockTransp.authError = &httpTransport.TransportError{
 				Type:    httpTransport.ErrorTypeNetwork,
 				Message: "connection refused",
 			}
 
-			// Cancel context after transport is set up but the mock returns error
-			// We need to NOT cancel before Execute (that's tested in Context Cancellation above)
-			// Instead, simulate: transport returns error AND context is cancelled
-			cancel()
-
-			// Even though auth fails, context cancellation should propagate
 			err := act.Execute(ctx, dependencies)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("context"))
+			Expect(err.Error()).To(ContainSubstring("context canceled"))
 		})
 	})
 })
 
 type mockTransport struct {
-	authCallCount int
-	authResponse  transport.AuthResponse
-	authError     error
+	authCallCount    int
+	authResponse     transport.AuthResponse
+	authError        error
+	cancelDuringAuth context.CancelFunc
 }
 
 func (m *mockTransport) Authenticate(ctx context.Context, req transport.AuthRequest) (transport.AuthResponse, error) {
 	m.authCallCount++
+
+	if m.cancelDuringAuth != nil {
+		m.cancelDuringAuth()
+	}
 
 	if m.authError != nil {
 		return transport.AuthResponse{}, m.authError


### PR DESCRIPTION
## Problem

Every auth retry fires two Sentry events: `SentryWarn("authentication_failed")` from the action and `SentryError("action_failed")` from the action executor. The executor treats any non-nil return as a programming error — correct for bugs, wrong for expected auth failures. A misconfigured instance at 60s retry produces ~2880 events/day.

## Fix

Classified `TransportError`s return nil from `Execute()`. `RecordTypedError()` updates `ConsecutiveErrors` and `LastErrorType` in deps before returning, so `StartingState`'s backoff logic is unchanged — it reads the snapshot, not the action return value.

Non-`TransportError` errors (programming bugs) still propagate to the executor. The distinction uses `errors.As(err, &transportErr)` — the same pattern as push/pull actions (ENG-4450). Context cancellation propagates immediately for correct shutdown behavior.

Same pattern as `PushAction`/`PullAction` in ENG-4450 (#2465).

## Stack

1. **→ This PR** → staging
2. Tiered alerting (#2485) → this branch
3. AuthFailedState (#2487) → #2485

Part of ENG-4576. Resolves: ENG-4647.

## Test plan

- [x] All classified auth errors (including `ErrorTypeUnknown`) return nil
- [x] Non-`TransportError` errors propagate to executor
- [x] Context cancellation during `Authenticate()` returns the error
- [x] `ConsecutiveErrors` still tracks via `RecordTypedError`
- [x] `go vet` clean
- [ ] Integration tests (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)