### PR TITLE
chore: adopt Unreleased changelog convention + add missing v0.44.12 entries

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -110,7 +110,7 @@ jobs:
           echo "::error::No changes to umh-core/CHANGELOG.md detected."
           echo ""
           echo "This PR modifies code but doesn't include a changelog entry."
-          echo "Add an entry under the topmost version section (e.g. ## [X.Y.Z]) in umh-core/CHANGELOG.md,"
+          echo "Add an entry under the ## Unreleased section in umh-core/CHANGELOG.md,"
           echo "or add the 'skip-changelog-guard' label if not needed (CI/CD, refactoring, or test-only changes)"
           echo "and push a commit to re-trigger CI."
           echo ""

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,17 +134,10 @@ The United Manufacturing Hub (UMH) is an Industrial IoT platform for manufacturi
 
 ### Changelog
 
-Every PR with user-visible changes must add an entry to `umh-core/CHANGELOG.md` under the current (topmost) version section. Use the `/changelog-entry` skill to generate entries when available. For writing guidelines and voice, follow the `changelog-writing` skill. When skills are unavailable (e.g., in subagents), follow these rules:
+Every PR with user-visible changes must add an entry to `umh-core/CHANGELOG.md` under the `## Unreleased` section at the top. For format, voice, and what to include/skip, follow the `changelog-writing` skill (use `/changelog-entry` to generate entries). Never create a new version section — only add to `## Unreleased`. The section is renamed to a version number at release time (see `umh-core/RELEASING.md`).
 
-- **Format**: Plain bullets with no bold lead-in — lead with the problem ("Previously, ..."), then the solution ("Now, ...")
-- **Categories** (in order): `### Breaking Changes`, `### New Features`, `### Improvements`, `### Fixes`
-- **No entry needed** for: CI/CD changes, refactoring, test-only changes, documentation-only changes
-- **Never create a new version section** — only add to the existing topmost `## [X.Y.Z]` section
-- **No trailing periods** on bullet points
-- On tag push, a sync workflow automatically creates entries in changelog.umh.app from CHANGELOG.md
-- **Release titles**: Use format `vX.Y.Z - Short Descriptive Title` (e.g., `v0.44.12 - Modbus Per-Slave Address Mapping`). The part after the dash becomes the changelog.umh.app entry title.
-- GitHub Release notes are automatically populated from CHANGELOG.md by the `update-github-release.yml` workflow (runs on tag push). The job extracts the version's section, transforms headers for standalone display, and appends a changelog.umh.app link. You can still edit the Release body manually after if needed.
 - **CI enforcement**: PRs with code changes must modify CHANGELOG.md, or CI will fail. Add the `skip-changelog-guard` label to bypass (for CI/CD, refactoring, or test-only changes).
+- **Automation**: On tag push, workflows sync entries to changelog.umh.app and populate GitHub Release notes from CHANGELOG.md.
 
 ## Support & Troubleshooting Workflows
 

--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## Unreleased
+
 ## [0.44.12]
 
 ### Improvements

--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Improvements
 
-- Bridges can now be stopped and started from the Management Console -- previously, bridges were always active and could only be removed entirely
+- Starting with this version, umh-core supports stopping and starting bridges. Previously, bridges were always active and could only be removed entirely. A Management Console update is required to expose this in the UI
 
 ### Fixes
 

--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -2,14 +2,20 @@
 
 ## [0.44.12]
 
+### Improvements
+
+- Bridges can now be stopped and started from the Management Console -- previously, bridges were always active and could only be removed entirely
+
 ### Fixes
 
 - The container previously restarted hundreds of times per minute when config.yaml was missing or invalid and now waits 60 seconds before retrying, giving you time to fix the configuration
 - Previously, memory monitoring read host-level values even inside containers, while CPU monitoring already used cgroup-aware values. Memory metrics now read cgroup v2 limits and usage, so dashboards show correct container memory utilization
+- Fixed debug logging settings being lost when editing bridges or data flows -- the debug_level flag is now preserved across configuration changes
 
 ### Preview: FSMv2 Communicator
 
 - Instances could appear permanently offline in the Management Console even though the pod was running and healthy -- only a restart would fix it. This happened because token re-authentication briefly caused child workers to enter a stopping state from which they could not recover, leaving the communicator stuck indefinitely. Workers now always complete the stop and automatically recover when the parent is healthy again. Requires `USE_FSMV2_TRANSPORT=true`
+- Temporary network errors (DNS failures, HTTP timeouts, connection resets) no longer trigger alerts. These transient errors are still tracked in metrics and the system retries automatically -- if they persist above 90% failure rate for roughly 10 minutes, a warning is escalated. Requires `USE_FSMV2_TRANSPORT=true`
 
 ## [0.44.11]
 

--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -15,7 +15,6 @@
 ### Preview: FSMv2 Communicator
 
 - Instances could appear permanently offline in the Management Console even though the pod was running and healthy -- only a restart would fix it. This happened because token re-authentication briefly caused child workers to enter a stopping state from which they could not recover, leaving the communicator stuck indefinitely. Workers now always complete the stop and automatically recover when the parent is healthy again. Requires `USE_FSMV2_TRANSPORT=true`
-- Temporary network errors (DNS failures, HTTP timeouts, connection resets) no longer trigger alerts. These transient errors are still tracked in metrics and the system retries automatically -- if they persist above 90% failure rate for roughly 10 minutes, a warning is escalated. Requires `USE_FSMV2_TRANSPORT=true`
 
 ## [0.44.11]
 

--- a/umh-core/RELEASING.md
+++ b/umh-core/RELEASING.md
@@ -4,6 +4,10 @@
 
 All development happens on `staging`. To release, merge `staging` into `main` via PR, then create a GitHub Release on `main`. Creating the Release also creates the git tag, which triggers all downstream automation.
 
+## Changelog convention
+
+During development, all changelog entries go under `## Unreleased` at the top of `CHANGELOG.md`. At release time, this section is renamed to the version number (e.g., `## [0.44.12]`) and a fresh empty `## Unreleased` is added above it. This keeps it clear during PR review which entries are pending release, and defers the version number decision to release time.
+
 ## Pre-release (nightly)
 
 1. Create a PR from `staging` → `main`, review and merge
@@ -22,8 +26,8 @@ All development happens on `staging`. To release, merge `staging` into `main` vi
 
 ## Stable release
 
-1. Ensure `umh-core/CHANGELOG.md` has a section for this version (e.g., `## [0.44.10]`) with all entries
-2. Create a PR from `staging` → `main` (if not already merged for a pre-release), review and merge
+1. In `CHANGELOG.md`, rename `## Unreleased` to the version being released (e.g., `## [0.44.12]`) and add a fresh empty `## Unreleased` section above it. Review all entries.
+2. Create a PR from `staging` → `main`, review and merge
 3. Go to [Releases > Draft a new release](https://github.com/united-manufacturing-hub/united-manufacturing-hub/releases/new)
 4. Create a **new tag** with the format `v0.X.Y` (e.g., `v0.44.10`) — no `-pre.` suffix
 5. Target: `main`
@@ -54,6 +58,7 @@ Both staging and production MC instances are notified.
 - [ ] Verify the GitHub Release body was updated with CHANGELOG.md content
 - [ ] Merge the changelog.umh.app PR created by `sync-changelog.yml` (the changelog link in the GitHub Release is a 404 until this PR is merged)
 - [ ] Verify MC shows the new version (check both staging and production)
+- [ ] Bump the version section on `staging`: ensure `## Unreleased` exists at the top of `CHANGELOG.md` for the next cycle
 
 ## Troubleshooting
 

--- a/umh-core/RELEASING.md
+++ b/umh-core/RELEASING.md
@@ -63,7 +63,7 @@ Both staging and production MC instances are notified.
 ## Troubleshooting
 
 ### GitHub Release body is empty or wrong
-Check the `update-github-release.yml` run in the Actions tab. Common causes: missing `## [X.Y.Z]` section in CHANGELOG.md (shows as warning in the workflow summary). Re-run via Actions > Update GitHub Release > Run workflow > enter the tag name.
+Check the `update-github-release.yml` run in the Actions tab. Common causes: `## Unreleased` was not renamed to `## [X.Y.Z]` before tagging, or the version section is missing entirely (shows as warning in the workflow summary). Re-run via Actions > Update GitHub Release > Run workflow > enter the tag name.
 
 ### changelog.umh.app entry was not created
 Re-trigger via Actions > Sync Changelog > Run workflow > enter the version. Supports `dry_run` mode for testing.

--- a/umh-core/RELEASING.md
+++ b/umh-core/RELEASING.md
@@ -31,9 +31,10 @@ During development, all changelog entries go under `## Unreleased` at the top of
 3. Go to [Releases > Draft a new release](https://github.com/united-manufacturing-hub/united-manufacturing-hub/releases/new)
 4. Create a **new tag** with the format `v0.X.Y` (e.g., `v0.44.10`) — no `-pre.` suffix
 5. Target: `main`
-6. Body (optional): paste the CHANGELOG.md section for this version as a fallback. Automation will overwrite it with a formatted version including the changelog.umh.app link. If automation fails, the original body is preserved.
-7. Do NOT check "Set as a pre-release"
-8. Click **Publish release**
+6. Release name (title): use format `v0.X.Y - Short Descriptive Title` (e.g., `v0.44.12 - Bridge Activate and Memory Fixes`). The part after the dash becomes the changelog.umh.app entry title. The sync workflow will fail without this.
+7. Body (optional): paste the CHANGELOG.md section for this version as a fallback. Automation will overwrite it with a formatted version including the changelog.umh.app link. If automation fails, the original body is preserved.
+8. Do NOT check "Set as a pre-release"
+9. Click **Publish release**
 
 ### What happens automatically
 
@@ -58,7 +59,7 @@ Both staging and production MC instances are notified.
 - [ ] Verify the GitHub Release body was updated with CHANGELOG.md content
 - [ ] Merge the changelog.umh.app PR created by `sync-changelog.yml` (the changelog link in the GitHub Release is a 404 until this PR is merged)
 - [ ] Verify MC shows the new version (check both staging and production)
-- [ ] Bump the version section on `staging`: ensure `## Unreleased` exists at the top of `CHANGELOG.md` for the next cycle
+- [ ] Verify that `staging` has an empty `## Unreleased` section at the top of `CHANGELOG.md` for the next development cycle
 
 ## Troubleshooting
 

--- a/umh-core/RELEASING.md
+++ b/umh-core/RELEASING.md
@@ -26,7 +26,7 @@ During development, all changelog entries go under `## Unreleased` at the top of
 
 ## Stable release
 
-1. In `CHANGELOG.md`, rename `## Unreleased` to the version being released (e.g., `## [0.44.12]`) and add a fresh empty `## Unreleased` section above it. Review all entries.
+1. Create a PR to `staging` that renames `## Unreleased` in `CHANGELOG.md` to the version being released (e.g., `## [0.44.12]`) and adds a fresh empty `## Unreleased` section above it. Review all entries. Merge this PR.
 2. Create a PR from `staging` → `main`, review and merge
 3. Go to [Releases > Draft a new release](https://github.com/united-manufacturing-hub/united-manufacturing-hub/releases/new)
 4. Create a **new tag** with the format `v0.X.Y` (e.g., `v0.44.10`) — no `-pre.` suffix


### PR DESCRIPTION
## Summary

Prep work before releasing v0.44.12. Two things in one PR:

**Process changes** (agreed with Janik in today's 1:1):
- Move `RELEASING.md` into `umh-core/` next to `CHANGELOG.md`
- Add `## Unreleased` convention to `RELEASING.md` (entries accumulate under `## Unreleased`, renamed to version number at release time)
- Point `CLAUDE.md` changelog section at the `changelog-writing` skill instead of duplicating its rules
- CI error message now says `## Unreleased` instead of `## [X.Y.Z]`
- Add empty `## Unreleased` above finalized `## [0.44.12]` so staging is ready for the next cycle

**Missing changelog entries** (these PRs merged before changelog enforcement shipped):
- Activate/deactivate bridge support (#2380)
- debug_level flag redeployment fix (#2389)

## Test plan

- [ ] CI passes (changelog guard skipped via label)
- [ ] Review changelog entries for accuracy
- [ ] `RELEASING.md` renders correctly at new path


🤖 Generated with [Claude Code](https://claude.com/claude-code)
