### PR TITLE
feat(fsmv2): add AuthFailedState for permanent auth errors (ENG-4649)

### DIFF
--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Preview: FSMv2 Communicator
 
 - Brief network interruptions during authentication (DNS failures, server errors) no longer produce Sentry warnings. If authentication keeps failing for five consecutive failures, a single `persistent_auth_failure` warning is logged. Permanent errors like invalid credentials or a deleted instance still warn immediately on first occurrence. Only affects instances with `USE_FSMV2_TRANSPORT=true`
+- When authentication permanently fails (invalid credentials or deleted instance), the transport worker now enters a dedicated failed state instead of retrying indefinitely. It re-attempts authentication automatically when the configuration changes (new auth token, relay URL, or instance UUID). Only affects instances with `USE_FSMV2_TRANSPORT=true`
 
 ## [0.44.13]
 

--- a/umh-core/pkg/fsmv2/workers/transport/action/authenticate.go
+++ b/umh-core/pkg/fsmv2/workers/transport/action/authenticate.go
@@ -119,6 +119,11 @@ func (a *AuthenticateAction) Execute(ctx context.Context, depsAny any) error {
 		deps.RecordAuthError(errType, retryAfter)
 		deps.MetricsRecorder().IncrementCounter(httpTransport.CounterForErrorType(errType), 1)
 
+		// Store the config that caused the failure so AuthFailedState can detect config changes.
+		if !errType.IsTransient() {
+			deps.SetFailedAuthConfig(a.AuthToken, a.RelayURL, a.InstanceUUID)
+		}
+
 		// Persistent errors get an immediate first-occurrence SentryWarn.
 		// Transient errors are silent -- the failurerate.Tracker in RecordAuthError
 		// fires SentryWarn("persistent_auth_failure") if they sustain.

--- a/umh-core/pkg/fsmv2/workers/transport/action/authenticate_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/action/authenticate_test.go
@@ -308,6 +308,72 @@ var _ = Describe("AuthenticateAction", func() {
 		})
 	})
 
+	Describe("SetFailedAuthConfig Plumbing", func() {
+		It("should call SetFailedAuthConfig on permanent error (InvalidToken)", func() {
+			ctx := context.Background()
+			mockTransp.authError = &httpTransport.TransportError{
+				Type:    httpTransport.ErrorTypeInvalidToken,
+				Message: "invalid credentials",
+			}
+
+			err := act.Execute(ctx, dependencies)
+			Expect(err).NotTo(HaveOccurred())
+
+			token, relayURL, uuid := dependencies.GetFailedAuthConfig()
+			Expect(token).To(Equal("test-token"))
+			Expect(relayURL).To(Equal("https://relay.example.com"))
+			Expect(uuid).To(Equal("test-uuid"))
+		})
+
+		It("should call SetFailedAuthConfig on permanent error (InstanceDeleted)", func() {
+			ctx := context.Background()
+			mockTransp.authError = &httpTransport.TransportError{
+				Type:    httpTransport.ErrorTypeInstanceDeleted,
+				Message: "instance not found",
+			}
+
+			err := act.Execute(ctx, dependencies)
+			Expect(err).NotTo(HaveOccurred())
+
+			token, relayURL, uuid := dependencies.GetFailedAuthConfig()
+			Expect(token).To(Equal("test-token"))
+			Expect(relayURL).To(Equal("https://relay.example.com"))
+			Expect(uuid).To(Equal("test-uuid"))
+		})
+
+		It("should NOT call SetFailedAuthConfig on transient error (Network)", func() {
+			ctx := context.Background()
+			mockTransp.authError = &httpTransport.TransportError{
+				Type:    httpTransport.ErrorTypeNetwork,
+				Message: "connection refused",
+			}
+
+			err := act.Execute(ctx, dependencies)
+			Expect(err).NotTo(HaveOccurred())
+
+			token, relayURL, uuid := dependencies.GetFailedAuthConfig()
+			Expect(token).To(BeEmpty())
+			Expect(relayURL).To(BeEmpty())
+			Expect(uuid).To(BeEmpty())
+		})
+
+		It("should NOT call SetFailedAuthConfig on transient error (ServerError)", func() {
+			ctx := context.Background()
+			mockTransp.authError = &httpTransport.TransportError{
+				Type:    httpTransport.ErrorTypeServerError,
+				Message: "internal server error",
+			}
+
+			err := act.Execute(ctx, dependencies)
+			Expect(err).NotTo(HaveOccurred())
+
+			token, relayURL, uuid := dependencies.GetFailedAuthConfig()
+			Expect(token).To(BeEmpty())
+			Expect(relayURL).To(BeEmpty())
+			Expect(uuid).To(BeEmpty())
+		})
+	})
+
 	Describe("Tiered Auth Error Handling", func() {
 		It("should suppress transient auth errors without SentryWarn from action", func() {
 			ctx := context.Background()

--- a/umh-core/pkg/fsmv2/workers/transport/dependencies.go
+++ b/umh-core/pkg/fsmv2/workers/transport/dependencies.go
@@ -71,6 +71,10 @@ type TransportDependencies struct {
 	jwtToken        string
 	instanceUUID    string
 
+	failedAuthToken    string
+	failedRelayURL     string
+	failedInstanceUUID string
+
 	lastErrorType            httpTransport.ErrorType
 	persistentAuthErrorCount int
 
@@ -166,16 +170,41 @@ func (d *TransportDependencies) RecordAuthError(errType httpTransport.ErrorType,
 	}
 }
 
-// RecordSuccess resets all error tracking state.
+// RecordSuccess resets all error tracking state including the failed auth config.
+// The failed auth config fields are cleared inline (not via SetFailedAuthConfig) to
+// avoid a mutex deadlock — this method already holds d.mu.
 func (d *TransportDependencies) RecordSuccess() {
 	d.mu.Lock()
 	d.lastErrorType = httpTransport.ErrorTypeUnknown
 	d.lastAuthAttemptAt = time.Time{}
 	d.persistentAuthErrorCount = 0
+	d.failedAuthToken = ""
+	d.failedRelayURL = ""
+	d.failedInstanceUUID = ""
 	d.mu.Unlock()
 
 	d.RetryTracker().RecordSuccess()
 	d.authFailureRate.Reset()
+}
+
+// SetFailedAuthConfig stores the auth config that caused a permanent auth failure.
+// Called by AuthenticateAction when InvalidToken or InstanceDeleted is returned.
+func (d *TransportDependencies) SetFailedAuthConfig(token, relayURL, uuid string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.failedAuthToken = token
+	d.failedRelayURL = relayURL
+	d.failedInstanceUUID = uuid
+}
+
+// GetFailedAuthConfig returns the auth config from the last permanent auth failure.
+// Returns empty strings if no permanent failure has been recorded (or after RecordSuccess).
+func (d *TransportDependencies) GetFailedAuthConfig() (token, relayURL, uuid string) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	return d.failedAuthToken, d.failedRelayURL, d.failedInstanceUUID
 }
 
 // GetConsecutiveErrors returns the current consecutive error count.

--- a/umh-core/pkg/fsmv2/workers/transport/dependencies_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/dependencies_test.go
@@ -390,6 +390,51 @@ var _ = Describe("TransportDependencies", func() {
 		})
 	})
 
+	Describe("FailedAuthConfig tracking", func() {
+		var deps *transport.TransportDependencies
+
+		BeforeEach(func() {
+			identity := depspkg.Identity{ID: "test-id", WorkerType: "transport"}
+			deps = transport.NewTransportDependencies(mt, logger, nil, identity)
+		})
+
+		Describe("SetFailedAuthConfig and GetFailedAuthConfig", func() {
+			It("should store and return the failed auth config values", func() {
+				deps.SetFailedAuthConfig("my-token", "https://relay.example.com", "instance-uuid-123")
+
+				token, relay, uuid := deps.GetFailedAuthConfig()
+				Expect(token).To(Equal("my-token"))
+				Expect(relay).To(Equal("https://relay.example.com"))
+				Expect(uuid).To(Equal("instance-uuid-123"))
+			})
+
+			It("should return empty strings when no failed auth config is set", func() {
+				token, relay, uuid := deps.GetFailedAuthConfig()
+				Expect(token).To(BeEmpty())
+				Expect(relay).To(BeEmpty())
+				Expect(uuid).To(BeEmpty())
+			})
+		})
+
+		Describe("RecordSuccess clears FailedAuthConfig", func() {
+			It("should clear all failed auth config fields on success", func() {
+				deps.SetFailedAuthConfig("my-token", "https://relay.example.com", "instance-uuid-123")
+
+				token, relay, uuid := deps.GetFailedAuthConfig()
+				Expect(token).To(Equal("my-token"))
+				Expect(relay).To(Equal("https://relay.example.com"))
+				Expect(uuid).To(Equal("instance-uuid-123"))
+
+				deps.RecordSuccess()
+
+				token, relay, uuid = deps.GetFailedAuthConfig()
+				Expect(token).To(BeEmpty())
+				Expect(relay).To(BeEmpty())
+				Expect(uuid).To(BeEmpty())
+			})
+		})
+	})
+
 	Describe("Dependencies interface implementation", func() {
 		It("should implement deps.Dependencies interface", func() {
 			identity := depspkg.Identity{ID: "test-id", WorkerType: "transport"}

--- a/umh-core/pkg/fsmv2/workers/transport/snapshot/snapshot.go
+++ b/umh-core/pkg/fsmv2/workers/transport/snapshot/snapshot.go
@@ -63,6 +63,10 @@ type TransportDependencies interface {
 
 	// RetryTracker for backoff and modulo-trigger breaking after transport reset
 	RetryTracker() retry.Tracker
+
+	// Failed auth config tracking for AuthFailedState config-change detection
+	SetFailedAuthConfig(token, relayURL, uuid string)
+	GetFailedAuthConfig() (token, relayURL, uuid string)
 }
 
 // TransportSnapshot represents a point-in-time view of the transport worker state.
@@ -112,6 +116,21 @@ func (d *TransportDesiredState) ShouldBeRunning() bool {
 	return d.GetState() == config.DesiredStateRunning
 }
 
+// FailedAuthConfig captures the auth configuration that was used in the last
+// permanently-failed auth attempt (InvalidToken or InstanceDeleted). Stored in
+// dependencies, exposed via CollectObservedState, and compared against the current
+// desired state by AuthFailedState to detect config changes that warrant a retry.
+type FailedAuthConfig struct {
+	AuthToken    string `json:"auth_token,omitempty"`
+	RelayURL     string `json:"relay_url,omitempty"`
+	InstanceUUID string `json:"instance_uuid,omitempty"`
+}
+
+// IsEmpty returns true if no failed auth config has been recorded.
+func (f FailedAuthConfig) IsEmpty() bool {
+	return f.AuthToken == "" && f.RelayURL == "" && f.InstanceUUID == ""
+}
+
 // TransportObservedState represents the current state of the transport worker.
 type TransportObservedState struct {
 	CollectedAt time.Time `json:"collected_at"`
@@ -123,6 +142,12 @@ type TransportObservedState struct {
 
 	// Children contains the observed state of child workers (PushWorker, PullWorker).
 	Children map[string]fsmv2.ObservedState `json:"children,omitempty"`
+
+	// FailedAuthConfig holds the auth config (token, relay URL, instance UUID) that was
+	// used in the last permanently-failed auth attempt. Set by AuthenticateAction on
+	// InvalidToken/InstanceDeleted, cleared by RecordSuccess. AuthFailedState compares
+	// snap.Desired fields against this to detect config changes that warrant a retry.
+	FailedAuthConfig FailedAuthConfig `json:"failed_auth_config,omitempty"`
 
 	State string `json:"state"` // Observed lifecycle state (e.g., "running_healthy")
 
@@ -138,11 +163,11 @@ type TransportObservedState struct {
 	// adding a CSE secret tier to persist locally but exclude from delta sync.
 	JWTToken string `json:"jwt_token,omitempty"`
 
-	// DesiredState embedded for state consistency
-	TransportDesiredState `json:",inline"`
-
 	// LastActionResults contains the action history from the last collection cycle (supervisor-managed).
 	LastActionResults []deps.ActionResult `json:"last_action_results,omitempty"`
+
+	// DesiredState embedded for state consistency
+	TransportDesiredState `json:",inline"`
 
 	deps.MetricsEmbedder `json:",inline"`
 

--- a/umh-core/pkg/fsmv2/workers/transport/state/auth_failed.go
+++ b/umh-core/pkg/fsmv2/workers/transport/state/auth_failed.go
@@ -41,6 +41,9 @@ func (s *AuthFailedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 		return fsmv2.Result[any, any](&StoppingState{}, fsmv2.SignalNone, nil, "Shutdown requested, transitioning to Stopping")
 	}
 
+	// FailedAuthConfig is guaranteed populated here because only permanent errors
+	// (which call SetFailedAuthConfig via the !IsTransient() guard in authenticate.go)
+	// reach AuthFailedState via isPermanentAuthError().
 	tokenChanged := snap.Desired.AuthToken != snap.Observed.FailedAuthConfig.AuthToken
 	relayChanged := snap.Desired.RelayURL != snap.Observed.FailedAuthConfig.RelayURL
 	uuidChanged := snap.Desired.InstanceUUID != snap.Observed.FailedAuthConfig.InstanceUUID

--- a/umh-core/pkg/fsmv2/workers/transport/state/auth_failed.go
+++ b/umh-core/pkg/fsmv2/workers/transport/state/auth_failed.go
@@ -1,0 +1,62 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package state
+
+import (
+	"fmt"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/internal/helpers"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/snapshot"
+)
+
+// AuthFailedState represents a permanent authentication failure (InvalidToken or
+// InstanceDeleted). The worker dispatches no actions and waits for a configuration
+// change (AuthToken, RelayURL, or InstanceUUID) before transitioning back to
+// StartingState for a fresh attempt.
+//
+// Uses StartingBase because the worker has not reached Running -- children remain
+// stopped (they only start when the parent enters RunningHealthy).
+type AuthFailedState struct {
+	helpers.StartingBase
+}
+
+// Next evaluates the current snapshot and returns the next state or action.
+func (s *AuthFailedState) Next(snapAny any) fsmv2.NextResult[any, any] {
+	snap := helpers.ConvertSnapshot[snapshot.TransportObservedState, *snapshot.TransportDesiredState](snapAny)
+
+	if snap.Desired.IsShutdownRequested() {
+		return fsmv2.Result[any, any](&StoppingState{}, fsmv2.SignalNone, nil, "Shutdown requested, transitioning to Stopping")
+	}
+
+	tokenChanged := snap.Desired.AuthToken != snap.Observed.FailedAuthConfig.AuthToken
+	relayChanged := snap.Desired.RelayURL != snap.Observed.FailedAuthConfig.RelayURL
+	uuidChanged := snap.Desired.InstanceUUID != snap.Observed.FailedAuthConfig.InstanceUUID
+
+	if tokenChanged || relayChanged || uuidChanged {
+		return fsmv2.Result[any, any](&StartingState{}, fsmv2.SignalNone, nil,
+			fmt.Sprintf("config changed (token=%t, relay=%t, uuid=%t), retrying auth",
+				tokenChanged, relayChanged, uuidChanged))
+	}
+
+	return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil,
+		fmt.Sprintf("auth failed (%s), waiting for config change",
+			snap.Observed.LastErrorType))
+}
+
+// String returns the state name derived from the type.
+func (s *AuthFailedState) String() string {
+	return helpers.DeriveStateName(s)
+}

--- a/umh-core/pkg/fsmv2/workers/transport/state/starting.go
+++ b/umh-core/pkg/fsmv2/workers/transport/state/starting.go
@@ -101,6 +101,9 @@ func isPermanentAuthError(errType httpTransport.ErrorType) bool {
 // to skip stale permanent errors after a config change. AuthFailedState performs the same
 // comparison inline to capture per-field diagnostics in the reason string.
 func authConfigChanged(desired *snapshot.TransportDesiredState, observed snapshot.TransportObservedState) bool {
+	if observed.FailedAuthConfig.IsEmpty() {
+		return false
+	}
 	return desired.AuthToken != observed.FailedAuthConfig.AuthToken ||
 		desired.RelayURL != observed.FailedAuthConfig.RelayURL ||
 		desired.InstanceUUID != observed.FailedAuthConfig.InstanceUUID

--- a/umh-core/pkg/fsmv2/workers/transport/state/starting.go
+++ b/umh-core/pkg/fsmv2/workers/transport/state/starting.go
@@ -21,6 +21,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/internal/helpers"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator/backoff"
+	httpTransport "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator/transport/http"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/action"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/snapshot"
 )
@@ -44,7 +45,17 @@ func (s *StartingState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	// If we don't have a valid token, authenticate (with backoff on repeated failures)
 	if !snap.Observed.HasValidToken() {
-		if snap.Observed.ConsecutiveErrors > 0 && !snap.Observed.LastAuthAttemptAt.IsZero() {
+		configChanged := authConfigChanged(snap.Desired, snap.Observed)
+
+		// Apply error handling only when config hasn't changed since last attempt.
+		// If config changed, stale errors and backoff are irrelevant — go straight to auth dispatch.
+		if !configChanged && snap.Observed.ConsecutiveErrors > 0 && !snap.Observed.LastAuthAttemptAt.IsZero() {
+			if isPermanentAuthError(snap.Observed.LastErrorType) {
+				return fsmv2.Result[any, any](&AuthFailedState{}, fsmv2.SignalNone, nil,
+					fmt.Sprintf("permanent auth failure (%s after %d errors), entering AuthFailed",
+						snap.Observed.LastErrorType, snap.Observed.ConsecutiveErrors))
+			}
+
 			delay := backoff.CalculateDelayForErrorType(
 				snap.Observed.LastErrorType,
 				snap.Observed.ConsecutiveErrors,
@@ -70,6 +81,29 @@ func (s *StartingState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	// Authenticated — transition to Running. Children start via ChildStartStates
 	// once parent enters Running; RunningState handles unhealthy children.
 	return fsmv2.Result[any, any](&RunningState{}, fsmv2.SignalNone, nil, "Authenticated, transitioning to Running")
+}
+
+// isPermanentAuthError returns true for error types that indicate a configuration
+// problem requiring human intervention (new token, re-registration).
+//
+// This is intentionally narrower than !IsTransient(): ProxyBlock, CloudflareChallenge,
+// and ErrorTypeUnknown are non-transient but may self-resolve (infrastructure issues,
+// not config problems). Only InvalidToken and InstanceDeleted warrant parking in
+// AuthFailedState. SetFailedAuthConfig in the action uses the broader !IsTransient()
+// guard so that config changes also skip backoff for those error types.
+func isPermanentAuthError(errType httpTransport.ErrorType) bool {
+	return errType == httpTransport.ErrorTypeInvalidToken ||
+		errType == httpTransport.ErrorTypeInstanceDeleted
+}
+
+// authConfigChanged returns true if the current desired auth config differs from the
+// config that was used in the last permanently-failed auth attempt. Used by StartingState
+// to skip stale permanent errors after a config change. AuthFailedState performs the same
+// comparison inline to capture per-field diagnostics in the reason string.
+func authConfigChanged(desired *snapshot.TransportDesiredState, observed snapshot.TransportObservedState) bool {
+	return desired.AuthToken != observed.FailedAuthConfig.AuthToken ||
+		desired.RelayURL != observed.FailedAuthConfig.RelayURL ||
+		desired.InstanceUUID != observed.FailedAuthConfig.InstanceUUID
 }
 
 // String returns the state name derived from the type.

--- a/umh-core/pkg/fsmv2/workers/transport/state/state_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/state/state_test.go
@@ -59,12 +59,71 @@ func makeSnapshotWithBackoff(shutdownRequested bool, desiredState string, jwtTok
 		LastErrorType:         lastErrorType,
 		LastAuthAttemptAt:     lastAuthAttemptAt,
 		LastRetryAfter:        lastRetryAfter,
+		FailedAuthConfig: snapshot.FailedAuthConfig{
+			AuthToken:    desired.AuthToken,
+			RelayURL:     desired.RelayURL,
+			InstanceUUID: desired.InstanceUUID,
+		},
 	}
 
 	return fsmv2.Snapshot{
 		Observed: observed,
 		Desired:  desired,
 	}
+}
+
+// makeAuthFailedSnapshot creates a snapshot for testing AuthFailedState.
+// The failed config matches the desired config (simulating "config unchanged since failure").
+func makeAuthFailedSnapshot(authToken, relayURL, instanceUUID string, shutdownRequested bool) fsmv2.Snapshot {
+	desired := &snapshot.TransportDesiredState{
+		BaseDesiredState: config.BaseDesiredState{
+			State:             config.DesiredStateRunning,
+			ShutdownRequested: shutdownRequested,
+		},
+		InstanceUUID: instanceUUID,
+		AuthToken:    authToken,
+		RelayURL:     relayURL,
+		Timeout:      30 * time.Second,
+	}
+	observed := snapshot.TransportObservedState{
+		CollectedAt:   time.Now(),
+		LastErrorType: httpTransport.ErrorTypeInvalidToken,
+		FailedAuthConfig: snapshot.FailedAuthConfig{
+			AuthToken:    authToken,
+			RelayURL:     relayURL,
+			InstanceUUID: instanceUUID,
+		},
+		ConsecutiveErrors: 3,
+	}
+	return fsmv2.Snapshot{Observed: observed, Desired: desired}
+}
+
+// makeAuthFailedStartingSnapshot creates a snapshot for testing StartingState's transition
+// to AuthFailedState with separate desired and failed config values.
+func makeAuthFailedStartingSnapshot(
+	desiredToken, desiredRelay, desiredUUID string,
+	failedToken, failedRelay, failedUUID string,
+	consecutiveErrors int, lastErrorType httpTransport.ErrorType,
+) fsmv2.Snapshot {
+	desired := &snapshot.TransportDesiredState{
+		BaseDesiredState: config.BaseDesiredState{State: config.DesiredStateRunning},
+		InstanceUUID:     desiredUUID,
+		AuthToken:        desiredToken,
+		RelayURL:         desiredRelay,
+		Timeout:          30 * time.Second,
+	}
+	observed := snapshot.TransportObservedState{
+		CollectedAt:       time.Now(),
+		ConsecutiveErrors: consecutiveErrors,
+		LastErrorType:     lastErrorType,
+		LastAuthAttemptAt: time.Now(),
+		FailedAuthConfig: snapshot.FailedAuthConfig{
+			AuthToken:    failedToken,
+			RelayURL:     failedRelay,
+			InstanceUUID: failedUUID,
+		},
+	}
+	return fsmv2.Snapshot{Observed: observed, Desired: desired}
 }
 
 var _ = Describe("TransportWorker States", func() {
@@ -200,6 +259,57 @@ var _ = Describe("TransportWorker States", func() {
 			Expect(result.State).To(BeAssignableToTypeOf(&state.StartingState{}))
 			Expect(result.Action).NotTo(BeNil())
 			Expect(result.Action.Name()).To(Equal("authenticate"))
+		})
+
+		It("should transition to AuthFailed on InvalidToken after first failure", func() {
+			snap := makeAuthFailedStartingSnapshot(
+				"test-auth-token", "https://relay.test.com", "test-uuid",
+				"test-auth-token", "https://relay.test.com", "test-uuid",
+				1, httpTransport.ErrorTypeInvalidToken)
+			result := s.Next(snap)
+
+			Expect(result.State).To(BeAssignableToTypeOf(&state.AuthFailedState{}))
+			Expect(result.Reason).To(ContainSubstring("permanent auth failure"))
+			Expect(result.Reason).To(ContainSubstring("invalid_token"))
+		})
+
+		It("should transition to AuthFailed on InstanceDeleted after first failure", func() {
+			snap := makeAuthFailedStartingSnapshot(
+				"test-auth-token", "https://relay.test.com", "test-uuid",
+				"test-auth-token", "https://relay.test.com", "test-uuid",
+				1, httpTransport.ErrorTypeInstanceDeleted)
+			result := s.Next(snap)
+
+			Expect(result.State).To(BeAssignableToTypeOf(&state.AuthFailedState{}))
+			Expect(result.Reason).To(ContainSubstring("permanent auth failure"))
+			Expect(result.Reason).To(ContainSubstring("instance_deleted"))
+		})
+
+		It("should NOT transition to AuthFailed on transient Network error", func() {
+			snap := makeSnapshotWithBackoff(
+				false, config.DesiredStateRunning, "", time.Time{}, 0, 0,
+				3, httpTransport.ErrorTypeNetwork,
+				time.Now().Add(-10*time.Minute), // well past any backoff
+				0,
+			)
+			result := s.Next(snap)
+
+			Expect(result.State).To(BeAssignableToTypeOf(&state.StartingState{}))
+			Expect(result.Action).NotTo(BeNil())
+			Expect(result.Action.Name()).To(Equal("authenticate"))
+		})
+
+		It("should NOT transition to AuthFailed on transient ServerError", func() {
+			snap := makeSnapshotWithBackoff(
+				false, config.DesiredStateRunning, "", time.Time{}, 0, 0,
+				3, httpTransport.ErrorTypeServerError,
+				time.Now().Add(-10*time.Minute),
+				0,
+			)
+			result := s.Next(snap)
+
+			Expect(result.State).To(BeAssignableToTypeOf(&state.StartingState{}))
+			Expect(result.Action).NotTo(BeNil())
 		})
 
 		It("should respect Retry-After from server", func() {
@@ -491,6 +601,173 @@ var _ = Describe("TransportWorker States", func() {
 		})
 	})
 
+	Describe("AuthFailedState", func() {
+		var s *state.AuthFailedState
+
+		BeforeEach(func() {
+			s = &state.AuthFailedState{}
+		})
+
+		It("should compile and instantiate", func() {
+			Expect(s).NotTo(BeNil())
+		})
+
+		It("should return AuthFailed for String()", func() {
+			Expect(s.String()).To(Equal("AuthFailed"))
+		})
+
+		It("should return PhaseStarting for LifecyclePhase()", func() {
+			Expect(s.LifecyclePhase()).To(Equal(config.PhaseStarting))
+		})
+
+		// Scenario 4: Shutdown during AuthFailed
+		It("should transition to Stopping when shutdown requested", func() {
+			snap := makeAuthFailedSnapshot("test-auth-token", "https://relay.test.com", "test-uuid", true)
+			result := s.Next(snap)
+
+			Expect(result.Signal).To(Equal(fsmv2.SignalNone))
+			Expect(result.State).To(BeAssignableToTypeOf(&state.StoppingState{}))
+		})
+
+		// Scenario 1 tick 2: AuthFailed stays when config unchanged
+		It("should stay in AuthFailed when desired matches failed config", func() {
+			snap := makeAuthFailedSnapshot("test-auth-token", "https://relay.test.com", "test-uuid", false)
+			result := s.Next(snap)
+
+			Expect(result.State).To(BeAssignableToTypeOf(&state.AuthFailedState{}))
+			Expect(result.Action).To(BeNil())
+			Expect(result.Reason).To(ContainSubstring("waiting for config change"))
+		})
+
+		// Scenario 1 tick 3: AuthFailed exits when AuthToken changes
+		It("should transition to Starting when AuthToken changes", func() {
+			desired := &snapshot.TransportDesiredState{
+				BaseDesiredState: config.BaseDesiredState{State: config.DesiredStateRunning},
+				InstanceUUID:     "test-uuid",
+				AuthToken:        "new-auth-token",
+				RelayURL:         "https://relay.test.com",
+				Timeout:          30 * time.Second,
+			}
+			observed := snapshot.TransportObservedState{
+				CollectedAt:        time.Now(),
+				FailedAuthConfig: snapshot.FailedAuthConfig{
+					AuthToken:    "old-auth-token",
+					RelayURL:     "https://relay.test.com",
+					InstanceUUID: "test-uuid",
+				},
+				ConsecutiveErrors:  3,
+				LastErrorType:      httpTransport.ErrorTypeInvalidToken,
+			}
+			result := s.Next(fsmv2.Snapshot{Observed: observed, Desired: desired})
+
+			Expect(result.State).To(BeAssignableToTypeOf(&state.StartingState{}))
+			Expect(result.Reason).To(ContainSubstring("config changed"))
+			Expect(result.Reason).To(ContainSubstring("token=true"))
+		})
+
+		// Scenario 7: Only relay changes
+		It("should transition to Starting when RelayURL changes", func() {
+			desired := &snapshot.TransportDesiredState{
+				BaseDesiredState: config.BaseDesiredState{State: config.DesiredStateRunning},
+				InstanceUUID:     "test-uuid",
+				AuthToken:        "test-auth-token",
+				RelayURL:         "https://new-relay.test.com",
+				Timeout:          30 * time.Second,
+			}
+			observed := snapshot.TransportObservedState{
+				CollectedAt:        time.Now(),
+				FailedAuthConfig: snapshot.FailedAuthConfig{
+					AuthToken:    "test-auth-token",
+					RelayURL:     "https://relay.test.com",
+					InstanceUUID: "test-uuid",
+				},
+				ConsecutiveErrors:  3,
+				LastErrorType:      httpTransport.ErrorTypeInvalidToken,
+			}
+			result := s.Next(fsmv2.Snapshot{Observed: observed, Desired: desired})
+
+			Expect(result.State).To(BeAssignableToTypeOf(&state.StartingState{}))
+			Expect(result.Reason).To(ContainSubstring("relay=true"))
+		})
+
+		// Scenario 2: InstanceDeleted → UUID changes
+		It("should transition to Starting when InstanceUUID changes", func() {
+			desired := &snapshot.TransportDesiredState{
+				BaseDesiredState: config.BaseDesiredState{State: config.DesiredStateRunning},
+				InstanceUUID:     "new-uuid",
+				AuthToken:        "test-auth-token",
+				RelayURL:         "https://relay.test.com",
+				Timeout:          30 * time.Second,
+			}
+			observed := snapshot.TransportObservedState{
+				CollectedAt:        time.Now(),
+				FailedAuthConfig: snapshot.FailedAuthConfig{
+					AuthToken:    "test-auth-token",
+					RelayURL:     "https://relay.test.com",
+					InstanceUUID: "test-uuid",
+				},
+				ConsecutiveErrors:  3,
+				LastErrorType:      httpTransport.ErrorTypeInstanceDeleted,
+			}
+			result := s.Next(fsmv2.Snapshot{Observed: observed, Desired: desired})
+
+			Expect(result.State).To(BeAssignableToTypeOf(&state.StartingState{}))
+			Expect(result.Reason).To(ContainSubstring("uuid=true"))
+		})
+
+		// Scenario 8: Empty failed config = safety net (fresh deps after restart)
+		It("should transition to Starting when failed config is empty (safety net)", func() {
+			desired := &snapshot.TransportDesiredState{
+				BaseDesiredState: config.BaseDesiredState{State: config.DesiredStateRunning},
+				InstanceUUID:     "test-uuid",
+				AuthToken:        "test-auth-token",
+				RelayURL:         "https://relay.test.com",
+			}
+			observed := snapshot.TransportObservedState{
+				CollectedAt:       time.Now(),
+				ConsecutiveErrors: 3,
+				LastErrorType:     httpTransport.ErrorTypeInvalidToken,
+				// FailedAuth* fields all empty (zero values) — simulates fresh deps
+			}
+			result := s.Next(fsmv2.Snapshot{Observed: observed, Desired: desired})
+
+			Expect(result.State).To(BeAssignableToTypeOf(&state.StartingState{}))
+			Expect(result.Reason).To(ContainSubstring("config changed"))
+		})
+	})
+
+	// Scenario 9+10: StartingState + stale permanent errors + config change
+	Describe("StartingState AuthFailed transitions with FailedAuth config", func() {
+		var s *state.StartingState
+
+		BeforeEach(func() {
+			s = &state.StartingState{}
+		})
+
+		// Scenario 10: Stale permanent error + same config → AuthFailed
+		It("should enter AuthFailed when config unchanged and permanent error present", func() {
+			snap := makeAuthFailedStartingSnapshot("old-token", "https://relay.test.com", "test-uuid",
+				"old-token", "https://relay.test.com", "test-uuid",
+				1, httpTransport.ErrorTypeInvalidToken)
+			result := s.Next(snap)
+
+			Expect(result.State).To(BeAssignableToTypeOf(&state.AuthFailedState{}))
+			Expect(result.Reason).To(ContainSubstring("permanent auth failure"))
+		})
+
+		// Scenario 9: Stale permanent error + config changed → dispatch fresh auth
+		It("should dispatch auth when config changed despite stale permanent error", func() {
+			snap := makeAuthFailedStartingSnapshot("new-token", "https://relay.test.com", "test-uuid",
+				"old-token", "https://relay.test.com", "test-uuid",
+				3, httpTransport.ErrorTypeInvalidToken)
+			result := s.Next(snap)
+
+			Expect(result.State).To(BeAssignableToTypeOf(&state.StartingState{}))
+			Expect(result.Action).NotTo(BeNil())
+			Expect(result.Action.Name()).To(Equal("authenticate"))
+		})
+	})
+
 	Describe("Architecture Compliance", func() {
 		It("all states should have non-nil return values", func() {
 			states := []fsmv2.State[any, any]{
@@ -499,6 +776,7 @@ var _ = Describe("TransportWorker States", func() {
 				&state.RunningState{},
 				&state.DegradedState{},
 				&state.StoppingState{},
+				&state.AuthFailedState{},
 			}
 
 			snap := makeSnapshot(false, config.DesiredStateRunning, "", time.Time{}, 0, 0)
@@ -520,6 +798,7 @@ var _ = Describe("TransportWorker States", func() {
 				{&state.RunningState{}, "Running"},
 				{&state.DegradedState{}, "Degraded"},
 				{&state.StoppingState{}, "Stopping"},
+				{&state.AuthFailedState{}, "AuthFailed"},
 			}
 
 			for _, tt := range stateTests {
@@ -537,6 +816,7 @@ var _ = Describe("TransportWorker States", func() {
 				{&state.RunningState{}, config.PhaseRunningHealthy},
 				{&state.DegradedState{}, config.PhaseRunningDegraded},
 				{&state.StoppingState{}, config.PhaseStopping},
+				{&state.AuthFailedState{}, config.PhaseStarting},
 			}
 
 			for _, tt := range stateTests {

--- a/umh-core/pkg/fsmv2/workers/transport/state/state_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/state/state_test.go
@@ -325,6 +325,33 @@ var _ = Describe("TransportWorker States", func() {
 			Expect(result.Action).To(BeNil())
 			Expect(result.Reason).To(ContainSubstring("auth backoff"))
 		})
+
+		It("should apply backoff after transient error even when FailedAuthConfig is empty", func() {
+			desired := &snapshot.TransportDesiredState{
+				BaseDesiredState: config.BaseDesiredState{State: config.DesiredStateRunning},
+				InstanceUUID:     "test-uuid",
+				AuthToken:        "test-auth-token",
+				RelayURL:         "https://relay.test.com",
+				Timeout:          30 * time.Second,
+			}
+			observed := snapshot.TransportObservedState{
+				CollectedAt:       time.Now(),
+				ConsecutiveErrors: 3,
+				LastErrorType:     httpTransport.ErrorTypeNetwork,
+				LastAuthAttemptAt: time.Now(),
+			}
+
+			Expect(observed.FailedAuthConfig.IsEmpty()).To(BeTrue(),
+				"precondition: FailedAuthConfig must be empty to simulate transient error path")
+
+			snap := fsmv2.Snapshot{Observed: observed, Desired: desired}
+			result := s.Next(snap)
+
+			Expect(result.State).To(BeAssignableToTypeOf(&state.StartingState{}))
+			Expect(result.Action).To(BeNil(),
+				"should NOT dispatch auth during backoff — transient error with empty FailedAuthConfig must still respect backoff")
+			Expect(result.Reason).To(ContainSubstring("auth backoff"))
+		})
 	})
 
 	Describe("RunningState", func() {

--- a/umh-core/pkg/fsmv2/workers/transport/worker.go
+++ b/umh-core/pkg/fsmv2/workers/transport/worker.go
@@ -37,11 +37,14 @@
 // State flow:
 //
 //	Stopped ──→ Starting ──→ Running ⇄ Degraded
-//	                ↑         ↓ (token expired)
-//	                └─────────┘
+//	                ↑   ↘       ↓ (token expired)
+//	                │  AuthFailed ← (InvalidToken/InstanceDeleted)
+//	                │    ↓ (config changed)
+//	                └────┘
 //
 // All active states transition to Stopping → Stopped on shutdown.
-// Auth failures in Starting retry in place (no dedicated error state).
+// Permanent auth errors (InvalidToken, InstanceDeleted) enter AuthFailedState,
+// which waits for a config change before retrying.
 package transport
 
 import (
@@ -119,6 +122,8 @@ func (w *TransportWorker) CollectObservedState(ctx context.Context) (fsmv2.Obser
 
 	deps := w.GetDependencies()
 
+	failedToken, failedRelay, failedUUID := deps.GetFailedAuthConfig()
+
 	// Build observed state
 	observed := snapshot.TransportObservedState{
 		CollectedAt:       time.Now(),
@@ -129,6 +134,11 @@ func (w *TransportWorker) CollectObservedState(ctx context.Context) (fsmv2.Obser
 		LastErrorType:     deps.GetLastErrorType(),
 		LastAuthAttemptAt: deps.GetLastAuthAttemptAt(),
 		LastRetryAfter:    deps.GetLastRetryAfter(),
+		FailedAuthConfig: snapshot.FailedAuthConfig{
+			AuthToken:    failedToken,
+			RelayURL:     failedRelay,
+			InstanceUUID: failedUUID,
+		},
 	}
 
 	// Framework metrics copy (architecture requirement)

--- a/umh-core/pkg/fsmv2/workers/transport/worker_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/worker_test.go
@@ -114,6 +114,32 @@ var _ = Describe("TransportWorker", func() {
 			Expect(typedObs.Metrics).NotTo(BeNil())
 		})
 
+		It("should populate FailedAuthConfig from dependencies", func() {
+			// Set failed auth config on the worker's dependencies
+			workerDeps := worker.GetDependencies()
+			workerDeps.SetFailedAuthConfig("failed-token", "https://failed-relay.example.com", "failed-uuid")
+
+			ctx := context.Background()
+			observed, err := worker.CollectObservedState(ctx)
+
+			Expect(err).ToNot(HaveOccurred())
+			typedObs, ok := observed.(snapshot.TransportObservedState)
+			Expect(ok).To(BeTrue())
+			Expect(typedObs.FailedAuthConfig.AuthToken).To(Equal("failed-token"))
+			Expect(typedObs.FailedAuthConfig.RelayURL).To(Equal("https://failed-relay.example.com"))
+			Expect(typedObs.FailedAuthConfig.InstanceUUID).To(Equal("failed-uuid"))
+		})
+
+		It("should return empty FailedAuthConfig when none is set", func() {
+			ctx := context.Background()
+			observed, err := worker.CollectObservedState(ctx)
+
+			Expect(err).ToNot(HaveOccurred())
+			typedObs, ok := observed.(snapshot.TransportObservedState)
+			Expect(ok).To(BeTrue())
+			Expect(typedObs.FailedAuthConfig.IsEmpty()).To(BeTrue())
+		})
+
 		It("should call GetActionHistory from dependencies", func() {
 			ctx := context.Background()
 			observed, err := worker.CollectObservedState(ctx)


### PR DESCRIPTION
## Problem

When auth fails with InvalidToken or InstanceDeleted, the transport worker stays in `StartingState` forever — retrying at 60s (token) or 5min (deleted) backoff with no way out. The instance stops sending heartbeats (no JWT = no push children), so MC shows a stale "last seen" timestamp. Nothing in the logs indicates this needs a config change.

## Fix

New `AuthFailedState`. `StartingState` checks `LastErrorType` after a failure: if InvalidToken or InstanceDeleted, transition to `AuthFailedState` instead of entering backoff.

`AuthFailedState` is passive — dispatches no actions, just ticks. On each tick it compares three config fields between `snap.Desired` (current config) and `snap.Observed.FailedAuthConfig` (config at time of failure):

- `AuthToken`
- `RelayURL`
- `InstanceUUID`

When any field differs, it transitions back to `StartingState` for a fresh auth attempt. On shutdown, it transitions to `StoppingState`.

### Config detection via FailedAuthConfig

The failed auth config is stored in dependencies (`SetFailedAuthConfig`) and exposed via `CollectObservedState` as a `FailedAuthConfig` struct on `TransportObservedState`. This is necessary because the embedded `TransportDesiredState` in observed state is never populated with auth fields by the collector — comparing `snap.Observed.AuthToken` would always see empty strings.

`SetFailedAuthConfig` is called atomically with `RecordAuthError` inside `AuthenticateAction.Execute()` for permanent errors. `RecordSuccess()` clears it. `AuthFailedState` compares `snap.Desired.*` against `snap.Observed.FailedAuthConfig.*`.

### Stale error guard in StartingState

When `AuthFailedState` detects a config change and transitions to `StartingState`, the error state (`ConsecutiveErrors > 0`, `LastErrorType = InvalidToken`) persists in deps. Without a guard, `StartingState` would see the permanent error and transition right back to `AuthFailedState` without trying auth with the new config. The `authConfigChanged()` guard skips the permanent-error check when the desired config differs from the stored failed config.

### Architecture compliance

- Empty struct (embeds `helpers.StartingBase` only)
- Shutdown check first
- `PhaseStarting` lifecycle (children stay stopped — correct, no JWT)
- 10 new tests + added to all Architecture Compliance lists (64/64 pass)

## Stack

1. Suppress SentryError (#2483) → staging
2. Tiered alerting (#2485) → #2483
3. **→ This PR** → #2485

Part of ENG-4576. Resolves: ENG-4649.

## Test plan

- [x] `StartingState` → `AuthFailedState` on InvalidToken
- [x] `StartingState` → `AuthFailedState` on InstanceDeleted
- [x] `StartingState` does NOT transition on transient errors (Network, ServerError)
- [x] `AuthFailedState` → `StartingState` on AuthToken change
- [x] `AuthFailedState` → `StartingState` on RelayURL change
- [x] `AuthFailedState` → `StartingState` on InstanceUUID change
- [x] `AuthFailedState` stays when config unchanged
- [x] `AuthFailedState` → `StoppingState` on shutdown
- [x] Stale errors don't block retry after config change (P1 fix)
- [x] Architecture tests pass (64/64)
- [x] `go vet` clean
- [ ] Integration tests (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)