### PR TITLE
feat(gk): wiring to fsmv2 and main

### DIFF
--- a/umh-core/cmd/main.go
+++ b/umh-core/cmd/main.go
@@ -46,8 +46,12 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/application"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator/snapshot"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/certfetcher"
 	_ "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/persistence"
 	transportWorker "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/gatekeeper"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/gatekeeper/certificatehandler"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/gatekeeper/validator"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/logger"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/metrics"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/models"
@@ -492,6 +496,27 @@ func enableFSMv2BackendConnection(
 	communicator.SetChannelProvider(channelAdapter)
 	transportWorker.SetChannelProvider(channelAdapter)
 
+	// Create gatekeeper between bridge and Router.
+	inboundRaw, outboundRaw := channelAdapter.RawChannels()
+	certHandler := certificatehandler.NewHandler(
+		validator.NewValidator(logger),
+		"", // JWT set after auth via polling
+		configData.Agent.APIURL,
+		configData.Agent.AuthToken,
+		"", // instanceUUID set after auth via polling
+		configData.Agent.AllowInsecureTLS,
+		logger,
+	)
+	gk := gatekeeper.New(
+		inboundRaw,
+		outboundRaw,
+		certHandler,
+		validator.NewValidator(logger),
+		logger,
+	)
+	gk.Start(ctx)
+	communicationState.Gatekeeper = gk
+
 	// Build YAML config for FSMv2 ApplicationSupervisor
 	// Note: instanceUUID in config is a placeholder - the real UUID is returned by the backend
 	// and will be set via onAuthSuccessCallback (Bug #6 fix)
@@ -508,6 +533,10 @@ children:
         timeout: "10s"
         state: "running"
 `, configData.Agent.APIURL, placeholderUUID, configData.Agent.AuthToken)
+
+	yamlConfig += `  - name: "certfetcher"
+    workerType: "certfetcher"
+`
 
 	if configData.Agent.UseFSMv2MemoryCleanup {
 		yamlConfig += `  - name: "persistence"
@@ -543,6 +572,7 @@ children:
 	fsmv2Deps := map[string]any{
 		"channelProvider":       channelAdapter,
 		"onAuthSuccessCallback": onAuthSuccessCallback,
+		"certHandler":           certHandler,
 	}
 	if configData.Agent.UseFSMv2MemoryCleanup {
 		fsmv2Deps["store"] = store
@@ -582,8 +612,14 @@ children:
 		configData,
 		communicationState.SystemSnapshotManager,
 		communicationState.ConfigManager,
-		channelAdapter.GetOutboundWriteChannel(), // FSMv2 mode: bypass Pusher, write directly to FSMv2 transport
+		gk.VerifiedOutboundChan(), // FSMv2 mode: write MessageWithSender to gatekeeper
 	)
+
+	// Set SubHandler on certfetcher worker (created by supervisor via factory)
+	if cfWorker, ok := fsmv2Deps["certfetcherWorker"]; ok && cfWorker != nil {
+		cfWorker.(*certfetcher.CertFetcherWorker).GetDependencies().SetSubHandler(communicationState.SubscriberHandler)
+	}
+
 	communicationState.InitializeRouterForFSMv2()
 
 	// Poll ObservedState for AuthenticatedUUID and update SetLoginResponseForFSMv2.
@@ -607,14 +643,21 @@ children:
 					continue
 				}
 
-				if observed.AuthenticatedUUID != "" && observed.AuthenticatedUUID != placeholderUUID {
-					logger.Infow("Detected real UUID from ObservedState, updating LoginResponse",
-						"realUUID", observed.AuthenticatedUUID,
-						"placeholderUUID", placeholderUUID)
-					communicationState.SetLoginResponseForFSMv2(observed.AuthenticatedUUID)
+				// Update cert handler JWT from observed state
+			if observed.JWTToken != "" {
+				certHandler.SetJWT(observed.JWTToken)
+			}
 
-					return
-				}
+			if observed.AuthenticatedUUID != "" && observed.AuthenticatedUUID != placeholderUUID {
+				logger.Infow("Detected real UUID from ObservedState, updating LoginResponse",
+					"realUUID", observed.AuthenticatedUUID,
+					"placeholderUUID", placeholderUUID)
+				communicationState.SetLoginResponseForFSMv2(observed.AuthenticatedUUID)
+				certHandler.SetInstanceUUID(observed.AuthenticatedUUID)
+				gk.SetInstanceUUID(observed.AuthenticatedUUID)
+
+				return
+			}
 			}
 		}
 	}()

--- a/umh-core/pkg/communicator/communication_state/communication_state.go
+++ b/umh-core/pkg/communicator/communication_state/communication_state.go
@@ -27,6 +27,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/communicator/pkg/subscriber"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/communicator/pkg/tools/watchdog"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/communicator/router"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/gatekeeper"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/communicator/topicbrowser"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants"
@@ -50,6 +51,7 @@ type CommunicationState struct {
 	SubscriberHandler     *subscriber.Handler
 	OutboundChannel       chan *models.UMHMessage
 	Router                *router.Router
+	Gatekeeper            *gatekeeper.Gatekeeper
 	SystemSnapshotManager *fsm.SnapshotManager
 	Logger                *zap.SugaredLogger
 	TopicBrowserCache     *topicbrowser.Cache
@@ -243,7 +245,7 @@ func (c *CommunicationState) UpdateTopicBrowserCache() error {
 // InitialiseAndStartSubscriberHandler creates a new subscriber handler and starts it
 // ttl is the time until a subscriber is considered dead (if no new subscriber message is received)
 // cull is the cycle time to remove dead subscribers.
-func (c *CommunicationState) InitialiseAndStartSubscriberHandler(ttl time.Duration, cull time.Duration, config *config.FullConfig, systemSnapshotManager *fsm.SnapshotManager, configManager config.ConfigManager, fsmOutboundChannel chan<- *transport.UMHMessage) {
+func (c *CommunicationState) InitialiseAndStartSubscriberHandler(ttl time.Duration, cull time.Duration, config *config.FullConfig, systemSnapshotManager *fsm.SnapshotManager, configManager config.ConfigManager, fsmOutboundChannel chan<- *transport.MessageWithSender) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -430,6 +432,12 @@ func (c *CommunicationState) SetLoginResponseForFSMv2(instanceUUID string) {
 // InitializeRouterForFSMv2 initializes the Router for FSMv2 mode.
 // Unlike InitialiseAndStartRouter, this does not require a Puller (FSMv2 handles pulling).
 func (c *CommunicationState) InitializeRouterForFSMv2() {
+	if c.Gatekeeper == nil {
+		sentry.ReportIssuef(sentry.IssueTypeError, c.Logger, "Gatekeeper is nil, cannot start router for FSMv2")
+
+		return
+	}
+
 	if c.Pusher == nil {
 		sentry.ReportIssuef(sentry.IssueTypeError, c.Logger, "Pusher is nil, cannot start router for FSMv2")
 
@@ -444,8 +452,7 @@ func (c *CommunicationState) InitializeRouterForFSMv2() {
 
 	c.mu.Lock()
 	c.LoginResponseMu.RLock()
-	// Note: Puller is nil for FSMv2 mode - FSMv2 handles pulling via SyncAction
-	c.Router = router.NewRouter(c.Watchdog, c.InboundChannel, c.LoginResponse.UUID, c.OutboundChannel, c.ReleaseChannel, c.SubscriberHandler, c.SystemSnapshotManager, c.ConfigManager, c.Logger)
+	c.Router = router.NewRouterForFSMv2(c.Watchdog, c.Gatekeeper.VerifiedInboundChan(), c.LoginResponse.UUID, c.Gatekeeper.LegacyOutboundChan(), c.ReleaseChannel, c.SubscriberHandler, c.SystemSnapshotManager, c.ConfigManager, c.Logger)
 	c.LoginResponseMu.RUnlock()
 	c.mu.Unlock()
 

--- a/umh-core/pkg/communicator/fsmv2_adapter/legacy_bridge.go
+++ b/umh-core/pkg/communicator/fsmv2_adapter/legacy_bridge.go
@@ -269,3 +269,8 @@ func (b *LegacyChannelBridge) GetInboundStats(_ string) (capacity int, length in
 func (b *LegacyChannelBridge) GetOutboundWriteChannel() chan<- *transport.UMHMessage {
 	return b.fsmOutbound
 }
+
+// RawChannels returns the raw bidirectional FSMv2 channels for the gatekeeper.
+func (b *LegacyChannelBridge) RawChannels() (inbound chan *transport.UMHMessage, outbound chan *transport.UMHMessage) {
+	return b.fsmInbound, b.fsmOutbound
+}

--- a/umh-core/pkg/communicator/pkg/subscriber/subscribers.go
+++ b/umh-core/pkg/communicator/pkg/subscriber/subscribers.go
@@ -41,7 +41,7 @@ type Handler struct {
 	configManager              config.ConfigManager
 	subscriberRegistry         *subscribers.Registry
 	pusher                     *push.Pusher
-	fsmOutboundChannel         chan<- *transport.UMHMessage // FSMv2 direct channel (nil for legacy mode)
+	fsmOutboundChannel         chan<- *transport.MessageWithSender // FSMv2: gatekeeper's verifiedOutbound (nil for legacy mode)
 	StatusCollector            *generator.StatusCollectorType
 	systemSnapshotManager      *fsm.SnapshotManager
 	topicBrowserCommunicator   *topicbrowser.TopicBrowserCommunicator
@@ -63,7 +63,7 @@ func NewHandler(
 	configManager config.ConfigManager,
 	logger *zap.SugaredLogger,
 	topicBrowserCommunicator *topicbrowser.TopicBrowserCommunicator,
-	fsmOutboundChannel chan<- *transport.UMHMessage, // FSMv2 direct channel (nil for legacy mode)
+	fsmOutboundChannel chan<- *transport.MessageWithSender, // FSMv2: gatekeeper's verifiedOutbound (nil for legacy mode)
 ) *Handler {
 	s := &Handler{}
 	s.subscriberRegistry = subscribers.NewRegistry(cull, ttl)
@@ -179,33 +179,35 @@ func (s *Handler) notify() {
 			return
 		}
 
-		message, err := encoding.EncodeMessageFromUMHInstanceToUser(models.UMHMessageContent{
-			MessageType: models.Status,
-			Payload:     statusMessage,
-		})
-		if err != nil {
-			s.logger.Warnf("Failed to encrypt message for subscriber %s", email)
-
-			return
-		}
-
-		// FSMv2 mode: write directly to FSMv2 outbound channel (bypasses legacy Pusher)
-		// Legacy mode: use Pusher as before
+		// FSMv2 mode: write raw MessageWithSender to gatekeeper's verifiedOutbound
+		// Legacy mode: encode and use Pusher
 		if s.fsmOutboundChannel != nil {
-			msg := &transport.UMHMessage{
-				InstanceUUID: s.GetInstanceUUID().String(),
-				Content:      message,
-				Email:        email,
+			msg := &transport.MessageWithSender{
+				Content: models.UMHMessageContent{
+					MessageType: models.Status,
+					Payload:     statusMessage,
+				},
+				SenderEmail: email,
 			}
 			select {
 			case s.fsmOutboundChannel <- msg:
-				// Successfully sent to FSMv2 transport
+				// Successfully sent to gatekeeper
 			default:
-				s.logger.Warnf("FSMv2 outbound channel full, dropping message for subscriber %s", email)
+				s.logger.Warnf("Gatekeeper outbound channel full, dropping message for subscriber %s", email)
 
 				return
 			}
 		} else {
+			message, err := encoding.EncodeMessageFromUMHInstanceToUser(models.UMHMessageContent{
+				MessageType: models.Status,
+				Payload:     statusMessage,
+			})
+			if err != nil {
+				s.logger.Warnf("Failed to encrypt message for subscriber %s", email)
+
+				return
+			}
+
 			s.pusher.Push(models.UMHMessage{
 				Content:      message,
 				Email:        email,

--- a/umh-core/pkg/communicator/pkg/subscriber/subscribers_fsmv2_test.go
+++ b/umh-core/pkg/communicator/pkg/subscriber/subscribers_fsmv2_test.go
@@ -30,7 +30,7 @@ var _ = Describe("FSMv2 Direct Channel Mode", func() {
 	var (
 		handler            *subscriber.Handler
 		logger             *zap.SugaredLogger
-		fsmOutboundChannel chan *transport.UMHMessage
+		fsmOutboundChannel chan *transport.MessageWithSender
 	)
 
 	BeforeEach(func() {
@@ -48,7 +48,7 @@ var _ = Describe("FSMv2 Direct Channel Mode", func() {
 	Describe("FSMv2 mode (fsmOutboundChannel != nil)", func() {
 		BeforeEach(func() {
 			// Create buffered channel for FSMv2 mode
-			fsmOutboundChannel = make(chan *transport.UMHMessage, 10)
+			fsmOutboundChannel = make(chan *transport.MessageWithSender, 10)
 
 			handler = subscriber.NewHandler(
 				&mockWatchdog{},
@@ -133,7 +133,7 @@ var _ = Describe("FSMv2 Direct Channel Mode", func() {
 			)
 
 			// Create FSMv2 handler (with channel)
-			fsmv2Channel := make(chan *transport.UMHMessage, 10)
+			fsmv2Channel := make(chan *transport.MessageWithSender, 10)
 			defer close(fsmv2Channel)
 
 			fsmv2Handler := subscriber.NewHandler(

--- a/umh-core/pkg/gatekeeper/encryption/csev1.go
+++ b/umh-core/pkg/gatekeeper/encryption/csev1.go
@@ -20,22 +20,21 @@ import (
 	"go.uber.org/zap"
 )
 
-// CseV1Handler handles client-side encryption v1. Not yet implemented.
+// CseV1Handler handles client-side encryption v1.
+// TODO(ENG-4627): Add cryptolib build tag split when MC cryptolib is integrated.
 type CseV1Handler struct {
 	log *zap.SugaredLogger
 }
 
-// NewCseV1Handler creates a client-side encryption v1 handler (stub, not yet implemented).
+// NewCseV1Handler creates a CSE v1 handler.
 func NewCseV1Handler(log *zap.SugaredLogger) Handler {
 	return &CseV1Handler{log: log}
 }
 
-func (h *CseV1Handler) Decrypt(data []byte) ([]byte, error) {
-	// TODO(ENG-4627): Implement actual decryption
-	return nil, errors.New("cseV1 decryption not yet implemented")
+func (h *CseV1Handler) Decrypt(_ []byte, _ string) ([]byte, error) {
+	return nil, errors.New("cseV1 not yet implemented")
 }
 
-func (h *CseV1Handler) Encrypt(data []byte) ([]byte, error) {
-	// TODO(ENG-4627): Implement actual encryption
-	return nil, errors.New("cseV1 encryption not yet implemented")
+func (h *CseV1Handler) Encrypt(_ []byte, _ string) ([]byte, error) {
+	return nil, errors.New("cseV1 not yet implemented")
 }

--- a/umh-core/pkg/gatekeeper/encryption/interface.go
+++ b/umh-core/pkg/gatekeeper/encryption/interface.go
@@ -17,6 +17,6 @@ package encryption
 
 // Handler handles encryption/decryption for a specific protocol version.
 type Handler interface {
-	Decrypt(data []byte) ([]byte, error)
-	Encrypt(data []byte) ([]byte, error)
+	Decrypt(data []byte, email string) ([]byte, error)
+	Encrypt(data []byte, email string) ([]byte, error)
 }

--- a/umh-core/pkg/gatekeeper/encryption/v0.go
+++ b/umh-core/pkg/gatekeeper/encryption/v0.go
@@ -26,10 +26,10 @@ func NewV0Handler(log *zap.SugaredLogger) Handler {
 	return &V0Handler{log: log}
 }
 
-func (h *V0Handler) Decrypt(data []byte) ([]byte, error) {
+func (h *V0Handler) Decrypt(data []byte, _ string) ([]byte, error) {
 	return data, nil
 }
 
-func (h *V0Handler) Encrypt(data []byte) ([]byte, error) {
+func (h *V0Handler) Encrypt(data []byte, _ string) ([]byte, error) {
 	return data, nil
 }

--- a/umh-core/pkg/gatekeeper/gatekeeper.go
+++ b/umh-core/pkg/gatekeeper/gatekeeper.go
@@ -201,7 +201,7 @@ func (g *Gatekeeper) handleInbound(ctx context.Context, msg *transport.UMHMessag
 	cryptHandler := g.protocolDetector.Detect(msg)
 
 	// 2. Decrypt
-	decrypted, err := cryptHandler.Decrypt([]byte(msg.Content))
+	decrypted, err := cryptHandler.Decrypt([]byte(msg.Content), msg.Email)
 	if err != nil {
 		g.logger.Warnw("Failed to decrypt message", "email", msg.Email, "error", err)
 		return

--- a/umh-core/pkg/gatekeeper/protocol/detector_test.go
+++ b/umh-core/pkg/gatekeeper/protocol/detector_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Detector", func() {
 				Email:   "test@example.com",
 			}
 			handler := det.Detect(msg)
-			out, err := handler.Decrypt([]byte("hello"))
+			out, err := handler.Decrypt([]byte("hello"), "test@example.com")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(string(out)).To(Equal("hello"))
 		})
@@ -49,7 +49,7 @@ var _ = Describe("Detector", func() {
 				ProtocolVersion: transport.CseV1,
 			}
 			handler := det.Detect(msg)
-			_, err := handler.Decrypt([]byte("hello"))
+			_, err := handler.Decrypt([]byte("hello"), "test@example.com")
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("not yet implemented"))
 		})


### PR DESCRIPTION
# Description

This PR adjusts/fixes the following things:

- `certificateFetcher` gets ported to FSMv2
- `subHandler` accessed without locked
- race-condition in `handleInbound`
- don't close `verifiedInbound´  when ´processInbound´  may still write

Fixes ENG-4611