### PR TITLE
ci: add stale-branch warning to changelog guard

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -263,6 +263,22 @@ jobs:
           fi
 
           echo "Released sections unchanged vs merge-base — OK"
+
+          # Informational: warn if the released section on this branch differs from the tag.
+          # This happens when a feature branch was forked before the release was tagged.
+          # Not an error (the PR didn't cause it), but the branch should be updated eventually.
+          # The 2>/dev/null intentionally suppresses git errors (missing file at tag, shallow
+          # clone, etc.) — this is a best-effort informational check, not a gate.
+          if TAG_CHANGELOG=$(git show "$LATEST_TAG:$CHANGELOG" 2>/dev/null); then
+            TAG_LINE=$(printf '%s\n' "$TAG_CHANGELOG" | grep -Fn "$HEADER" | head -1 | cut -d: -f1 || true)
+            if [[ -n "$TAG_LINE" ]]; then
+              TAG_TAIL=$(printf '%s\n' "$TAG_CHANGELOG" | tail -n +"$TAG_LINE")
+              if [[ "$(printf '%s' "$TAG_TAIL")" != "$(printf '%s' "$CURRENT_TAIL")" ]]; then
+                echo ""
+                echo "::warning file=$CHANGELOG::The '$HEADER' section on this branch differs from the $LATEST_TAG tag. Your base branch ($BASE_REF) was forked before the release was tagged. This is not blocking. Merge 'staging' into '$BASE_REF' to pick up release-time edits."
+              fi
+            fi
+          fi
       - name: Validate CHANGELOG.md
         run: npx tsx changelog-scripts/.github/scripts/validate-changelog.ts --format version --changelog-path umh-core/CHANGELOG.md
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -156,6 +156,7 @@ jobs:
         shell: bash
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           set -euo pipefail
 
@@ -275,7 +276,7 @@ jobs:
               TAG_TAIL=$(printf '%s\n' "$TAG_CHANGELOG" | tail -n +"$TAG_LINE")
               if [[ "$(printf '%s' "$TAG_TAIL")" != "$(printf '%s' "$CURRENT_TAIL")" ]]; then
                 echo ""
-                echo "::warning file=$CHANGELOG::The '$HEADER' section on this branch differs from the $LATEST_TAG tag. Your base branch ($BASE_REF) was forked before the release was tagged. This is not blocking. Merge 'staging' into '$BASE_REF' to pick up release-time edits."
+                echo "::warning file=$CHANGELOG::The '$HEADER' section on this branch differs from the $LATEST_TAG tag. Your branch was forked before the release was tagged. This is not blocking. Merge '$BASE_REF' into '$HEAD_REF' to pick up release-time edits."
               fi
             fi
           fi


### PR DESCRIPTION
Janik's PR #2493 (`feat/ff-gatekeeper` → `feat/gatekeeper`) hit a confusing CI failure: "Released CHANGELOG sections have been modified!" He hadn't touched released content. His base branch was forked before v0.44.12, so the `[0.44.12]` section was stale.

The merge-base guard (PR #2488) already fixes the false failure. But developers still get zero signal that their branch is behind. This adds a non-blocking `::warning` on `umh-core/CHANGELOG.md` when the released section differs from the tag, telling them to merge staging.

Resolves ENG-4669

## Test plan
- [x] 7/7 local scenarios pass (clean PR, modified released section, stale branch, predates tag, no tags, missing CHANGELOG in tag, exact match)
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)