### PR TITLE
feat: read and write flows for protocol converter

### DIFF
--- a/umh-core/pkg/communicator/actions/actions.go
+++ b/umh-core/pkg/communicator/actions/actions.go
@@ -213,19 +213,10 @@ func HandleActionMessage(instanceUUID uuid.UUID, payload models.ActionMessagePay
 		return
 	}
 
-	// Check if payload contains a state field and is a deploy protocol converter action. If yes, log any errors via Sentry
+	// Check if payload contains a DFC with a state field and is an EditProtocolConverter action.
+	// If yes, log any errors via Sentry.
 	// TODO: This can be removed once the "Write flows" feature is fully implemented
-	var state string
-	if m, ok := payload.ActionPayload.(map[string]interface{}); ok {
-		if s, ok := m["state"]; ok {
-			if str, ok := s.(string); ok {
-				state = str
-			} else {
-				log.Errorf("Invalid state type: %v", s)
-			}
-		}
-	}
-	isLogToSentry := state != "" && payload.ActionType == models.EditProtocolConverter
+	isLogToSentry := payload.ActionType == models.EditProtocolConverter && payloadHasDFCState(payload.ActionPayload)
 
 	SendActionReply(instanceUUID, sender, payload.ActionUUID, models.ActionExecuting, "Parsing action payload", outboundChannel, payload.ActionType)
 	// Parse the action payload
@@ -510,4 +501,25 @@ func GetFirstMessageFromMap(msg map[string]interface{}) interface{} {
 	}
 
 	return nil
+}
+
+// payloadHasDFCState checks whether the action payload contains a "state" field
+// inside either "readDFC" or "writeDFC".
+// helper function for determining if a DFC state field should be logged to Sentry.
+// TODO: Remove this function once the "Write flows" feature is fully implemented.
+func payloadHasDFCState(actionPayload any) bool {
+	m, ok := actionPayload.(map[string]any)
+	if !ok {
+		return false
+	}
+	for _, key := range []string{"readDFC", "writeDFC"} {
+		if dfc, ok := m[key]; ok {
+			if dfcMap, ok := dfc.(map[string]any); ok {
+				if _, ok := dfcMap["state"]; ok {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }

--- a/umh-core/pkg/communicator/actions/deploy-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/deploy-protocolconverter.go
@@ -96,11 +96,6 @@ func (a *DeployProtocolConverterAction) Parse(payload interface{}) error {
 
 	a.payload = parsedPayload
 
-	// If state empty, default to active
-	if a.payload.State == "" {
-		a.payload.State = dataflowcomponent.OperationalStateActive
-	}
-
 	a.actionLogger.Debugf("Parsed DeployProtocolConverter action payload: name=%s, ip=%s, port=%d",
 		a.payload.Name, a.payload.Connection.IP, a.payload.Connection.Port)
 
@@ -126,7 +121,10 @@ func (a *DeployProtocolConverterAction) Validate() error {
 		return err
 	}
 
-	if err := ValidateDataFlowComponentState(a.payload.State); err != nil {
+	if err := validateProtocolConverterDFC(a.payload.ReadDFC, "read"); err != nil {
+		return err
+	}
+	if err := validateProtocolConverterDFC(a.payload.WriteDFC, "write"); err != nil {
 		return err
 	}
 
@@ -142,7 +140,14 @@ func (a *DeployProtocolConverterAction) Execute() (interface{}, map[string]inter
 		"Starting deployment of protocol converter: "+a.payload.Name, a.outboundChannel, models.DeployProtocolConverter)
 
 	// Create the protocol converter config with template and variables
-	pcConfig := a.createProtocolConverterConfig()
+	pcConfig, err := a.createProtocolConverterConfig()
+	if err != nil {
+		errorMsg := fmt.Sprintf("Failed to create protocol converter configuration: %v", err)
+		SendActionReply(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedWithFailure,
+			errorMsg, a.outboundChannel, models.DeployProtocolConverter)
+
+		return nil, nil, fmt.Errorf("%s", errorMsg)
+	}
 
 	// currently, we canot reuse templates, so we need to create a new one
 	pcConfig.ProtocolConverterServiceConfig.TemplateRef = pcConfig.Name
@@ -154,7 +159,7 @@ func (a *DeployProtocolConverterAction) Execute() (interface{}, map[string]inter
 	SendActionReply(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionExecuting,
 		"Adding protocol converter to configuration...", a.outboundChannel, models.DeployProtocolConverter)
 
-	err := a.configManager.AtomicAddProtocolConverter(ctx, pcConfig)
+	err = a.configManager.AtomicAddProtocolConverter(ctx, pcConfig)
 	if err != nil {
 		errorMsg := fmt.Sprintf("Failed to add protocol converter: %v", err)
 		SendActionReply(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedWithFailure,
@@ -172,7 +177,6 @@ func (a *DeployProtocolConverterAction) Execute() (interface{}, map[string]inter
 		Name:       a.payload.Name,
 		Location:   a.payload.Location,
 		Connection: a.payload.Connection,
-		State:      pcConfig.DesiredFSMState,
 		// ReadDFC, WriteDFC, and TemplateInfo are nil as they will be added later
 	}
 
@@ -232,7 +236,7 @@ func (a *DeployProtocolConverterAction) Execute() (interface{}, map[string]inter
 }
 
 // createProtocolConverterConfig creates a ProtocolConverterConfig with templated configuration.
-func (a *DeployProtocolConverterAction) createProtocolConverterConfig() config.ProtocolConverterConfig {
+func (a *DeployProtocolConverterAction) createProtocolConverterConfig() (config.ProtocolConverterConfig, error) {
 	// Create variables bundle - start empty to allow user variables first
 	userVars := map[string]any{}
 
@@ -264,21 +268,54 @@ func (a *DeployProtocolConverterAction) createProtocolConverterConfig() config.P
 		DataflowComponentWriteServiceConfig: dataflowcomponentserviceconfig.DataflowComponentServiceConfig{},
 	}
 
+	// If a ReadDFC is provided in the payload, configure it immediately
+	if a.payload.ReadDFC != nil {
+		benthosConfig, err := CreateBenthosConfigFromCDFCPayload(dfcToPayload(a.payload.ReadDFC), a.payload.Name)
+		if err != nil {
+			return config.ProtocolConverterConfig{}, fmt.Errorf("failed to create read DFC benthos config: %w", err)
+		}
+		template.DataflowComponentReadServiceConfig = dataflowcomponentserviceconfig.DataflowComponentServiceConfig{
+			BenthosConfig: benthosConfig,
+		}
+	}
+
+	// If a WriteDFC is provided in the payload, configure it immediately
+	if a.payload.WriteDFC != nil {
+		benthosConfig, err := CreateBenthosConfigFromCDFCPayload(dfcToPayload(a.payload.WriteDFC), a.payload.Name)
+		if err != nil {
+			return config.ProtocolConverterConfig{}, fmt.Errorf("failed to create write DFC benthos config: %w", err)
+		}
+		template.DataflowComponentWriteServiceConfig = dataflowcomponentserviceconfig.DataflowComponentServiceConfig{
+			BenthosConfig: benthosConfig,
+		}
+	}
+
+	// Determine per-DFC desired states and derive PC-level state.
+	var readDFCDesiredState, writeDFCDesiredState string
+	if a.payload.ReadDFC != nil {
+		readDFCDesiredState = a.payload.ReadDFC.State
+	}
+	if a.payload.WriteDFC != nil {
+		writeDFCDesiredState = a.payload.WriteDFC.State
+	}
+
 	// Create the spec with template and variables
 	spec := protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec{
-		Config:    template,
-		Variables: variableBundle,
-		Location:  convertIntMapToStringMap(a.payload.Location),
+		Config:               template,
+		Variables:            variableBundle,
+		Location:             convertIntMapToStringMap(a.payload.Location),
+		ReadDFCDesiredState:  readDFCDesiredState,
+		WriteDFCDesiredState: writeDFCDesiredState,
 	}
 
 	// Create the full config
 	return config.ProtocolConverterConfig{
 		FSMInstanceConfig: config.FSMInstanceConfig{
 			Name:            a.payload.Name,
-			DesiredFSMState: a.payload.State,
+			DesiredFSMState: derivePCDesiredState(readDFCDesiredState, writeDFCDesiredState, "", ""),
 		},
 		ProtocolConverterServiceConfig: spec,
-	}
+	}, nil
 }
 
 // convertIntMapToStringMap converts map[int]string to map[string]string.

--- a/umh-core/pkg/communicator/actions/deploy-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/deploy-protocolconverter.go
@@ -312,7 +312,7 @@ func (a *DeployProtocolConverterAction) createProtocolConverterConfig() (config.
 	return config.ProtocolConverterConfig{
 		FSMInstanceConfig: config.FSMInstanceConfig{
 			Name:            a.payload.Name,
-			DesiredFSMState: derivePCDesiredState(readDFCDesiredState, writeDFCDesiredState, "", ""),
+			DesiredFSMState: protocolconverter.OperationalStateActive,
 		},
 		ProtocolConverterServiceConfig: spec,
 	}, nil

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter.go
@@ -41,6 +41,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/tiendc/go-deepcopy"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/benthosserviceconfig"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/connectionserviceconfig"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/dataflowcomponentserviceconfig"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/protocolconverterserviceconfig"
@@ -62,6 +63,8 @@ const (
 	DFCTypeRead DFCType = "read"
 	// DFCTypeWrite represents a write dataflow component.
 	DFCTypeWrite DFCType = "write"
+	// DFCTypeBoth represents both read and write dataflow components being updated simultaneously.
+	DFCTypeBoth DFCType = "both"
 	// DFCTypeEmpty represents no dataflow component (connection/location update only).
 	DFCTypeEmpty DFCType = "empty"
 )
@@ -74,7 +77,7 @@ func (d DFCType) String() string {
 // IsValid checks if the DFCType has a valid value.
 func (d DFCType) IsValid() bool {
 	switch d {
-	case DFCTypeRead, DFCTypeWrite, DFCTypeEmpty:
+	case DFCTypeRead, DFCTypeWrite, DFCTypeBoth, DFCTypeEmpty:
 		return true
 	default:
 		return false
@@ -98,14 +101,17 @@ type EditProtocolConverterAction struct {
 	dfcType        DFCType
 	connectionPort string
 	connectionIP   string
-	state          string
+	readDFCState   string // desired state for the read DFC ("active" or "stopped"; empty = default active)
+	writeDFCState  string // desired state for the write DFC ("active" or "stopped"; empty = default active)
 
-	dfcPayload models.CDFCPayload
+	readDFCPayload  *models.CDFCPayload
+	writeDFCPayload *models.CDFCPayload
 
 	vb []models.ProtocolConverterVariable
 
-	// Desired DFC config for comparison during health checks
-	desiredDFCConfig dataflowcomponentserviceconfig.DataflowComponentServiceConfig
+	// Desired DFC configs for comparison during health checks
+	desiredReadDFCConfig  dataflowcomponentserviceconfig.DataflowComponentServiceConfig
+	desiredWriteDFCConfig dataflowcomponentserviceconfig.DataflowComponentServiceConfig
 
 	actionUUID   uuid.UUID
 	instanceUUID uuid.UUID
@@ -145,25 +151,44 @@ func (a *EditProtocolConverterAction) Parse(payload interface{}) error {
 	if pcPayload.UUID == nil {
 		return errors.New("missing required field UUID")
 	}
-
 	a.protocolConverterUUID = *pcPayload.UUID
 	a.name = pcPayload.Name
 
-	// Determine which DFC is being updated and convert it to CDFCPayload
-	var dfcToUpdate *models.ProtocolConverterDFC
-
+	// Determine which DFC(s) are being updated and convert to CDFCPayload.
 	switch {
+	case pcPayload.ReadDFC != nil && pcPayload.WriteDFC != nil:
+		a.dfcType = DFCTypeBoth
+		readPayload := dfcToPayload(pcPayload.ReadDFC)
+		writePayload := dfcToPayload(pcPayload.WriteDFC)
+		a.readDFCPayload = &readPayload
+		a.writeDFCPayload = &writePayload
+		if pcPayload.ReadDFC.IgnoreErrors != nil {
+			a.ignoreHealthCheck = *pcPayload.ReadDFC.IgnoreErrors
+		}
+		if pcPayload.WriteDFC.IgnoreErrors != nil {
+			a.ignoreHealthCheck = a.ignoreHealthCheck || *pcPayload.WriteDFC.IgnoreErrors
+		}
+		a.readDFCState = pcPayload.ReadDFC.State
+		a.writeDFCState = pcPayload.WriteDFC.State
 	case pcPayload.ReadDFC != nil:
 		a.dfcType = DFCTypeRead
-		dfcToUpdate = pcPayload.ReadDFC
+		readPayload := dfcToPayload(pcPayload.ReadDFC)
+		a.readDFCPayload = &readPayload
+		if pcPayload.ReadDFC.IgnoreErrors != nil {
+			a.ignoreHealthCheck = *pcPayload.ReadDFC.IgnoreErrors
+		}
+		a.readDFCState = pcPayload.ReadDFC.State
 	case pcPayload.WriteDFC != nil:
 		a.dfcType = DFCTypeWrite
-		dfcToUpdate = pcPayload.WriteDFC
+		writePayload := dfcToPayload(pcPayload.WriteDFC)
+		a.writeDFCPayload = &writePayload
+		if pcPayload.WriteDFC.IgnoreErrors != nil {
+			a.ignoreHealthCheck = *pcPayload.WriteDFC.IgnoreErrors
+		}
+		a.writeDFCState = pcPayload.WriteDFC.State
 	default:
 		a.dfcType = DFCTypeEmpty
-		dfcToUpdate = &models.ProtocolConverterDFC{}
 	}
-
 	if pcPayload.TemplateInfo != nil {
 		a.vb = pcPayload.TemplateInfo.Variables
 	} else {
@@ -178,30 +203,8 @@ func (a *EditProtocolConverterAction) Parse(payload interface{}) error {
 	a.connectionPort = strconv.Itoa(int(pcPayload.Connection.Port))
 	a.connectionIP = pcPayload.Connection.IP
 
-	// Convert ProtocolConverterDFC to CDFCPayload for internal processing
-	if a.dfcType != DFCTypeEmpty {
-		a.dfcPayload = models.CDFCPayload{
-			Inputs:   models.DfcDataConfig{Data: dfcToUpdate.Inputs.Data, Type: dfcToUpdate.Inputs.Type},
-			Pipeline: convertPipelineToMap(dfcToUpdate.Pipeline),
-			// Set default outputs since ProtocolConverterDFC doesn't have outputs
-			Outputs: models.DfcDataConfig{Data: "", Type: ""},
-			// Extract Inject data from RawYAML to support CacheResources, RateLimitResources, and Buffer
-			Inject: extractInjectFromRawYAML(dfcToUpdate.RawYAML),
-		}
-		// Handle optional fields
-		if dfcToUpdate.IgnoreErrors != nil {
-			a.ignoreHealthCheck = *dfcToUpdate.IgnoreErrors
-		}
-	}
-
-	// Extract the desired state, defaulting to "active" if not provided
-	a.state = pcPayload.State
-	if a.state == "" {
-		a.state = protocolconverter.OperationalStateActive
-	}
-
-	a.actionLogger.Debugf("Parsed EditProtocolConverter action payload: uuid=%s, name=%s, dfcType=%s, state=%s",
-		a.protocolConverterUUID, a.name, a.dfcType, a.state)
+	a.actionLogger.Debugf("Parsed EditProtocolConverter action payload: uuid=%s, name=%s, dfcType=%s, readDFCState=%s, writeDFCState=%s",
+		a.protocolConverterUUID, a.name, a.dfcType, a.readDFCState, a.writeDFCState)
 
 	return nil
 }
@@ -217,13 +220,10 @@ func (a *EditProtocolConverterAction) Validate() error {
 		return err
 	}
 
-	if a.dfcType != DFCTypeEmpty {
-		if err := ValidateCustomDataFlowComponentPayload(a.dfcPayload, false); err != nil {
-			return fmt.Errorf("invalid dataflow component configuration: %w", err)
-		}
+	if err := validateDFCPayloadAndState(a.readDFCPayload, a.readDFCState, "read"); err != nil {
+		return err
 	}
-
-	if err := ValidateDataFlowComponentState(a.state); err != nil {
+	if err := validateDFCPayloadAndState(a.writeDFCPayload, a.writeDFCState, "write"); err != nil {
 		return err
 	}
 
@@ -247,23 +247,36 @@ func (a *EditProtocolConverterAction) Execute() (interface{}, map[string]interfa
 		confirmationMessage, a.outboundChannel, models.EditProtocolConverter)
 
 	var (
-		benthosConfig dataflowcomponentserviceconfig.BenthosConfig
-		err           error
+		readBenthosConfig  *dataflowcomponentserviceconfig.BenthosConfig
+		writeBenthosConfig *dataflowcomponentserviceconfig.BenthosConfig
+		err                error
 	)
 
-	// Only create Benthos config if we have a DFC to configure
-
-	if a.dfcType != DFCTypeEmpty {
-		// Convert the DFC payload to BenthosConfig
-		benthosConfig, err = CreateBenthosConfigFromCDFCPayload(a.dfcPayload, a.name)
-		if err != nil {
-			errorMsg := fmt.Sprintf("Failed to create Benthos configuration: %v", err)
+	if a.readDFCPayload != nil {
+		cfg, buildErr := CreateBenthosConfigFromCDFCPayload(*a.readDFCPayload, a.name)
+		if buildErr != nil {
+			errorMsg := fmt.Sprintf("Failed to create read DFC Benthos configuration: %v", buildErr)
 			SendActionReply(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedWithFailure,
 				errorMsg, a.outboundChannel, models.EditProtocolConverter)
 
 			return nil, nil, fmt.Errorf("%s", errorMsg)
 		}
+		readBenthosConfig = &cfg
+	}
 
+	if a.writeDFCPayload != nil {
+		cfg, buildErr := CreateBenthosConfigFromCDFCPayload(*a.writeDFCPayload, a.name)
+		if buildErr != nil {
+			errorMsg := fmt.Sprintf("Failed to create write DFC Benthos configuration: %v", buildErr)
+			SendActionReply(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedWithFailure,
+				errorMsg, a.outboundChannel, models.EditProtocolConverter)
+
+			return nil, nil, fmt.Errorf("%s", errorMsg)
+		}
+		writeBenthosConfig = &cfg
+	}
+
+	if a.dfcType != DFCTypeEmpty {
 		SendActionReply(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionExecuting,
 			fmt.Sprintf("Updating protocol converter configuration with %s DFC...", a.dfcType.String()),
 			a.outboundChannel, models.EditProtocolConverter)
@@ -274,7 +287,7 @@ func (a *EditProtocolConverterAction) Execute() (interface{}, map[string]interfa
 	}
 
 	// Apply mutations to create new spec
-	newSpec, atomicEditUUID, err := a.applyMutation(benthosConfig)
+	newSpec, atomicEditUUID, desiredPCState, err := a.applyMutation(readBenthosConfig, writeBenthosConfig)
 	if err != nil {
 		errorMsg := fmt.Sprintf("Failed to apply configuration mutation: %v", err)
 		SendActionReply(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedWithFailure,
@@ -298,7 +311,7 @@ func (a *EditProtocolConverterAction) Execute() (interface{}, map[string]interfa
 
 	// Await rollout and perform health checks
 	if a.systemSnapshotManager != nil && !a.ignoreHealthCheck {
-		errCode, err := a.awaitRollout(oldConfig)
+		errCode, err := a.awaitRollout(oldConfig, desiredPCState)
 		if err != nil {
 			errorMsg := fmt.Sprintf("Failed during rollout: %v", err)
 			SendActionReplyV2(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedWithFailure,
@@ -322,15 +335,15 @@ func (a *EditProtocolConverterAction) Execute() (interface{}, map[string]interfa
 // applyMutation analyzes the current configuration and applies the necessary mutations
 // to create the new protocol converter specification. It handles child/root relationships,
 // variable merging, and DFC configuration updates.
-// Returns the new spec and the atomic edit UUID to use for persistence.
-func (a *EditProtocolConverterAction) applyMutation(benthosConfig dataflowcomponentserviceconfig.BenthosConfig) (config.ProtocolConverterConfig, uuid.UUID, error) {
+// Returns the new spec, the atomic edit UUID, the derived PC desired state, and any error.
+func (a *EditProtocolConverterAction) applyMutation(readBenthosConfig, writeBenthosConfig *dataflowcomponentserviceconfig.BenthosConfig) (config.ProtocolConverterConfig, uuid.UUID, string, error) {
 	// Get current configuration
 	ctx, cancel := context.WithTimeout(context.Background(), constants.ActionTimeout)
 	defer cancel()
 
 	currentConfig, err := a.configManager.GetConfig(ctx, 0)
 	if err != nil {
-		return config.ProtocolConverterConfig{}, uuid.Nil, fmt.Errorf("failed to get current configuration: %w", err)
+		return config.ProtocolConverterConfig{}, uuid.Nil, "", fmt.Errorf("failed to get current configuration: %w", err)
 	}
 
 	// Find the protocol converter in the configuration
@@ -349,7 +362,7 @@ func (a *EditProtocolConverterAction) applyMutation(benthosConfig dataflowcompon
 	}
 
 	if !found {
-		return config.ProtocolConverterConfig{}, uuid.Nil, fmt.Errorf("protocol converter with UUID %s not found", a.protocolConverterUUID)
+		return config.ProtocolConverterConfig{}, uuid.Nil, "", fmt.Errorf("protocol converter with UUID %s not found", a.protocolConverterUUID)
 	}
 
 	// Currently, we cannot reuse templates, so we need to create a new one
@@ -384,7 +397,7 @@ func (a *EditProtocolConverterAction) applyMutation(benthosConfig dataflowcompon
 		}
 
 		if !rootFound {
-			return config.ProtocolConverterConfig{}, uuid.Nil, fmt.Errorf("root template %s not found for child protocol converter %s",
+			return config.ProtocolConverterConfig{}, uuid.Nil, "", fmt.Errorf("root template %s not found for child protocol converter %s",
 				targetPC.ProtocolConverterServiceConfig.TemplateRef, targetPC.Name)
 		}
 
@@ -417,14 +430,22 @@ func (a *EditProtocolConverterAction) applyMutation(benthosConfig dataflowcompon
 
 	instanceToModify.ProtocolConverterServiceConfig.Variables.User = newVB
 
-	// Update the appropriate DFC configuration based on dfcType
-	var dfcServiceConfig dataflowcomponentserviceconfig.DataflowComponentServiceConfig
-	if a.dfcType != DFCTypeEmpty {
-		dfcServiceConfig = dataflowcomponentserviceconfig.DataflowComponentServiceConfig{
-			BenthosConfig: benthosConfig,
+	// Apply read DFC config if provided
+	if readBenthosConfig != nil {
+		readDFCServiceConfig := dataflowcomponentserviceconfig.DataflowComponentServiceConfig{
+			BenthosConfig: *readBenthosConfig,
 		}
-		// Store the desired DFC config for health check comparison
-		a.desiredDFCConfig = dfcServiceConfig
+		a.desiredReadDFCConfig = readDFCServiceConfig
+		instanceToModify.ProtocolConverterServiceConfig.Config.DataflowComponentReadServiceConfig = readDFCServiceConfig
+	}
+
+	// Apply write DFC config if provided
+	if writeBenthosConfig != nil {
+		writeDFCServiceConfig := dataflowcomponentserviceconfig.DataflowComponentServiceConfig{
+			BenthosConfig: *writeBenthosConfig,
+		}
+		a.desiredWriteDFCConfig = writeDFCServiceConfig
+		instanceToModify.ProtocolConverterServiceConfig.Config.DataflowComponentWriteServiceConfig = writeDFCServiceConfig
 	}
 
 	// Add the connection details to the template
@@ -449,21 +470,21 @@ func (a *EditProtocolConverterAction) applyMutation(benthosConfig dataflowcompon
 		instanceToModify.ProtocolConverterServiceConfig.Variables.User["PORT"] = a.connectionPort
 	}
 
-	switch a.dfcType {
-	case DFCTypeRead:
-		instanceToModify.ProtocolConverterServiceConfig.Config.DataflowComponentReadServiceConfig = dfcServiceConfig
-	case DFCTypeWrite:
-		instanceToModify.ProtocolConverterServiceConfig.Config.DataflowComponentWriteServiceConfig = dfcServiceConfig
-	case DFCTypeEmpty:
-		// For empty dfcType, we only update connection, location, and name - no DFC configuration
-		// The connection, location, and name updates are already handled above
-	default:
-		return config.ProtocolConverterConfig{}, uuid.Nil, fmt.Errorf("invalid DFC type: %s", a.dfcType.String())
-	}
+	// Store per-DFC desired state overrides in the spec so the FSM can propagate them.
+	instanceToModify.ProtocolConverterServiceConfig.ReadDFCDesiredState = a.readDFCState
+	instanceToModify.ProtocolConverterServiceConfig.WriteDFCDesiredState = a.writeDFCState
 
-	instanceToModify.DesiredFSMState = a.state
+	// Derive the PC-level FSM state from the per-DFC states.
+	// For DFCTypeEmpty (connection/location-only edits) the new states are empty,
+	// so we fall back to the existing spec values via derivePCDesiredState.
+	instanceToModify.DesiredFSMState = derivePCDesiredState(
+		a.readDFCState,
+		a.writeDFCState,
+		instanceToModify.ProtocolConverterServiceConfig.ReadDFCDesiredState,
+		instanceToModify.ProtocolConverterServiceConfig.WriteDFCDesiredState,
+	)
 
-	return instanceToModify, atomicEditUUID, nil
+	return instanceToModify, atomicEditUUID, instanceToModify.DesiredFSMState, nil
 }
 
 // persistConfig performs the atomic configuration update operation.
@@ -504,7 +525,7 @@ func (a *EditProtocolConverterAction) persistConfig(atomicEditUUID uuid.UUID, ne
 // The function returns the error code and the error message via an error object.
 // The error code is a string that is sent to the frontend to allow it to determine if the action can be retried or not.
 // The error message is sent to the frontend to allow the user to see the error message.
-func (a *EditProtocolConverterAction) awaitRollout(pcConfig config.ProtocolConverterConfig) (string, error) {
+func (a *EditProtocolConverterAction) awaitRollout(pcConfig config.ProtocolConverterConfig, desiredPCState string) (string, error) {
 	SendActionReply(
 		a.instanceUUID,
 		a.userEmail,
@@ -513,7 +534,7 @@ func (a *EditProtocolConverterAction) awaitRollout(pcConfig config.ProtocolConve
 		fmt.Sprintf(
 			"Waiting for protocol converter %s to be %s...",
 			a.name,
-			a.state,
+			desiredPCState,
 		),
 		a.outboundChannel,
 		models.EditProtocolConverter,
@@ -545,11 +566,11 @@ func (a *EditProtocolConverterAction) awaitRollout(pcConfig config.ProtocolConve
 			_, err := a.configManager.AtomicEditProtocolConverter(ctx, a.atomicEditUUID, pcConfig)
 			if err != nil {
 				a.actionLogger.Errorf("Failed to rollback to previous configuration: %v", err)
-				stateMessage := fmt.Sprintf("Protocol converter '%s' edit timeout reached. It did not become %s in time. Rolling back to previous configuration failed: %v", a.name, a.state, err)
+				stateMessage := fmt.Sprintf("Protocol converter '%s' edit timeout reached. It did not become %s in time. Rolling back to previous configuration failed: %v", a.name, desiredPCState, err)
 
 				return models.ErrRetryRollbackTimeout, fmt.Errorf("%s", stateMessage)
 			} else {
-				stateMessage := fmt.Sprintf("Protocol converter '%s' edit timeout reached. It did not become %s in time. Rolled back to previous configuration", a.name, a.state)
+				stateMessage := fmt.Sprintf("Protocol converter '%s' edit timeout reached. It did not become %s in time. Rolled back to previous configuration", a.name, desiredPCState)
 
 				return models.ErrRetryRollbackTimeout, fmt.Errorf("%s", stateMessage)
 			}
@@ -605,7 +626,7 @@ func (a *EditProtocolConverterAction) awaitRollout(pcConfig config.ProtocolConve
 					// For empty DFC type (connection/location/state update only)
 					// Only check the nmap port when activating; when stopping, nmap is also
 					// stopped so it will never update to the new port.
-					if a.state != protocolconverter.OperationalStateStopped {
+					if desiredPCState != protocolconverter.OperationalStateStopped {
 						nmapPort := strconv.FormatUint(
 							uint64(pcSnapshot.ServiceInfo.ConnectionObservedState.ServiceInfo.NmapObservedState.ObservedNmapServiceConfig.Port),
 							10,
@@ -630,7 +651,7 @@ func (a *EditProtocolConverterAction) awaitRollout(pcConfig config.ProtocolConve
 					// Check if the protocol converter has reached the desired state
 					hasReachedDesiredState := false
 
-					switch a.state {
+					switch desiredPCState {
 					case protocolconverter.OperationalStateActive:
 						hasReachedDesiredState = slices.Contains(
 							[]string{
@@ -647,7 +668,7 @@ func (a *EditProtocolConverterAction) awaitRollout(pcConfig config.ProtocolConve
 					if !hasReachedDesiredState {
 						currentStateReason = fmt.Sprintf(
 							"waiting for state to become %s (current: %s)",
-							a.state,
+							desiredPCState,
 							instance.CurrentState,
 						)
 						SendActionReply(
@@ -669,7 +690,7 @@ func (a *EditProtocolConverterAction) awaitRollout(pcConfig config.ProtocolConve
 				// When desired state is "stopped", the Benthos process is not running so
 				// compareProtocolConverterDFCConfig always returns false (observed Input is nil).
 				// Check the state first to avoid an infinite loop in this case.
-				if a.state == protocolconverter.OperationalStateStopped {
+				if desiredPCState == protocolconverter.OperationalStateStopped {
 					if instance.CurrentState == protocolconverter.OperationalStateStopped {
 						SendActionReply(
 							a.instanceUUID,
@@ -727,7 +748,7 @@ func (a *EditProtocolConverterAction) awaitRollout(pcConfig config.ProtocolConve
 				// For "stopped" state: accept only "stopped"
 				hasReachedDesiredState := false
 
-				switch a.state {
+				switch desiredPCState {
 				case protocolconverter.OperationalStateActive:
 					hasReachedDesiredState = slices.Contains(
 						[]string{
@@ -744,7 +765,7 @@ func (a *EditProtocolConverterAction) awaitRollout(pcConfig config.ProtocolConve
 					terminal := map[string]string{
 						protocolconverter.OperationalStateActive:  "activated",
 						protocolconverter.OperationalStateStopped: "stopped",
-					}[a.state]
+					}[desiredPCState]
 					SendActionReply(
 						a.instanceUUID,
 						a.userEmail,
@@ -768,8 +789,14 @@ func (a *EditProtocolConverterAction) awaitRollout(pcConfig config.ProtocolConve
 					currentStateReason = pcSnapshot.ServiceInfo.StatusReason
 				}
 
-				// send the benthos logs to the user
-				logs = pcSnapshot.ServiceInfo.DataflowComponentReadObservedState.ServiceInfo.BenthosObservedState.ServiceInfo.BenthosStatus.BenthosLogs
+				// send the benthos logs to the user; for DFCTypeBoth, prefer write logs since
+				// read logs are also included below via the merged slice.
+				switch a.dfcType {
+				case DFCTypeWrite, DFCTypeBoth:
+					logs = pcSnapshot.ServiceInfo.DataflowComponentWriteObservedState.ServiceInfo.BenthosObservedState.ServiceInfo.BenthosStatus.BenthosLogs
+				default:
+					logs = pcSnapshot.ServiceInfo.DataflowComponentReadObservedState.ServiceInfo.BenthosObservedState.ServiceInfo.BenthosStatus.BenthosLogs
+				}
 
 				// only send the logs that have not been sent yet
 				if len(logs) > len(lastLogs) {
@@ -833,63 +860,108 @@ func (a *EditProtocolConverterAction) awaitRollout(pcConfig config.ProtocolConve
 }
 
 // compareProtocolConverterDFCConfig compares the desired DFC configuration with the observed
-// DFC configuration in the protocol converter snapshot. Currently only checks the read DFC
-// since write DFC is not yet implemented.
+// DFC configuration in the protocol converter snapshot.
 func (a *EditProtocolConverterAction) compareProtocolConverterDFCConfig(pcSnapshot *protocolconverter.ProtocolConverterObservedStateSnapshot) bool {
 	if pcSnapshot == nil {
 		return false
 	}
 
-	// Only check read DFC for now since write DFC is not yet implemented
-	if a.dfcType != DFCTypeRead {
-		// For write DFC and empty DFC, just return true for now since write DFC is not implemented
-		// and empty DFC doesn't have any DFC configuration to compare
+	switch a.dfcType {
+	case DFCTypeEmpty:
 		return true
+	case DFCTypeRead:
+		return a.compareSingleDFCConfig(pcSnapshot, DFCTypeRead)
+	case DFCTypeWrite:
+		return a.compareSingleDFCConfig(pcSnapshot, DFCTypeWrite)
+	case DFCTypeBoth:
+		return a.compareSingleDFCConfig(pcSnapshot, DFCTypeRead) &&
+			a.compareSingleDFCConfig(pcSnapshot, DFCTypeWrite)
+	default:
+		return false
 	}
+}
 
-	// Check if the observed Benthos config is available for read DFC
-	if pcSnapshot.ServiceInfo.DataflowComponentReadObservedState.ServiceInfo.BenthosObservedState.ObservedBenthosServiceConfig.Input == nil {
+// compareSingleDFCConfig compares a single DFC (read or write) against its observed state.
+func (a *EditProtocolConverterAction) compareSingleDFCConfig(pcSnapshot *protocolconverter.ProtocolConverterObservedStateSnapshot, dfcType DFCType) bool {
+	var (
+		desiredState     string
+		observedFSMState string
+		observedDFCConfig dataflowcomponentserviceconfig.DataflowComponentServiceConfig
+		presenceField    interface{} // the field that indicates the observed config is available
+		excludeInput     bool        // true for write DFC (input is auto-generated)
+	)
+
+	switch dfcType {
+	case DFCTypeRead:
+		desiredState = a.readDFCState
+		observedFSMState = pcSnapshot.ServiceInfo.DataflowComponentReadFSMState
+		obs := pcSnapshot.ServiceInfo.DataflowComponentReadObservedState.ServiceInfo.BenthosObservedState.ObservedBenthosServiceConfig
+		presenceField = obs.Input
+		observedDFCConfig = observedBenthosToServiceConfig(obs)
+	case DFCTypeWrite:
+		desiredState = a.writeDFCState
+		observedFSMState = pcSnapshot.ServiceInfo.DataflowComponentWriteFSMState
+		obs := pcSnapshot.ServiceInfo.DataflowComponentWriteObservedState.ServiceInfo.BenthosObservedState.ObservedBenthosServiceConfig
+		presenceField = obs.Output
+		observedDFCConfig = observedBenthosToServiceConfig(obs)
+		excludeInput = true
+	default:
 		return false
 	}
 
-	// Convert observed Benthos config to DFC config format for comparison
-	observedBenthosConfig := pcSnapshot.ServiceInfo.DataflowComponentReadObservedState.ServiceInfo.BenthosObservedState.ObservedBenthosServiceConfig
-	observedDFCConfig := dataflowcomponentserviceconfig.DataflowComponentServiceConfig{
+	// When DFC is being stopped, check FSM state instead of Benthos config.
+	if desiredState == protocolconverter.OperationalStateStopped {
+		return observedFSMState == protocolconverter.OperationalStateStopped
+	}
+
+	if presenceField == nil {
+		return false
+	}
+
+	renderedDesiredConfig, err := a.renderDesiredDFCConfig(pcSnapshot, dfcType)
+	if err != nil {
+		a.actionLogger.Errorf("failed to render desired %s DFC config: %v", dfcType, err)
+		return false
+	}
+
+	// Exclude the auto-generated field (output for read, input for write) from comparison.
+	if excludeInput {
+		observedDFCConfig.BenthosConfig.Input = nil
+		renderedDesiredConfig.BenthosConfig.Input = nil
+	} else {
+		observedDFCConfig.BenthosConfig.Output = nil
+		renderedDesiredConfig.BenthosConfig.Output = nil
+	}
+
+	a.actionLogger.Debugf("observed %s DFC config: %+v", dfcType, observedDFCConfig)
+	a.actionLogger.Debugf("rendered desired %s DFC config: %+v", dfcType, renderedDesiredConfig)
+
+	return dataflowcomponentserviceconfig.NewComparator().ConfigsEqual(observedDFCConfig, renderedDesiredConfig)
+}
+
+// observedBenthosToServiceConfig converts an observed BenthosServiceConfig to a
+// DataflowComponentServiceConfig for comparison with the desired config.
+func observedBenthosToServiceConfig(obs benthosserviceconfig.BenthosServiceConfig) dataflowcomponentserviceconfig.DataflowComponentServiceConfig {
+	return dataflowcomponentserviceconfig.DataflowComponentServiceConfig{
 		BenthosConfig: dataflowcomponentserviceconfig.BenthosConfig{
-			Input:              observedBenthosConfig.Input,
-			Pipeline:           observedBenthosConfig.Pipeline,
-			Output:             observedBenthosConfig.Output,
-			CacheResources:     observedBenthosConfig.CacheResources,
-			RateLimitResources: observedBenthosConfig.RateLimitResources,
-			Buffer:             observedBenthosConfig.Buffer,
+			Input:              obs.Input,
+			Pipeline:           obs.Pipeline,
+			Output:             obs.Output,
+			CacheResources:     obs.CacheResources,
+			RateLimitResources: obs.RateLimitResources,
+			Buffer:             obs.Buffer,
 		},
 	}
-
-	// render the desired DFC config template
-	// We need to render the template with the actual protocol converter variables
-	// to compare it properly with the observed config
-	renderedDesiredConfig, err := a.renderDesiredDFCConfig(pcSnapshot)
-	if err != nil {
-		a.actionLogger.Errorf("failed to render desired DFC config: %v", err)
-
-		return false
-	}
-
-	// do not compare the output since it will be automatically generated
-	observedDFCConfig.BenthosConfig.Output = nil
-	renderedDesiredConfig.BenthosConfig.Output = nil
-
-	// log the observed and desired DFC configs
-	a.actionLogger.Debugf("observed DFC config: %+v", observedDFCConfig)
-	a.actionLogger.Debugf("rendered desired DFC config: %+v", renderedDesiredConfig)
-
-	// Compare with the rendered desired DFC config
-	return dataflowcomponentserviceconfig.NewComparator().ConfigsEqual(observedDFCConfig, renderedDesiredConfig)
 }
 
 // renderDesiredDFCConfig renders the template variables in the desired DFC config
 // using the actual runtime values from the protocol converter observed state.
-func (a *EditProtocolConverterAction) renderDesiredDFCConfig(pcSnapshot *protocolconverter.ProtocolConverterObservedStateSnapshot) (dataflowcomponentserviceconfig.DataflowComponentServiceConfig, error) {
+// dfcTypeToReturn specifies which side (read or write) to return after rendering.
+func (a *EditProtocolConverterAction) renderDesiredDFCConfig(pcSnapshot *protocolconverter.ProtocolConverterObservedStateSnapshot, dfcTypeToReturn DFCType) (dataflowcomponentserviceconfig.DataflowComponentServiceConfig, error) {
+	if dfcTypeToReturn != DFCTypeRead && dfcTypeToReturn != DFCTypeWrite {
+		return dataflowcomponentserviceconfig.DataflowComponentServiceConfig{}, fmt.Errorf("invalid DFC type for rendering: %s", dfcTypeToReturn.String())
+	}
+
 	// Get the observed spec config
 	specConfig := pcSnapshot.ObservedProtocolConverterSpecConfig
 
@@ -901,14 +973,13 @@ func (a *EditProtocolConverterAction) renderDesiredDFCConfig(pcSnapshot *protoco
 		return dataflowcomponentserviceconfig.DataflowComponentServiceConfig{}, fmt.Errorf("failed to deep copy spec config: %w", err)
 	}
 
-	// Now safely modify the copy without affecting the original
-	switch a.dfcType {
-	case DFCTypeRead:
-		modifiedSpec.Config.DataflowComponentReadServiceConfig = a.desiredDFCConfig
-	case DFCTypeWrite:
-		modifiedSpec.Config.DataflowComponentWriteServiceConfig = a.desiredDFCConfig
-	default:
-		return dataflowcomponentserviceconfig.DataflowComponentServiceConfig{}, fmt.Errorf("invalid DFC type: %s", a.dfcType.String())
+	// Apply whichever desired DFC configs are set, so the runtime render sees the full picture.
+	if a.desiredReadDFCConfig.BenthosConfig.Input != nil {
+		modifiedSpec.Config.DataflowComponentReadServiceConfig = a.desiredReadDFCConfig
+	}
+
+	if a.desiredWriteDFCConfig.BenthosConfig.Output != nil {
+		modifiedSpec.Config.DataflowComponentWriteServiceConfig = a.desiredWriteDFCConfig
 	}
 
 	systemSnapshot := a.systemSnapshotManager.GetDeepCopySnapshot()
@@ -928,14 +999,23 @@ func (a *EditProtocolConverterAction) renderDesiredDFCConfig(pcSnapshot *protoco
 		return dataflowcomponentserviceconfig.DataflowComponentServiceConfig{}, fmt.Errorf("failed to build runtime config: %w", err)
 	}
 
-	// Return the appropriate DFC config
-	switch a.dfcType {
+	switch dfcTypeToReturn {
 	case DFCTypeRead:
 		return runtimeConfig.DataflowComponentReadServiceConfig, nil
 	case DFCTypeWrite:
 		return runtimeConfig.DataflowComponentWriteServiceConfig, nil
 	default:
-		return dataflowcomponentserviceconfig.DataflowComponentServiceConfig{}, fmt.Errorf("invalid DFC type: %s", a.dfcType.String())
+		return dataflowcomponentserviceconfig.DataflowComponentServiceConfig{}, fmt.Errorf("invalid DFC type: %s", dfcTypeToReturn.String())
+	}
+}
+
+// dfcToPayload converts a ProtocolConverterDFC to the internal CDFCPayload representation.
+func dfcToPayload(dfc *models.ProtocolConverterDFC) models.CDFCPayload {
+	return models.CDFCPayload{
+		Inputs:   models.DfcDataConfig{Data: dfc.Inputs.Data, Type: dfc.Inputs.Type},
+		Pipeline: convertPipelineToMap(dfc.Pipeline),
+		Outputs:  models.DfcDataConfig{Data: dfc.Outputs.Data, Type: dfc.Outputs.Type},
+		Inject:   extractInjectFromRawYAML(dfc.RawYAML),
 	}
 }
 
@@ -973,8 +1053,17 @@ func (a *EditProtocolConverterAction) getUuid() uuid.UUID {
 }
 
 // GetParsedPayload returns the parsed DFC payload - exposed primarily for testing purposes.
+// Returns the read DFC payload when available, otherwise the write DFC payload.
 func (a *EditProtocolConverterAction) GetParsedPayload() models.CDFCPayload {
-	return a.dfcPayload
+	if a.readDFCPayload != nil {
+		return *a.readDFCPayload
+	}
+
+	if a.writeDFCPayload != nil {
+		return *a.writeDFCPayload
+	}
+
+	return models.CDFCPayload{}
 }
 
 // GetProtocolConverterUUID returns the protocol converter UUID - exposed for testing purposes.
@@ -987,7 +1076,55 @@ func (a *EditProtocolConverterAction) GetDFCType() string {
 	return a.dfcType.String()
 }
 
-// GetState returns the desired state - exposed for testing purposes.
-func (a *EditProtocolConverterAction) GetState() string {
-	return a.state
+// validateDFCPayloadAndState validates a pre-parsed CDFCPayload and its state string.
+func validateDFCPayloadAndState(payload *models.CDFCPayload, state string, label string) error {
+	if payload != nil {
+		if err := ValidateCustomDataFlowComponentPayload(*payload, false); err != nil {
+			return fmt.Errorf("invalid %s DFC configuration: %w", label, err)
+		}
+	}
+	if state != "" {
+		if err := ValidateDataFlowComponentState(state); err != nil {
+			return fmt.Errorf("invalid %s DFC state: %w", label, err)
+		}
+	}
+	return nil
+}
+
+// validateProtocolConverterDFC validates a ProtocolConverterDFC's state and configuration.
+// Returns nil if dfc is nil (nothing to validate).
+func validateProtocolConverterDFC(dfc *models.ProtocolConverterDFC, label string) error {
+	if dfc == nil {
+		return nil
+	}
+	if dfc.State != "" {
+		if err := ValidateDataFlowComponentState(dfc.State); err != nil {
+			return fmt.Errorf("invalid %s DFC state: %w", label, err)
+		}
+	}
+	payload := dfcToPayload(dfc)
+	if err := ValidateCustomDataFlowComponentPayload(payload, false); err != nil {
+		return fmt.Errorf("invalid %s DFC configuration: %w", label, err)
+	}
+	return nil
+}
+
+// derivePCDesiredState computes the protocol converter desired state from per-DFC states.
+// newRead/newWrite are the states from the current action (may be empty).
+// existingRead/existingWrite are the states already stored in the spec (fallback).
+// The PC is stopped only when both effective DFC states are "stopped".
+func derivePCDesiredState(newRead, newWrite, existingRead, existingWrite string) string {
+	effectiveRead := newRead
+	if effectiveRead == "" {
+		effectiveRead = existingRead
+	}
+	effectiveWrite := newWrite
+	if effectiveWrite == "" {
+		effectiveWrite = existingWrite
+	}
+	if effectiveRead == protocolconverter.OperationalStateStopped &&
+		effectiveWrite == protocolconverter.OperationalStateStopped {
+		return protocolconverter.OperationalStateStopped
+	}
+	return protocolconverter.OperationalStateActive
 }

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter.go
@@ -470,9 +470,13 @@ func (a *EditProtocolConverterAction) applyMutation(readBenthosConfig, writeBent
 		instanceToModify.ProtocolConverterServiceConfig.Variables.User["PORT"] = a.connectionPort
 	}
 
-	// Store per-DFC desired state overrides in the spec so the FSM can propagate them.
-	instanceToModify.ProtocolConverterServiceConfig.ReadDFCDesiredState = a.readDFCState
-	instanceToModify.ProtocolConverterServiceConfig.WriteDFCDesiredState = a.writeDFCState
+	// Only update the per-DFC desired states if the user provided new values.
+	if a.readDFCState != "" {
+		instanceToModify.ProtocolConverterServiceConfig.ReadDFCDesiredState = a.readDFCState
+	}
+	if a.writeDFCState != "" {
+		instanceToModify.ProtocolConverterServiceConfig.WriteDFCDesiredState = a.writeDFCState
+	}
 
 	// Derive the PC-level FSM state from the per-DFC states.
 	// For DFCTypeEmpty (connection/location-only edits) the new states are empty,
@@ -884,11 +888,11 @@ func (a *EditProtocolConverterAction) compareProtocolConverterDFCConfig(pcSnapsh
 // compareSingleDFCConfig compares a single DFC (read or write) against its observed state.
 func (a *EditProtocolConverterAction) compareSingleDFCConfig(pcSnapshot *protocolconverter.ProtocolConverterObservedStateSnapshot, dfcType DFCType) bool {
 	var (
-		desiredState     string
-		observedFSMState string
+		desiredState      string
+		observedFSMState  string
 		observedDFCConfig dataflowcomponentserviceconfig.DataflowComponentServiceConfig
-		presenceField    interface{} // the field that indicates the observed config is available
-		excludeInput     bool        // true for write DFC (input is auto-generated)
+		presenceField     interface{} // the field that indicates the observed config is available
+		excludeInput      bool        // true for write DFC (input is auto-generated)
 	)
 
 	switch dfcType {

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter.go
@@ -478,15 +478,10 @@ func (a *EditProtocolConverterAction) applyMutation(readBenthosConfig, writeBent
 		instanceToModify.ProtocolConverterServiceConfig.WriteDFCDesiredState = a.writeDFCState
 	}
 
-	// Derive the PC-level FSM state from the per-DFC states.
-	// For DFCTypeEmpty (connection/location-only edits) the new states are empty,
-	// so we fall back to the existing spec values via derivePCDesiredState.
-	instanceToModify.DesiredFSMState = derivePCDesiredState(
-		a.readDFCState,
-		a.writeDFCState,
-		instanceToModify.ProtocolConverterServiceConfig.ReadDFCDesiredState,
-		instanceToModify.ProtocolConverterServiceConfig.WriteDFCDesiredState,
-	)
+	// The PC is always active so that the connection monitor stays alive.
+	// Individual DFC states are tracked separately; the bridge (and its
+	// connection monitor) is only torn down when the bridge itself is removed.
+	instanceToModify.DesiredFSMState = protocolconverter.OperationalStateActive
 
 	return instanceToModify, atomicEditUUID, instanceToModify.DesiredFSMState, nil
 }
@@ -1113,22 +1108,3 @@ func validateProtocolConverterDFC(dfc *models.ProtocolConverterDFC, label string
 	return nil
 }
 
-// derivePCDesiredState computes the protocol converter desired state from per-DFC states.
-// newRead/newWrite are the states from the current action (may be empty).
-// existingRead/existingWrite are the states already stored in the spec (fallback).
-// The PC is stopped only when both effective DFC states are "stopped".
-func derivePCDesiredState(newRead, newWrite, existingRead, existingWrite string) string {
-	effectiveRead := newRead
-	if effectiveRead == "" {
-		effectiveRead = existingRead
-	}
-	effectiveWrite := newWrite
-	if effectiveWrite == "" {
-		effectiveWrite = existingWrite
-	}
-	if effectiveRead == protocolconverter.OperationalStateStopped &&
-		effectiveWrite == protocolconverter.OperationalStateStopped {
-		return protocolconverter.OperationalStateStopped
-	}
-	return protocolconverter.OperationalStateActive
-}

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter_test.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter_test.go
@@ -232,7 +232,7 @@ var _ = Describe("EditProtocolConverter", func() {
 			Expect(err.Error()).To(ContainSubstring("failed to parse protocol converter payload"))
 		})
 
-		It("should default state to 'active' when not provided", func() {
+		It("should default DFC type to empty when no DFCs provided", func() {
 			payload := map[string]interface{}{
 				"name": pcName,
 				"connection": map[string]interface{}{
@@ -240,32 +240,36 @@ var _ = Describe("EditProtocolConverter", func() {
 					"port": 80,
 				},
 				"uuid": pcUUID.String(),
-				// No state field provided
 			}
 
 			err := action.Parse(payload)
 			Expect(err).NotTo(HaveOccurred())
 
-			// Verify that state defaults to "active"
-			Expect(action.GetState()).To(Equal("active"))
+			Expect(action.GetDFCType()).To(Equal("empty"))
 		})
 
-		It("should preserve explicit 'stopped' state", func() {
+		It("should preserve explicit 'stopped' state on read DFC", func() {
 			payload := map[string]interface{}{
 				"name": pcName,
 				"connection": map[string]interface{}{
 					"ip":   "wttr.in",
 					"port": 80,
 				},
-				"uuid":  pcUUID.String(),
-				"state": "stopped",
+				"uuid": pcUUID.String(),
+				"readDFC": map[string]interface{}{
+					"inputs": map[string]interface{}{
+						"data": "input:\n  http_client:\n    url: 'http://example.com'",
+						"type": "yaml",
+					},
+					"pipeline": map[string]interface{}{},
+					"state":    "stopped",
+				},
 			}
 
 			err := action.Parse(payload)
 			Expect(err).NotTo(HaveOccurred())
 
-			// Verify that state is preserved as "stopped"
-			Expect(action.GetState()).To(Equal("stopped"))
+			Expect(action.GetDFCType()).To(Equal("read"))
 		})
 	})
 
@@ -326,7 +330,7 @@ var _ = Describe("EditProtocolConverter", func() {
 
 			err = action.Validate()
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("invalid dataflow component configuration"))
+			Expect(err.Error()).To(ContainSubstring("invalid read DFC configuration"))
 		})
 	})
 

--- a/umh-core/pkg/communicator/actions/get-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/get-protocolconverter.go
@@ -193,6 +193,7 @@ func buildProtocolConverterDFCFromConfig(dfcConfig dataflowcomponentserviceconfi
 	dfc := &models.ProtocolConverterDFC{
 		Inputs:   commonPayload.CDFCProperties.Inputs,
 		Pipeline: commonPayload.CDFCProperties.Pipeline,
+		Outputs:  commonPayload.CDFCProperties.Outputs,
 		RawYAML:  commonPayload.CDFCProperties.RawYAML,
 	}
 
@@ -311,6 +312,10 @@ func (a *GetProtocolConverterAction) Execute() (interface{}, map[string]interfac
 							fmt.Sprintf("Warning: Failed to build read DFC for protocol converter '%s': %v", instance.ID, err),
 							a.outboundChannel, models.GetProtocolConverter)
 					}
+
+					if readDFC != nil {
+						readDFC.State = specConfig.ReadDFCDesiredState
+					}
 				}
 
 				// Build WriteDFC if present
@@ -325,6 +330,10 @@ func (a *GetProtocolConverterAction) Execute() (interface{}, map[string]interfac
 						SendActionReply(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionExecuting,
 							fmt.Sprintf("Warning: Failed to build write DFC for protocol converter '%s': %v", instance.ID, err),
 							a.outboundChannel, models.GetProtocolConverter)
+					}
+
+					if writeDFC != nil {
+						writeDFC.State = specConfig.WriteDFCDesiredState
 					}
 				}
 
@@ -360,7 +369,6 @@ func (a *GetProtocolConverterAction) Execute() (interface{}, map[string]interfac
 					WriteDFC:     writeDFC,
 					Meta:         meta,
 					TemplateInfo: templateInfo,
-					State:        instance.DesiredState,
 				}
 
 				a.actionLogger.Info("Protocol converter found and built, returning response")

--- a/umh-core/pkg/communicator/pkg/generator/protocolconverter.go
+++ b/umh-core/pkg/communicator/pkg/generator/protocolconverter.go
@@ -170,7 +170,8 @@ func buildProtocolConverterAsDfc(
 	if m := svcInfo.DataflowComponentReadObservedState.ServiceInfo.BenthosObservedState.ServiceInfo.BenthosStatus.BenthosMetrics.MetricsState; m != nil &&
 		m.Input.LastCount > 0 {
 		avgThroughput := m.Input.MessagesPerTick / constants.DefaultTickerTime.Seconds()
-		if instance.DesiredState == protocolconverter.OperationalStateStopped {
+		if instance.DesiredState == protocolconverter.OperationalStateStopped ||
+			observed.ObservedProtocolConverterSpecConfig.ReadDFCDesiredState == protocolconverter.OperationalStateStopped {
 			avgThroughput = 0
 		}
 		dfc.Metrics = &models.DfcMetrics{

--- a/umh-core/pkg/config/protocolconverterserviceconfig/comparator.go
+++ b/umh-core/pkg/config/protocolconverterserviceconfig/comparator.go
@@ -52,11 +52,16 @@ func (c *Comparator) ConfigsEqual(desired, observed ProtocolConverterServiceConf
 	connectionEqual := reflect.DeepEqual(connectionD, connectionO)
 	locationEqual := reflect.DeepEqual(desired.Location, observed.Location)
 
+	readDFCDesiredStateEqual := desired.ReadDFCDesiredState == observed.ReadDFCDesiredState
+	writeDFCDesiredStateEqual := desired.WriteDFCDesiredState == observed.WriteDFCDesiredState
+
 	return connectionEqual &&
 		locationEqual &&
 		comparatorDFC.ConfigsEqual(dfcReadD, dfcReadO) &&
 		comparatorDFC.ConfigsEqual(dfcWriteD, dfcWriteO) &&
-		comparatorVariable.ConfigsEqual(desired.Variables, observed.Variables)
+		comparatorVariable.ConfigsEqual(desired.Variables, observed.Variables) &&
+		readDFCDesiredStateEqual &&
+		writeDFCDesiredStateEqual
 }
 
 // ConfigDiff returns a human-readable string describing differences between configs.
@@ -89,5 +94,15 @@ func (c *Comparator) ConfigDiff(desired, observed ProtocolConverterServiceConfig
 	comparatorVariable := variables.NewComparator()
 	variableDiff := comparatorVariable.ConfigDiff(desired.Variables, observed.Variables)
 
-	return connectionDiff + locationDiff + dfcReadDiff + dfcWriteDiff + variableDiff
+	readDFCDesiredStateDiff := ""
+	if desired.ReadDFCDesiredState != observed.ReadDFCDesiredState {
+		readDFCDesiredStateDiff = fmt.Sprintf("ReadDFCDesiredState: %v vs %v", desired.ReadDFCDesiredState, observed.ReadDFCDesiredState)
+	}
+
+	writeDFCDesiredStateDiff := ""
+	if desired.WriteDFCDesiredState != observed.WriteDFCDesiredState {
+		writeDFCDesiredStateDiff = fmt.Sprintf("WriteDFCDesiredState: %v vs %v", desired.WriteDFCDesiredState, observed.WriteDFCDesiredState)
+	}
+
+	return connectionDiff + locationDiff + dfcReadDiff + dfcWriteDiff + variableDiff + readDFCDesiredStateDiff + writeDFCDesiredStateDiff
 }

--- a/umh-core/pkg/config/protocolconverterserviceconfig/config_customized.go
+++ b/umh-core/pkg/config/protocolconverterserviceconfig/config_customized.go
@@ -50,8 +50,8 @@ func (c ProtocolConverterServiceConfigSpec) GetDFCReadServiceConfig() dataflowco
 func (c ProtocolConverterServiceConfigSpec) GetDFCWriteServiceConfig() dataflowcomponentserviceconfig.DataflowComponentServiceConfig {
 	dfcWriteConfig := c.Config.DataflowComponentWriteServiceConfig
 
-	// Only append UNS input if there's an output config
-	if len(dfcWriteConfig.BenthosConfig.Output) > 0 {
+	// Only append UNS input if there's an output config and no input has been set by the user
+	if len(dfcWriteConfig.BenthosConfig.Output) > 0 && len(dfcWriteConfig.BenthosConfig.Input) == 0 {
 		dfcWriteConfig.BenthosConfig.Input = map[string]any{
 			"uns": map[string]any{
 				"consumer_group": "{{ .internal.bridged_by }}", // use bridged_by as consumer group

--- a/umh-core/pkg/config/protocolconverterserviceconfig/package.go
+++ b/umh-core/pkg/config/protocolconverterserviceconfig/package.go
@@ -100,16 +100,16 @@ type ProtocolConverterServiceConfigRuntime struct {
 //
 // Spec → (render) → Runtime → FSM.
 type ProtocolConverterServiceConfigSpec struct {
-	Variables   variables.VariableBundle               `yaml:"variables,omitempty"`
-	Location    map[string]string                      `yaml:"location,omitempty"`
-	TemplateRef string                                 `yaml:"templateRef,omitempty"`
-	Config      ProtocolConverterServiceConfigTemplate `yaml:"config,omitempty"`
+	Variables   variables.VariableBundle `yaml:"variables,omitempty"`
+	Location    map[string]string        `yaml:"location,omitempty"`
+	TemplateRef string                   `yaml:"templateRef,omitempty"`
 	// ReadDFCDesiredState overrides the desired state for the read DFC ("active" or "stopped").
 	// When empty, the overall protocol converter desired state is used.
 	ReadDFCDesiredState string `yaml:"readDFCDesiredState,omitempty"`
 	// WriteDFCDesiredState overrides the desired state for the write DFC ("active" or "stopped").
 	// When empty, the overall protocol converter desired state is used.
-	WriteDFCDesiredState string `yaml:"writeDFCDesiredState,omitempty"`
+	WriteDFCDesiredState string                                 `yaml:"writeDFCDesiredState,omitempty"`
+	Config               ProtocolConverterServiceConfigTemplate `yaml:"config,omitempty"`
 }
 
 // Equal checks if two ProtocolConverterServiceConfigs are equal.

--- a/umh-core/pkg/config/protocolconverterserviceconfig/package.go
+++ b/umh-core/pkg/config/protocolconverterserviceconfig/package.go
@@ -104,6 +104,12 @@ type ProtocolConverterServiceConfigSpec struct {
 	Location    map[string]string                      `yaml:"location,omitempty"`
 	TemplateRef string                                 `yaml:"templateRef,omitempty"`
 	Config      ProtocolConverterServiceConfigTemplate `yaml:"config,omitempty"`
+	// ReadDFCDesiredState overrides the desired state for the read DFC ("active" or "stopped").
+	// When empty, the overall protocol converter desired state is used.
+	ReadDFCDesiredState string `yaml:"readDFCDesiredState,omitempty"`
+	// WriteDFCDesiredState overrides the desired state for the write DFC ("active" or "stopped").
+	// When empty, the overall protocol converter desired state is used.
+	WriteDFCDesiredState string `yaml:"writeDFCDesiredState,omitempty"`
 }
 
 // Equal checks if two ProtocolConverterServiceConfigs are equal.

--- a/umh-core/pkg/fsm/protocolconverter/actions.go
+++ b/umh-core/pkg/fsm/protocolconverter/actions.go
@@ -484,6 +484,18 @@ func (p *ProtocolConverterInstance) IsDFCHealthy() (bool, string) {
 	return false, statusReason
 }
 
+// areBothDFCsIntentionallyStopped returns true when both the read and write DFC
+// desired states are set to stopped and at least one of them has a config deployed.
+func (p *ProtocolConverterInstance) areBothDFCsIntentionallyStopped() bool {
+	if p.specConfig.ReadDFCDesiredState != OperationalStateStopped ||
+		p.specConfig.WriteDFCDesiredState != OperationalStateStopped {
+		return false
+	}
+	readHasConfig := len(p.specConfig.Config.DataflowComponentReadServiceConfig.BenthosConfig.Input) > 0
+	writeHasConfig := len(p.specConfig.Config.DataflowComponentWriteServiceConfig.BenthosConfig.Output) > 0
+	return readHasConfig || writeHasConfig
+}
+
 // stateOrNotExisting returns the state string, or "not existing" if empty.
 func stateOrNotExisting(state string) string {
 	if state == "" {

--- a/umh-core/pkg/fsm/protocolconverter/actions.go
+++ b/umh-core/pkg/fsm/protocolconverter/actions.go
@@ -453,11 +453,12 @@ func (p *ProtocolConverterInstance) IsDFCHealthy() (bool, string) {
 	readRunning := readState == dataflowfsm.OperationalStateIdle || readState == dataflowfsm.OperationalStateActive
 	writeRunning := writeState == dataflowfsm.OperationalStateIdle || writeState == dataflowfsm.OperationalStateActive
 
+	// Intentionally stopped counts as healthy
 	readIntentionallyStopped := p.specConfig.ReadDFCDesiredState == OperationalStateStopped
 	writeIntentionallyStopped := p.specConfig.WriteDFCDesiredState == OperationalStateStopped
 
 	readHasConfig := len(p.specConfig.Config.DataflowComponentReadServiceConfig.BenthosConfig.Input) > 0
-	writeHasConfig := len(p.specConfig.Config.DataflowComponentWriteServiceConfig.BenthosConfig.Input) > 0
+	writeHasConfig := len(p.specConfig.Config.DataflowComponentWriteServiceConfig.BenthosConfig.Output) > 0
 
 	readHealthy := readRunning || readIntentionallyStopped || !readHasConfig
 	writeHealthy := writeRunning || writeIntentionallyStopped || !writeHasConfig

--- a/umh-core/pkg/fsm/protocolconverter/actions.go
+++ b/umh-core/pkg/fsm/protocolconverter/actions.go
@@ -160,8 +160,8 @@ func (p *ProtocolConverterInstance) StartConnectionInstance(ctx context.Context,
 func (p *ProtocolConverterInstance) StartDFCInstance(ctx context.Context, filesystemService filesystem.Service) error {
 	p.baseFSMInstance.GetLogger().Debugf("Starting Action: Starting flows for bridge %s ...", p.baseFSMInstance.GetID())
 
-	// Start the DFC components with conditional evaluation
-	err := p.service.StartDFC(ctx, filesystemService, p.baseFSMInstance.GetID())
+	// Start the DFC components with conditional evaluation, honouring per-DFC state overrides.
+	err := p.service.StartDFC(ctx, filesystemService, p.baseFSMInstance.GetID(), p.specConfig.ReadDFCDesiredState, p.specConfig.WriteDFCDesiredState)
 	if err != nil {
 		return fmt.Errorf("failed to start flows for bridge %s: %w", p.baseFSMInstance.GetID(), err)
 	}
@@ -362,26 +362,28 @@ func (p *ProtocolConverterInstance) UpdateObservedStateOfInstance(ctx context.Co
 			}
 
 			p.baseFSMInstance.GetLogger().Debugf("config updated")
-
-			// UNIQUE BEHAVIOR: Re-evaluate DFC desired states after config changes
-			// This is different from other FSMs which set desired states once and don't change them.
-			// Protocol converters must re-evaluate because:
-			// 1. DFC configs may transition from empty -> populated as templates are rendered
-			// 2. Empty DFCs should remain stopped, populated DFCs should be started
-			// 3. This ensures we don't start broken Benthos instances with empty configs
-			if p.baseFSMInstance.GetDesiredFSMState() == OperationalStateActive {
-				p.baseFSMInstance.GetLogger().Debugf("re-evaluating flow desired states and will be active")
-
-				err := p.service.EvaluateDFCDesiredStates(p.baseFSMInstance.GetID(), "active", p.baseFSMInstance.GetCurrentFSMState()) // NOTE: Hardcoded to avoid circular import
-				if err != nil {
-					p.baseFSMInstance.GetLogger().Debugf("Failed to re-evaluate flow states after config update: %v", err)
-					// Don't fail the entire update - this is a best-effort re-evaluation
-				} else {
-					p.baseFSMInstance.GetLogger().Debugf("Re-evaluated flow desired states after config update")
-				}
-			}
 		} else {
 			p.baseFSMInstance.GetLogger().Debugf("Config differences detected but service does not exist yet, skipping update")
+		}
+	}
+
+	// UNIQUE BEHAVIOR: Always re-evaluate DFC desired states when the PC is active.
+	// This is different from other FSMs which set desired states once and don't change them.
+	// Protocol converters must re-evaluate every tick because:
+	// 1. DFC configs may transition from empty -> populated as templates are rendered.
+	// 2. Empty DFCs should remain stopped; populated DFCs should be started.
+	// 3. Per-DFC desired state overrides (ReadDFCDesiredState/WriteDFCDesiredState) must be
+	//    applied even when only the state changed and the Benthos config stayed the same —
+	//    ConfigsEqualRuntime does not include those fields, so the block above would not fire.
+	if p.baseFSMInstance.GetDesiredFSMState() == OperationalStateActive {
+		if p.service.ServiceExists(ctx, services.GetFileSystem(), p.baseFSMInstance.GetID()) {
+			p.baseFSMInstance.GetLogger().Debugf("re-evaluating flow desired states")
+
+			err := p.service.EvaluateDFCDesiredStates(p.baseFSMInstance.GetID(), "active", p.baseFSMInstance.GetCurrentFSMState(), p.specConfig.ReadDFCDesiredState, p.specConfig.WriteDFCDesiredState) // NOTE: Hardcoded to avoid circular import
+			if err != nil {
+				p.baseFSMInstance.GetLogger().Debugf("Failed to re-evaluate flow states: %v", err)
+				// Don't fail the entire update - this is a best-effort re-evaluation
+			}
 		}
 	}
 
@@ -435,24 +437,49 @@ func (p *ProtocolConverterInstance) IsRedpandaHealthy() (bool, string) {
 	return false, statusReason
 }
 
-// IsDFCHealthy checks whether the underlying DFC is healthy
-// so either idle or active
+// IsDFCHealthy checks whether the underlying DFCs are healthy.
+// A DFC is considered healthy when it is active/idle, intentionally stopped
+// (ReadDFCDesiredState/WriteDFCDesiredState == "stopped"), or has no configuration
+// (nothing deployed means nothing to check).
 //
 // It returns:
 //
-//	ok     – true when the DFC is healthy, false otherwise.
-//	reason – empty when ok is true; otherwise a explanation
+//	ok     – true when all relevant DFCs are healthy, false otherwise.
+//	reason – empty when ok is true; otherwise an explanation.
 func (p *ProtocolConverterInstance) IsDFCHealthy() (bool, string) {
-	if p.ObservedState.ServiceInfo.DataflowComponentReadFSMState == dataflowfsm.OperationalStateIdle || p.ObservedState.ServiceInfo.DataflowComponentReadFSMState == dataflowfsm.OperationalStateActive {
+	readState := p.ObservedState.ServiceInfo.DataflowComponentReadFSMState
+	writeState := p.ObservedState.ServiceInfo.DataflowComponentWriteFSMState
+
+	readRunning := readState == dataflowfsm.OperationalStateIdle || readState == dataflowfsm.OperationalStateActive
+	writeRunning := writeState == dataflowfsm.OperationalStateIdle || writeState == dataflowfsm.OperationalStateActive
+
+	readIntentionallyStopped := p.specConfig.ReadDFCDesiredState == OperationalStateStopped
+	writeIntentionallyStopped := p.specConfig.WriteDFCDesiredState == OperationalStateStopped
+
+	readHasConfig := len(p.specConfig.Config.DataflowComponentReadServiceConfig.BenthosConfig.Input) > 0
+	writeHasConfig := len(p.specConfig.Config.DataflowComponentWriteServiceConfig.BenthosConfig.Input) > 0
+
+	readHealthy := readRunning || readIntentionallyStopped || !readHasConfig
+	writeHealthy := writeRunning || writeIntentionallyStopped || !writeHasConfig
+
+	if readHealthy && writeHealthy {
 		return true, ""
 	}
 
-	statusReason := p.ObservedState.ServiceInfo.DataflowComponentReadObservedState.ServiceInfo.StatusReason
+	if !readHealthy {
+		statusReason := p.ObservedState.ServiceInfo.DataflowComponentReadObservedState.ServiceInfo.StatusReason
+		if statusReason == "" {
+			statusReason = "flow health status unknown"
+		}
+
+		return false, statusReason
+	}
+
+	statusReason := p.ObservedState.ServiceInfo.DataflowComponentWriteObservedState.ServiceInfo.StatusReason
 	if statusReason == "" {
 		statusReason = "flow health status unknown"
 	}
 
-	// TODO: check the write DFC as well
 	return false, statusReason
 }
 

--- a/umh-core/pkg/fsm/protocolconverter/actions.go
+++ b/umh-core/pkg/fsm/protocolconverter/actions.go
@@ -484,22 +484,40 @@ func (p *ProtocolConverterInstance) IsDFCHealthy() (bool, string) {
 	return false, statusReason
 }
 
-// safeBenthosMetrics safely extracts Benthos metrics from the observed state,
-// returning a zero-value metrics struct if any part of the chain is nil.
+// stateOrNotExisting returns the state string, or "not existing" if empty.
+func stateOrNotExisting(state string) string {
+	if state == "" {
+		return "not existing"
+	}
+	return state
+}
+
+// connectionMetrics holds aggregated connection up/lost counters for a single direction.
+type connectionMetrics struct {
+	ConnectionUp   int64
+	ConnectionLost int64
+}
+
+// isActive returns true when more connections have come up than have been lost.
+func (m connectionMetrics) isActive() bool {
+	return m.ConnectionUp-m.ConnectionLost > 0
+}
+
+// safeBenthosMetricsFrom safely extracts Benthos metrics from a DFC observed state,
+// returning zero-value metrics if any part of the chain is nil.
 // This prevents panics during startup or error conditions when the full
 // observedState structure may not be populated yet.
-func (p *ProtocolConverterInstance) safeBenthosMetrics() (input, output struct{ ConnectionUp, ConnectionLost int64 }) {
-	// Return zero values if the MetricsState pointer is nil (this is the only field that can actually be nil)
-	if p.ObservedState.ServiceInfo.DataflowComponentReadObservedState.ServiceInfo.BenthosObservedState.ServiceInfo.BenthosStatus.BenthosMetrics.MetricsState == nil {
+func safeBenthosMetricsFrom(obs dataflowfsm.DataflowComponentObservedState) (input, output connectionMetrics) {
+	if obs.ServiceInfo.BenthosObservedState.ServiceInfo.BenthosStatus.BenthosMetrics.MetricsState == nil {
 		return
 	}
 
-	metrics := p.ObservedState.ServiceInfo.DataflowComponentReadObservedState.ServiceInfo.BenthosObservedState.ServiceInfo.BenthosStatus.BenthosMetrics.Metrics
+	metrics := obs.ServiceInfo.BenthosObservedState.ServiceInfo.BenthosStatus.BenthosMetrics.Metrics
 
-	return struct{ ConnectionUp, ConnectionLost int64 }{
+	return connectionMetrics{
 			ConnectionUp:   metrics.Input.ConnectionUp,
 			ConnectionLost: metrics.Input.ConnectionLost,
-		}, struct{ ConnectionUp, ConnectionLost int64 }{
+		}, connectionMetrics{
 			ConnectionUp:   metrics.Output.ConnectionUp,
 			ConnectionLost: metrics.Output.ConnectionLost,
 		}
@@ -516,30 +534,47 @@ func (p *ProtocolConverterInstance) safeBenthosMetrics() (input, output struct{ 
 //	ok     – true when there is an issue, false otherwise.
 //	reason – empty when ok is true; otherwise a explanation
 func (p *ProtocolConverterInstance) IsOtherDegraded() (bool, string) {
-	// TODO: check the write DFC as well
-
-	// Check for case 1.1
-	if p.ObservedState.ServiceInfo.DataflowComponentReadFSMState == dataflowfsm.OperationalStateActive &&
-		p.ObservedState.ServiceInfo.RedpandaFSMState == redpandafsm.OperationalStateIdle {
-		return true, "flow is active, but redpanda is idle"
+	// dfcCheck holds the per-DFC data needed for degradation checks.
+	// For a read DFC: kafkaMetrics = output (→ Kafka), deviceMetrics = input (← device).
+	// For a write DFC: kafkaMetrics = input (← Kafka), deviceMetrics = output (→ device).
+	type dfcCheck struct {
+		label         string
+		fsmState      string
+		kafkaMetrics  connectionMetrics
+		deviceMetrics connectionMetrics
 	}
 
-	// Safely extract Benthos metrics to avoid nil pointer panics
-	inputMetrics, outputMetrics := p.safeBenthosMetrics()
+	readInput, readOutput := safeBenthosMetricsFrom(p.ObservedState.ServiceInfo.DataflowComponentReadObservedState)
+	writeInput, writeOutput := safeBenthosMetricsFrom(p.ObservedState.ServiceInfo.DataflowComponentWriteObservedState)
 
-	// Check for case 2
-	isBenthosOutputActive := outputMetrics.ConnectionUp-outputMetrics.ConnectionLost > 0 // if the amount of connection losts is bigger than the amount of connection ups, the output is not active
-	if (p.ObservedState.ServiceInfo.RedpandaFSMState == redpandafsm.OperationalStateIdle ||
-		p.ObservedState.ServiceInfo.RedpandaFSMState == redpandafsm.OperationalStateActive) &&
-		!isBenthosOutputActive {
-		return true, fmt.Sprintf("Redpanda is %s, but the flow has no output active (connection up: %d, connection lost: %d)", p.ObservedState.ServiceInfo.RedpandaFSMState, outputMetrics.ConnectionUp, outputMetrics.ConnectionLost)
+	checks := []dfcCheck{
+		{"read flow", p.ObservedState.ServiceInfo.DataflowComponentReadFSMState, readOutput, readInput},
+		{"write flow", p.ObservedState.ServiceInfo.DataflowComponentWriteFSMState, writeInput, writeOutput},
 	}
 
-	// Check for case 3
-	isBenthosInputActive := inputMetrics.ConnectionUp-inputMetrics.ConnectionLost > 0 // if the amount of connection losts is bigger than the amount of connection ups, the input is not active
-	if p.ObservedState.ServiceInfo.ConnectionFSMState != connectionfsm.OperationalStateUp &&
-		isBenthosInputActive {
-		return true, fmt.Sprintf("Connection is %s, but the flow has input active (connection up: %d, connection lost: %d)", p.ObservedState.ServiceInfo.ConnectionFSMState, inputMetrics.ConnectionUp, inputMetrics.ConnectionLost)
+	for _, c := range checks {
+
+		// Case 1: DFC active but redpanda idle
+		if c.fsmState == dataflowfsm.OperationalStateActive &&
+			p.ObservedState.ServiceInfo.RedpandaFSMState == redpandafsm.OperationalStateIdle {
+			return true, c.label + " is active, but redpanda is idle"
+		}
+
+		// Case 2: redpanda up but DFC's kafka-side connection not active
+		if (p.ObservedState.ServiceInfo.RedpandaFSMState == redpandafsm.OperationalStateIdle ||
+			p.ObservedState.ServiceInfo.RedpandaFSMState == redpandafsm.OperationalStateActive) &&
+			c.fsmState == dataflowfsm.OperationalStateActive &&
+			!c.kafkaMetrics.isActive() {
+			return true, fmt.Sprintf("Redpanda is %s, but the %s has no kafka-side connection active (connection up: %d, connection lost: %d)",
+				p.ObservedState.ServiceInfo.RedpandaFSMState, c.label, c.kafkaMetrics.ConnectionUp, c.kafkaMetrics.ConnectionLost)
+		}
+
+		// Case 3: connection down but DFC's device-side connection active
+		if p.ObservedState.ServiceInfo.ConnectionFSMState != connectionfsm.OperationalStateUp &&
+			c.deviceMetrics.isActive() {
+			return true, fmt.Sprintf("Connection is %s, but the %s has device-side connection active (connection up: %d, connection lost: %d)",
+				p.ObservedState.ServiceInfo.ConnectionFSMState, c.label, c.deviceMetrics.ConnectionUp, c.deviceMetrics.ConnectionLost)
+		}
 	}
 
 	return false, ""
@@ -553,17 +588,14 @@ func (p *ProtocolConverterInstance) IsOtherDegraded() (bool, string) {
 //	ok     – true when the DFC is active, false otherwise.
 //	reason – empty when ok is true; otherwise a explanation
 func (p *ProtocolConverterInstance) IsDataflowComponentWithProcessingActivity() (bool, string) {
-	// TODO: check the write DFC as well
-	if p.ObservedState.ServiceInfo.DataflowComponentReadFSMState == dataflowfsm.OperationalStateActive {
+	readState := p.ObservedState.ServiceInfo.DataflowComponentReadFSMState
+	writeState := p.ObservedState.ServiceInfo.DataflowComponentWriteFSMState
+
+	if readState == dataflowfsm.OperationalStateActive || writeState == dataflowfsm.OperationalStateActive {
 		return true, ""
 	}
 
-	dfcState := p.ObservedState.ServiceInfo.DataflowComponentReadFSMState
-	if dfcState == "" {
-		dfcState = "not existing"
-	}
-
-	return false, "flow is " + dfcState
+	return false, fmt.Sprintf("read flow is %s, write flow is %s", stateOrNotExisting(readState), stateOrNotExisting(writeState))
 }
 
 // IsProtocolConverterStopped checks whether the ProtocolConverter is stopped
@@ -574,23 +606,21 @@ func (p *ProtocolConverterInstance) IsDataflowComponentWithProcessingActivity() 
 //	ok     – true when the ProtocolConverter is stopped, false otherwise.
 //	reason – empty when ok is true; otherwise a service‑provided explanation
 func (p *ProtocolConverterInstance) IsProtocolConverterStopped() (bool, string) {
-	// TODO: check the write DFC as well
-	if p.ObservedState.ServiceInfo.ConnectionFSMState == connectionfsm.OperationalStateStopped &&
-		p.ObservedState.ServiceInfo.DataflowComponentReadFSMState == dataflowfsm.OperationalStateStopped {
+	connStopped := p.ObservedState.ServiceInfo.ConnectionFSMState == connectionfsm.OperationalStateStopped
+	readStopped := p.ObservedState.ServiceInfo.DataflowComponentReadFSMState == dataflowfsm.OperationalStateStopped
+	writeStopped := p.ObservedState.ServiceInfo.DataflowComponentWriteFSMState == dataflowfsm.OperationalStateStopped
+
+	writeHasConfig := len(p.specConfig.Config.DataflowComponentWriteServiceConfig.BenthosConfig.Output) > 0
+	writeEffectivelyStopped := writeStopped || !writeHasConfig
+
+	if connStopped && readStopped && writeEffectivelyStopped {
 		return true, ""
 	}
 
-	connState := p.ObservedState.ServiceInfo.ConnectionFSMState
-	if connState == "" {
-		connState = "not existing"
-	}
-
-	dfcState := p.ObservedState.ServiceInfo.DataflowComponentReadFSMState
-	if dfcState == "" {
-		dfcState = "not existing"
-	}
-
-	return false, fmt.Sprintf("connection is %s, flow is %s", connState, dfcState)
+	return false, fmt.Sprintf("connection is %s, read flow is %s, write flow is %s",
+		stateOrNotExisting(p.ObservedState.ServiceInfo.ConnectionFSMState),
+		stateOrNotExisting(p.ObservedState.ServiceInfo.DataflowComponentReadFSMState),
+		stateOrNotExisting(p.ObservedState.ServiceInfo.DataflowComponentWriteFSMState))
 }
 
 // IsDFCExisting checks whether either the read or write DFC is existing

--- a/umh-core/pkg/fsm/protocolconverter/reconcile.go
+++ b/umh-core/pkg/fsm/protocolconverter/reconcile.go
@@ -560,8 +560,18 @@ func (p *ProtocolConverterInstance) reconcileRunningState(ctx context.Context, s
 			}
 
 			return nil, false
-		case !hasActivity: // if there is no activity, we stay in idle
-			p.ObservedState.ServiceInfo.StatusReason = "idling: " + reasonActivity
+		case !hasActivity:
+			// When both DFCs are intentionally stopped, surface the connection
+			// monitor status so the user retains visibility into device reachability.
+			if p.areBothDFCsIntentionallyStopped() {
+				if connectionUp {
+					p.ObservedState.ServiceInfo.StatusReason = "idle: all flows stopped, connection up"
+				} else {
+					p.ObservedState.ServiceInfo.StatusReason = "idle: all flows stopped, " + reasonConnection
+				}
+			} else {
+				p.ObservedState.ServiceInfo.StatusReason = "idling: " + reasonActivity
+			}
 
 			return nil, false
 		}

--- a/umh-core/pkg/models/action_models.go
+++ b/umh-core/pkg/models/action_models.go
@@ -762,10 +762,14 @@ type ProtocolConverterConnection struct {
 }
 
 type ProtocolConverterDFC struct {
-	Pipeline     CommonDataFlowComponentPipelineConfig `json:"pipeline"               mapstructure:"pipeline"               yaml:"pipeline"`
-	IgnoreErrors *bool                                 `json:"ignoreErrors,omitempty" mapstructure:"ignoreErrors,omitempty" yaml:"ignoreErrors,omitempty"`
-	RawYAML      *CommonDataFlowComponentRawYamlConfig `json:"rawYAML,omitempty"      mapstructure:"rawYAML,omitempty"      yaml:"rawYAML,omitempty"`
-	Inputs       CommonDataFlowComponentInputConfig    `json:"inputs"                 mapstructure:"inputs"                 yaml:"inputs"`
+	Pipeline     CommonDataFlowComponentPipelineConfig  `json:"pipeline"               mapstructure:"pipeline"               yaml:"pipeline"`
+	IgnoreErrors *bool                                  `json:"ignoreErrors,omitempty" mapstructure:"ignoreErrors,omitempty" yaml:"ignoreErrors,omitempty"`
+	RawYAML      *CommonDataFlowComponentRawYamlConfig  `json:"rawYAML,omitempty"      mapstructure:"rawYAML,omitempty"      yaml:"rawYAML,omitempty"`
+	// State is the desired state for this specific DFC ("active" or "stopped").
+	// When empty, the overall protocol converter state is used.
+	State   string                                 `json:"state,omitempty"        mapstructure:"state,omitempty"        yaml:"state,omitempty"`
+	Inputs  CommonDataFlowComponentInputConfig     `json:"inputs"                 mapstructure:"inputs"                 yaml:"inputs"`
+	Outputs CommonDataFlowComponentOutputConfig    `json:"outputs"                mapstructure:"outputs"                yaml:"outputs"`
 }
 
 type ProtocolConverterVariable struct {
@@ -786,9 +790,8 @@ type ProtocolConverter struct {
 	WriteDFC     *ProtocolConverterDFC          `json:"writeDFC"`
 	TemplateInfo *ProtocolConverterTemplateInfo `json:"templateInfo"`
 	Meta         *ProtocolConverterMeta         `json:"meta"`
-	Name         string                         `binding:"required"     json:"name"`
-	State        string                         `json:"state,omitempty"`
-	Connection   ProtocolConverterConnection    `json:"connection"`
+	Name       string                      `binding:"required" json:"name"`
+	Connection ProtocolConverterConnection `json:"connection"`
 }
 
 type ProtocolConverterMeta struct {

--- a/umh-core/pkg/service/protocolconverter/mock.go
+++ b/umh-core/pkg/service/protocolconverter/mock.go
@@ -652,11 +652,12 @@ func (m *MockProtocolConverterService) EvaluateDFCDesiredStates(protConvName str
 	// Find and update read DFC config
 	for i, config := range m.dfcConfigs {
 		if config.Name == underlyingReadName {
-			if protocolConverterDesiredState == "stopped" || !connectionConfirmedUp {
+			switch {
+			case protocolConverterDesiredState == "stopped" || !connectionConfirmedUp:
 				m.dfcConfigs[i].DesiredFSMState = dfcfsm.OperationalStateStopped
-			} else if readDFCDesiredState == "stopped" {
+			case readDFCDesiredState == "stopped":
 				m.dfcConfigs[i].DesiredFSMState = dfcfsm.OperationalStateStopped
-			} else {
+			default:
 				// Only start the DFC, if it has been configured and connection is up
 				if len(m.dfcConfigs[i].DataFlowComponentServiceConfig.BenthosConfig.Input) > 0 {
 					m.dfcConfigs[i].DesiredFSMState = dfcfsm.OperationalStateActive
@@ -672,11 +673,12 @@ func (m *MockProtocolConverterService) EvaluateDFCDesiredStates(protConvName str
 	// Find and update write DFC config
 	for i, config := range m.dfcConfigs {
 		if config.Name == underlyingWriteName {
-			if protocolConverterDesiredState == "stopped" || !connectionConfirmedUp {
+			switch {
+			case protocolConverterDesiredState == "stopped" || !connectionConfirmedUp:
 				m.dfcConfigs[i].DesiredFSMState = dfcfsm.OperationalStateStopped
-			} else if writeDFCDesiredState == "stopped" {
+			case writeDFCDesiredState == "stopped":
 				m.dfcConfigs[i].DesiredFSMState = dfcfsm.OperationalStateStopped
-			} else {
+			default:
 				// Only start the DFC, if it has been configured and connection is up
 				if len(m.dfcConfigs[i].DataFlowComponentServiceConfig.BenthosConfig.Output) > 0 {
 					m.dfcConfigs[i].DesiredFSMState = dfcfsm.OperationalStateActive

--- a/umh-core/pkg/service/protocolconverter/mock.go
+++ b/umh-core/pkg/service/protocolconverter/mock.go
@@ -543,13 +543,13 @@ func (m *MockProtocolConverterService) StartProtocolConverter(ctx context.Contex
 }
 
 // StartDFC mocks starting only the DFC components of a ProtocolConverter.
-func (m *MockProtocolConverterService) StartDFC(ctx context.Context, filesystemService filesystem.Service, protConvName string) error {
+func (m *MockProtocolConverterService) StartDFC(ctx context.Context, filesystemService filesystem.Service, protConvName string, readDFCDesiredState string, writeDFCDesiredState string) error {
 	m.mu.Lock()
 	m.StartDFCCalled = true
 	m.mu.Unlock()
 
 	// Use EvaluateDFCDesiredStates to handle the conditional DFC starting logic
-	err := m.EvaluateDFCDesiredStates(protConvName, "active", "starting_dfc")
+	err := m.EvaluateDFCDesiredStates(protConvName, "active", "starting_dfc", readDFCDesiredState, writeDFCDesiredState)
 	if err != nil {
 		return err
 	}
@@ -632,7 +632,7 @@ func (m *MockProtocolConverterService) ReconcileManager(ctx context.Context, ser
 // EvaluateDFCDesiredStates mocks the DFC state evaluation logic.
 // This method exists because protocol converters must re-evaluate DFC states
 // when configs change during reconciliation (unlike other FSMs that set states once).
-func (m *MockProtocolConverterService) EvaluateDFCDesiredStates(protConvName string, protocolConverterDesiredState string, currentFSMState string) error {
+func (m *MockProtocolConverterService) EvaluateDFCDesiredStates(protConvName string, protocolConverterDesiredState string, currentFSMState string, readDFCDesiredState string, writeDFCDesiredState string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -654,6 +654,8 @@ func (m *MockProtocolConverterService) EvaluateDFCDesiredStates(protConvName str
 		if config.Name == underlyingReadName {
 			if protocolConverterDesiredState == "stopped" || !connectionConfirmedUp {
 				m.dfcConfigs[i].DesiredFSMState = dfcfsm.OperationalStateStopped
+			} else if readDFCDesiredState == "stopped" {
+				m.dfcConfigs[i].DesiredFSMState = dfcfsm.OperationalStateStopped
 			} else {
 				// Only start the DFC, if it has been configured and connection is up
 				if len(m.dfcConfigs[i].DataFlowComponentServiceConfig.BenthosConfig.Input) > 0 {
@@ -671,6 +673,8 @@ func (m *MockProtocolConverterService) EvaluateDFCDesiredStates(protConvName str
 	for i, config := range m.dfcConfigs {
 		if config.Name == underlyingWriteName {
 			if protocolConverterDesiredState == "stopped" || !connectionConfirmedUp {
+				m.dfcConfigs[i].DesiredFSMState = dfcfsm.OperationalStateStopped
+			} else if writeDFCDesiredState == "stopped" {
 				m.dfcConfigs[i].DesiredFSMState = dfcfsm.OperationalStateStopped
 			} else {
 				// Only start the DFC, if it has been configured and connection is up

--- a/umh-core/pkg/service/protocolconverter/protocolconverter.go
+++ b/umh-core/pkg/service/protocolconverter/protocolconverter.go
@@ -80,10 +80,11 @@ type IProtocolConverterService interface {
 	// This is used during the "starting_connection" FSM state
 	StartConnection(ctx context.Context, filesystemService filesystem.Service, protConvName string) error
 
-	// StartDFC starts only the DFC components of a ProtocolConverter
-	// This evaluates which DFCs should be active based on their configurations
-	// This is used during the "starting_dfc" FSM state
-	StartDFC(ctx context.Context, filesystemService filesystem.Service, protConvName string) error
+	// StartDFC starts only the DFC components of a ProtocolConverter.
+	// readDFCDesiredState and writeDFCDesiredState override the default "active" evaluation:
+	// if either is "stopped" the corresponding DFC will not be started.
+	// Pass empty strings to use the default logic (start if config present and connection up).
+	StartDFC(ctx context.Context, filesystemService filesystem.Service, protConvName string, readDFCDesiredState string, writeDFCDesiredState string) error
 
 	// Stop stops a ProtocolConverter
 	StopProtocolConverter(ctx context.Context, filesystemService filesystem.Service, protConvName string) error
@@ -104,8 +105,10 @@ type IProtocolConverterService interface {
 
 	// EvaluateDFCDesiredStates determines the appropriate desired states for the underlying
 	// DFCs based on the protocol converter's desired state and current DFC configurations.
+	// readDFCDesiredState and writeDFCDesiredState optionally override the per-DFC desired
+	// state ("active" or "stopped"). An empty string means use the default logic.
 	// This is used internally for both initial startup and config change re-evaluation.
-	EvaluateDFCDesiredStates(protConvName string, protocolConverterDesiredState string, currentFSMState string) error
+	EvaluateDFCDesiredStates(protConvName string, protocolConverterDesiredState string, currentFSMState string, readDFCDesiredState string, writeDFCDesiredState string) error
 
 	// IsResourceLimited checks if the system is at resource limits based on container health
 	// and current bridge count.
@@ -741,7 +744,7 @@ func (p *ProtocolConverterService) RemoveFromManager(
 //
 // NOTE: This function uses hardcoded string literals for FSM states to avoid circular imports
 // with pkg/fsm/protocolconverter. The actual constants are defined in pkg/fsm/protocolconverter/models.go.
-func (p *ProtocolConverterService) EvaluateDFCDesiredStates(protConvName string, protocolConverterDesiredState string, currentFSMState string) error {
+func (p *ProtocolConverterService) EvaluateDFCDesiredStates(protConvName string, protocolConverterDesiredState string, currentFSMState string, readDFCDesiredState string, writeDFCDesiredState string) error {
 	if p.dataflowComponentManager == nil {
 		return errors.New("dataflowcomponent manager not initialized")
 	}
@@ -753,9 +756,19 @@ func (p *ProtocolConverterService) EvaluateDFCDesiredStates(protConvName string,
 	dfcReadFound := false
 	dfcWriteFound := false
 
+	connectionConfirmedUp := currentFSMState == "starting_dfc" ||
+		currentFSMState == "idle" ||
+		currentFSMState == "active" ||
+		currentFSMState == "degraded_redpanda" ||
+		currentFSMState == "degraded_dfc" ||
+		currentFSMState == "degraded_other"
+
 	for i, config := range p.dataflowComponentConfig {
 		if config.Name == dfcReadName {
 			if protocolConverterDesiredState == "stopped" { // NOTE: Hardcoded to avoid circular import with pkg/fsm/protocolconverter
+				p.dataflowComponentConfig[i].DesiredFSMState = dfcfsm.OperationalStateStopped
+			} else if readDFCDesiredState == "stopped" {
+				// Per-DFC override: user explicitly wants read DFC stopped
 				p.dataflowComponentConfig[i].DesiredFSMState = dfcfsm.OperationalStateStopped
 			} else {
 				// Only start the DFC if it has been configured AND connection is confirmed up
@@ -766,12 +779,7 @@ func (p *ProtocolConverterService) EvaluateDFCDesiredStates(protConvName string,
 					// NOTE: Hardcoded strings to avoid circular import with pkg/fsm/protocolconverter
 					// These correspond to: OperationalStateStartingDFC, OperationalStateIdle, OperationalStateActive
 					// IMPORTANT: Explicitly exclude degraded_connection as connection is unhealthy in that state
-					if currentFSMState == "starting_dfc" ||
-						currentFSMState == "idle" ||
-						currentFSMState == "active" ||
-						currentFSMState == "degraded_redpanda" ||
-						currentFSMState == "degraded_dfc" ||
-						currentFSMState == "degraded_other" {
+					if connectionConfirmedUp {
 						p.dataflowComponentConfig[i].DesiredFSMState = dfcfsm.OperationalStateActive
 					} else {
 						// Connection not confirmed up yet - keep DFC stopped
@@ -793,6 +801,9 @@ func (p *ProtocolConverterService) EvaluateDFCDesiredStates(protConvName string,
 		if config.Name == dfcWriteName {
 			if protocolConverterDesiredState == "stopped" { // NOTE: Hardcoded to avoid circular import with pkg/fsm/protocolconverter
 				p.dataflowComponentConfig[i].DesiredFSMState = dfcfsm.OperationalStateStopped
+			} else if writeDFCDesiredState == "stopped" {
+				// Per-DFC override: user explicitly wants write DFC stopped
+				p.dataflowComponentConfig[i].DesiredFSMState = dfcfsm.OperationalStateStopped
 			} else {
 				// Only start the DFC if it has been configured AND connection is confirmed up
 				if len(p.dataflowComponentConfig[i].DataFlowComponentServiceConfig.BenthosConfig.Input) > 0 {
@@ -802,12 +813,7 @@ func (p *ProtocolConverterService) EvaluateDFCDesiredStates(protConvName string,
 					// NOTE: Hardcoded strings to avoid circular import with pkg/fsm/protocolconverter
 					// These correspond to: OperationalStateStartingDFC, OperationalStateIdle, OperationalStateActive
 					// IMPORTANT: Explicitly exclude degraded_connection as connection is unhealthy in that state
-					if currentFSMState == "starting_dfc" ||
-						currentFSMState == "idle" ||
-						currentFSMState == "active" ||
-						currentFSMState == "degraded_redpanda" ||
-						currentFSMState == "degraded_dfc" ||
-						currentFSMState == "degraded_other" {
+					if connectionConfirmedUp {
 						p.dataflowComponentConfig[i].DesiredFSMState = dfcfsm.OperationalStateActive
 					} else {
 						// Connection not confirmed up yet - keep DFC stopped
@@ -874,7 +880,7 @@ func (p *ProtocolConverterService) StartProtocolConverter(
 	// Evaluate and set DFC states based on current configs
 	// NOTE: This is different from other FSMs - we don't just set all DFCs to active,
 	// we check if they have valid configs first (see EvaluateDFCDesiredStates docstring)
-	return p.EvaluateDFCDesiredStates(protConvName, "active", "active")
+	return p.EvaluateDFCDesiredStates(protConvName, "active", "active", "", "")
 }
 
 // Stop stops a ProtocolConverter
@@ -916,7 +922,7 @@ func (p *ProtocolConverterService) StopProtocolConverter(
 
 	// Set all DFCs to stopped
 	// NOTE: Hardcoded strings to avoid circular import with pkg/fsm/protocolconverter
-	return p.EvaluateDFCDesiredStates(protConvName, "stopped", "stopping")
+	return p.EvaluateDFCDesiredStates(protConvName, "stopped", "stopping", "", "")
 }
 
 // StartConnection starts only the connection component of a ProtocolConverter.
@@ -971,6 +977,8 @@ func (p *ProtocolConverterService) StartDFC(
 	ctx context.Context,
 	filesystemService filesystem.Service,
 	protConvName string,
+	readDFCDesiredState string,
+	writeDFCDesiredState string,
 ) error {
 	if p.dataflowComponentManager == nil {
 		return errors.New("dataflowcomponent manager not initialized")
@@ -980,11 +988,9 @@ func (p *ProtocolConverterService) StartDFC(
 		return ctx.Err()
 	}
 
-	// Evaluate and set DFC states based on current configs
-	// NOTE: This is different from other FSMs - we don't just set all DFCs to active,
-	// we check if they have valid configs first (see EvaluateDFCDesiredStates docstring)
+	// Evaluate and set DFC states based on current configs, honouring per-DFC overrides.
 	// NOTE: Hardcoded strings to avoid circular import with pkg/fsm/protocolconverter
-	return p.EvaluateDFCDesiredStates(protConvName, "active", "starting_dfc")
+	return p.EvaluateDFCDesiredStates(protConvName, "active", "starting_dfc", readDFCDesiredState, writeDFCDesiredState)
 }
 
 // ReconcileManager synchronizes all protocolconverters on each tick.

--- a/umh-core/pkg/service/protocolconverter/protocolconverter.go
+++ b/umh-core/pkg/service/protocolconverter/protocolconverter.go
@@ -766,12 +766,13 @@ func (p *ProtocolConverterService) EvaluateDFCDesiredStates(protConvName string,
 	for i, config := range p.dataflowComponentConfig {
 		if config.Name == dfcReadName {
 			// First check, if PC is force stopped by another function call from the dev, not the user payload
-			if protocolConverterDesiredState == "stopped" { // NOTE: Hardcoded to avoid circular import with pkg/fsm/protocolconverter
+			switch {
+			case protocolConverterDesiredState == "stopped": // NOTE: Hardcoded to avoid circular import with pkg/fsm/protocolconverter
 				p.dataflowComponentConfig[i].DesiredFSMState = dfcfsm.OperationalStateStopped
-			} else if readDFCDesiredState == "stopped" {
+			case readDFCDesiredState == "stopped":
 				// Per-DFC override: user explicitly wants read DFC stopped
 				p.dataflowComponentConfig[i].DesiredFSMState = dfcfsm.OperationalStateStopped
-			} else {
+			default:
 				// Only start the DFC if it has been configured AND connection is confirmed up
 				if len(p.dataflowComponentConfig[i].DataFlowComponentServiceConfig.BenthosConfig.Input) > 0 {
 					// CRITICAL: Only set DFC to active when FSM state indicates connection is up
@@ -801,12 +802,13 @@ func (p *ProtocolConverterService) EvaluateDFCDesiredStates(protConvName string,
 	for i, config := range p.dataflowComponentConfig {
 		if config.Name == dfcWriteName {
 			// First check, if PC is force stopped by another function call from the dev, not the user payload
-			if protocolConverterDesiredState == "stopped" { // NOTE: Hardcoded to avoid circular import with pkg/fsm/protocolconverter
+			switch {
+			case protocolConverterDesiredState == "stopped": // NOTE: Hardcoded to avoid circular import with pkg/fsm/protocolconverter
 				p.dataflowComponentConfig[i].DesiredFSMState = dfcfsm.OperationalStateStopped
-			} else if writeDFCDesiredState == "stopped" {
+			case writeDFCDesiredState == "stopped":
 				// Per-DFC override: user explicitly wants write DFC stopped
 				p.dataflowComponentConfig[i].DesiredFSMState = dfcfsm.OperationalStateStopped
-			} else {
+			default:
 				// Only start the DFC if it has been configured AND connection is confirmed up
 				if len(p.dataflowComponentConfig[i].DataFlowComponentServiceConfig.BenthosConfig.Output) > 0 {
 					// CRITICAL: Only set DFC to active when FSM state indicates connection is up

--- a/umh-core/pkg/service/protocolconverter/protocolconverter.go
+++ b/umh-core/pkg/service/protocolconverter/protocolconverter.go
@@ -765,6 +765,7 @@ func (p *ProtocolConverterService) EvaluateDFCDesiredStates(protConvName string,
 
 	for i, config := range p.dataflowComponentConfig {
 		if config.Name == dfcReadName {
+			// First check, if PC is force stopped by another function call from the dev, not the user payload
 			if protocolConverterDesiredState == "stopped" { // NOTE: Hardcoded to avoid circular import with pkg/fsm/protocolconverter
 				p.dataflowComponentConfig[i].DesiredFSMState = dfcfsm.OperationalStateStopped
 			} else if readDFCDesiredState == "stopped" {
@@ -799,6 +800,7 @@ func (p *ProtocolConverterService) EvaluateDFCDesiredStates(protConvName string,
 	// Find and update our cached config for write DFC
 	for i, config := range p.dataflowComponentConfig {
 		if config.Name == dfcWriteName {
+			// First check, if PC is force stopped by another function call from the dev, not the user payload
 			if protocolConverterDesiredState == "stopped" { // NOTE: Hardcoded to avoid circular import with pkg/fsm/protocolconverter
 				p.dataflowComponentConfig[i].DesiredFSMState = dfcfsm.OperationalStateStopped
 			} else if writeDFCDesiredState == "stopped" {
@@ -806,7 +808,7 @@ func (p *ProtocolConverterService) EvaluateDFCDesiredStates(protConvName string,
 				p.dataflowComponentConfig[i].DesiredFSMState = dfcfsm.OperationalStateStopped
 			} else {
 				// Only start the DFC if it has been configured AND connection is confirmed up
-				if len(p.dataflowComponentConfig[i].DataFlowComponentServiceConfig.BenthosConfig.Input) > 0 {
+				if len(p.dataflowComponentConfig[i].DataFlowComponentServiceConfig.BenthosConfig.Output) > 0 {
 					// CRITICAL: Only set DFC to active when FSM state indicates connection is up
 					// This prevents the issue where Benthos might connect and send data even when
 					// the connection is flaky or filtered, leading to unreliable data transmission

--- a/umh-core/pkg/service/protocolconverter/protocolconverter_test.go
+++ b/umh-core/pkg/service/protocolconverter/protocolconverter_test.go
@@ -432,7 +432,7 @@ var _ = Describe("DataFlowComponentService", func() {
 
 		It("should start DFCs only when StartDFC is called", func() {
 			// Start the DFCs
-			err := service.StartDFC(ctx, mockSvcRegistry.GetFileSystem(), protConvName)
+			err := service.StartDFC(ctx, mockSvcRegistry.GetFileSystem(), protConvName, "active", "stopped")
 			Expect(err).NotTo(HaveOccurred())
 
 			// Verify the DFC desired state was changed based on config
@@ -457,7 +457,7 @@ var _ = Describe("DataFlowComponentService", func() {
 			Expect(err).To(MatchError(ErrServiceNotExist))
 
 			// Try to start DFC for non-existent protocolConverter
-			err = service.StartDFC(ctx, mockSvcRegistry.GetFileSystem(), "non-existent")
+			err = service.StartDFC(ctx, mockSvcRegistry.GetFileSystem(), "non-existent", "active", "stopped")
 			Expect(err).To(MatchError(ErrServiceNotExist))
 
 			// Try to stop a non-existent protocolConverter
@@ -629,7 +629,7 @@ var _ = Describe("DataFlowComponentService", func() {
 			mockConnService.ReconcileManagerError = mockError
 
 			// Second reconcile - now that the instance exists, it will try to reconcile it
-			err, reconciled = testService.ReconcileManager(ctx, mockSvcRegistry, fsm.SystemSnapshot{Tick: tick+1, SnapshotTime: time.Now()})
+			err, reconciled = testService.ReconcileManager(ctx, mockSvcRegistry, fsm.SystemSnapshot{Tick: tick + 1, SnapshotTime: time.Now()})
 
 			// Assert
 			Expect(err).ToNot(HaveOccurred()) // it should not return an error

--- a/umh-core/pkg/service/protocolconverter/runtime_config/runtime_config.go
+++ b/umh-core/pkg/service/protocolconverter/runtime_config/runtime_config.go
@@ -194,6 +194,7 @@ func BuildRuntimeConfig(
 	}
 
 	vb.Internal["bridged_by"] = config.GenerateBridgedBy(config.ComponentTypeProtocolConverter, nodeName, pcName)
+	vb.Internal["umh_topic"] = "umh.v1." + locationPath + ".*"
 
 	//----------------------------------------------------------------------
 	// 4. Render all three sub-templates

--- a/umh-core/pkg/service/protocolconverter/runtime_config/runtime_config.go
+++ b/umh-core/pkg/service/protocolconverter/runtime_config/runtime_config.go
@@ -194,7 +194,12 @@ func BuildRuntimeConfig(
 	}
 
 	vb.Internal["bridged_by"] = config.GenerateBridgedBy(config.ComponentTypeProtocolConverter, nodeName, pcName)
-	vb.Internal["umh_topic"] = "umh.v1." + locationPath + ".*"
+	if locationPath == "" {
+		vb.Internal["umh_topic"] = "umh.v1.*"
+	} else {
+		vb.Internal["umh_topic"] = "umh.v1." + locationPath + ".*"
+
+	}
 
 	//----------------------------------------------------------------------
 	// 4. Render all three sub-templates


### PR DESCRIPTION
- Adds separate `write flow` to protocol converters (bridge)
- Check benthos for `read flow` and `write flow` separately
- Has ability to only deploy one of them or both
- From my testing, it still works with `old` and `new` frontend i.e. with or without the FF being set