### PR TITLE
feat(models): add FeatureUsage to status messages (ENG-4580)

### DIFF
--- a/umh-core/cmd/main.go
+++ b/umh-core/cmd/main.go
@@ -139,18 +139,12 @@ func main() {
 
 	configData.Agent.UseFSMv2ProtocolConverter = v
 
-	now := time.Now()
-	var configBackupEnabledSince *time.Time
-	if configBackupEnabled {
-		configBackupEnabledSince = &now
-	}
 	featureUsage := &models.FeatureUsage{
-		ConfigBackupEnabledSince: configBackupEnabledSince,
-		ConfigBackupEnabled:      configBackupEnabled,
-		FSMv2Transport:           configData.Agent.UseFSMv2Transport,
-		FSMv2MemoryCleanup:       configData.Agent.UseFSMv2MemoryCleanup,
-		FSMv2ProtocolConverter:   configData.Agent.UseFSMv2ProtocolConverter,
-		ResourceLimitBlocking:    configData.Agent.EnableResourceLimitBlocking,
+		ConfigBackupEnabled:           configBackupEnabled,
+		FSMv2TransportEnabled:         configData.Agent.UseFSMv2Transport,
+		FSMv2MemoryCleanupEnabled:     configData.Agent.UseFSMv2MemoryCleanup,
+		FSMv2ProtocolConverterEnabled: configData.Agent.UseFSMv2ProtocolConverter,
+		ResourceLimitBlockingEnabled:  configData.Agent.EnableResourceLimitBlocking,
 	}
 
 	// Ensure the S6 repository directory exists

--- a/umh-core/cmd/main.go
+++ b/umh-core/cmd/main.go
@@ -95,12 +95,12 @@ func main() {
 
 	// Config backup feature flag: must be set before LoadConfigWithEnvOverrides,
 	// which writes config on startup and should back up the pre-write state.
-	v, err := env.GetAsBool("ENABLE_CONFIG_BACKUP", false, false)
+	configBackupEnabled, err := env.GetAsBool("ENABLE_CONFIG_BACKUP", false, false)
 	if err != nil {
 		log.Warnf("Failed to parse ENABLE_CONFIG_BACKUP: %v", err)
 	}
 
-	configManager.SetConfigBackupEnabled(v)
+	configManager.SetConfigBackupEnabled(configBackupEnabled)
 
 	// Load or create configuration with environment variable overrides
 	// This loads the config file if it exists, applies any environment variables as overrides,
@@ -118,7 +118,7 @@ func main() {
 	// FSMv2 feature flags: read directly from env vars, not persisted to config.yaml.
 	// These bypass the config manager intentionally — they are temporary migration flags
 	// that will be replaced when the config manager becomes an FSMv2 worker.
-	v, err = env.GetAsBool("USE_FSMV2_TRANSPORT", false, false)
+	v, err := env.GetAsBool("USE_FSMV2_TRANSPORT", false, false)
 	if err != nil {
 		log.Warnf("Failed to parse USE_FSMV2_TRANSPORT: %v", err)
 	}
@@ -138,6 +138,20 @@ func main() {
 	}
 
 	configData.Agent.UseFSMv2ProtocolConverter = v
+
+	now := time.Now()
+	var configBackupEnabledSince *time.Time
+	if configBackupEnabled {
+		configBackupEnabledSince = &now
+	}
+	featureUsage := &models.FeatureUsage{
+		ConfigBackupEnabledSince: configBackupEnabledSince,
+		ConfigBackupEnabled:      configBackupEnabled,
+		FSMv2Transport:           configData.Agent.UseFSMv2Transport,
+		FSMv2MemoryCleanup:       configData.Agent.UseFSMv2MemoryCleanup,
+		FSMv2ProtocolConverter:   configData.Agent.UseFSMv2ProtocolConverter,
+		ResourceLimitBlocking:    configData.Agent.EnableResourceLimitBlocking,
+	}
 
 	// Ensure the S6 repository directory exists
 	// This is particularly important when using /tmp/umh-core/services (the default)
@@ -179,6 +193,7 @@ func main() {
 		logger.For(logger.ComponentCommunicator),
 		configData.Agent.AllowInsecureTLS,
 		topicbrowser.NewCache(),
+		featureUsage,
 	)
 
 	// Initialize the topic browser simulator (cache update logic moved to subscriber notification pipeline)

--- a/umh-core/cmd/main_test.go
+++ b/umh-core/cmd/main_test.go
@@ -80,6 +80,7 @@ var _ = Describe("Backend Connection", Ordered, func() {
 			log,
 			configData.Agent.AllowInsecureTLS,
 			topicbrowser.NewCache(),
+			nil, // featureUsage
 		)
 	})
 

--- a/umh-core/pkg/communicator/actions/edit_instance_test.go
+++ b/umh-core/pkg/communicator/actions/edit_instance_test.go
@@ -639,3 +639,8 @@ func (w *writeFailingMockConfigManager) AtomicDeleteStreamProcessor(ctx context.
 
 	return nil
 }
+
+// GetBackupCount returns 0 for the mock (no real backups are created).
+func (w *writeFailingMockConfigManager) GetBackupCount() uint64 {
+	return 0
+}

--- a/umh-core/pkg/communicator/communication_state/communication_state.go
+++ b/umh-core/pkg/communicator/communication_state/communication_state.go
@@ -56,6 +56,7 @@ type CommunicationState struct {
 	// TopicBrowserSimulator is used to access the simulated topic browser state if the agent is running in simulator mode
 	// it is accessed by the generator to generate the topic browser part of the status message
 	TopicBrowserSimulator *topicbrowser.Simulator
+	FeatureUsage          *models.FeatureUsage
 	ReleaseChannel        config.ReleaseChannel
 	ApiUrl                string
 	InsecureTLS           bool
@@ -75,6 +76,7 @@ func NewCommunicationState(
 	logger *zap.SugaredLogger,
 	insecureTLS bool,
 	topicBrowserCache *topicbrowser.Cache,
+	featureUsage *models.FeatureUsage,
 ) *CommunicationState {
 	return &CommunicationState{
 		mu:                    &sync.RWMutex{},
@@ -89,6 +91,7 @@ func NewCommunicationState(
 		Logger:                logger,
 		InsecureTLS:           insecureTLS,
 		TopicBrowserCache:     topicBrowserCache,
+		FeatureUsage:          featureUsage,
 	}
 }
 
@@ -295,6 +298,7 @@ func (c *CommunicationState) InitialiseAndStartSubscriberHandler(ttl time.Durati
 		c.Logger,
 		topicBrowserCommunicator,
 		fsmOutboundChannel, // FSMv2 direct channel (nil for legacy mode)
+		c.FeatureUsage,
 	)
 	if c.SubscriberHandler == nil {
 		sentry.ReportIssuef(sentry.IssueTypeError, c.Logger, "Failed to create subscriber handler")

--- a/umh-core/pkg/communicator/communication_state/communication_state_lock_test.go
+++ b/umh-core/pkg/communicator/communication_state/communication_state_lock_test.go
@@ -51,6 +51,7 @@ var _ = Describe("CommunicationState Lock Ordering", func() {
 			logger,
 			false,
 			nil, // topicBrowserCache
+			nil, // featureUsage
 		)
 	})
 

--- a/umh-core/pkg/communicator/pkg/generator/generator.go
+++ b/umh-core/pkg/communicator/pkg/generator/generator.go
@@ -38,6 +38,8 @@ type StatusCollectorType struct {
 	featureUsage             *models.FeatureUsage
 }
 
+// NewStatusCollector creates a status collector that generates periodic status payloads
+// including system snapshots, topic browser data, and feature usage metrics.
 func NewStatusCollector(
 	dog watchdog.Iface,
 	systemSnapshotManager *fsm.SnapshotManager,

--- a/umh-core/pkg/communicator/pkg/generator/generator.go
+++ b/umh-core/pkg/communicator/pkg/generator/generator.go
@@ -234,6 +234,16 @@ func (s *StatusCollectorType) GenerateStatusMessage(ctx context.Context, isBoots
 	}
 
 	// Step 3: Create the status message
+
+	// Copy the base FeatureUsage struct and overlay the dynamic backup count so
+	// the original (immutable after startup) is never mutated.
+	var featureUsage *models.FeatureUsage
+	if s.featureUsage != nil {
+		fu := *s.featureUsage
+		fu.ConfigBackupCount = int(s.configManager.GetBackupCount())
+		featureUsage = &fu
+	}
+
 	statusMessage := &models.StatusMessage{
 		Core: models.Core{
 			Agent: models.Agent{
@@ -247,7 +257,7 @@ func (s *StatusCollectorType) GenerateStatusMessage(ctx context.Context, isBoots
 			TopicBrowser:  *topicBrowserData,
 			DataModels:    dataModelData,
 			DataContracts: dataContractData,
-			FeatureUsage:  s.featureUsage,
+			FeatureUsage:  featureUsage,
 			Release: models.Release{
 				Health: &models.Health{
 					Message:       "",

--- a/umh-core/pkg/communicator/pkg/generator/generator.go
+++ b/umh-core/pkg/communicator/pkg/generator/generator.go
@@ -35,6 +35,7 @@ type StatusCollectorType struct {
 	logger                   *zap.SugaredLogger
 	configManager            config.ConfigManager
 	topicBrowserCommunicator *topicbrowser.TopicBrowserCommunicator
+	featureUsage             *models.FeatureUsage
 }
 
 func NewStatusCollector(
@@ -43,6 +44,7 @@ func NewStatusCollector(
 	configManager config.ConfigManager,
 	logger *zap.SugaredLogger,
 	topicBrowserCommunicator *topicbrowser.TopicBrowserCommunicator,
+	featureUsage *models.FeatureUsage,
 ) *StatusCollectorType {
 	collector := &StatusCollectorType{
 		dog:                      dog,
@@ -50,6 +52,7 @@ func NewStatusCollector(
 		logger:                   logger,
 		configManager:            configManager,
 		topicBrowserCommunicator: topicBrowserCommunicator,
+		featureUsage:             featureUsage,
 	}
 
 	return collector
@@ -244,6 +247,7 @@ func (s *StatusCollectorType) GenerateStatusMessage(ctx context.Context, isBoots
 			TopicBrowser:  *topicBrowserData,
 			DataModels:    dataModelData,
 			DataContracts: dataContractData,
+			FeatureUsage:  s.featureUsage,
 			Release: models.Release{
 				Health: &models.Health{
 					Message:       "",

--- a/umh-core/pkg/communicator/pkg/subscriber/subscribers.go
+++ b/umh-core/pkg/communicator/pkg/subscriber/subscribers.go
@@ -64,6 +64,7 @@ func NewHandler(
 	logger *zap.SugaredLogger,
 	topicBrowserCommunicator *topicbrowser.TopicBrowserCommunicator,
 	fsmOutboundChannel chan<- *transport.UMHMessage, // FSMv2 direct channel (nil for legacy mode)
+	featureUsage *models.FeatureUsage,
 ) *Handler {
 	s := &Handler{}
 	s.subscriberRegistry = subscribers.NewRegistry(cull, ttl)
@@ -81,6 +82,7 @@ func NewHandler(
 		configManager,
 		logger,
 		topicBrowserCommunicator,
+		featureUsage,
 	)
 
 	return s

--- a/umh-core/pkg/communicator/pkg/subscriber/subscribers.go
+++ b/umh-core/pkg/communicator/pkg/subscriber/subscribers.go
@@ -51,6 +51,8 @@ type Handler struct {
 	disableHardwareStatusCheck bool //nolint:unused // will be used in the future
 }
 
+// NewHandler creates a subscriber handler that manages instance subscriptions
+// and coordinates status collection with the management console.
 func NewHandler(
 	dog watchdog.Iface,
 	pusher *push.Pusher,

--- a/umh-core/pkg/communicator/pkg/subscriber/subscribers_fsmv2_test.go
+++ b/umh-core/pkg/communicator/pkg/subscriber/subscribers_fsmv2_test.go
@@ -63,6 +63,7 @@ var _ = Describe("FSMv2 Direct Channel Mode", func() {
 				logger,
 				nil, // topicBrowserCommunicator
 				fsmOutboundChannel,
+				nil, // featureUsage
 			)
 		})
 
@@ -99,6 +100,7 @@ var _ = Describe("FSMv2 Direct Channel Mode", func() {
 				logger,
 				nil, // topicBrowserCommunicator
 				nil, // fsmOutboundChannel - nil for legacy mode
+				nil, // featureUsage
 			)
 		})
 
@@ -130,6 +132,7 @@ var _ = Describe("FSMv2 Direct Channel Mode", func() {
 				logger,
 				nil,
 				nil, // legacy mode
+				nil, // featureUsage
 			)
 
 			// Create FSMv2 handler (with channel)
@@ -149,6 +152,7 @@ var _ = Describe("FSMv2 Direct Channel Mode", func() {
 				logger,
 				nil,
 				fsmv2Channel, // FSMv2 mode
+				nil,          // featureUsage
 			)
 
 			// Both handlers should work independently

--- a/umh-core/pkg/communicator/pkg/subscriber/subscribers_race_test.go
+++ b/umh-core/pkg/communicator/pkg/subscriber/subscribers_race_test.go
@@ -61,6 +61,7 @@ var _ = Describe("SubscriberHandler Race Condition", func() {
 			logger,
 			nil, // topicBrowserCommunicator
 			nil, // fsmOutboundChannel - nil for legacy mode test
+			nil, // featureUsage
 		)
 	})
 

--- a/umh-core/pkg/config/manager.go
+++ b/umh-core/pkg/config/manager.go
@@ -26,6 +26,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"go.uber.org/zap"
@@ -109,6 +110,8 @@ type ConfigManager interface {
 	UpdateAndGetCacheModTime(ctx context.Context) (time.Time, error)
 	// WriteYAMLConfigFromString writes a config from a string to the config file
 	WriteYAMLConfigFromString(ctx context.Context, configStr string, expectedModTime string) error
+	// GetBackupCount returns the number of config backups created since startup.
+	GetBackupCount() uint64
 
 	// TODO: Add AtomicUnlinkFromTemplate method
 	// AtomicUnlinkFromTemplate converts a templated configuration (using YAML anchors/aliases)
@@ -160,6 +163,9 @@ type FileConfigManager struct {
 
 	// ---------- background refresh state ----------
 	refreshMu sync.Mutex // prevents concurrent background refreshes
+
+	// backupCount tracks the number of config backups created since startup.
+	backupCount atomic.Uint64
 
 	// backupEnabled controls whether config backups are created before writes.
 	backupEnabled bool
@@ -551,6 +557,16 @@ func (m *FileConfigManagerWithBackoff) Stop() {
 // SetConfigBackupEnabled controls whether config backups are created before writes.
 func (m *FileConfigManagerWithBackoff) SetConfigBackupEnabled(enabled bool) {
 	m.configManager.backupEnabled = enabled
+}
+
+// GetBackupCount returns the number of config backups created since startup.
+func (m *FileConfigManagerWithBackoff) GetBackupCount() uint64 {
+	return m.configManager.GetBackupCount()
+}
+
+// GetBackupCount returns the number of config backups created since startup.
+func (m *FileConfigManager) GetBackupCount() uint64 {
+	return m.backupCount.Load()
 }
 
 // writeConfig writes the config to the file
@@ -1225,6 +1241,8 @@ func (m *FileConfigManager) createConfigBackup(ctx context.Context) {
 
 		return
 	}
+
+	m.backupCount.Add(1)
 
 	m.cleanupOldBackups(ctx)
 }

--- a/umh-core/pkg/config/mock.go
+++ b/umh-core/pkg/config/mock.go
@@ -1247,6 +1247,11 @@ func (m *MockConfigManager) WriteYAMLConfigFromString(ctx context.Context, confi
 	return nil
 }
 
+// GetBackupCount returns 0 for the mock (no real backups are created).
+func (m *MockConfigManager) GetBackupCount() uint64 {
+	return 0
+}
+
 // IsGetConfigCalled returns true if GetConfig has been called (thread-safe).
 func (m *MockConfigManager) IsGetConfigCalled() bool {
 	return atomic.LoadInt32(&m.GetConfigCalled) != 0

--- a/umh-core/pkg/models/feature_usage.go
+++ b/umh-core/pkg/models/feature_usage.go
@@ -1,0 +1,28 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package models
+
+import "time"
+
+// FeatureUsage captures which feature flags are enabled on this instance.
+// Populated once at startup from env vars and YAML config. Immutable after construction.
+type FeatureUsage struct {
+	ConfigBackupEnabledSince *time.Time `json:"configBackupEnabledSince,omitempty"`
+	ConfigBackupEnabled      bool       `json:"configBackupEnabled"`
+	FSMv2Transport           bool       `json:"fsmv2Transport"`
+	FSMv2MemoryCleanup       bool       `json:"fsmv2MemoryCleanup"`
+	FSMv2ProtocolConverter   bool       `json:"fsmv2ProtocolConverter"`
+	ResourceLimitBlocking    bool       `json:"resourceLimitBlocking"`
+}

--- a/umh-core/pkg/models/feature_usage.go
+++ b/umh-core/pkg/models/feature_usage.go
@@ -14,15 +14,27 @@
 
 package models
 
-import "time"
-
-// FeatureUsage captures which feature flags are enabled on this instance.
-// Populated once at startup from env vars and YAML config. Immutable after construction.
+// FeatureUsage reports which feature flags are active on this instance and
+// tracks per-feature usage metrics.
+//
+// Bool fields ending in Enabled are auto-mapped to feature_{snake_case} PostHog
+// properties by the MC frontend. To add a new flag: add a bool field ending in
+// Enabled here, set it in cmd/main.go, and add the field to the TS interface
+// in statusMessage.svelte.ts.
+//
+// Non-bool usage metrics (like ConfigBackupCount) are mapped manually with a
+// usage_ prefix in instanceTelemetry.ts.
 type FeatureUsage struct {
-	ConfigBackupEnabledSince *time.Time `json:"configBackupEnabledSince,omitempty"`
-	ConfigBackupEnabled      bool       `json:"configBackupEnabled"`
-	FSMv2Transport           bool       `json:"fsmv2Transport"`
-	FSMv2MemoryCleanup       bool       `json:"fsmv2MemoryCleanup"`
-	FSMv2ProtocolConverter   bool       `json:"fsmv2ProtocolConverter"`
-	ResourceLimitBlocking    bool       `json:"resourceLimitBlocking"`
+	// ConfigBackupCount tracks the number of config backups created since startup.
+	ConfigBackupCount int `json:"configBackupCount"`
+	// ConfigBackupEnabled reports whether ENABLE_CONFIG_BACKUP is set.
+	ConfigBackupEnabled bool `json:"configBackupEnabled"`
+	// FSMv2TransportEnabled reports whether USE_FSMV2_TRANSPORT is set.
+	FSMv2TransportEnabled bool `json:"fsmv2TransportEnabled"`
+	// FSMv2MemoryCleanupEnabled reports whether USE_FSMV2_MEMORY_CLEANUP is set.
+	FSMv2MemoryCleanupEnabled bool `json:"fsmv2MemoryCleanupEnabled"`
+	// FSMv2ProtocolConverterEnabled reports whether USE_FSMV2_PROTOCOL_CONVERTER is set.
+	FSMv2ProtocolConverterEnabled bool `json:"fsmv2ProtocolConverterEnabled"`
+	// ResourceLimitBlockingEnabled reports whether agent.enableResourceLimitBlocking is set.
+	ResourceLimitBlockingEnabled bool `json:"resourceLimitBlockingEnabled"`
 }

--- a/umh-core/pkg/models/feature_usage.go
+++ b/umh-core/pkg/models/feature_usage.go
@@ -35,6 +35,6 @@ type FeatureUsage struct {
 	FSMv2MemoryCleanupEnabled bool `json:"fsmv2MemoryCleanupEnabled"`
 	// FSMv2ProtocolConverterEnabled reports whether USE_FSMV2_PROTOCOL_CONVERTER is set.
 	FSMv2ProtocolConverterEnabled bool `json:"fsmv2ProtocolConverterEnabled"`
-	// ResourceLimitBlockingEnabled reports whether agent.enableResourceLimitBlocking is set.
+	// ResourceLimitBlockingEnabled reports the value of agent.enableResourceLimitBlocking in config.yaml (defaults to true).
 	ResourceLimitBlockingEnabled bool `json:"resourceLimitBlockingEnabled"`
 }

--- a/umh-core/pkg/models/feature_usage_suite_test.go
+++ b/umh-core/pkg/models/feature_usage_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package models_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestFeatureUsage(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "FeatureUsage Suite")
+}

--- a/umh-core/pkg/models/feature_usage_test.go
+++ b/umh-core/pkg/models/feature_usage_test.go
@@ -16,7 +16,6 @@ package models_test
 
 import (
 	"encoding/json"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -24,31 +23,6 @@ import (
 )
 
 var _ = Describe("FeatureUsage", func() {
-	It("marshals all fields to correct JSON", func() {
-		now := time.Now().UTC().Truncate(time.Second)
-		fu := models.FeatureUsage{
-			ConfigBackupEnabledSince: &now,
-			ConfigBackupEnabled:      true,
-			FSMv2Transport:           true,
-			FSMv2MemoryCleanup:       true,
-			FSMv2ProtocolConverter:   true,
-			ResourceLimitBlocking:    true,
-		}
-
-		data, err := json.Marshal(fu)
-		Expect(err).NotTo(HaveOccurred())
-
-		var raw map[string]interface{}
-		Expect(json.Unmarshal(data, &raw)).To(Succeed())
-
-		Expect(raw).To(HaveKey("configBackupEnabled"))
-		Expect(raw).To(HaveKey("configBackupEnabledSince"))
-		Expect(raw).To(HaveKey("fsmv2Transport"))
-		Expect(raw).To(HaveKey("fsmv2MemoryCleanup"))
-		Expect(raw).To(HaveKey("fsmv2ProtocolConverter"))
-		Expect(raw).To(HaveKey("resourceLimitBlocking"))
-	})
-
 	It("omits featureUsage from Core JSON when nil", func() {
 		core := models.Core{
 			FeatureUsage: nil,
@@ -61,20 +35,5 @@ var _ = Describe("FeatureUsage", func() {
 		Expect(json.Unmarshal(data, &raw)).To(Succeed())
 
 		Expect(raw).NotTo(HaveKey("featureUsage"))
-	})
-
-	It("omits configBackupEnabledSince when nil", func() {
-		fu := models.FeatureUsage{
-			ConfigBackupEnabledSince: nil,
-			ConfigBackupEnabled:      true,
-		}
-
-		data, err := json.Marshal(fu)
-		Expect(err).NotTo(HaveOccurred())
-
-		var raw map[string]interface{}
-		Expect(json.Unmarshal(data, &raw)).To(Succeed())
-
-		Expect(raw).NotTo(HaveKey("configBackupEnabledSince"))
 	})
 })

--- a/umh-core/pkg/models/feature_usage_test.go
+++ b/umh-core/pkg/models/feature_usage_test.go
@@ -1,0 +1,80 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package models_test
+
+import (
+	"encoding/json"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/models"
+)
+
+var _ = Describe("FeatureUsage", func() {
+	It("marshals all fields to correct JSON", func() {
+		now := time.Now().UTC().Truncate(time.Second)
+		fu := models.FeatureUsage{
+			ConfigBackupEnabledSince: &now,
+			ConfigBackupEnabled:      true,
+			FSMv2Transport:           true,
+			FSMv2MemoryCleanup:       true,
+			FSMv2ProtocolConverter:   true,
+			ResourceLimitBlocking:    true,
+		}
+
+		data, err := json.Marshal(fu)
+		Expect(err).NotTo(HaveOccurred())
+
+		var raw map[string]interface{}
+		Expect(json.Unmarshal(data, &raw)).To(Succeed())
+
+		Expect(raw).To(HaveKey("configBackupEnabled"))
+		Expect(raw).To(HaveKey("configBackupEnabledSince"))
+		Expect(raw).To(HaveKey("fsmv2Transport"))
+		Expect(raw).To(HaveKey("fsmv2MemoryCleanup"))
+		Expect(raw).To(HaveKey("fsmv2ProtocolConverter"))
+		Expect(raw).To(HaveKey("resourceLimitBlocking"))
+	})
+
+	It("omits featureUsage from Core JSON when nil", func() {
+		core := models.Core{
+			FeatureUsage: nil,
+		}
+
+		data, err := json.Marshal(core)
+		Expect(err).NotTo(HaveOccurred())
+
+		var raw map[string]interface{}
+		Expect(json.Unmarshal(data, &raw)).To(Succeed())
+
+		Expect(raw).NotTo(HaveKey("featureUsage"))
+	})
+
+	It("omits configBackupEnabledSince when nil", func() {
+		fu := models.FeatureUsage{
+			ConfigBackupEnabledSince: nil,
+			ConfigBackupEnabled:      true,
+		}
+
+		data, err := json.Marshal(fu)
+		Expect(err).NotTo(HaveOccurred())
+
+		var raw map[string]interface{}
+		Expect(json.Unmarshal(data, &raw)).To(Succeed())
+
+		Expect(raw).NotTo(HaveKey("configBackupEnabledSince"))
+	})
+})

--- a/umh-core/pkg/models/status_message.go
+++ b/umh-core/pkg/models/status_message.go
@@ -21,13 +21,14 @@ type StatusMessage struct {
 }
 
 type Core struct {
-	Health        *Health        `json:"health"`
 	Agent         Agent          `json:"agent"`
+	Health        *Health        `json:"health"`
+	FeatureUsage  *FeatureUsage  `json:"featureUsage,omitempty"`
 	Container     Container      `json:"container"`
-	Dfcs          []Dfc          `json:"dfcs"`
-	Redpanda      Redpanda       `json:"redpanda"`
 	TopicBrowser  TopicBrowser   `json:"topicBrowser"`
 	Release       Release        `json:"release"`
+	Dfcs          []Dfc          `json:"dfcs"`
+	Redpanda      Redpanda       `json:"redpanda"`
 	DataModels    []DataModel    `json:"dataModels"`
 	DataContracts []DataContract `json:"dataContracts"`
 }
@@ -123,7 +124,6 @@ type CPU struct {
 	Health         *Health `json:"health"`
 	TotalUsageMCpu float64 `json:"totalUsageMCpu"` // Total usage in milli-cores (1000m = 1 core)
 	CoreCount      int     `json:"coreCount"`      // Number of CPU cores
-	
 	// Cgroup-specific fields for container resource limits
 	CgroupCores   float64 `json:"cgroupCores,omitempty"`   // CPU quota from cgroup (e.g., 2.0 = 2 cores)
 	ThrottleRatio float64 `json:"throttleRatio,omitempty"` // Ratio of time throttled (0.0-1.0)

--- a/umh-core/test/communicator/subscribe_and_receive_test.go
+++ b/umh-core/test/communicator/subscribe_and_receive_test.go
@@ -195,6 +195,7 @@ var _ = Describe("Subscribe and Receive Test", func() {
 			logger.For(logger.ComponentCommunicator),
 			topicBrowserCommunicator,
 			nil, // fsmOutboundChannel - nil for legacy mode test
+			nil, // featureUsage
 		)
 		subHandler.StartNotifier()
 


### PR DESCRIPTION
Adds a `FeatureUsage` struct to the status message so the Management Console can report which feature flags are active on each instance.

The struct carries one boolean per feature flag (config backup, FSMv2 transport/memory/protocol, resource limiting) plus a backup count that increments on each successful config backup write. Bool fields all end in `Enabled` so the frontend can auto-map them to PostHog properties without maintaining a manual list.

Built in `cmd/main.go` from env vars and YAML config, threaded through the status collector, included in every status push. Old instances that don't have this field just omit it (pointer + omitempty).

## How to verify

- `go test ./pkg/models/...` -- omitempty contract test
- `go test ./...` -- full suite
- `make betteralign-fix && git diff` -- no alignment changes