### PR TITLE
chore: release v0.44.13 -- gRPC security fix (CVE-2026-33186)

### DIFF
--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## [0.44.13]
+
+### Fixes
+
+- Updated gRPC to v1.79.3 to patch CVE-2026-33186, a critical authorization bypass where path-based access control policies could be circumvented via malformed HTTP/2 requests
+
 ## [0.44.12]
 
 ### Improvements
@@ -188,7 +194,7 @@ docker exec -it <container-name> sh
 grep fsmv2 /data/logs/umh-core/current
 ```
 
-You should see log entries with `fsmv2` and states like `Syncing` or `Recovering`.
+You should see log entries with `fsmv2` and states like `Syncing` or `TryingToAuthenticate`.
 
 **Note:** To disable later, you must explicitly set `useFSMv2Transport: false` in config.yaml.
 


### PR DESCRIPTION
## Summary

- Releases v0.44.13 with the gRPC security fix from #2498 (ENG-4700)
- Restores v0.44.5 historical entry that was edited in #2490 (released sections are immutable per CI guard)

## What's in v0.44.13

One fix: gRPC bumped to v1.79.3 for CVE-2026-33186 (CVSS 9.1). An attacker could bypass
path-based authorization by sending HTTP/2 requests without a leading slash in `:path`.
The `golang.org/x/net` bump is a transitive dependency, not a separate CVE.

This is a security-only release. No features, no behavior changes.

## Why a standalone release

The vuln is CVSS 9.1 and the fix is already on staging (#2498 merged). Bundling it with
the next feature release would delay the patch for no reason.

This is also the first release where we include security fixes in the changelog
(umh-marketplace#8 updates the changelog-writing skill to cover this).

## Process

Per RELEASING.md step 1: renames `## Unreleased` to `## [0.44.13]`, adds fresh
`## Unreleased`. After this merges, PR #2499 (staging -> main) picks it up automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)