### PR TITLE
refactor: auto-generate Sentry feature tags from worker type (ENG-4718)

### DIFF
--- a/umh-core/pkg/fsmv2/deps/deps.go
+++ b/umh-core/pkg/fsmv2/deps/deps.go
@@ -63,6 +63,8 @@ type Dependencies interface {
 	GetStateReader() StateReader
 	// GetHierarchyPath returns the worker's hierarchy path for Sentry routing.
 	GetHierarchyPath() string
+	// GetWorkerType returns the worker's type identifier for Sentry feature tagging.
+	GetWorkerType() string
 }
 
 // BaseDependencies provides common tools for all workers.

--- a/umh-core/pkg/fsmv2/deps/feature.go
+++ b/umh-core/pkg/fsmv2/deps/feature.go
@@ -27,7 +27,7 @@ type Feature string
 const (
 	// FeatureFSMv2 covers the FSMv2 supervisor core: lifecycle, reconciliation,
 	// tick panics, circuit breakers, and child management.
-	// Worker-owned events (action_failed, collector_timeout, etc.) use
+	// Worker-owned events (action_failed, collector_observation_failed, etc.) use
 	// FeatureForWorker(workerType) instead.
 	FeatureFSMv2 Feature = "fsmv2"
 

--- a/umh-core/pkg/fsmv2/deps/feature.go
+++ b/umh-core/pkg/fsmv2/deps/feature.go
@@ -17,10 +17,8 @@ package deps
 // Feature identifies the subsystem for Sentry routing and alerting.
 // Using a typed enum prevents typos at compile time.
 //
-// For worker-specific events, use FeatureForWorker(workerType) to auto-generate
-// the feature from the worker's type string. This ensures each worker produces
-// Sentry events under its own feature tag for ownership routing.
-//
+// Worker-specific events use [FeatureForWorker] to derive the feature
+// from the worker's type string (e.g., "pull", "push", "certfetcher").
 // Static constants below cover non-worker subsystems.
 type Feature string
 
@@ -46,8 +44,8 @@ const (
 )
 
 // FeatureForWorker returns the Feature for a specific worker type.
-// The feature tag matches the worker type string (e.g., "pull", "push",
-// "certfetcher", "persistence"), enabling per-worker Sentry alert routing.
+// The returned feature tag matches the worker type string (e.g., "pull",
+// "push", "certfetcher"), so each worker's Sentry events route separately.
 func FeatureForWorker(workerType string) Feature {
 	return Feature(workerType)
 }

--- a/umh-core/pkg/fsmv2/deps/feature.go
+++ b/umh-core/pkg/fsmv2/deps/feature.go
@@ -15,11 +15,43 @@
 package deps
 
 // Feature identifies the subsystem for Sentry routing and alerting.
-// Using a typed enum prevents typos at compile time.
+// Sentry uses this tag to group issues and route alerts to the right owner.
 //
-// Worker-specific events use [FeatureForWorker] to derive the feature
-// from the worker's type string (e.g., "pull", "push", "certfetcher").
-// Static constants below cover non-worker subsystems.
+// # Choosing a feature tag
+//
+// Use [FeatureForWorker] when a worker interface method executes in the
+// failing path. Worker interface methods include Execute, Name (on actions),
+// CollectObservedState, DeriveDesiredState, and Next (on states).
+// The worker team investigates these errors.
+//
+// Use [FeatureFSMv2] when only supervisor infrastructure executes. No worker
+// interface method runs. A framework engineer investigates these errors.
+//
+// Ask: "does a worker interface method execute before this error?" If yes,
+// use [FeatureForWorker]. If only supervisor machinery runs (storage loading,
+// goroutine lifecycle, circuit breakers, signal processing), use [FeatureFSMv2].
+//
+// # Examples
+//
+// FeatureForWorker (worker interface method executes):
+//   - action_failed: the action's Execute() returns an error
+//   - authentication_failed: the auth action's Execute() runs
+//   - collector_observation_failed: CollectObservedState returns an error
+//
+// FeatureFSMv2 (supervisor infrastructure only):
+//   - snapshot_load_failed: CSE deserialization, no worker method involved
+//   - collector_start_failed: supervisor starts a goroutine, no worker method runs yet
+//   - tick_panic: panic recovery in the supervisor tick loop
+//   - circuit_breaker_opened: supervisor health tracking
+//
+// # Gray areas
+//
+// Collector lifecycle operations (start, restart, stop) are supervisor
+// infrastructure. Some collector restart events in reconciliation.go use
+// [FeatureForWorker] because they are triggered by stale observations from
+// a specific worker, even though the restart itself is supervisor machinery.
+// When in doubt, route to the worker team — they have the most context to
+// investigate.
 type Feature string
 
 const (
@@ -46,6 +78,8 @@ const (
 // FeatureForWorker returns the Feature for a specific worker type.
 // The returned feature tag matches the worker type string (e.g., "pull",
 // "push", "certfetcher"), so each worker's Sentry events route separately.
+//
+// See the [Feature] type documentation for when to use this vs [FeatureFSMv2].
 func FeatureForWorker(workerType string) Feature {
 	return Feature(workerType)
 }

--- a/umh-core/pkg/fsmv2/deps/feature.go
+++ b/umh-core/pkg/fsmv2/deps/feature.go
@@ -17,13 +17,18 @@ package deps
 // Feature identifies the subsystem for Sentry routing and alerting.
 // Using a typed enum prevents typos at compile time.
 //
-// Each Feature maps to a Sentry alert owner. When adding new subsystems,
-// define a new Feature constant and document the owner.
+// For worker-specific events, use FeatureForWorker(workerType) to auto-generate
+// the feature from the worker's type string. This ensures each worker produces
+// Sentry events under its own feature tag for ownership routing.
+//
+// Static constants below cover non-worker subsystems.
 type Feature string
 
 const (
 	// FeatureFSMv2 covers the FSMv2 supervisor core: lifecycle, reconciliation,
-	// collection, action execution, and health monitoring.
+	// tick panics, circuit breakers, and child management.
+	// Worker-owned events (action_failed, collector_timeout, etc.) use
+	// FeatureForWorker(workerType) instead.
 	FeatureFSMv2 Feature = "fsmv2"
 
 	// FeatureExamples covers example workers used for testing and documentation.
@@ -32,12 +37,6 @@ const (
 	// FeatureCSE covers the CSE (Convergent State Engine) storage layer.
 	FeatureCSE Feature = "cse"
 
-	// FeatureCommunicator covers the communicator worker for external communication.
-	FeatureCommunicator Feature = "communicator"
-
-	// FeaturePersistence covers the persistence layer for state storage.
-	FeaturePersistence Feature = "persistence"
-
 	// FeatureFSMv1ConfigManager covers the FSMv1 config manager: config loading,
 	// writing, backup, and validation.
 	FeatureFSMv1ConfigManager Feature = "fsmv1_config_manager"
@@ -45,3 +44,10 @@ const (
 	// FeatureDisableReadFlows controls the feature about activating and deactivating read flows.
 	FeatureDisableReadFlows Feature = "disable_read_flows"
 )
+
+// FeatureForWorker returns the Feature for a specific worker type.
+// The feature tag matches the worker type string (e.g., "pull", "push",
+// "certfetcher", "persistence"), enabling per-worker Sentry alert routing.
+func FeatureForWorker(workerType string) Feature {
+	return Feature(workerType)
+}

--- a/umh-core/pkg/fsmv2/sentry/doc.go
+++ b/umh-core/pkg/fsmv2/sentry/doc.go
@@ -40,10 +40,24 @@
 //   - Keys matching a sensitive-name denylist (password, secret, token, etc.)
 //   - String values are truncated at 1024 characters
 //
+// # Feature Tags
+//
+// Worker-owned events use auto-generated features via [deps.FeatureForWorker]:
+// each worker produces Sentry events tagged with its own worker type
+// (e.g., feature:pull, feature:push, feature:certfetcher, feature:persistence).
+// Supervisor-internal events (tick panics, circuit breakers) use feature:fsmv2.
+//
+// This enables per-worker Sentry ownership routing. Configure ownership rules
+// in Sentry (Settings > Projects > Ownership Rules):
+//
+//	tags.feature:certfetcher {certfetcher-owner-email}
+//	tags.feature:fsmv2 {fsmv2-owner-email}
+//	tags.feature:* {default-owner-email}
+//
 // # Creating Sentry Alerts
 //
-//	level:error feature:communicator
-//	level:error feature:fsmv2 event_name:action_failed
+//	level:error feature:pull
+//	level:error feature:fsmv2 event_name:tick_panic
 //	level:error worker_chain:application/communicator
 //
 // # Tag Design: hierarchy_path vs worker_chain

--- a/umh-core/pkg/fsmv2/sentry/doc.go
+++ b/umh-core/pkg/fsmv2/sentry/doc.go
@@ -40,15 +40,15 @@
 //   - Keys matching a sensitive-name denylist (password, secret, token, etc.)
 //   - String values are truncated at 1024 characters
 //
-// # Feature Tags
+// # Feature tags
 //
-// Worker-owned events use auto-generated features via [deps.FeatureForWorker]:
-// each worker produces Sentry events tagged with its own worker type
-// (e.g., feature:pull, feature:push, feature:certfetcher, feature:persistence).
-// Supervisor-internal events (tick panics, circuit breakers) use feature:fsmv2.
+// Each worker's Sentry events are tagged with its own type via
+// [deps.FeatureForWorker] (e.g., feature:pull, feature:push,
+// feature:certfetcher). Supervisor-internal events (tick panics,
+// circuit breakers) use feature:fsmv2.
 //
-// This enables per-worker Sentry ownership routing. Configure ownership rules
-// in Sentry (Settings > Projects > Ownership Rules):
+// Sentry ownership rules route alerts per worker type
+// (Settings > Projects > Ownership Rules):
 //
 //	tags.feature:certfetcher {certfetcher-owner-email}
 //	tags.feature:fsmv2 {fsmv2-owner-email}

--- a/umh-core/pkg/fsmv2/sentry/hook_test.go
+++ b/umh-core/pkg/fsmv2/sentry/hook_test.go
@@ -1358,7 +1358,7 @@ var _ = Describe("FSMLogger to Sentry Event Mapping", func() {
 	})
 
 	It("SentryError with hierarchy_path derives fsm_version, worker_type, and worker_chain", func() {
-		fsmLogger.SentryError(deps.FeatureCommunicator, "app(application)/worker(communicator)", io.EOF, "action_failed")
+		fsmLogger.SentryError(deps.FeatureForWorker("communicator"), "app(application)/worker(communicator)", io.EOF, "action_failed")
 
 		Eventually(func() int {
 			return store.Len()

--- a/umh-core/pkg/fsmv2/sentry/hook_test.go
+++ b/umh-core/pkg/fsmv2/sentry/hook_test.go
@@ -1365,6 +1365,7 @@ var _ = Describe("FSMLogger to Sentry Event Mapping", func() {
 		}, time.Second, 10*time.Millisecond).Should(BeNumerically(">=", 1))
 
 		event := store.GetLast()
+		Expect(event.Tags["feature"]).To(Equal("communicator"))
 		Expect(event.Tags["fsm_version"]).To(Equal("v2"))
 		Expect(event.Tags["worker_type"]).To(Equal("communicator"))
 		Expect(event.Tags["worker_chain"]).To(Equal("application/communicator"))

--- a/umh-core/pkg/fsmv2/supervisor/internal/collection/collector.go
+++ b/umh-core/pkg/fsmv2/supervisor/internal/collection/collector.go
@@ -158,7 +158,7 @@ func (c *Collector[TObserved]) TriggerNow() {
 	c.mu.RUnlock()
 
 	if !running {
-		c.config.Logger.SentryWarn(deps.FeatureFSMv2, c.config.Identity.HierarchyPath, "collector_trigger_now_failed",
+		c.config.Logger.SentryWarn(deps.FeatureForWorker(c.config.Identity.WorkerType), c.config.Identity.HierarchyPath, "collector_trigger_now_failed",
 			deps.Reason("not_running"),
 			deps.String("current_state", c.state.String()))
 
@@ -185,7 +185,7 @@ func (c *Collector[TObserved]) Restart() {
 	c.mu.RUnlock()
 
 	if !running {
-		c.config.Logger.SentryWarn(deps.FeatureFSMv2, c.config.Identity.HierarchyPath, "collector_restart_failed",
+		c.config.Logger.SentryWarn(deps.FeatureForWorker(c.config.Identity.WorkerType), c.config.Identity.HierarchyPath, "collector_restart_failed",
 			deps.Reason("not_running"),
 			deps.String("current_state", c.state.String()))
 
@@ -211,12 +211,12 @@ func (c *Collector[TObserved]) Restart() {
 	// Error handling preserved for future extensibility (e.g., context validation, resource allocation).
 	if parentCtx != nil {
 		if err := c.Start(parentCtx); err != nil {
-			c.config.Logger.SentryError(deps.FeatureFSMv2, c.config.Identity.HierarchyPath, err, "collector_restart_start_failed")
+			c.config.Logger.SentryError(deps.FeatureForWorker(c.config.Identity.WorkerType), c.config.Identity.HierarchyPath, err, "collector_restart_start_failed")
 		} else {
 			c.config.Logger.Info("collector_restart_complete")
 		}
 	} else {
-		c.config.Logger.SentryError(deps.FeatureFSMv2, c.config.Identity.HierarchyPath, errors.New("no_parent_context"), "collector_restart_failed")
+		c.config.Logger.SentryError(deps.FeatureForWorker(c.config.Identity.WorkerType), c.config.Identity.HierarchyPath, errors.New("no_parent_context"), "collector_restart_failed")
 	}
 }
 
@@ -224,7 +224,7 @@ func (c *Collector[TObserved]) Stop(ctx context.Context) {
 	c.mu.Lock()
 
 	if c.state != collectorStateRunning {
-		c.config.Logger.SentryWarn(deps.FeatureFSMv2, c.config.Identity.HierarchyPath, "collector_stop_skipped",
+		c.config.Logger.SentryWarn(deps.FeatureForWorker(c.config.Identity.WorkerType), c.config.Identity.HierarchyPath, "collector_stop_skipped",
 			deps.Reason("not_running"),
 			deps.String("current_state", c.state.String()))
 		c.mu.Unlock()
@@ -245,10 +245,10 @@ func (c *Collector[TObserved]) Stop(ctx context.Context) {
 		c.config.Logger.Debug("collector_stopped",
 			deps.String("result", "success"))
 	case <-ctx.Done():
-		c.config.Logger.SentryWarn(deps.FeatureFSMv2, c.config.Identity.HierarchyPath, "collector_stopped",
+		c.config.Logger.SentryWarn(deps.FeatureForWorker(c.config.Identity.WorkerType), c.config.Identity.HierarchyPath, "collector_stopped",
 			deps.String("result", "context_cancelled"))
 	case <-stopTimer.C:
-		c.config.Logger.SentryWarn(deps.FeatureFSMv2, c.config.Identity.HierarchyPath, "collector_stopped",
+		c.config.Logger.SentryWarn(deps.FeatureForWorker(c.config.Identity.WorkerType), c.config.Identity.HierarchyPath, "collector_stopped",
 			deps.String("result", "timeout"))
 	}
 }
@@ -267,7 +267,7 @@ func (c *Collector[TObserved]) CollectFinalObservation(ctx context.Context) erro
 		currentState := c.state.String()
 		c.mu.RUnlock()
 
-		c.config.Logger.SentryWarn(deps.FeatureFSMv2, c.config.Identity.HierarchyPath, "collector_final_observation_skipped",
+		c.config.Logger.SentryWarn(deps.FeatureForWorker(c.config.Identity.WorkerType), c.config.Identity.HierarchyPath, "collector_final_observation_skipped",
 			deps.Reason("not_running"),
 			deps.String("current_state", currentState))
 
@@ -284,7 +284,7 @@ func (c *Collector[TObserved]) CollectFinalObservation(ctx context.Context) erro
 
 	err := c.collectAndSaveObservedState(collectCtx)
 	if err != nil {
-		c.config.Logger.SentryWarn(deps.FeatureFSMv2, c.config.Identity.HierarchyPath, "collector_final_observation_failed",
+		c.config.Logger.SentryWarn(deps.FeatureForWorker(c.config.Identity.WorkerType), c.config.Identity.HierarchyPath, "collector_final_observation_failed",
 			deps.Err(err))
 
 		return err
@@ -333,7 +333,7 @@ func (c *Collector[TObserved]) observationLoop() {
 
 			collectCtx, cancel := context.WithTimeout(ctx, timeout)
 			if err := c.collectAndSaveObservedState(collectCtx); err != nil {
-				c.config.Logger.SentryError(deps.FeatureFSMv2, c.config.Identity.HierarchyPath, err, "collector_observation_failed",
+				c.config.Logger.SentryError(deps.FeatureForWorker(c.config.Identity.WorkerType), c.config.Identity.HierarchyPath, err, "collector_observation_failed",
 					deps.String("trigger", "restart"))
 			}
 
@@ -342,7 +342,7 @@ func (c *Collector[TObserved]) observationLoop() {
 		case <-ticker.C:
 			collectCtx, cancel := context.WithTimeout(ctx, timeout)
 			if err := c.collectAndSaveObservedState(collectCtx); err != nil {
-				c.config.Logger.SentryError(deps.FeatureFSMv2, c.config.Identity.HierarchyPath, err, "collector_observation_failed",
+				c.config.Logger.SentryError(deps.FeatureForWorker(c.config.Identity.WorkerType), c.config.Identity.HierarchyPath, err, "collector_observation_failed",
 					deps.String("trigger", "ticker"))
 			}
 
@@ -445,7 +445,7 @@ func (c *Collector[TObserved]) collectAndSaveObservedState(ctx context.Context) 
 	observedTyped, ok := observed.(TObserved)
 	if !ok {
 		err := fmt.Errorf("observed state type mismatch: expected %T, got %T", *new(TObserved), observed)
-		c.config.Logger.SentryError(deps.FeatureFSMv2, c.config.Identity.HierarchyPath, err, "collector_type_mismatch",
+		c.config.Logger.SentryError(deps.FeatureForWorker(c.config.Identity.WorkerType), c.config.Identity.HierarchyPath, err, "collector_type_mismatch",
 			deps.String("expected_type", fmt.Sprintf("%T", *new(TObserved))),
 			deps.String("actual_type", fmt.Sprintf("%T", observed)))
 
@@ -455,7 +455,7 @@ func (c *Collector[TObserved]) collectAndSaveObservedState(ctx context.Context) 
 	ts, ok := c.config.Store.(*storage.TriangularStore)
 	if !ok {
 		err := fmt.Errorf("store is not *TriangularStore, got %T", c.config.Store)
-		c.config.Logger.SentryError(deps.FeatureFSMv2, c.config.Identity.HierarchyPath, err, "collector_store_type_mismatch",
+		c.config.Logger.SentryError(deps.FeatureForWorker(c.config.Identity.WorkerType), c.config.Identity.HierarchyPath, err, "collector_store_type_mismatch",
 			deps.String("expected_type", "*storage.TriangularStore"),
 			deps.String("actual_type", fmt.Sprintf("%T", c.config.Store)))
 
@@ -502,7 +502,7 @@ func (c *Collector[TObserved]) handleCollectorPanic(r interface{}) (err error) {
 			func() {
 				defer func() { recover() }() //nolint:errcheck // recover() return value is intentionally unused in safety net
 
-				logger.SentryError(deps.FeatureFSMv2, hierarchyPath, err, "collector_double_panic",
+				logger.SentryError(deps.FeatureForWorker(c.config.Identity.WorkerType), hierarchyPath, err, "collector_double_panic",
 					deps.String("stack", string(debug.Stack())))
 			}()
 		}
@@ -513,7 +513,7 @@ func (c *Collector[TObserved]) handleCollectorPanic(r interface{}) (err error) {
 
 	metrics.RecordPanicRecovery(hierarchyPath, panicType)
 
-	logger.SentryError(deps.FeatureFSMv2, hierarchyPath, err, "collector_panic",
+	logger.SentryError(deps.FeatureForWorker(c.config.Identity.WorkerType), hierarchyPath, err, "collector_panic",
 		deps.Field{Key: "panic_value", Value: fmt.Sprintf("%v", r)},
 		deps.Field{Key: "panic_type", Value: panicType},
 		deps.Field{Key: "stack_trace", Value: string(debug.Stack())})

--- a/umh-core/pkg/fsmv2/supervisor/internal/execution/action_executor.go
+++ b/umh-core/pkg/fsmv2/supervisor/internal/execution/action_executor.go
@@ -179,7 +179,7 @@ func (ae *ActionExecutor) executeWorkWithRecovery(ctx context.Context, work acti
 			err = fmt.Errorf("action panicked: %v", r)
 			status = "panic"
 
-			ae.logger.SentryError(deps.FeatureFSMv2, ae.identity.HierarchyPath, err, "action_panic",
+			ae.logger.SentryError(deps.FeatureForWorker(ae.identity.WorkerType), ae.identity.HierarchyPath, err, "action_panic",
 				deps.CorrelationID(work.actionID),
 				deps.ActionName(work.action.Name()),
 				deps.Int64("timeout_ms", work.timeout.Milliseconds()),
@@ -258,13 +258,13 @@ func (ae *ActionExecutor) executeWorkWithRecovery(ctx context.Context, work acti
 		if errors.Is(err, context.DeadlineExceeded) {
 			metrics.RecordActionTimeout(ae.identity.HierarchyPath, work.action.Name())
 
-			ae.logger.SentryError(deps.FeatureFSMv2, ae.identity.HierarchyPath, err, "action_failed",
+			ae.logger.SentryError(deps.FeatureForWorker(ae.identity.WorkerType), ae.identity.HierarchyPath, err, "action_failed",
 				deps.CorrelationID(work.actionID),
 				deps.ActionName(work.action.Name()),
 				deps.DurationMs(duration.Milliseconds()),
 				deps.Int64("timeout_ms", work.timeout.Milliseconds()))
 		} else {
-			ae.logger.SentryError(deps.FeatureFSMv2, ae.identity.HierarchyPath, err, "action_failed",
+			ae.logger.SentryError(deps.FeatureForWorker(ae.identity.WorkerType), ae.identity.HierarchyPath, err, "action_failed",
 				deps.CorrelationID(work.actionID),
 				deps.ActionName(work.action.Name()),
 				deps.DurationMs(duration.Milliseconds()))
@@ -288,7 +288,7 @@ func (ae *ActionExecutor) EnqueueAction(actionID string, action fsmv2.Action[any
 		inProgressCount := len(ae.inProgress)
 		ae.mu.Unlock()
 
-		ae.logger.SentryWarn(deps.FeatureFSMv2, ae.identity.HierarchyPath, "action_enqueue_rejected",
+		ae.logger.SentryWarn(deps.FeatureForWorker(ae.identity.WorkerType), ae.identity.HierarchyPath, "action_enqueue_rejected",
 			deps.CorrelationID(actionID),
 			deps.ActionName(action.Name()),
 			deps.Reason("executor_stopped"),
@@ -301,7 +301,7 @@ func (ae *ActionExecutor) EnqueueAction(actionID string, action fsmv2.Action[any
 	if _, exists := ae.inProgress[actionID]; exists {
 		ae.mu.Unlock()
 
-		ae.logger.SentryWarn(deps.FeatureFSMv2, ae.identity.HierarchyPath, "action_enqueue_rejected",
+		ae.logger.SentryWarn(deps.FeatureForWorker(ae.identity.WorkerType), ae.identity.HierarchyPath, "action_enqueue_rejected",
 			deps.CorrelationID(actionID),
 			deps.ActionName(action.Name()),
 			deps.Reason("already_in_progress"))
@@ -346,7 +346,7 @@ func (ae *ActionExecutor) EnqueueAction(actionID string, action fsmv2.Action[any
 		ae.mu.Unlock()
 
 		queueErr := errors.New("action queue full")
-		ae.logger.SentryError(deps.FeatureFSMv2, ae.identity.HierarchyPath, queueErr, "action_queue_full",
+		ae.logger.SentryError(deps.FeatureForWorker(ae.identity.WorkerType), ae.identity.HierarchyPath, queueErr, "action_queue_full",
 			deps.CorrelationID(actionID),
 			deps.ActionName(action.Name()),
 			deps.Capacity(cap(ae.actionQueue)),
@@ -407,7 +407,7 @@ func (ae *ActionExecutor) metricsReporter(ctx context.Context) {
 			for _, stuck := range stuckActions {
 				if stuck.forceRemove {
 					metrics.RecordStuckActionForceRemoved(ae.identity.HierarchyPath, stuck.actionName)
-					ae.logger.SentryError(deps.FeatureFSMv2, ae.identity.HierarchyPath, fmt.Errorf("action %s stuck for %dms (timeout %dms), force-removed", stuck.actionName, stuck.elapsedMs, stuck.timeoutMs), "stuck_action_force_removed",
+					ae.logger.SentryError(deps.FeatureForWorker(ae.identity.WorkerType), ae.identity.HierarchyPath, fmt.Errorf("action %s stuck for %dms (timeout %dms), force-removed", stuck.actionName, stuck.elapsedMs, stuck.timeoutMs), "stuck_action_force_removed",
 						deps.Field{Key: "action_id", Value: stuck.actionID},
 						deps.Field{Key: "action_name", Value: stuck.actionName},
 						deps.Field{Key: "elapsed_ms", Value: stuck.elapsedMs},
@@ -424,7 +424,7 @@ func (ae *ActionExecutor) metricsReporter(ctx context.Context) {
 					}
 				} else {
 					metrics.RecordStuckActionDetected(ae.identity.HierarchyPath, stuck.actionName)
-					ae.logger.SentryWarn(deps.FeatureFSMv2, ae.identity.HierarchyPath, "stuck_action_detected",
+					ae.logger.SentryWarn(deps.FeatureForWorker(ae.identity.WorkerType), ae.identity.HierarchyPath, "stuck_action_detected",
 						deps.Field{Key: "action_id", Value: stuck.actionID},
 						deps.Field{Key: "action_name", Value: stuck.actionName},
 						deps.Field{Key: "elapsed_ms", Value: stuck.elapsedMs},

--- a/umh-core/pkg/fsmv2/supervisor/internal/health/doc.go
+++ b/umh-core/pkg/fsmv2/supervisor/internal/health/doc.go
@@ -111,6 +111,7 @@
 //	checker := health.NewFreshnessChecker(
 //	    5 * time.Second,   // staleThreshold
 //	    30 * time.Second,  // timeout
+//	    "pull",            // workerType
 //	    logger,
 //	)
 //

--- a/umh-core/pkg/fsmv2/supervisor/internal/health/freshness.go
+++ b/umh-core/pkg/fsmv2/supervisor/internal/health/freshness.go
@@ -28,13 +28,15 @@ type FreshnessChecker struct {
 	logger         deps.FSMLogger
 	staleThreshold time.Duration
 	timeout        time.Duration
+	workerType     string
 }
 
 // NewFreshnessChecker creates a checker with the given thresholds.
-func NewFreshnessChecker(staleThreshold, timeout time.Duration, logger deps.FSMLogger) *FreshnessChecker {
+func NewFreshnessChecker(staleThreshold, timeout time.Duration, workerType string, logger deps.FSMLogger) *FreshnessChecker {
 	return &FreshnessChecker{
 		staleThreshold: staleThreshold,
 		timeout:        timeout,
+		workerType:     workerType,
 		logger:         logger,
 	}
 }
@@ -57,7 +59,7 @@ func (f *FreshnessChecker) extractTimestamp(snapshot *fsmv2.Snapshot) (time.Time
 	// Fall back to Document lookup for raw document access
 	doc, ok := snapshot.Observed.(persistence.Document)
 	if !ok {
-		f.logger.SentryWarn(deps.FeatureFSMv2, snapshot.Identity.HierarchyPath, "observed_state_type_unknown",
+		f.logger.SentryWarn(deps.FeatureForWorker(f.workerType), snapshot.Identity.HierarchyPath, "observed_state_type_unknown",
 			deps.String("type", fmt.Sprintf("%T", snapshot.Observed)),
 			deps.String("action", "assuming_fresh"))
 
@@ -67,7 +69,7 @@ func (f *FreshnessChecker) extractTimestamp(snapshot *fsmv2.Snapshot) (time.Time
 	// Check collected_at field (JSON-serialized from struct's CollectedAt)
 	ts, exists := doc["collected_at"]
 	if !exists {
-		f.logger.SentryWarn(deps.FeatureFSMv2, snapshot.Identity.HierarchyPath, "observed_state_missing_timestamp",
+		f.logger.SentryWarn(deps.FeatureForWorker(f.workerType), snapshot.Identity.HierarchyPath, "observed_state_missing_timestamp",
 			deps.String("action", "assuming_fresh"))
 
 		return time.Time{}, false
@@ -83,7 +85,7 @@ func (f *FreshnessChecker) extractTimestamp(snapshot *fsmv2.Snapshot) (time.Time
 	case string:
 		collectedAt, err := time.Parse(time.RFC3339Nano, v)
 		if err != nil {
-			f.logger.SentryWarn(deps.FeatureFSMv2, snapshot.Identity.HierarchyPath, "observed_state_invalid_timestamp",
+			f.logger.SentryWarn(deps.FeatureForWorker(f.workerType), snapshot.Identity.HierarchyPath, "observed_state_invalid_timestamp",
 				deps.String("value", v),
 				deps.String("action", "assuming_fresh"))
 
@@ -92,7 +94,7 @@ func (f *FreshnessChecker) extractTimestamp(snapshot *fsmv2.Snapshot) (time.Time
 
 		return collectedAt, true
 	default:
-		f.logger.SentryWarn(deps.FeatureFSMv2, snapshot.Identity.HierarchyPath, "observed_state_unknown_timestamp_type",
+		f.logger.SentryWarn(deps.FeatureForWorker(f.workerType), snapshot.Identity.HierarchyPath, "observed_state_unknown_timestamp_type",
 			deps.String("type", fmt.Sprintf("%T", v)),
 			deps.String("action", "assuming_fresh"))
 
@@ -137,7 +139,7 @@ func (f *FreshnessChecker) IsTimeout(snapshot *fsmv2.Snapshot) bool {
 	isTimedOut := age >= f.timeout
 
 	if isTimedOut {
-		f.logger.SentryWarn(deps.FeatureFSMv2, snapshot.Identity.HierarchyPath, "observed_state_timeout",
+		f.logger.SentryWarn(deps.FeatureForWorker(f.workerType), snapshot.Identity.HierarchyPath, "observed_state_timeout",
 			deps.Duration("age", age),
 			deps.Int64("age_ms", age.Milliseconds()),
 			deps.Duration("threshold", f.timeout),

--- a/umh-core/pkg/fsmv2/supervisor/internal/health/freshness.go
+++ b/umh-core/pkg/fsmv2/supervisor/internal/health/freshness.go
@@ -26,9 +26,9 @@ import (
 // FreshnessChecker validates observation data age against thresholds.
 type FreshnessChecker struct {
 	logger         deps.FSMLogger
+	workerType     string
 	staleThreshold time.Duration
 	timeout        time.Duration
-	workerType     string
 }
 
 // NewFreshnessChecker creates a checker with the given thresholds.

--- a/umh-core/pkg/fsmv2/supervisor/internal/health/freshness_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/internal/health/freshness_test.go
@@ -31,6 +31,7 @@ var _ = Describe("FreshnessChecker", func() {
 			checker := health.NewFreshnessChecker(
 				10*time.Second,
 				20*time.Second,
+				"test",
 				deps.NewNopFSMLogger(),
 			)
 
@@ -53,6 +54,7 @@ var _ = Describe("FreshnessChecker", func() {
 			checker := health.NewFreshnessChecker(
 				10*time.Second,
 				20*time.Second,
+				"test",
 				deps.NewNopFSMLogger(),
 			)
 
@@ -75,6 +77,7 @@ var _ = Describe("FreshnessChecker", func() {
 			checker := health.NewFreshnessChecker(
 				10*time.Second,
 				20*time.Second,
+				"test",
 				deps.NewNopFSMLogger(),
 			)
 

--- a/umh-core/pkg/fsmv2/supervisor/reconciliation.go
+++ b/umh-core/pkg/fsmv2/supervisor/reconciliation.go
@@ -209,11 +209,11 @@ func (s *Supervisor[TObserved, TDesired]) tickWorker(ctx context.Context, worker
 			if restartCount >= s.collectorHealth.maxRestartAttempts {
 				// Max attempts reached - escalate to shutdown (Layer 3)
 				maxAttemptsErr := fmt.Errorf("collector unresponsive after %d restart attempts", s.collectorHealth.maxRestartAttempts)
-				s.logger.SentryError(deps.FeatureFSMv2, s.GetHierarchyPathUnlocked(), maxAttemptsErr, "collector_unresponsive_max_attempts",
+				s.logger.SentryError(deps.FeatureForWorker(s.workerType), s.GetHierarchyPathUnlocked(), maxAttemptsErr, "collector_unresponsive_max_attempts",
 					deps.Attempts(s.collectorHealth.maxRestartAttempts))
 
 				if shutdownErr := s.requestShutdown(ctx, workerID, maxAttemptsErr.Error()); shutdownErr != nil {
-					s.logger.SentryError(deps.FeatureFSMv2, workerCtx.identity.HierarchyPath, shutdownErr, "shutdown_request_failed")
+					s.logger.SentryError(deps.FeatureForWorker(s.workerType), workerCtx.identity.HierarchyPath, shutdownErr, "shutdown_request_failed")
 				}
 
 				return errors.New("collector unresponsive, shutdown requested")
@@ -227,7 +227,7 @@ func (s *Supervisor[TObserved, TDesired]) tickWorker(ctx context.Context, worker
 				maxAttempts := s.collectorHealth.maxRestartAttempts
 				s.mu.RUnlock()
 
-				s.logger.SentryError(deps.FeatureFSMv2, workerCtx.identity.HierarchyPath, err, "collector_restart_failed",
+				s.logger.SentryError(deps.FeatureForWorker(s.workerType), workerCtx.identity.HierarchyPath, err, "collector_restart_failed",
 					deps.Int("restart_attempt", restartAttempt),
 					deps.Int("max_attempts", maxAttempts))
 
@@ -366,7 +366,7 @@ func (s *Supervisor[TObserved, TDesired]) tickWorker(ctx context.Context, worker
 			deps.String("action_id", actionID))
 
 		if err := workerCtx.executor.EnqueueAction(actionID, result.Action, workerDeps); err != nil {
-			s.logger.SentryError(deps.FeatureFSMv2, workerCtx.identity.HierarchyPath, err, "action_enqueue_failed",
+			s.logger.SentryError(deps.FeatureForWorker(s.workerType), workerCtx.identity.HierarchyPath, err, "action_enqueue_failed",
 				deps.String("action_id", actionID))
 
 			return fmt.Errorf("failed to enqueue action: %w", err)
@@ -1254,14 +1254,14 @@ func (s *Supervisor[TObserved, TDesired]) restartCollector(ctx context.Context, 
 			escalationRisk = "imminent"
 		}
 
-		s.logger.SentryWarn(deps.FeatureFSMv2, s.GetHierarchyPathUnlocked(), "collector_restarting",
+		s.logger.SentryWarn(deps.FeatureForWorker(s.workerType), s.GetHierarchyPathUnlocked(), "collector_restarting",
 			deps.Err(fmt.Errorf("collector restart attempt %d of %d", restartCount, maxRestartAttempts)),
 			deps.Int("restart_attempt", restartCount),
 			deps.Int("max_attempts", maxRestartAttempts),
 			deps.Duration("backoff", backoff),
 			deps.String("escalation_risk", escalationRisk))
 	} else {
-		s.logger.SentryWarn(deps.FeatureFSMv2, s.GetHierarchyPathUnlocked(), "collector_restarting",
+		s.logger.SentryWarn(deps.FeatureForWorker(s.workerType), s.GetHierarchyPathUnlocked(), "collector_restarting",
 			deps.Int("restart_attempt", restartCount),
 			deps.Int("max_attempts", maxRestartAttempts),
 			deps.Duration("backoff", backoff))
@@ -1273,7 +1273,7 @@ func (s *Supervisor[TObserved, TDesired]) restartCollector(ctx context.Context, 
 
 	if !exists {
 		notFoundErr := errors.New("worker not found")
-		s.logger.SentryError(deps.FeatureFSMv2, s.GetHierarchyPathUnlocked(), notFoundErr, "collector_restart_worker_not_found",
+		s.logger.SentryError(deps.FeatureForWorker(s.workerType), s.GetHierarchyPathUnlocked(), notFoundErr, "collector_restart_worker_not_found",
 			deps.String("target_worker_id", workerID))
 
 		return notFoundErr
@@ -1304,7 +1304,7 @@ func (s *Supervisor[TObserved, TDesired]) checkDataFreshness(snapshot *fsmv2.Sna
 	}
 
 	if !hasTimestamp {
-		s.logger.SentryWarn(deps.FeatureFSMv2, snapshot.Identity.HierarchyPath, "snapshot_missing_timestamp",
+		s.logger.SentryWarn(deps.FeatureForWorker(s.workerType), snapshot.Identity.HierarchyPath, "snapshot_missing_timestamp",
 			deps.Reason("Snapshot.Observed does not implement GetTimestamp()"),
 			deps.String("impact", "cannot check freshness"))
 
@@ -1339,7 +1339,7 @@ func (s *Supervisor[TObserved, TDesired]) logFreshnessWarning(isShuttingDown boo
 			deps.Duration("age", age),
 			deps.Duration("threshold", threshold))
 	} else {
-		s.logger.SentryWarn(deps.FeatureFSMv2, hierarchyPath, msg,
+		s.logger.SentryWarn(deps.FeatureForWorker(s.workerType), hierarchyPath, msg,
 			deps.Duration("age", age),
 			deps.Duration("threshold", threshold))
 	}

--- a/umh-core/pkg/fsmv2/supervisor/supervisor.go
+++ b/umh-core/pkg/fsmv2/supervisor/supervisor.go
@@ -246,7 +246,7 @@ func NewSupervisor[TObserved fsmv2.ObservedState, TDesired fsmv2.DesiredState](c
 		deps.Duration("stale_threshold", staleThreshold),
 		deps.Duration("collector_timeout", timeout))
 
-	freshnessChecker := health.NewFreshnessChecker(staleThreshold, timeout, cfg.Logger)
+	freshnessChecker := health.NewFreshnessChecker(staleThreshold, timeout, cfg.WorkerType, cfg.Logger)
 
 	lm := lockmanager.NewLockManager()
 

--- a/umh-core/pkg/fsmv2/workers/persistence/worker.go
+++ b/umh-core/pkg/fsmv2/workers/persistence/worker.go
@@ -88,7 +88,7 @@ func (w *PersistenceWorker) CollectObservedState(ctx context.Context) (fsmv2.Obs
 		} else if errors.Is(err, persistencepkg.ErrNotFound) && !d.IsObservedStateLoaded() {
 			d.GetLogger().Debug("no previous observed state found, using zero-value defaults")
 		} else {
-			d.GetLogger().SentryWarn(deps.FeaturePersistence, d.GetHierarchyPath(), "previous_observed_load_failed",
+			d.GetLogger().SentryWarn(deps.FeatureForWorker(d.GetWorkerType()), d.GetHierarchyPath(), "previous_observed_load_failed",
 				deps.Err(err),
 				deps.String("worker_type", d.GetWorkerType()),
 				deps.String("worker_id", d.GetWorkerID()))

--- a/umh-core/pkg/fsmv2/workers/transport/action/authenticate.go
+++ b/umh-core/pkg/fsmv2/workers/transport/action/authenticate.go
@@ -123,7 +123,7 @@ func (a *AuthenticateAction) Execute(ctx context.Context, depsAny any) error {
 		// Transient errors are silent -- the failurerate.Tracker in RecordAuthError
 		// fires SentryWarn("persistent_auth_failure") if they sustain.
 		if !errType.IsTransient() && deps.GetPersistentAuthErrorCount() == 1 {
-			deps.GetLogger().SentryWarn(depspkg.FeatureCommunicator, deps.GetHierarchyPath(), "authentication_failed",
+			deps.GetLogger().SentryWarn(depspkg.FeatureForWorker(deps.GetWorkerType()), deps.GetHierarchyPath(), "authentication_failed",
 				depspkg.Err(err), depspkg.String("errorType", errType.String()))
 		}
 
@@ -151,7 +151,7 @@ func (a *AuthenticateAction) Execute(ctx context.Context, depsAny any) error {
 		)
 		deps.SetAuthenticatedUUID(authResp.InstanceUUID)
 	} else {
-		logger.SentryWarn(depspkg.FeatureCommunicator, deps.GetHierarchyPath(), "instance_uuid_missing_in_auth_response",
+		logger.SentryWarn(depspkg.FeatureForWorker(deps.GetWorkerType()), deps.GetHierarchyPath(), "instance_uuid_missing_in_auth_response",
 			depspkg.String("instance_name", authResp.InstanceName),
 			depspkg.Bool("has_token", authResp.Token != ""))
 	}

--- a/umh-core/pkg/fsmv2/workers/transport/dependencies.go
+++ b/umh-core/pkg/fsmv2/workers/transport/dependencies.go
@@ -160,7 +160,7 @@ func (d *TransportDependencies) RecordAuthError(errType httpTransport.ErrorType,
 	}
 
 	if d.authFailureRate.RecordOutcome(false) {
-		d.BaseDependencies.GetLogger().SentryWarn(deps.FeatureCommunicator, d.GetHierarchyPath(), "persistent_auth_failure",
+		d.BaseDependencies.GetLogger().SentryWarn(deps.FeatureForWorker(d.GetWorkerType()), d.GetHierarchyPath(), "persistent_auth_failure",
 			deps.String("error_type", errType.String()),
 			deps.Float64("failure_rate", d.authFailureRate.FailureRate()))
 	}

--- a/umh-core/pkg/fsmv2/workers/transport/dependencies.go
+++ b/umh-core/pkg/fsmv2/workers/transport/dependencies.go
@@ -223,7 +223,7 @@ func (d *TransportDependencies) GetOutboundChan() <-chan *communicator_transport
 func (d *TransportDependencies) GetInboundChanStats() (capacity int, length int) {
 	provider := GetChannelProvider()
 	if provider == nil {
-		d.GetLogger().SentryWarn(deps.FeatureCommunicator, d.GetHierarchyPath(), "channel_provider_not_initialized",
+		d.GetLogger().SentryWarn(deps.FeatureForWorker(d.GetWorkerType()), d.GetHierarchyPath(), "channel_provider_not_initialized",
 			deps.WorkerID(d.GetWorkerID()))
 
 		return 0, 0

--- a/umh-core/pkg/fsmv2/workers/transport/pull/action/pull.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/action/pull.go
@@ -74,7 +74,7 @@ func (a *PullAction) Execute(ctx context.Context, depsAny any) error {
 	if len(pending) > 0 {
 		inChan := pullDeps.GetInboundChan()
 		if inChan == nil {
-			pullDeps.GetLogger().SentryWarn(depspkg.FeatureCommunicator, pullDeps.GetHierarchyPath(), "pull_skipped_nil_inbound_chan_pending_delivery")
+			pullDeps.GetLogger().SentryWarn(depspkg.FeatureForWorker(pullDeps.GetWorkerType()), pullDeps.GetHierarchyPath(), "pull_skipped_nil_inbound_chan_pending_delivery")
 			pullDeps.StorePendingMessages(pending)
 
 			return nil
@@ -105,7 +105,7 @@ func (a *PullAction) Execute(ctx context.Context, depsAny any) error {
 	// Phase 2: Backpressure check
 	inChan := pullDeps.GetInboundChan()
 	if inChan == nil {
-		pullDeps.GetLogger().SentryWarn(depspkg.FeatureCommunicator, pullDeps.GetHierarchyPath(), "pull_skipped_nil_inbound_chan")
+		pullDeps.GetLogger().SentryWarn(depspkg.FeatureForWorker(pullDeps.GetWorkerType()), pullDeps.GetHierarchyPath(), "pull_skipped_nil_inbound_chan")
 
 		return nil
 	}
@@ -122,7 +122,7 @@ func (a *PullAction) Execute(ctx context.Context, depsAny any) error {
 	}
 
 	if shouldSkip && !wasBackpressured {
-		pullDeps.GetLogger().SentryWarn(depspkg.FeatureCommunicator, pullDeps.GetHierarchyPath(), "backpressure_entering",
+		pullDeps.GetLogger().SentryWarn(depspkg.FeatureForWorker(pullDeps.GetWorkerType()), pullDeps.GetHierarchyPath(), "backpressure_entering",
 			depspkg.Int("available", available), depspkg.Int("threshold", ExpectedBatchSize))
 		pullDeps.SetBackpressured(true)
 		metrics.SetGauge(depspkg.GaugeBackpressureActive, 1)
@@ -130,7 +130,7 @@ func (a *PullAction) Execute(ctx context.Context, depsAny any) error {
 	}
 
 	if !shouldSkip && wasBackpressured {
-		pullDeps.GetLogger().SentryWarn(depspkg.FeatureCommunicator, pullDeps.GetHierarchyPath(), "backpressure_exiting",
+		pullDeps.GetLogger().SentryWarn(depspkg.FeatureForWorker(pullDeps.GetWorkerType()), pullDeps.GetHierarchyPath(), "backpressure_exiting",
 			depspkg.Int("available", available), depspkg.Int("low_water_mark", ExpectedBatchSize*LowWaterMarkMultiplier))
 		pullDeps.SetBackpressured(false)
 		metrics.SetGauge(depspkg.GaugeBackpressureActive, 0)

--- a/umh-core/pkg/fsmv2/workers/transport/pull/action/pull_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/action/pull_test.go
@@ -113,6 +113,10 @@ func (m *mockPullDeps) GetHierarchyPath() string {
 	return ""
 }
 
+func (m *mockPullDeps) GetWorkerType() string {
+	return "pull"
+}
+
 func (m *mockPullDeps) GetStateReader() deps.StateReader {
 	return nil
 }

--- a/umh-core/pkg/fsmv2/workers/transport/pull/dependencies.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/dependencies.go
@@ -88,7 +88,7 @@ func (d *PullDependencies) RecordTypedError(errType httpTransport.ErrorType, ret
 	d.parentDeps.RecordTypedError(errType, retryAfter)
 
 	if d.failureRate.RecordOutcome(false) {
-		d.BaseDependencies.GetLogger().SentryWarn(deps.FeatureCommunicator, d.GetHierarchyPath(), "persistent_pull_failure",
+		d.BaseDependencies.GetLogger().SentryWarn(deps.FeatureForWorker(d.GetWorkerType()), d.GetHierarchyPath(), "persistent_pull_failure",
 			deps.String("error_type", errType.String()),
 			deps.Float64("failure_rate", d.failureRate.FailureRate()))
 	}
@@ -111,7 +111,7 @@ func (d *PullDependencies) RecordError() {
 	d.RetryTracker().RecordError()
 	d.parentDeps.RecordError()
 	if d.failureRate.RecordOutcome(false) {
-		d.BaseDependencies.GetLogger().SentryWarn(deps.FeatureCommunicator, d.GetHierarchyPath(), "persistent_pull_failure",
+		d.BaseDependencies.GetLogger().SentryWarn(deps.FeatureForWorker(d.GetWorkerType()), d.GetHierarchyPath(), "persistent_pull_failure",
 			deps.Float64("failure_rate", d.failureRate.FailureRate()))
 	}
 }
@@ -141,7 +141,7 @@ func (d *PullDependencies) StorePendingMessages(msgs []*communicator_transport.U
 	if len(d.pendingMessages) > maxPendingMessages {
 		dropped := len(d.pendingMessages) - maxPendingMessages
 		d.pendingMessages = d.pendingMessages[len(d.pendingMessages)-maxPendingMessages:]
-		d.BaseDependencies.GetLogger().SentryWarn(deps.FeatureCommunicator, d.GetHierarchyPath(), "pending_buffer_overflow",
+		d.BaseDependencies.GetLogger().SentryWarn(deps.FeatureForWorker(d.GetWorkerType()), d.GetHierarchyPath(), "pending_buffer_overflow",
 			deps.Int("dropped", dropped), deps.Int("cap", maxPendingMessages))
 		d.MetricsRecorder().IncrementCounter(deps.CounterMessagesDropped, int64(dropped))
 	}

--- a/umh-core/pkg/fsmv2/workers/transport/push/action/push.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/action/push.go
@@ -209,7 +209,7 @@ func (a *PushAction) retryPending(ctx context.Context, t transport.Transport, pu
 				return pending[i:], fmt.Errorf("pending retry failed (recoverable by parent): %w", err)
 			}
 
-			pushDeps.GetLogger().SentryWarn(depspkg.FeatureCommunicator, pushDeps.GetHierarchyPath(), "dropping_poison_message",
+			pushDeps.GetLogger().SentryWarn(depspkg.FeatureForWorker(pushDeps.GetWorkerType()), pushDeps.GetHierarchyPath(), "dropping_poison_message",
 				depspkg.String("errorType", errType.String()),
 				depspkg.Err(err),
 				depspkg.Int("remaining", len(pending)-i-1))

--- a/umh-core/pkg/fsmv2/workers/transport/push/action/push_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/action/push_test.go
@@ -110,6 +110,10 @@ func (m *mockPushDeps) GetHierarchyPath() string {
 	return ""
 }
 
+func (m *mockPushDeps) GetWorkerType() string {
+	return "push"
+}
+
 func (m *mockPushDeps) GetOutboundChan() <-chan *transport.UMHMessage {
 	return m.outboundChan
 }

--- a/umh-core/pkg/fsmv2/workers/transport/push/dependencies.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/dependencies.go
@@ -80,7 +80,7 @@ func (d *PushDependencies) RecordTypedError(errType httpTransport.ErrorType, ret
 	d.parentDeps.RecordTypedError(errType, retryAfter)
 
 	if d.failureRate.RecordOutcome(false) {
-		d.BaseDependencies.GetLogger().SentryWarn(deps.FeatureCommunicator, d.GetHierarchyPath(), "persistent_push_failure",
+		d.BaseDependencies.GetLogger().SentryWarn(deps.FeatureForWorker(d.GetWorkerType()), d.GetHierarchyPath(), "persistent_push_failure",
 			deps.String("error_type", errType.String()),
 			deps.Float64("failure_rate", d.failureRate.FailureRate()))
 	}
@@ -103,7 +103,7 @@ func (d *PushDependencies) RecordError() {
 	d.RetryTracker().RecordError()
 	d.parentDeps.RecordError()
 	if d.failureRate.RecordOutcome(false) {
-		d.BaseDependencies.GetLogger().SentryWarn(deps.FeatureCommunicator, d.GetHierarchyPath(), "persistent_push_failure",
+		d.BaseDependencies.GetLogger().SentryWarn(deps.FeatureForWorker(d.GetWorkerType()), d.GetHierarchyPath(), "persistent_push_failure",
 			deps.Float64("failure_rate", d.failureRate.FailureRate()))
 	}
 }
@@ -130,7 +130,7 @@ func (d *PushDependencies) StorePendingMessages(msgs []*communicator_transport.U
 	if len(d.pendingMessages) > maxPendingMessages {
 		dropped := len(d.pendingMessages) - maxPendingMessages
 		d.pendingMessages = d.pendingMessages[len(d.pendingMessages)-maxPendingMessages:]
-		d.BaseDependencies.GetLogger().SentryWarn(deps.FeatureCommunicator, d.GetHierarchyPath(), "pending_buffer_overflow",
+		d.BaseDependencies.GetLogger().SentryWarn(deps.FeatureForWorker(d.GetWorkerType()), d.GetHierarchyPath(), "pending_buffer_overflow",
 			deps.Int("dropped", dropped), deps.Int("cap", maxPendingMessages))
 		d.MetricsRecorder().IncrementCounter(deps.CounterMessagesDropped, int64(dropped))
 	}


### PR DESCRIPTION
## Problem

Sentry fingerprints group issues by `level + feature + event_name + error_types`. The FSMv2 supervisor tags everything with `feature:fsmv2`, so a pull `action_failed` and a push `action_failed` land in the same Sentry issue. Janik can't get certfetcher alerts auto-assigned because they're all lumped under `fsmv2`.

On top of that, workers like pull and push tag their own `SentryWarn` calls with `FeatureCommunicator` ("communicator"), even though their actual type is "pull" or "push". A single pull worker produces events under two different features depending on whether the supervisor or the worker emitted them.

## Fix

One feature per worker, everywhere. The feature tag now matches the worker type.

`FeatureForWorker(workerType)` auto-generates the feature from the worker's type string. A pull worker's events get `feature:pull`. A push worker gets `feature:push`. A certfetcher gets `feature:certfetcher`. `FeatureCommunicator` and `FeaturePersistence` are deleted.

Supervisor-internal events (tick panics, circuit breakers, child management) stay under `feature:fsmv2` because those are framework bugs, not worker bugs.

This splits fingerprints: a pull `action_failed` and a push `action_failed` now create separate Sentry issues. Old issues stop accumulating once customers upgrade. No migration needed.

## After merge (manual Sentry config)

Add ownership rules in Settings > Projects > umh-core > Ownership Rules:
```
tags.feature:certfetcher {certfetcher-owner-email}
tags.feature:fsmv2 {fsmv2-owner-email}
tags.feature:* {default-owner-email}
```
Specific rules go first. Verify actual emails before configuring.

Closes ENG-4718