### PR TITLE
fix(fs): replace os.ReadFile with fs.ReadFile

### DIFF
--- a/umh-core/pkg/service/container_monitor/cgroup_cpu.go
+++ b/umh-core/pkg/service/container_monitor/cgroup_cpu.go
@@ -117,6 +117,9 @@ func (c *ContainerMonitorService) getCgroupCPUInfo(ctx context.Context) (*CPUCgr
 
 	cpuStatData, err := c.fs.ReadFile(ctx, cpuStatPath)
 	if err != nil {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
 		// cpu.stat might not exist in all environments
 		c.logger.Debugf("Could not read cpu.stat: %v", err)
 

--- a/umh-core/pkg/service/container_monitor/cgroup_cpu.go
+++ b/umh-core/pkg/service/container_monitor/cgroup_cpu.go
@@ -17,7 +17,6 @@ package container_monitor
 import (
 	"context"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 
@@ -99,10 +98,7 @@ func (c *ContainerMonitorService) getCgroupCPUInfo(ctx context.Context) (*CPUCgr
 	// Read cpu.max for quota/period
 	cpuMaxPath := "/sys/fs/cgroup/cpu.max"
 
-	// TODO paralellize with stadnard approach with errgroups both of the ReadFiles
-	// potentially even using the filesystem package for it
-
-	cpuMaxData, err := os.ReadFile(cpuMaxPath)
+	cpuMaxData, err := c.fs.ReadFile(ctx, cpuMaxPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read cpu.max: %w", err)
 	}
@@ -119,7 +115,7 @@ func (c *ContainerMonitorService) getCgroupCPUInfo(ctx context.Context) (*CPUCgr
 	// Read cpu.stat for throttling information
 	cpuStatPath := "/sys/fs/cgroup/cpu.stat"
 
-	cpuStatData, err := os.ReadFile(cpuStatPath)
+	cpuStatData, err := c.fs.ReadFile(ctx, cpuStatPath)
 	if err != nil {
 		// cpu.stat might not exist in all environments
 		c.logger.Debugf("Could not read cpu.stat: %v", err)

--- a/umh-core/pkg/service/container_monitor/cgroup_memory.go
+++ b/umh-core/pkg/service/container_monitor/cgroup_memory.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 )
@@ -76,10 +75,7 @@ func parseMemoryCurrent(data []byte) (currentBytes int64, err error) {
 func (c *ContainerMonitorService) getCgroupMemoryInfo(ctx context.Context) (*MemoryCgroupInfo, error) {
 	info := &MemoryCgroupInfo{}
 
-	// TODO: ENG-4555 - use the filesystem service abstraction (c.fs.ReadFile) instead of os.ReadFile
-	// for proper context propagation and testability (same as cgroup_cpu.go)
-
-	memMaxData, err := os.ReadFile("/sys/fs/cgroup/memory.max")
+	memMaxData, err := c.fs.ReadFile(ctx, "/sys/fs/cgroup/memory.max")
 	if err != nil {
 		return nil, fmt.Errorf("failed to read memory.max: %w", err)
 	}
@@ -92,7 +88,7 @@ func (c *ContainerMonitorService) getCgroupMemoryInfo(ctx context.Context) (*Mem
 	info.LimitBytes = limitBytes
 	info.Unlimited = unlimited
 
-	memCurrentData, err := os.ReadFile("/sys/fs/cgroup/memory.current")
+	memCurrentData, err := c.fs.ReadFile(ctx, "/sys/fs/cgroup/memory.current")
 	if err != nil {
 		return nil, fmt.Errorf("failed to read memory.current: %w", err)
 	}

--- a/umh-core/pkg/service/container_monitor/container_monitor.go
+++ b/umh-core/pkg/service/container_monitor/container_monitor.go
@@ -263,6 +263,9 @@ func (c *ContainerMonitorService) getCPUMetrics(ctx context.Context) (*models.CP
 
 	// Get cgroup info for throttling and limits
 	cgroupInfo, cgroupErr := c.getCgroupCPUInfo(ctx)
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
 
 	// Default to Active health
 	category := models.Active
@@ -380,6 +383,9 @@ func (c *ContainerMonitorService) updateThrottleWindow(cgroupInfo *CPUCgroupInfo
 func (c *ContainerMonitorService) getRawCPUMetrics(ctx context.Context) (usageMCores float64, coreCount int, usagePercent float64, err error) {
 	// Try to get cgroup info first for accurate container limits
 	cgroupInfo, cgroupErr := c.getCgroupCPUInfo(ctx)
+	if ctx.Err() != nil {
+		return 0, 0, 0, ctx.Err()
+	}
 
 	// Get actual CPU usage
 	usagePercentages, err := cpu.PercentWithContext(ctx, 0, false)
@@ -427,6 +433,9 @@ func (c *ContainerMonitorService) getMemoryMetrics(ctx context.Context) (*models
 
 	// Try cgroup values: prefer container-aware limits over host values
 	cgroupInfo, cgroupErr := c.getCgroupMemoryInfo(ctx)
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
 	if cgroupErr == nil {
 		usedBytes = uint64(cgroupInfo.CurrentBytes)
 		if !cgroupInfo.Unlimited && cgroupInfo.LimitBytes > 0 {


### PR DESCRIPTION
# Description

This PR replaces `os.ReadFile` with the existing `filesystem.ReadFile` using a proper context for canellation.

Fixes ENG-4555