### PR TITLE
Eng 4756 separate start and stop for read and write flows

### DIFF
--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Previously, if a read flow had a stale error, a new deployment would always fail, even if the current state is healthy. Now, we first always stop the flow, redeploy it and only check the current state, not any stale states.
+
 ## [0.44.14]
 
 ### Improvements

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter.go
@@ -155,41 +155,29 @@ func (a *EditProtocolConverterAction) Parse(payload interface{}) error {
 	a.protocolConverterUUID = *pcPayload.UUID
 	a.name = pcPayload.Name
 
-	// Determine which DFC(s) are being updated and convert to CDFCPayload.
-	switch {
-	case pcPayload.ReadDFC != nil && pcPayload.WriteDFC != nil:
-		a.dfcType = DFCTypeBoth
+	// Parse each DFC side independently.
+	if pcPayload.ReadDFC != nil {
 		readPayload := dfcToPayload(pcPayload.ReadDFC)
-		writePayload := dfcToPayload(pcPayload.WriteDFC)
 		a.readDFCPayload = &readPayload
-		a.writeDFCPayload = &writePayload
+		a.readDFCState = pcPayload.ReadDFC.State
 		if pcPayload.ReadDFC.IgnoreErrors != nil {
 			a.ignoreHealthCheck = *pcPayload.ReadDFC.IgnoreErrors
 		}
+	}
+	if pcPayload.WriteDFC != nil {
+		writePayload := dfcToPayload(pcPayload.WriteDFC)
+		a.writeDFCPayload = &writePayload
+		a.writeDFCState = pcPayload.WriteDFC.State
 		if pcPayload.WriteDFC.IgnoreErrors != nil {
 			a.ignoreHealthCheck = a.ignoreHealthCheck || *pcPayload.WriteDFC.IgnoreErrors
 		}
-		a.readDFCState = pcPayload.ReadDFC.State
-		a.writeDFCState = pcPayload.WriteDFC.State
-	case pcPayload.ReadDFC != nil:
-		a.dfcType = DFCTypeRead
-		readPayload := dfcToPayload(pcPayload.ReadDFC)
-		a.readDFCPayload = &readPayload
-		if pcPayload.ReadDFC.IgnoreErrors != nil {
-			a.ignoreHealthCheck = *pcPayload.ReadDFC.IgnoreErrors
-		}
-		a.readDFCState = pcPayload.ReadDFC.State
-	case pcPayload.WriteDFC != nil:
-		a.dfcType = DFCTypeWrite
-		writePayload := dfcToPayload(pcPayload.WriteDFC)
-		a.writeDFCPayload = &writePayload
-		if pcPayload.WriteDFC.IgnoreErrors != nil {
-			a.ignoreHealthCheck = *pcPayload.WriteDFC.IgnoreErrors
-		}
-		a.writeDFCState = pcPayload.WriteDFC.State
-	default:
-		a.dfcType = DFCTypeEmpty
 	}
+
+	// Determine dfcType by comparing incoming DFC configs against what is
+	// currently deployed. Only DFCs that actually differ need to be stopped
+	// and restarted.
+	a.dfcType = a.deriveDFCType()
+
 	if pcPayload.TemplateInfo != nil {
 		a.vb = pcPayload.TemplateInfo.Variables
 	} else {
@@ -1157,6 +1145,97 @@ func extractInjectFromRawYAML(rawYAML *models.CommonDataFlowComponentRawYamlConf
 	}
 
 	return rawYAML.Data
+}
+
+// deriveDFCType compares the incoming DFC payloads against the currently
+// deployed config and returns a DFCType that only includes the sides that
+// actually differ. If no config is deployed yet (first edit) or the config
+// cannot be read, it falls back to payload presence.
+func (a *EditProtocolConverterAction) deriveDFCType() DFCType {
+	hasRead := a.readDFCPayload != nil
+	hasWrite := a.writeDFCPayload != nil
+
+	if !hasRead && !hasWrite {
+		return DFCTypeEmpty
+	}
+
+	// Try to fetch the current config for diff comparison.
+	ctx, cancel := context.WithTimeout(context.Background(), constants.ActionTimeout)
+	defer cancel()
+
+	currentConfig, err := a.configManager.GetConfig(ctx, 0)
+	if err != nil {
+		a.actionLogger.Debugf("Cannot read current config for diff, falling back to payload presence: %v", err)
+		return dfcTypeFromPresence(hasRead, hasWrite)
+	}
+
+	// Find the protocol converter in the current config.
+	var currentPC *config.ProtocolConverterConfig
+	for i, pc := range currentConfig.ProtocolConverter {
+		if dataflowcomponentserviceconfig.GenerateUUIDFromName(pc.Name) == a.protocolConverterUUID {
+			currentPC = &currentConfig.ProtocolConverter[i]
+			break
+		}
+	}
+	if currentPC == nil {
+		a.actionLogger.Debugf("Protocol converter %s not found in current config, falling back to payload presence", a.protocolConverterUUID)
+		return dfcTypeFromPresence(hasRead, hasWrite)
+	}
+
+	readChanged := hasRead && a.dfcPayloadDiffers(*a.readDFCPayload, a.readDFCState,
+		currentPC.ProtocolConverterServiceConfig.Config.DataflowComponentReadServiceConfig,
+		currentPC.ProtocolConverterServiceConfig.ReadDFCDesiredState)
+	writeChanged := hasWrite && a.dfcPayloadDiffers(*a.writeDFCPayload, a.writeDFCState,
+		currentPC.ProtocolConverterServiceConfig.Config.DataflowComponentWriteServiceConfig,
+		currentPC.ProtocolConverterServiceConfig.WriteDFCDesiredState)
+
+	derived := dfcTypeFromPresence(readChanged, writeChanged)
+	a.actionLogger.Debugf("Derived dfcType=%s (readChanged=%v, writeChanged=%v)", derived, readChanged, writeChanged)
+
+	return derived
+}
+
+// dfcPayloadDiffers checks whether an incoming DFC payload differs from the
+// persisted config in config.yaml. This is intentionally simpler than
+// compareSingleDFCConfig, which compares rendered templates against runtime
+// observed state from the FSM snapshot. Here we only need to know whether the
+// user sent something new relative to what is already on disk.
+func (a *EditProtocolConverterAction) dfcPayloadDiffers(
+	payload models.CDFCPayload,
+	incomingState string,
+	deployedConfig dataflowcomponentserviceconfig.DataflowComponentServiceConfig,
+	deployedState string,
+) bool {
+	// State change counts as a diff.
+	if incomingState != "" && incomingState != deployedState {
+		return true
+	}
+
+	incomingBenthos, err := CreateBenthosConfigFromCDFCPayload(payload, a.name)
+	if err != nil {
+		a.actionLogger.Debugf("Cannot build benthos config for diff, treating as changed: %v", err)
+		return true
+	}
+
+	incomingDFCConfig := dataflowcomponentserviceconfig.DataflowComponentServiceConfig{
+		BenthosConfig: incomingBenthos,
+	}
+
+	return !deployedConfig.Equal(incomingDFCConfig)
+}
+
+// dfcTypeFromPresence returns a DFCType based on boolean flags for read/write.
+func dfcTypeFromPresence(read, write bool) DFCType {
+	switch {
+	case read && write:
+		return DFCTypeBoth
+	case read:
+		return DFCTypeRead
+	case write:
+		return DFCTypeWrite
+	default:
+		return DFCTypeEmpty
+	}
 }
 
 // getUserEmail implements the Action interface by returning the user email associated with this action.

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter.go
@@ -47,6 +47,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/protocolconverterserviceconfig"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/dataflowcomponent"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/protocolconverter"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/logger"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/models"
@@ -299,14 +300,43 @@ func (a *EditProtocolConverterAction) Execute() (interface{}, map[string]interfa
 	// Store the atomic edit UUID for use in rollback operations
 	a.atomicEditUUID = atomicEditUUID
 
-	// Persist the configuration changes
-	oldConfig, err := a.persistConfig(atomicEditUUID, newSpec)
-	if err != nil {
-		errorMsg := fmt.Sprintf("Failed to persist configuration changes: %v", err)
-		SendActionReply(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedWithFailure,
-			errorMsg, a.outboundChannel, models.EditProtocolConverter)
+	var oldConfig config.ProtocolConverterConfig
 
-		return nil, nil, fmt.Errorf("%s", errorMsg)
+	// For DFC modifications, stop the affected DFCs first to ensure a clean redeployment.
+	// This prevents stale errors from a previously degraded DFC from blocking the new deployment.
+	if a.dfcType != DFCTypeEmpty && a.systemSnapshotManager != nil && !a.ignoreHealthCheck {
+		var stopErr error
+		oldConfig, stopErr = a.stopAndAwaitDFCs(atomicEditUUID, newSpec)
+		if stopErr != nil {
+			errorMsg := fmt.Sprintf("Failed to stop DFCs before edit: %v", stopErr)
+			SendActionReply(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedWithFailure,
+				errorMsg, a.outboundChannel, models.EditProtocolConverter)
+
+			return nil, nil, fmt.Errorf("%s", errorMsg)
+		}
+
+		// Persist the actual new config (DFCs will start fresh from stopped state)
+		persistCtx, persistCancel := context.WithTimeout(context.Background(), constants.ActionTimeout)
+		defer persistCancel()
+
+		_, err = a.configManager.AtomicEditProtocolConverter(persistCtx, atomicEditUUID, newSpec)
+		if err != nil {
+			errorMsg := fmt.Sprintf("Failed to persist new configuration: %v", err)
+			SendActionReply(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedWithFailure,
+				errorMsg, a.outboundChannel, models.EditProtocolConverter)
+
+			return nil, nil, fmt.Errorf("%s", errorMsg)
+		}
+	} else {
+		// No DFC changes or no health check — just persist directly
+		oldConfig, err = a.persistConfig(atomicEditUUID, newSpec)
+		if err != nil {
+			errorMsg := fmt.Sprintf("Failed to persist configuration changes: %v", err)
+			SendActionReply(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedWithFailure,
+				errorMsg, a.outboundChannel, models.EditProtocolConverter)
+
+			return nil, nil, fmt.Errorf("%s", errorMsg)
+		}
 	}
 
 	// Await rollout and perform health checks
@@ -516,6 +546,89 @@ func (a *EditProtocolConverterAction) persistConfig(atomicEditUUID uuid.UUID, ne
 	return oldConfig, nil
 }
 
+// stopAndAwaitDFCs stops the affected DFCs before applying a new configuration.
+// This ensures a clean redeployment: any previously degraded DFC is stopped first,
+// then started fresh with the new config, avoiding stale errors blocking progress.
+// Returns the original (pre-edit) config for rollback purposes.
+func (a *EditProtocolConverterAction) stopAndAwaitDFCs(atomicEditUUID uuid.UUID, newSpec config.ProtocolConverterConfig) (config.ProtocolConverterConfig, error) {
+	// Build a stop variant: same new config but affected DFCs set to stopped.
+	stopSpec := newSpec
+	switch a.dfcType {
+	case DFCTypeRead:
+		stopSpec.ProtocolConverterServiceConfig.ReadDFCDesiredState = dataflowcomponent.OperationalStateStopped
+	case DFCTypeWrite:
+		stopSpec.ProtocolConverterServiceConfig.WriteDFCDesiredState = dataflowcomponent.OperationalStateStopped
+	case DFCTypeBoth:
+		stopSpec.ProtocolConverterServiceConfig.ReadDFCDesiredState = dataflowcomponent.OperationalStateStopped
+		stopSpec.ProtocolConverterServiceConfig.WriteDFCDesiredState = dataflowcomponent.OperationalStateStopped
+	}
+
+	oldConfig, err := a.persistConfig(atomicEditUUID, stopSpec)
+	if err != nil {
+		return config.ProtocolConverterConfig{}, fmt.Errorf("failed to persist stop config: %w", err)
+	}
+
+	SendActionReply(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionExecuting,
+		"Stopping affected data flow components for clean redeployment...",
+		a.outboundChannel, models.EditProtocolConverter)
+
+	ticker := time.NewTicker(constants.ActionTickerTime)
+	defer ticker.Stop()
+
+	// Use half the normal timeout for the stop phase, leaving enough time for the start phase.
+	timeout := time.After(constants.DataflowComponentWaitForActiveTimeout / 2)
+
+	for {
+		select {
+		case <-timeout:
+			a.actionLogger.Warnf("timeout waiting for DFCs to stop, continuing with deployment")
+
+			return oldConfig, nil
+		case <-ticker.C:
+			systemSnapshot := a.systemSnapshotManager.GetDeepCopySnapshot()
+
+			pcManager, exists := systemSnapshot.Managers[constants.ProtocolConverterManagerName]
+			if !exists {
+				continue
+			}
+
+			for _, instance := range pcManager.GetInstances() {
+				if instance.ID != a.name {
+					continue
+				}
+
+				pcSnapshot, ok := instance.LastObservedState.(*protocolconverter.ProtocolConverterObservedStateSnapshot)
+				if !ok {
+					continue
+				}
+
+				readStopped := true
+				writeStopped := true
+
+				if a.dfcType == DFCTypeRead || a.dfcType == DFCTypeBoth {
+					readStopped = pcSnapshot.ServiceInfo.DataflowComponentReadFSMState == dataflowcomponent.OperationalStateStopped
+				}
+
+				if a.dfcType == DFCTypeWrite || a.dfcType == DFCTypeBoth {
+					writeStopped = pcSnapshot.ServiceInfo.DataflowComponentWriteFSMState == dataflowcomponent.OperationalStateStopped
+				}
+
+				if readStopped && writeStopped {
+					a.actionLogger.Infof("DFCs stopped successfully, proceeding with new config")
+
+					return oldConfig, nil
+				}
+
+				SendActionReply(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionExecuting,
+					fmt.Sprintf("Waiting for DFCs to stop (read: %s, write: %s)...",
+						pcSnapshot.ServiceInfo.DataflowComponentReadFSMState,
+						pcSnapshot.ServiceInfo.DataflowComponentWriteFSMState),
+					a.outboundChannel, models.EditProtocolConverter)
+			}
+		}
+	}
+}
+
 // awaitRollout waits for the protocol converter to reach the desired state and performs health checks.
 // Returns error code and error message for proper error handling in the caller.
 //
@@ -652,6 +765,7 @@ func (a *EditProtocolConverterAction) awaitRollout(pcConfig config.ProtocolConve
 
 					switch desiredPCState {
 					case protocolconverter.OperationalStateActive:
+
 						hasReachedDesiredState = slices.Contains(
 							[]string{
 								protocolconverter.OperationalStateActive,
@@ -747,8 +861,10 @@ func (a *EditProtocolConverterAction) awaitRollout(pcConfig config.ProtocolConve
 				// For "stopped" state: accept only "stopped"
 				hasReachedDesiredState := false
 
+				a.actionLogger.Errorf("desiredPCState empty: %s, currentState empty: %s", desiredPCState, instance.CurrentState)
 				switch desiredPCState {
 				case protocolconverter.OperationalStateActive:
+
 					hasReachedDesiredState = slices.Contains(
 						[]string{
 							protocolconverter.OperationalStateActive,
@@ -790,6 +906,7 @@ func (a *EditProtocolConverterAction) awaitRollout(pcConfig config.ProtocolConve
 
 				// send the benthos logs to the user; for DFCTypeBoth, prefer write logs since
 				// read logs are also included below via the merged slice.
+
 				switch a.dfcType {
 				case DFCTypeWrite, DFCTypeBoth:
 					logs = pcSnapshot.ServiceInfo.DataflowComponentWriteObservedState.ServiceInfo.BenthosObservedState.ServiceInfo.BenthosStatus.BenthosLogs
@@ -800,6 +917,7 @@ func (a *EditProtocolConverterAction) awaitRollout(pcConfig config.ProtocolConve
 				// only send the logs that have not been sent yet
 				if len(logs) > len(lastLogs) {
 					lastLogs = SendLimitedLogs(logs, lastLogs, a.instanceUUID, a.userEmail, a.actionUUID, a.outboundChannel, models.EditProtocolConverter, remainingSeconds)
+
 				}
 
 				// CheckBenthosLogLinesForConfigErrors is used to detect fatal configuration errors that would cause
@@ -1107,4 +1225,3 @@ func validateProtocolConverterDFC(dfc *models.ProtocolConverterDFC, label string
 	}
 	return nil
 }
-

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter.go
@@ -849,7 +849,6 @@ func (a *EditProtocolConverterAction) awaitRollout(pcConfig config.ProtocolConve
 				// For "stopped" state: accept only "stopped"
 				hasReachedDesiredState := false
 
-				a.actionLogger.Errorf("desiredPCState empty: %s, currentState empty: %s", desiredPCState, instance.CurrentState)
 				switch desiredPCState {
 				case protocolconverter.OperationalStateActive:
 

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter.go
@@ -1181,6 +1181,17 @@ func (a *EditProtocolConverterAction) deriveDFCType() DFCType {
 		return dfcTypeFromPresence(hasRead, hasWrite)
 	}
 
+	// Connection IP/PORT changes affect all DFCs since they use {{ .IP }}/{{ .PORT }} templates.
+	// So if a change is detected, all present DFCs need redeploy.
+	deployedVars := currentPC.ProtocolConverterServiceConfig.Variables.User
+	connectionChanged := fmt.Sprint(deployedVars["IP"]) != a.connectionIP ||
+		fmt.Sprint(deployedVars["PORT"]) != a.connectionPort
+	if connectionChanged {
+		a.actionLogger.Debugf("Connection changed (IP or PORT), all present DFCs need redeploy")
+		return dfcTypeFromPresence(hasRead, hasWrite)
+	}
+
+	// Check if read or write payload is different from the deployed config.
 	readChanged := hasRead && a.dfcPayloadDiffers(*a.readDFCPayload, a.readDFCState,
 		currentPC.ProtocolConverterServiceConfig.Config.DataflowComponentReadServiceConfig,
 		currentPC.ProtocolConverterServiceConfig.ReadDFCDesiredState)

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter.go
@@ -47,7 +47,6 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/protocolconverterserviceconfig"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/dataflowcomponent"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/protocolconverter"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/logger"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/models"
@@ -288,43 +287,13 @@ func (a *EditProtocolConverterAction) Execute() (interface{}, map[string]interfa
 	// Store the atomic edit UUID for use in rollback operations
 	a.atomicEditUUID = atomicEditUUID
 
-	var oldConfig config.ProtocolConverterConfig
+	oldConfig, err := a.persistConfig(atomicEditUUID, newSpec)
+	if err != nil {
+		errorMsg := fmt.Sprintf("Failed to persist configuration changes: %v", err)
+		SendActionReply(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedWithFailure,
+			errorMsg, a.outboundChannel, models.EditProtocolConverter)
 
-	// For DFC modifications, stop the affected DFCs first to ensure a clean redeployment.
-	// This prevents stale errors from a previously degraded DFC from blocking the new deployment.
-	if a.dfcType != DFCTypeEmpty && a.systemSnapshotManager != nil && !a.ignoreHealthCheck {
-		var stopErr error
-		oldConfig, stopErr = a.stopAndAwaitDFCs(atomicEditUUID, newSpec)
-		if stopErr != nil {
-			errorMsg := fmt.Sprintf("Failed to stop DFCs before edit: %v", stopErr)
-			SendActionReply(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedWithFailure,
-				errorMsg, a.outboundChannel, models.EditProtocolConverter)
-
-			return nil, nil, fmt.Errorf("%s", errorMsg)
-		}
-
-		// Persist the actual new config (DFCs will start fresh from stopped state)
-		persistCtx, persistCancel := context.WithTimeout(context.Background(), constants.ActionTimeout)
-		defer persistCancel()
-
-		_, err = a.configManager.AtomicEditProtocolConverter(persistCtx, atomicEditUUID, newSpec)
-		if err != nil {
-			errorMsg := fmt.Sprintf("Failed to persist new configuration: %v", err)
-			SendActionReply(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedWithFailure,
-				errorMsg, a.outboundChannel, models.EditProtocolConverter)
-
-			return nil, nil, fmt.Errorf("%s", errorMsg)
-		}
-	} else {
-		// No DFC changes or no health check — just persist directly
-		oldConfig, err = a.persistConfig(atomicEditUUID, newSpec)
-		if err != nil {
-			errorMsg := fmt.Sprintf("Failed to persist configuration changes: %v", err)
-			SendActionReply(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedWithFailure,
-				errorMsg, a.outboundChannel, models.EditProtocolConverter)
-
-			return nil, nil, fmt.Errorf("%s", errorMsg)
-		}
+		return nil, nil, fmt.Errorf("%s", errorMsg)
 	}
 
 	// Await rollout and perform health checks
@@ -532,89 +501,6 @@ func (a *EditProtocolConverterAction) persistConfig(atomicEditUUID uuid.UUID, ne
 	}
 
 	return oldConfig, nil
-}
-
-// stopAndAwaitDFCs stops the affected DFCs before applying a new configuration.
-// This ensures a clean redeployment: any previously degraded DFC is stopped first,
-// then started fresh with the new config, avoiding stale errors blocking progress.
-// Returns the original (pre-edit) config for rollback purposes.
-func (a *EditProtocolConverterAction) stopAndAwaitDFCs(atomicEditUUID uuid.UUID, newSpec config.ProtocolConverterConfig) (config.ProtocolConverterConfig, error) {
-	// Build a stop variant: same new config but affected DFCs set to stopped.
-	stopSpec := newSpec
-	switch a.dfcType {
-	case DFCTypeRead:
-		stopSpec.ProtocolConverterServiceConfig.ReadDFCDesiredState = dataflowcomponent.OperationalStateStopped
-	case DFCTypeWrite:
-		stopSpec.ProtocolConverterServiceConfig.WriteDFCDesiredState = dataflowcomponent.OperationalStateStopped
-	case DFCTypeBoth:
-		stopSpec.ProtocolConverterServiceConfig.ReadDFCDesiredState = dataflowcomponent.OperationalStateStopped
-		stopSpec.ProtocolConverterServiceConfig.WriteDFCDesiredState = dataflowcomponent.OperationalStateStopped
-	}
-
-	oldConfig, err := a.persistConfig(atomicEditUUID, stopSpec)
-	if err != nil {
-		return config.ProtocolConverterConfig{}, fmt.Errorf("failed to persist stop config: %w", err)
-	}
-
-	SendActionReply(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionExecuting,
-		"Stopping affected data flow components for clean redeployment...",
-		a.outboundChannel, models.EditProtocolConverter)
-
-	ticker := time.NewTicker(constants.ActionTickerTime)
-	defer ticker.Stop()
-
-	// Use half the normal timeout for the stop phase, leaving enough time for the start phase.
-	timeout := time.After(constants.DataflowComponentWaitForActiveTimeout / 2)
-
-	for {
-		select {
-		case <-timeout:
-			a.actionLogger.Warnf("timeout waiting for DFCs to stop, continuing with deployment")
-
-			return oldConfig, nil
-		case <-ticker.C:
-			systemSnapshot := a.systemSnapshotManager.GetDeepCopySnapshot()
-
-			pcManager, exists := systemSnapshot.Managers[constants.ProtocolConverterManagerName]
-			if !exists {
-				continue
-			}
-
-			for _, instance := range pcManager.GetInstances() {
-				if instance.ID != a.name {
-					continue
-				}
-
-				pcSnapshot, ok := instance.LastObservedState.(*protocolconverter.ProtocolConverterObservedStateSnapshot)
-				if !ok {
-					continue
-				}
-
-				readStopped := true
-				writeStopped := true
-
-				if a.dfcType == DFCTypeRead || a.dfcType == DFCTypeBoth {
-					readStopped = pcSnapshot.ServiceInfo.DataflowComponentReadFSMState == dataflowcomponent.OperationalStateStopped
-				}
-
-				if a.dfcType == DFCTypeWrite || a.dfcType == DFCTypeBoth {
-					writeStopped = pcSnapshot.ServiceInfo.DataflowComponentWriteFSMState == dataflowcomponent.OperationalStateStopped
-				}
-
-				if readStopped && writeStopped {
-					a.actionLogger.Infof("DFCs stopped successfully, proceeding with new config")
-
-					return oldConfig, nil
-				}
-
-				SendActionReply(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionExecuting,
-					fmt.Sprintf("Waiting for DFCs to stop (read: %s, write: %s)...",
-						pcSnapshot.ServiceInfo.DataflowComponentReadFSMState,
-						pcSnapshot.ServiceInfo.DataflowComponentWriteFSMState),
-					a.outboundChannel, models.EditProtocolConverter)
-			}
-		}
-	}
 }
 
 // awaitRollout waits for the protocol converter to reach the desired state and performs health checks.

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter.go
@@ -173,8 +173,7 @@ func (a *EditProtocolConverterAction) Parse(payload interface{}) error {
 	}
 
 	// Determine dfcType by comparing incoming DFC configs against what is
-	// currently deployed. Only DFCs that actually differ need to be stopped
-	// and restarted.
+	// currently deployed. Only DFCs that actually differ need redeployment.
 	a.dfcType = a.deriveDFCType()
 
 	if pcPayload.TemplateInfo != nil {
@@ -1069,9 +1068,15 @@ func (a *EditProtocolConverterAction) deriveDFCType() DFCType {
 
 	// Connection IP/PORT changes affect all DFCs since they use {{ .IP }}/{{ .PORT }} templates.
 	// So if a change is detected, all present DFCs need redeploy.
+	// Use comma-ok map lookups: if IP/PORT keys are absent (e.g. PCs created
+	// before these variables were standard), skip the connection-change check
+	// rather than treating it as changed. Without this, fmt.Sprint(nil) returns
+	// "<nil>" which never equals any real value, forcing a spurious redeploy.
 	deployedVars := currentPC.ProtocolConverterServiceConfig.Variables.User
-	connectionChanged := fmt.Sprint(deployedVars["IP"]) != a.connectionIP ||
-		fmt.Sprint(deployedVars["PORT"]) != a.connectionPort
+	deployedIP, ipOk := deployedVars["IP"]
+	deployedPort, portOk := deployedVars["PORT"]
+	connectionChanged := ipOk && portOk &&
+		(fmt.Sprint(deployedIP) != a.connectionIP || fmt.Sprint(deployedPort) != a.connectionPort)
 	if connectionChanged {
 		a.actionLogger.Debugf("Connection changed (IP or PORT), all present DFCs need redeploy")
 		return dfcTypeFromPresence(hasRead, hasWrite)

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter.go
@@ -1107,8 +1107,12 @@ func (a *EditProtocolConverterAction) dfcPayloadDiffers(
 	deployedConfig dataflowcomponentserviceconfig.DataflowComponentServiceConfig,
 	deployedState string,
 ) bool {
-	// State change counts as a diff.
-	if incomingState != "" && incomingState != deployedState {
+	// State change counts as a diff, but only when both sides are populated.
+	// On freshly upgraded systems the deployed config may not have the
+	// ReadDFCDesiredState/WriteDFCDesiredState fields yet (they unmarshal to "").
+	// Treating "" != "active" as a diff would force an unnecessary redeploy
+	// on every first edit after upgrade.
+	if incomingState != "" && deployedState != "" && incomingState != deployedState {
 		return true
 	}
 

--- a/umh-core/pkg/fsm/benthos/actions.go
+++ b/umh-core/pkg/fsm/benthos/actions.go
@@ -787,19 +787,21 @@ func (b *BenthosInstance) IsBenthosMetricsErrorFree() (bool, string) {
 //	degraded – true when degraded, false when still healthy.
 //	reason   – empty when degraded is false; otherwise the first failure cause.
 func (b *BenthosInstance) IsBenthosDegraded(currentTime time.Time, logWindow time.Duration, currentTick uint64) (bool, string) {
-	// Same order as during starting phase
 	running, reason := b.IsBenthosS6Running()
 	if !running {
 		return true, reason
 	}
 
-	loaded, reason := b.IsBenthosConfigLoaded()
-	if !loaded {
-		return true, reason
-	}
-
-	logsFine, reason := b.IsBenthosLogsFine(currentTime, logWindow)
-	if !logsFine {
+	// Use the same validation as the starting path
+	// (IsBenthosRunningForSomeTimeWithoutErrors) instead of the weaker
+	// IsBenthosConfigLoaded + IsBenthosLogsFine combination.  This ensures
+	// that after a process restart (e.g. config change while degraded) the
+	// full 10-second uptime + clean-logs + clean-metrics check must pass
+	// before recovery, matching the starting_waiting_for_service_to_remain_running
+	// gate.  Without this the degraded → idle transition fires at ~5 s,
+	// skipping error detection for the new config.
+	stableRun, reason := b.IsBenthosRunningForSomeTimeWithoutErrors(currentTime, logWindow)
+	if !stableRun {
 		return true, reason
 	}
 

--- a/umh-core/pkg/fsm/benthos/actions.go
+++ b/umh-core/pkg/fsm/benthos/actions.go
@@ -744,6 +744,16 @@ func (b *BenthosInstance) IsBenthosRunningForSomeTimeWithoutErrors(currentTime t
 //	ok     – true when logs look clean, false otherwise.
 //	reason – empty when ok is true; otherwise the first offending log line.
 func (b *BenthosInstance) IsBenthosLogsFine(currentTime time.Time, logWindow time.Duration) (bool, string) {
+	// Cap the log window to the current process uptime so that errors from a
+	// previous process instance (before a stop/start or config-change restart)
+	// are ignored. When uptime is 0 (process not yet running or just started),
+	// the window becomes 0 and no historical logs are considered.
+	currentUptime := b.ObservedState.ServiceInfo.S6ObservedState.ServiceInfo.Uptime
+	uptimeDuration := time.Duration(currentUptime) * time.Second
+	if uptimeDuration < logWindow {
+		logWindow = uptimeDuration
+	}
+
 	logsFine, logEntry := b.service.IsLogsFine(b.ObservedState.ServiceInfo.BenthosStatus.BenthosLogs, currentTime, logWindow)
 	if !logsFine {
 		timeUntilClear := logEntry.Timestamp.Add(logWindow).Sub(currentTime)


### PR DESCRIPTION
This PR does two things
- Only find the relevant DFC type (read or write) to be acted upon, when an `edit` action comes in. It compares the sent payload for both read and write to the `config.yaml` and checks, if an action is necessary. It then propagates this info via `DFCWrite`, `DFCRead`, `DFCBoth` or `DFCEmpty`
- Before editing/re-redploying a DFC (read or write), it first stops the the running flow. Afterwards it tries to start it as as usual, but it now correctly only reads inspects the logs from the the most recent deployment. This fixes the problem, where stale errors from a previous deployment would contaminate the new redeployment.