### PR TITLE
fix(sentry): strip v prefix from release name for semver detection (ENG-4763)

### DIFF
--- a/umh-core/Makefile
+++ b/umh-core/Makefile
@@ -80,7 +80,7 @@ MEMORY = 4096m
 CPUS = 2
 
 # Determine version based on git
-VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "0.0.0-dev")
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "v0.0.0-dev")
 
 install:
 	sudo chown vscode:vscode data || true

--- a/umh-core/pkg/constants/sentry.go
+++ b/umh-core/pkg/constants/sentry.go
@@ -14,12 +14,12 @@
 
 package constants
 
-const SentryTestVersion = "0.0.0-test"
-const DefaultAppVersion = "0.0.0-dev"
+const SentryTestVersion = "v0.0.0-test"
+const DefaultAppVersion = "v0.0.0-dev"
 const DefaultDevelopmentEnvironment = "development"
 const DefaultProductionEnvironment = "production"
 
 // IntegrationTestVersion enables Sentry in FSMv2 integration tests
 // with a distinct environment tag for filtering.
-const IntegrationTestVersion = "0.0.0-integration"
+const IntegrationTestVersion = "v0.0.0-integration"
 const IntegrationTestEnvironment = "integration-test"

--- a/umh-core/pkg/sentry/sentry.go
+++ b/umh-core/pkg/sentry/sentry.go
@@ -63,7 +63,7 @@ func InitSentry(appVersion string, debounceErrors bool) {
 		// management.umh.app is not working anymore, so we use the direct DSN
 		Dsn:           "https://1e1f51c30e576ff39d2445e76dc89da7@o4507265932394496.ingest.de.sentry.io/4509039283798097",
 		Environment:   environment,
-		Release:       "umhcore@" + appVersion,
+		Release:       "umhcore@" + strings.TrimPrefix(appVersion, "v"),
 		EnableTracing: false, // no need for tracing, it doesnt work anyway
 	})
 	if err != nil {

--- a/umh-core/pkg/version/version.go
+++ b/umh-core/pkg/version/version.go
@@ -24,6 +24,8 @@ import (
 var AppVersion = constants.DefaultAppVersion
 
 // GetAppVersion returns the current application version string.
+// The returned value is always v-prefixed (e.g., "v0.2.9", "v0.2.10-pre.1").
+// In local development builds, it defaults to "v0.0.0-dev".
 func GetAppVersion() string {
 	return AppVersion
 }


### PR DESCRIPTION
## Summary

Sentry kept reopening issues we'd already fixed. Turns out it never recognized our version numbers as semver.

## What happened

On March 19, I marked UMH-CORE-23V (DNS pull failure) as "Resolved in Next Release" after the ENG-4450 fix stack shipped in v0.44.12. A week later, an event from a v0.44.8 instance rolled in and Sentry marked the issue as regressed. v0.44.8 is clearly older than v0.44.11 (the version at resolution time), so Sentry should have ignored it.

It didn't, because Sentry never parsed our releases as semver in the first place. Our releases are formatted `umhcore@v0.44.12`, but Sentry requires `package@MAJOR.MINOR.PATCH` with no `v` prefix ([docs](https://sentry.zendesk.com/hc/en-us/articles/39401527753499)). Without semver, it falls back to date-based ordering, which is a [known source of false regressions](https://github.com/getsentry/sentry/issues/89191).

Every "Resolved in Next Release" we've used has been running on broken ordering.

## Fix

One line in `sentry.go`:

```go
Release: "umhcore@" + strings.TrimPrefix(appVersion, "v"),
```

Git tags stay `v0.44.12`. MC backend version reporting is unaffected (uses `GetAppVersion()` directly). The `semver.NewVersion()` call for environment detection already handles the `v` prefix via regex.

## Test plan

- [x] `go vet` and `go test ./pkg/sentry/...` pass
- [ ] After deploy: verify Sentry UI detects releases as semver
- [ ] Re-resolve UMH-CORE-23V, confirm old-instance events don't trigger false regression

Closes ENG-4763