### PR TITLE
fix: drain outbound channel during pending retry to prevent starvation (ENG-4741)

### DIFF
--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Previously, a Flow only exposed a single health and throughput metric. Starting with this version, umh-core exposes separate throughput metrics and health status for read and write flows.
 
+### Preview: FSMv2 Communicator
+
+- Previously, healthy instances could appear offline in Management Console when earlier status messages failed to send. New status messages now continue to reach Management Console while previous ones are being retried. Only affects instances with `USE_FSMV2_TRANSPORT=true`
+
 ## [0.44.15]
 
 Fix issue when redeploying a bridge.

--- a/umh-core/pkg/fsmv2/workers/transport/push/action/push.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/action/push.go
@@ -210,6 +210,7 @@ func (a *PushAction) retryPending(ctx context.Context, t transport.Transport, pu
 		default:
 		}
 
+		pushStart := time.Now()
 		if err := t.Push(ctx, jwtToken, []*transport.UMHMessage{msg}); err != nil {
 			errType, retryAfter := httpTransport.ExtractErrorType(err)
 			pushDeps.RecordTypedError(errType, retryAfter)
@@ -229,10 +230,18 @@ func (a *PushAction) retryPending(ctx context.Context, t transport.Transport, pu
 				return pending[i:], fmt.Errorf("pending retry failed (recoverable by parent): %w", err)
 			}
 
-			// Poison drop. Includes ErrorTypeUnknown — non-classifiable
-			// errors are dropped rather than retried indefinitely so a
-			// truly broken message cannot block the retry queue. Visible
-			// via SentryWarn + CounterMessagesDropped.
+			// Architecture decision: drop poison messages instead of retrying.
+			//
+			// ErrorTypeUnknown (unclassifiable) and ErrorTypeInstanceDeleted
+			// (terminal) reach this branch. There is no per-message retry
+			// counter in the system — preserving these would retry every tick
+			// until transport reset (5 consecutive errors) wipes the entire
+			// pending buffer, losing all messages instead of just the bad one.
+			//
+			// If ExtractErrorType misses a new infrastructure error, the fix
+			// is adding the type to IsTransient() or isRecoverableByParent(),
+			// not retrying unknowns here. SentryWarn fires on every drop so
+			// a spike is visible in Sentry.
 			pushDeps.GetLogger().SentryWarn(depspkg.FeatureForWorker(pushDeps.GetWorkerType()), pushDeps.GetHierarchyPath(), "dropping_poison_message",
 				depspkg.String("errorType", errType.String()),
 				depspkg.Err(err),
@@ -242,10 +251,13 @@ func (a *PushAction) retryPending(ctx context.Context, t transport.Transport, pu
 			continue
 		}
 
+		pushLatency := time.Since(pushStart)
 		pushDeps.RecordSuccess()
 		metrics.IncrementCounter(depspkg.CounterPushOps, 1)
 		metrics.IncrementCounter(depspkg.CounterPushSuccess, 1)
 		metrics.IncrementCounter(depspkg.CounterMessagesPushed, 1)
+		metrics.IncrementCounter(depspkg.CounterBytesPushed, int64(len(msg.InstanceUUID)+len(msg.Content)+len(msg.Email)))
+		metrics.SetGauge(depspkg.GaugeLastPushLatencyMs, float64(pushLatency.Milliseconds()))
 	}
 
 	return nil, nil

--- a/umh-core/pkg/fsmv2/workers/transport/push/action/push.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/action/push.go
@@ -73,7 +73,13 @@ func (a *PushAction) Execute(ctx context.Context, depsAny any) error {
 
 		metrics.SetGauge(depspkg.GaugePendingMessages, float64(pushDeps.PendingMessageCount()))
 
-		return err
+		if err != nil || len(remaining) > 0 {
+			if ctx.Err() == nil {
+				a.drainChannelToPending(pushDeps, metrics)
+			}
+
+			return err
+		}
 	}
 
 	// Phase 2: Drain and batch-push new messages
@@ -182,7 +188,11 @@ func (a *PushAction) retryPending(ctx context.Context, t transport.Transport, pu
 	authenticatedUUID := pushDeps.GetAuthenticatedUUID()
 
 	for i, msg := range pending {
-		if msg != nil && authenticatedUUID != "" {
+		if msg == nil {
+			continue // protects t.Push below from nil dereference
+		}
+
+		if authenticatedUUID != "" {
 			msg.InstanceUUID = authenticatedUUID
 		}
 
@@ -225,6 +235,41 @@ func (a *PushAction) retryPending(ctx context.Context, t transport.Transport, pu
 	}
 
 	return nil, nil
+}
+
+// drainChannelToPending exists to prevent outbound channel overflow when
+// pending retry cannot make progress.
+//
+// Example: MC is unreachable. Every tick, retryPending returns a transient
+// error and Phase 2 never runs. New status messages keep arriving on the
+// outbound channel. Without this rescue, the channel fills to capacity,
+// subscribers drop messages, and MC shows the instance as offline even
+// though it is healthy (ENG-4741).
+func (a *PushAction) drainChannelToPending(pushDeps snapshot.PushDependencies, metrics *depspkg.MetricsRecorder) {
+	outChan := pushDeps.GetOutboundChan()
+
+	var drained []*transport.UMHMessage
+
+drainLoop:
+	for {
+		select {
+		case msg, ok := <-outChan:
+			if !ok {
+				break drainLoop
+			}
+
+			if msg != nil {
+				drained = append(drained, msg)
+			}
+		default:
+			break drainLoop
+		}
+	}
+
+	if len(drained) > 0 {
+		pushDeps.StorePendingMessages(drained)
+		metrics.SetGauge(depspkg.GaugePendingMessages, float64(pushDeps.PendingMessageCount()))
+	}
 }
 
 // isRecoverableByParent returns true for persistent error types where the

--- a/umh-core/pkg/fsmv2/workers/transport/push/action/push.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/action/push.go
@@ -212,11 +212,13 @@ func (a *PushAction) retryPending(ctx context.Context, t transport.Transport, pu
 
 		pushStart := time.Now()
 		if err := t.Push(ctx, jwtToken, []*transport.UMHMessage{msg}); err != nil {
+			pushLatency := time.Since(pushStart)
 			errType, retryAfter := httpTransport.ExtractErrorType(err)
 			pushDeps.RecordTypedError(errType, retryAfter)
 			metrics.IncrementCounter(httpTransport.CounterForErrorType(errType), 1)
 			metrics.IncrementCounter(depspkg.CounterPushOps, 1)
 			metrics.IncrementCounter(depspkg.CounterPushFailures, 1)
+			metrics.SetGauge(depspkg.GaugeLastPushLatencyMs, float64(pushLatency.Milliseconds()))
 
 			if ctx.Err() != nil {
 				return pending[i:], fmt.Errorf("context canceled during retry: %w", ctx.Err())

--- a/umh-core/pkg/fsmv2/workers/transport/push/action/push.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/action/push.go
@@ -73,6 +73,10 @@ func (a *PushAction) Execute(ctx context.Context, depsAny any) error {
 
 		metrics.SetGauge(depspkg.GaugePendingMessages, float64(pushDeps.PendingMessageCount()))
 
+		// Drain outbound into pending on transient/recoverable failure so the
+		// channel does not fill up across ticks while pending keeps failing
+		// (ENG-4741). Skipped when ctx is canceled — the messages survive in
+		// the channel until the next tick.
 		if err != nil || len(remaining) > 0 {
 			if ctx.Err() == nil {
 				a.drainChannelToPending(pushDeps, metrics)
@@ -82,7 +86,8 @@ func (a *PushAction) Execute(ctx context.Context, depsAny any) error {
 		}
 	}
 
-	// Phase 2: Drain and batch-push new messages
+	// Phase 2: Drain and batch-push new messages.
+	// Only reached when Phase 1 cleared all pending successfully.
 	outChan := pushDeps.GetOutboundChan()
 	if outChan == nil {
 		return errors.New("outbound channel is nil")
@@ -173,12 +178,15 @@ drainLoop:
 //  1. Context canceled (pre-push) → return remaining messages immediately.
 //  2. Push fails, context expired during push → return remaining with
 //     cancellation error.
-//  3. Recoverable by parent (auth failure, proxy block, etc.) → return
+//  3. Transient error (network, server, rate limit, channel full) → return
+//     remaining with nil error. The caller drains the outbound channel into
+//     pending so it does not fill up while the transport recovers (ENG-4741).
+//  4. Recoverable by parent (auth failure, proxy block, etc.) → return
 //     remaining messages with error so the parent triggers re-authentication
 //     or transport reset.
-//  4. Poison message (unrecoverable) → log SentryWarn, drop the message,
+//  5. Poison message (unrecoverable) → log SentryWarn, drop the message,
 //     continue to next.
-//  5. Success → record metrics, continue.
+//  6. Success → record metrics, continue.
 //
 // Returns (nil, nil) when all messages are sent successfully. Otherwise
 // returns the unsent tail of pending so the caller can buffer them for
@@ -206,6 +214,8 @@ func (a *PushAction) retryPending(ctx context.Context, t transport.Transport, pu
 			errType, retryAfter := httpTransport.ExtractErrorType(err)
 			pushDeps.RecordTypedError(errType, retryAfter)
 			metrics.IncrementCounter(httpTransport.CounterForErrorType(errType), 1)
+			metrics.IncrementCounter(depspkg.CounterPushOps, 1)
+			metrics.IncrementCounter(depspkg.CounterPushFailures, 1)
 
 			if ctx.Err() != nil {
 				return pending[i:], fmt.Errorf("context canceled during retry: %w", ctx.Err())
@@ -219,6 +229,10 @@ func (a *PushAction) retryPending(ctx context.Context, t transport.Transport, pu
 				return pending[i:], fmt.Errorf("pending retry failed (recoverable by parent): %w", err)
 			}
 
+			// Poison drop. Includes ErrorTypeUnknown — non-classifiable
+			// errors are dropped rather than retried indefinitely so a
+			// truly broken message cannot block the retry queue. Visible
+			// via SentryWarn + CounterMessagesDropped.
 			pushDeps.GetLogger().SentryWarn(depspkg.FeatureForWorker(pushDeps.GetWorkerType()), pushDeps.GetHierarchyPath(), "dropping_poison_message",
 				depspkg.String("errorType", errType.String()),
 				depspkg.Err(err),

--- a/umh-core/pkg/fsmv2/workers/transport/push/action/push_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/action/push_test.go
@@ -17,6 +17,7 @@ package action_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -205,10 +206,10 @@ func (m *mockPushDeps) GetAuthenticatedUUID() string {
 
 var _ = Describe("PushAction", func() {
 	var (
-		act           *action.PushAction
-		mockDeps      *mockPushDeps
-		mockTrans     *mockTransport
-		outboundBi    chan *transport.UMHMessage
+		act        *action.PushAction
+		mockDeps   *mockPushDeps
+		mockTrans  *mockTransport
+		outboundBi chan *transport.UMHMessage
 	)
 
 	BeforeEach(func() {
@@ -506,6 +507,13 @@ var _ = Describe("PushAction", func() {
 
 			Expect(outboundBi).To(HaveLen(0), "channel must be drained even when retry has transient error")
 			Expect(mockDeps.PendingMessageCount()).To(Equal(4), "remaining pending (2) + drained channel (2)")
+
+			// FIFO contract: failed pending (older) must come before drained
+			// channel messages (newer) so the next tick retries them in order.
+			Expect(mockDeps.pendingMessages[0].Content).To(Equal("pending2"))
+			Expect(mockDeps.pendingMessages[1].Content).To(Equal("pending3"))
+			Expect(mockDeps.pendingMessages[2].Content).To(Equal("channel-msg1"))
+			Expect(mockDeps.pendingMessages[3].Content).To(Equal("channel-msg2"))
 		})
 
 		It("should drain channel to pending when retry hits parent-recoverable error", func() {
@@ -544,10 +552,10 @@ var _ = Describe("PushAction", func() {
 			outboundBi <- &transport.UMHMessage{Content: "channel-msg2"}
 
 			var phase2Msgs []*transport.UMHMessage
-			callCount := 0
 			mockTrans.pushFunc = func(_ context.Context, _ string, msgs []*transport.UMHMessage) error {
-				callCount++
-				if callCount > 2 {
+				// Phase 2 is the only call that batches > 1 message
+				// (Phase 1 retries pending one-at-a-time).
+				if len(msgs) > 1 {
 					phase2Msgs = msgs
 				}
 				return nil
@@ -640,13 +648,81 @@ var _ = Describe("PushAction", func() {
 				}
 			}
 
-			initialTypedErrors := len(mockDeps.recordTypedErrorCalls)
-			initialSuccesses := mockDeps.recordSuccessCalls
-
 			_ = act.Execute(context.Background(), mockDeps)
 
-			Expect(mockDeps.recordTypedErrorCalls).To(HaveLen(initialTypedErrors+1), "only 1 RecordTypedError from the retry push, none from channel drain")
-			Expect(mockDeps.recordSuccessCalls).To(Equal(initialSuccesses), "no RecordSuccess from channel drain")
+			Expect(mockDeps.recordTypedErrorCalls).To(HaveLen(1), "only 1 RecordTypedError from the retry push, none from channel drain")
+			Expect(mockDeps.recordSuccessCalls).To(Equal(0), "no RecordSuccess from channel drain")
+		})
+
+		It("should prevent channel overflow across multiple ticks of sustained pending failure", func() {
+			// Regression test for ENG-4741. Without drainChannelToPending,
+			// Phase 1's early return left the outbound channel undrained
+			// every tick. After ~50 ticks (channel cap 100, ~2 msgs/tick)
+			// the channel filled, subscribers dropped messages, and the
+			// instance appeared offline in Management Console.
+			//
+			// With the fix, drainChannelToPending rescues the channel each
+			// tick. This test guards against a future refactor that puts
+			// the drain behind a first-tick-only condition.
+			mockDeps.pendingMessages = []*transport.UMHMessage{
+				{Content: "initial-pending"},
+			}
+
+			mockTrans.pushFunc = func(_ context.Context, _ string, _ []*transport.UMHMessage) error {
+				return &httpTransport.TransportError{
+					Type:    httpTransport.ErrorTypeNetwork,
+					Message: "connection refused",
+				}
+			}
+
+			const ticks = 10
+			const messagesPerTick = 5
+
+			for tick := 0; tick < ticks; tick++ {
+				for j := 0; j < messagesPerTick; j++ {
+					outboundBi <- &transport.UMHMessage{Content: fmt.Sprintf("tick%d-msg%d", tick, j)}
+				}
+
+				err := act.Execute(context.Background(), mockDeps)
+				Expect(err).NotTo(HaveOccurred(), "transient error should be suppressed at tick %d", tick)
+
+				Expect(outboundBi).To(HaveLen(0), "channel must be drained on tick %d (would overflow without ENG-4741 fix)", tick)
+			}
+
+			// Pending grew by messagesPerTick per tick (drain rescued the
+			// channel) plus the original failed retry that keeps coming back.
+			Expect(mockDeps.PendingMessageCount()).To(BeNumerically(">=", ticks*messagesPerTick),
+				"pending should grow by drained channel messages each tick")
+		})
+
+		It("should increment push ops metrics on pending retry failure", func() {
+			// Verifies that retryPending failure increments CounterPushOps
+			// and CounterPushFailures, matching Phase 2 metric semantics.
+			mockDeps.pendingMessages = []*transport.UMHMessage{
+				{Content: "msg1"},
+				{Content: "msg2"},
+			}
+
+			callCount := 0
+			mockTrans.pushFunc = func(_ context.Context, _ string, _ []*transport.UMHMessage) error {
+				callCount++
+				if callCount == 2 {
+					return &httpTransport.TransportError{
+						Type:    httpTransport.ErrorTypeNetwork,
+						Message: "connection refused",
+					}
+				}
+				return nil
+			}
+
+			err := act.Execute(context.Background(), mockDeps)
+			Expect(err).NotTo(HaveOccurred())
+
+			drained := mockDeps.metricsRecorder.Drain()
+			Expect(drained.Counters[string(deps.CounterPushOps)]).To(Equal(int64(2)), "1 success + 1 failure both count as ops")
+			Expect(drained.Counters[string(deps.CounterPushSuccess)]).To(Equal(int64(1)))
+			Expect(drained.Counters[string(deps.CounterPushFailures)]).To(Equal(int64(1)))
+			Expect(drained.Counters[string(deps.CounterNetworkErrorsTotal)]).To(Equal(int64(1)))
 		})
 	})
 

--- a/umh-core/pkg/fsmv2/workers/transport/push/action/push_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/action/push_test.go
@@ -381,7 +381,7 @@ var _ = Describe("PushAction", func() {
 			Expect(mockDeps.PendingMessageCount()).To(Equal(2))
 		})
 
-		It("should not drain channel when pending messages exist", func() {
+		It("should drain channel via Phase 2 after all pending messages succeed", func() {
 			mockDeps.pendingMessages = []*transport.UMHMessage{
 				{Content: "pending1"},
 			}
@@ -390,11 +390,8 @@ var _ = Describe("PushAction", func() {
 			err := act.Execute(context.Background(), mockDeps)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(mockTrans.pushCallCount).To(Equal(1))
-			Expect(mockTrans.pushedMsgs).To(HaveLen(1))
-			Expect(mockTrans.pushedMsgs[0].Content).To(Equal("pending1"))
-
-			Expect(outboundBi).To(HaveLen(1))
+			Expect(mockTrans.pushCallCount).To(Equal(2), "1 for pending retry + 1 for Phase 2 batch")
+			Expect(outboundBi).To(HaveLen(0), "channel must be drained after pending succeeds")
 		})
 
 		It("should retry pending one-by-one and drop on non-infrastructure error", func() {
@@ -479,6 +476,177 @@ var _ = Describe("PushAction", func() {
 			Expect(err.Error()).To(ContainSubstring("recoverable by parent"))
 
 			Expect(mockDeps.PendingMessageCount()).To(Equal(2))
+		})
+	})
+
+	Describe("Channel drain during pending retry (ENG-4741)", func() {
+		It("should drain channel to pending when retry hits transient error", func() {
+			mockDeps.pendingMessages = []*transport.UMHMessage{
+				{Content: "pending1"},
+				{Content: "pending2"},
+				{Content: "pending3"},
+			}
+			outboundBi <- &transport.UMHMessage{Content: "channel-msg1"}
+			outboundBi <- &transport.UMHMessage{Content: "channel-msg2"}
+
+			callCount := 0
+			mockTrans.pushFunc = func(_ context.Context, _ string, _ []*transport.UMHMessage) error {
+				callCount++
+				if callCount == 2 {
+					return &httpTransport.TransportError{
+						Type:    httpTransport.ErrorTypeNetwork,
+						Message: "connection refused",
+					}
+				}
+				return nil
+			}
+
+			err := act.Execute(context.Background(), mockDeps)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(outboundBi).To(HaveLen(0), "channel must be drained even when retry has transient error")
+			Expect(mockDeps.PendingMessageCount()).To(Equal(4), "remaining pending (2) + drained channel (2)")
+		})
+
+		It("should drain channel to pending when retry hits parent-recoverable error", func() {
+			mockDeps.pendingMessages = []*transport.UMHMessage{
+				{Content: "pending1"},
+				{Content: "pending2"},
+			}
+			outboundBi <- &transport.UMHMessage{Content: "channel-msg1"}
+
+			callCount := 0
+			mockTrans.pushFunc = func(_ context.Context, _ string, _ []*transport.UMHMessage) error {
+				callCount++
+				if callCount == 1 {
+					return &httpTransport.TransportError{
+						Type:    httpTransport.ErrorTypeInvalidToken,
+						Message: "HTTP 401: invalid_token",
+					}
+				}
+				return nil
+			}
+
+			err := act.Execute(context.Background(), mockDeps)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("recoverable by parent"))
+
+			Expect(outboundBi).To(HaveLen(0), "channel must be drained even on auth error")
+			Expect(mockDeps.PendingMessageCount()).To(Equal(3), "remaining pending (2) + drained channel (1)")
+		})
+
+		It("should fall through to Phase 2 when all pending succeed", func() {
+			mockDeps.pendingMessages = []*transport.UMHMessage{
+				{Content: "pending1"},
+				{Content: "pending2"},
+			}
+			outboundBi <- &transport.UMHMessage{Content: "channel-msg1"}
+			outboundBi <- &transport.UMHMessage{Content: "channel-msg2"}
+
+			var phase2Msgs []*transport.UMHMessage
+			callCount := 0
+			mockTrans.pushFunc = func(_ context.Context, _ string, msgs []*transport.UMHMessage) error {
+				callCount++
+				if callCount > 2 {
+					phase2Msgs = msgs
+				}
+				return nil
+			}
+
+			err := act.Execute(context.Background(), mockDeps)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(outboundBi).To(HaveLen(0), "channel must be drained")
+			Expect(phase2Msgs).To(HaveLen(2), "Phase 2 should batch-push channel messages")
+			Expect(phase2Msgs[0].Content).To(Equal("channel-msg1"))
+			Expect(phase2Msgs[1].Content).To(Equal("channel-msg2"))
+		})
+
+		It("should not push channel messages when relay is unhealthy", func() {
+			mockDeps.pendingMessages = []*transport.UMHMessage{
+				{Content: "pending1"},
+			}
+			outboundBi <- &transport.UMHMessage{Content: "channel-msg1"}
+
+			mockTrans.pushFunc = func(_ context.Context, _ string, _ []*transport.UMHMessage) error {
+				return &httpTransport.TransportError{
+					Type:    httpTransport.ErrorTypeNetwork,
+					Message: "timeout",
+				}
+			}
+
+			err := act.Execute(context.Background(), mockDeps)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(mockTrans.pushCallCount).To(Equal(1), "only the pending retry push, no Phase 2 push")
+			Expect(outboundBi).To(HaveLen(0), "channel still drained to pending")
+			Expect(mockDeps.PendingMessageCount()).To(Equal(2), "failed pending (1) + drained channel (1)")
+		})
+
+		It("should skip channel drain when context is canceled during retry", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+
+			mockDeps.pendingMessages = []*transport.UMHMessage{
+				{Content: "pending1"},
+				{Content: "pending2"},
+			}
+			outboundBi <- &transport.UMHMessage{Content: "channel-msg1"}
+
+			mockTrans.pushFunc = func(_ context.Context, _ string, _ []*transport.UMHMessage) error {
+				cancel()
+				return nil
+			}
+
+			err := act.Execute(ctx, mockDeps)
+			Expect(err).To(MatchError(context.Canceled))
+
+			Expect(outboundBi).To(HaveLen(1), "channel should NOT be drained when ctx is canceled")
+			Expect(mockDeps.PendingMessageCount()).To(Equal(1), "remaining pending message must be stored")
+		})
+
+		It("should drain closed channel without panic", func() {
+			mockDeps.pendingMessages = []*transport.UMHMessage{
+				{Content: "pending1"},
+			}
+			outboundBi <- &transport.UMHMessage{Content: "channel-msg1"}
+			outboundBi <- &transport.UMHMessage{Content: "channel-msg2"}
+			close(outboundBi)
+
+			mockTrans.pushFunc = func(_ context.Context, _ string, _ []*transport.UMHMessage) error {
+				return &httpTransport.TransportError{
+					Type:    httpTransport.ErrorTypeNetwork,
+					Message: "timeout",
+				}
+			}
+
+			err := act.Execute(context.Background(), mockDeps)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(mockDeps.PendingMessageCount()).To(Equal(3), "1 remaining pending + 2 drained from closed channel")
+		})
+
+		It("should not call Record* when draining channel to pending", func() {
+			mockDeps.pendingMessages = []*transport.UMHMessage{
+				{Content: "pending1"},
+			}
+			outboundBi <- &transport.UMHMessage{Content: "channel-msg1"}
+			outboundBi <- &transport.UMHMessage{Content: "channel-msg2"}
+			outboundBi <- &transport.UMHMessage{Content: "channel-msg3"}
+
+			mockTrans.pushFunc = func(_ context.Context, _ string, _ []*transport.UMHMessage) error {
+				return &httpTransport.TransportError{
+					Type:    httpTransport.ErrorTypeNetwork,
+					Message: "connection refused",
+				}
+			}
+
+			initialTypedErrors := len(mockDeps.recordTypedErrorCalls)
+			initialSuccesses := mockDeps.recordSuccessCalls
+
+			_ = act.Execute(context.Background(), mockDeps)
+
+			Expect(mockDeps.recordTypedErrorCalls).To(HaveLen(initialTypedErrors+1), "only 1 RecordTypedError from the retry push, none from channel drain")
+			Expect(mockDeps.recordSuccessCalls).To(Equal(initialSuccesses), "no RecordSuccess from channel drain")
 		})
 	})
 

--- a/umh-core/pkg/fsmv2/workers/transport/push/action/push_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/action/push_test.go
@@ -648,9 +648,11 @@ var _ = Describe("PushAction", func() {
 				}
 			}
 
-			_ = act.Execute(context.Background(), mockDeps)
+			err := act.Execute(context.Background(), mockDeps)
+			Expect(err).NotTo(HaveOccurred())
 
 			Expect(mockDeps.recordTypedErrorCalls).To(HaveLen(1), "only 1 RecordTypedError from the retry push, none from channel drain")
+			Expect(mockDeps.recordErrorCalls).To(Equal(0), "no RecordError from channel drain")
 			Expect(mockDeps.recordSuccessCalls).To(Equal(0), "no RecordSuccess from channel drain")
 		})
 


### PR DESCRIPTION
## Summary

Healthy instances could appear offline in Management Console when earlier status messages failed to send. The fix drains the outbound channel into the pending buffer during retry failure, so new status messages keep reaching MC instead of piling up in the channel until it overflows.

Affects preview users running `USE_FSMV2_TRANSPORT=true`.

## Root cause

The push action ran in two phases:

1. **Phase 1** retried previously-failed messages one at a time.
2. **Phase 2** drained the outbound channel and batch-pushed new ones.

Phase 1 returned early whenever the pending retry had errors or any unsent messages remaining. During sustained transport failure — MC unreachable, connection reset, DNS flake — Phase 2 never ran. The outbound channel filled to its cap (100), subscribers started dropping new status messages, and MC showed the instance as offline even though the agent was healthy and producing data the whole time.

## Fix

When Phase 1 has remaining work, drain the outbound channel into the pending buffer before returning. Messages are preserved for the next tick; the channel never fills. `StorePendingMessages` already caps the pending buffer at 1000 with a `SentryWarn` on overflow, so bounded growth is a solved problem.

## Tests

- **Multi-tick regression test** — 10 ticks × 5 messages/tick against a permanently-failing transport. Asserts the channel never overflows. Would fail on tick 1 without the fix.
- **FIFO ordering assertion** — pending retries (older) stay ahead of drained channel messages (newer) in the pending buffer, so message order is preserved across ticks.
- **Metric parity** — `retryPending` failures now increment `CounterPushOps` and `CounterPushFailures`, matching Phase 2. Fixes a pre-existing accounting gap where retry failures were invisible in Prometheus (noticed during self-review, scope was small enough to fold in here).

## Commits

Kept as two commits for review clarity:

1. **`fix: drain outbound channel during pending retry`** — the fix itself, `drainChannelToPending` function with godoc explaining why it exists, and CHANGELOG entry.
2. **`fixup(eng-4741): self-review polish`** — `retryPending` godoc step documenting the transient path that triggers the new drain, inline comments at the call sites, retry metric parity fix, FIFO assertion, multi-tick regression test, metric test, test cleanups.

## Self-review

Ran \`agent-workflows:self-review\` (12 review agents + DA triage). All findings addressed inline. Notable: removed a redundant nil-channel guard in \`drainChannelToPending\` — Go's \`select { case <-nilChan; default: break }\` already handles nil channels, the explicit check was dead code.

Fixes [ENG-4741](https://linear.app/united-manufacturing-hub/issue/ENG-4741).