### PR TITLE
fix(config): the currently running config is now backed up (ENG-4464)

### DIFF
--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 - Previously, a Flow only exposed a single health and throughput metric. Starting with this version, umh-core exposes separate throughput metrics and health status for read and write flows.
 
+### Preview: Config Backup
+
+- `ENABLE_CONFIG_BACKUP=true` saves a timestamped copy of `config.yaml` to `/data/config-backups/` every time umh-core writes the config (Management Console actions, and startup after a manual edit). umh-core keeps the 100 most recent backups and deletes older ones. Use these to roll back a bad config
+- Fixed: the first config change after a restart was not backed up, because the pre-write file matched the latest backup and the duplicate check skipped it. Backups now run after the write. One caveat: the most recent backup mirrors the most recent write, so to recover the state from before a bad write, use the second-most-recent backup
+
 ### Preview: FSMv2 Communicator
 
 - Previously, healthy instances could appear offline in Management Console when earlier status messages failed to send. New status messages now continue to reach Management Console while previous ones are being retried. Only affects instances with `USE_FSMV2_TRANSPORT=true`

--- a/umh-core/pkg/config/manager.go
+++ b/umh-core/pkg/config/manager.go
@@ -584,8 +584,6 @@ func (m *FileConfigManager) writeConfig(ctx context.Context, config FullConfig) 
 		return ctx.Err()
 	}
 
-	m.createConfigBackup(ctx)
-
 	// Create the directory if it doesn't exist
 	dir := filepath.Dir(m.configPath)
 	if err := m.fsService.EnsureDirectory(ctx, dir); err != nil {
@@ -608,6 +606,11 @@ func (m *FileConfigManager) writeConfig(ctx context.Context, config FullConfig) 
 	if err := m.fsService.WriteFile(ctx, m.configPath, data, 0666); err != nil {
 		return fmt.Errorf("failed to write config file: %w", err)
 	}
+
+	// Back up the newly written config. Must run after WriteFile so the backup
+	// captures the new content; running before would cause dedup to skip when
+	// pre-write config matches the latest backup (ENG-4464).
+	m.createConfigBackup(ctx)
 
 	// get the file stats for the config file
 	fileStats, err := m.fsService.Stat(ctx, m.configPath)
@@ -1135,8 +1138,6 @@ func (m *FileConfigManager) WriteYAMLConfigFromString(ctx context.Context, confi
 		}
 	}
 
-	m.createConfigBackup(ctx)
-
 	// Create the directory if it doesn't exist
 	dir := filepath.Dir(m.configPath)
 	if err := m.fsService.EnsureDirectory(ctx, dir); err != nil {
@@ -1147,6 +1148,11 @@ func (m *FileConfigManager) WriteYAMLConfigFromString(ctx context.Context, confi
 	if err := m.fsService.WriteFile(ctx, m.configPath, []byte(configStr), 0666); err != nil {
 		return fmt.Errorf("failed to write config file: %w", err)
 	}
+
+	// Back up the newly written config. Must run after WriteFile so the backup
+	// captures the new content; running before would cause dedup to skip when
+	// pre-write config matches the latest backup (ENG-4464).
+	m.createConfigBackup(ctx)
 
 	// Get the file stats for the config file to update cache with new mod time
 	fileStats, err := m.fsService.Stat(ctx, m.configPath)

--- a/umh-core/pkg/config/manager_test.go
+++ b/umh-core/pkg/config/manager_test.go
@@ -1286,15 +1286,12 @@ agent:
 			})
 
 			// ENG-4464 regression guard: createConfigBackup runs AFTER WriteFile,
-			// so it should NOT be called when WriteFile fails. Verifies the
-			// spec's "no backup I/O on failure path" invariant.
+			// so it must not be called when WriteFile fails. If a future refactor
+			// reorders the calls, this test catches it.
 			It("should NOT create a backup when WriteFile fails in writeConfig", func() {
 				mockFS.WithWriteFileFunc(func(ctx context.Context, path string, data []byte, perm os.FileMode) error {
 					writeFileCalls = append(writeFileCalls, path)
-					if !strings.HasPrefix(path, constants.ConfigBackupDir) {
-						return errors.New("disk full")
-					}
-					return nil
+					return errors.New("disk full")
 				})
 
 				config := FullConfig{}
@@ -1303,6 +1300,23 @@ agent:
 				config.Agent.ReleaseChannel = ReleaseChannelStable
 
 				err := configManager.writeConfig(ctx, config)
+				Expect(err).To(HaveOccurred())
+
+				backupWrites := filterBackupDirPaths(writeFileCalls)
+				Expect(backupWrites).To(BeEmpty(),
+					"when WriteFile fails, createConfigBackup must not run (post-fix ordering)")
+			})
+
+			// ENG-4464 regression guard: same invariant for the
+			// WriteYAMLConfigFromString code path.
+			It("should NOT create a backup when WriteFile fails in WriteYAMLConfigFromString", func() {
+				mockFS.WithWriteFileFunc(func(ctx context.Context, path string, data []byte, perm os.FileMode) error {
+					writeFileCalls = append(writeFileCalls, path)
+					return errors.New("disk full")
+				})
+
+				validYAML := "agent:\n  metricsPort: 9090\n  releaseChannel: stable\n  location:\n    0: test\n"
+				err := configManager.WriteYAMLConfigFromString(ctx, validYAML, "")
 				Expect(err).To(HaveOccurred())
 
 				backupWrites := filterBackupDirPaths(writeFileCalls)
@@ -1368,13 +1382,13 @@ agent:
 			})
 		})
 
-		Describe("multi-write backup sequence (Daniel H scenario)", func() {
-			// Reproduces the bug found during config backup testing with Daniel Helmersson
-			// on 2026-03-05: after startup writes a backup, the first MC-pushed config change
-			// creates no new backup because dedup compares pre-write config (unchanged) against
-			// the startup backup and skips.
+		Describe("multi-write backup sequence (ENG-4464 dedup-before-write bug)", func() {
+			// Reproduces the dedup-before-write bug: after startup writes a backup,
+			// the first MC-pushed config change creates no new backup because dedup
+			// compares pre-write config (unchanged) against the startup backup and
+			// skips.
 			//
-			// Sequence:
+			// Sequence (pre-fix behavior):
 			//   1. Startup: writeConfig(A) → backup of A created
 			//   2. MC change: writeConfig(B) → createConfigBackup reads A (pre-write),
 			//      dedup sees A == startup backup A → SKIPS. Then writes B to config.yaml.
@@ -1451,7 +1465,7 @@ agent:
 					"startup backup should contain the startup metricsPort value")
 
 				// Step 2: MC pushes a config change (different content).
-				// This is where Daniel changed timeBetweenRequests from 300→303.
+				// Simulates the first MC-pushed config change after startup.
 				mcConfig := FullConfig{}
 				mcConfig.Agent.MetricsPort = 9090 // changed value
 				mcConfig.Agent.Location = map[int]string{0: "test"}

--- a/umh-core/pkg/config/manager_test.go
+++ b/umh-core/pkg/config/manager_test.go
@@ -1352,8 +1352,9 @@ agent:
 					return nil
 				})
 
-				// Step 1: Startup writes config (same content, applies env overrides).
-				// writeConfig calls createConfigBackup BEFORE writing.
+				// Step 1: Startup writes config. Post-fix, createConfigBackup runs
+				// AFTER WriteFile, so the backup captures the newly written (marshaled)
+				// content, not the pre-write file content.
 				startupConfig := FullConfig{}
 				startupConfig.Agent.MetricsPort = 8080
 				startupConfig.Agent.Location = map[int]string{0: "test"}
@@ -1364,8 +1365,8 @@ agent:
 				Expect(backupFiles).To(HaveLen(1), "startup should create one backup")
 
 				startupBackupContent := files[backupFiles[0]]
-				Expect(startupBackupContent).To(Equal(initialConfig),
-					"startup backup should contain the initial config")
+				Expect(string(startupBackupContent)).To(ContainSubstring("metricsPort: 8080"),
+					"startup backup should contain the startup metricsPort value")
 
 				// Step 2: MC pushes a config change (different content).
 				// This is where Daniel changed timeBetweenRequests from 300→303.
@@ -1377,12 +1378,9 @@ agent:
 				err = configManager.writeConfig(ctx, mcConfig)
 				Expect(err).NotTo(HaveOccurred())
 
-				// THE BUG: with current code, backupFiles still has length 1 because
-				// createConfigBackup read config.yaml (still = initial content at pre-write time),
-				// compared it to the startup backup (same content), and skipped.
-				//
-				// EXPECTED: after writing mcConfig, there should be a backup containing it.
-				// Find any backup that contains the new config's metricsPort: 9090.
+				// Post-fix: createConfigBackup runs AFTER WriteFile, so the backup
+				// captures the newly written content. A backup containing the new
+				// metricsPort: 9090 value must exist.
 				var foundNewBackup bool
 				for _, path := range backupFiles {
 					if strings.Contains(string(files[path]), "9090") {

--- a/umh-core/pkg/config/manager_test.go
+++ b/umh-core/pkg/config/manager_test.go
@@ -1286,6 +1286,115 @@ agent:
 			})
 		})
 
+		Describe("multi-write backup sequence (Daniel H scenario)", func() {
+			// Reproduces the bug found during config backup testing with Daniel Helmersson
+			// on 2026-03-05: after startup writes a backup, the first MC-pushed config change
+			// creates no new backup because dedup compares pre-write config (unchanged) against
+			// the startup backup and skips.
+			//
+			// Sequence:
+			//   1. Startup: writeConfig(A) → backup of A created
+			//   2. MC change: writeConfig(B) → createConfigBackup reads A (pre-write),
+			//      dedup sees A == startup backup A → SKIPS. Then writes B to config.yaml.
+			//   3. Result: config.yaml = B, only backup = A. No backup of B exists.
+
+			It("should create a backup of the new config after each write", func() {
+				// Stateful mini-filesystem: tracks actual file contents across calls
+				files := map[string][]byte{}
+				backupFiles := []string{} // tracks backup filenames in order
+
+				initialConfig := []byte("agent:\n  metricsPort: 8080\n  releaseChannel: stable\n  location:\n    0: test\n")
+				files[DefaultConfigPath] = initialConfig
+
+				mockFS.WithFileExistsFunc(func(ctx context.Context, path string) (bool, error) {
+					_, ok := files[path]
+					return ok, nil
+				})
+
+				mockFS.WithReadFileFunc(func(ctx context.Context, path string) ([]byte, error) {
+					if data, ok := files[path]; ok {
+						return data, nil
+					}
+					return nil, fmt.Errorf("file not found: %s", path)
+				})
+
+				mockFS.WithWriteFileFunc(func(ctx context.Context, path string, data []byte, perm os.FileMode) error {
+					captured := make([]byte, len(data))
+					copy(captured, data)
+					files[path] = captured
+					if strings.HasPrefix(path, constants.ConfigBackupDir+"/") {
+						backupFiles = append(backupFiles, path)
+					}
+					return nil
+				})
+
+				mockFS.WithReadDirFunc(func(ctx context.Context, path string) ([]os.DirEntry, error) {
+					if path != constants.ConfigBackupDir {
+						return nil, nil
+					}
+					var entries []os.DirEntry
+					for _, name := range backupFiles {
+						entries = append(entries, newMockDirEntry(filepath.Base(name), false))
+					}
+					return entries, nil
+				})
+
+				mockFS.WithEnsureDirectoryFunc(func(ctx context.Context, path string) error {
+					return nil
+				})
+
+				mockFS.WithStatFunc(func(ctx context.Context, path string) (os.FileInfo, error) {
+					return mockFS.NewMockFileInfo(filepath.Base(path), 100, 0644, time.Now(), false), nil
+				})
+
+				mockFS.WithRemoveFunc(func(ctx context.Context, path string) error {
+					delete(files, path)
+					return nil
+				})
+
+				// Step 1: Startup writes config (same content, applies env overrides).
+				// writeConfig calls createConfigBackup BEFORE writing.
+				startupConfig := FullConfig{}
+				startupConfig.Agent.MetricsPort = 8080
+				startupConfig.Agent.Location = map[int]string{0: "test"}
+				startupConfig.Agent.ReleaseChannel = ReleaseChannelStable
+
+				err := configManager.writeConfig(ctx, startupConfig)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(backupFiles).To(HaveLen(1), "startup should create one backup")
+
+				startupBackupContent := files[backupFiles[0]]
+				Expect(startupBackupContent).To(Equal(initialConfig),
+					"startup backup should contain the initial config")
+
+				// Step 2: MC pushes a config change (different content).
+				// This is where Daniel changed timeBetweenRequests from 300→303.
+				mcConfig := FullConfig{}
+				mcConfig.Agent.MetricsPort = 9090 // changed value
+				mcConfig.Agent.Location = map[int]string{0: "test"}
+				mcConfig.Agent.ReleaseChannel = ReleaseChannelStable
+
+				err = configManager.writeConfig(ctx, mcConfig)
+				Expect(err).NotTo(HaveOccurred())
+
+				// THE BUG: with current code, backupFiles still has length 1 because
+				// createConfigBackup read config.yaml (still = initial content at pre-write time),
+				// compared it to the startup backup (same content), and skipped.
+				//
+				// EXPECTED: after writing mcConfig, there should be a backup containing it.
+				// Find any backup that contains the new config's metricsPort: 9090.
+				var foundNewBackup bool
+				for _, path := range backupFiles {
+					if strings.Contains(string(files[path]), "9090") {
+						foundNewBackup = true
+						break
+					}
+				}
+				Expect(foundNewBackup).To(BeTrue(),
+					"after MC config change, a backup containing the new config (metricsPort: 9090) should exist")
+			})
+		})
+
 		Describe("getLatestBackupContent", func() {
 			Context("when backup directory is empty", func() {
 				BeforeEach(func() {

--- a/umh-core/pkg/config/manager_test.go
+++ b/umh-core/pkg/config/manager_test.go
@@ -1284,6 +1284,88 @@ agent:
 				}
 				Expect(configWrites).NotTo(BeEmpty())
 			})
+
+			// ENG-4464 regression guard: createConfigBackup runs AFTER WriteFile,
+			// so it should NOT be called when WriteFile fails. Verifies the
+			// spec's "no backup I/O on failure path" invariant.
+			It("should NOT create a backup when WriteFile fails in writeConfig", func() {
+				mockFS.WithWriteFileFunc(func(ctx context.Context, path string, data []byte, perm os.FileMode) error {
+					writeFileCalls = append(writeFileCalls, path)
+					if !strings.HasPrefix(path, constants.ConfigBackupDir) {
+						return errors.New("disk full")
+					}
+					return nil
+				})
+
+				config := FullConfig{}
+				config.Agent.MetricsPort = 9090
+				config.Agent.Location = map[int]string{0: "test"}
+				config.Agent.ReleaseChannel = ReleaseChannelStable
+
+				err := configManager.writeConfig(ctx, config)
+				Expect(err).To(HaveOccurred())
+
+				backupWrites := filterBackupDirPaths(writeFileCalls)
+				Expect(backupWrites).To(BeEmpty(),
+					"when WriteFile fails, createConfigBackup must not run (post-fix ordering)")
+			})
+
+			// ENG-4464 regression guard: after the fix, dedup still prevents
+			// backup spam when identical content is written twice in a row.
+			It("should skip backup when writeConfig is called twice with identical content", func() {
+				files := map[string][]byte{}
+				backupFiles := []string{}
+
+				mockFS.WithFileExistsFunc(func(ctx context.Context, path string) (bool, error) {
+					_, ok := files[path]
+					return ok, nil
+				})
+				mockFS.WithReadFileFunc(func(ctx context.Context, path string) ([]byte, error) {
+					if data, ok := files[path]; ok {
+						return data, nil
+					}
+					return nil, fmt.Errorf("file not found: %s", path)
+				})
+				mockFS.WithWriteFileFunc(func(ctx context.Context, path string, data []byte, perm os.FileMode) error {
+					captured := make([]byte, len(data))
+					copy(captured, data)
+					files[path] = captured
+					if strings.HasPrefix(path, constants.ConfigBackupDir+"/") {
+						backupFiles = append(backupFiles, path)
+					}
+					return nil
+				})
+				mockFS.WithReadDirFunc(func(ctx context.Context, path string) ([]os.DirEntry, error) {
+					if path != constants.ConfigBackupDir {
+						return nil, nil
+					}
+					var entries []os.DirEntry
+					for _, name := range backupFiles {
+						entries = append(entries, newMockDirEntry(filepath.Base(name), false))
+					}
+					return entries, nil
+				})
+				mockFS.WithEnsureDirectoryFunc(func(ctx context.Context, path string) error { return nil })
+				mockFS.WithStatFunc(func(ctx context.Context, path string) (os.FileInfo, error) {
+					return mockFS.NewMockFileInfo(filepath.Base(path), 100, 0644, time.Now(), false), nil
+				})
+				mockFS.WithRemoveFunc(func(ctx context.Context, path string) error {
+					delete(files, path)
+					return nil
+				})
+
+				config := FullConfig{}
+				config.Agent.MetricsPort = 8080
+				config.Agent.Location = map[int]string{0: "test"}
+				config.Agent.ReleaseChannel = ReleaseChannelStable
+
+				Expect(configManager.writeConfig(ctx, config)).To(Succeed())
+				Expect(backupFiles).To(HaveLen(1), "first write should create a backup")
+
+				Expect(configManager.writeConfig(ctx, config)).To(Succeed())
+				Expect(backupFiles).To(HaveLen(1),
+					"second write with identical content should be deduped (no new backup)")
+			})
 		})
 
 		Describe("multi-write backup sequence (Daniel H scenario)", func() {


### PR DESCRIPTION
## What the bug actually was

During live testing of `ENABLE_CONFIG_BACKUP=true` on a test instance on 2026-03-05, I paired with a colleague on the Value Engineering team to verify the feature. We observed two distinct behaviors, which together meant the feature was doing nothing useful on the most common path.

**Behavior 1**: The first config change after startup produced no backup at all. Backup count stayed at 1 (the startup backup).

**Behavior 2**: The second config change produced a new backup, but when we opened it, it contained the **pre-change** state, not the value we just set.

Net effect across the feature: **the currently running config is never in a backup.** At steady state you have backups of every prior state but never the state that is actually live on disk. If `config.yaml` gets corrupted, the live state is unrecoverable. If an operator wants to inspect what was running at a particular time, that state may not be in any backup file.

## Root cause

`createConfigBackup()` was called **before** `WriteFile()` in both `writeConfig()` and `WriteYAMLConfigFromString()`. It reads the current `config.yaml`, compares it with the latest backup, and skips if identical. This deduplication check exists to prevent backup spam during crash loops.

The two observed behaviors share this one root cause:

- **First change after startup**: `GetConfigWithOverwritesOrCreateNew` wrote the config and created the first backup in the same call, so `config.yaml` and the latest backup have identical content. When the Management Console pushes the first change, `createConfigBackup` reads pre-write `config.yaml` (= startup state), compares with latest backup (= startup state), `bytes.Equal` is true, skips. New config is written. **No backup.**
- **Later changes**: `createConfigBackup` reads pre-write `config.yaml`, which now differs from the latest backup (because that latest backup is one write old). It creates a backup, but the content is the pre-write state, not the new state. **Backup is one version behind.**

The dedup check alone is fine. The pre-write call site alone is fine. The combination produces the bug.

## The fix

Move `createConfigBackup(ctx)` from before `WriteFile()` to after `WriteFile()` in both call sites. After the move, `createConfigBackup` reads the newly written content. The new content differs from the latest backup (because it is new), so dedup does not skip. Every write now produces a backup of the exact state that was written.

Two call sites touched:

- `writeConfig()`, used by most config-mutating actions (AtomicAddProtocolConverter, AtomicSetLocation, etc.)
- `WriteYAMLConfigFromString()`, used by the `set-config-file` MC action (YAML editor)

## One semantic change

Before the fix, backups captured the **pre-write** state, which meant the latest backup mirrored the state immediately before the most recent change. After the fix, backups capture the **post-write** state, so the latest backup mirrors the state immediately after the most recent successful write.

For crash recovery the post-write semantic is strictly better: the currently running config is always in a backup.

For rollback it requires a small change in operator behavior. To recover the state from before a bad write, use the **second-most-recent** backup, not the latest. The CHANGELOG entry states this explicitly.

## How I verified this

Four independent sources:

1. **Unit test** in `manager_test.go`, "multi-write backup sequence". A stateful mock filesystem models the write/read interaction, exercises the two-write sequence, fails before the fix and passes after.
2. **Live MC experiment reproducing the bug** (2026-04-14). Ran a fresh container with `ENABLE_CONFIG_BACKUP=true`, registered it to a test instance via the Management Console, edited `metricsPort` through the YAML editor twice. First write: backup count unchanged, `config.yaml` had the new value, no backup contained it (Bug 1 reproduced). Second write: a new backup appeared but contained the pre-write value, not the new one (Bug 2 reproduced).
3. **Live MC experiment verifying the fix** (2026-04-15). Ran two fresh containers with the fixed image. On each, pushed a first MC config change. Both runs produced a new backup whose file mtime fell inside the write execution window (microseconds between action-start log and success log) and whose content was the newly-written `metricsPort` value. That ordering is only reachable under post-write semantics. A follow-up second write produced the expected second backup with its own new value; an identical-content save produced no new backup (dedup holds). A separate 5-save consistency run (2026-04-15, third container) pushed `metricsPort` through 9091→9092→9093→9094→9095 with 30-second spacing. All five saves produced distinct backups with their respective values. Write count increased by exactly five, backup count increased by exactly five, no filename collisions. The fix behaves consistently across repeated writes, not just on the first one.
4. **Original live test (2026-03-05)**. Same symptoms observed on a test instance, same dedup-before-write root cause.

## Expected side effect: +1 backup per restart

The 2026-04-15 experiment also surfaced a behavioral change worth calling out. On container restart, umh-core writes the default config at startup before the Management Console re-pushes the stored user state. Pre-fix, the dedup check coincidentally skipped this startup write (pre-write content matched the latest backup, so it looked like a no-op). Post-fix, the dedup check correctly notices that the written content (defaults) differs from the latest backup (user state) and creates a backup.

Net effect: each container restart now produces one extra backup file (5-20 KB). Retention is capped at 100, so growth is bounded. At daily restart frequency that is about 99 days of retention. Reviewed and accepted as expected post-fix behavior — the underlying startup-overwrites-stored-state pattern is a separate preexisting issue that will get its own ticket. It is not a regression introduced by this PR.

## What I intentionally did not fix

Two items from the original ticket are not in this PR:

- **Off-by-one in cleanup (101 vs 100 files)**: cosmetic, one extra 5-20 KB file, no user impact.
- **Silent backup failure logging**: already done. Every error path in `createConfigBackup` has `SentryWarn()`, which writes to both local logs and Sentry.

## Tests

Four tests in `manager_test.go`:

- "multi-write backup sequence" reproduces the bug (red before, green after)
- "should NOT create a backup when WriteFile fails in writeConfig" is a regression guard for the post-fix ordering
- "should NOT create a backup when WriteFile fails in WriteYAMLConfigFromString" is the same guard for the other call site
- "should skip backup when writeConfig is called twice with identical content" confirms dedup still works after the move

Full suite passes: `go test ./pkg/config/`

## Release notes

See CHANGELOG.md under "Preview: Config Backup". This stays under Preview because `ENABLE_CONFIG_BACKUP=true` is still opt-in. Rollout to default-on is tracked in ENG-4568.

## Review

Ran `/self-review` before opening this PR.

---

Closes ENG-4464.
