### PR TITLE
feat(fsmv2): enable communicator transport and memory cleanup by default (ENG-4231)

### DIFF
--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Improvements
 
-- The FSMv2 communicator is now enabled by default. Previously, enterprise networks with firewalls that dropped idle connections could leave instances appearing offline in the Management Console until the container was restarted. The new communicator uses separate connections for status and commands, so a dropped pull connection no longer prevents heartbeats from reaching the backend, and it recovers automatically when the connection comes back. The memory cleanup routine it depends on is also on by default. To roll back, set `USE_FSMV2_TRANSPORT=false` and `USE_FSMV2_MEMORY_CLEANUP=false`.
+- The FSMv2 communicator is now enabled by default. Previously, enterprise networks with firewalls that dropped idle connections could leave instances appearing offline in the Management Console until the container was restarted. The new communicator uses separate connections for status and commands, so a dropped pull connection no longer prevents heartbeats from reaching the backend, and it recovers automatically when the connection comes back. The memory cleanup routine it depends on is also enabled by default. If you previously disabled FSMv2 by setting `useFSMv2Transport: false` in `config.yaml`, that setting has had no effect since v0.44.8 -- to keep the legacy communicator you must set `USE_FSMV2_TRANSPORT=false` as an environment variable. To roll back, set `USE_FSMV2_TRANSPORT=false` and `USE_FSMV2_MEMORY_CLEANUP=false`.
 - Updated Go dependencies, includes security fixes for OIDC and JOSE authentication libraries
 
 ## [0.44.16]

--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Improvements
 
+- The FSMv2 communicator is now enabled by default. Previously, enterprise networks with firewalls that dropped idle connections could leave instances appearing offline in the Management Console until the container was restarted. The new communicator uses separate connections for status and commands, so a dropped pull connection no longer prevents heartbeats from reaching the backend, and it recovers automatically when the connection comes back. The memory cleanup routine it depends on is also on by default. To roll back, set `USE_FSMV2_TRANSPORT=false` and `USE_FSMV2_MEMORY_CLEANUP=false`.
 - Updated Go dependencies, includes security fixes for OIDC and JOSE authentication libraries
 
 ## [0.44.16]

--- a/umh-core/cmd/main.go
+++ b/umh-core/cmd/main.go
@@ -120,9 +120,15 @@ func main() {
 	// GetAsBool with required=false never returns an error (silently falls back
 	// to the default on parse failure); see ENG-4809 for the signature fix.
 	transportEnabled, _ := env.GetAsBool("USE_FSMV2_TRANSPORT", false, true)
-	configData.Agent.UseFSMv2Transport = transportEnabled
-
 	memoryCleanupEnabled, _ := env.GetAsBool("USE_FSMV2_MEMORY_CLEANUP", false, true)
+
+	// Memory cleanup is required whenever transport is on; running transport
+	// without cleanup reintroduces the unbounded state-growth risk (ENG-4292).
+	if transportEnabled {
+		memoryCleanupEnabled = true
+	}
+
+	configData.Agent.UseFSMv2Transport = transportEnabled
 	configData.Agent.UseFSMv2MemoryCleanup = memoryCleanupEnabled
 
 	protocolConverterEnabled, _ := env.GetAsBool("USE_FSMV2_PROTOCOL_CONVERTER", false, false)

--- a/umh-core/cmd/main.go
+++ b/umh-core/cmd/main.go
@@ -118,14 +118,14 @@ func main() {
 	// FSMv2 feature flags: read directly from env vars, not persisted to config.yaml.
 	// These bypass the config manager intentionally — they are temporary migration flags
 	// that will be replaced when the config manager becomes an FSMv2 worker.
-	v, err := env.GetAsBool("USE_FSMV2_TRANSPORT", false, false)
+	v, err := env.GetAsBool("USE_FSMV2_TRANSPORT", false, true)
 	if err != nil {
 		log.Warnf("Failed to parse USE_FSMV2_TRANSPORT: %v", err)
 	}
 
 	configData.Agent.UseFSMv2Transport = v
 
-	v, err = env.GetAsBool("USE_FSMV2_MEMORY_CLEANUP", false, false)
+	v, err = env.GetAsBool("USE_FSMV2_MEMORY_CLEANUP", false, true)
 	if err != nil {
 		log.Warnf("Failed to parse USE_FSMV2_MEMORY_CLEANUP: %v", err)
 	}

--- a/umh-core/cmd/main.go
+++ b/umh-core/cmd/main.go
@@ -95,10 +95,9 @@ func main() {
 
 	// Config backup feature flag: must be set before LoadConfigWithEnvOverrides,
 	// which writes config on startup and should back up the pre-write state.
-	configBackupEnabled, err := env.GetAsBool("ENABLE_CONFIG_BACKUP", false, false)
-	if err != nil {
-		log.Warnf("Failed to parse ENABLE_CONFIG_BACKUP: %v", err)
-	}
+	// GetAsBool with required=false never returns an error (silently falls back
+	// to the default on parse failure); see ENG-4809 for the signature fix.
+	configBackupEnabled, _ := env.GetAsBool("ENABLE_CONFIG_BACKUP", false, false)
 
 	configManager.SetConfigBackupEnabled(configBackupEnabled)
 
@@ -118,26 +117,16 @@ func main() {
 	// FSMv2 feature flags: read directly from env vars, not persisted to config.yaml.
 	// These bypass the config manager intentionally — they are temporary migration flags
 	// that will be replaced when the config manager becomes an FSMv2 worker.
-	v, err := env.GetAsBool("USE_FSMV2_TRANSPORT", false, true)
-	if err != nil {
-		log.Warnf("Failed to parse USE_FSMV2_TRANSPORT: %v", err)
-	}
+	// GetAsBool with required=false never returns an error (silently falls back
+	// to the default on parse failure); see ENG-4809 for the signature fix.
+	transportEnabled, _ := env.GetAsBool("USE_FSMV2_TRANSPORT", false, true)
+	configData.Agent.UseFSMv2Transport = transportEnabled
 
-	configData.Agent.UseFSMv2Transport = v
+	memoryCleanupEnabled, _ := env.GetAsBool("USE_FSMV2_MEMORY_CLEANUP", false, true)
+	configData.Agent.UseFSMv2MemoryCleanup = memoryCleanupEnabled
 
-	v, err = env.GetAsBool("USE_FSMV2_MEMORY_CLEANUP", false, true)
-	if err != nil {
-		log.Warnf("Failed to parse USE_FSMV2_MEMORY_CLEANUP: %v", err)
-	}
-
-	configData.Agent.UseFSMv2MemoryCleanup = v
-
-	v, err = env.GetAsBool("USE_FSMV2_PROTOCOL_CONVERTER", false, false)
-	if err != nil {
-		log.Warnf("Failed to parse USE_FSMV2_PROTOCOL_CONVERTER: %v", err)
-	}
-
-	configData.Agent.UseFSMv2ProtocolConverter = v
+	protocolConverterEnabled, _ := env.GetAsBool("USE_FSMV2_PROTOCOL_CONVERTER", false, false)
+	configData.Agent.UseFSMv2ProtocolConverter = protocolConverterEnabled
 
 	featureUsage := &models.FeatureUsage{
 		ConfigBackupEnabled:           configBackupEnabled,

--- a/umh-core/pkg/fsmv2/README.md
+++ b/umh-core/pkg/fsmv2/README.md
@@ -310,7 +310,6 @@ docker run -d \
   -e API_URL=https://management.umh.app \
   -e USE_FSMV2_TRANSPORT=true \
   -e USE_FSMV2_MEMORY_CLEANUP=true \
-  -e USE_FSMV2_PROTOCOL_CONVERTER=true \
   umh-core:latest
 ```
 
@@ -320,7 +319,6 @@ docker run -d \
 | `API_URL` | Yes | Backend relay server URL (e.g., `https://management.umh.app`) |
 | `USE_FSMV2_TRANSPORT` | No | Enables the FSMv2 communicator. Defaults to `true`. Set to `false` to fall back to the legacy communicator |
 | `USE_FSMV2_MEMORY_CLEANUP` | No | Enables the FSMv2 memory cleanup (persistence worker). Defaults to `true`. Set to `false` to disable |
-| `USE_FSMV2_PROTOCOL_CONVERTER` | No | Enables the FSMv2 protocol converter. Defaults to `false`. Set to `true` to enable |
 
 ### Disabling FSMv2 Features
 
@@ -329,8 +327,6 @@ docker run -d \
 ```bash
 -e USE_FSMV2_TRANSPORT=false
 ```
-
-`USE_FSMV2_PROTOCOL_CONVERTER` defaults to `false`; omit it or set it to `false` to keep the legacy behavior.
 
 ### Verifying FSMv2 Communicator
 

--- a/umh-core/pkg/fsmv2/README.md
+++ b/umh-core/pkg/fsmv2/README.md
@@ -318,17 +318,19 @@ docker run -d \
 |----------|----------|-------------|
 | `AUTH_TOKEN` | Yes | Authentication token from Management Console |
 | `API_URL` | Yes | Backend relay server URL (e.g., `https://management.umh.app`) |
-| `USE_FSMV2_TRANSPORT` | No | Set to `true` to enable FSMv2 communicator |
-| `USE_FSMV2_MEMORY_CLEANUP` | No | Set to `true` to enable FSMv2 memory cleanup (persistence worker) |
-| `USE_FSMV2_PROTOCOL_CONVERTER` | No | Set to `true` to enable FSMv2 protocol converter |
+| `USE_FSMV2_TRANSPORT` | No | Enables the FSMv2 communicator. Defaults to `true`. Set to `false` to fall back to the legacy communicator |
+| `USE_FSMV2_MEMORY_CLEANUP` | No | Enables the FSMv2 memory cleanup (persistence worker). Defaults to `true`. Set to `false` to disable |
+| `USE_FSMV2_PROTOCOL_CONVERTER` | No | Set to `true` to enable FSMv2 protocol converter. Defaults to `false` |
 
 ### Disabling FSMv2 Features
 
-To revert to the legacy behavior, set the corresponding flag to `false` or omit it (defaults to `false`):
+`USE_FSMV2_TRANSPORT` and `USE_FSMV2_MEMORY_CLEANUP` default to `true`. To revert to the legacy communicator, set the corresponding flag to `false`:
 
 ```bash
 -e USE_FSMV2_TRANSPORT=false
 ```
+
+`USE_FSMV2_PROTOCOL_CONVERTER` defaults to `false`; omit it or set it to `false` to keep the legacy behavior.
 
 ### Verifying FSMv2 Communicator
 

--- a/umh-core/pkg/fsmv2/README.md
+++ b/umh-core/pkg/fsmv2/README.md
@@ -320,7 +320,7 @@ docker run -d \
 | `API_URL` | Yes | Backend relay server URL (e.g., `https://management.umh.app`) |
 | `USE_FSMV2_TRANSPORT` | No | Enables the FSMv2 communicator. Defaults to `true`. Set to `false` to fall back to the legacy communicator |
 | `USE_FSMV2_MEMORY_CLEANUP` | No | Enables the FSMv2 memory cleanup (persistence worker). Defaults to `true`. Set to `false` to disable |
-| `USE_FSMV2_PROTOCOL_CONVERTER` | No | Set to `true` to enable FSMv2 protocol converter. Defaults to `false` |
+| `USE_FSMV2_PROTOCOL_CONVERTER` | No | Enables the FSMv2 protocol converter. Defaults to `false`. Set to `true` to enable |
 
 ### Disabling FSMv2 Features
 


### PR DESCRIPTION
Closes Stage 3 of [ENG-4231](https://linear.app/united-manufacturing-hub/issue/ENG-4231/fsmv2-communicator-rollout). Stage 4 (4-week stability window) begins post-merge.

## What

Flip two env-var defaults in `cmd/main.go`:

- `USE_FSMV2_TRANSPORT`: `false` → `true`
- `USE_FSMV2_MEMORY_CLEANUP`: `false` → `true`

Plus the corresponding `pkg/fsmv2/README.md` table and one CHANGELOG entry.

## Why now

All Stage 2 gates were met:

- Sentry feature tags in place; no new blocking issues for 4+ weeks with the flag on
- v-prefix fix (#2511) holding; Sentry clean on v0.44.12+
- VE team ran FSMv2 at customer sites in the preview window; confirmed ready
- Rollout approved at product meeting (15.04)

## Why both flags flip together

The memory cleanup routine is paired with the transport. Flipping `USE_FSMV2_TRANSPORT` alone would re-expose the unbounded state growth that `USE_FSMV2_MEMORY_CLEANUP` fixes (13 GB RAM incident under ENG-4292) for anyone who hadn't already opted into both. v0.44.8's CHANGELOG told users to set them as a pair, so this PR keeps that pairing.

`USE_FSMV2_PROTOCOL_CONVERTER` stays default-false — that migration is a separate rollout outside ENG-4231's scope.

## Rollback

```bash
docker run -e USE_FSMV2_TRANSPORT=false -e USE_FSMV2_MEMORY_CLEANUP=false ...
```

No config.yaml fallback — the `useFSMv2Transport:` yaml path was deprecated in v0.44.8.

## Reviewers

- Janik (code)
- Yannic (additional; led the FSMv2 chaos testing)
