### PR TITLE
chore: add github actions upgrades to renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,15 +1,26 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
+  "extends": ["config:recommended", "helpers:pinGitHubActionDigests"],
   "labels": ["dependencies", "skip-changelog-guard"],
   "commitMessagePrefix": "[renovate]chore(deps):",
   "includePaths": ["umh-core/**"],
-  "enabledManagers": ["dockerfile", "gomod"],
+  "enabledManagers": ["dockerfile", "gomod", "github-actions"],
   "postUpdateOptions": ["gomodTidy", "gomodVendor", "gomodUpdateImportPaths"],
   "minimumReleaseAge": "7 days",
   "timezone": "Europe/Berlin",
   "schedule": ["* * * * 0"],
   "packageRules": [
+    {
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch", "digest", "pinDigest"],
+      "enabled": false
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "github-actions major updates",
+      "enabled": true
+    },
     {
       "matchManagers": ["gomod"],
       "matchUpdateTypes": [

--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
   "extends": ["config:recommended", "helpers:pinGitHubActionDigests"],
   "labels": ["dependencies", "skip-changelog-guard"],
   "commitMessagePrefix": "[renovate]chore(deps):",
-  "includePaths": ["umh-core/**"],
+  "includePaths": ["umh-core/**", ".github/**"],
   "enabledManagers": ["dockerfile", "gomod", "github-actions"],
   "postUpdateOptions": ["gomodTidy", "gomodVendor", "gomodUpdateImportPaths"],
   "minimumReleaseAge": "7 days",


### PR DESCRIPTION
- Need to upgrade lots of github actions before June because of node version 20 not supported any more
- Just add it to renovate
- Will only create a PR for major github action version upgrades to avoid spam