### PR TITLE
fsmv2: fix data race in HTTPTransport.Reset by switching httpClient to atomic.Pointer

### DIFF
--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Preview: FSMv2 Communicator
+
+- Previously, the FSMv2 communicator could stop working if it rebuilt its HTTP connection (which happens after persistent network failures) while a message was being sent or received. Connection rebuilds and in-flight requests are now coordinated so they cannot interfere. Only affects instances with `USE_FSMV2_TRANSPORT=true`
+
 ## [0.44.18]
 
 Enables FSMv2 communicator by default.

--- a/umh-core/pkg/fsmv2/workers/transport/http/concurrency_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/http/concurrency_test.go
@@ -1,0 +1,78 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This spec fails under "go test -race" because Push reads t.httpClient
+// and Reset writes t.httpClient with no synchronization. Without -race
+// the data race is not visible and the spec passes.
+// The race is resolved when httpClient is switched to atomic.Pointer[http.Client].
+
+package transport_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+
+	httpTransport "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/http"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/types"
+)
+
+var _ = Describe("HTTPTransport concurrency", func() {
+	It("does not race when Push and Reset run concurrently (RED until atomic.Pointer[http.Client] fix)", func() {
+		// The server always returns 200 OK. The test only checks that the race
+		// detector reports a data race, not that individual requests succeed.
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = io.Copy(io.Discard, r.Body)
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		transport := httpTransport.NewHTTPTransport(server.URL, 5*time.Second)
+		defer transport.Close()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		// 10,000 iterations is enough to make the race detector trip reliably; reduce on slow CI if needed.
+		const iterations = 10000
+		// msgs is read-only and shared across both goroutines.
+		msgs := []*types.UMHMessage{{InstanceUUID: "race-test", Email: "race@example.com", Content: "{}"}}
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		// Goroutine A calls Push repeatedly; Push reads t.httpClient on every call.
+		go func() {
+			defer wg.Done()
+			for range iterations {
+				_ = transport.Push(ctx, "race-token", msgs)
+			}
+		}()
+
+		// Goroutine B calls Reset repeatedly; Reset writes t.httpClient with no synchronization.
+		go func() {
+			defer wg.Done()
+			for range iterations {
+				transport.Reset()
+			}
+		}()
+
+		wg.Wait()
+	})
+})

--- a/umh-core/pkg/fsmv2/workers/transport/http/concurrency_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/http/concurrency_test.go
@@ -61,6 +61,7 @@ var _ = Describe("HTTPTransport concurrency", func() {
 
 		// Goroutine A calls Push repeatedly; Push reads t.httpClient on every call.
 		go func() {
+			defer GinkgoRecover()
 			defer wg.Done()
 			for range iterations {
 				_ = transport.Push(ctx, "race-token", msgs)
@@ -69,6 +70,7 @@ var _ = Describe("HTTPTransport concurrency", func() {
 
 		// Goroutine B calls Reset repeatedly; Reset atomically replaces t.httpClient via atomic.Pointer.Store.
 		go func() {
+			defer GinkgoRecover()
 			defer wg.Done()
 			for range iterations {
 				transport.Reset()

--- a/umh-core/pkg/fsmv2/workers/transport/http/concurrency_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/http/concurrency_test.go
@@ -12,10 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This spec fails under "go test -race" because Push reads t.httpClient
-// and Reset writes t.httpClient with no synchronization. Without -race
-// the data race is not visible and the spec passes.
-// The race is resolved when httpClient is switched to atomic.Pointer[http.Client].
+// This spec is the regression guard for the atomic.Pointer-based fix
+// in HTTPTransport. It runs concurrent Push and Reset goroutines under
+// the race detector; the test passes only because httpClient is
+// atomic.Pointer[http.Client]. If a future change reverts to a raw
+// pointer (or any non-synchronized field), -race will catch the
+// regression here.
 
 package transport_test
 
@@ -34,9 +36,9 @@ import (
 )
 
 var _ = Describe("HTTPTransport concurrency", func() {
-	It("does not race when Push and Reset run concurrently (RED until atomic.Pointer[http.Client] fix)", func() {
-		// The server always returns 200 OK. The test only checks that the race
-		// detector reports a data race, not that individual requests succeed.
+	// Previously RED under -race; kept as regression guard after the atomic.Pointer fix.
+	It("does not race when Push and Reset run concurrently", func() {
+		// The test checks that no data race occurs under concurrent Push and Reset; the server always returns 200 OK.
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			_, _ = io.Copy(io.Discard, r.Body)
 			w.WriteHeader(http.StatusOK)
@@ -65,7 +67,7 @@ var _ = Describe("HTTPTransport concurrency", func() {
 			}
 		}()
 
-		// Goroutine B calls Reset repeatedly; Reset writes t.httpClient with no synchronization.
+		// Goroutine B calls Reset repeatedly; Reset atomically replaces t.httpClient via atomic.Pointer.Store.
 		go func() {
 			defer wg.Done()
 			for range iterations {

--- a/umh-core/pkg/fsmv2/workers/transport/http/http.go
+++ b/umh-core/pkg/fsmv2/workers/transport/http/http.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/communicator/pkg/hash"
@@ -171,51 +172,70 @@ func newTransportError(statusCode int, body []byte, headers http.Header, baseErr
 }
 
 // HTTPTransport implements HTTP-based communication using umh-core protocol.
+//
+// HTTPTransport publishes httpClient via atomic.Pointer so Push, Pull, and Authenticate
+// can read it concurrently while Reset replaces it without a mutex. Readers Load() a
+// local *http.Client and complete the in-flight call against that captured pointer;
+// subsequent calls observe the pointer from the most recent Store call.
+// CloseIdleConnections on the old client's transport acquires http.Transport's internal
+// idleMu, which is independent of any synchronization on HTTPTransport itself, so there
+// is no deadlock between Reset's cleanup and concurrent Do() calls. Reset publishes the
+// new client before closing idle connections on the old one.
+//
+// HTTPTransport must be created via NewHTTPTransport; a zero-value HTTPTransport is invalid.
 type HTTPTransport struct {
-	httpClient *http.Client
+	// Field order set by betteralign-fix.
+	httpClient atomic.Pointer[http.Client]
 	RelayURL   string
 }
 
 // NewHTTPTransport creates a new HTTP transport.
 // If timeout is 0, defaults to LongPollingDuration (30 seconds).
 // Transport settings match legacy communicator to avoid Cloudflare issues.
+// Connection pooling replaces the legacy DisableKeepAlives setting.
 func NewHTTPTransport(relayURL string, timeout time.Duration) *HTTPTransport {
 	if timeout == 0 {
 		timeout = LongPollingDuration
 	}
 
-	// Connection pooling replaces DisableKeepAlives for better performance (Bug #7 fix)
 	t := &HTTPTransport{
 		RelayURL: relayURL,
-		httpClient: &http.Client{
-			Timeout: timeout,
-			Transport: &http.Transport{
-				// Disable HTTP/2 to match Cloudflare behavior
-				ForceAttemptHTTP2: false,
-				TLSNextProto:      make(map[string]func(authority string, c *tls.Conn) http.RoundTripper),
-				Proxy:             http.ProxyFromEnvironment,
-
-				// Connection pooling (minimal for low-traffic FSMv2)
-				MaxIdleConns:        5, // Total idle connections
-				MaxIdleConnsPerHost: 1, // 1 idle connection to relay endpoint
-				MaxConnsPerHost:     2, // Up to 2 concurrent (auth + pull/push)
-
-				// Dial settings
-				DialContext: (&net.Dialer{
-					Timeout:   30 * time.Second,
-					KeepAlive: 30 * time.Second,
-				}).DialContext,
-
-				// Timeouts
-				IdleConnTimeout:       30 * time.Second, // Match legacy keepAliveTimeout
-				TLSHandshakeTimeout:   10 * time.Second,
-				ResponseHeaderTimeout: 30 * time.Second,
-				ExpectContinueTimeout: 1 * time.Second,
-			},
-		},
 	}
+	t.httpClient.Store(buildHTTPClient(timeout))
 
 	return t
+}
+
+// buildHTTPClient constructs the *http.Client used by NewHTTPTransport and
+// Reset. Both call paths produce a client with identical settings, so this
+// function centralizes the configuration.
+func buildHTTPClient(timeout time.Duration) *http.Client {
+	return &http.Client{
+		Timeout: timeout,
+		Transport: &http.Transport{
+			// Disable HTTP/2 to match Cloudflare behavior
+			ForceAttemptHTTP2: false,
+			TLSNextProto:      make(map[string]func(authority string, c *tls.Conn) http.RoundTripper),
+			Proxy:             http.ProxyFromEnvironment,
+
+			// Connection pooling (minimal for low-traffic FSMv2)
+			MaxIdleConns:        5, // Total idle connections
+			MaxIdleConnsPerHost: 1, // 1 idle connection to relay endpoint
+			MaxConnsPerHost:     2, // Up to 2 concurrent (auth + pull/push)
+
+			// Dial settings
+			DialContext: (&net.Dialer{
+				Timeout:   30 * time.Second,
+				KeepAlive: 30 * time.Second,
+			}).DialContext,
+
+			// Timeouts
+			IdleConnTimeout:       30 * time.Second, // Match legacy keepAliveTimeout
+			TLSHandshakeTimeout:   10 * time.Second,
+			ResponseHeaderTimeout: 30 * time.Second,
+			ExpectContinueTimeout: 1 * time.Second,
+		},
+	}
 }
 
 // Authenticate performs JWT authentication using double-hashed token in Authorization header.
@@ -234,7 +254,8 @@ func (t *HTTPTransport) Authenticate(ctx context.Context, req types.AuthRequest)
 	httpReq.Header.Set("Authorization", "Bearer "+hashedToken)
 	httpReq.Header.Set("Content-Type", "application/json")
 
-	resp, err := t.httpClient.Do(httpReq)
+	client := t.httpClient.Load()
+	resp, err := client.Do(httpReq)
 	if err != nil {
 		return types.AuthResponse{}, &types.TransportError{
 			Type:    types.ErrorTypeNetwork,
@@ -320,7 +341,8 @@ func (t *HTTPTransport) Pull(ctx context.Context, jwtToken string) ([]*types.UMH
 
 	httpReq.AddCookie(&http.Cookie{Name: "token", Value: jwtToken})
 
-	resp, err := t.httpClient.Do(httpReq)
+	client := t.httpClient.Load()
+	resp, err := client.Do(httpReq)
 	if err != nil {
 		return nil, &types.TransportError{
 			Type:    types.ErrorTypeNetwork,
@@ -386,7 +408,8 @@ func (t *HTTPTransport) Push(ctx context.Context, jwtToken string, messages []*t
 	httpReq.Header.Set("Content-Type", "application/json")
 	httpReq.AddCookie(&http.Cookie{Name: "token", Value: jwtToken})
 
-	resp, err := t.httpClient.Do(httpReq)
+	client := t.httpClient.Load()
+	resp, err := client.Do(httpReq)
 	if err != nil {
 		return &types.TransportError{
 			Type:    types.ErrorTypeNetwork,
@@ -408,43 +431,45 @@ func (t *HTTPTransport) Push(ctx context.Context, jwtToken string, messages []*t
 	return nil
 }
 
-// ResetClient resets the HTTP client (closes idle connections).
+// ResetClient closes idle connections on the current HTTP client without
+// replacing it. Safe to call concurrently with Push, Pull, and Authenticate.
+// http.Transport.CloseIdleConnections acquires the transport's internal
+// idleMu, which is independent of any synchronization on HTTPTransport.
 func (t *HTTPTransport) ResetClient() {
-	if tr, ok := t.httpClient.Transport.(*http.Transport); ok {
-		tr.CloseIdleConnections()
+	if c := t.httpClient.Load(); c != nil {
+		// If Transport is not *http.Transport, idle-connection draining is skipped.
+		if tr, ok := c.Transport.(*http.Transport); ok {
+			tr.CloseIdleConnections()
+		}
 	}
 }
 
-// Close closes the transport.
+// Close drains idle connections but does not prevent new requests; callers must
+// cancel the context to stop in-flight and future calls.
 func (t *HTTPTransport) Close() {
 	t.ResetClient()
 }
 
-// Reset recreates the HTTP client to establish fresh connections when retries aren't helping.
+// Reset recreates the HTTP client to establish fresh connections when retries
+// aren't helping. The new client is published atomically; concurrent Push,
+// Pull, and Authenticate either observe the old client (and finish their
+// in-flight call against it) or the new one. Reset is non-blocking. The
+// atomic Store does not wait for in-flight reads.
+// Reset must be called from a single goroutine; the FSMv2 reconciler is the only intended caller.
 func (t *HTTPTransport) Reset() {
-	// Close existing connections
-	t.ResetClient()
+	old := t.httpClient.Load()
 
-	t.httpClient = &http.Client{
-		Timeout: t.httpClient.Timeout,
-		Transport: &http.Transport{
-			ForceAttemptHTTP2: false,
-			TLSNextProto:      make(map[string]func(authority string, c *tls.Conn) http.RoundTripper),
-			Proxy:             http.ProxyFromEnvironment,
+	timeout := LongPollingDuration
+	if old != nil {
+		timeout = old.Timeout
+	}
 
-			MaxIdleConns:        5,
-			MaxIdleConnsPerHost: 1,
-			MaxConnsPerHost:     2,
+	t.httpClient.Store(buildHTTPClient(timeout))
 
-			DialContext: (&net.Dialer{
-				Timeout:   30 * time.Second,
-				KeepAlive: 30 * time.Second,
-			}).DialContext,
-
-			IdleConnTimeout:       30 * time.Second,
-			TLSHandshakeTimeout:   10 * time.Second,
-			ResponseHeaderTimeout: 30 * time.Second,
-			ExpectContinueTimeout: 1 * time.Second,
-		},
+	if old != nil {
+		// If Transport is not *http.Transport, idle-connection draining is skipped.
+		if tr, ok := old.Transport.(*http.Transport); ok {
+			tr.CloseIdleConnections()
+		}
 	}
 }


### PR DESCRIPTION
### Background

`HTTPTransport.Reset()` reassigns the inner `*http.Client` with no synchronization. Push, Pull, and Authenticate run as separate FSMv2 child-worker goroutines and read `t.httpClient` on every tick. They share one `*HTTPTransport` instance via a singleton channel provider (`pkg/fsmv2/workers/transport/channel_provider.go`). The field write in `Reset()` races against every concurrent read.

The existing `TransportDependencies.mu` lock guards the `Transport` interface slot on the dependency wrapper, not the `*http.Client` field inside the concrete `HTTPTransport` struct. `HTTPTransport` itself has no mutex. `go test -race` reproduces.

The race has been latent since the FSMv2 transport worker was split out from the communicator worker and Push, Pull, and Authenticate became child workers running on their own goroutines — concurrent access to a struct designed for a single owner. Surfaced by @FalconTube during a code review.

### What this PR does

Changes `HTTPTransport.httpClient` from `*http.Client` to `atomic.Pointer[http.Client]`:
- `Authenticate`, `Pull`, `Push` capture a local client via `t.httpClient.Load()` before the HTTP round-trip
- `Reset()` constructs the new client, calls `CloseIdleConnections()` on the old client's transport, and publishes the new client via `t.httpClient.Store(...)`
- No mutex on the struct — the atomic pointer's load/store is the synchronization primitive

Adds a package-doc comment on `HTTPTransport` describing the concurrency contract.

### What this PR does NOT do

- **Reset still recreates the client.** That semantic is intentional (FSMv1 had a bug here that the recreation was designed to avoid). Atomic publication protects the existing recreate; it does not change it. `CloseIdleConnections()`-only is explicitly out of scope.
- No changes to `resetGeneration` or the child-clearing flow.
- No changes to `TransportDependencies.mu` — that guards a different concern.

### Why `atomic.Pointer` and not `sync.RWMutex`

`atomic.Pointer[http.Client]` is the textbook Go answer for this access pattern: a single field swapped wholesale, many concurrent readers, one rare writer. The struct shrinks (no 24-byte mutex), each call site shrinks (one line instead of three), and the type encodes the intent — a reader of the struct definition immediately sees "swappable singleton, atomically replaceable." Reset is also non-blocking: if Push is mid-call against a slow endpoint, `Store()` does not wait for the call to finish.

`sync.RWMutex` would also work and would mirror the existing `TransportDependencies.mu` pattern, but it adds bookkeeping the access pattern doesn't need. If you'd prefer RWMutex during review, the change to flip back is ~6 lines.

### Tests

This PR is written test-first. The race-reproducing test was added in its own commit and verified RED — `go test -race` flagged the data race in `t.httpClient` — before any synchronization was added. The lock lands in a follow-up commit that turns the same test GREEN. Git history shows the ordering: failing-test commit, then fix commit. The race is timing-dependent without `-race`, so the race detector is the correct primary mechanism.

Existing transport-worker tests pass unchanged.

`go test -race ./pkg/fsmv2/workers/transport/...`, `go vet ./...`, `golangci-lint run` all clean.

### Stacked on

PR #2547 — transport package move. Cannot merge before that lands.

### Changelog

```
### Preview: FSMv2 Communicator

- Previously, the FSMv2 communicator could stop working if it rebuilt its HTTP connection (which happens after persistent network failures) while a message was being sent or received. Connection rebuilds and in-flight requests are now coordinated so they cannot interfere. Only affects instances with `USE_FSMV2_TRANSPORT=true`
```


Closes ENG-4865
