### PR TITLE
ENG-4880: stop sending fake config errors to Sentry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ compass_artifact*
 # Test results
 *.result.txt
 .worktrees/
+.self-review/

--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Improvements
+
+- A typo in `releaseChannel` in `config.yaml` (e.g. `nigtly`) used to be silently swapped for a placeholder, with nothing surfacing in Management Console. The agent now flags it as degraded with the offending value and the allowed options (`nightly`, `stable`, `enterprise`), and runs on `stable` until you fix the YAML
+
 ## [0.44.19]
 
 ### Improvements

--- a/umh-core/pkg/communicator/actions/edit_instance_test.go
+++ b/umh-core/pkg/communicator/actions/edit_instance_test.go
@@ -645,8 +645,3 @@ func (w *writeFailingMockConfigManager) GetBackupCount() uint64 {
 	return 0
 }
 
-// GetConfigValidationIssues returns nil for the mock — this test fixture is
-// scoped to write-failure paths and has no validation surface to assert.
-func (w *writeFailingMockConfigManager) GetConfigValidationIssues() []config.ConfigValidationIssue {
-	return nil
-}

--- a/umh-core/pkg/communicator/actions/edit_instance_test.go
+++ b/umh-core/pkg/communicator/actions/edit_instance_test.go
@@ -644,3 +644,9 @@ func (w *writeFailingMockConfigManager) AtomicDeleteStreamProcessor(ctx context.
 func (w *writeFailingMockConfigManager) GetBackupCount() uint64 {
 	return 0
 }
+
+// GetConfigValidationIssues returns nil for the mock — this test fixture is
+// scoped to write-failure paths and has no validation surface to assert.
+func (w *writeFailingMockConfigManager) GetConfigValidationIssues() []config.ConfigValidationIssue {
+	return nil
+}

--- a/umh-core/pkg/communicator/pkg/generator/agent.go
+++ b/umh-core/pkg/communicator/pkg/generator/agent.go
@@ -61,12 +61,12 @@ func buildAgent(
 		return defaultAgent(), "n/a", "n/a", []models.Version{}, errors.New("invalid observed-state")
 	}
 
-	// Prefer the dynamic HealthMessage when set (e.g. config-validation issues
-	// projected by agent_monitor.Status). Fall back to the canned per-category text
-	// so default Active/Degraded paths look unchanged from the user's perspective.
-	message := snap.ServiceInfoSnapshot.HealthMessage
-	if message == "" {
-		message = getAgentHealthMessage(snap.ServiceInfoSnapshot.OverallHealth)
+	// HealthMessage is only meaningful when the category is non-Active. Producers
+	// set it alongside an Active->Degraded escalation; treating it as authoritative
+	// when the category is Active would let a stale message override a healthy state.
+	message := getAgentHealthMessage(snap.ServiceInfoSnapshot.OverallHealth)
+	if snap.ServiceInfoSnapshot.OverallHealth != models.Active && snap.ServiceInfoSnapshot.HealthMessage != "" {
+		message = snap.ServiceInfoSnapshot.HealthMessage
 	}
 	agent := models.Agent{
 		Location: snap.ServiceInfoSnapshot.Location,

--- a/umh-core/pkg/communicator/pkg/generator/agent.go
+++ b/umh-core/pkg/communicator/pkg/generator/agent.go
@@ -61,10 +61,17 @@ func buildAgent(
 		return defaultAgent(), "n/a", "n/a", []models.Version{}, errors.New("invalid observed-state")
 	}
 
+	// Prefer the dynamic HealthMessage when set (e.g. config-validation issues
+	// projected by agent_monitor.Status). Fall back to the canned per-category text
+	// so default Active/Degraded paths look unchanged from the user's perspective.
+	message := snap.ServiceInfoSnapshot.HealthMessage
+	if message == "" {
+		message = getAgentHealthMessage(snap.ServiceInfoSnapshot.OverallHealth)
+	}
 	agent := models.Agent{
 		Location: snap.ServiceInfoSnapshot.Location,
 		Health: &models.Health{
-			Message:       getAgentHealthMessage(snap.ServiceInfoSnapshot.OverallHealth),
+			Message:       message,
 			ObservedState: instance.CurrentState,
 			DesiredState:  instance.DesiredState,
 			Category:      snap.ServiceInfoSnapshot.OverallHealth,

--- a/umh-core/pkg/communicator/pkg/generator/agent_test.go
+++ b/umh-core/pkg/communicator/pkg/generator/agent_test.go
@@ -74,6 +74,27 @@ var _ = Describe("buildAgent (P13)", func() {
 		Expect(agent.Health.Message).To(Equal("Agent operating normally"))
 	})
 
+	It("ignores HealthMessage when category is Active (guards against stale message)", func() {
+		snap := &agentfsm.AgentObservedStateSnapshot{
+			ServiceInfoSnapshot: agentsvc.ServiceInfo{
+				OverallHealth: models.Active,
+				HealthMessage: "ignore me — stale Degraded message",
+				Release:       &models.Release{Channel: "stable", Version: "1.0.0"},
+			},
+		}
+		instance := fsm.FSMInstanceSnapshot{
+			ID:                "Core",
+			CurrentState:      "active",
+			DesiredState:      "active",
+			LastObservedState: snap,
+		}
+
+		agent, _, _, _, err := buildAgent(instance, log)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(agent.Health).NotTo(BeNil())
+		Expect(agent.Health.Message).To(Equal("Agent operating normally"))
+	})
+
 	It("falls back to canned message when HealthMessage is empty (Degraded)", func() {
 		snap := &agentfsm.AgentObservedStateSnapshot{
 			ServiceInfoSnapshot: agentsvc.ServiceInfo{

--- a/umh-core/pkg/communicator/pkg/generator/agent_test.go
+++ b/umh-core/pkg/communicator/pkg/generator/agent_test.go
@@ -1,0 +1,96 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
+	agentfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/agent_monitor"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/models"
+	agentsvc "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/agent_monitor"
+	"go.uber.org/zap"
+)
+
+var _ = Describe("buildAgent (P13)", func() {
+	var log *zap.SugaredLogger
+
+	BeforeEach(func() {
+		log = zap.NewNop().Sugar()
+	})
+
+	It("uses ServiceInfoSnapshot.HealthMessage when non-empty", func() {
+		snap := &agentfsm.AgentObservedStateSnapshot{
+			ServiceInfoSnapshot: agentsvc.ServiceInfo{
+				OverallHealth: models.Degraded,
+				HealthMessage: `Invalid agent.releaseChannel value "nigtly". Allowed: nightly, stable, enterprise.`,
+				Release:       &models.Release{Channel: "stable", Version: "1.0.0"},
+			},
+		}
+		instance := fsm.FSMInstanceSnapshot{
+			ID:                "Core",
+			CurrentState:      "active",
+			DesiredState:      "active",
+			LastObservedState: snap,
+		}
+
+		agent, _, _, _, err := buildAgent(instance, log)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(agent.Health).NotTo(BeNil())
+		Expect(agent.Health.Message).To(ContainSubstring("nigtly"))
+		Expect(agent.Health.Message).To(ContainSubstring("agent.releaseChannel"))
+		Expect(agent.Health.Category).To(Equal(models.Degraded))
+	})
+
+	It("falls back to canned message when HealthMessage is empty (Active)", func() {
+		snap := &agentfsm.AgentObservedStateSnapshot{
+			ServiceInfoSnapshot: agentsvc.ServiceInfo{
+				OverallHealth: models.Active,
+				Release:       &models.Release{Channel: "stable", Version: "1.0.0"},
+			},
+		}
+		instance := fsm.FSMInstanceSnapshot{
+			ID:                "Core",
+			CurrentState:      "active",
+			DesiredState:      "active",
+			LastObservedState: snap,
+		}
+
+		agent, _, _, _, err := buildAgent(instance, log)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(agent.Health).NotTo(BeNil())
+		Expect(agent.Health.Message).To(Equal("Agent operating normally"))
+	})
+
+	It("falls back to canned message when HealthMessage is empty (Degraded)", func() {
+		snap := &agentfsm.AgentObservedStateSnapshot{
+			ServiceInfoSnapshot: agentsvc.ServiceInfo{
+				OverallHealth: models.Degraded,
+				Release:       &models.Release{Channel: "stable", Version: "1.0.0"},
+			},
+		}
+		instance := fsm.FSMInstanceSnapshot{
+			ID:                "Core",
+			CurrentState:      "degraded",
+			DesiredState:      "active",
+			LastObservedState: snap,
+		}
+
+		agent, _, _, _, err := buildAgent(instance, log)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(agent.Health).NotTo(BeNil())
+		Expect(agent.Health.Message).To(Equal("Agent degraded"))
+	})
+})

--- a/umh-core/pkg/config/config.go
+++ b/umh-core/pkg/config/config.go
@@ -140,6 +140,16 @@ const (
 	ReleaseChannelEnterprise ReleaseChannel = "enterprise"
 )
 
+// ConfigValidationIssue describes a user-facing config-content problem
+// surfaced via the agent health message. Validators that detect bad
+// values emit one of these instead of calling SentryWarn — see doc.go
+// for policy. Internal type; never on the wire.
+type ConfigValidationIssue struct {
+	Field          string   // dotted path: "agent.releaseChannel"
+	OffendingValue string   // exactly what the user wrote
+	AllowedValues  []string // optional
+}
+
 // S6FSMConfig contains configuration for creating a service.
 type S6FSMConfig struct {
 	// For the FSM

--- a/umh-core/pkg/config/datacontract_config_test.go
+++ b/umh-core/pkg/config/datacontract_config_test.go
@@ -113,7 +113,7 @@ dataContracts:
 				Expect(writtenData).NotTo(BeEmpty())
 
 				// Parse the written data to verify it contains the data contract
-				writtenConfig, err := ParseConfig(writtenData, ctx, false)
+				writtenConfig, err := ParseConfig(writtenData, ctx, false, false)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(writtenConfig.DataContracts).To(HaveLen(1))
 				Expect(writtenConfig.DataContracts[0].Name).To(Equal("test-contract"))

--- a/umh-core/pkg/config/datamodel_config_test.go
+++ b/umh-core/pkg/config/datamodel_config_test.go
@@ -77,7 +77,7 @@ dataModels:
           unit:
             _payloadshape: timeseries-number
 `
-				config, err := ParseConfig([]byte(validYAML), ctx, false)
+				config, err := ParseConfig([]byte(validYAML), ctx, false, false)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(config.Internal.Services).To(HaveLen(1))
@@ -118,7 +118,7 @@ dataModels:
               name: device-info
               version: v1
 `
-				config, err := ParseConfig([]byte(complexYAML), ctx, false)
+				config, err := ParseConfig([]byte(complexYAML), ctx, false, false)
 				Expect(err).NotTo(HaveOccurred())
 
 				// Test complex data model parsing
@@ -159,7 +159,7 @@ dataModels:
               name: sensor-metadata
               version: v1
 `
-				config, err := ParseConfig([]byte(multiVersionYAML), ctx, false)
+				config, err := ParseConfig([]byte(multiVersionYAML), ctx, false, false)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(config.DataModels).To(HaveLen(1))
@@ -265,7 +265,7 @@ dataModels:
 				Expect(writtenData).NotTo(BeEmpty())
 
 				// Parse the written data to verify it contains the data model
-				writtenConfig, err := ParseConfig(writtenData, ctx, false)
+				writtenConfig, err := ParseConfig(writtenData, ctx, false, false)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(writtenConfig.DataModels).To(HaveLen(1))
 				Expect(writtenConfig.DataModels[0].Name).To(Equal("temperature"))
@@ -402,7 +402,7 @@ dataModels:
 				Expect(writtenData).NotTo(BeEmpty())
 
 				// Parse the written data to verify it contains both versions
-				writtenConfig, err := ParseConfig(writtenData, ctx, false)
+				writtenConfig, err := ParseConfig(writtenData, ctx, false, false)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(writtenConfig.DataModels).To(HaveLen(1))
 				Expect(writtenConfig.DataModels[0].Name).To(Equal("temperature"))
@@ -517,7 +517,7 @@ dataModels:
 				Expect(writtenData).NotTo(BeEmpty())
 
 				// Parse the written data to verify the correct model was removed
-				writtenConfig, err := ParseConfig(writtenData, ctx, false)
+				writtenConfig, err := ParseConfig(writtenData, ctx, false, false)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(writtenConfig.DataModels).To(HaveLen(1))
 				Expect(writtenConfig.DataModels[0].Name).To(Equal("pressure"))

--- a/umh-core/pkg/config/doc.go
+++ b/umh-core/pkg/config/doc.go
@@ -1,0 +1,28 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package config manages the YAML configuration for umh-core.
+//
+// # Sentry vs ConfigValidationIssue policy
+//
+// Validators that read user-supplied YAML field VALUES (e.g. releaseChannel
+// not in the allowed enum) MUST surface via ConfigValidationIssue → degraded
+// agent health message. They MUST NOT call SentryWarn / SentryError. The user
+// is the one who can fix the value; Sentry routes are for engineering signals
+// only.
+//
+// IO / filesystem / parser failures (file unreadable, backup write failed,
+// config_manager_permanently_failed) continue using SentryWarn / SentryError —
+// those are real engineering signals about disk / OS / bug surface.
+package config

--- a/umh-core/pkg/config/manager.go
+++ b/umh-core/pkg/config/manager.go
@@ -484,15 +484,6 @@ func (m *FileConfigManager) readAndParseConfig(ctx context.Context) (FullConfig,
 		return FullConfig{}, "", fmt.Errorf("config file is empty: %s", m.configPath)
 	}
 
-	// Validate the location map
-	// This ensures downstream code doesn't panic when trying to access the location map
-	if config.Agent.Location == nil {
-		m.logger.SentryWarn(deps.FeatureFSMv1ConfigManager, configManagerHierarchyPath,
-			"config_missing_location_map", deps.String("path", m.configPath))
-
-		config.Agent.Location = make(map[int]string)
-	}
-
 	// Validate that the release channel is valid
 	// This prevent weird values from being set by the user
 	if config.Agent.ReleaseChannel != ReleaseChannelNightly && config.Agent.ReleaseChannel != ReleaseChannelStable && config.Agent.ReleaseChannel != ReleaseChannelEnterprise {

--- a/umh-core/pkg/config/manager.go
+++ b/umh-core/pkg/config/manager.go
@@ -467,7 +467,7 @@ func (m *FileConfigManager) readAndParseConfig(ctx context.Context) (FullConfig,
 		return FullConfig{}, "", ctx.Err()
 	}
 
-	config, err := ParseConfig(data, ctx, false)
+	config, err := ParseConfig(data, ctx, false, true)
 	if err != nil {
 		return FullConfig{}, "", fmt.Errorf("failed to parse config file: %w", err)
 	}
@@ -637,13 +637,17 @@ func (m *FileConfigManager) WithConfigPath(configPath string) *FileConfigManager
 }
 
 // ParseConfig parses YAML configuration data into a FullConfig struct with optional validation.
-// It performs two main operations:
+// It performs three main operations:
 // 1. Decodes the YAML data using strict field validation (unless allowUnknownFields is true)
 // 2. Processes any templateRef resolution for protocol converters
+// 3. When applyDefaults is true, applies defaults for omitempty fields (location, releaseChannel)
 //
 // Parameters:
 //   - data: Raw YAML configuration data as bytes
 //   - allowUnknownFields: If true, allows unknown fields in the YAML; if false, rejects them
+//   - applyDefaults: If true, defaults nil location to empty map and empty releaseChannel to "stable".
+//     Production callers (readAndParseConfig) pass true. Test callers that round-trip configs
+//     should pass false to preserve the original empty-equals-empty semantics.
 //
 // Returns:
 //   - FullConfig: The parsed and processed configuration
@@ -651,7 +655,7 @@ func (m *FileConfigManager) WithConfigPath(configPath string) *FileConfigManager
 //
 // Note: This function is exported primarily for use in runtime_config_test to provide
 // comprehensive test coverage of the configuration parsing functionality.
-func ParseConfig(data []byte, ctx context.Context, allowUnknownFields bool) (FullConfig, error) {
+func ParseConfig(data []byte, ctx context.Context, allowUnknownFields, applyDefaults bool) (FullConfig, error) {
 	var rawConfig FullConfig
 
 	// First decode the YAML into the raw config structure using standard YAML functions
@@ -666,6 +670,15 @@ func ParseConfig(data []byte, ctx context.Context, allowUnknownFields bool) (Ful
 	processedConfig, err := convertYamlToSpec(rawConfig, ctx)
 	if err != nil {
 		return FullConfig{}, fmt.Errorf("failed to resolve protocol converter template references: %w", err)
+	}
+
+	if applyDefaults {
+		if processedConfig.Agent.Location == nil {
+			processedConfig.Agent.Location = make(map[int]string)
+		}
+		if strings.TrimSpace(string(processedConfig.Agent.ReleaseChannel)) == "" {
+			processedConfig.Agent.ReleaseChannel = ReleaseChannelStable
+		}
 	}
 
 	return processedConfig, nil
@@ -1102,11 +1115,11 @@ func (m *FileConfigManagerWithBackoff) UpdateAndGetCacheModTime(ctx context.Cont
 // otherwise be processed through the template system.
 func (m *FileConfigManager) WriteYAMLConfigFromString(ctx context.Context, configStr string, expectedModTime string) error {
 	// First parse the config with strict validation to detect syntax errors and schema problems
-	_, err := ParseConfig([]byte(configStr), ctx, false)
+	_, err := ParseConfig([]byte(configStr), ctx, false, false)
 	if err != nil {
 		// If strict parsing fails, try again with allowUnknownFields=true
 		// This allows YAML anchors and other custom fields
-		_, err = ParseConfig([]byte(configStr), ctx, true)
+		_, err = ParseConfig([]byte(configStr), ctx, true, false)
 		if err != nil {
 			return fmt.Errorf("failed to parse config: %w", err)
 		}
@@ -1164,7 +1177,7 @@ func (m *FileConfigManager) WriteYAMLConfigFromString(ctx context.Context, confi
 	// We already validated the config above, so this should succeed
 	// This parsing step is crucial as it converts the raw YAML to the proper spec config format,
 	// ensuring template references are resolved and the cache contains valid, usable config data
-	newConfig, err := ParseConfig([]byte(configStr), ctx, true) // Allow unknown fields for YAML anchors
+	newConfig, err := ParseConfig([]byte(configStr), ctx, true, true) // Allow unknown fields for YAML anchors; apply defaults so cache matches readAndParseConfig
 	if err != nil {
 		// If parsing fails, invalidate cache to force fresh read later
 		m.cacheMu.Lock()

--- a/umh-core/pkg/config/manager.go
+++ b/umh-core/pkg/config/manager.go
@@ -160,23 +160,23 @@ type FileConfigManager struct {
 
 	cacheRawConfig string
 
-	cacheConfig FullConfig // struct obtained from that file
-
 	// validationIssues holds the results of the last config-content validation pass.
 	// Always swapped wholesale (never appended to) by readAndParseConfig — see swapValidationIssues.
 	validationIssues []ConfigValidationIssue
 
+	cacheConfig FullConfig // struct obtained from that file
+
+	// backupCount tracks the number of config backups created since startup.
+	backupCount atomic.Uint64
+
 	// ---------- in-memory cache (read-only after RLock) ----------
 	cacheMu sync.RWMutex // guards the two fields below
-
-	// ---------- background refresh state ----------
-	refreshMu sync.Mutex // prevents concurrent background refreshes
 
 	// validationIssuesMu guards validationIssues.
 	validationIssuesMu sync.RWMutex
 
-	// backupCount tracks the number of config backups created since startup.
-	backupCount atomic.Uint64
+	// ---------- background refresh state ----------
+	refreshMu sync.Mutex // prevents concurrent background refreshes
 
 	// backupEnabled controls whether config backups are created before writes.
 	backupEnabled bool

--- a/umh-core/pkg/config/manager.go
+++ b/umh-core/pkg/config/manager.go
@@ -527,17 +527,25 @@ func (m *FileConfigManager) validateConfig(config *FullConfig) []ConfigValidatio
 	return issues
 }
 
-// swapValidationIssues replaces the validation-issues list wholesale.
-// Called only from readAndParseConfig — never from cache hits or the backup write path.
-// This guarantees that fixed configs clear stale issues on the next successful parse.
+// swapValidationIssues replaces the validation-issues list wholesale. Mutex-protected
+// so concurrent GetConfigValidationIssues readers always observe a consistent slice.
+// Callers are readAndParseConfig (read path) and WriteYAMLConfigFromString (write path);
+// cache-hit GetConfig does not call this — see manager.go's FAST PATH — which is the
+// invariant that lets a successful parse decide what the latest issues list is.
+// The cache (cacheConfig + cacheModTime) and the issues list are decoupled by design:
+// they live behind separate mutexes and update independently, since validation runs
+// after parsing whereas the cache stores the parsed result.
 func (m *FileConfigManager) swapValidationIssues(fresh []ConfigValidationIssue) {
 	m.validationIssuesMu.Lock()
 	defer m.validationIssuesMu.Unlock()
 	m.validationIssues = fresh
 }
 
-// GetConfigValidationIssues returns a copy of the validation issues from the most recent parse.
-// Safe to call concurrently with swapValidationIssues.
+// GetConfigValidationIssues returns a defensive copy of the validation issues recorded
+// by the most recent successful parse (read or write path). The returned slice is
+// owned by the caller; mutating it does not affect the manager's internal list.
+// Safe to call concurrently with swapValidationIssues. An empty slice means the
+// last parse passed validation; nil and empty are equivalent here.
 func (m *FileConfigManager) GetConfigValidationIssues() []ConfigValidationIssue {
 	m.validationIssuesMu.RLock()
 	defer m.validationIssuesMu.RUnlock()
@@ -691,10 +699,15 @@ func (m *FileConfigManager) WithConfigPath(configPath string) *FileConfigManager
 //
 // Parameters:
 //   - data: Raw YAML configuration data as bytes
-//   - allowUnknownFields: If true, allows unknown fields in the YAML; if false, rejects them
+//   - ctx: Context for cancellation propagated through templateRef resolution
+//   - allowUnknownFields: If true, allows unknown fields in the YAML; if false, rejects them.
+//     readAndParseConfig passes false (strict); WriteYAMLConfigFromString first tries
+//     false then retries with true to keep YAML anchors working for hand-edited files.
 //   - applyDefaults: If true, defaults nil location to empty map and empty releaseChannel to "stable".
-//     Production callers (readAndParseConfig) pass true. Test callers that round-trip configs
-//     should pass false to preserve the original empty-equals-empty semantics.
+//     The read path (readAndParseConfig) and the cache-update parse inside
+//     WriteYAMLConfigFromString pass true so downstream consumers always see populated
+//     fields; pure-validation parses (the strict pre-write check) and tests that need
+//     to assert original empty-equals-empty semantics pass false.
 //
 // Returns:
 //   - FullConfig: The parsed and processed configuration

--- a/umh-core/pkg/config/manager.go
+++ b/umh-core/pkg/config/manager.go
@@ -491,13 +491,22 @@ func (m *FileConfigManager) readAndParseConfig(ctx context.Context) (FullConfig,
 		return FullConfig{}, "", fmt.Errorf("config file is empty: %s", m.configPath)
 	}
 
-	// Validate that the release channel is valid
-	// This prevent weird values from being set by the user
-	if config.Agent.ReleaseChannel != ReleaseChannelNightly && config.Agent.ReleaseChannel != ReleaseChannelStable && config.Agent.ReleaseChannel != ReleaseChannelEnterprise {
-		m.logger.SentryWarn(deps.FeatureFSMv1ConfigManager, configManagerHierarchyPath,
-			"config_invalid_release_channel", deps.String("release_channel", string(config.Agent.ReleaseChannel)))
-		config.Agent.ReleaseChannel = "n/a"
+	// Validate that the release channel is one of the allowed enum values.
+	// Empty values are defaulted to "stable" inside ParseConfig (applyDefaults=true) and
+	// never reach this branch — only non-empty typos do. We do NOT call SentryWarn here:
+	// see doc.go for the Sentry-vs-validation policy.
+	var issues []ConfigValidationIssue
+	if config.Agent.ReleaseChannel != ReleaseChannelNightly &&
+		config.Agent.ReleaseChannel != ReleaseChannelStable &&
+		config.Agent.ReleaseChannel != ReleaseChannelEnterprise {
+		issues = append(issues, ConfigValidationIssue{
+			Field:          "agent.releaseChannel",
+			OffendingValue: string(config.Agent.ReleaseChannel),
+			AllowedValues:  []string{"nightly", "stable", "enterprise"},
+		})
+		config.Agent.ReleaseChannel = ReleaseChannelStable
 	}
+	m.swapValidationIssues(issues)
 
 	// Return both config and raw data for atomic cache update by caller
 	return config, string(data), nil

--- a/umh-core/pkg/config/manager.go
+++ b/umh-core/pkg/config/manager.go
@@ -495,10 +495,20 @@ func (m *FileConfigManager) readAndParseConfig(ctx context.Context) (FullConfig,
 		return FullConfig{}, "", fmt.Errorf("config file is empty: %s", m.configPath)
 	}
 
-	// Validate that the release channel is one of the allowed enum values.
-	// Empty values are defaulted to "stable" inside ParseConfig (applyDefaults=true) and
-	// never reach this branch — only non-empty typos do. We do NOT call SentryWarn here:
-	// see doc.go for the Sentry-vs-validation policy.
+	m.swapValidationIssues(m.validateConfig(&config))
+
+	// Return both config and raw data for atomic cache update by caller
+	return config, string(data), nil
+}
+
+// validateConfig inspects the parsed config for known invariants and returns
+// a list of validation issues. Side effect: coerces invalid values to safe
+// defaults on the passed-in config (e.g. an unrecognized releaseChannel resets
+// to "stable" so downstream code never branches on the typo). Empty values are
+// defaulted to "stable" inside ParseConfig (applyDefaults=true) and never reach
+// this branch — only non-empty typos do. We do NOT call SentryWarn here: see
+// doc.go for the Sentry-vs-validation policy.
+func (m *FileConfigManager) validateConfig(config *FullConfig) []ConfigValidationIssue {
 	var issues []ConfigValidationIssue
 	if config.Agent.ReleaseChannel != ReleaseChannelNightly &&
 		config.Agent.ReleaseChannel != ReleaseChannelStable &&
@@ -510,10 +520,8 @@ func (m *FileConfigManager) readAndParseConfig(ctx context.Context) (FullConfig,
 		})
 		config.Agent.ReleaseChannel = ReleaseChannelStable
 	}
-	m.swapValidationIssues(issues)
 
-	// Return both config and raw data for atomic cache update by caller
-	return config, string(data), nil
+	return issues
 }
 
 // swapValidationIssues replaces the validation-issues list wholesale.
@@ -1225,6 +1233,13 @@ func (m *FileConfigManager) WriteYAMLConfigFromString(ctx context.Context, confi
 
 		return fmt.Errorf("failed to parse new config for cache update: %w", err)
 	}
+
+	// Re-run validation on the just-written config so that fixing a typo via MC
+	// clears stale issues immediately (and a freshly introduced typo surfaces
+	// without waiting for the next mtime change). validateConfig may coerce
+	// invalid fields on the passed-in struct; the cache stores the coerced copy
+	// so subsequent reads observe the same value as readAndParseConfig.
+	m.swapValidationIssues(m.validateConfig(&newConfig))
 
 	// Update cache with the new config, raw data, and mod time
 	m.cacheMu.Lock()

--- a/umh-core/pkg/config/manager.go
+++ b/umh-core/pkg/config/manager.go
@@ -112,6 +112,10 @@ type ConfigManager interface {
 	WriteYAMLConfigFromString(ctx context.Context, configStr string, expectedModTime string) error
 	// GetBackupCount returns the number of config backups created since startup.
 	GetBackupCount() uint64
+	// GetConfigValidationIssues returns the validation issues from the most recent parse.
+	// Used by agent_monitor.Status to escalate the agent to Degraded with a dynamic
+	// health message when user-supplied YAML field values fail validation.
+	GetConfigValidationIssues() []ConfigValidationIssue
 
 	// TODO: Add AtomicUnlinkFromTemplate method
 	// AtomicUnlinkFromTemplate converts a templated configuration (using YAML anchors/aliases)

--- a/umh-core/pkg/config/manager.go
+++ b/umh-core/pkg/config/manager.go
@@ -158,11 +158,18 @@ type FileConfigManager struct {
 
 	cacheConfig FullConfig // struct obtained from that file
 
+	// validationIssues holds the results of the last config-content validation pass.
+	// Always swapped wholesale (never appended to) by readAndParseConfig — see swapValidationIssues.
+	validationIssues []ConfigValidationIssue
+
 	// ---------- in-memory cache (read-only after RLock) ----------
 	cacheMu sync.RWMutex // guards the two fields below
 
 	// ---------- background refresh state ----------
 	refreshMu sync.Mutex // prevents concurrent background refreshes
+
+	// validationIssuesMu guards validationIssues.
+	validationIssuesMu sync.RWMutex
 
 	// backupCount tracks the number of config backups created since startup.
 	backupCount atomic.Uint64
@@ -496,6 +503,25 @@ func (m *FileConfigManager) readAndParseConfig(ctx context.Context) (FullConfig,
 	return config, string(data), nil
 }
 
+// swapValidationIssues replaces the validation-issues list wholesale.
+// Called only from readAndParseConfig — never from cache hits or the backup write path.
+// This guarantees that fixed configs clear stale issues on the next successful parse.
+func (m *FileConfigManager) swapValidationIssues(fresh []ConfigValidationIssue) {
+	m.validationIssuesMu.Lock()
+	defer m.validationIssuesMu.Unlock()
+	m.validationIssues = fresh
+}
+
+// GetConfigValidationIssues returns a copy of the validation issues from the most recent parse.
+// Safe to call concurrently with swapValidationIssues.
+func (m *FileConfigManager) GetConfigValidationIssues() []ConfigValidationIssue {
+	m.validationIssuesMu.RLock()
+	defer m.validationIssuesMu.RUnlock()
+	out := make([]ConfigValidationIssue, len(m.validationIssues))
+	copy(out, m.validationIssues)
+	return out
+}
+
 // FileConfigManagerWithBackoff wraps a FileConfigManager and implements backoff for GetConfig errors.
 type FileConfigManagerWithBackoff struct {
 	// The wrapped file config manager
@@ -553,6 +579,12 @@ func (m *FileConfigManagerWithBackoff) SetConfigBackupEnabled(enabled bool) {
 // GetBackupCount returns the number of config backups created since startup.
 func (m *FileConfigManagerWithBackoff) GetBackupCount() uint64 {
 	return m.configManager.GetBackupCount()
+}
+
+// GetConfigValidationIssues delegates to the wrapped FileConfigManager.
+// Returns a copy of the validation issues from the most recent parse.
+func (m *FileConfigManagerWithBackoff) GetConfigValidationIssues() []ConfigValidationIssue {
+	return m.configManager.GetConfigValidationIssues()
 }
 
 // GetBackupCount returns the number of config backups created since startup.

--- a/umh-core/pkg/config/manager.go
+++ b/umh-core/pkg/config/manager.go
@@ -112,10 +112,13 @@ type ConfigManager interface {
 	WriteYAMLConfigFromString(ctx context.Context, configStr string, expectedModTime string) error
 	// GetBackupCount returns the number of config backups created since startup.
 	GetBackupCount() uint64
-	// GetConfigValidationIssues returns the validation issues from the most recent parse.
-	// Used by agent_monitor.Status to escalate the agent to Degraded with a dynamic
-	// health message when user-supplied YAML field values fail validation.
-	GetConfigValidationIssues() []ConfigValidationIssue
+
+	// GetConfigValidationIssues is intentionally NOT on this interface. The
+	// narrow surface lives at agent_monitor.ConfigValidationProvider, which
+	// FileConfigManager and FileConfigManagerWithBackoff satisfy structurally.
+	// Keeping it off ConfigManager prevents unrelated mocks from having to
+	// stub it out, and signals that callers needing validation issues should
+	// depend on the narrow provider type.
 
 	// TODO: Add AtomicUnlinkFromTemplate method
 	// AtomicUnlinkFromTemplate converts a templated configuration (using YAML anchors/aliases)

--- a/umh-core/pkg/config/manager.go
+++ b/umh-core/pkg/config/manager.go
@@ -466,6 +466,10 @@ func (m *FileConfigManager) backgroundRefresh(modTime time.Time) {
 // readAndParseConfig contains the shared logic for reading and parsing the config file
 // Returns both the parsed config and the raw data to allow atomic cache updates.
 func (m *FileConfigManager) readAndParseConfig(ctx context.Context) (FullConfig, string, error) {
+	// Clear stale validation issues at the start. Each parse rebuilds the list;
+	// if the parse fails or the file is empty, no issue is recorded for this read.
+	m.swapValidationIssues(nil)
+
 	// Read the file
 	// Allow half of the timeout for the read operation
 	readFileCtx, cancel := context.WithTimeout(ctx, constants.ConfigGetConfigTimeout/2)

--- a/umh-core/pkg/config/manager.go
+++ b/umh-core/pkg/config/manager.go
@@ -785,10 +785,10 @@ func (m *FileConfigManager) WithConfigPath(configPath string) *FileConfigManager
 //     readAndParseConfig passes false (strict); WriteYAMLConfigFromString first tries
 //     false then retries with true to keep YAML anchors working for hand-edited files.
 //   - applyDefaults: If true, defaults nil location to empty map and empty releaseChannel to "stable".
-//     The read path (readAndParseConfig) and the cache-update parse inside
-//     WriteYAMLConfigFromString pass true so downstream consumers always see populated
-//     fields; pure-validation parses (the strict pre-write check) and tests that need
-//     to assert original empty-equals-empty semantics pass false.
+//     Production callers pass false: defaulting is now centralized in validateConfig
+//     (see round-3 Fix A). The branch is retained for the exported function signature
+//     and direct test callers. Tests asserting original empty-equals-empty semantics
+//     also pass false.
 //
 // Returns:
 //   - FullConfig: The parsed and processed configuration

--- a/umh-core/pkg/config/manager.go
+++ b/umh-core/pkg/config/manager.go
@@ -538,12 +538,12 @@ func (m *FileConfigManager) validateConfig(config *FullConfig) []ConfigValidatio
 
 // swapValidationIssues replaces the validation-issues list wholesale. Mutex-protected
 // so concurrent GetConfigValidationIssues readers always observe a consistent slice.
-// Callers are readAndParseConfig (read path) and WriteYAMLConfigFromString (write path);
-// cache-hit GetConfig does not call this — see manager.go's FAST PATH — which is the
-// invariant that lets a successful parse decide what the latest issues list is.
-// The cache (cacheConfig + cacheModTime) and the issues list are decoupled by design:
-// they live behind separate mutexes and update independently, since validation runs
-// after parsing whereas the cache stores the parsed result.
+// Callers are readAndParseConfig (boot/refresh read path), WriteYAMLConfigFromString
+// (editor save path) and writeConfig (Atomic* mutator path); cache-hit GetConfig does
+// not call this — see manager.go's FAST PATH — which is the invariant that lets a
+// successful parse or write decide what the latest issues list is.
+// The cache (cacheConfig + cacheModTime) and the issues list live behind separate
+// mutexes since validation runs after parsing whereas the cache stores the result.
 func (m *FileConfigManager) swapValidationIssues(fresh []ConfigValidationIssue) {
 	m.validationIssuesMu.Lock()
 	defer m.validationIssuesMu.Unlock()
@@ -682,11 +682,19 @@ func (m *FileConfigManager) writeConfig(ctx context.Context, config FullConfig) 
 		return fmt.Errorf("failed to get file stats: %w", err)
 	}
 
+	// Re-validate the just-written config so the issues list reflects what is
+	// now on disk. Without this, an Atomic* round-trip (which reads the cached
+	// post-coercion config and writes it back) leaves a stale validation issue
+	// pointing at a value the user no longer sees in their YAML — see
+	// WriteYAMLConfigFromString for the same pattern on the editor save path.
+	m.swapValidationIssues(m.validateConfig(&config))
+
 	// update the cache
 	m.cacheMu.Lock()
 	m.cacheModTime = fileStats.ModTime()
 	m.cacheConfig = config
 	m.cacheRawConfig = string(data)
+	m.cacheError = nil
 	m.cacheMu.Unlock()
 
 	m.logger.Info("Successfully wrote config", deps.String("path", m.configPath))

--- a/umh-core/pkg/config/manager.go
+++ b/umh-core/pkg/config/manager.go
@@ -490,7 +490,14 @@ func (m *FileConfigManager) readAndParseConfig(ctx context.Context) (FullConfig,
 		return FullConfig{}, "", ctx.Err()
 	}
 
-	config, err := ParseConfig(data, ctx, false, true)
+	// Decode without applying defaults so the empty-config safety net below can
+	// distinguish a genuinely empty file (e.g. truncated by docker cp during a
+	// write window, partial deploy script, manual mis-edit) from a file that
+	// merely omits optional fields. Defaulting Location/ReleaseChannel here
+	// would make every empty file deep-equal to a populated FullConfig and
+	// silently disable the safety net (the agent then reconciles an empty
+	// desired state and tears down running services).
+	config, err := ParseConfig(data, ctx, false, false)
 	if err != nil {
 		return FullConfig{}, "", fmt.Errorf("failed to parse config file: %w", err)
 	}
@@ -507,6 +514,15 @@ func (m *FileConfigManager) readAndParseConfig(ctx context.Context) (FullConfig,
 		return FullConfig{}, "", fmt.Errorf("config file is empty: %s", m.configPath)
 	}
 
+	// Apply the same defaults ParseConfig(applyDefaults=true) would, but only
+	// after the empty-config check so the safety net stays armed.
+	if config.Agent.Location == nil {
+		config.Agent.Location = make(map[int]string)
+	}
+	if strings.TrimSpace(string(config.Agent.ReleaseChannel)) == "" {
+		config.Agent.ReleaseChannel = ReleaseChannelStable
+	}
+
 	m.swapValidationIssues(m.validateConfig(&config))
 
 	// Return both config and raw data for atomic cache update by caller
@@ -517,9 +533,10 @@ func (m *FileConfigManager) readAndParseConfig(ctx context.Context) (FullConfig,
 // a list of validation issues. Side effect: coerces invalid values to safe
 // defaults on the passed-in config (e.g. an unrecognized releaseChannel resets
 // to "stable" so downstream code never branches on the typo). Empty values are
-// defaulted to "stable" inside ParseConfig (applyDefaults=true) and never reach
-// this branch — only non-empty typos do. We do NOT call SentryWarn here: see
-// doc.go for the Sentry-vs-validation policy.
+// defaulted to "stable" by callers before reaching this branch (readAndParseConfig
+// applies defaults manually after the empty-config safety net; ParseConfig with
+// applyDefaults=true does the same for write callers) — only non-empty typos do.
+// We do NOT call SentryWarn here: see doc.go for the Sentry-vs-validation policy.
 func (m *FileConfigManager) validateConfig(config *FullConfig) []ConfigValidationIssue {
 	var issues []ConfigValidationIssue
 	if config.Agent.ReleaseChannel != ReleaseChannelNightly &&

--- a/umh-core/pkg/config/manager.go
+++ b/umh-core/pkg/config/manager.go
@@ -163,8 +163,10 @@ type FileConfigManager struct {
 
 	cacheRawConfig string
 
-	// validationIssues holds the results of the last config-content validation pass.
-	// Always swapped wholesale (never appended to) by readAndParseConfig — see swapValidationIssues.
+	// validationIssues lists user-facing config-content problems detected by
+	// validateConfig. Replaced wholesale by swapValidationIssues; never
+	// appended in place. Cleared at the start of readAndParseConfig and
+	// repopulated after a successful parse.
 	validationIssues []ConfigValidationIssue
 
 	cacheConfig FullConfig // struct obtained from that file

--- a/umh-core/pkg/config/manager.go
+++ b/umh-core/pkg/config/manager.go
@@ -175,7 +175,10 @@ type FileConfigManager struct {
 	backupCount atomic.Uint64
 
 	// ---------- in-memory cache (read-only after RLock) ----------
-	cacheMu sync.RWMutex // guards the two fields below
+	// cacheMu guards cacheConfig, cacheRawConfig, cacheError, and cacheModTime.
+	// All fast-path reads in GetConfig hold this mutex; readAndParseConfig
+	// updates it after a successful parse.
+	cacheMu sync.RWMutex
 
 	// validationIssuesMu guards validationIssues.
 	validationIssuesMu sync.RWMutex

--- a/umh-core/pkg/config/manager.go
+++ b/umh-core/pkg/config/manager.go
@@ -456,12 +456,28 @@ func (m *FileConfigManager) backgroundRefresh(modTime time.Time) {
 
 	config, rawConfig, err := m.readAndParseConfig(ctx)
 
-	// Update cache atomically
+	// Update cache atomically.
+	//
+	// LOAD-BEARING: cacheConfig is intentionally clobbered to FullConfig{} on
+	// parse error (not preserved as last-known-good). The empty-deep-equal check
+	// in GetConfig's SLOW PATH relies on cacheConfig being zero to surface
+	// cacheError. A future "improvement" that preserves the prior valid config
+	// here would silently swallow parse errors — DO NOT do that.
+	//
+	// LOAD-BEARING: cacheModTime is only updated on successful parse. On parse
+	// error, leaving cacheModTime at its previous (last-known-good) value
+	// ensures subsequent GetConfig calls re-enter SLOW PATH (file mtime ≠
+	// cached mtime) where the empty-deep-equal check at GetConfig:435 surfaces
+	// cacheError. Without this guard, the next tick's FAST PATH would match
+	// (file mtime == cached mtime) and silently serve the clobbered FullConfig{}
+	// with hardcoded nil error, defeating the empty-config safety net.
 	m.cacheMu.Lock()
 	m.cacheConfig = config
 	m.cacheRawConfig = rawConfig
-	m.cacheModTime = modTime
 	m.cacheError = err
+	if err == nil {
+		m.cacheModTime = modTime
+	}
 	m.cacheMu.Unlock()
 
 	duration := time.Since(start)

--- a/umh-core/pkg/config/manager.go
+++ b/umh-core/pkg/config/manager.go
@@ -507,20 +507,19 @@ func (m *FileConfigManager) readAndParseConfig(ctx context.Context) (FullConfig,
 		return FullConfig{}, "", ctx.Err()
 	}
 
-	// If the config is empty, return an error
-	// Note: sometimes it can happen that due to a filesystem error or maybe in the tests due to docker cp, the file is empty
-	// In this case we want to return an error, which is then ignored by the control loop and will retry in the next cycle
+	// Empty-config safety net. If the parsed file decodes to a zero FullConfig
+	// (truncated by docker cp during a write window, partial deploy stub, manual
+	// mis-edit), return an error so the control loop ignores this tick and retries
+	// next cycle. Without this, the control loop would reconcile an empty desired
+	// state and tear down every running flow, bridge, and stream processor.
+	//
+	// LOAD-BEARING ORDERING: this check MUST run BEFORE validateConfig.
+	// validateConfig defaults Location to an empty non-nil map and ReleaseChannel
+	// to "stable" — once defaulted, the FullConfig is no longer deep-equal to
+	// FullConfig{} and this check silently goes dead. Do not move this below
+	// validateConfig.
 	if reflect.DeepEqual(config, FullConfig{}) {
 		return FullConfig{}, "", fmt.Errorf("config file is empty: %s", m.configPath)
-	}
-
-	// Apply the same defaults ParseConfig(applyDefaults=true) would, but only
-	// after the empty-config check so the safety net stays armed.
-	if config.Agent.Location == nil {
-		config.Agent.Location = make(map[int]string)
-	}
-	if strings.TrimSpace(string(config.Agent.ReleaseChannel)) == "" {
-		config.Agent.ReleaseChannel = ReleaseChannelStable
 	}
 
 	m.swapValidationIssues(m.validateConfig(&config))
@@ -529,15 +528,47 @@ func (m *FileConfigManager) readAndParseConfig(ctx context.Context) (FullConfig,
 	return config, string(data), nil
 }
 
-// validateConfig inspects the parsed config for known invariants and returns
-// a list of validation issues. Side effect: coerces invalid values to safe
-// defaults on the passed-in config (e.g. an unrecognized releaseChannel resets
-// to "stable" so downstream code never branches on the typo). Empty values are
-// defaulted to "stable" by callers before reaching this branch (readAndParseConfig
-// applies defaults manually after the empty-config safety net; ParseConfig with
-// applyDefaults=true does the same for write callers) — only non-empty typos do.
+// validateConfig defaults empty fields per the omitempty contract, then records
+// issues for non-empty values that fail the allowed set. Side effect: mutates
+// the passed-in config (defaults empties to safe values; coerces typos to stable
+// so downstream code never branches on the typo).
+//
+// Callers MUST NOT default empty fields before calling this function. All
+// defaulting happens here exclusively. If a future engineer finds themselves
+// adding a defaulter at a call site, the call site is wrong — either the call
+// site shouldn't be calling validateConfig (e.g. should call ParseConfig
+// directly without subsequent validation), or the field should be added to
+// this function. Keeping defaulting in one place prevents drift across the
+// three call sites (readAndParseConfig, writeConfig, WriteYAMLConfigFromString).
+//
+// Empty values do NOT get recorded as issues — they are user-omitted optional
+// fields, not typos. Only non-empty values that fail the allowed set become
+// issues. This is the spec's intent: "Empty releaseChannel defaults to stable
+// silently."
+//
+// Idempotent: re-calling on an already-defaulted config produces the same
+// result (defaulting branches skip the no-op).
+//
+// The empty-config safety net in readAndParseConfig (the reflect.DeepEqual
+// check above this function's only read-path call site) MUST still run BEFORE
+// this function. Once empty fields are defaulted, the FullConfig is no longer
+// deep-equal to FullConfig{} and the safety net cannot fire. See the
+// LOAD-BEARING ORDERING comment at that site for detail.
+//
 // We do NOT call SentryWarn here: see doc.go for the Sentry-vs-validation policy.
 func (m *FileConfigManager) validateConfig(config *FullConfig) []ConfigValidationIssue {
+	// Default empties first. Idempotent: a non-nil map skips, a non-empty
+	// release channel skips. The whitespace check on ReleaseChannel matches the
+	// behavior previously living in ParseConfig's applyDefaults branch.
+	if config.Agent.Location == nil {
+		config.Agent.Location = make(map[int]string)
+	}
+	if strings.TrimSpace(string(config.Agent.ReleaseChannel)) == "" {
+		config.Agent.ReleaseChannel = ReleaseChannelStable
+	}
+
+	// Then flag typos. Empty values were defaulted to stable above and won't
+	// reach this branch.
 	var issues []ConfigValidationIssue
 	if config.Agent.ReleaseChannel != ReleaseChannelNightly &&
 		config.Agent.ReleaseChannel != ReleaseChannelStable &&
@@ -1271,7 +1302,11 @@ func (m *FileConfigManager) WriteYAMLConfigFromString(ctx context.Context, confi
 	// We already validated the config above, so this should succeed
 	// This parsing step is crucial as it converts the raw YAML to the proper spec config format,
 	// ensuring template references are resolved and the cache contains valid, usable config data
-	newConfig, err := ParseConfig([]byte(configStr), ctx, true, true) // Allow unknown fields for YAML anchors; apply defaults so cache matches readAndParseConfig
+	// Allow unknown fields for YAML anchors. applyDefaults=false because
+	// validateConfig below now handles defaulting (Fix A round 3) — keeping
+	// applyDefaults=true here would be a redundant code path with no behavioral
+	// difference, just an extra place where defaulting logic could drift.
+	newConfig, err := ParseConfig([]byte(configStr), ctx, true, false)
 	if err != nil {
 		// If parsing fails, invalidate cache to force fresh read later
 		m.cacheMu.Lock()

--- a/umh-core/pkg/config/manager_test.go
+++ b/umh-core/pkg/config/manager_test.go
@@ -1649,6 +1649,39 @@ var _ = Describe("ConfigValidationIssue surface", func() {
 		after := m.GetConfigValidationIssues()
 		Expect(after).To(Equal(before))
 	})
+
+	It("survives concurrent swap+read (P9)", func() {
+		m, _ := newTestManagerWithYAML("agent: {}\n")
+		defer m.Stop()
+
+		done := make(chan struct{})
+		go func() {
+			defer GinkgoRecover()
+			for i := 0; i < 1000; i++ {
+				_ = m.GetConfigValidationIssues()
+			}
+			close(done)
+		}()
+		for i := 0; i < 1000; i++ {
+			m.swapValidationIssues([]ConfigValidationIssue{
+				{Field: "x", OffendingValue: "y"},
+			})
+		}
+		<-done
+	})
+
+	It("FileConfigManagerWithBackoff delegates GetConfigValidationIssues (P10)", func() {
+		m, _ := newTestManagerWithYAML("agent:\n  releaseChannel: nigtly\n")
+		defer m.Stop()
+		_, _, err := m.readAndParseConfig(ctx)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Wrap directly without going through the singleton constructor so the test
+		// is hermetic and doesn't conflict with other suites.
+		wrapped := &FileConfigManagerWithBackoff{configManager: m}
+		Expect(wrapped.GetConfigValidationIssues()).To(HaveLen(1))
+		Expect(wrapped.GetConfigValidationIssues()[0].Field).To(Equal("agent.releaseChannel"))
+	})
 })
 
 var _ = Describe("ParseConfig defaulting", func() {

--- a/umh-core/pkg/config/manager_test.go
+++ b/umh-core/pkg/config/manager_test.go
@@ -307,7 +307,7 @@ agent:
     0: Enterprise
     1: Site
 `
-				config, err := ParseConfig([]byte(validYAML), ctx, false)
+				config, err := ParseConfig([]byte(validYAML), ctx, false, false)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(config.Internal.Services).To(HaveLen(1))
@@ -321,14 +321,14 @@ agent:
 			})
 
 			It("should handle empty input", func() {
-				config, err := ParseConfig([]byte{}, ctx, false)
+				config, err := ParseConfig([]byte{}, ctx, false, false)
 				Expect(err).To(HaveOccurred())
 				Expect(config).To(Equal(FullConfig{}))
 			})
 
 			It("should handle empty but valid YAML", func() {
 				emptyYAML := "---\n"
-				config, err := ParseConfig([]byte(emptyYAML), ctx, false)
+				config, err := ParseConfig([]byte(emptyYAML), ctx, false, false)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(config).To(Equal(FullConfig{}))
 			})
@@ -339,7 +339,7 @@ internal: {
   services: [
     { name: service1, desiredState: running,
 `
-				_, err := ParseConfig([]byte(malformedYAML), ctx, false)
+				_, err := ParseConfig([]byte(malformedYAML), ctx, false, false)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("did not find expected node content"))
 			})
@@ -354,7 +354,7 @@ internal:
   unknownSection:
     key: value
 `
-				_, err := ParseConfig([]byte(yamlWithUnknownFields), ctx, false)
+				_, err := ParseConfig([]byte(yamlWithUnknownFields), ctx, false, false)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("failed to decode config"))
 			})
@@ -372,7 +372,7 @@ internal:
 agent:
   location: null
 `
-				config, err := ParseConfig([]byte(yamlWithNulls), ctx, false)
+				config, err := ParseConfig([]byte(yamlWithNulls), ctx, false, false)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(config.Internal.Services).To(HaveLen(1))
 				Expect(config.Internal.Services[0].Name).To(Equal("service1"))
@@ -397,7 +397,7 @@ internal:
         configFiles:
           "file with spaces.txt": "content with multiple\nlines\nand \"quotes\""
 `
-				config, err := ParseConfig([]byte(complexYAML), ctx, false)
+				config, err := ParseConfig([]byte(complexYAML), ctx, false, false)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(config.Internal.Services).To(HaveLen(1))
@@ -442,7 +442,7 @@ internal:
 					data, err := fsService.ReadFile(ctx, filepath.Join("../../examples", file.Name()))
 					Expect(err).NotTo(HaveOccurred())
 
-					_, err = ParseConfig(data, ctx, false)
+					_, err = ParseConfig(data, ctx, false, false)
 					Expect(err).NotTo(HaveOccurred(), "Failed to parse "+file.Name())
 				}
 			})
@@ -452,7 +452,7 @@ internal:
 				data, err := fsService.ReadFile(ctx, "../../examples/example-config-protocolconverter-templated.yaml")
 				Expect(err).NotTo(HaveOccurred())
 
-				config, err := ParseConfig(data, ctx, true)
+				config, err := ParseConfig(data, ctx, true, false)
 				Expect(err).NotTo(HaveOccurred())
 
 				// The example should have at least one protocol converter using a template
@@ -484,7 +484,7 @@ internal:
 				Expect(err).NotTo(HaveOccurred())
 
 				// Parse the config with anchor extraction enabled
-				config, err := ParseConfig(originalData, ctx, true)
+				config, err := ParseConfig(originalData, ctx, true, false)
 				Expect(err).NotTo(HaveOccurred())
 
 				// Verify we have the expected structure
@@ -526,7 +526,7 @@ internal:
 				Expect(writtenData).NotTo(BeEmpty())
 
 				// Parse the written data to verify it's still valid
-				writtenConfig, err := ParseConfig(writtenData, ctx, true)
+				writtenConfig, err := ParseConfig(writtenData, ctx, true, false)
 				Expect(err).NotTo(HaveOccurred())
 
 				// Verify the structure is preserved
@@ -557,7 +557,7 @@ internal:
 				Expect(err).NotTo(HaveOccurred())
 
 				// Parse the config with anchor extraction enabled
-				config, err := ParseConfig(originalData, ctx, true)
+				config, err := ParseConfig(originalData, ctx, true, false)
 				Expect(err).NotTo(HaveOccurred())
 
 				// Verify we have the expected structure
@@ -625,7 +625,7 @@ internal:
 				Expect(writtenData).NotTo(BeEmpty())
 
 				// Parse the written data to verify it's still valid
-				writtenConfig, err := ParseConfig(writtenData, ctx, true)
+				writtenConfig, err := ParseConfig(writtenData, ctx, true, false)
 				Expect(err).NotTo(HaveOccurred())
 
 				// Verify the structure is preserved
@@ -697,7 +697,7 @@ internal:
 			Expect(err).NotTo(HaveOccurred())
 
 			// Parse and write initial config
-			config, err := ParseConfig(originalData, ctx, true)
+			config, err := ParseConfig(originalData, ctx, true, false)
 			Expect(err).NotTo(HaveOccurred())
 
 			err = configManager.writeConfig(ctx, config)

--- a/umh-core/pkg/config/manager_test.go
+++ b/umh-core/pkg/config/manager_test.go
@@ -1597,7 +1597,7 @@ var _ = Describe("ConfigValidationIssue surface", func() {
 	It("emits a ConfigValidationIssue for invalid releaseChannel (P3)", func() {
 		m, _ := newTestManagerWithYAML("agent:\n  releaseChannel: nigtly\n")
 		defer m.Stop()
-		_, _, err := m.readAndParseConfig(ctx)
+		cfg, _, err := m.readAndParseConfig(ctx)
 		Expect(err).NotTo(HaveOccurred())
 
 		issues := m.GetConfigValidationIssues()
@@ -1605,7 +1605,24 @@ var _ = Describe("ConfigValidationIssue surface", func() {
 		Expect(issues[0].Field).To(Equal("agent.releaseChannel"))
 		Expect(issues[0].OffendingValue).To(Equal("nigtly"))
 		Expect(issues[0].AllowedValues).To(ConsistOf("nightly", "stable", "enterprise"))
+
+		// After validation, the channel must be coerced to stable so downstream
+		// code (auto-update, dashboards) doesn't branch on the typo.
+		Expect(cfg.Agent.ReleaseChannel).To(Equal(ReleaseChannelStable))
 	})
+
+	DescribeTable("valid releaseChannel values produce no validation issue (P4-readAndParseConfig)",
+		func(channel string) {
+			m, _ := newTestManagerWithYAML(fmt.Sprintf("agent:\n  releaseChannel: %s\n", channel))
+			defer m.Stop()
+			_, _, err := m.readAndParseConfig(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(m.GetConfigValidationIssues()).To(BeEmpty())
+		},
+		Entry("nightly", "nightly"),
+		Entry("stable", "stable"),
+		Entry("enterprise", "enterprise"),
+	)
 
 	It("clears validation issues when YAML is fixed (P5)", func() {
 		m, mockFS := newTestManagerWithYAML("agent:\n  releaseChannel: nigtly\n")
@@ -1635,19 +1652,80 @@ var _ = Describe("ConfigValidationIssue surface", func() {
 	})
 
 	It("does not change the list on cache hits (P7)", func() {
-		// readAndParseConfig is the only mutator. A direct call here exercises that
-		// non-readAndParseConfig paths cannot mutate the slice. Cache hit semantics
-		// in GetConfig (skipping readAndParseConfig) therefore preserve the list.
-		m, _ := newTestManagerWithYAML("agent:\n  releaseChannel: nigtly\n")
+		// readAndParseConfig is the only reader-path mutator of validationIssues.
+		// We populate via readAndParseConfig, then mutate the issues list out-of-band
+		// (a sentinel value) and seed the cache so a subsequent GetConfig call hits
+		// the FAST PATH. If the cache hit path were to (incorrectly) re-run
+		// swapValidationIssues, our sentinel would be overwritten by the freshly
+		// computed list. Surviving the second call proves cache hits don't mutate.
+		m, mockFS := newTestManagerWithYAML("agent:\n  releaseChannel: nigtly\n")
 		defer m.Stop()
+		fixedMod := time.Unix(1700000000, 0)
+		mockFS.WithStatFunc(func(ctx context.Context, path string) (os.FileInfo, error) {
+			return &mockFileInfo{name: filepath.Base(path), size: int64(len("x")), modTime: fixedMod}, nil
+		})
+
 		_, _, err := m.readAndParseConfig(ctx)
 		Expect(err).NotTo(HaveOccurred())
-		before := m.GetConfigValidationIssues()
-		Expect(before).To(HaveLen(1))
+		Expect(m.GetConfigValidationIssues()).To(HaveLen(1))
 
-		// Read GetConfigValidationIssues again without re-parsing
+		// Seed the cache so GetConfig's FAST PATH triggers (mtime match + non-empty
+		// cached config + cleared error).
+		cfg, _, err := m.readAndParseConfig(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		m.cacheMu.Lock()
+		m.cacheConfig = cfg
+		m.cacheModTime = fixedMod
+		m.cacheError = nil
+		m.cacheMu.Unlock()
+
+		// Mutate the in-memory issues list out-of-band so we can detect a re-run.
+		m.swapValidationIssues([]ConfigValidationIssue{{Field: "marker", OffendingValue: "sentinel"}})
+
+		// Cache hit must not re-run validateConfig.
+		_, err = m.GetConfig(ctx, 0)
+		Expect(err).NotTo(HaveOccurred())
 		after := m.GetConfigValidationIssues()
-		Expect(after).To(Equal(before))
+		Expect(after).To(HaveLen(1))
+		Expect(after[0].Field).To(Equal("marker"))
+	})
+
+	It("WriteYAMLConfigFromString clears stale issues when user fixes the typo via MC (P7-write-clear)", func() {
+		m, mockFS := newTestManagerWithYAML("agent:\n  releaseChannel: nigtly\n")
+		defer m.Stop()
+		// Capture writes so subsequent reads see the new content.
+		mockFS.WithWriteFileFunc(func(ctx context.Context, path string, data []byte, perm os.FileMode) error {
+			mockFS.WithReadFileFunc(func(ctx context.Context, path string) ([]byte, error) { return data, nil })
+			return nil
+		})
+
+		_, _, err := m.readAndParseConfig(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(m.GetConfigValidationIssues()).To(HaveLen(1))
+
+		err = m.WriteYAMLConfigFromString(ctx, "agent:\n  releaseChannel: stable\n", "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(m.GetConfigValidationIssues()).To(BeEmpty())
+	})
+
+	It("WriteYAMLConfigFromString flags a freshly-introduced typo (P7-write-flag)", func() {
+		m, mockFS := newTestManagerWithYAML("agent:\n  releaseChannel: stable\n")
+		defer m.Stop()
+		mockFS.WithWriteFileFunc(func(ctx context.Context, path string, data []byte, perm os.FileMode) error {
+			mockFS.WithReadFileFunc(func(ctx context.Context, path string) ([]byte, error) { return data, nil })
+			return nil
+		})
+
+		_, _, err := m.readAndParseConfig(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(m.GetConfigValidationIssues()).To(BeEmpty())
+
+		err = m.WriteYAMLConfigFromString(ctx, "agent:\n  releaseChannel: nigtly\n", "")
+		Expect(err).NotTo(HaveOccurred())
+		issues := m.GetConfigValidationIssues()
+		Expect(issues).To(HaveLen(1))
+		Expect(issues[0].Field).To(Equal("agent.releaseChannel"))
+		Expect(issues[0].OffendingValue).To(Equal("nigtly"))
 	})
 
 	It("survives concurrent swap+read (P9)", func() {

--- a/umh-core/pkg/config/manager_test.go
+++ b/umh-core/pkg/config/manager_test.go
@@ -1551,6 +1551,54 @@ agent:
 	})
 })
 
+var _ = Describe("ParseConfig defaulting", func() {
+	var ctx context.Context
+
+	BeforeEach(func() {
+		ctx = context.Background()
+	})
+
+	It("defaults empty releaseChannel to stable when applyDefaults=true (P1)", func() {
+		yaml := []byte("agent:\n  releaseChannel: \"\"\n")
+		cfg, err := ParseConfig(yaml, ctx, false, true)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cfg.Agent.ReleaseChannel).To(Equal(ReleaseChannelStable))
+	})
+
+	It("defaults nil Location to empty map when applyDefaults=true (P2)", func() {
+		yaml := []byte("agent: {}\n")
+		cfg, err := ParseConfig(yaml, ctx, false, true)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cfg.Agent.Location).NotTo(BeNil())
+		Expect(cfg.Agent.Location).To(BeEmpty())
+	})
+
+	It("preserves empty values when applyDefaults=false (P11)", func() {
+		yaml := []byte("agent: {}\n")
+		cfg, err := ParseConfig(yaml, ctx, false, false)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(cfg.Agent.ReleaseChannel)).To(BeEmpty())
+		Expect(cfg.Agent.Location).To(BeNil())
+	})
+
+	DescribeTable("ReleaseChannel defaulting fuzz (P4b)",
+		func(input string, expected ReleaseChannel) {
+			yaml := []byte(fmt.Sprintf("agent:\n  releaseChannel: %q\n", input))
+			cfg, err := ParseConfig(yaml, ctx, false, true)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg.Agent.ReleaseChannel).To(Equal(expected))
+		},
+		Entry("empty string", "", ReleaseChannelStable),
+		Entry("single space", " ", ReleaseChannelStable),
+		Entry("multiple spaces", "  ", ReleaseChannelStable),
+		Entry("Stable (capital)", "Stable", ReleaseChannel("Stable")),
+		Entry("STABLE", "STABLE", ReleaseChannel("STABLE")),
+		Entry("nightly", "nightly", ReleaseChannelNightly),
+		Entry("stable", "stable", ReleaseChannelStable),
+		Entry("enterprise", "enterprise", ReleaseChannelEnterprise),
+	)
+})
+
 // filterBackupDirPaths returns only paths that start with the backup directory.
 func filterBackupDirPaths(paths []string) []string {
 	var result []string

--- a/umh-core/pkg/config/manager_test.go
+++ b/umh-core/pkg/config/manager_test.go
@@ -1551,6 +1551,106 @@ agent:
 	})
 })
 
+// newTestManagerWithYAML returns a FileConfigManager wired to a MockFileSystem
+// pre-loaded with the given YAML content. Used by ConfigValidationIssue tests.
+func newTestManagerWithYAML(yaml string) (*FileConfigManager, *filesystem.MockFileSystem) {
+	mockFS := filesystem.NewMockFileSystem()
+	current := []byte(yaml)
+	mockFS.WithFileExistsFunc(func(ctx context.Context, path string) (bool, error) {
+		return true, nil
+	})
+	mockFS.WithReadFileFunc(func(ctx context.Context, path string) ([]byte, error) {
+		return current, nil
+	})
+	mockFS.WithStatFunc(func(ctx context.Context, path string) (os.FileInfo, error) {
+		return &mockFileInfo{name: filepath.Base(path), size: int64(len(current)), modTime: time.Now()}, nil
+	})
+	mockFS.WithEnsureDirectoryFunc(func(ctx context.Context, path string) error {
+		return nil
+	})
+	cm := NewFileConfigManager()
+	cm.WithFileSystemService(mockFS)
+	return cm, mockFS
+}
+
+// mockFileInfo is a minimal os.FileInfo stub for tests.
+type mockFileInfo struct {
+	modTime time.Time
+	name    string
+	size    int64
+}
+
+func (m *mockFileInfo) Name() string       { return m.name }
+func (m *mockFileInfo) Size() int64        { return m.size }
+func (m *mockFileInfo) Mode() os.FileMode  { return 0644 }
+func (m *mockFileInfo) ModTime() time.Time { return m.modTime }
+func (m *mockFileInfo) IsDir() bool        { return false }
+func (m *mockFileInfo) Sys() any           { return nil }
+
+var _ = Describe("ConfigValidationIssue surface", func() {
+	var ctx context.Context
+
+	BeforeEach(func() {
+		ctx = context.Background()
+	})
+
+	It("emits a ConfigValidationIssue for invalid releaseChannel (P3)", func() {
+		m, _ := newTestManagerWithYAML("agent:\n  releaseChannel: nigtly\n")
+		defer m.Stop()
+		_, _, err := m.readAndParseConfig(ctx)
+		Expect(err).NotTo(HaveOccurred())
+
+		issues := m.GetConfigValidationIssues()
+		Expect(issues).To(HaveLen(1))
+		Expect(issues[0].Field).To(Equal("agent.releaseChannel"))
+		Expect(issues[0].OffendingValue).To(Equal("nigtly"))
+		Expect(issues[0].AllowedValues).To(ConsistOf("nightly", "stable", "enterprise"))
+	})
+
+	It("clears validation issues when YAML is fixed (P5)", func() {
+		m, mockFS := newTestManagerWithYAML("agent:\n  releaseChannel: nigtly\n")
+		defer m.Stop()
+		_, _, err := m.readAndParseConfig(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(m.GetConfigValidationIssues()).To(HaveLen(1))
+
+		// Swap YAML to a valid value and re-parse
+		fixed := []byte("agent:\n  releaseChannel: stable\n")
+		mockFS.WithReadFileFunc(func(ctx context.Context, path string) ([]byte, error) {
+			return fixed, nil
+		})
+		_, _, err = m.readAndParseConfig(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(m.GetConfigValidationIssues()).To(BeEmpty())
+	})
+
+	It("does not duplicate on repeated bad reads (P6)", func() {
+		m, _ := newTestManagerWithYAML("agent:\n  releaseChannel: nigtly\n")
+		defer m.Stop()
+		_, _, err := m.readAndParseConfig(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		_, _, err = m.readAndParseConfig(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(m.GetConfigValidationIssues()).To(HaveLen(1))
+	})
+
+	It("does not change the list on cache hits (P7)", func() {
+		// readAndParseConfig is the only mutator. A direct call here exercises that
+		// non-readAndParseConfig paths cannot mutate the slice. Cache hit semantics
+		// in GetConfig (skipping readAndParseConfig) therefore preserve the list.
+		m, _ := newTestManagerWithYAML("agent:\n  releaseChannel: nigtly\n")
+		defer m.Stop()
+		_, _, err := m.readAndParseConfig(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		before := m.GetConfigValidationIssues()
+		Expect(before).To(HaveLen(1))
+
+		// Read GetConfigValidationIssues again without re-parsing
+		after := m.GetConfigValidationIssues()
+		Expect(after).To(Equal(before))
+	})
+})
+
 var _ = Describe("ParseConfig defaulting", func() {
 	var ctx context.Context
 

--- a/umh-core/pkg/config/manager_test.go
+++ b/umh-core/pkg/config/manager_test.go
@@ -1624,6 +1624,22 @@ var _ = Describe("ConfigValidationIssue surface", func() {
 		Entry("enterprise", "enterprise"),
 	)
 
+	DescribeTable("non-empty invalid releaseChannel values produce exactly one validation issue (P4b-readAndParseConfig)",
+		func(channel string) {
+			m, _ := newTestManagerWithYAML(fmt.Sprintf("agent:\n  releaseChannel: %s\n", channel))
+			defer m.Stop()
+			_, _, err := m.readAndParseConfig(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			issues := m.GetConfigValidationIssues()
+			Expect(issues).To(HaveLen(1))
+			Expect(issues[0].OffendingValue).To(Equal(channel))
+		},
+		Entry("production", "production"),
+		Entry("preview", "preview"),
+		Entry("Stable (case mismatch)", "Stable"),
+		Entry("STABLE (case mismatch)", "STABLE"),
+	)
+
 	It("clears validation issues when YAML is fixed (P5)", func() {
 		m, mockFS := newTestManagerWithYAML("agent:\n  releaseChannel: nigtly\n")
 		defer m.Stop()
@@ -1821,6 +1837,8 @@ var _ = Describe("ParseConfig defaulting", func() {
 		Entry("multiple spaces", "  ", ReleaseChannelStable),
 		Entry("Stable (capital)", "Stable", ReleaseChannel("Stable")),
 		Entry("STABLE", "STABLE", ReleaseChannel("STABLE")),
+		Entry("production", "production", ReleaseChannel("production")),
+		Entry("preview", "preview", ReleaseChannel("preview")),
 		Entry("nightly", "nightly", ReleaseChannelNightly),
 		Entry("stable", "stable", ReleaseChannelStable),
 		Entry("enterprise", "enterprise", ReleaseChannelEnterprise),

--- a/umh-core/pkg/config/manager_test.go
+++ b/umh-core/pkg/config/manager_test.go
@@ -1690,6 +1690,23 @@ var _ = Describe("ConfigValidationIssue surface", func() {
 		Expect(after[0].Field).To(Equal("marker"))
 	})
 
+	It("clears stale validation issues if the YAML becomes unparseable (P-stale)", func() {
+		m, mockFS := newTestManagerWithYAML("agent:\n  releaseChannel: nigtly\n")
+		defer m.Stop()
+		_, _, err := m.readAndParseConfig(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(m.GetConfigValidationIssues()).To(HaveLen(1))
+
+		// User now breaks the YAML.
+		mockFS.WithReadFileFunc(func(ctx context.Context, path string) ([]byte, error) {
+			return []byte("agent: { releaseChannel: \n  unbalanced["), nil
+		})
+		_, _, err = m.readAndParseConfig(ctx)
+		Expect(err).To(HaveOccurred())
+		// Stale issue from previous parse must NOT linger.
+		Expect(m.GetConfigValidationIssues()).To(BeEmpty())
+	})
+
 	It("WriteYAMLConfigFromString clears stale issues when user fixes the typo via MC (P7-write-clear)", func() {
 		m, mockFS := newTestManagerWithYAML("agent:\n  releaseChannel: nigtly\n")
 		defer m.Stop()

--- a/umh-core/pkg/config/manager_test.go
+++ b/umh-core/pkg/config/manager_test.go
@@ -1835,6 +1835,25 @@ var _ = Describe("ConfigValidationIssue surface", func() {
 		<-done
 	})
 
+	DescribeTable(
+		"readAndParseConfig empty-config safety net (P-empty)",
+		// Each input decodes to a zero FullConfig{}. With applyDefaults runs
+		// before the DeepEqual check, the safety net silently went dead and the
+		// control loop would tear down running services on the next tick.
+		// Verifies the safety net is reachable for each canonical empty form.
+		func(yamlInput string) {
+			m, _ := newTestManagerWithYAML(yamlInput)
+			defer m.Stop()
+
+			_, _, err := m.readAndParseConfig(ctx)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("config file is empty"))
+		},
+		Entry("empty document marker", "---\n"),
+		Entry("empty mapping", "{}\n"),
+		Entry("empty agent stanza", "agent: {}\n"),
+	)
+
 	It("FileConfigManagerWithBackoff delegates GetConfigValidationIssues (P10)", func() {
 		m, _ := newTestManagerWithYAML("agent:\n  releaseChannel: nigtly\n")
 		defer m.Stop()

--- a/umh-core/pkg/config/manager_test.go
+++ b/umh-core/pkg/config/manager_test.go
@@ -1761,6 +1761,60 @@ var _ = Describe("ConfigValidationIssue surface", func() {
 		Expect(issues[0].OffendingValue).To(Equal("nigtly"))
 	})
 
+	It("writeConfig clears stale issues after an Atomic* round-trip (P-write-atomic-clear)", func() {
+		// Setup mirrors P7-write-clear: file holds a typo, manager records it, then
+		// the Atomic* round-trip (modeled as writeConfig with the cache's coerced
+		// struct) writes back to disk. Pre-fix: validationIssues stayed at [{nigtly}]
+		// because writeConfig never re-validated. Post-fix: writeConfig calls
+		// swapValidationIssues so the list reflects what is now on disk.
+		m, mockFS := newTestManagerWithYAML("agent:\n  releaseChannel: nigtly\n")
+		defer m.Stop()
+		mockFS.WithWriteFileFunc(func(ctx context.Context, path string, data []byte, perm os.FileMode) error {
+			mockFS.WithReadFileFunc(func(ctx context.Context, path string) ([]byte, error) { return data, nil })
+			return nil
+		})
+
+		// Boot read records the issue and coerces the cached struct to stable.
+		cfg, _, err := m.readAndParseConfig(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(m.GetConfigValidationIssues()).To(HaveLen(1))
+		Expect(cfg.Agent.ReleaseChannel).To(Equal(ReleaseChannelStable))
+
+		// Simulate the Atomic* round-trip: take the post-coerced struct GetConfig
+		// would hand to a mutator, write back. The bug pre-fix: validationIssues
+		// stays [{nigtly}] forever even though disk now says stable.
+		err = m.writeConfig(ctx, cfg)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(m.GetConfigValidationIssues()).To(BeEmpty())
+	})
+
+	It("writeConfig flags a typo introduced by a non-Atomic caller (P-write-atomic-flag)", func() {
+		// Defensive: every current writeConfig caller funnels through GetConfig (so
+		// the struct is already coerced). This test pins the contract for any future
+		// caller that constructs a FullConfig from scratch — validateConfig must
+		// catch the typo and record an issue, mirroring P7-write-flag.
+		m, mockFS := newTestManagerWithYAML("agent:\n  releaseChannel: stable\n")
+		defer m.Stop()
+		mockFS.WithWriteFileFunc(func(ctx context.Context, path string, data []byte, perm os.FileMode) error {
+			mockFS.WithReadFileFunc(func(ctx context.Context, path string) ([]byte, error) { return data, nil })
+			return nil
+		})
+
+		_, _, err := m.readAndParseConfig(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(m.GetConfigValidationIssues()).To(BeEmpty())
+
+		synthetic := FullConfig{Agent: AgentConfig{ReleaseChannel: ReleaseChannel("nigtly")}}
+		err = m.writeConfig(ctx, synthetic)
+		Expect(err).NotTo(HaveOccurred())
+
+		issues := m.GetConfigValidationIssues()
+		Expect(issues).To(HaveLen(1))
+		Expect(issues[0].Field).To(Equal("agent.releaseChannel"))
+		Expect(issues[0].OffendingValue).To(Equal("nigtly"))
+	})
+
 	It("survives concurrent swap+read (P9)", func() {
 		m, _ := newTestManagerWithYAML("agent: {}\n")
 		defer m.Stop()

--- a/umh-core/pkg/config/manager_test.go
+++ b/umh-core/pkg/config/manager_test.go
@@ -1854,6 +1854,116 @@ var _ = Describe("ConfigValidationIssue surface", func() {
 		Entry("empty agent stanza", "agent: {}\n"),
 	)
 
+	It("validateConfig defaults empty fields silently (P-validate-defaults-empty)", func() {
+		// Pins Fix A's structural invariant: validateConfig is the single defaulter.
+		// Empty Location and ReleaseChannel are user-omitted optional fields, not
+		// typos, so validateConfig must default them silently without recording an
+		// issue. Pre-fix: validateConfig flagged "" as a typo with OffendingValue
+		// "" — the regression that produced the fresh-install phantom message.
+		m, _ := newTestManagerWithYAML("agent: {}\n")
+		defer m.Stop()
+
+		cfg := FullConfig{}
+		issues := m.validateConfig(&cfg)
+
+		Expect(issues).To(BeEmpty())
+		Expect(cfg.Agent.Location).NotTo(BeNil())
+		Expect(cfg.Agent.Location).To(BeEmpty())
+		Expect(cfg.Agent.ReleaseChannel).To(Equal(ReleaseChannelStable))
+	})
+
+	It("validateConfig is idempotent on already-defaulted input (P-validate-idempotent)", func() {
+		// Calling validateConfig twice produces the same end state. Important
+		// because some call paths (e.g. WriteYAMLConfigFromString post Fix A) hand
+		// validateConfig a struct that ParseConfig didn't default; others hand it
+		// a struct that ParseConfig DID default. Both must work.
+		m, _ := newTestManagerWithYAML("agent: {}\n")
+		defer m.Stop()
+
+		cfg := FullConfig{}
+		issues1 := m.validateConfig(&cfg)
+		issues2 := m.validateConfig(&cfg)
+
+		Expect(issues1).To(BeEmpty())
+		Expect(issues2).To(BeEmpty())
+		Expect(cfg.Agent.Location).To(BeEmpty())
+		Expect(cfg.Agent.ReleaseChannel).To(Equal(ReleaseChannelStable))
+	})
+
+	It("writeConfig on fresh install records no validation issues (P-fresh-install)", func() {
+		// Reproduces Finding #2 from claude[bot] round 3. Fresh install: no
+		// /data/config.yaml, RELEASE_CHANNEL env var unset. GetConfigWithOverwrites
+		// OrCreateNew constructs a FullConfig{} with empty ReleaseChannel and
+		// calls writeConfig. Pre-Fix-A: writeConfig invokes validateConfig on the
+		// empty struct, which records a phantom ConfigValidationIssue with empty
+		// OffendingValue. Post-Fix-A: validateConfig defaults the empty value to
+		// stable silently, no issue recorded.
+		m, mockFS := newTestManagerWithYAML("")
+		defer m.Stop()
+		mockFS.WithWriteFileFunc(func(ctx context.Context, path string, data []byte, perm os.FileMode) error {
+			mockFS.WithReadFileFunc(func(ctx context.Context, path string) ([]byte, error) { return data, nil })
+			return nil
+		})
+
+		freshConfig := FullConfig{}
+		err := m.writeConfig(ctx, freshConfig)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(m.GetConfigValidationIssues()).To(BeEmpty())
+	})
+
+	It("backgroundRefresh preserves cacheModTime when parse fails (P-empty-cache-poison)", func() {
+		// Reproduces Finding #1 from claude[bot] round 3. After f8b5ef7 restored
+		// the empty-config safety net, backgroundRefresh would still update
+		// cacheModTime to the truncated file's mtime AND set cacheError. Next
+		// tick: GetConfig FAST PATH matches mtime, returns cacheConfig (which is
+		// FullConfig{}) with hardcoded nil error — control loop tears down
+		// services. Fix B: don't update cacheModTime when readAndParseConfig
+		// returns an error, so subsequent calls re-enter SLOW PATH where the
+		// empty-deep-equal check at line 435 surfaces cacheError.
+		validModTime := time.Unix(1000, 0)
+		truncatedModTime := time.Unix(2000, 0)
+		current := []byte("agent:\n  releaseChannel: stable\n")
+		currentMod := validModTime
+
+		mockFS := filesystem.NewMockFileSystem()
+		mockFS.WithFileExistsFunc(func(ctx context.Context, path string) (bool, error) { return true, nil })
+		mockFS.WithReadFileFunc(func(ctx context.Context, path string) ([]byte, error) { return current, nil })
+		mockFS.WithStatFunc(func(ctx context.Context, path string) (os.FileInfo, error) {
+			return &mockFileInfo{name: filepath.Base(path), size: int64(len(current)), modTime: currentMod}, nil
+		})
+		mockFS.WithEnsureDirectoryFunc(func(ctx context.Context, path string) error { return nil })
+
+		m := NewFileConfigManager()
+		m.WithFileSystemService(mockFS)
+		defer m.Stop()
+
+		// Boot: prime cache with valid config at validModTime via backgroundRefresh.
+		m.refreshMu.Lock()
+		m.backgroundRefresh(validModTime)
+		Expect(m.cacheError).NotTo(HaveOccurred())
+		Expect(m.cacheModTime).To(Equal(validModTime))
+		Expect(m.cacheConfig.Agent.ReleaseChannel).To(Equal(ReleaseChannelStable))
+
+		// Truncate the file: empty content + new mtime (T1).
+		current = []byte("---\n")
+		currentMod = truncatedModTime
+
+		// Trigger backgroundRefresh as the SLOW PATH would. With Fix B: cacheModTime
+		// stays at validModTime, cacheConfig is clobbered to FullConfig{},
+		// cacheError holds the empty-config error. Without Fix B: cacheModTime
+		// would be set to truncatedModTime, poisoning the FAST PATH for tick 2.
+		m.refreshMu.Lock()
+		m.backgroundRefresh(truncatedModTime)
+		Expect(m.cacheError).To(HaveOccurred())
+		Expect(m.cacheError.Error()).To(ContainSubstring("config file is empty"))
+		Expect(m.cacheConfig).To(Equal(FullConfig{}))
+		// The load-bearing assertion: cacheModTime must NOT have been updated to
+		// the truncated file's mtime. Otherwise FAST PATH would silently serve
+		// FullConfig{} on the next tick.
+		Expect(m.cacheModTime).To(Equal(validModTime))
+	})
+
 	It("FileConfigManagerWithBackoff delegates GetConfigValidationIssues (P10)", func() {
 		m, _ := newTestManagerWithYAML("agent:\n  releaseChannel: nigtly\n")
 		defer m.Stop()

--- a/umh-core/pkg/config/mock.go
+++ b/umh-core/pkg/config/mock.go
@@ -1252,6 +1252,12 @@ func (m *MockConfigManager) GetBackupCount() uint64 {
 	return 0
 }
 
+// GetConfigValidationIssues returns nil for the mock — tests that need to assert
+// validation behaviour should drive the real FileConfigManager via newTestManagerWithYAML.
+func (m *MockConfigManager) GetConfigValidationIssues() []ConfigValidationIssue {
+	return nil
+}
+
 // IsGetConfigCalled returns true if GetConfig has been called (thread-safe).
 func (m *MockConfigManager) IsGetConfigCalled() bool {
 	return atomic.LoadInt32(&m.GetConfigCalled) != 0

--- a/umh-core/pkg/config/mock.go
+++ b/umh-core/pkg/config/mock.go
@@ -1225,11 +1225,11 @@ func (m *MockConfigManager) WriteYAMLConfigFromString(ctx context.Context, confi
 	}
 
 	// First parse the config with strict validation to detect syntax errors and schema problems
-	parsedConfig, err := ParseConfig([]byte(config), ctx, false)
+	parsedConfig, err := ParseConfig([]byte(config), ctx, false, false)
 	if err != nil {
 		// If strict parsing fails, try again with allowUnknownFields=true
 		// This allows YAML anchors and other custom fields
-		parsedConfig, err = ParseConfig([]byte(config), ctx, true)
+		parsedConfig, err = ParseConfig([]byte(config), ctx, true, false)
 		if err != nil {
 			return fmt.Errorf("failed to parse config: %w", err)
 		}

--- a/umh-core/pkg/config/mock.go
+++ b/umh-core/pkg/config/mock.go
@@ -1252,12 +1252,6 @@ func (m *MockConfigManager) GetBackupCount() uint64 {
 	return 0
 }
 
-// GetConfigValidationIssues returns nil for the mock — tests that need to assert
-// validation behaviour should drive the real FileConfigManager via newTestManagerWithYAML.
-func (m *MockConfigManager) GetConfigValidationIssues() []ConfigValidationIssue {
-	return nil
-}
-
 // IsGetConfigCalled returns true if GetConfig has been called (thread-safe).
 func (m *MockConfigManager) IsGetConfigCalled() bool {
 	return atomic.LoadInt32(&m.GetConfigCalled) != 0

--- a/umh-core/pkg/config/parse_config_benchmark_test.go
+++ b/umh-core/pkg/config/parse_config_benchmark_test.go
@@ -32,7 +32,7 @@ func BenchmarkParseConfig_100(b *testing.B) {
 	ctx := context.Background()
 
 	for range b.N {
-		_, err := ParseConfig(cfg, ctx, false)
+		_, err := ParseConfig(cfg, ctx, false, false)
 		if err != nil {
 			b.Fatalf("parseConfig failed: %v", err)
 		}
@@ -51,7 +51,7 @@ func BenchmarkParseConfig_Comm(b *testing.B) {
 	ctx := context.Background()
 
 	for range b.N {
-		_, err := ParseConfig(cfg, ctx, false)
+		_, err := ParseConfig(cfg, ctx, false, false)
 		if err != nil {
 			b.Fatalf("parseConfig failed: %v", err)
 		}

--- a/umh-core/pkg/config/validation.go
+++ b/umh-core/pkg/config/validation.go
@@ -14,7 +14,11 @@
 
 package config
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
 
 // ValidateComponentName validates that a component name contains only valid characters
 // and is not empty. Valid characters are letters (a-z, A-Z), numbers (0-9), underscores (_) and hyphens (-).
@@ -34,4 +38,25 @@ func ValidateComponentName(name string) error {
 	}
 
 	return nil
+}
+
+// FormatConfigValidationMessage projects validation issues into the
+// agent health message string. Pure function. Returns empty when no issues.
+func FormatConfigValidationMessage(issues []ConfigValidationIssue) string {
+	if len(issues) == 0 {
+		return ""
+	}
+	if len(issues) == 1 {
+		i := issues[0]
+		msg := fmt.Sprintf("Invalid %s value %q", i.Field, i.OffendingValue)
+		if len(i.AllowedValues) > 0 {
+			msg += ". Allowed: " + strings.Join(i.AllowedValues, ", ")
+		}
+		return msg + "."
+	}
+	parts := make([]string, len(issues))
+	for n, i := range issues {
+		parts[n] = fmt.Sprintf("%s=%q", i.Field, i.OffendingValue)
+	}
+	return fmt.Sprintf("%d configuration issues: %s", len(issues), strings.Join(parts, "; "))
 }

--- a/umh-core/pkg/config/validation_test.go
+++ b/umh-core/pkg/config/validation_test.go
@@ -225,3 +225,35 @@ var _ = Describe("ValidateComponentName", func() {
 		})
 	})
 })
+
+var _ = Describe("FormatConfigValidationMessage (P8)", func() {
+	It("returns empty string for no issues", func() {
+		Expect(config.FormatConfigValidationMessage(nil)).To(Equal(""))
+		Expect(config.FormatConfigValidationMessage([]config.ConfigValidationIssue{})).To(Equal(""))
+	})
+
+	It("formats a single issue with allowed values", func() {
+		issue := config.ConfigValidationIssue{
+			Field:          "agent.releaseChannel",
+			OffendingValue: "nigtly",
+			AllowedValues:  []string{"nightly", "stable", "enterprise"},
+		}
+		msg := config.FormatConfigValidationMessage([]config.ConfigValidationIssue{issue})
+		Expect(msg).To(Equal(`Invalid agent.releaseChannel value "nigtly". Allowed: nightly, stable, enterprise.`))
+	})
+
+	It("formats a single issue without allowed values", func() {
+		issue := config.ConfigValidationIssue{Field: "agent.foo", OffendingValue: "bar"}
+		msg := config.FormatConfigValidationMessage([]config.ConfigValidationIssue{issue})
+		Expect(msg).To(Equal(`Invalid agent.foo value "bar".`))
+	})
+
+	It("formats multiple issues with count + semicolons", func() {
+		issues := []config.ConfigValidationIssue{
+			{Field: "agent.releaseChannel", OffendingValue: "nigtly"},
+			{Field: "agent.foo", OffendingValue: "bar"},
+		}
+		msg := config.FormatConfigValidationMessage(issues)
+		Expect(msg).To(Equal(`2 configuration issues: agent.releaseChannel="nigtly"; agent.foo="bar"`))
+	})
+})

--- a/umh-core/pkg/control/loop.go
+++ b/umh-core/pkg/control/loop.go
@@ -122,7 +122,7 @@ func NewControlLoop(configManager config.ConfigManager) *ControlLoop {
 		benthos.NewBenthosManager(constants.DefaultManagerName),
 		container.NewContainerManager(constants.DefaultManagerName),
 		redpanda.NewRedpandaManager(constants.DefaultManagerName),
-		agent_monitor.NewAgentManager(constants.DefaultManagerName),
+		agent_monitor.NewAgentManager(constants.DefaultManagerName, configManager),
 		nmap.NewNmapManager(constants.DefaultManagerName),
 		dataflowcomponent.NewDataflowComponentManager(constants.DefaultManagerName),
 		connection.NewConnectionManager(constants.DefaultManagerName),

--- a/umh-core/pkg/control/loop.go
+++ b/umh-core/pkg/control/loop.go
@@ -62,6 +62,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/logger"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/metrics"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/sentry"
+	agentmonitorsvc "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/agent_monitor"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/filesystem"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/serviceregistry"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/starvationchecker"
@@ -116,13 +117,22 @@ func NewControlLoop(configManager config.ConfigManager) *ControlLoop {
 		sentry.ReportIssuef(sentry.IssueTypeFatal, log, "Failed to create service registry: %s", err)
 	}
 
+	// agent_monitor only needs the narrow ConfigValidationProvider surface, not
+	// the full ConfigManager interface. Concrete types (FileConfigManager,
+	// FileConfigManagerWithBackoff) satisfy it structurally; mocks intentionally
+	// don't, and pass nil so agent_monitor falls back to its no-validation path.
+	var validationProvider agentmonitorsvc.ConfigValidationProvider
+	if cvp, ok := configManager.(agentmonitorsvc.ConfigValidationProvider); ok {
+		validationProvider = cvp
+	}
+
 	// Create the managers
 	managers := []fsm.FSMManager[any]{
 		s6.NewS6Manager(constants.DefaultManagerName),
 		benthos.NewBenthosManager(constants.DefaultManagerName),
 		container.NewContainerManager(constants.DefaultManagerName),
 		redpanda.NewRedpandaManager(constants.DefaultManagerName),
-		agent_monitor.NewAgentManager(constants.DefaultManagerName, configManager),
+		agent_monitor.NewAgentManager(constants.DefaultManagerName, validationProvider),
 		nmap.NewNmapManager(constants.DefaultManagerName),
 		dataflowcomponent.NewDataflowComponentManager(constants.DefaultManagerName),
 		connection.NewConnectionManager(constants.DefaultManagerName),

--- a/umh-core/pkg/fsm/agent_monitor/machine.go
+++ b/umh-core/pkg/fsm/agent_monitor/machine.go
@@ -32,8 +32,18 @@ import (
 )
 
 // NewAgentInstance creates a new AgentInstance with the standard transitions.
-func NewAgentInstance(config config.AgentMonitorConfig) *AgentInstance {
-	return NewAgentInstanceWithService(config, agent_monitor.NewAgentMonitorService(agent_monitor.WithFilesystemService(filesystem.NewDefaultService()), agent_monitor.WithS6Service(s6.NewDefaultService())))
+// configValidationProvider may be nil for tests; production passes the singleton
+// FileConfigManagerWithBackoff so config-validation issues escalate the agent
+// to Degraded with a dynamic health message.
+func NewAgentInstance(config config.AgentMonitorConfig, configValidationProvider agent_monitor.ConfigValidationProvider) *AgentInstance {
+	opts := []agent_monitor.AgentMonitorServiceOption{
+		agent_monitor.WithFilesystemService(filesystem.NewDefaultService()),
+		agent_monitor.WithS6Service(s6.NewDefaultService()),
+	}
+	if configValidationProvider != nil {
+		opts = append(opts, agent_monitor.WithConfigValidationProvider(configValidationProvider))
+	}
+	return NewAgentInstanceWithService(config, agent_monitor.NewAgentMonitorService(opts...))
 }
 
 // NewAgentInstanceWithService creates a new AgentInstance with a custom monitor service.

--- a/umh-core/pkg/fsm/agent_monitor/manager.go
+++ b/umh-core/pkg/fsm/agent_monitor/manager.go
@@ -24,6 +24,7 @@ import (
 	public_fsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/logger"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/metrics"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/agent_monitor"
 )
 
 // AgentManager is the FSM manager for the agent monitor instance.
@@ -40,7 +41,9 @@ type AgentManagerSnapshot struct {
 func (a *AgentManagerSnapshot) IsObservedStateSnapshot() {}
 
 // NewAgentManager constructs a manager.
-func NewAgentManager(name string) *AgentManager {
+// configValidationProvider may be nil; production wires the FileConfigManagerWithBackoff
+// so config-validation issues surface via the agent's health message.
+func NewAgentManager(name string, configValidationProvider agent_monitor.ConfigValidationProvider) *AgentManager {
 	managerName := fmt.Sprintf("%s_%s", logger.AgentManagerComponentName, name)
 
 	baseMgr := public_fsm.NewBaseFSMManager[config.AgentMonitorConfig](
@@ -68,7 +71,7 @@ func NewAgentManager(name string) *AgentManager {
 		},
 		// Create instance
 		func(fc config.AgentMonitorConfig) (public_fsm.FSMInstance, error) {
-			inst := NewAgentInstance(fc)
+			inst := NewAgentInstance(fc, configValidationProvider)
 
 			return inst, nil
 		},

--- a/umh-core/pkg/service/agent_monitor/agent.go
+++ b/umh-core/pkg/service/agent_monitor/agent.go
@@ -59,6 +59,11 @@ type ServiceInfo struct {
 	// Release: Channel, Version, Supported Feature
 	Release *models.Release `json:"release"`
 
+	// HealthMessage carries a dynamic agent-health message — typically a projection of
+	// ConfigValidationIssues. Empty for the default "operating normally" / canned-message
+	// path; non-empty when readers should prefer this over the canned text.
+	HealthMessage string `json:"healthMessage,omitempty"`
+
 	// AgentLogs contains the structured s6 log entries emitted by the
 	// agent service.
 	//
@@ -77,11 +82,6 @@ type ServiceInfo struct {
 	// Therefore we override the default behaviour and copy only the 3-word
 	// slice header (24 B on amd64) — see CopyAgentLogs below.
 	AgentLogs []s6.LogEntry `json:"agentLogs"`
-
-	// HealthMessage carries a dynamic agent-health message — typically a projection of
-	// ConfigValidationIssues. Empty for the default "operating normally" / canned-message
-	// path; non-empty when readers should prefer this over the canned text.
-	HealthMessage string `json:"healthMessage,omitempty"`
 
 	// Health: Overall, Latency, Release
 	OverallHealth models.HealthCategory `json:"overallHealth"`

--- a/umh-core/pkg/service/agent_monitor/agent.go
+++ b/umh-core/pkg/service/agent_monitor/agent.go
@@ -42,6 +42,14 @@ type IAgentMonitorService interface {
 	GetFilesystemService() filesystem.Service
 }
 
+// ConfigValidationProvider is the surface AgentMonitorService needs to check for
+// config-content validation issues. Implemented by *config.FileConfigManagerWithBackoff.
+// When issues are present, Status flips OverallHealth to Degraded and projects them
+// into HealthMessage so the existing MC alert renders the user-facing detail.
+type ConfigValidationProvider interface {
+	GetConfigValidationIssues() []config.ConfigValidationIssue
+}
+
 // ServiceInfo contains both raw metrics and health assessments.
 type ServiceInfo struct {
 	// General: Location, Latency, Agent Logs, Agent Metrics
@@ -69,6 +77,11 @@ type ServiceInfo struct {
 	// Therefore we override the default behaviour and copy only the 3-word
 	// slice header (24 B on amd64) — see CopyAgentLogs below.
 	AgentLogs []s6.LogEntry `json:"agentLogs"`
+
+	// HealthMessage carries a dynamic agent-health message — typically a projection of
+	// ConfigValidationIssues. Empty for the default "operating normally" / canned-message
+	// path; non-empty when readers should prefer this over the canned text.
+	HealthMessage string `json:"healthMessage,omitempty"`
 
 	// Health: Overall, Latency, Release
 	OverallHealth models.HealthCategory `json:"overallHealth"`
@@ -104,11 +117,12 @@ func (si *ServiceInfo) CopyAgentLogs(src []s6.LogEntry) error {
 
 // AgentMonitorService implements the Service interface.
 type AgentMonitorService struct {
-	lastCollectedAt time.Time
-	fs              filesystem.Service
-	s6Service       s6.Service
-	logger          *zap.SugaredLogger
-	instanceName    string
+	lastCollectedAt          time.Time
+	fs                       filesystem.Service
+	s6Service                s6.Service
+	logger                   *zap.SugaredLogger
+	configValidationProvider ConfigValidationProvider
+	instanceName             string
 }
 
 // NewAgentMonitorService creates a new agent monitor service instance.
@@ -140,6 +154,14 @@ func WithS6Service(s6Service s6.Service) AgentMonitorServiceOption {
 func WithFilesystemService(fs filesystem.Service) AgentMonitorServiceOption {
 	return func(s *AgentMonitorService) {
 		s.fs = fs
+	}
+}
+
+// WithConfigValidationProvider injects a provider used by Status to surface
+// config-content validation issues as a degraded agent health state.
+func WithConfigValidationProvider(p ConfigValidationProvider) AgentMonitorServiceOption {
+	return func(s *AgentMonitorService) {
+		s.configValidationProvider = p
 	}
 }
 
@@ -210,6 +232,16 @@ func (c *AgentMonitorService) Status(ctx context.Context, systemSnapshot fsm.Sys
 	}
 
 	status.Release = release
+
+	// Surface config-content validation issues as a degraded agent state with a
+	// dynamic message. The user is the one who can fix the offending YAML; we
+	// route this through the existing health channel rather than Sentry.
+	if c.configValidationProvider != nil {
+		if issues := c.configValidationProvider.GetConfigValidationIssues(); len(issues) > 0 {
+			status.OverallHealth = models.Degraded
+			status.HealthMessage = config.FormatConfigValidationMessage(issues)
+		}
+	}
 
 	return status, nil
 }

--- a/umh-core/pkg/service/agent_monitor/agent.go
+++ b/umh-core/pkg/service/agent_monitor/agent.go
@@ -236,6 +236,12 @@ func (c *AgentMonitorService) Status(ctx context.Context, systemSnapshot fsm.Sys
 	// Surface config-content validation issues as a degraded agent state with a
 	// dynamic message. The user is the one who can fix the offending YAML; we
 	// route this through the existing health channel rather than Sentry.
+	//
+	// HealthMessage is only meaningful when paired with a non-Active OverallHealth.
+	// buildAgent (in pkg/communicator/pkg/generator/agent.go) enforces this
+	// invariant by ignoring HealthMessage on Active — keep the producer side
+	// aligned: if you set HealthMessage, also escalate OverallHealth to Degraded
+	// (or stronger) above.
 	if c.configValidationProvider != nil {
 		if issues := c.configValidationProvider.GetConfigValidationIssues(); len(issues) > 0 {
 			status.OverallHealth = models.Degraded

--- a/umh-core/pkg/service/agent_monitor/agent_test.go
+++ b/umh-core/pkg/service/agent_monitor/agent_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/models"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/agent_monitor"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/filesystem"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/s6"
@@ -325,5 +326,90 @@ var _ = Describe("Agent Monitor Service", func() {
 			expectedPath := filepath.Join(constants.S6BaseDir, "umh-core")
 			Expect(customMockS6.lastServicePath).To(Equal(expectedPath))
 		})
+	})
+})
+
+// fakeConfigValidationProvider is a stub implementation of ConfigValidationProvider for tests.
+type fakeConfigValidationProvider struct {
+	issues []config.ConfigValidationIssue
+}
+
+func (f *fakeConfigValidationProvider) GetConfigValidationIssues() []config.ConfigValidationIssue {
+	return f.issues
+}
+
+var _ = Describe("Agent Monitor Service config validation escalation (P12)", func() {
+	var (
+		mockFS       *filesystem.MockFileSystem
+		mockS6       *s6.MockService
+		ctx          context.Context
+		mockSnapshot fsm.SystemSnapshot
+	)
+
+	BeforeEach(func() {
+		mockFS = filesystem.NewMockFileSystem()
+		mockS6 = s6.NewMockService()
+		ctx = context.Background()
+
+		mockSnapshot = fsm.SystemSnapshot{
+			CurrentConfig: config.FullConfig{
+				Agent: config.AgentConfig{
+					Location:       map[int]string{0: "Plant"},
+					ReleaseChannel: config.ReleaseChannelStable,
+				},
+			},
+			SnapshotTime: time.Now(),
+			Tick:         1,
+		}
+
+		mockS6.GetLogsResult = []s6.LogEntry{}
+	})
+
+	It("escalates to Degraded with formatted message when validation issues exist", func() {
+		fp := &fakeConfigValidationProvider{issues: []config.ConfigValidationIssue{
+			{
+				Field:          "agent.releaseChannel",
+				OffendingValue: "nigtly",
+				AllowedValues:  []string{"nightly", "stable", "enterprise"},
+			},
+		}}
+		svc := agent_monitor.NewAgentMonitorService(
+			agent_monitor.WithFilesystemService(mockFS),
+			agent_monitor.WithS6Service(mockS6),
+			agent_monitor.WithConfigValidationProvider(fp),
+		)
+
+		info, err := svc.Status(ctx, mockSnapshot)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(info.OverallHealth).To(Equal(models.Degraded))
+		Expect(info.HealthMessage).To(ContainSubstring("agent.releaseChannel"))
+		Expect(info.HealthMessage).To(ContainSubstring("nigtly"))
+		Expect(info.HealthMessage).To(ContainSubstring("nightly, stable, enterprise"))
+	})
+
+	It("stays Active with empty HealthMessage when no validation issues", func() {
+		fp := &fakeConfigValidationProvider{issues: nil}
+		svc := agent_monitor.NewAgentMonitorService(
+			agent_monitor.WithFilesystemService(mockFS),
+			agent_monitor.WithS6Service(mockS6),
+			agent_monitor.WithConfigValidationProvider(fp),
+		)
+
+		info, err := svc.Status(ctx, mockSnapshot)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(info.OverallHealth).To(Equal(models.Active))
+		Expect(info.HealthMessage).To(BeEmpty())
+	})
+
+	It("stays Active when no provider is wired (nil-guard)", func() {
+		svc := agent_monitor.NewAgentMonitorService(
+			agent_monitor.WithFilesystemService(mockFS),
+			agent_monitor.WithS6Service(mockS6),
+		)
+
+		info, err := svc.Status(ctx, mockSnapshot)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(info.OverallHealth).To(Equal(models.Active))
+		Expect(info.HealthMessage).To(BeEmpty())
 	})
 })

--- a/umh-core/pkg/service/agent_monitor/agent_test.go
+++ b/umh-core/pkg/service/agent_monitor/agent_test.go
@@ -401,6 +401,44 @@ var _ = Describe("Agent Monitor Service config validation escalation (P12)", fun
 		Expect(info.HealthMessage).To(BeEmpty())
 	})
 
+	It("validation message wins when location is also empty (P12 ordering)", func() {
+		// When BOTH the nil-location escalation and the config-validation block
+		// fire, the validation block runs last in Status() and overwrites the
+		// (empty) HealthMessage. OverallHealth is already Degraded from the
+		// location escalation, so the categories compose; what we assert is
+		// that the user-actionable validation message wins over the silent
+		// "no location" fallback because we want the user to see why we
+		// degraded, not just that we did.
+		nilLocSnapshot := fsm.SystemSnapshot{
+			CurrentConfig: config.FullConfig{
+				Agent: config.AgentConfig{
+					Location:       nil,
+					ReleaseChannel: config.ReleaseChannelStable,
+				},
+			},
+			SnapshotTime: time.Now(),
+			Tick:         1,
+		}
+		fp := &fakeConfigValidationProvider{issues: []config.ConfigValidationIssue{
+			{
+				Field:          "agent.releaseChannel",
+				OffendingValue: "nigtly",
+				AllowedValues:  []string{"nightly", "stable", "enterprise"},
+			},
+		}}
+		svc := agent_monitor.NewAgentMonitorService(
+			agent_monitor.WithFilesystemService(mockFS),
+			agent_monitor.WithS6Service(mockS6),
+			agent_monitor.WithConfigValidationProvider(fp),
+		)
+
+		info, err := svc.Status(ctx, nilLocSnapshot)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(info.OverallHealth).To(Equal(models.Degraded))
+		Expect(info.HealthMessage).To(ContainSubstring("agent.releaseChannel"))
+		Expect(info.HealthMessage).To(ContainSubstring("nigtly"))
+	})
+
 	It("stays Active when no provider is wired (nil-guard)", func() {
 		svc := agent_monitor.NewAgentMonitorService(
 			agent_monitor.WithFilesystemService(mockFS),

--- a/umh-core/pkg/service/protocolconverter/runtime_config/runtime_config_test.go
+++ b/umh-core/pkg/service/protocolconverter/runtime_config/runtime_config_test.go
@@ -49,7 +49,7 @@ var _ = Describe("BuildRuntimeConfig", func() {
 
 		// Use the config manager's parseConfig function to properly handle templates and anchors
 		ctx := context.Background()
-		fullConfig, err := config.ParseConfig(data, ctx, true) // Allow unknown fields for template handling
+		fullConfig, err := config.ParseConfig(data, ctx, true, false) // Allow unknown fields for template handling
 		Expect(err).NotTo(HaveOccurred(), "Failed to parse example config")
 
 		// Extract the first protocol converter (temperature-sensor-pc)

--- a/umh-core/pkg/service/streamprocessor/streamprocessor_test.go
+++ b/umh-core/pkg/service/streamprocessor/streamprocessor_test.go
@@ -417,7 +417,7 @@ var _ = Describe("StreamProcessorService", func() {
 
 			// Use the config manager's parseConfig function to properly handle templates and anchors
 			ctx := context.Background()
-			fullConfig, err := config.ParseConfig(data, ctx, true) // Allow unknown fields for template handling
+			fullConfig, err := config.ParseConfig(data, ctx, true, false) // Allow unknown fields for template handling
 			Expect(err).NotTo(HaveOccurred(), "Failed to parse example config")
 
 			// Extract the first stream processor (pump-processor)


### PR DESCRIPTION
## Problem

We're shipping the config backup feature. We added Sentry tracking under `feature:fsmv1_config_manager`. Two of the events turned out to be "fake" errors — user configuration decisions, not programming errors. Empty `releaseChannel:` and missing `location:` each fired ~18,000 times on production since 2026-02-20 with zero user impact.

There was also a real bug hiding behind this. If the user wrote `releaseChannel: nigtly`, the agent silently fell back to `"n/a"` and the typo never reached the user's screen.

## Solution

Empty `releaseChannel` defaults to `stable`; missing `location:` defaults to an empty map. Both silently. The two SentryWarns are gone.

A real typo in `releaseChannel` (e.g. `nigtly`) flips the agent's health to `degraded` with a dynamic message that names the field, the offending value, and the allowed list. The existing alert at `InstanceDetailsCore.svelte` renders it. No frontend work.

## How it works

### What `ConfigValidationIssue` is

`ConfigValidationIssue` is the umh-core internal type for a single "user wrote something invalid in `config.yaml`" finding. It exists so config-content problems the user can fix surface in the MC agent-health channel instead of going to Sentry as engineering noise.

### What it catches today

Exactly one thing: `releaseChannel` set to a value that isn't `nightly` / `stable` / `enterprise`. The `nigtly` typo case.

Empty `releaseChannel` and missing `location:` get silently defaulted (no issue recorded), and there's no other validator wired in yet.

### How the data flows

```
user edits config.yaml
        │
        ▼
FileConfigManager.readAndParseConfig
   ├── ParseConfig — defaults empty values to stable / empty map
   └── validateConfig — checks releaseChannel against allowed enum
        │ produces []ConfigValidationIssue
        │ coerces invalid value to "stable" so the agent keeps running
        ▼
   m.swapValidationIssues(issues)   ← stored under mutex
        ▼
agent_monitor.AgentMonitorService.Status()
   reads issues via ConfigValidationProvider interface
   if non-empty:
     • OverallHealth = Degraded
     • HealthMessage = "Invalid agent.releaseChannel value \"nigtly\". Allowed: nightly, stable, enterprise."
        ▼
buildAgent (in the status payload generator)
   if HealthMessage non-empty AND category != Active:
     use HealthMessage instead of canned "Agent degraded"
        ▼
status payload pushed to Management Console
        ▼
InstanceDetailsCore.svelte:171-175 (existing alert, no MC change)
   renders the message in the yellow Agent card
```

## Out of scope

Location-map shape validation, MC settings page redesign, runtime behaviour changes for valid channels, and the other config-manager Sentry events (`config_manager_permanently_failed`, `config_backup_*_failed`). Those are real engineering signals about disk and IO. Pre-existing 22B/22C events get resolved as fixed-in-release; we don't backfill.

## Resolves

- [UMH-CORE-22B](https://united-manufacturing-hub.sentry.io/issues/UMH-CORE-22B) — `config_invalid_release_channel`
- [UMH-CORE-22C](https://united-manufacturing-hub.sentry.io/issues/UMH-CORE-22C) — `config_missing_location_map`

Closes ENG-4880. Spec attached as a Linear document.

## Test plan

- [ ] CI green: `go test ./...` and `go test -race ./pkg/config/... ./pkg/service/agent_monitor/... ./pkg/communicator/pkg/generator/...`
- [ ] P1–P13 covered (see spec §3.1)
- [ ] Manual: edit a test instance YAML to `releaseChannel: nigtly`; agent card flips yellow with the descriptive message
- [ ] Manual: fix the YAML; agent card returns to active without a process restart
- [ ] 24h post-deploy: UMH-CORE-22B/22C see zero new events