### PR TITLE
fix(s6): bridges self-recover from corrupted service directory (ENG-4862)

### DIFF
--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Fixes
 
-- A bridge that got stuck in a starting state due to file corruption now recovers automatically. Previously, recovery required restarting umh-core or recreating the bridge under a different name.
+- A data flow (bridge, standalone, or stream processor) could get stuck in a starting state when its on-disk service directory was left in an inconsistent state — for example after a container restart or OOM-kill interrupted setup. umh-core now detects the inconsistency and rebuilds the directory automatically. Previously, recovery required restarting umh-core or recreating the data flow under a different name.
 
 ## [0.44.19]
 

--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Previously, the component tasked with communicating with the UI could stop working if it rebuilt its HTTP connection (which happens after persistent network failures) while a message was being sent or received. Connection rebuilds and in-flight requests are now coordinated so they cannot interfere.
 - Config backup is now enabled by default. Previously, automatic config.yaml backups required setting `ENABLE_CONFIG_BACKUP=true`. After validating the feature in customer environments for over two months, every umh-core instance now writes timestamped copies of `config.yaml` to `/data/config-backups/` on every config write, retaining the 100 most recent versions (roughly 5–20 MB). To opt out, set `ENABLE_CONFIG_BACKUP=false`. To roll back a bad config, use the second-most-recent backup — the most recent one mirrors the bad write
 
+### Fixes
+
+- A bridge whose underlying service directory got corrupted at runtime previously stayed in a starting state until umh-core was restarted or replaced with a different bridge name. umh-core now detects the corruption and recovers the bridge automatically.
+
 ## [0.44.19]
 
 ### Improvements

--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Fixes
 
-- A bridge whose underlying service directory got corrupted at runtime previously stayed in a starting state until umh-core was restarted or replaced with a different bridge name. umh-core now detects the corruption and recovers the bridge automatically.
+- A bridge that got stuck in a starting state due to file corruption now recovers automatically. Previously, recovery required restarting umh-core or recreating the bridge under a different name.
 
 ## [0.44.19]
 

--- a/umh-core/pkg/fsm/s6/healthbad_lifecycle_integration_test.go
+++ b/umh-core/pkg/fsm/s6/healthbad_lifecycle_integration_test.go
@@ -1,0 +1,114 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package s6_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
+	s6fsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/s6"
+	s6service "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/s6"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/serviceregistry"
+)
+
+var _ = Describe("S6 recovery directive — FSM dispatch", func() {
+	var (
+		ctx      context.Context
+		cancel   context.CancelFunc
+		mockSvc  *s6service.MockService
+		registry serviceregistry.Provider
+		inst     *s6fsm.S6Instance
+	)
+
+	BeforeEach(func() {
+		ctx, cancel = context.WithCancel(context.Background())
+
+		mockSvc = s6service.NewMockService()
+		mockSvc.MockExists = true
+		mockSvc.MockHealthAction = s6service.ActionOK
+
+		registry = serviceregistry.NewMockRegistry()
+		cfg := config.S6FSMConfig{
+			FSMInstanceConfig: config.FSMInstanceConfig{
+				Name:            "test-svc",
+				DesiredFSMState: s6fsm.OperationalStateRunning,
+			},
+		}
+		var err error
+		inst, err = s6fsm.NewS6InstanceWithService("/dev/null", cfg, mockSvc)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() { cancel() })
+
+	// driveTicks runs Reconcile across `count` ticks starting at `startTick`,
+	// returning early if the FSM reaches Removed. Errors are intentionally
+	// swallowed so the loop can drive past tick boundaries.
+	driveTicks := func(startTick uint64, count int) {
+		for tick := startTick; tick < startTick+uint64(count); tick++ {
+			_, _ = inst.Reconcile(ctx, fsm.SystemSnapshot{Tick: tick}, registry)
+			if inst.IsRemoved() {
+				return
+			}
+		}
+	}
+
+	It("drives the FSM to Removed when Health returns ActionRecreate from any state", func() {
+		mockSvc.MockHealthAction = s6service.ActionRecreate
+
+		driveTicks(1, 30)
+
+		Expect(inst.IsRemoved()).To(BeTrue(),
+			"FSM must reach Removed via Health() recovery dispatch within 30 ticks")
+		Expect(mockSvc.ForceRemoveCalled).To(BeTrue(),
+			"ForceRemove must fire on the underlying service to clear corruption")
+	})
+
+	It("does not re-fire after recovery (ForceRemove called exactly once across 50 post-recovery ticks)", func() {
+		mockSvc.MockHealthAction = s6service.ActionRecreate
+		driveTicks(1, 30)
+		Expect(inst.IsRemoved()).To(BeTrue())
+		Expect(mockSvc.ForceRemoveCallCount).To(Equal(1),
+			"ForceRemove fires exactly once per corruption event")
+
+		mockSvc.MockHealthAction = s6service.ActionOK
+
+		for tick := uint64(31); tick < 81; tick++ {
+			_, _ = inst.Reconcile(ctx, fsm.SystemSnapshot{Tick: tick}, registry)
+		}
+
+		Expect(mockSvc.ForceRemoveCallCount).To(Equal(1),
+			"once Health flips back to ActionOK, no further ForceRemove calls may fire")
+	})
+
+	It("escapes from operational state when Health returns ActionRecreate mid-flight", func() {
+		driveTicks(1, 30)
+		Expect(inst.IsRemoved()).To(BeFalse(),
+			"baseline: FSM should not be Removed under healthy mock with desired=Running")
+		Expect(mockSvc.ForceRemoveCalled).To(BeFalse(),
+			"baseline: no recovery should fire under healthy mock")
+
+		mockSvc.MockHealthAction = s6service.ActionRecreate
+		driveTicks(31, 30)
+
+		Expect(inst.IsRemoved()).To(BeTrue(),
+			"FSM must escape from operational state via Health() recovery dispatch")
+		Expect(mockSvc.ForceRemoveCalled).To(BeTrue())
+	})
+})

--- a/umh-core/pkg/fsm/s6/healthbad_lifecycle_integration_test.go
+++ b/umh-core/pkg/fsm/s6/healthbad_lifecycle_integration_test.go
@@ -20,6 +20,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	internalfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/internal/fsm"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
 	s6fsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/s6"
@@ -95,6 +96,67 @@ var _ = Describe("S6 recovery directive — FSM dispatch", func() {
 
 		Expect(mockSvc.ForceRemoveCallCount).To(Equal(1),
 			"once Health flips back to ActionOK, no further ForceRemove calls may fire")
+	})
+
+	// driveUntilState advances ticks (up to maxTicks) until the FSM reports the
+	// target state, returning the tick at which the state was first observed or
+	// -1 if it never arrived. Errors are swallowed so transient reconcile failures
+	// don't abort the loop.
+	driveUntilState := func(startTick uint64, maxTicks int, target string) (uint64, int) {
+		for i := 0; i < maxTicks; i++ {
+			tick := startTick + uint64(i)
+			_, _ = inst.Reconcile(ctx, fsm.SystemSnapshot{Tick: tick}, registry)
+			if inst.GetCurrentFSMState() == target {
+				return tick, i + 1
+			}
+		}
+
+		return 0, -1
+	}
+
+	It("drives the FSM to Removed when Health returns ActionRecreate from Creating", func() {
+		// Tick 1 takes the FSM through ReconcileLifecycleStates from
+		// to_be_created -> CreateInstance -> SendEvent(LifecycleEventCreate),
+		// landing in LifecycleStateCreating before the next tick runs Health().
+		// We assert that state is reached, then flip Health to ActionRecreate
+		// so the recovery dispatch must fire from Creating specifically -- the
+		// gap the reviewer flagged on the original "from to_be_created" test.
+		_, _ = inst.Reconcile(ctx, fsm.SystemSnapshot{Tick: 1}, registry)
+		Expect(inst.GetCurrentFSMState()).To(Equal(internalfsm.LifecycleStateCreating),
+			"after tick 1 the FSM should have transitioned to_be_created -> Creating")
+
+		mockSvc.MockHealthAction = s6service.ActionRecreate
+
+		driveTicks(2, 30)
+
+		Expect(inst.IsRemoved()).To(BeTrue(),
+			"FSM must escape from Creating via Health() recovery dispatch within 30 ticks")
+		Expect(mockSvc.ForceRemoveCalled).To(BeTrue(),
+			"ForceRemove must fire on the underlying service to clear corruption from Creating")
+	})
+
+	It("drives the FSM to Removed when Health returns ActionRecreate from Running", func() {
+		// NewS6Instance hard-codes the desired operational state to Stopped
+		// regardless of the FSMInstanceConfig passed in, so the BeforeEach
+		// alone parks the FSM at Stopped. We have to flip the desired state
+		// explicitly to drive the FSM through Starting into Running.
+		Expect(inst.SetDesiredFSMState(s6fsm.OperationalStateRunning)).To(Succeed())
+
+		_, ticksToRunning := driveUntilState(1, 20, s6fsm.OperationalStateRunning)
+		Expect(ticksToRunning).To(BeNumerically(">", 0),
+			"FSM must reach Running under the healthy mock within 20 ticks")
+		Expect(inst.GetCurrentFSMState()).To(Equal(s6fsm.OperationalStateRunning))
+		Expect(mockSvc.ForceRemoveCalled).To(BeFalse(),
+			"baseline: no recovery should fire while Health is ActionOK")
+
+		mockSvc.MockHealthAction = s6service.ActionRecreate
+
+		driveTicks(uint64(ticksToRunning+1), 30)
+
+		Expect(inst.IsRemoved()).To(BeTrue(),
+			"FSM must escape from Running via Health() recovery dispatch within 30 ticks")
+		Expect(mockSvc.ForceRemoveCalled).To(BeTrue(),
+			"ForceRemove must fire on the underlying service to clear corruption from Running")
 	})
 
 	It("escapes from operational state when Health returns ActionRecreate mid-flight", func() {

--- a/umh-core/pkg/fsm/s6/healthbad_lifecycle_integration_test.go
+++ b/umh-core/pkg/fsm/s6/healthbad_lifecycle_integration_test.go
@@ -69,7 +69,7 @@ var _ = Describe("S6 recovery directive — FSM dispatch", func() {
 		}
 	}
 
-	It("drives the FSM to Removed when Health returns ActionRecreate from any state", func() {
+	It("drives the FSM to Removed when Health returns ActionRecreate from to_be_created", func() {
 		mockSvc.MockHealthAction = s6service.ActionRecreate
 
 		driveTicks(1, 30)

--- a/umh-core/pkg/fsm/s6/reconcile.go
+++ b/umh-core/pkg/fsm/s6/reconcile.go
@@ -199,6 +199,44 @@ func (s *S6Instance) reconcileStateTransition(ctx context.Context, services serv
 	currentState := s.baseFSMInstance.GetCurrentFSMState()
 	desiredState := s.baseFSMInstance.GetDesiredFSMState()
 
+	// Recovery dispatch: ask the s6 service whether normal lifecycle work can
+	// proceed. Health collapses three previously-scattered signals (artifact
+	// presence, directory integrity, in-flight removal) into one directive.
+	//
+	// ActionRecreate returns a permanent failure that lands at SetError; on
+	// the next tick the error-backoff block (ShouldSkipReconcileBecauseOfError)
+	// at the top of Reconcile sees IsPermanentFailureError and dispatches
+	// HandlePermanentError, which runs ForceRemove and transitions the FSM to
+	// Removed. After ForceRemove succeeds the service clears its artifacts
+	// pointer and Health returns ActionOK on subsequent ticks, so recovery
+	// does not re-fire.
+	//
+	// This single check supersedes the operational-state HealthBad escape
+	// added under ENG-3468/ENG-3473 (and closes the lifecycle gap that
+	// produced ENG-4862). The remaining HealthBad branches in
+	// reconcileTransitionToRunning are now defensive belt-and-suspenders.
+	switch directive := s.service.Health(ctx, services.GetFileSystem()); directive {
+	case s6service.ActionOK:
+		// Healthy — fall through to normal lifecycle/operational dispatch.
+	case s6service.ActionRecreate:
+		s.baseFSMInstance.GetLogger().Errorf(
+			"S6 service %s requires recreation (state=%s)",
+			s.baseFSMInstance.GetID(), currentState,
+		)
+		// reconciled=false because the caller at Reconcile.reconcileStateTransition
+		// discards the boolean when err != nil and the recovery itself happens on
+		// the next tick via HandlePermanentError; reporting "reconciled" would
+		// misrepresent that nothing changed this tick.
+		return fmt.Errorf("%s: directory corrupted in state %s", backoff.PermanentFailureError, currentState), false
+	case s6service.ActionWait:
+		return nil, false
+	default:
+		s.baseFSMInstance.GetLogger().Errorf(
+			"unknown RecoveryAction %v from s6 service Health for %s - falling through to normal dispatch",
+			directive, s.baseFSMInstance.GetID(),
+		)
+	}
+
 	// Handle lifecycle states first - these take precedence over operational states
 	if internal_fsm.IsLifecycleState(currentState) {
 		err, reconciled := s.baseFSMInstance.ReconcileLifecycleStates(ctx, services, currentState, s.CreateInstance, s.RemoveInstance, s.CheckForCreation)
@@ -238,20 +276,11 @@ func (s *S6Instance) reconcileOperationalStates(ctx context.Context, services se
 		metrics.ObserveReconcileTime(metrics.ComponentS6Instance, s.baseFSMInstance.GetID()+".reconcileOperationalStates", time.Since(start))
 	}()
 
-	// Check for directory health issues and trigger force removal if needed
-	// When directory health is bad (corrupted/deleted), we're in an undefined state
-	// and cannot go through normal state transitions. Return a permanent error to
-	// trigger force removal and direct transition to "removed" state.
-	if s.ObservedState.DirectoryHealth == s6service.HealthBad {
-		s.baseFSMInstance.GetLogger().Errorf(
-			"S6 service %s has bad directory integrity - triggering force removal for recreation",
-			s.baseFSMInstance.GetID(),
-		)
-		// Return permanent error to trigger HandlePermanentError which will:
-		// 1. Call ForceRemove to clean up everything including orphaned symlinks
-		// 2. Transition FSM directly to "removed" state
-		return fmt.Errorf("%s: directory corrupted or deleted", backoff.PermanentFailureError), true
-	}
+	// Operational HealthBad escape replaced by the top-level Health() dispatch
+	// in reconcileStateTransition. The remaining HealthBad branches in this
+	// function (skip-stop, consider-stopped) are now structurally unreachable
+	// when corruption is observed, but kept as defensive belt-and-suspenders
+	// pending follow-up cleanup once the recovery directive bakes one release.
 
 	switch desiredState {
 	case OperationalStateRunning:

--- a/umh-core/pkg/fsm/s6/reconcile.go
+++ b/umh-core/pkg/fsm/s6/reconcile.go
@@ -214,7 +214,7 @@ func (s *S6Instance) reconcileStateTransition(ctx context.Context, services serv
 	// This single check supersedes the operational-state HealthBad escape
 	// added under ENG-3468/ENG-3473 (and closes the lifecycle gap that
 	// produced ENG-4862). The remaining HealthBad branches in
-	// reconcileTransitionToRunning are now defensive belt-and-suspenders.
+	// reconcileTransitionToStopped are now defensive belt-and-suspenders.
 	switch directive := s.service.Health(ctx, services.GetFileSystem()); directive {
 	case s6service.ActionOK:
 		// Healthy — fall through to normal lifecycle/operational dispatch.
@@ -229,7 +229,13 @@ func (s *S6Instance) reconcileStateTransition(ctx context.Context, services serv
 		// misrepresent that nothing changed this tick.
 		return fmt.Errorf("%s: directory corrupted in state %s", backoff.PermanentFailureError, currentState), false
 	case s6service.ActionWait:
-		return nil, false
+		// ActionWait applies only to operational states. Lifecycle states (especially
+		// LifecycleStateRemoving) must fall through to ReconcileLifecycleStates to
+		// retry RemoveInstance. Blocking that retry when RemovalProgress != nil would
+		// permanently stall removal if RemoveArtifacts fails mid-sequence.
+		if IsOperationalState(currentState) {
+			return nil, false
+		}
 	default:
 		s.baseFSMInstance.GetLogger().Errorf(
 			"unknown RecoveryAction %v from s6 service Health for %s - falling through to normal dispatch",

--- a/umh-core/pkg/service/s6/health_directive_test.go
+++ b/umh-core/pkg/service/s6/health_directive_test.go
@@ -1,0 +1,176 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package s6
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/logger"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/filesystem"
+)
+
+// healthyFS returns a MockFileSystem where every file/path probe reports the
+// resource as present. Used as the baseline for "all tracked files exist".
+func healthyFS() *filesystem.MockFileSystem {
+	fs := filesystem.NewMockFileSystem()
+	fs.WithFileExistsFunc(func(ctx context.Context, path string) (bool, error) {
+		return true, nil
+	})
+	fs.WithPathExistsFunc(func(ctx context.Context, path string) (bool, error) {
+		return true, nil
+	})
+
+	return fs
+}
+
+var _ = Describe("Health() recovery directive contract", func() {
+	var (
+		ctx         context.Context
+		service     *DefaultService
+		servicePath string
+		repoPath    string
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		service = &DefaultService{logger: logger.For("test")}
+		servicePath = filepath.Join(constants.S6BaseDir, "test-service")
+		repoPath = filepath.Join(constants.GetS6RepositoryBaseDir(), "test-service")
+	})
+
+	It("returns ActionOK when no artifacts are tracked (post-cleanup or pre-Create)", func() {
+		service.artifacts.Store(nil)
+
+		Expect(service.Health(ctx, healthyFS())).To(Equal(ActionOK))
+	})
+
+	It("returns ActionOK when all tracked files exist on disk", func() {
+		service.artifacts.Store(&ServiceArtifacts{
+			ServiceDir:    servicePath,
+			RepositoryDir: repoPath,
+			CreatedFiles: []string{
+				filepath.Join(repoPath, "run"),
+				filepath.Join(repoPath, "type"),
+			},
+		})
+
+		Expect(service.Health(ctx, healthyFS())).To(Equal(ActionOK))
+	})
+
+	It("returns ActionRecreate when tracked files are missing (corruption observed)", func() {
+		service.artifacts.Store(&ServiceArtifacts{
+			ServiceDir:    servicePath,
+			RepositoryDir: repoPath,
+			CreatedFiles: []string{
+				filepath.Join(repoPath, "run"),
+				filepath.Join(repoPath, "type"),
+			},
+		})
+
+		fs := filesystem.NewMockFileSystem()
+		fs.WithFileExistsFunc(func(ctx context.Context, path string) (bool, error) {
+			if strings.HasSuffix(path, "/run") {
+				return false, nil
+			}
+
+			return true, nil
+		})
+		fs.WithPathExistsFunc(func(ctx context.Context, path string) (bool, error) {
+			return true, nil
+		})
+
+		Expect(service.Health(ctx, fs)).To(Equal(ActionRecreate))
+	})
+
+	It("returns ActionWait on transient I/O error from filesystem", func() {
+		service.artifacts.Store(&ServiceArtifacts{
+			ServiceDir:    servicePath,
+			RepositoryDir: repoPath,
+			CreatedFiles:  []string{filepath.Join(repoPath, "run")},
+		})
+
+		fs := filesystem.NewMockFileSystem()
+		fs.WithFileExistsFunc(func(ctx context.Context, path string) (bool, error) {
+			return false, errors.New("I/O timeout")
+		})
+
+		Expect(service.Health(ctx, fs)).To(Equal(ActionWait))
+	})
+
+	It("returns ActionWait while RemoveArtifacts is in flight (RemovalProgress != nil)", func() {
+		artifacts := &ServiceArtifacts{
+			ServiceDir:    servicePath,
+			RepositoryDir: repoPath,
+			CreatedFiles:  []string{filepath.Join(repoPath, "run")},
+		}
+		artifacts.InitRemovalProgress()
+		service.artifacts.Store(artifacts)
+
+		fs := filesystem.NewMockFileSystem()
+		fs.WithFileExistsFunc(func(ctx context.Context, path string) (bool, error) {
+			return false, nil
+		})
+
+		Expect(service.Health(ctx, fs)).To(Equal(ActionWait))
+	})
+
+	It("flips ActionRecreate → ActionOK after cleanup clears tracking", func() {
+		artifacts := &ServiceArtifacts{
+			ServiceDir:    servicePath,
+			RepositoryDir: repoPath,
+			CreatedFiles:  []string{filepath.Join(repoPath, "run")},
+		}
+		service.artifacts.Store(artifacts)
+
+		brokenFS := filesystem.NewMockFileSystem()
+		brokenFS.WithFileExistsFunc(func(ctx context.Context, path string) (bool, error) {
+			return false, nil
+		})
+		brokenFS.WithPathExistsFunc(func(ctx context.Context, path string) (bool, error) {
+			return true, nil
+		})
+		Expect(service.Health(ctx, brokenFS)).To(Equal(ActionRecreate))
+
+		service.artifacts.Store(nil)
+		Expect(service.Health(ctx, brokenFS)).To(Equal(ActionOK))
+	})
+
+	It("flips ActionOK → ActionRecreate when files are externally deleted", func() {
+		artifacts := &ServiceArtifacts{
+			ServiceDir:    servicePath,
+			RepositoryDir: repoPath,
+			CreatedFiles:  []string{filepath.Join(repoPath, "run")},
+		}
+		service.artifacts.Store(artifacts)
+
+		Expect(service.Health(ctx, healthyFS())).To(Equal(ActionOK))
+
+		brokenFS := filesystem.NewMockFileSystem()
+		brokenFS.WithFileExistsFunc(func(ctx context.Context, path string) (bool, error) {
+			return false, nil
+		})
+		brokenFS.WithPathExistsFunc(func(ctx context.Context, path string) (bool, error) {
+			return true, nil
+		})
+		Expect(service.Health(ctx, brokenFS)).To(Equal(ActionRecreate))
+	})
+})

--- a/umh-core/pkg/service/s6/lifecycle_force.go
+++ b/umh-core/pkg/service/s6/lifecycle_force.go
@@ -75,12 +75,26 @@ func (s *DefaultService) ForceCleanup(ctx context.Context, artifacts *ServiceArt
 		s.logger.Warnf("Failed to remove log directory: %v", err)
 	}
 
+	// Step 4: Remove the repository directory. The scan dir (ServiceDir) is a
+	// symlink; the actual service files live in RepositoryDir. Without this step
+	// the repository is orphaned on disk and only recovered when the next Create
+	// call detects the stale directory.
+	if artifacts.RepositoryDir != "" {
+		if err := s.removeDirectoryWithTimeout(ctx, artifacts.RepositoryDir, fsService); err != nil {
+			s.logger.Warnf("Failed to remove repository directory: %v", err)
+		}
+	}
+
 	// Verify cleanup completed
 	serviceExists, _ := fsService.PathExists(ctx, artifacts.ServiceDir)
 	logExists, _ := fsService.PathExists(ctx, artifacts.LogDir)
+	repoExists := false
+	if artifacts.RepositoryDir != "" {
+		repoExists, _ = fsService.PathExists(ctx, artifacts.RepositoryDir)
+	}
 
-	if serviceExists || logExists {
-		return fmt.Errorf("force cleanup incomplete: service=%v, log=%v", serviceExists, logExists)
+	if serviceExists || logExists || repoExists {
+		return fmt.Errorf("force cleanup incomplete: service=%v, log=%v, repo=%v", serviceExists, logExists, repoExists)
 	}
 
 	s.logger.Infof("Force cleanup completed for service: %s", filepath.Base(artifacts.ServiceDir))

--- a/umh-core/pkg/service/s6/lifecycle_force.go
+++ b/umh-core/pkg/service/s6/lifecycle_force.go
@@ -85,12 +85,23 @@ func (s *DefaultService) ForceCleanup(ctx context.Context, artifacts *ServiceArt
 		}
 	}
 
-	// Verify cleanup completed
-	serviceExists, _ := fsService.PathExists(ctx, artifacts.ServiceDir)
-	logExists, _ := fsService.PathExists(ctx, artifacts.LogDir)
+	// Verify cleanup completed. Propagate PathExists errors rather than
+	// treating them as "not exists" — a false negative would cause ForceCleanup
+	// to return nil while directories may still exist on disk.
+	serviceExists, err := fsService.PathExists(ctx, artifacts.ServiceDir)
+	if err != nil {
+		return fmt.Errorf("failed to verify service cleanup: %w", err)
+	}
+	logExists, err := fsService.PathExists(ctx, artifacts.LogDir)
+	if err != nil {
+		return fmt.Errorf("failed to verify log cleanup: %w", err)
+	}
 	repoExists := false
 	if artifacts.RepositoryDir != "" {
-		repoExists, _ = fsService.PathExists(ctx, artifacts.RepositoryDir)
+		repoExists, err = fsService.PathExists(ctx, artifacts.RepositoryDir)
+		if err != nil {
+			return fmt.Errorf("failed to verify repository cleanup: %w", err)
+		}
 	}
 
 	if serviceExists || logExists || repoExists {

--- a/umh-core/pkg/service/s6/lifecycle_test.go
+++ b/umh-core/pkg/service/s6/lifecycle_test.go
@@ -392,7 +392,7 @@ var _ = Describe("LifecycleManager", func() {
 
 		It("should return HealthUnknown when artifacts are nil", func() {
 			// Simulate a fresh start or post-restart scenario
-			service.artifacts = nil
+			service.artifacts.Store(nil)
 			
 			health := service.CheckServiceDirectoryIntegrity(ctx, servicePath, mockFS)
 			Expect(health).To(Equal(HealthUnknown))
@@ -400,14 +400,14 @@ var _ = Describe("LifecycleManager", func() {
 
 		It("should return HealthOK when all tracked files exist", func() {
 			// Set up artifacts with tracked files
-			service.artifacts = &ServiceArtifacts{
+			service.artifacts.Store(&ServiceArtifacts{
 				ServiceDir: servicePath,
 				CreatedFiles: []string{
 					filepath.Join(servicePath, "run"),
 					filepath.Join(servicePath, "type"),
 					filepath.Join(servicePath, ".complete"),
 				},
-			}
+			})
 			
 			// Mock all files as existing
 			mockFS.WithFileExistsFunc(func(ctx context.Context, path string) (bool, error) {
@@ -423,14 +423,14 @@ var _ = Describe("LifecycleManager", func() {
 
 		It("should return HealthBad when tracked files are missing", func() {
 			// Set up artifacts with tracked files
-			service.artifacts = &ServiceArtifacts{
+			service.artifacts.Store(&ServiceArtifacts{
 				ServiceDir: servicePath,
 				CreatedFiles: []string{
 					filepath.Join(servicePath, "run"),
 					filepath.Join(servicePath, "type"),
 					filepath.Join(servicePath, ".complete"),
 				},
-			}
+			})
 			
 			// Mock run file as missing
 			mockFS.WithFileExistsFunc(func(ctx context.Context, path string) (bool, error) {
@@ -450,12 +450,12 @@ var _ = Describe("LifecycleManager", func() {
 
 		It("should return HealthUnknown on I/O errors", func() {
 			// Set up artifacts
-			service.artifacts = &ServiceArtifacts{
+			service.artifacts.Store(&ServiceArtifacts{
 				ServiceDir: servicePath,
 				CreatedFiles: []string{
 					filepath.Join(servicePath, "run"),
 				},
-			}
+			})
 			
 			// Simulate I/O error
 			mockFS.WithPathExistsFunc(func(ctx context.Context, path string) (bool, error) {
@@ -468,12 +468,12 @@ var _ = Describe("LifecycleManager", func() {
 
 		It("should return HealthUnknown on context cancellation", func() {
 			// Set up artifacts
-			service.artifacts = &ServiceArtifacts{
+			service.artifacts.Store(&ServiceArtifacts{
 				ServiceDir: servicePath,
 				CreatedFiles: []string{
 					filepath.Join(servicePath, "run"),
 				},
-			}
+			})
 			
 			// Create cancelled context
 			cancelledCtx, cancel := context.WithCancel(ctx)
@@ -491,13 +491,13 @@ var _ = Describe("LifecycleManager", func() {
 		It("should handle config files with absolute paths correctly", func() {
 			// Test the fix for config file path tracking bug
 			configPath := filepath.Join(servicePath, "config", "app.yaml")
-			service.artifacts = &ServiceArtifacts{
+			service.artifacts.Store(&ServiceArtifacts{
 				ServiceDir: servicePath,
 				CreatedFiles: []string{
 					filepath.Join(servicePath, "run"),
 					configPath, // Absolute path (the fix)
 				},
-			}
+			})
 			
 			// Mock all files as existing
 			mockFS.WithFileExistsFunc(func(ctx context.Context, path string) (bool, error) {
@@ -513,14 +513,14 @@ var _ = Describe("LifecycleManager", func() {
 
 		It("should not check for down files", func() {
 			// Test that down files are not tracked (the fix for down file issue)
-			service.artifacts = &ServiceArtifacts{
+			service.artifacts.Store(&ServiceArtifacts{
 				ServiceDir: servicePath,
 				CreatedFiles: []string{
 					filepath.Join(servicePath, "run"),
 					filepath.Join(servicePath, "type"),
 					// Note: no down file in tracked files
 				},
-			}
+			})
 			
 			// Mock: down file doesn't exist (service is running)
 			mockFS.WithFileExistsFunc(func(ctx context.Context, path string) (bool, error) {

--- a/umh-core/pkg/service/s6/mock.go
+++ b/umh-core/pkg/service/s6/mock.go
@@ -83,10 +83,36 @@ type MockService struct {
 	GetLogsCalled                 bool
 	GetStructuredLogsCalled       bool
 
+	// ForceRemoveCallCount records how many times ForceRemove was invoked.
+	// Tests use this to verify recovery dispatch fires exactly once per
+	// corruption event (the post-recovery re-fire bug at the heart of
+	// ENG-4862 manifests as a count above 1 across many ticks).
+	ForceRemoveCallCount int
+
 	ServiceExistsResult bool
 	// New fields for EnsureSupervision
 	MockExists bool
 	ErrorMode  bool
+
+	// MockHealthAction is the value MockService.Health returns. The zero value
+	// is ActionOK, so &MockService{} returns ActionOK without explicit setup.
+	// Tests pin it to ActionRecreate to drive the recovery dispatch and to
+	// ActionWait for transient-pending semantics.
+	//
+	// Create, Remove, and ForceRemove deliberately do NOT auto-mutate this
+	// field. Tests that exercise post-recovery flips must set it explicitly.
+	// This is a deliberate gap relative to DefaultService.Health (where
+	// Store(nil) inside ForceRemove is what flips Health back to ActionOK);
+	// the white-box health_directive_test.go asserts that flip directly. The
+	// integration test simulates the post-recovery reality by setting
+	// MockHealthAction manually.
+	//
+	// Concurrency: MockService.Health and ForceRemove acquire m.mu, but tests
+	// that mutate this field directly do so without the lock (see
+	// healthbad_lifecycle_integration_test.go). That is safe only when the
+	// mock is driven from a single goroutine. Tests that fan reconcile out to
+	// background goroutines must guard mutations with m.mu.Lock().
+	MockHealthAction RecoveryAction
 }
 
 // NewMockService creates a new mock S6 service.
@@ -230,7 +256,11 @@ func (m *MockService) GetS6ConfigFile(ctx context.Context, servicePath string, c
 
 // ForceRemove is a mock method.
 func (m *MockService) ForceRemove(ctx context.Context, servicePath string, filesystemService filesystem.Service) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	m.ForceRemoveCalled = true
+	m.ForceRemoveCallCount++
 	m.ForceRemovePath = servicePath
 
 	return m.ForceRemoveError
@@ -276,7 +306,17 @@ func (m *MockService) CheckServiceDirectoryIntegrity(ctx context.Context, servic
 	if !m.MockExists {
 		return HealthBad
 	}
-	
+
 	// Default to HealthOK
 	return HealthOK
+}
+
+// Health returns the recovery directive pinned by tests. The zero value is
+// ActionOK so &MockService{} returns ActionOK without explicit setup, which
+// keeps existing tests working without modification.
+func (m *MockService) Health(ctx context.Context, fsService filesystem.Service) RecoveryAction {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return m.MockHealthAction
 }

--- a/umh-core/pkg/service/s6/s6.go
+++ b/umh-core/pkg/service/s6/s6.go
@@ -27,6 +27,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -99,6 +100,40 @@ func (h HealthStatus) String() string {
 		return "bad"
 	default:
 		return "invalid"
+	}
+}
+
+// RecoveryAction is the directive returned by Health(): the service tells
+// callers what to do based on its current state instead of having callers
+// compose policy from low-level signals like artifact presence and directory
+// integrity.
+type RecoveryAction int
+
+const (
+	// ActionOK indicates the service is healthy or has no tracked state to
+	// verify; callers should proceed with normal lifecycle work. ActionOK is
+	// the zero value so MockService{} returns it without explicit setup.
+	ActionOK RecoveryAction = iota
+	// ActionWait indicates a transient condition (I/O error, in-flight removal,
+	// or unknown state); callers should retry on the next tick.
+	ActionWait
+	// ActionRecreate indicates corruption was observed; callers must tear down
+	// and rebuild the service from scratch (typically by returning a permanent
+	// failure to drive HandlePermanentError → ForceRemove).
+	ActionRecreate
+)
+
+// String returns a string representation of the recovery action.
+func (a RecoveryAction) String() string {
+	switch a {
+	case ActionOK:
+		return "ok"
+	case ActionWait:
+		return "wait"
+	case ActionRecreate:
+		return "recreate"
+	default:
+		return fmt.Sprintf("invalid(%d)", int(a))
 	}
 }
 
@@ -193,6 +228,11 @@ type Service interface {
 	// CheckServiceDirectoryIntegrity checks the integrity of the S6 service directory structure
 	// Returns HealthUnknown for I/O errors, HealthOK for intact structure, HealthBad for broken/missing directories
 	CheckServiceDirectoryIntegrity(ctx context.Context, servicePath string, fsService filesystem.Service) HealthStatus
+	// Health returns a recovery directive based on the service's current
+	// tracked state. Callers switch on the result instead of composing policy
+	// from CheckServiceDirectoryIntegrity, artifact presence, and removal
+	// progress separately. See RecoveryAction.
+	Health(ctx context.Context, fsService filesystem.Service) RecoveryAction
 }
 
 // logState is the per-log-file cursor used by GetLogs.
@@ -239,9 +279,15 @@ type logState struct {
 
 // DefaultService is the default implementation of the S6 Service interface.
 type DefaultService struct {
-	logger     *zap.SugaredLogger
-	artifacts  *ServiceArtifacts // cached artifacts for the service
-	logCursors sync.Map          // map[string]*logState (key = abs log path)
+	logger *zap.SugaredLogger
+	// artifacts tracks the files this service created on disk. Lifecycle:
+	// nil before Create or after Remove/ForceRemove succeed; populated by
+	// Create on success. Atomic so the lock-free reader in Health() sees a
+	// consistent pointer while writers run inside withLifecycleGuard.
+	// Clearing artifacts on cleanup is what flips Health() back to ActionOK
+	// after recovery, breaking the post-ForceRemove re-fire loop (ENG-4862).
+	artifacts  atomic.Pointer[ServiceArtifacts]
+	logCursors sync.Map // map[string]*logState (key = abs log path)
 
 	// Lifecycle management with concurrency protection
 	mu sync.Mutex // serializes all state-changing calls
@@ -295,13 +341,14 @@ func (s *DefaultService) Create(ctx context.Context, servicePath string, config 
 				return err
 			}
 
-			s.artifacts = artifacts
+			s.artifacts.Store(artifacts)
 
 			return nil
 		}
 
 		// 2. Directory exists but we have no artifacts → orphaned directory from restart
-		if s.artifacts == nil {
+		current := s.artifacts.Load()
+		if current == nil {
 			s.logger.Debugf("Service %s exists but has no artifacts (orphaned from restart), removing and recreating", servicePath)
 			// Remove the orphaned directory immediately - we can't track what files were created
 			if err := fsService.RemoveAll(ctx, servicePath); err != nil {
@@ -313,13 +360,13 @@ func (s *DefaultService) Create(ctx context.Context, servicePath string, config 
 				return err
 			}
 
-			s.artifacts = artifacts
+			s.artifacts.Store(artifacts)
 
 			return nil
 		}
 
 		// 3. Directory exists and we have artifacts → check health
-		health, err := s.CheckArtifactsHealth(ctx, s.artifacts, fsService)
+		health, err := s.CheckArtifactsHealth(ctx, current, fsService)
 		if err != nil && health != HealthUnknown {
 			return fmt.Errorf("failed to check service health: %w", err)
 		}
@@ -327,16 +374,18 @@ func (s *DefaultService) Create(ctx context.Context, servicePath string, config 
 		if health == HealthBad {
 			s.logger.Debugf("Service %s is unhealthy, removing and recreating", servicePath)
 
-			if err := s.ForceCleanup(ctx, s.artifacts, fsService); err != nil {
+			if err := s.ForceCleanup(ctx, current, fsService); err != nil {
 				return fmt.Errorf("failed to remove unhealthy service: %w", err)
 			}
+
+			s.artifacts.Store(nil)
 
 			artifacts, err := s.CreateArtifacts(ctx, servicePath, config, fsService)
 			if err != nil {
 				return err
 			}
 
-			s.artifacts = artifacts
+			s.artifacts.Store(artifacts)
 
 			return nil
 		}
@@ -357,16 +406,18 @@ func (s *DefaultService) Create(ctx context.Context, servicePath string, config 
 		// 6. Different config → remove and recreate
 		s.logger.Debugf("Service %s config changed, removing and recreating", servicePath)
 
-		if err := s.RemoveArtifacts(ctx, s.artifacts, fsService); err != nil {
+		if err := s.RemoveArtifacts(ctx, current, fsService); err != nil {
 			return fmt.Errorf("failed to remove service for recreation: %w", err)
 		}
+
+		s.artifacts.Store(nil)
 
 		artifacts, err := s.CreateArtifacts(ctx, servicePath, config, fsService)
 		if err != nil {
 			return err
 		}
 
-		s.artifacts = artifacts
+		s.artifacts.Store(artifacts)
 
 		return nil
 	})
@@ -394,15 +445,24 @@ func (s *DefaultService) Remove(ctx context.Context, servicePath string, fsServi
 
 	return s.withLifecycleGuard(func() error {
 		// If we have tracked artifacts, use them for proper removal
-		if s.artifacts != nil && len(s.artifacts.CreatedFiles) > 0 {
-			return s.RemoveArtifacts(ctx, s.artifacts, fsService)
+		current := s.artifacts.Load()
+		if current != nil && len(current.CreatedFiles) > 0 {
+			if err := s.RemoveArtifacts(ctx, current, fsService); err != nil {
+				return err
+			}
+
+			s.artifacts.Store(nil)
+
+			return nil
 		}
 
-		// No tracked files - service is in an inconsistent state
-		// Remove() requires tracked files to work properly
+		// No tracked files - service is in an inconsistent state. Returning the
+		// typed ErrServiceNotExist lets the FSM-layer caller use errors.Is to
+		// treat a no-tracking Remove as success (idempotent), rather than
+		// pattern-matching a string error.
 		s.logger.Debugf("No tracked files for service %s, cannot do tracked removal", servicePath)
 
-		return fmt.Errorf("service %s has no tracked files - use ForceRemove() instead", servicePath)
+		return ErrServiceNotExist
 	})
 }
 
@@ -648,22 +708,86 @@ func (s *DefaultService) CheckServiceDirectoryIntegrity(ctx context.Context, ser
 	// 1. Before Create() is called on a new instance
 	// 2. After agent restart when in-memory tracking is lost
 	// Return HealthUnknown to indicate we need more information
-	if s.artifacts == nil {
+	artifacts := s.artifacts.Load()
+	if artifacts == nil {
 		s.logger.Debugf("No artifacts tracked for service %s - directory integrity unknown", servicePath)
-		
+
 		return HealthUnknown
 	}
-	
+
 	// Delegate to CheckArtifactsHealth which validates all tracked files exist
-	health, err := s.CheckArtifactsHealth(ctx, s.artifacts, fsService)
+	health, err := s.CheckArtifactsHealth(ctx, artifacts, fsService)
 	if err != nil {
 		s.logger.Debugf("Error checking artifacts health for %s: %v", servicePath, err)
 		// CheckArtifactsHealth returns error for context cancellation or nil artifacts
 		// Both cases mean we can't determine health, so return Unknown
 		return HealthUnknown
 	}
-	
+
 	return health
+}
+
+// Health returns a recovery directive based on this service's tracked state.
+// It collapses the three signals callers used to compose by hand
+// (CheckServiceDirectoryIntegrity, artifact presence, in-flight removal) into
+// a single switchable result.
+//
+// Lifecycle invariant:
+//   - artifacts == nil → ActionOK. The service has no tracked state to
+//     verify, which is the steady state both before Create succeeds and
+//     after Remove/ForceRemove succeed. Returning ActionOK in the
+//     post-cleanup case is what stops Health() from re-entering recovery
+//     after ForceRemove flipped the directory away.
+//   - artifacts populated, RemovalProgress != nil → ActionWait. RemoveArtifacts
+//     drains the directory across multiple ticks; CheckArtifactsHealth would
+//     see files vanishing one-by-one and report HealthBad mid-Remove, which
+//     would permanent-error a Remove that is making progress.
+//   - artifacts populated, files present → ActionOK.
+//   - artifacts populated, files missing → ActionRecreate. Corruption is
+//     the wedge condition: tracked files vanished externally while the
+//     service was running.
+//   - artifacts populated, transient I/O error → ActionWait.
+//
+// During Create's recreate paths there is a window between Store(nil) and
+// Store(new artifacts) when a concurrent reader sees nil → ActionOK. That is
+// fine because Create runs under withLifecycleGuard, so any concurrent
+// reader is observing either the pre-Create or the post-Store snapshot — the
+// nil window is invisible to subsequent FSM ticks (the next tick observes
+// the post-Store state and reverts to ActionOK only if the new artifacts
+// are healthy).
+func (s *DefaultService) Health(ctx context.Context, fsService filesystem.Service) RecoveryAction {
+	artifacts := s.artifacts.Load()
+	if artifacts == nil {
+		return ActionOK
+	}
+
+	artifacts.RemovalProgressMu.RLock()
+	inFlightRemoval := artifacts.RemovalProgress != nil
+	artifacts.RemovalProgressMu.RUnlock()
+
+	if inFlightRemoval {
+		return ActionWait
+	}
+
+	health, err := s.CheckArtifactsHealth(ctx, artifacts, fsService)
+	if err != nil {
+		s.logger.Debugf("Health probe error for %s: %v - returning ActionWait", artifacts.ServiceDir, err)
+
+		return ActionWait
+	}
+
+	switch health {
+	case HealthOK:
+		return ActionOK
+	case HealthBad:
+		return ActionRecreate
+	case HealthUnknown:
+		return ActionWait
+	default:
+		s.logger.Errorf("unknown HealthStatus %v from CheckArtifactsHealth for %s - defaulting to ActionWait", health, artifacts.ServiceDir)
+
+		return ActionWait
+	}
 }
 
 // GetConfig gets the actual service config from s6.
@@ -1115,7 +1239,16 @@ func (s *DefaultService) ForceRemove(
 		}
 
 		// Use lifecycle manager for aggressive cleanup
-		return s.ForceCleanup(ctx, artifacts, fsService)
+		if err := s.ForceCleanup(ctx, artifacts, fsService); err != nil {
+			return err
+		}
+
+		// Drop tracking only on success: callers driving recovery via
+		// HandlePermanentError need s.artifacts == nil afterwards so Health()
+		// flips back to ActionOK and the FSM stops re-entering recovery.
+		s.artifacts.Store(nil)
+
+		return nil
 	})
 }
 
@@ -1606,28 +1739,3 @@ func (s *DefaultService) findLatestRotatedFile(entries []string) string {
 	return latestFile
 }
 
-// CheckHealth performs tri-state health check with lifecycle manager:
-// - Uses cached artifacts to avoid repeated path calculations
-// - Implements proper separation of observation from action
-// - Optional s6-svok integration for runtime health verification
-// Returns:
-//   - HealthUnknown: probe failed due to I/O errors, timeouts, etc. - retry next tick
-//   - HealthOK: service directory is healthy and complete
-//   - HealthBad: service directory is definitely broken - triggers FSM transition
-func (s *DefaultService) CheckHealth(ctx context.Context, servicePath string, fsService filesystem.Service) (HealthStatus, error) {
-	// Context already cancelled → Unknown, never Bad
-	if ctx.Err() != nil {
-		return HealthUnknown, ctx.Err()
-	}
-
-	// If we don't have tracked artifacts, the service is in an inconsistent state
-	artifacts := s.artifacts
-	if artifacts == nil || len(artifacts.CreatedFiles) == 0 {
-		s.logger.Debugf("No tracked files for service %s, returning HealthBad", servicePath)
-
-		return HealthBad, nil
-	}
-
-	// Use lifecycle manager for comprehensive health check
-	return s.CheckArtifactsHealth(ctx, artifacts, fsService)
-}

--- a/umh-core/pkg/service/s6/s6.go
+++ b/umh-core/pkg/service/s6/s6.go
@@ -197,7 +197,9 @@ type LogEntry struct {
 type Service interface {
 	// Create creates the service with specific configuration
 	Create(ctx context.Context, servicePath string, config s6serviceconfig.S6ServiceConfig, fsService filesystem.Service) error
-	// Remove removes the service directory structure
+	// Remove removes the service directory structure. Returns ErrServiceNotExist
+	// when the service has no tracked files (idempotent — callers may treat this
+	// as success). Clears the service's artifact tracking on success.
 	Remove(ctx context.Context, servicePath string, fsService filesystem.Service) error
 	// Start starts the service
 	Start(ctx context.Context, servicePath string, fsService filesystem.Service) error
@@ -1229,13 +1231,15 @@ func (s *DefaultService) ForceRemove(
 	s.logger.Warnf("Force removing S6 service %s", servicePath)
 
 	return s.withLifecycleGuard(func() error {
-		// ForceRemove doesn't need tracked files - it does aggressive cleanup
-		// Create minimal artifacts for cleanup operations
+		// ForceRemove uses a minimal stub with the three directory paths ForceCleanup
+		// needs. CreatedFiles is intentionally empty — ForceCleanup removes directories
+		// wholesale rather than per-file. RepositoryDir must be set so ForceCleanup
+		// removes the repository (the scan dir is only a symlink).
 		serviceName := filepath.Base(servicePath)
 		artifacts := &ServiceArtifacts{
-			ServiceDir: servicePath,
-			LogDir:     filepath.Join(constants.S6LogBaseDir, serviceName),
-			// CreatedFiles intentionally empty - we don't care about tracked files for force cleanup
+			ServiceDir:    servicePath,
+			RepositoryDir: filepath.Join(constants.GetS6RepositoryBaseDir(), serviceName),
+			LogDir:        filepath.Join(constants.S6LogBaseDir, serviceName),
 		}
 
 		// Use lifecycle manager for aggressive cleanup

--- a/umh-core/pkg/service/s6/s6.go
+++ b/umh-core/pkg/service/s6/s6.go
@@ -31,6 +31,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/backoff"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/s6serviceconfig"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/logger"
@@ -458,11 +459,43 @@ func (s *DefaultService) Remove(ctx context.Context, servicePath string, fsServi
 			return nil
 		}
 
-		// No tracked files - service is in an inconsistent state. Returning the
-		// typed ErrServiceNotExist lets the FSM-layer caller use errors.Is to
-		// treat a no-tracking Remove as success (idempotent), rather than
-		// pattern-matching a string error.
-		s.logger.Debugf("No tracked files for service %s, cannot do tracked removal", servicePath)
+		// No in-memory tracking. On-disk state may still exist if umh-core
+		// crashed after Create populated artifacts but before clean shutdown —
+		// the atomic.Pointer is in-memory only, but disk state persists. If we
+		// reported ErrServiceNotExist here unconditionally, the FSM would
+		// transition to Removed and the manager would delete the instance,
+		// orphaning the directories on disk. Probe the canonical service/repo/log
+		// paths and escalate to ForceRemove via permanent failure if anything
+		// exists. ForceRemove constructs synthetic artifacts from the same
+		// conventional paths (s6.go ForceRemove) and runs ForceCleanup.
+		serviceName := filepath.Base(servicePath)
+		repoPath := filepath.Join(constants.GetS6RepositoryBaseDir(), serviceName)
+		logPath := filepath.Join(constants.S6LogBaseDir, serviceName)
+
+		serviceExists, err := fsService.PathExists(ctx, servicePath)
+		if err != nil {
+			return fmt.Errorf("failed to probe service path during no-tracking remove: %w", err)
+		}
+		repoExists, err := fsService.PathExists(ctx, repoPath)
+		if err != nil {
+			return fmt.Errorf("failed to probe repository path during no-tracking remove: %w", err)
+		}
+		logExists, err := fsService.PathExists(ctx, logPath)
+		if err != nil {
+			return fmt.Errorf("failed to probe log path during no-tracking remove: %w", err)
+		}
+
+		if serviceExists || repoExists || logExists {
+			s.logger.Warnf(
+				"No tracking for service %s but on-disk state exists (service=%v, repo=%v, log=%v) — escalating to ForceRemove",
+				serviceName, serviceExists, repoExists, logExists,
+			)
+
+			return fmt.Errorf("%s: untracked on-disk state for service %s",
+				backoff.PermanentFailureError, serviceName)
+		}
+
+		s.logger.Debugf("No tracked files for service %s and no on-disk state, treating as already removed", servicePath)
 
 		return ErrServiceNotExist
 	})
@@ -1742,4 +1775,3 @@ func (s *DefaultService) findLatestRotatedFile(entries []string) string {
 
 	return latestFile
 }
-

--- a/umh-core/pkg/service/s6/s6_test.go
+++ b/umh-core/pkg/service/s6/s6_test.go
@@ -459,7 +459,7 @@ var _ = Describe("S6 Service", func() {
 
 		It("removes both service and log directory (normal case)", func() {
 			// Simulate a service with tracked files
-			svc.artifacts = &ServiceArtifacts{
+			svc.artifacts.Store(&ServiceArtifacts{
 				ServiceDir: svcPath,
 				LogDir:     logDir,
 				CreatedFiles: []string{
@@ -472,7 +472,7 @@ var _ = Describe("S6 Service", func() {
 					filepath.Join(svcPath, "dependencies.d", "base"),
 					filepath.Join(svcPath, ".complete"),
 				},
-			}
+			})
 
 			err := svc.Remove(ctx, svcPath, mockFS)
 			Expect(err).NotTo(HaveOccurred())
@@ -482,7 +482,7 @@ var _ = Describe("S6 Service", func() {
 
 		It("is successful when only the log dir had to be removed", func() {
 			// Simulate a service with tracked files
-			svc.artifacts = &ServiceArtifacts{
+			svc.artifacts.Store(&ServiceArtifacts{
 				ServiceDir: svcPath,
 				LogDir:     logDir,
 				CreatedFiles: []string{
@@ -495,7 +495,7 @@ var _ = Describe("S6 Service", func() {
 					filepath.Join(svcPath, "dependencies.d", "base"),
 					filepath.Join(svcPath, ".complete"),
 				},
-			}
+			})
 
 			exists.Delete(svcPath) // service dir already gone
 
@@ -506,7 +506,7 @@ var _ = Describe("S6 Service", func() {
 
 		It("is idempotent (everything already gone)", func() {
 			// Simulate a service with tracked files
-			svc.artifacts = &ServiceArtifacts{
+			svc.artifacts.Store(&ServiceArtifacts{
 				ServiceDir: svcPath,
 				LogDir:     logDir,
 				CreatedFiles: []string{
@@ -519,7 +519,7 @@ var _ = Describe("S6 Service", func() {
 					filepath.Join(svcPath, "dependencies.d", "base"),
 					filepath.Join(svcPath, ".complete"),
 				},
-			}
+			})
 
 			exists = sync.Map{} // nothing exists
 
@@ -537,7 +537,7 @@ var _ = Describe("S6 Service", func() {
 
 		It("returns an error when deletion fails", func() {
 			// Simulate a service with tracked files
-			svc.artifacts = &ServiceArtifacts{
+			svc.artifacts.Store(&ServiceArtifacts{
 				ServiceDir: svcPath,
 				LogDir:     logDir,
 				CreatedFiles: []string{
@@ -550,7 +550,7 @@ var _ = Describe("S6 Service", func() {
 					filepath.Join(svcPath, "dependencies.d", "base"),
 					filepath.Join(svcPath, ".complete"),
 				},
-			}
+			})
 
 			boom := errors.New("IO error")
 			mockFS.WithRemoveAllFunc(func(ctx context.Context, path string) error {

--- a/umh-core/pkg/service/s6/s6_test.go
+++ b/umh-core/pkg/service/s6/s6_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cactus/tai64"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/backoff"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/s6serviceconfig"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/filesystem"
@@ -571,6 +572,71 @@ var _ = Describe("S6 Service", func() {
 			err := svc.Remove(ctx, svcPath, mockFS)
 			Expect(err).To(MatchError(ContainSubstring("IO error")))
 		})
+
+		// Fix 3 — disk-fallback when in-memory artifacts is lost (e.g., post-restart).
+		// The atomic.Pointer is in-memory only; if umh-core crashes between Create and
+		// clean shutdown, restart leaves on-disk state with no tracking. Without the
+		// fallback, Remove() would falsely report ErrServiceNotExist (idempotent
+		// success) and the FSM would transition to Removed, orphaning the directories.
+		Describe("disk-fallback when artifacts is nil (post-restart orphan recovery)", func() {
+			repoPath := func() string {
+				return filepath.Join(constants.GetS6RepositoryBaseDir(), "my-service")
+			}
+
+			It("returns permanent-failure error when service dir exists on disk", func() {
+				// artifacts NOT stored — simulates post-crash-restart state.
+				exists = sync.Map{}
+				exists.Store(svcPath, true) // orphaned service dir on disk
+
+				err := svc.Remove(ctx, svcPath, mockFS)
+
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring(backoff.PermanentFailureError),
+					"must escalate to permanent failure so HandlePermanentError → ForceRemove fires next tick")
+			})
+
+			It("returns permanent-failure error when repository dir exists on disk", func() {
+				exists = sync.Map{}
+				exists.Store(repoPath(), true) // orphaned repo dir on disk
+
+				err := svc.Remove(ctx, svcPath, mockFS)
+
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring(backoff.PermanentFailureError))
+			})
+
+			It("returns permanent-failure error when log dir exists on disk", func() {
+				exists = sync.Map{}
+				exists.Store(logDir, true) // orphaned log dir on disk
+
+				err := svc.Remove(ctx, svcPath, mockFS)
+
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring(backoff.PermanentFailureError))
+			})
+
+			It("returns ErrServiceNotExist when artifacts=nil and nothing exists on disk", func() {
+				exists = sync.Map{} // nothing on disk
+
+				err := svc.Remove(ctx, svcPath, mockFS)
+
+				Expect(err).To(MatchError(ErrServiceNotExist),
+					"genuinely-empty case stays idempotent")
+			})
+
+			It("propagates PathExists I/O errors", func() {
+				boom := errors.New("filesystem I/O error")
+				mockFS.WithPathExistsFunc(func(ctx context.Context, p string) (bool, error) {
+					return false, boom
+				})
+
+				err := svc.Remove(ctx, svcPath, mockFS)
+
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("filesystem I/O error"),
+					"I/O errors must propagate, not be silently treated as 'doesn't exist'")
+			})
+		})
 	})
 })
 
@@ -747,4 +813,3 @@ var _ = Describe("MaxFunc Approach for Rotated Files", func() {
 		Expect(result).To(Equal(expectedLatest))
 	})
 })
-

--- a/umh-core/pkg/service/s6/s6_test.go
+++ b/umh-core/pkg/service/s6/s6_test.go
@@ -478,6 +478,7 @@ var _ = Describe("S6 Service", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(pathExists(svcPath)).To(BeFalse())
 			Expect(pathExists(logDir)).To(BeFalse())
+			Expect(svc.artifacts.Load()).To(BeNil(), "Remove must clear artifact tracking so Health() returns ActionOK after cleanup")
 		})
 
 		It("is successful when only the log dir had to be removed", func() {
@@ -502,6 +503,7 @@ var _ = Describe("S6 Service", func() {
 			err := svc.Remove(ctx, svcPath, mockFS)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(pathExists(logDir)).To(BeFalse())
+			Expect(svc.artifacts.Load()).To(BeNil(), "Remove must clear artifact tracking so Health() returns ActionOK after cleanup")
 		})
 
 		It("is idempotent (everything already gone)", func() {
@@ -533,6 +535,7 @@ var _ = Describe("S6 Service", func() {
 			err := svc.Remove(ctx, svcPath, mockFS)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(removeCalls).To(Equal(0), "RemoveAll should not be called when nothing exists")
+			Expect(svc.artifacts.Load()).To(BeNil(), "Remove must clear artifact tracking so Health() returns ActionOK after cleanup")
 		})
 
 		It("returns an error when deletion fails", func() {


### PR DESCRIPTION

## Problem

When a bridge's internal service directory gets corrupted or deleted at runtime, umh-core detects the problem but cannot recover. The bridge gets stuck in a starting state. The UI shows it spinning, manual delete fails, and the only fix is to restart umh-core or recreate the bridge under a different name. This pattern has appeared at multiple customer sites since 2024 (ENG-3877, ENG-4760 still open in Ideas).

Why it gets stuck: umh-core already had a force-remove fallback for corruption that happens while a bridge is running or stopped (PR #2259, ENG-3468). But the lifecycle states (`Creating`, `to_be_created`, `Removing`) had no equivalent. When corruption hit during startup, the bridge entered `Creating` and stayed there. This PR closes that gap.

## What we're shipping

Introduced a simplified API: `Service.Health(ctx, fs)`. Every S6 service now checks in all available states whether health is OK, whether to wait (`ActionWait`), or whether to recreate (`ActionRecreate`).

| Directive | Meaning |
|-----------|---------|
| `ActionOK` | Proceed normally |
| `ActionWait` | Transient condition (I/O error or removal in progress); skip this tick |
| `ActionRecreate` | Corruption detected; trigger force-remove and rebuild |

## What we're NOT shipping

- **FSMv2**: no s6 worker exists in FSMv2 yet. The service layer migrates unchanged when it does.
- **`Teardown(mode)` consolidation**: collapsing `Remove` + `ForceRemove` into one method; larger blast radius, deferred.
- **20-tick fallback no-op**: `(*BaseFSMInstance).Remove` returns nil for `Creating` state; the fallback fires but does nothing. The `Health()` path makes this irrelevant for the corruption case, but the underlying no-op is a separate fix.
- **13 sibling FSMs**: all have the same `IsLifecycleState` dispatch pattern. They don't have the same `artifacts` tracking as s6, so the bug class doesn't apply now. Deferred cleanup once this bakes.
- **Root cause**: what corrupts the service directory in the first place (network blip, OOM, disk hiccup). A filesystem snapshot at the next occurrence is needed. This PR handles the recovery; diagnosis is separate.