### PR TITLE
feat: enable config backup by default (ENG-4568)

### DIFF
--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Improvements
 
 - Previously, the component tasked with communicating with the UI could stop working if it rebuilt its HTTP connection (which happens after persistent network failures) while a message was being sent or received. Connection rebuilds and in-flight requests are now coordinated so they cannot interfere.
+- Config backup is now enabled by default. Previously, automatic config.yaml backups required setting `ENABLE_CONFIG_BACKUP=true`. After validating the feature in customer environments for over two months, every umh-core instance now writes timestamped copies of `config.yaml` to `/data/config-backups/` on every config write, retaining the 100 most recent versions (roughly 5–20 MB). To opt out, set `ENABLE_CONFIG_BACKUP=false`. To roll back a bad config, use the second-most-recent backup — the most recent one mirrors the bad write
 
 ## [0.44.19]
 

--- a/umh-core/cmd/main.go
+++ b/umh-core/cmd/main.go
@@ -97,7 +97,7 @@ func main() {
 	// which writes config on startup and should back up the pre-write state.
 	// GetAsBool with required=false never returns an error (silently falls back
 	// to the default on parse failure); see ENG-4809 for the signature fix.
-	configBackupEnabled, _ := env.GetAsBool("ENABLE_CONFIG_BACKUP", false, false)
+	configBackupEnabled, _ := env.GetAsBool("ENABLE_CONFIG_BACKUP", false, true)
 
 	configManager.SetConfigBackupEnabled(configBackupEnabled)
 


### PR DESCRIPTION
Resolves https://linear.app/united-manufacturing-hub/issue/ENG-4568

## What changes
Flip the default of `ENABLE_CONFIG_BACKUP` from `false` to `true` in `cmd/main.go`. Customers who explicitly set `ENABLE_CONFIG_BACKUP=false` keep their opt-out — only the default changes.

## Changelog Entry

**Component:** umh-core
**Category:** Improvements

- Config backup is now enabled by default. Previously, automatic config.yaml backups required setting `ENABLE_CONFIG_BACKUP=true`. After validating the feature in customer environments for over two months, every umh-core instance now writes timestamped copies of `config.yaml` to `/data/config-backups/` on every config write, retaining the 100 most recent versions (roughly 5–20 MB). To opt out, set `ENABLE_CONFIG_BACKUP=false`. To roll back a bad config, use the second-most-recent backup — the most recent one mirrors the bad write
