### PR TITLE
refactor: FSMv2 signal disambiguation (worker-api-v2 5/5)

### DIFF
--- a/umh-core/pkg/fsmv2/CLAUDE.md
+++ b/umh-core/pkg/fsmv2/CLAUDE.md
@@ -11,7 +11,7 @@ The `architecture_test.go` validates ALL workers via file-system scanning (not r
 | Rule | Description |
 |------|-------------|
 | Empty State Structs | States have no fields (except embedded base) |
-| Shutdown Check First | Check `IsShutdownRequested()` as FIRST conditional in `Next()` |
+| Shutdown Check First | Check `IsBeingRemoved` as FIRST conditional in `Next()` |
 | State XOR Action | Return state OR action, never both |
 | Single Type Assertion | `Next()` has exactly one type assertion at entry |
 | Pure DeriveDesiredState | No dependency access - only use `spec` parameter |
@@ -42,15 +42,15 @@ Children aggregation (health counts) is handled by the supervisor, not in `Colle
 
 Parents have two semantically distinct ways to stop children:
 
-1. **`ChildSpec.Enabled = false`** — "disable this child, possibly preserve state in future". The CHANGE-19 reducer (`supervisor/reconciliation.go`) translates `Enabled=false` into `IsShutdownRequested=true` on resident children synchronously, before the child's tick. For non-resident specs (cold boot), the supervisor skips creation entirely (PR3-I).
+1. **`ChildSpec.Enabled = false`** — "disable this child, possibly preserve state in future". The CHANGE-19 reducer (`supervisor/reconciliation.go`) translates `Enabled=false` into `IsBeingRemoved=true` on resident children synchronously, before the child's tick. For non-resident specs (cold boot), the supervisor skips creation entirely (PR3-I).
 2. **Omit the spec from `[]config.ChildSpec{}`** — "this child should not exist". The supervisor's Phase-1 absent-from-specs path drives full teardown (`RequestShutdown` → child's `NeedsRemoval` → removal from `s.workers`).
 
-Today, both options converge to "child gone" because the default `StoppedState.Next()` pattern signals `NeedsRemoval` on `IsShutdownRequested`. Internal state (counters, connection handles, pending buffers) is lost; respawn starts fresh.
+Today, both options converge to "child gone" because the default `StoppedState.Next()` pattern signals `NeedsRemoval` on `IsBeingRemoved`. Internal state (counters, connection handles, pending buffers) is lost; respawn starts fresh.
 
 Default `StoppedState.Next()` shape:
 
 ```go
-if snap.Desired.IsShutdownRequested() {
+if snap.Desired.IsBeingRemoved() {
     return fsmv2.Transition(s, fsmv2.SignalNeedsRemoval, nil, "shutdown requested", nil)
 }
 if !snap.ShouldStop() {
@@ -106,7 +106,7 @@ func (s *RunningState) Next(snapAny any) fsmv2.NextResult[any, any] {
     snap := helpers.ConvertSnapshot[...](snapAny)  // Single type assertion
 
     // Shutdown check FIRST
-    if snap.Desired.IsShutdownRequested() {
+    if snap.Desired.IsBeingRemoved() {
         return fsmv2.Transition(&StoppingState{}, fsmv2.SignalNone, nil, "Shutdown requested")
     }
 
@@ -178,7 +178,7 @@ New workers should use `WorkerBase[TConfig, TStatus, TDeps]` instead of the lega
 - **`WrapAction[TDeps]`** — *(deprecated, removed in PR3)* adapts typed actions to `Action[any]`. Prefer passing `&MyAction{}` directly to `fsmv2.Transition` — the framework auto-wraps via reflection.
 - **`register.Worker[TConfig, TStatus, TDeps]`** — one-line registration (factory + supervisor + CSE types). Use `register.NoDeps` for zero-dep workers.
 
-**Architecture validators** accept both APIs: `ConvertWorkerSnapshot` and `ConvertSnapshot` are valid entry points. The shutdown check uses `snap.ShouldStop()` (merged user-shutdown + parent-stop signal) or `snap.Desired.IsShutdownRequested()` (raw user-shutdown flag, used when the state needs to distinguish self-driven shutdown from parent-driven stop). The deprecated `snap.IsShutdownRequested` field is gone.
+**Architecture validators** accept both APIs: `ConvertWorkerSnapshot` and `ConvertSnapshot` are valid entry points. The shutdown check uses `snap.ShouldStop()` (merged user-shutdown + parent-stop signal) or `snap.Desired.IsBeingRemoved` (raw user-shutdown flag, used when the state needs to distinguish self-driven shutdown from parent-driven stop). The deprecated `snap.IsBeingRemoved` field is gone.
 
 **Capability interfaces** (optional, detected via type assertion on first instantiation):
 - `ActionProvider` — `Actions() map[string]Action[any]`
@@ -311,6 +311,6 @@ This prevents failure rate dilution: if idle ticks feed phantom "successes" into
 - CI enforced: `ValidateStoppingStateNoCatchAllSelfReturn` in `internal/validator/state.go`
 - See any `state_stopping.go` for the pattern
 
-### Parent-driven stop flows through IsShutdownRequested
+### Parent-driven stop flows through IsBeingRemoved
 
-There is no longer a separate `ParentMappedState` signal on `Observation[T]`. When a parent wants a child stopped it sets `ChildSpec.Enabled=false`; the CHANGE-19 reducer translates that into `IsShutdownRequested=true` on the child synchronously. State files therefore only need `snap.ShouldStop()` (which returns `Desired.IsShutdownRequested()`) — there is no parent-mapped-state path for child workers using `Observation[T]` to consult.
+There is no longer a separate `ParentMappedState` signal on `Observation[T]`. When a parent wants a child stopped it sets `ChildSpec.Enabled=false`; the CHANGE-19 reducer translates that into `IsBeingRemoved=true` on the child synchronously. State files therefore only need `snap.ShouldStop()` (which now ORs `Desired.IsBeingRemoved`, `Desired.IsDisabled()`, and Config-level "stopped") — there is no parent-mapped-state path for child workers using `Observation[T]` to consult.

--- a/umh-core/pkg/fsmv2/CLAUDE.md
+++ b/umh-core/pkg/fsmv2/CLAUDE.md
@@ -4,19 +4,22 @@ This file captures patterns and insights for working with the FSMv2 framework.
 
 ## Architecture Test Compliance
 
-The `architecture_test.go` validates ALL workers via file-system scanning (not runtime reflection). Compliance must be satisfied from day one - tests will fail if any invariant is violated.
+The `architecture_test.go` validates a subset of worker invariants via file-system scanning (not runtime reflection). The CI-enforced rules will fail builds; the conventions are reviewer-enforced — code authors and reviewers should hold the line.
 
 **Key invariants to follow:**
 
-| Rule | Description |
-|------|-------------|
-| Empty State Structs | States have no fields (except embedded base) |
-| Shutdown Check First | Check `IsBeingRemoved` as FIRST conditional in `Next()` |
-| State XOR Action | Return state OR action, never both |
-| Single Type Assertion | `Next()` has exactly one type assertion at entry |
-| Pure DeriveDesiredState | No dependency access - only use `spec` parameter |
+| Rule | Description | Enforcement |
+|------|-------------|-------------|
+| Empty State Structs | States have no fields (except embedded base) | Convention |
+| Stop Check First | Check `IsBeingRemoved` (or `ShouldStop`) as FIRST conditional in `Next()` | Convention |
+| State XOR Action | Return state OR action, never both | CI (`ValidateStateXORAction`) |
+| No Nil State Returns | `Transition`'s state argument is non-nil | CI (`ValidateNoNilStateReturns`) |
+| Signal/State Mutual Exclusion | A `Next()` does not return both `SignalNeedsRemoval` and a non-self state | CI (`ValidateSignalStateMutualExclusion`) |
+| StoppingState Progress | StoppingState catch-all must not self-return without an action | CI (`ValidateStoppingStateNoCatchAllSelfReturn`) |
+| Single Type Assertion | `Next()` has exactly one type assertion at entry | Convention |
+| Pure DeriveDesiredState | No dependency access - only use `spec` parameter | Convention |
 
-Run architecture tests after every change:
+Run CI-enforced architecture tests after every change:
 ```bash
 go test ./pkg/fsmv2/... -run "Architecture" -v
 ```
@@ -38,31 +41,71 @@ func (w *ParentWorker) DeriveDesiredState(spec interface{}) (fsmv2.DesiredState,
 
 Children aggregation (health counts) is handled by the supervisor, not in `CollectObservedState`. The supervisor calls `SetChildrenCounts()` after collection.
 
-## Stopping a child worker — two options
+## Stopping a worker — six cases, three signals
 
-Parents have two semantically distinct ways to stop children:
+A worker can be wanted-stopped for six semantically distinct reasons. PR5
+disambiguated these into three primitive signals on `WrappedDesiredState`,
+plus the umbrella check `WorkerSnapshot.ShouldStop()`.
 
-1. **`ChildSpec.Enabled = false`** — "disable this child, possibly preserve state in future". The CHANGE-19 reducer (`supervisor/reconciliation.go`) translates `Enabled=false` into `IsBeingRemoved=true` on resident children synchronously, before the child's tick. For non-resident specs (cold boot), the supervisor skips creation entirely (PR3-I).
-2. **Omit the spec from `[]config.ChildSpec{}`** — "this child should not exist". The supervisor's Phase-1 absent-from-specs path drives full teardown (`RequestRemoval` → child's `NeedsRemoval` → removal from `s.workers`).
+### The three primitive signals
 
-Today, both options converge to "child gone" because the default `StoppedState.Next()` pattern signals `NeedsRemoval` on `IsBeingRemoved`. Internal state (counters, connection handles, pending buffers) is lost; respawn starts fresh.
+| Signal | Permanence | Source | Meaning |
+|--------|------------|--------|---------|
+| `Desired.IsBeingRemoved()` | Permanent (this instance gone) | Supervisor (`SetBeingRemoved`) | Tear down: emit `SignalNeedsRemoval` from `Stopped`, lose retained state |
+| `Desired.IsDisabled()` | Transient (parent says pause) | CHANGE-19 reducer (parent's `ChildSpec.Enabled=false`) | Stop and stay resident; flipping `Enabled=true` resumes |
+| `Desired.Config.GetState()=="stopped"` | Transient (user says pause) | User YAML (`state: stopped`) | Stop and stay resident; flipping back to `running` resumes |
 
-Default `StoppedState.Next()` shape:
+`WorkerSnapshot.ShouldStop()` is the umbrella OR of all three. State files
+that don't care about the source ("just stop") use it directly. The Stopped
+state needs to discriminate (permanent → emit removal; transient → stay
+resident); see `helpers.StoppedNext` below for the canonical pattern.
+
+### The six cases
+
+| # | Case | Source | Permanence | Mapped signal |
+|---|------|--------|------------|---------------|
+| A | User `state: stopped` (YAML) | user config | Transient | `Config.GetState()=="stopped"` |
+| B | Parent disable (`ChildSpec.Enabled=false`) | parent's `renderChildren` | Transient | `Desired.IsDisabled()` |
+| C | Parent remove (omit from spec list) | parent returns shorter `[]ChildSpec` | Permanent | `Desired.IsBeingRemoved()` |
+| D | Self-driven restart (`SignalNeedsRestart`) | worker self | Permanent (this instance) | `Desired.IsBeingRemoved()` |
+| E | Graceful process shutdown | process exit | Permanent (this process) | `Desired.IsBeingRemoved()` |
+| F | Supervisor self-protection (collector unresponsive) | Layer-3 escalation | Permanent (this instance) | `Desired.IsBeingRemoved()` |
+
+Cases C, D, E, F all converge on `IsBeingRemoved=true` — they are different
+upstream causes for the same "this instance must be torn down" outcome.
+Cases A and B are the genuinely transient ones: the worker stops but stays
+resident in `s.children`, ready to resume when the signal clears.
+
+### Canonical Stopped state — `helpers.StoppedNext`
+
+Most workers' `StoppedState.Next()` is a three-branch decision over the
+three signals. The framework provides `internal/helpers.StoppedNext` so
+state files don't have to reimplement it:
 
 ```go
-if snap.Desired.IsBeingRemoved() {
-    return fsmv2.Transition(s, fsmv2.SignalNeedsRemoval, nil, "shutdown requested", nil)
+func (s *StoppedState) Next(snapAny any) fsmv2.NextResult[any, any] {
+    snap := fsmv2.ConvertWorkerSnapshot[Config, Status](snapAny)
+    return helpers.StoppedNext(s, snap, &TryingToConnectState{}, "attempting to connect")
 }
-if !snap.ShouldStop() {
-    return fsmv2.Transition(&NextState{}, fsmv2.SignalNone, nil, "advancing", nil)
-}
-return fsmv2.Transition(s, fsmv2.SignalNone, nil, "staying stopped", nil)
 ```
 
-### When to use which
+Three branches:
 
-- **`Enabled=false`**: per-child temporary disable. Useful when the parent wants finer control than "all-or-nothing" (e.g., one of N children disabled by config).
-- **`[]ChildSpec{}`**: parent's whole "stopped" semantics. The parent is itself stopped/draining; children should not exist during this period.
+1. **`Desired.IsBeingRemoved()`** → `SignalNeedsRemoval` (permanent: cases C, D, E, F)
+2. **`!ShouldStop()`** → advance to the next state (signal cleared; resume)
+3. **else** → stay in `Stopped` (transient: cases A and B; preserves in-memory state)
+
+Workers with custom Stopped semantics (children rendering, additional
+preconditions before advancing, custom signals) hand-roll the three branches
+and keep `helpers.StoppedNext` as the reference. `transport/state_stopped.go`
+is one such case — it emits children even while stopped.
+
+### When to use which signal
+
+- **`Enabled=false` (case B)**: per-child transient disable. The parent wants finer control than "all-or-nothing" (e.g., one of N children paused by config). Worker stays resident; flipping back to `Enabled=true` resumes.
+- **Omit child from spec list (case C)**: parent's "this child should not exist anymore." Drives the supervisor's Phase-1 absent-from-specs teardown via `RequestRemoval` → `IsBeingRemoved=true` → `NeedsRemoval` → removal from `s.children`.
+- **`SetBeingRemoved` directly (cases D, E, F)**: framework-driven removal — `SignalNeedsRestart` from a state, graceful process shutdown, or supervisor self-protection. State files don't write this flag; they emit signals and let the supervisor set it.
+- **Config `state: stopped` (case A)**: user-facing stop. The worker stays resident; the user can resume by editing config back to `state: running`.
 
 ### Future: state-preservation across respawn
 
@@ -71,9 +114,11 @@ Designed but not yet implemented. See `003_klaus/artifacts/2026-04-09_fsmv2_stat
 1. **`cse:"retain"` struct tag**: workers annotate `Status` fields that should survive restart. The collector merges retained values from `prevObserved` into the fresh COS-returned struct, only when the fresh value is zero. Workers don't change code — just struct tags.
 2. **`DependencyHydrator` interface**: optional `HydrateDependencies(ctx, prevObs)` called once before first COS, for workers whose Dependencies must be warm before any state observation (e.g., CertFetcher's `CertHandler` map for TLS).
 
-When that lands, `Enabled=false` becomes truly state-preserving (children stay resident; their retained fields survive the disable cycle). `[]ChildSpec{}` continues to mean full removal.
-
-Until then, both options behave the same. Choose based on which intent reads more clearly at the call site.
+This design lands on top of the disambiguated signals: `IsDisabled` (case B,
+transient) keeps the worker resident, so retained state on `Status` survives
+the disable cycle automatically once `cse:"retain"` is implemented.
+`IsBeingRemoved` (cases C, D, E, F) tears the worker down, so retained state
+is lost — that is the intended boundary.
 
 ## Channel Singleton Pattern
 
@@ -105,9 +150,11 @@ type RunningState struct {
 func (s *RunningState) Next(snapAny any) fsmv2.NextResult[any, any] {
     snap := helpers.ConvertSnapshot[...](snapAny)  // Single type assertion
 
-    // Shutdown check FIRST
+    // Stop check FIRST — IsBeingRemoved (permanent) routes to StoppingState.
+    // Non-Stopped states that don't care about source can use snap.ShouldStop()
+    // instead (umbrella over IsBeingRemoved + IsDisabled + Config "stopped").
     if snap.Desired.IsBeingRemoved() {
-        return fsmv2.Transition(&StoppingState{}, fsmv2.SignalNone, nil, "Shutdown requested")
+        return fsmv2.Transition(&StoppingState{}, fsmv2.SignalNone, nil, "removal requested")
     }
 
     // Business logic — pass typed actions directly, the framework
@@ -123,9 +170,9 @@ func (s *RunningState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 `fsmv2.Transition` is the canonical return shape for state files. It is a non-generic alias for `fsmv2.Result[any, any]` that also accepts typed `Action[TDeps]` values directly.
 
-> **Deprecated — removed in PR3**
+> **Compat seam — migration window only**
 >
-> `fsmv2.Result[any, any](...)` and the `fsmv2.WrapAction[TDeps](&MyAction{})` wrapper remain as a compat seam for workers still mid-migration but will be deleted in PR3. New state files must use `fsmv2.Transition` + direct `&MyAction{}` construction.
+> `fsmv2.Result[any, any](...)` and the `fsmv2.WrapAction[TDeps](&MyAction{})` wrapper remain as a compat seam for any code still using the old shape. Delete once all callsites use `fsmv2.Transition` + direct `&MyAction{}` construction. New state files must NOT use `Result`/`WrapAction`.
 
 ## Reason Strings in State Transitions
 
@@ -170,7 +217,7 @@ New workers should use `WorkerBase[TConfig, TStatus, TDeps]` instead of the lega
 
 - **`WorkerBase[TConfig, TStatus, TDeps]`** — embed in your worker struct; provides `InitBase`, `Config()`, `DeriveDesiredState`. Use `register.NoDeps` as `TDeps` for workers with no custom deps.
 - **`NewObservation[TStatus](status)`** — preferred constructor for `CollectObservedState` return values; the collector fills CollectedAt, framework metrics, action history, and accumulated worker metrics automatically after COS returns
-- **`Observation[TStatus]`** — flat JSON serialization with framework fields (state, shutdown, children counts)
+- **`Observation[TStatus]`** — flat JSON serialization with framework fields (state, isBeingRemoved, children counts)
 - **`WrappedDesiredState[TConfig]`** — promotes `BaseDesiredState` fields alongside TConfig
 - **`WorkerSnapshot[TConfig, TStatus]`** — typed snapshot for state `Next()` methods
 - **`ConvertWorkerSnapshot[TConfig, TStatus]`** — entry-point type assertion in states
@@ -178,7 +225,7 @@ New workers should use `WorkerBase[TConfig, TStatus, TDeps]` instead of the lega
 - **`WrapAction[TDeps]`** — *(deprecated, removed in PR3)* adapts typed actions to `Action[any]`. Prefer passing `&MyAction{}` directly to `fsmv2.Transition` — the framework auto-wraps via reflection.
 - **`register.Worker[TConfig, TStatus, TDeps]`** — one-line registration (factory + supervisor + CSE types). Use `register.NoDeps` for zero-dep workers.
 
-**Architecture validators** accept both APIs: `ConvertWorkerSnapshot` and `ConvertSnapshot` are valid entry points. The shutdown check uses `snap.ShouldStop()` (merged user-shutdown + parent-stop signal) or `snap.Desired.IsBeingRemoved` (raw user-shutdown flag, used when the state needs to distinguish self-driven shutdown from parent-driven stop). The deprecated `snap.IsBeingRemoved` field is gone.
+**Architecture validators** accept both APIs: `ConvertWorkerSnapshot` and `ConvertSnapshot` are valid entry points. The stop check uses `snap.ShouldStop()` (umbrella over `IsBeingRemoved`, `IsDisabled`, and `Config.GetState()=="stopped"`) for non-Stopped states that just need "should I stop?". Stopped states discriminate further: `snap.Desired.IsBeingRemoved()` for permanent removal (emit `SignalNeedsRemoval`) versus the transient signals (stay resident). `helpers.StoppedNext` encodes the canonical pattern. The deprecated flat `snap.IsBeingRemoved` field is gone — read it via `snap.Desired.IsBeingRemoved()`.
 
 **Capability interfaces** (optional, detected via type assertion on first instantiation):
 - `ActionProvider` — `Actions() map[string]Action[any]`
@@ -311,6 +358,10 @@ This prevents failure rate dilution: if idle ticks feed phantom "successes" into
 - CI enforced: `ValidateStoppingStateNoCatchAllSelfReturn` in `internal/validator/state.go`
 - See any `state_stopping.go` for the pattern
 
-### Parent-driven stop flows through IsBeingRemoved
+### Parent-driven stop flows through IsDisabled
 
-There is no longer a separate `ParentMappedState` signal on `Observation[T]`. When a parent wants a child stopped it sets `ChildSpec.Enabled=false`; the CHANGE-19 reducer translates that into `IsBeingRemoved=true` on the child synchronously. State files therefore only need `snap.ShouldStop()` (which now ORs `Desired.IsBeingRemoved`, `Desired.IsDisabled()`, and Config-level "stopped") — there is no parent-mapped-state path for child workers using `Observation[T]` to consult.
+There is no longer a separate `ParentMappedState` signal on `Observation[T]`. When a parent wants a child paused it sets `ChildSpec.Enabled=false`; the CHANGE-19 reducer (`supervisor/reconciliation.go`) translates that into `IsDisabled=true` on the child synchronously, before the child's tick. The child stays resident in `s.children` and resumes when the parent flips `Enabled=true` again.
+
+When a parent wants a child gone permanently it omits the spec from its `[]ChildSpec` return; the supervisor's Phase-1 absent-from-specs path drives `RequestRemoval` → `IsBeingRemoved=true` → `SignalNeedsRemoval` from Stopped → removal from `s.children`. This is one-way: a removed child does not come back without a fresh spec.
+
+State files therefore use `snap.ShouldStop()` (umbrella over `IsBeingRemoved`, `IsDisabled`, and Config "stopped") for non-Stopped states that don't care about the source, and discriminate in `Stopped` via `helpers.StoppedNext`. There is no parent-mapped-state path for child workers using `Observation[T]` to consult.

--- a/umh-core/pkg/fsmv2/CLAUDE.md
+++ b/umh-core/pkg/fsmv2/CLAUDE.md
@@ -43,7 +43,7 @@ Children aggregation (health counts) is handled by the supervisor, not in `Colle
 Parents have two semantically distinct ways to stop children:
 
 1. **`ChildSpec.Enabled = false`** — "disable this child, possibly preserve state in future". The CHANGE-19 reducer (`supervisor/reconciliation.go`) translates `Enabled=false` into `IsBeingRemoved=true` on resident children synchronously, before the child's tick. For non-resident specs (cold boot), the supervisor skips creation entirely (PR3-I).
-2. **Omit the spec from `[]config.ChildSpec{}`** — "this child should not exist". The supervisor's Phase-1 absent-from-specs path drives full teardown (`RequestShutdown` → child's `NeedsRemoval` → removal from `s.workers`).
+2. **Omit the spec from `[]config.ChildSpec{}`** — "this child should not exist". The supervisor's Phase-1 absent-from-specs path drives full teardown (`RequestRemoval` → child's `NeedsRemoval` → removal from `s.workers`).
 
 Today, both options converge to "child gone" because the default `StoppedState.Next()` pattern signals `NeedsRemoval` on `IsBeingRemoved`. Internal state (counters, connection handles, pending buffers) is lost; respawn starts fresh.
 

--- a/umh-core/pkg/fsmv2/DEPENDENCIES.md
+++ b/umh-core/pkg/fsmv2/DEPENDENCIES.md
@@ -224,8 +224,8 @@ if holder, ok := observed.(deps.MetricsHolder); ok {
 }
 
 // Check if DesiredState supports shutdown
-if sr, ok := any(desired).(fsmv2.ShutdownRequestable); ok {
-    sr.SetShutdownRequested(true)
+if sr, ok := any(desired).(fsmv2.RemovalRequestable); ok {
+    sr.SetBeingRemoved(true)
 }
 ```
 

--- a/umh-core/pkg/fsmv2/MIGRATION.md
+++ b/umh-core/pkg/fsmv2/MIGRATION.md
@@ -120,7 +120,7 @@ func (s *StoppedState) Next(snapAny any) (fsmv2.State[any, any], fsmv2.Signal, f
     snap := helpers.ConvertSnapshot[MyObservedState, *MyDesiredState](snapAny)
 
     // ALWAYS check shutdown first
-    if snap.Desired.IsShutdownRequested() {
+    if snap.Desired.IsBeingRemoved() {
         return s, fsmv2.SignalNeedsRemoval, nil
     }
 
@@ -315,7 +315,7 @@ type StoppedState struct{}
 func (s *StoppedState) Next(snapAny any) (fsmv2.State[any, any], fsmv2.Signal, fsmv2.Action[any]) {
     snap := helpers.ConvertSnapshot[MyObservedState, *MyDesiredState](snapAny)
 
-    if snap.Desired.IsShutdownRequested() {
+    if snap.Desired.IsBeingRemoved() {
         return s, fsmv2.SignalNeedsRemoval, nil
     }
 
@@ -730,7 +730,7 @@ return s, fsmv2.SignalNone, &SomeAction{}
 
 ### Check shutdown first in every state
 
-Every state's Next() method should check IsShutdownRequested() as the first condition.
+Every state's Next() method should check IsBeingRemoved() as the first condition.
 
 **Required pattern:**
 ```go
@@ -738,7 +738,7 @@ func (s *AnyState) Next(snapAny any) (fsmv2.State[any, any], fsmv2.Signal, fsmv2
     snap := helpers.ConvertSnapshot[MyObservedState, *MyDesiredState](snapAny)
 
     // ALWAYS check shutdown first
-    if snap.Desired.IsShutdownRequested() {
+    if snap.Desired.IsBeingRemoved() {
         return &StoppedState{}, fsmv2.SignalNeedsRemoval, nil
         // Or transition to TryingToStop if cleanup needed
     }
@@ -783,8 +783,8 @@ Worker API v2 replaces the 7-file pattern with a single-file approach using gene
 | `dependencies.go` with custom deps struct | `deps.Identity`, `deps.FSMLogger`, `deps.StateReader` passed to constructor |
 | `init()` with `factory.RegisterWorkerType[...]` + supervisor factory | `register.Worker[TConfig, TStatus, register.NoDeps]("type", constructor)` |
 | `helpers.ConvertSnapshot[Obs, *Des](snapAny)` in states | `fsmv2.ConvertWorkerSnapshot[TConfig, TStatus](snapAny)` in states |
-| `snap.Desired.IsShutdownRequested()` method call | `snap.ShouldStop()` (merged shutdown + parent-stop) or `snap.Desired.IsShutdownRequested()` (raw shutdown flag) |
-| Manual `SetState`, `SetShutdownRequested`, `SetChildrenCounts` in ObservedState | Automatic via collector duck-typing on `Observation` |
+| `snap.Desired.IsBeingRemoved` method call | `snap.ShouldStop()` (merged shutdown + parent-stop) or `snap.Desired.IsBeingRemoved` (raw shutdown flag) |
+| Manual `SetState`, `SetBeingRemoved`, `SetChildrenCounts` in ObservedState | Automatic via collector duck-typing on `Observation` |
 
 ### Migration steps
 
@@ -793,7 +793,7 @@ Worker API v2 replaces the 7-file pattern with a single-file approach using gene
 3. **Replace constructor** — call `w.InitBase(id, logger, sr)` instead of manual dependency wiring
 4. **Simplify CollectObservedState** — use `fsmv2.ExtractConfig[TConfig](desired)` for config access, return `fsmv2.NewObservation(TStatus{...})` (the collector handles CollectedAt, framework metrics, action history, and metric accumulation automatically)
 5. **Delete DeriveDesiredState and GetInitialState** — provided by WorkerBase (override only if needed)
-6. **Update states** — use `fsmv2.ConvertWorkerSnapshot[TConfig, TStatus](snapAny)` and `snap.ShouldStop()` (or `snap.Desired.IsShutdownRequested()` when distinguishing self-shutdown from parent-stop)
+6. **Update states** — use `fsmv2.ConvertWorkerSnapshot[TConfig, TStatus](snapAny)` and `snap.ShouldStop()` (or `snap.Desired.IsBeingRemoved` when distinguishing self-shutdown from parent-stop)
 7. **Replace registration** — single `register.Worker[TConfig, TStatus, register.NoDeps]("type", constructor)` call (replace `register.NoDeps` with your deps type if using typed deps)
 8. **Delete snapshot/, dependencies.go, userspec.go** — no longer needed
 9. **Implement capability interfaces** on your worker struct if needed (ActionProvider, ChildSpecProvider, etc.)

--- a/umh-core/pkg/fsmv2/README.md
+++ b/umh-core/pkg/fsmv2/README.md
@@ -178,7 +178,7 @@ func (s *TryingToStartState) Next(snapAny any) fsmv2.NextResult[any, any] {
     snap := helpers.ConvertSnapshot[ObservedState, *DesiredState](snapAny)
 
     // ALWAYS check shutdown first
-    if snap.Desired.IsShutdownRequested() {
+    if snap.Desired.IsBeingRemoved() {
         return fsmv2.Transition(&StoppedState{}, fsmv2.SignalNone, nil, "Shutdown requested")
     }
     // Check observation - did the process start?
@@ -456,7 +456,7 @@ Developers implement business logic; the supervisor handles:
 | **Actions** | Worker pool, panic recovery, timeout | 10 workers, 30s timeout, auto-retry |
 | **Metrics** | FrameworkMetrics auto-injected | TimeInCurrentStateMs, StateTransitionsTotal |
 | **Persistence** | Delta checking (skips unchanged writes) | Automatic I/O reduction |
-| **Shutdown** | `IsShutdownRequested()` propagated to all states | Graceful cleanup |
+| **Shutdown** | `IsBeingRemoved` propagated to all states | Graceful cleanup |
 | **Templates** | Variable expansion (User/Global/Internal) | Strict mode (fails on missing) |
 | **Children** | Spawn, manage, reconcile child workers | Automatic lifecycle |
 
@@ -551,7 +551,7 @@ ginkgo run --focus="Architecture" -v ./pkg/fsmv2/
 
 1. **State transitions**: Call `Next()` with test snapshots
 2. **Action idempotency**: Verify actions are safe to call multiple times
-3. **Shutdown handling**: Test `IsShutdownRequested()` path in all states
+3. **Shutdown handling**: Test `IsBeingRemoved` path in all states
 
 **Example test pattern:**
 
@@ -576,7 +576,7 @@ It("should transition to Running when process is observed", func() {
 |---------|-------|------------|
 | Stuck in `TryingTo*` state | Action logs for errors | Fix action failure or external dependency |
 | Running but not working | Observation timestamps | Verify `CollectObservedState()` queries actual system |
-| Won't shut down | `IsShutdownRequested()` check | Ensure all states check shutdown first |
+| Won't shut down | `IsBeingRemoved` check | Ensure all states check shutdown first |
 | Action runs multiple times | Action idempotency | Add "already done" check before work |
 | Data considered stale | Circuit breaker metrics | Check observation collection errors |
 

--- a/umh-core/pkg/fsmv2/api.go
+++ b/umh-core/pkg/fsmv2/api.go
@@ -32,12 +32,12 @@ const (
 	SignalNone Signal = iota
 
 	// SignalNeedsRemoval tells supervisor this worker has completed cleanup and can be removed.
-	// Emitted by Stopped state when IsShutdownRequested() returns true and cleanup is complete.
+	// Emitted by Stopped state when IsBeingRemoved returns true and cleanup is complete.
 	SignalNeedsRemoval
 
 	// SignalNeedsRestart tells supervisor the worker has detected an unrecoverable error
 	// and needs a full restart. The supervisor will:
-	//   1. Call SetShutdownRequested(true) (trigger graceful shutdown)
+	//   1. Call SetBeingRemoved(true) (trigger graceful shutdown)
 	//   2. Wait for worker to complete shutdown and emit SignalNeedsRemoval
 	//   3. Reset worker to initial state instead of removing it
 	//   4. Restart the observation collector
@@ -76,20 +76,25 @@ type TimestampProvider interface {
 }
 
 // DesiredState represents the target state derived from user configuration.
+//
+// Concrete DesiredState types embed config.BaseDesiredState, which provides the
+// IsBeingRemoved() reader method (against the BeingRemoved field) and the
+// SetBeingRemoved setter (RemovalRequestable interface). State files read the
+// flag through snap.Desired.IsBeingRemoved().
 type DesiredState interface {
-	// IsShutdownRequested is set by supervisor to initiate graceful shutdown.
-	// States should check this first in their Next() method.
-	IsShutdownRequested() bool
+	// IsBeingRemoved is set by supervisor to initiate graceful removal of the
+	// worker. States should check this first in their Next() method.
+	IsBeingRemoved() bool
 }
 
-// ShutdownRequestable allows setting the shutdown flag on any DesiredState.
+// RemovalRequestable allows setting the shutdown flag on any DesiredState.
 // Embed config.BaseDesiredState (from pkg/fsmv2/config) to satisfy this interface.
-type ShutdownRequestable interface {
-	SetShutdownRequested(bool)
+type RemovalRequestable interface {
+	SetBeingRemoved(bool)
 }
 
 // Disablable is implemented by desired states that can be transiently disabled
-// by their parent (ChildSpec.Enabled=false). Distinct from ShutdownRequestable
+// by their parent (ChildSpec.Enabled=false). Distinct from RemovalRequestable
 // (permanent removal) and Config-level state stops.
 type Disablable interface {
 	SetDisabled(bool)
@@ -357,7 +362,7 @@ func wrapTypedAction(action any) Action[any] {
 }
 
 // Worker is the business logic interface that developers implement.
-// Note: Shutdown is managed by the supervisor via ShutdownRequested in desired state,
+// Note: Shutdown is managed by the supervisor via IsBeingRemoved in desired state,
 // not by a method on this interface.
 type Worker interface {
 	// CollectObservedState monitors the actual system state.

--- a/umh-core/pkg/fsmv2/api.go
+++ b/umh-core/pkg/fsmv2/api.go
@@ -81,21 +81,43 @@ type TimestampProvider interface {
 // IsBeingRemoved() reader method (against the BeingRemoved field) and the
 // SetBeingRemoved setter (RemovalRequestable interface). State files read the
 // flag through snap.Desired.IsBeingRemoved().
+//
+// IsBeingRemoved is the permanent-removal signal — one of three primitives PR5
+// disambiguated. Transient parent-disable lives on the Disablable interface;
+// user-driven "stopped" lives on TConfig via BaseUserSpec.GetState(). See
+// WorkerSnapshot.ShouldStop for the umbrella OR, and pkg/fsmv2/CLAUDE.md
+// "Stopping a worker — six cases, three signals" for the full case table.
 type DesiredState interface {
-	// IsBeingRemoved is set by supervisor to initiate graceful removal of the
-	// worker. States should check this first in their Next() method.
+	// IsBeingRemoved is set by the supervisor to initiate permanent teardown
+	// of this worker instance. Sources: parent omits child from spec list,
+	// state emits SignalNeedsRestart, graceful process shutdown, supervisor
+	// self-protection. States should check this first in their Next() method
+	// (or use the umbrella WorkerSnapshot.ShouldStop for non-Stopped states
+	// that don't need to discriminate the source).
 	IsBeingRemoved() bool
 }
 
-// RemovalRequestable allows setting the shutdown flag on any DesiredState.
-// Embed config.BaseDesiredState (from pkg/fsmv2/config) to satisfy this interface.
+// RemovalRequestable allows the supervisor to set the permanent-removal flag
+// on any DesiredState. Embed config.BaseDesiredState (from pkg/fsmv2/config)
+// to satisfy this interface. Setting BeingRemoved=true is irreversible from
+// the worker's perspective — the supervisor will tear the worker down and
+// remove it from s.children.
 type RemovalRequestable interface {
 	SetBeingRemoved(bool)
 }
 
 // Disablable is implemented by desired states that can be transiently disabled
 // by their parent (ChildSpec.Enabled=false). Distinct from RemovalRequestable
-// (permanent removal) and Config-level state stops.
+// (permanent removal — case C/D/E/F) and Config-level "stopped" (user pause —
+// case A): IsDisabled is case B, the parent's per-tick "pause this child"
+// signal. The CHANGE-19 reducer in supervisor/reconciliation.go writes
+// IsDisabled from the parent's ChildSpec.Enabled flag every tick. Disabled
+// children stay resident in s.children and resume when the parent flips
+// Enabled=true again.
+//
+// WrappedDesiredState satisfies this interface for all WorkerBase-using
+// workers; bespoke DesiredState types implement it directly if they need to
+// participate in the parent-driven pause flow.
 type Disablable interface {
 	SetDisabled(bool)
 	IsDisabled() bool

--- a/umh-core/pkg/fsmv2/api.go
+++ b/umh-core/pkg/fsmv2/api.go
@@ -88,6 +88,14 @@ type ShutdownRequestable interface {
 	SetShutdownRequested(bool)
 }
 
+// Disablable is implemented by desired states that can be transiently disabled
+// by their parent (ChildSpec.Enabled=false). Distinct from ShutdownRequestable
+// (permanent removal) and Config-level state stops.
+type Disablable interface {
+	SetDisabled(bool)
+	IsDisabled() bool
+}
+
 // Snapshot is the complete view of the worker at a point in time (immutable).
 type Snapshot struct {
 	Observed interface{}   // What is the actual state? (ObservedState or basic.Document).

--- a/umh-core/pkg/fsmv2/architecture_p1_8_test.go
+++ b/umh-core/pkg/fsmv2/architecture_p1_8_test.go
@@ -36,7 +36,7 @@ var _ = Describe("FSMv2 Architecture Validation — P1.8 Foundation Cap", func()
 			// body in collector.go (collector goroutine in the two-goroutine
 			// architecture documented in Design Intent §14). SaveObserved
 			// must be the LAST observation mutation in that function: any
-			// setter call (SetState, SetChildrenView, SetShutdownRequested,
+			// setter call (SetState, SetChildrenView, SetBeingRemoved,
 			// SetChildrenCounts, SetParentMappedState) that appears AFTER
 			// SaveObserved indicates an injection-after-persistence drift.
 			//
@@ -55,7 +55,7 @@ var _ = Describe("FSMv2 Architecture Validation — P1.8 Foundation Cap", func()
 			setterNames := map[string]bool{
 				"SetState":             true,
 				"SetChildrenView":      true,
-				"SetShutdownRequested": true,
+				"SetBeingRemoved": true,
 				"SetChildrenCounts":    true,
 				"SetParentMappedState": true,
 			}

--- a/umh-core/pkg/fsmv2/config/childspec.go
+++ b/umh-core/pkg/fsmv2/config/childspec.go
@@ -246,9 +246,9 @@ func NewChildSpec(name, workerType string, userSpec UserSpec) ChildSpec {
 //	return fsmv2.Transition(..., config.DisableAll(pkg.RenderChildren(snap)))
 //
 // CHANGE-19 reducer (supervisor/reconciliation.go ~line 1660) translates
-// Enabled=false into RequestShutdown synchronously before the child's tick,
+// Enabled=false into RequestRemoval synchronously before the child's tick,
 // so children stay resident in supervisor.children with IsBeingRemoved
-// set. Flipping back to Enabled=true issues ClearShutdownRequest for clean
+// set. Flipping back to Enabled=true issues ClearRemoval for clean
 // resume.
 func DisableAll(specs []ChildSpec) []ChildSpec {
 	for i := range specs {

--- a/umh-core/pkg/fsmv2/config/childspec.go
+++ b/umh-core/pkg/fsmv2/config/childspec.go
@@ -32,7 +32,7 @@ import (
 //	}
 //
 // Workers embedding BaseDesiredState automatically satisfy the DesiredState interface's
-// IsShutdownRequested() method and the ShutdownRequestable interface's SetShutdownRequested() method.
+// IsBeingRemoved() method and the RemovalRequestable interface's SetBeingRemoved() method.
 //
 // # Lifecycle Control Invariant
 //
@@ -40,33 +40,38 @@ import (
 // Do not add fields like ShouldRun, IsRunning, Enabled, or Active to your DesiredState.
 //
 // Correct lifecycle control:
-//   - ShutdownRequested: Inherited from this type. Set by supervisor for graceful shutdown.
+//   - BeingRemoved: Inherited from this type. Set by supervisor for graceful shutdown via
+//     SetBeingRemoved; read via the IsBeingRemoved() method.
 //     Parent-driven stop flows through the same flag: parent sets ChildSpec.Enabled=false,
-//     which the CHANGE-19 reducer translates into IsShutdownRequested=true on the child.
+//     which the CHANGE-19 reducer translates into BeingRemoved=true on the child.
 //   - User-facing state ("running"/"stopped"): Read from TConfig via BaseUserSpec.GetState() in
 //     state files. The wrapper-level BaseDesiredState does not carry a State field of its own.
 //
 // Correct ShouldBeRunning() implementations:
 //
 //	func (s *MyDesiredState) ShouldBeRunning() bool {
-//	    return !s.ShutdownRequested
+//	    return !s.IsBeingRemoved()
 //	}
 //
 // Custom lifecycle fields are forbidden; the framework controls lifecycle
 // exclusively via ShouldStop() and reconciliation.
 type BaseDesiredState struct {
-	ShutdownRequested bool `json:"ShutdownRequested" yaml:"ShutdownRequested"` //nolint:tagliatelle // Match JSON field name for API compatibility
+	BeingRemoved bool `json:"isBeingRemoved" yaml:"isBeingRemoved"` //nolint:tagliatelle // Match JSON field name for API compatibility
 }
 
-// IsShutdownRequested returns whether shutdown has been requested for this worker.
-func (b *BaseDesiredState) IsShutdownRequested() bool {
-	return b.ShutdownRequested
+// SetBeingRemoved sets the removal-requested flag.
+// This satisfies the RemovalRequestable interface.
+func (b *BaseDesiredState) SetBeingRemoved(v bool) {
+	b.BeingRemoved = v
 }
 
-// SetShutdownRequested sets the shutdown requested flag.
-// This satisfies the ShutdownRequestable interface.
-func (b *BaseDesiredState) SetShutdownRequested(v bool) {
-	b.ShutdownRequested = v
+// IsBeingRemoved returns the removal-requested flag.
+//
+// This is the canonical read accessor used by the DesiredState interface and
+// by state files. The underlying field is BeingRemoved (no Is-prefix) to mirror
+// the IsDisabled/Disabled pairing on WrappedDesiredState.
+func (b *BaseDesiredState) IsBeingRemoved() bool {
+	return b.BeingRemoved
 }
 
 // BaseUserSpec provides common fields for all user configuration types.
@@ -191,10 +196,10 @@ type ChildSpec struct {
 	WorkerType   string         `json:"workerType" yaml:"workerType"` // Type of worker to create (registered worker factory key)
 
 	// Enabled is the parent's per-tick enable signal for this child. The CHANGE-19
-	// reducer translates it to IsShutdownRequested on the child's desired state every
+	// reducer translates it to IsBeingRemoved on the child's desired state every
 	// tick. Three-state semantics:
 	//
-	//   - Name present, Enabled: true  → child runs (reducer writes IsShutdownRequested=false)
+	//   - Name present, Enabled: true  → child runs (reducer writes IsBeingRemoved=false)
 	//   - Name present, Enabled: false → stopped-but-resident: child reaches Stopped and stays
 	//     there; supervisor remains resident in s.children, NOT placed in s.pendingRemoval
 	//   - Name absent from spec list   → graceful despawn (full removal via pendingRemoval)
@@ -204,16 +209,16 @@ type ChildSpec struct {
 	// explicitly set Enabled: true in their renderChildren body.
 	//
 	// Pause/resume flow: setting Enabled=false drives the child to Stopped; setting
-	// Enabled=true again writes IsShutdownRequested=false, and the child's state machine
+	// Enabled=true again writes IsBeingRemoved=false, and the child's state machine
 	// transitions from Stopped back to TryingToStart on the next tick.
 	//
 	// One-way stop guarantee: once a child enters TryingToStop, it completes the stop
-	// before accepting a new IsShutdownRequested=false signal. The supervisor only
+	// before accepting a new IsBeingRemoved=false signal. The supervisor only
 	// manages the flag; the child's state machine enforces the trajectory.
 	//
-	// Children read snap.Desired.IsShutdownRequested() and never read Enabled directly
+	// Children read snap.Desired.IsBeingRemoved() and never read Enabled directly
 	// (Design Intent §4 no-Parent-references-in-children). Implemented by the CHANGE-19
-	// reducer in supervisor/reconciliation.go (the spec→IsShutdownRequested translation
+	// reducer in supervisor/reconciliation.go (the spec→IsBeingRemoved translation
 	// runs at the start of reconcileChildren, before Phase 1's pendingRemoval writes).
 	Enabled bool `json:"enabled" yaml:"enabled"`
 }
@@ -242,7 +247,7 @@ func NewChildSpec(name, workerType string, userSpec UserSpec) ChildSpec {
 //
 // CHANGE-19 reducer (supervisor/reconciliation.go ~line 1660) translates
 // Enabled=false into RequestShutdown synchronously before the child's tick,
-// so children stay resident in supervisor.children with IsShutdownRequested
+// so children stay resident in supervisor.children with IsBeingRemoved
 // set. Flipping back to Enabled=true issues ClearShutdownRequest for clean
 // resume.
 func DisableAll(specs []ChildSpec) []ChildSpec {
@@ -585,8 +590,8 @@ func (v ChildrenView) Counts() (healthy, unhealthy int) {
 // DesiredState represents what we want the system to be.
 // This is returned by Worker.DeriveDesiredState() and used by State.Next() for decisions.
 //
-// The supervisor injects shutdown requests by setting ShutdownRequested = true.
-// Workers must check IsShutdownRequested() first in their State.Next() implementations.
+// The supervisor injects shutdown requests by setting IsBeingRemoved = true.
+// Workers must check IsBeingRemoved first in their State.Next() implementations.
 //
 // # Children Management
 //
@@ -606,21 +611,21 @@ func (v ChildrenView) Counts() (healthy, unhealthy int) {
 // Example with shutdown:
 //
 //	DesiredState{
-//	    BaseDesiredState: BaseDesiredState{ShutdownRequested: true},  // Triggers shutdown sequence
+//	    BaseDesiredState: BaseDesiredState{BeingRemoved: true},  // Triggers shutdown sequence
 //	    ChildrenSpecs:    nil,                                        // Children removed during shutdown
 //	}
 type DesiredState struct {
 	OriginalUserSpec interface{}      `json:"-"                          yaml:"-"` // Captures the input that produced this DesiredState (for debugging/traceability); not serialized (would emit untyped any over the wire per §17).
-	BaseDesiredState `yaml:",inline"` // Provides ShutdownRequested field and methods (IsShutdownRequested, SetShutdownRequested)
+	BaseDesiredState `yaml:",inline"` // Provides BeingRemoved field and methods (IsBeingRemoved, SetBeingRemoved)
 	ChildrenSpecs    []ChildSpec      `json:"childrenSpecs,omitempty"    yaml:"childrenSpecs,omitempty"` // Declarative specification of child workers
 }
 
-// NOTE: IsShutdownRequested() and SetShutdownRequested() are provided by embedded BaseDesiredState.
-// The ShutdownRequested field is the canonical source of truth for shutdown state.
+// NOTE: IsBeingRemoved() and SetBeingRemoved() are provided by embedded BaseDesiredState.
+// The BeingRemoved field is the canonical source of truth for shutdown state.
 //
 // Shutdown flow:
-//  1. Supervisor sets ShutdownRequested = true via SetShutdownRequested()
-//  2. State.Next() calls IsShutdownRequested() → returns true
+//  1. Supervisor sets BeingRemoved = true via SetBeingRemoved()
+//  2. State.Next() calls IsBeingRemoved() → returns true
 //  3. State transitions to shutdown/cleanup states
 //  4. Eventually returns SignalNeedsRemoval
 //  5. Supervisor removes worker from system
@@ -630,7 +635,7 @@ type DesiredState struct {
 //	func (s RunningState) Next(snapshot fsmv2.Snapshot) (State, Signal, Action) {
 //	    desired := snapshot.Desired.(types.DesiredState)
 //	    // Always check shutdown first
-//	    if desired.IsShutdownRequested() {
+//	    if desired.IsBeingRemoved() {
 //	        return StoppingState{}, fsmv2.SignalNone, nil
 //	    }
 //	    // ... rest of logic

--- a/umh-core/pkg/fsmv2/config/childspec.go
+++ b/umh-core/pkg/fsmv2/config/childspec.go
@@ -21,8 +21,8 @@ import (
 	"hash/fnv"
 )
 
-// BaseDesiredState provides common shutdown functionality for all DesiredState types.
-// Workers embed this struct to get consistent shutdown handling without boilerplate.
+// BaseDesiredState provides the permanent-removal signal for all DesiredState types.
+// Workers embed this struct to get consistent removal handling without boilerplate.
 //
 // Example:
 //
@@ -37,24 +37,30 @@ import (
 // # Lifecycle Control Invariant
 //
 // The FSM controls worker lifecycle through state transitions, not through custom bool fields.
-// Do not add fields like ShouldRun, IsRunning, Enabled, or Active to your DesiredState.
+// Do not add fields like ShouldRun, IsRunning, or Active to your DesiredState. Per-child
+// transient pause is signalled via the separate IsDisabled flag on WrappedDesiredState
+// (set by the CHANGE-19 reducer from ChildSpec.Enabled=false), not on BaseDesiredState.
 //
-// Correct lifecycle control:
-//   - BeingRemoved: Inherited from this type. Set by supervisor for graceful shutdown via
-//     SetBeingRemoved; read via the IsBeingRemoved() method.
-//     Parent-driven stop flows through the same flag: parent sets ChildSpec.Enabled=false,
-//     which the CHANGE-19 reducer translates into BeingRemoved=true on the child.
-//   - User-facing state ("running"/"stopped"): Read from TConfig via BaseUserSpec.GetState() in
-//     state files. The wrapper-level BaseDesiredState does not carry a State field of its own.
+// PR5 disambiguated stop signals into three primitives. BaseDesiredState carries only one:
 //
-// Correct ShouldBeRunning() implementations:
+//   - BeingRemoved (this type): Permanent — set when this instance must be torn down.
+//     Sources: parent omits child from spec list, SignalNeedsRestart, graceful process
+//     shutdown, supervisor self-protection. Read via IsBeingRemoved(); set via
+//     SetBeingRemoved (RemovalRequestable interface).
+//   - IsDisabled (on WrappedDesiredState): Transient parent-disable. Worker stays resident.
+//   - Config.GetState()=="stopped": Transient user-driven stop. Worker stays resident.
 //
-//	func (s *MyDesiredState) ShouldBeRunning() bool {
-//	    return !s.IsBeingRemoved()
-//	}
+// State files use snap.ShouldStop() as the umbrella over all three (non-Stopped states),
+// or snap.Desired.IsBeingRemoved() to discriminate in Stopped (permanent → emit
+// SignalNeedsRemoval; transient → stay resident). See helpers.StoppedNext for the
+// canonical Stopped pattern, and pkg/fsmv2/CLAUDE.md "Stopping a worker — six cases,
+// three signals" for the full case table.
+//
+// User-facing state ("running"/"stopped") is read from TConfig via BaseUserSpec.GetState()
+// in state files. The wrapper-level BaseDesiredState does not carry a State field of its own.
 //
 // Custom lifecycle fields are forbidden; the framework controls lifecycle
-// exclusively via ShouldStop() and reconciliation.
+// exclusively via the three signals above and reconciliation.
 type BaseDesiredState struct {
 	BeingRemoved bool `json:"isBeingRemoved" yaml:"isBeingRemoved"` //nolint:tagliatelle // Match JSON field name for API compatibility
 }
@@ -196,30 +202,43 @@ type ChildSpec struct {
 	WorkerType   string         `json:"workerType" yaml:"workerType"` // Type of worker to create (registered worker factory key)
 
 	// Enabled is the parent's per-tick enable signal for this child. The CHANGE-19
-	// reducer translates it to IsBeingRemoved on the child's desired state every
+	// reducer translates it to IsDisabled on the child's WrappedDesiredState every
 	// tick. Three-state semantics:
 	//
-	//   - Name present, Enabled: true  → child runs (reducer writes IsBeingRemoved=false)
-	//   - Name present, Enabled: false → stopped-but-resident: child reaches Stopped and stays
-	//     there; supervisor remains resident in s.children, NOT placed in s.pendingRemoval
-	//   - Name absent from spec list   → graceful despawn (full removal via pendingRemoval)
+	//   - Name present, Enabled: true  → child runs (reducer writes IsDisabled=false)
+	//   - Name present, Enabled: false → stopped-but-resident: reducer writes
+	//     IsDisabled=true; child reaches Stopped via ShouldStop and stays there;
+	//     supervisor remains resident in s.children, NOT placed in s.pendingRemoval
+	//   - Name absent from spec list   → graceful despawn (full removal via pendingRemoval,
+	//     which sets IsBeingRemoved=true permanently)
 	//
 	// The zero value (§4-C LOCKED) is false: ChildSpec literals that omit Enabled
 	// produce a stopped-but-resident child. Parents that want a running child must
-	// explicitly set Enabled: true in their renderChildren body.
+	// explicitly set Enabled: true in their renderChildren body. Use NewChildSpec
+	// to set Enabled:true by default.
 	//
-	// Pause/resume flow: setting Enabled=false drives the child to Stopped; setting
-	// Enabled=true again writes IsBeingRemoved=false, and the child's state machine
-	// transitions from Stopped back to TryingToStart on the next tick.
+	// IsDisabled vs IsBeingRemoved: Enabled=false maps to the transient IsDisabled
+	// signal — the child stays resident and resumes when the parent flips Enabled
+	// back. Permanent removal (cases C/D/E/F: spec absence, SignalNeedsRestart,
+	// process shutdown, supervisor self-protection) goes through IsBeingRemoved
+	// instead, which tears the child down. PR5 disambiguated these into separate
+	// fields; before PR5 they were conflated as "ShutdownRequested". See
+	// pkg/fsmv2/CLAUDE.md "Stopping a worker — six cases, three signals".
+	//
+	// Pause/resume flow: setting Enabled=false drives the child to Stopped via
+	// IsDisabled; setting Enabled=true again writes IsDisabled=false, and the
+	// child's state machine transitions from Stopped back to TryingToStart on
+	// the next tick (helpers.StoppedNext takes the !ShouldStop branch).
 	//
 	// One-way stop guarantee: once a child enters TryingToStop, it completes the stop
-	// before accepting a new IsBeingRemoved=false signal. The supervisor only
+	// before accepting a new IsDisabled=false signal. The supervisor only
 	// manages the flag; the child's state machine enforces the trajectory.
 	//
-	// Children read snap.Desired.IsBeingRemoved() and never read Enabled directly
-	// (Design Intent §4 no-Parent-references-in-children). Implemented by the CHANGE-19
-	// reducer in supervisor/reconciliation.go (the spec→IsBeingRemoved translation
-	// runs at the start of reconcileChildren, before Phase 1's pendingRemoval writes).
+	// Children read snap.ShouldStop() (umbrella) or snap.Desired.IsDisabled()
+	// (specific) and never read Enabled directly (Design Intent §4
+	// no-Parent-references-in-children). Implemented by the CHANGE-19 reducer in
+	// supervisor/reconciliation.go (the spec→IsDisabled translation runs at the
+	// start of reconcileChildren, before Phase 1's pendingRemoval writes).
 	Enabled bool `json:"enabled" yaml:"enabled"`
 }
 
@@ -237,7 +256,7 @@ func NewChildSpec(name, workerType string, userSpec UserSpec) ChildSpec {
 }
 
 // DisableAll marks every ChildSpec in the slice as Enabled=false. Used by
-// parent state machines that want children resident-but-shutdown via the
+// parent state machines that want children resident-but-paused via the
 // CHANGE-19 reducer (e.g. parent in Stopped/Stopping/transient states).
 // Returns the slice for chaining. Mutates in place.
 //
@@ -245,11 +264,17 @@ func NewChildSpec(name, workerType string, userSpec UserSpec) ChildSpec {
 //
 //	return fsmv2.Transition(..., config.DisableAll(pkg.RenderChildren(snap)))
 //
-// CHANGE-19 reducer (supervisor/reconciliation.go ~line 1660) translates
-// Enabled=false into RequestRemoval synchronously before the child's tick,
-// so children stay resident in supervisor.children with IsBeingRemoved
-// set. Flipping back to Enabled=true issues ClearRemoval for clean
-// resume.
+// CHANGE-19 reducer (supervisor/reconciliation.go) translates Enabled=false
+// into IsDisabled=true on the child's WrappedDesiredState synchronously before
+// the child's tick, so children stay resident in supervisor.children with the
+// transient IsDisabled flag set. Flipping back to Enabled=true clears
+// IsDisabled and the child resumes from Stopped on the next tick.
+//
+// DisableAll signals transient pause (case B), not removal — children retain
+// their identity and (once retain/hydrate lands per
+// 003_klaus/artifacts/2026-04-09_fsmv2_state_recovery_design.md) their
+// in-memory state. For permanent removal, return a shorter spec list instead
+// (case C, drives IsBeingRemoved=true).
 func DisableAll(specs []ChildSpec) []ChildSpec {
 	for i := range specs {
 		specs[i].Enabled = false
@@ -590,8 +615,11 @@ func (v ChildrenView) Counts() (healthy, unhealthy int) {
 // DesiredState represents what we want the system to be.
 // This is returned by Worker.DeriveDesiredState() and used by State.Next() for decisions.
 //
-// The supervisor injects shutdown requests by setting IsBeingRemoved = true.
-// Workers must check IsBeingRemoved first in their State.Next() implementations.
+// The supervisor injects permanent removal by setting IsBeingRemoved=true via
+// SetBeingRemoved (RemovalRequestable). Workers check IsBeingRemoved (or the
+// umbrella ShouldStop) first in their State.Next() implementations. Transient
+// parent-disable goes through the separate IsDisabled flag on WrappedDesiredState
+// (CHANGE-19 reducer, written from ChildSpec.Enabled=false).
 //
 // # Children Management
 //
@@ -608,11 +636,11 @@ func (v ChildrenView) Counts() (healthy, unhealthy int) {
 //	    }, nil
 //	}
 //
-// Example with shutdown:
+// Example with permanent removal:
 //
 //	DesiredState{
-//	    BaseDesiredState: BaseDesiredState{BeingRemoved: true},  // Triggers shutdown sequence
-//	    ChildrenSpecs:    nil,                                        // Children removed during shutdown
+//	    BaseDesiredState: BaseDesiredState{BeingRemoved: true},  // Triggers teardown
+//	    ChildrenSpecs:    nil,                                   // Children removed alongside parent
 //	}
 type DesiredState struct {
 	OriginalUserSpec interface{}      `json:"-"                          yaml:"-"` // Captures the input that produced this DesiredState (for debugging/traceability); not serialized (would emit untyped any over the wire per §17).
@@ -621,23 +649,31 @@ type DesiredState struct {
 }
 
 // NOTE: IsBeingRemoved() and SetBeingRemoved() are provided by embedded BaseDesiredState.
-// The BeingRemoved field is the canonical source of truth for shutdown state.
+// The BeingRemoved field is the canonical signal for permanent removal.
 //
-// Shutdown flow:
-//  1. Supervisor sets BeingRemoved = true via SetBeingRemoved()
-//  2. State.Next() calls IsBeingRemoved() → returns true
-//  3. State transitions to shutdown/cleanup states
-//  4. Eventually returns SignalNeedsRemoval
-//  5. Supervisor removes worker from system
+// Permanent removal flow (cases C/D/E/F per CLAUDE.md):
+//  1. Trigger: parent omits child from spec list, SignalNeedsRestart from a state,
+//     graceful process shutdown, or supervisor self-protection
+//  2. Supervisor sets BeingRemoved = true via SetBeingRemoved()
+//  3. State.Next() calls IsBeingRemoved() → returns true
+//  4. State transitions to Stopping → Stopped
+//  5. Stopped emits SignalNeedsRemoval
+//  6. Supervisor removes worker from system
+//
+// Transient pause (cases A/B) does NOT flow through BeingRemoved — see
+// WrappedDesiredState.IsDisabled (parent disable) and Config.GetState()
+// (user "stopped"). Workers stay resident on transient signals.
 //
 // Example usage in State.Next():
 //
 //	func (s RunningState) Next(snapshot fsmv2.Snapshot) (State, Signal, Action) {
 //	    desired := snapshot.Desired.(types.DesiredState)
-//	    // Always check shutdown first
+//	    // Always check stop first — IsBeingRemoved (permanent) routes to Stopping.
 //	    if desired.IsBeingRemoved() {
 //	        return StoppingState{}, fsmv2.SignalNone, nil
 //	    }
+//	    // For non-Stopped states that don't care about source, use snap.ShouldStop()
+//	    // (umbrella over IsBeingRemoved + IsDisabled + Config "stopped").
 //	    // ... rest of logic
 //	}
 

--- a/umh-core/pkg/fsmv2/config/childspec_test.go
+++ b/umh-core/pkg/fsmv2/config/childspec_test.go
@@ -302,7 +302,7 @@ childrenSpecs:
 
 		It("should handle empty ChildrenSpecs correctly", func() {
 			yamlData := `
-ShutdownRequested: false
+isBeingRemoved: false
 `
 			var desired config.DesiredState
 			err := yaml.Unmarshal([]byte(yamlData), &desired)
@@ -312,18 +312,18 @@ ShutdownRequested: false
 		})
 	})
 
-	Describe("ShutdownRequested interface", func() {
+	Describe("IsBeingRemoved interface", func() {
 		It("should return false by default", func() {
 			desired := config.DesiredState{}
 
-			Expect(desired.IsShutdownRequested()).To(BeFalse())
+			Expect(desired.IsBeingRemoved()).To(BeFalse())
 		})
 
-		It("should return true when ShutdownRequested is set", func() {
+		It("should return true when BeingRemoved is set", func() {
 			desired := config.DesiredState{}
-			desired.SetShutdownRequested(true)
+			desired.SetBeingRemoved(true)
 
-			Expect(desired.IsShutdownRequested()).To(BeTrue())
+			Expect(desired.IsBeingRemoved()).To(BeTrue())
 		})
 	})
 })

--- a/umh-core/pkg/fsmv2/config/doc.go
+++ b/umh-core/pkg/fsmv2/config/doc.go
@@ -125,17 +125,17 @@
 //
 // # DesiredState and shutdown control
 //
-// DesiredState includes IsShutdownRequested() for graceful shutdown:
+// DesiredState includes IsBeingRemoved for graceful shutdown:
 //
 //	type DesiredState struct {
 //	    State            string
-//	    ShutdownRequested bool
+//	    IsBeingRemoved bool
 //	    ChildrenSpecs    []ChildSpec
 //	}
 //
-// The supervisor sets ShutdownRequested when shutdown is initiated. Workers
+// The supervisor sets IsBeingRemoved when shutdown is initiated. Workers
 // check this flag in their state transitions and complete cleanup states
-// before signaling removal. Parent shutdown propagates ShutdownRequested
+// before signaling removal. Parent shutdown propagates IsBeingRemoved
 // to all children, so children clean up before parent completes shutdown.
 //
 // # Template expansion

--- a/umh-core/pkg/fsmv2/doc.go
+++ b/umh-core/pkg/fsmv2/doc.go
@@ -332,7 +332,7 @@
 //
 // ## Shutdown handling
 //
-// Check IsShutdownRequested() as the first conditional in Next().
+// Check IsBeingRemoved as the first conditional in Next().
 // See workers/example/examplechild/state/ for examples.
 //
 // ## Type-safe dependencies
@@ -365,7 +365,7 @@
 //
 //   - Keep Next() pure (no side effects)
 //   - Make actions idempotent (check if work already done)
-//   - Check IsShutdownRequested() first in all states
+//   - Check IsBeingRemoved first in all states
 //   - Use type-safe state structs, not strings
 //   - Return action or transition, not both (the supervisor panics if both are returned)
 //   - Handle context cancellation in all async operations

--- a/umh-core/pkg/fsmv2/integration/helpers_test.go
+++ b/umh-core/pkg/fsmv2/integration/helpers_test.go
@@ -182,7 +182,7 @@ type MockDesiredState struct {
 	shutdownRequested bool
 }
 
-func (m *MockDesiredState) IsShutdownRequested() bool {
+func (m *MockDesiredState) IsBeingRemoved() bool {
 	return m.shutdownRequested
 }
 
@@ -190,7 +190,7 @@ func (m *MockDesiredState) GetState() string {
 	return "running"
 }
 
-func (m *MockDesiredState) SetShutdownRequested(requested bool) {
+func (m *MockDesiredState) SetBeingRemoved(requested bool) {
 	m.shutdownRequested = requested
 }
 

--- a/umh-core/pkg/fsmv2/integration/restart_scenario_test.go
+++ b/umh-core/pkg/fsmv2/integration/restart_scenario_test.go
@@ -65,7 +65,7 @@ var _ = Describe("Restart Scenario Integration", func() {
 		// 2. Parent signals children to run -> TryingToConnect
 		// 3. ConnectAction fails 5 times (simulated failures)
 		// 4. After 5th failure, TryingToConnectState.Next() returns SignalNeedsRestart
-		// 5. Supervisor marks worker in pendingRestart, sets ShutdownRequested=true
+		// 5. Supervisor marks worker in pendingRestart, sets IsBeingRemoved=true
 		// 6. Worker transitions: TryingToConnect -> TryingToStop -> Stopped
 		// 7. Stopped state emits SignalNeedsRemoval
 		// 8. Supervisor detects pendingRestart, calls handleWorkerRestart()

--- a/umh-core/pkg/fsmv2/integration/scenarios_test.go
+++ b/umh-core/pkg/fsmv2/integration/scenarios_test.go
@@ -512,7 +512,7 @@ func verifyNoOrphanedStates(store storage.TriangularStoreInterface) {
 		isTrying := strings.HasPrefix(state, "TryingTo")
 
 		// If shutdown requested, should not be in TryingTo* state
-		if shutdown, ok := w.Desired["ShutdownRequested"].(bool); ok && shutdown {
+		if shutdown, ok := w.Desired["isBeingRemoved"].(bool); ok && shutdown {
 			if isTrying {
 				GinkgoWriter.Printf("  Warning: %s/%s stuck in %s during shutdown\n",
 					w.WorkerType, w.WorkerID, state)

--- a/umh-core/pkg/fsmv2/internal/helpers/state_adapter.go
+++ b/umh-core/pkg/fsmv2/internal/helpers/state_adapter.go
@@ -32,7 +32,7 @@ import (
 //	    snap := ConvertSnapshot[MyObserved, *MyDesired](snapAny)
 //
 //	    // Direct typed access - no casting needed
-//	    if snap.Desired.IsShutdownRequested() {
+//	    if snap.Desired.IsBeingRemoved() {
 //	        return &StoppedState{}, SignalNone, nil
 //	    }
 //

--- a/umh-core/pkg/fsmv2/internal/helpers/state_adapter_test.go
+++ b/umh-core/pkg/fsmv2/internal/helpers/state_adapter_test.go
@@ -39,7 +39,7 @@ type testDesired struct {
 	shutdown bool
 }
 
-func (t *testDesired) IsShutdownRequested() bool {
+func (t *testDesired) IsBeingRemoved() bool {
 	return t.shutdown
 }
 
@@ -59,7 +59,7 @@ type wrongDesired struct {
 	value int
 }
 
-func (w *wrongDesired) IsShutdownRequested() bool {
+func (w *wrongDesired) IsBeingRemoved() bool {
 	return false
 }
 
@@ -94,7 +94,7 @@ var _ = Describe("StateAdapter", func() {
 				Expect(typedSnap.Identity.Name).To(Equal(identity.Name))
 				Expect(typedSnap.Identity.WorkerType).To(Equal(identity.WorkerType))
 				Expect(typedSnap.Observed.Value).To(Equal(observed.Value))
-				Expect(typedSnap.Desired.IsShutdownRequested()).To(BeTrue())
+				Expect(typedSnap.Desired.IsBeingRemoved()).To(BeTrue())
 			})
 
 			It("should handle value type observed", func() {
@@ -141,7 +141,7 @@ var _ = Describe("StateAdapter", func() {
 				typedSnap := helpers.ConvertSnapshot[testObserved, *testDesired](rawSnapshot)
 
 				Expect(typedSnap.Desired).NotTo(BeNil())
-				Expect(typedSnap.Desired.IsShutdownRequested()).To(BeTrue())
+				Expect(typedSnap.Desired.IsBeingRemoved()).To(BeTrue())
 			})
 		})
 
@@ -371,7 +371,7 @@ var _ = Describe("StateAdapter", func() {
 
 			Expect(typedSnap.Identity.ID).To(Equal("test-id"))
 			Expect(typedSnap.Observed.Value).To(Equal("direct-access-test"))
-			Expect(typedSnap.Desired.IsShutdownRequested()).To(BeTrue())
+			Expect(typedSnap.Desired.IsBeingRemoved()).To(BeTrue())
 		})
 	})
 })

--- a/umh-core/pkg/fsmv2/internal/helpers/stopped_next.go
+++ b/umh-core/pkg/fsmv2/internal/helpers/stopped_next.go
@@ -1,0 +1,58 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helpers
+
+import (
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
+)
+
+// StoppedNext implements the canonical two-tier StoppedState.Next pattern.
+//
+// PR5 introduced two distinct stop signals on top of the user-driven
+// "stopped" config: IsBeingRemoved (permanent) and IsDisabled (transient
+// parent-disable). StoppedState files have to discriminate between them
+// because the response differs:
+//
+//  1. Desired.IsBeingRemoved() — emit SignalNeedsRemoval. Permanent removal:
+//     Phase-1 absent-from-specs, SignalNeedsRestart, graceful shutdown,
+//     or supervisor self-protection. Drop retained state when implemented.
+//  2. !ShouldStop()             — advance to nextState. The umbrella signal
+//     cleared; the worker may resume.
+//  3. otherwise                 — stay stopped (resident), preserving
+//     in-memory state. IsDisabled (transient parent-disable) and
+//     Config.GetState()=="stopped" take this branch — the worker remains
+//     alive and ready to resume.
+//
+// Use this from a worker's StoppedState.Next when the worker's stopped
+// semantics match the canonical three-branch shape and there is no
+// worker-specific logic (children rendering, custom signals, additional
+// preconditions before advancing). Otherwise, hand-roll the three branches
+// and keep this helper as the reference pattern.
+func StoppedNext[TConfig any, TStatus any](
+	s fsmv2.State[any, any],
+	snap fsmv2.WorkerSnapshot[TConfig, TStatus],
+	nextState fsmv2.State[any, any],
+	advanceReason string,
+) fsmv2.NextResult[any, any] {
+	if snap.Desired.IsBeingRemoved() {
+		return fsmv2.Transition(s, fsmv2.SignalNeedsRemoval, nil, "shutdown requested, signaling removal", nil)
+	}
+
+	if !snap.ShouldStop() {
+		return fsmv2.Transition(nextState, fsmv2.SignalNone, nil, advanceReason, nil)
+	}
+
+	return fsmv2.Transition(s, fsmv2.SignalNone, nil, "worker is stopped", nil)
+}

--- a/umh-core/pkg/fsmv2/internal/helpers/stopped_next_test.go
+++ b/umh-core/pkg/fsmv2/internal/helpers/stopped_next_test.go
@@ -1,0 +1,163 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helpers_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/config"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/internal/helpers"
+)
+
+// stoppedNextStubConfig is a minimal TConfig that embeds BaseUserSpec so it
+// satisfies the GetState() interface used by WorkerSnapshot.ShouldStop.
+type stoppedNextStubConfig struct {
+	config.BaseUserSpec
+}
+
+// stoppedNextStubStatus is an empty TStatus for the snapshot.
+type stoppedNextStubStatus struct{}
+
+// stoppedNextStubState is a minimal fsmv2.State[any, any] used as the
+// `s` (self) and `nextState` parameters in StoppedNext tests.
+type stoppedNextStubState struct {
+	helpers.StoppedBase
+	name string
+}
+
+func (s *stoppedNextStubState) Next(any) fsmv2.NextResult[any, any] {
+	return fsmv2.NextResult[any, any]{}
+}
+
+func (s *stoppedNextStubState) String() string {
+	return s.name
+}
+
+// stoppedNextRunningStub stands in for the "advance to nextState" target.
+// It uses RunningHealthyBase to be distinguishable from the self state.
+type stoppedNextRunningStub struct {
+	helpers.RunningHealthyBase
+	name string
+}
+
+func (s *stoppedNextRunningStub) Next(any) fsmv2.NextResult[any, any] {
+	return fsmv2.NextResult[any, any]{}
+}
+
+func (s *stoppedNextRunningStub) String() string {
+	return s.name
+}
+
+// makeSnap builds a WorkerSnapshot with the given desired flags and
+// config-level state for use in StoppedNext branch tests.
+func makeSnap(beingRemoved, disabled bool, configState string) fsmv2.WorkerSnapshot[stoppedNextStubConfig, stoppedNextStubStatus] {
+	cfg := stoppedNextStubConfig{
+		BaseUserSpec: config.BaseUserSpec{State: configState},
+	}
+	wrapped := fsmv2.WrappedDesiredState[stoppedNextStubConfig]{
+		Config:   cfg,
+		Disabled: disabled,
+	}
+	wrapped.SetBeingRemoved(beingRemoved)
+
+	return fsmv2.WorkerSnapshot[stoppedNextStubConfig, stoppedNextStubStatus]{
+		Desired: wrapped,
+	}
+}
+
+var _ = Describe("StoppedNext", func() {
+	var (
+		self     *stoppedNextStubState
+		next     *stoppedNextRunningStub
+		advanced = "user wants worker running"
+	)
+
+	BeforeEach(func() {
+		self = &stoppedNextStubState{name: "Stopped"}
+		next = &stoppedNextRunningStub{name: "Running"}
+	})
+
+	Context("when IsBeingRemoved=true", func() {
+		It("emits SignalNeedsRemoval and stays in self", func() {
+			snap := makeSnap(true, false, config.DesiredStateRunning)
+
+			res := helpers.StoppedNext(self, snap, next, advanced)
+
+			Expect(res.Signal).To(Equal(fsmv2.SignalNeedsRemoval))
+			Expect(res.State).To(BeIdenticalTo(fsmv2.State[any, any](self)))
+			Expect(res.Action).To(BeNil())
+			Expect(res.Reason).To(ContainSubstring("removal"))
+		})
+
+		It("takes precedence over IsDisabled and Config-stopped", func() {
+			snap := makeSnap(true, true, config.DesiredStateStopped)
+
+			res := helpers.StoppedNext(self, snap, next, advanced)
+
+			Expect(res.Signal).To(Equal(fsmv2.SignalNeedsRemoval))
+			Expect(res.State).To(BeIdenticalTo(fsmv2.State[any, any](self)))
+		})
+	})
+
+	Context("when ShouldStop()=false (running, not removed, not disabled)", func() {
+		It("advances to nextState with the supplied reason", func() {
+			snap := makeSnap(false, false, config.DesiredStateRunning)
+
+			res := helpers.StoppedNext(self, snap, next, advanced)
+
+			Expect(res.Signal).To(Equal(fsmv2.SignalNone))
+			Expect(res.State).To(BeIdenticalTo(fsmv2.State[any, any](next)))
+			Expect(res.Action).To(BeNil())
+			Expect(res.Reason).To(Equal(advanced))
+		})
+
+		It("advances even when config state is empty (defaults to running)", func() {
+			snap := makeSnap(false, false, "")
+
+			res := helpers.StoppedNext(self, snap, next, advanced)
+
+			Expect(res.Signal).To(Equal(fsmv2.SignalNone))
+			Expect(res.State).To(BeIdenticalTo(fsmv2.State[any, any](next)))
+		})
+	})
+
+	Context("when IsDisabled=true (transient parent-disable)", func() {
+		It("stays in self with no signal", func() {
+			snap := makeSnap(false, true, config.DesiredStateRunning)
+
+			res := helpers.StoppedNext(self, snap, next, advanced)
+
+			Expect(res.Signal).To(Equal(fsmv2.SignalNone))
+			Expect(res.State).To(BeIdenticalTo(fsmv2.State[any, any](self)))
+			Expect(res.Action).To(BeNil())
+			Expect(res.Reason).To(Equal("worker is stopped"))
+		})
+	})
+
+	Context("when Config.GetState()==stopped (user-driven stop)", func() {
+		It("stays in self with no signal", func() {
+			snap := makeSnap(false, false, config.DesiredStateStopped)
+
+			res := helpers.StoppedNext(self, snap, next, advanced)
+
+			Expect(res.Signal).To(Equal(fsmv2.SignalNone))
+			Expect(res.State).To(BeIdenticalTo(fsmv2.State[any, any](self)))
+			Expect(res.Action).To(BeNil())
+			Expect(res.Reason).To(Equal("worker is stopped"))
+		})
+	})
+})

--- a/umh-core/pkg/fsmv2/internal/validator/doc.go
+++ b/umh-core/pkg/fsmv2/internal/validator/doc.go
@@ -23,7 +23,7 @@
 //   - State structs (empty fields, base embedding, String/Reason methods)
 //   - Action structs (stateless, context cancellation, no channels)
 //   - Worker files (DeriveDesiredState purity, dependency validation)
-//   - Snapshot files (CollectedAt timestamp, IsShutdownRequested method)
+//   - Snapshot files (CollectedAt timestamp, IsBeingRemoved method)
 //
 // # Pattern registry
 //

--- a/umh-core/pkg/fsmv2/observation.go
+++ b/umh-core/pkg/fsmv2/observation.go
@@ -147,8 +147,8 @@ type Observation[TStatus any] struct {
 	ChildrenHealthy int `json:"children_healthy"`
 	// ChildrenUnhealthy is the count of unhealthy children.
 	ChildrenUnhealthy int `json:"children_unhealthy"`
-	// ShutdownRequested mirrors the desired state's shutdown flag.
-	ShutdownRequested bool `json:"ShutdownRequested"` //nolint:tagliatelle // Match existing API field name
+	// BeingRemoved mirrors the desired state's shutdown flag.
+	BeingRemoved bool `json:"isBeingRemoved"` //nolint:tagliatelle // Match existing API field name
 }
 
 // observationFrameworkFields is the shared alias type used by MarshalJSON and UnmarshalJSON
@@ -166,7 +166,7 @@ type observationFrameworkFields struct {
 	deps.MetricsEmbedder
 	ChildrenHealthy   int  `json:"children_healthy"`
 	ChildrenUnhealthy int  `json:"children_unhealthy"`
-	ShutdownRequested bool `json:"ShutdownRequested"` //nolint:tagliatelle
+	BeingRemoved bool `json:"isBeingRemoved"` //nolint:tagliatelle
 }
 
 // MarshalJSON produces flat JSON with framework fields and TStatus fields at the same level.
@@ -176,7 +176,7 @@ func (o Observation[TStatus]) MarshalJSON() ([]byte, error) {
 		CollectedAt:       o.CollectedAt,
 		ChildrenView:      o.ChildrenView,
 		State:             o.State,
-		ShutdownRequested: o.ShutdownRequested,
+		BeingRemoved:      o.BeingRemoved,
 		LastActionResults: o.LastActionResults,
 		ChildrenHealthy:   o.ChildrenHealthy,
 		ChildrenUnhealthy: o.ChildrenUnhealthy,
@@ -228,7 +228,7 @@ func (o *Observation[TStatus]) UnmarshalJSON(data []byte) error {
 	o.CollectedAt = fw.CollectedAt
 	o.ChildrenView = fw.ChildrenView
 	o.State = fw.State
-	o.ShutdownRequested = fw.ShutdownRequested
+	o.BeingRemoved = fw.BeingRemoved
 	o.LastActionResults = fw.LastActionResults
 	o.ChildrenHealthy = fw.ChildrenHealthy
 	o.ChildrenUnhealthy = fw.ChildrenUnhealthy
@@ -278,11 +278,11 @@ func (o Observation[TStatus]) SetState(s string) ObservedState {
 	return o
 }
 
-// SetShutdownRequested sets the shutdown requested flag. Matches collector pattern:
+// SetBeingRemoved sets the shutdown requested flag. Matches collector pattern:
 //
-//	interface{ SetShutdownRequested(bool) fsmv2.ObservedState }
-func (o Observation[TStatus]) SetShutdownRequested(v bool) ObservedState {
-	o.ShutdownRequested = v
+//	interface{ SetBeingRemoved(bool) fsmv2.ObservedState }
+func (o Observation[TStatus]) SetBeingRemoved(v bool) ObservedState {
+	o.BeingRemoved = v
 
 	return o
 }

--- a/umh-core/pkg/fsmv2/observation_test.go
+++ b/umh-core/pkg/fsmv2/observation_test.go
@@ -71,9 +71,9 @@ var _ = Describe("Observation", func() {
 			Expect(ok).To(BeTrue(), "must satisfy SetState duck-type")
 
 			_, ok = obs.(interface {
-				SetShutdownRequested(bool) fsmv2.ObservedState
+				SetBeingRemoved(bool) fsmv2.ObservedState
 			})
-			Expect(ok).To(BeTrue(), "must satisfy SetShutdownRequested duck-type")
+			Expect(ok).To(BeTrue(), "must satisfy SetBeingRemoved duck-type")
 
 			_, ok = obs.(interface {
 				SetChildrenCounts(int, int) fsmv2.ObservedState
@@ -115,21 +115,21 @@ var _ = Describe("Observation", func() {
 			Expect(obs.State).To(Equal("stopped"))
 		})
 
-		It("SetShutdownRequested matches collector pattern and returns modified copy", func() {
-			obs := fsmv2.Observation[TestStatus]{ShutdownRequested: false}
+		It("SetBeingRemoved matches collector pattern and returns modified copy", func() {
+			obs := fsmv2.Observation[TestStatus]{BeingRemoved: false}
 			var asAny fsmv2.ObservedState = obs
 
 			setter, ok := asAny.(interface {
-				SetShutdownRequested(bool) fsmv2.ObservedState
+				SetBeingRemoved(bool) fsmv2.ObservedState
 			})
-			Expect(ok).To(BeTrue(), "must satisfy collector SetShutdownRequested duck-type")
+			Expect(ok).To(BeTrue(), "must satisfy collector SetBeingRemoved duck-type")
 
-			result := setter.SetShutdownRequested(true)
+			result := setter.SetBeingRemoved(true)
 			typed := result.(fsmv2.Observation[TestStatus])
-			Expect(typed.ShutdownRequested).To(BeTrue())
+			Expect(typed.BeingRemoved).To(BeTrue())
 
 			// Original unchanged.
-			Expect(obs.ShutdownRequested).To(BeFalse())
+			Expect(obs.BeingRemoved).To(BeFalse())
 		})
 
 		It("SetChildrenCounts matches collector pattern and returns modified copy", func() {
@@ -294,7 +294,7 @@ var _ = Describe("Observation", func() {
 			original := fsmv2.Observation[TestStatus]{
 				CollectedAt:       time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
 				State:             "running",
-				ShutdownRequested: true,
+				BeingRemoved:      true,
 				ChildrenHealthy:   3,
 				ChildrenUnhealthy: 1,
 				LastActionResults: []deps.ActionResult{
@@ -326,7 +326,7 @@ var _ = Describe("Observation", func() {
 			// Framework fields
 			Expect(restored.CollectedAt).To(Equal(original.CollectedAt))
 			Expect(restored.State).To(Equal("running"))
-			Expect(restored.ShutdownRequested).To(BeTrue())
+			Expect(restored.BeingRemoved).To(BeTrue())
 			Expect(restored.ChildrenHealthy).To(Equal(3))
 			Expect(restored.ChildrenUnhealthy).To(Equal(1))
 
@@ -347,18 +347,18 @@ var _ = Describe("Observation", func() {
 			Expect(restored.Metrics.Worker.Gauges["latency"]).To(Equal(1.5))
 		})
 
-		It("includes ShutdownRequested=false in JSON (not omitted)", func() {
+		It("includes isBeingRemoved=false in JSON (not omitted)", func() {
 			obs := fsmv2.Observation[TestStatus]{
-				State:             "stopped",
-				ShutdownRequested: false,
+				State:        "stopped",
+				BeingRemoved: false,
 			}
 
 			data, err := json.Marshal(obs)
 			Expect(err).NotTo(HaveOccurred())
 
-			// ShutdownRequested intentionally has no omitempty — false must appear in wire format.
-			Expect(strings.Contains(string(data), `"ShutdownRequested":false`)).To(BeTrue(),
-				"ShutdownRequested=false must be present in JSON, got: %s", string(data))
+			// BeingRemoved intentionally has no omitempty — false must appear in wire format.
+			Expect(strings.Contains(string(data), `"isBeingRemoved":false`)).To(BeTrue(),
+				"isBeingRemoved=false must be present in JSON, got: %s", string(data))
 		})
 
 		It("includes MetricsEmbedder fields at top level with correct values", func() {

--- a/umh-core/pkg/fsmv2/supervisor/api.go
+++ b/umh-core/pkg/fsmv2/supervisor/api.go
@@ -207,7 +207,13 @@ func (s *Supervisor[TObserved, TDesired]) AddWorker(identity deps.Identity, work
 				return true
 			}
 
-			return desired.IsShutdownRequested()
+			if ds, ok := any(desired).(fsmv2.DesiredState); ok {
+				return ds.IsBeingRemoved()
+			}
+			if ds, ok := any(&desired).(fsmv2.DesiredState); ok {
+				return ds.IsBeingRemoved()
+			}
+			return false
 		},
 		// A child is healthy ONLY if in PhaseRunningHealthy (fully stable).
 		// PhaseRunningDegraded is operational but NOT healthy.

--- a/umh-core/pkg/fsmv2/supervisor/api_boundary_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/api_boundary_test.go
@@ -119,7 +119,7 @@ var _ = Describe("Supervisor API Boundary", func() {
 		It("should NOT export signal processing methods", func() {
 			internalMethods := []string{
 				"processSignal",
-				// Note: RequestShutdown is now intentionally exported via SupervisorInterface
+				// Note: RequestRemoval is now intentionally exported via SupervisorInterface
 				// to support graceful shutdown of child supervisors
 			}
 

--- a/umh-core/pkg/fsmv2/supervisor/derive_desired_state_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/derive_desired_state_test.go
@@ -191,11 +191,11 @@ var _ = Describe("DeriveDesiredState saves to store", func() {
 			"SaveDesired (index %d) should be called BEFORE LoadSnapshot (index %d)", saveIdx, loadIdx)
 	})
 
-	It("should save derived state with ShutdownRequested field", func() {
+	It("should save derived state with IsBeingRemoved field", func() {
 		var savedShutdown interface{}
 
 		store.saveDesired = func(ctx context.Context, wt string, id string, desired persistence.Document) error {
-			savedShutdown = desired["ShutdownRequested"]
+			savedShutdown = desired["isBeingRemoved"]
 			if store.desired[wt] == nil {
 				store.desired[wt] = make(map[string]persistence.Document)
 			}
@@ -227,7 +227,7 @@ var _ = Describe("DeriveDesiredState saves to store", func() {
 			}, nil
 		}
 
-		// Create a simple worker that returns default desired state (ShutdownRequested=false).
+		// Create a simple worker that returns default desired state (IsBeingRemoved=false).
 		worker := &mockWorker{
 			observed: &mockObservedState{
 				ID:          workerID,
@@ -256,7 +256,7 @@ var _ = Describe("DeriveDesiredState saves to store", func() {
 		err = s.TestTick(ctx)
 		Expect(err).ToNot(HaveOccurred())
 
-		// mockWorker.DeriveDesiredState returns config.DesiredState{} (ShutdownRequested=false).
+		// mockWorker.DeriveDesiredState returns config.DesiredState{} (IsBeingRemoved=false).
 		Expect(savedShutdown).To(Equal(false))
 	})
 })

--- a/umh-core/pkg/fsmv2/supervisor/doc.go
+++ b/umh-core/pkg/fsmv2/supervisor/doc.go
@@ -420,7 +420,7 @@
 //
 // # Best practices
 //
-//   - Check IsShutdownRequested() as first condition in state.Next()
+//   - Check IsBeingRemoved as first condition in state.Next()
 //   - Make all actions idempotent (check if work already done)
 //   - Children are always-enabled when the parent is running; use
 //     ChildSpec.Enabled=false to deliberately disable a resident child

--- a/umh-core/pkg/fsmv2/supervisor/doc.go
+++ b/umh-core/pkg/fsmv2/supervisor/doc.go
@@ -203,7 +203,7 @@
 //
 // SignalNeedsRestart:
 //   - Marks for restart (pendingRestart flag)
-//   - Requests graceful shutdown via requestShutdown()
+//   - Requests graceful shutdown via requestRemoval()
 //   - Worker goes through shutdown states, emits SignalNeedsRemoval
 //   - On SignalNeedsRemoval: restarts instead of removes
 //

--- a/umh-core/pkg/fsmv2/supervisor/document_fields.go
+++ b/umh-core/pkg/fsmv2/supervisor/document_fields.go
@@ -29,14 +29,14 @@ const (
 	// FieldWorkerType is the worker type designation.
 	FieldWorkerType = "worker_type"
 
-	// FieldShutdownRequested is the graceful shutdown signal.
+	// FieldIsBeingRemoved is the graceful shutdown signal.
 	// Set in desired documents to request FSM shutdown.
-	// PascalCase matches struct tag: `json:"ShutdownRequested"`.
-	FieldShutdownRequested = "ShutdownRequested"
+	// PascalCase matches struct tag: `json:"isBeingRemoved"`.
+	FieldIsBeingRemoved = "isBeingRemoved"
 
 	// FieldIsDisabled is the transient parent-disable signal.
 	// Set in desired documents by the CHANGE-19 reducer when a parent flips
-	// ChildSpec.Enabled=false. Distinct from FieldShutdownRequested (permanent
+	// ChildSpec.Enabled=false. Distinct from FieldIsBeingRemoved (permanent
 	// removal): IsDisabled drives ShouldStop without signalling NeedsRemoval.
 	// camelCase matches struct tag: `json:"isDisabled,omitempty"`.
 	FieldIsDisabled = "isDisabled"

--- a/umh-core/pkg/fsmv2/supervisor/document_fields.go
+++ b/umh-core/pkg/fsmv2/supervisor/document_fields.go
@@ -34,6 +34,13 @@ const (
 	// PascalCase matches struct tag: `json:"ShutdownRequested"`.
 	FieldShutdownRequested = "ShutdownRequested"
 
+	// FieldIsDisabled is the transient parent-disable signal.
+	// Set in desired documents by the CHANGE-19 reducer when a parent flips
+	// ChildSpec.Enabled=false. Distinct from FieldShutdownRequested (permanent
+	// removal): IsDisabled drives ShouldStop without signalling NeedsRemoval.
+	// camelCase matches struct tag: `json:"isDisabled,omitempty"`.
+	FieldIsDisabled = "isDisabled"
+
 	// FieldParentID is the parent supervisor ID (renamed from "bridged_by").
 	FieldParentID = "parent_id"
 )

--- a/umh-core/pkg/fsmv2/supervisor/edge_cases_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/edge_cases_test.go
@@ -44,7 +44,7 @@ var _ = Describe("Edge Cases", func() {
 		})
 	})
 
-	Describe("RequestShutdown", func() {
+	Describe("RequestRemoval", func() {
 		Context("when shutdown is requested", func() {
 			It("should save desired state with shutdown flag", func() {
 				mockStore := newMockTriangularStore()
@@ -79,7 +79,7 @@ var _ = Describe("Edge Cases", func() {
 				err = s.AddWorker(identity, worker)
 				Expect(err).ToNot(HaveOccurred())
 
-				err = s.TestRequestShutdown(context.Background(), identity.ID, "test reason")
+				err = s.TestRequestRemoval(context.Background(), identity.ID, "test reason")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(mockStore.SaveDesiredCalled).To(BeNumerically(">", 1))
 			})
@@ -101,8 +101,8 @@ var _ = Describe("Edge Cases", func() {
 					},
 				})
 
-				// Don't add worker - test that requestShutdown fails for non-existent worker
-				err := s.TestRequestShutdown(context.Background(), identity.ID, "test reason")
+				// Don't add worker - test that requestRemoval fails for non-existent worker
+				err := s.TestRequestRemoval(context.Background(), identity.ID, "test reason")
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("not found"))
 			})
@@ -439,7 +439,7 @@ var _ = Describe("Edge Cases", func() {
 		})
 	})
 
-	Describe("RequestShutdown with valid worker", func() {
+	Describe("RequestRemoval with valid worker", func() {
 		Context("when worker exists", func() {
 			It("should set IsBeingRemoved in persistence when desired state exists", func() {
 				mockStore := newMockTriangularStore()
@@ -453,7 +453,7 @@ var _ = Describe("Edge Cases", func() {
 				err := mockStore.SaveIdentity(context.Background(), "container", identity.ID, identityDoc)
 				Expect(err).ToNot(HaveOccurred())
 
-				// Save a desired state that requestShutdown can load and modify
+				// Save a desired state that requestRemoval can load and modify
 				// Note: JSON key is "isBeingRemoved" (PascalCase) per the struct tag in testutil.DesiredState
 				desiredDoc := persistence.Document{
 					"isBeingRemoved": false,
@@ -475,8 +475,8 @@ var _ = Describe("Edge Cases", func() {
 				err = s.AddWorker(identity, worker)
 				Expect(err).ToNot(HaveOccurred())
 
-				// RequestShutdown should succeed and update persistence
-				err = s.TestRequestShutdown(context.Background(), identity.ID, "test reason")
+				// RequestRemoval should succeed and update persistence
+				err = s.TestRequestRemoval(context.Background(), identity.ID, "test reason")
 				Expect(err).ToNot(HaveOccurred())
 
 				// Verify IsBeingRemoved was set in the store
@@ -501,7 +501,7 @@ var _ = Describe("Edge Cases", func() {
 				err := mockStore.SaveIdentity(context.Background(), "container", identity.ID, identityDoc)
 				Expect(err).ToNot(HaveOccurred())
 
-				// Don't save any desired state - requestShutdown should return nil
+				// Don't save any desired state - requestRemoval should return nil
 
 				s := supervisor.NewSupervisor[*supervisor.TestObservedState, *supervisor.TestDesiredState](supervisor.Config{
 					WorkerType: "container",
@@ -517,8 +517,8 @@ var _ = Describe("Edge Cases", func() {
 				err = s.AddWorker(identity, worker)
 				Expect(err).ToNot(HaveOccurred())
 
-				// RequestShutdown should return nil when no desired state exists
-				err = s.TestRequestShutdown(context.Background(), identity.ID, "test reason")
+				// RequestRemoval should return nil when no desired state exists
+				err = s.TestRequestRemoval(context.Background(), identity.ID, "test reason")
 				Expect(err).ToNot(HaveOccurred())
 			})
 		})

--- a/umh-core/pkg/fsmv2/supervisor/edge_cases_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/edge_cases_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Edge Cases", func() {
 
 				desiredDoc := persistence.Document{
 					"id":                identity.ID,
-					"ShutdownRequested": false,
+					"isBeingRemoved": false,
 				}
 				_, err = mockStore.SaveDesired(context.Background(), "container", identity.ID, desiredDoc)
 				Expect(err).ToNot(HaveOccurred())
@@ -283,7 +283,7 @@ var _ = Describe("Edge Cases", func() {
 
 				desiredDoc := persistence.Document{
 					"id":                identity.ID,
-					"ShutdownRequested": false,
+					"isBeingRemoved": false,
 				}
 				_, err = mockStore.SaveDesired(context.Background(), "container", identity.ID, desiredDoc)
 				Expect(err).ToNot(HaveOccurred())
@@ -441,7 +441,7 @@ var _ = Describe("Edge Cases", func() {
 
 	Describe("RequestShutdown with valid worker", func() {
 		Context("when worker exists", func() {
-			It("should set ShutdownRequested in persistence when desired state exists", func() {
+			It("should set IsBeingRemoved in persistence when desired state exists", func() {
 				mockStore := newMockTriangularStore()
 
 				identity := mockIdentity()
@@ -454,9 +454,9 @@ var _ = Describe("Edge Cases", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				// Save a desired state that requestShutdown can load and modify
-				// Note: JSON key is "ShutdownRequested" (PascalCase) per the struct tag in testutil.DesiredState
+				// Note: JSON key is "isBeingRemoved" (PascalCase) per the struct tag in testutil.DesiredState
 				desiredDoc := persistence.Document{
-					"ShutdownRequested": false,
+					"isBeingRemoved": false,
 				}
 				_, err = mockStore.SaveDesired(context.Background(), "container", identity.ID, desiredDoc)
 				Expect(err).ToNot(HaveOccurred())
@@ -479,12 +479,12 @@ var _ = Describe("Edge Cases", func() {
 				err = s.TestRequestShutdown(context.Background(), identity.ID, "test reason")
 				Expect(err).ToNot(HaveOccurred())
 
-				// Verify ShutdownRequested was set in the store
+				// Verify IsBeingRemoved was set in the store
 				savedDesired, loadErr := mockStore.LoadDesired(context.Background(), "container", identity.ID)
 				Expect(loadErr).ToNot(HaveOccurred())
 				savedDoc, ok := savedDesired.(persistence.Document)
 				Expect(ok).To(BeTrue())
-				Expect(savedDoc["ShutdownRequested"]).To(BeTrue())
+				Expect(savedDoc["isBeingRemoved"]).To(BeTrue())
 			})
 		})
 
@@ -540,7 +540,7 @@ var _ = Describe("Edge Cases", func() {
 
 				desiredDoc := persistence.Document{
 					"id":                identity.ID,
-					"ShutdownRequested": false,
+					"isBeingRemoved": false,
 				}
 				_, err = mockStore.SaveDesired(context.Background(), "container", identity.ID, desiredDoc)
 				Expect(err).ToNot(HaveOccurred())
@@ -644,7 +644,7 @@ var _ = Describe("Type Safety (Invariant I16)", func() {
 
 				desiredDoc := persistence.Document{
 					"id":                identity.ID,
-					"ShutdownRequested": false,
+					"isBeingRemoved": false,
 				}
 				_, err = mockStore.SaveDesired(context.Background(), "container", identity.ID, desiredDoc)
 				Expect(err).ToNot(HaveOccurred())
@@ -693,7 +693,7 @@ var _ = Describe("Type Safety (Invariant I16)", func() {
 
 				desiredDoc := persistence.Document{
 					"id":                identity.ID,
-					"ShutdownRequested": false,
+					"isBeingRemoved": false,
 				}
 				_, err = mockStore.SaveDesired(context.Background(), "container", identity.ID, desiredDoc)
 				Expect(err).ToNot(HaveOccurred())

--- a/umh-core/pkg/fsmv2/supervisor/hierarchical_tick_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/hierarchical_tick_test.go
@@ -130,7 +130,7 @@ var _ = Describe("Hierarchical Tick Propagation (Task 0.6)", func() {
 
 			desiredDoc := persistence.Document{
 				"id":                identity.ID,
-				"ShutdownRequested": false,
+				"isBeingRemoved": false,
 			}
 			_, err = mockStore.SaveDesired(ctx, "parent", identity.ID, desiredDoc)
 			Expect(err).NotTo(HaveOccurred())
@@ -184,7 +184,7 @@ var _ = Describe("Hierarchical Tick Propagation (Task 0.6)", func() {
 
 			desiredDoc := persistence.Document{
 				"id":                identity.ID,
-				"ShutdownRequested": false,
+				"isBeingRemoved": false,
 			}
 			_, err = mockStore.SaveDesired(ctx, "parent", identity.ID, desiredDoc)
 			Expect(err).NotTo(HaveOccurred())
@@ -242,7 +242,7 @@ var _ = Describe("Hierarchical Tick Propagation (Task 0.6)", func() {
 
 			desiredDoc := persistence.Document{
 				"id":                identity.ID,
-				"ShutdownRequested": false,
+				"isBeingRemoved": false,
 			}
 			_, err = mockStore.SaveDesired(ctx, "parent", identity.ID, desiredDoc)
 			Expect(err).NotTo(HaveOccurred())
@@ -296,7 +296,7 @@ var _ = Describe("Hierarchical Tick Propagation (Task 0.6)", func() {
 
 			desiredDoc := persistence.Document{
 				"id":                identity.ID,
-				"ShutdownRequested": false,
+				"isBeingRemoved": false,
 			}
 			_, err = mockStore.SaveDesired(ctx, "parent", identity.ID, desiredDoc)
 			Expect(err).NotTo(HaveOccurred())
@@ -353,7 +353,7 @@ var _ = Describe("Hierarchical Tick Propagation (Task 0.6)", func() {
 
 			desiredDoc := persistence.Document{
 				"id":                identity.ID,
-				"ShutdownRequested": false,
+				"isBeingRemoved": false,
 			}
 			_, err = mockStore.SaveDesired(ctx, "parent", identity.ID, desiredDoc)
 			Expect(err).NotTo(HaveOccurred())
@@ -410,7 +410,7 @@ var _ = Describe("Hierarchical Tick Propagation (Task 0.6)", func() {
 
 			desiredDoc := persistence.Document{
 				"id":                identity.ID,
-				"ShutdownRequested": false,
+				"isBeingRemoved": false,
 			}
 			_, err = mockStore.SaveDesired(ctx, "parent", identity.ID, desiredDoc)
 			Expect(err).NotTo(HaveOccurred())

--- a/umh-core/pkg/fsmv2/supervisor/integration_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/integration_test.go
@@ -35,7 +35,7 @@ var _ = Describe("DataFreshness Full Cycle Integration", func() {
 			collectFunc: func(ctx context.Context) (fsmv2.ObservedState, error) {
 				return &mockObservedState{CollectedAt: snapshotTimestamp}, nil
 			},
-			requestShutdownFunc: func() {
+			requestRemovalFunc: func() {
 				shutdownRequested = true
 			},
 		}
@@ -45,7 +45,7 @@ var _ = Describe("DataFreshness Full Cycle Integration", func() {
 		store := newMockStore()
 
 		// Initialize the desired state in the store's internal map
-		// This is required because RequestShutdown calls LoadDesired first
+		// This is required because RequestRemoval calls LoadDesired first
 		if store.desired["test"] == nil {
 			store.desired["test"] = make(map[string]persistence.Document)
 		}

--- a/umh-core/pkg/fsmv2/supervisor/integration_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/integration_test.go
@@ -51,7 +51,7 @@ var _ = Describe("DataFreshness Full Cycle Integration", func() {
 		}
 		store.desired["test"]["test-worker"] = persistence.Document{
 			"id":                "test-worker",
-			"ShutdownRequested": false,
+			"isBeingRemoved": false,
 		}
 
 		// Initialize the observed state in the store's internal map
@@ -73,7 +73,7 @@ var _ = Describe("DataFreshness Full Cycle Integration", func() {
 
 			desired := persistence.Document{
 				"id":                "test-worker",
-				"ShutdownRequested": shutdownRequested,
+				"isBeingRemoved": shutdownRequested,
 			}
 
 			observed := persistence.Document{
@@ -94,7 +94,7 @@ var _ = Describe("DataFreshness Full Cycle Integration", func() {
 			store.desired[workerType][id] = desired
 
 			// Update closure variable for test assertions
-			if shutdown, ok := desired["ShutdownRequested"].(bool); ok {
+			if shutdown, ok := desired["isBeingRemoved"].(bool); ok {
 				shutdownRequested = shutdown
 			}
 

--- a/umh-core/pkg/fsmv2/supervisor/internal/collection/collector.go
+++ b/umh-core/pkg/fsmv2/supervisor/internal/collection/collector.go
@@ -457,9 +457,9 @@ func (c *Collector[TObserved]) collectAndSaveObservedState(ctx context.Context) 
 	if c.config.ShutdownRequestedProvider != nil {
 		shutdownRequested := c.config.ShutdownRequestedProvider()
 		if setter, ok := observed.(interface {
-			SetShutdownRequested(bool) fsmv2.ObservedState
+			SetBeingRemoved(bool) fsmv2.ObservedState
 		}); ok {
-			observed = setter.SetShutdownRequested(shutdownRequested)
+			observed = setter.SetBeingRemoved(shutdownRequested)
 		}
 	}
 

--- a/umh-core/pkg/fsmv2/supervisor/lifecycle.go
+++ b/umh-core/pkg/fsmv2/supervisor/lifecycle.go
@@ -449,9 +449,9 @@ func (s *Supervisor[TObserved, TDesired]) requestShutdown(ctx context.Context, w
 	// Guard against log flood: return early if shutdown is already requested.
 	// The reducer calls this every tick for every Enabled=false child, so logging
 	// unconditionally would produce ~100 Info lines/sec per disabled child.
-	if ds, ok := any(desired).(fsmv2.DesiredState); ok && ds.IsShutdownRequested() {
+	if ds, ok := any(desired).(fsmv2.DesiredState); ok && ds.IsBeingRemoved() {
 		return nil
-	} else if ds, ok := any(&desired).(fsmv2.DesiredState); ok && ds.IsShutdownRequested() {
+	} else if ds, ok := any(&desired).(fsmv2.DesiredState); ok && ds.IsBeingRemoved() {
 		return nil
 	}
 
@@ -459,13 +459,13 @@ func (s *Supervisor[TObserved, TDesired]) requestShutdown(ctx context.Context, w
 		deps.String("worker_id", workerID),
 		deps.Reason(reason))
 
-	// Set ShutdownRequested=true using the ShutdownRequestable interface
-	if sr, ok := any(desired).(fsmv2.ShutdownRequestable); ok {
-		sr.SetShutdownRequested(true)
-	} else if sr, ok := any(&desired).(fsmv2.ShutdownRequestable); ok {
-		sr.SetShutdownRequested(true)
+	// Set IsBeingRemoved=true using the RemovalRequestable interface
+	if sr, ok := any(desired).(fsmv2.RemovalRequestable); ok {
+		sr.SetBeingRemoved(true)
+	} else if sr, ok := any(&desired).(fsmv2.RemovalRequestable); ok {
+		sr.SetBeingRemoved(true)
 	} else {
-		return fmt.Errorf("desired state type %T does not implement ShutdownRequestable", desired)
+		return fmt.Errorf("desired state type %T does not implement RemovalRequestable", desired)
 	}
 
 	desiredJSON, err := json.Marshal(desired)
@@ -489,7 +489,7 @@ func (s *Supervisor[TObserved, TDesired]) requestShutdown(ctx context.Context, w
 	return nil
 }
 
-// RequestShutdown sets ShutdownRequested=true on all workers in this supervisor.
+// RequestShutdown sets IsBeingRemoved=true on all workers in this supervisor.
 // Workers continue ticking and can complete their FSM shutdown transitions.
 // This does NOT cancel the context - use Shutdown() for forced stop.
 //
@@ -525,7 +525,7 @@ func (s *Supervisor[TObserved, TDesired]) RequestShutdown(ctx context.Context, r
 //
 // Flow:
 //  1. RemoveWorker - stops collector, executor, removes from registry
-//  2. Clear ShutdownRequested in storage (so new worker starts fresh)
+//  2. Clear IsBeingRemoved in storage (so new worker starts fresh)
 //  3. factory.NewWorkerByType - creates completely new worker instance
 //  4. AddWorker - registers new worker
 //  5. Start collector and executor if supervisor is running
@@ -572,7 +572,7 @@ func (s *Supervisor[TObserved, TDesired]) handleWorkerRestart(ctx context.Contex
 		deps.HierarchyPath(identity.HierarchyPath))
 
 	// 2. Clear shutdown flag in storage BEFORE creating new worker.
-	if err := s.clearShutdownRequested(ctx, workerID); err != nil {
+	if err := s.clearIsBeingRemoved(ctx, workerID); err != nil {
 		s.logger.SentryWarn(deps.FeatureFSMv2, identity.HierarchyPath, "restart_clear_shutdown_failed",
 			deps.Err(err))
 		// Continue anyway - the new worker might still work
@@ -649,7 +649,7 @@ func (s *Supervisor[TObserved, TDesired]) handleWorkerRestart(ctx context.Contex
 	return nil
 }
 
-// ClearShutdownRequest clears IsShutdownRequested on all workers in this supervisor.
+// ClearShutdownRequest clears IsBeingRemoved on all workers in this supervisor.
 // Sibling of RequestShutdown. Used by the CHANGE-19 reducer to flip a
 // previously-disabled child back to enabled state.
 func (s *Supervisor[TObserved, TDesired]) ClearShutdownRequest(ctx context.Context) error {
@@ -663,7 +663,7 @@ func (s *Supervisor[TObserved, TDesired]) ClearShutdownRequest(ctx context.Conte
 	s.mu.RUnlock()
 
 	for _, id := range workerIDs {
-		if err := s.clearShutdownRequested(ctx, id); err != nil {
+		if err := s.clearIsBeingRemoved(ctx, id); err != nil {
 			return fmt.Errorf("clear shutdown request for %s: %w", id, err)
 		}
 	}
@@ -700,7 +700,7 @@ func (s *Supervisor[TObserved, TDesired]) SetDisabled(ctx context.Context, reaso
 
 // setDisabled writes the IsDisabled flag in storage for a single worker.
 // Mirrors requestShutdown but targets the IsDisabled signal via the Disablable
-// interface instead of IsShutdownRequested via ShutdownRequestable.
+// interface instead of IsBeingRemoved via RemovalRequestable.
 //
 //nolint:cyclop // mirrors requestShutdown structure
 func (s *Supervisor[TObserved, TDesired]) setDisabled(ctx context.Context, workerID string, reason string, disabled bool) error {
@@ -769,8 +769,8 @@ func (s *Supervisor[TObserved, TDesired]) setDisabled(ctx context.Context, worke
 	return nil
 }
 
-// clearShutdownRequested clears the ShutdownRequested flag in storage for restart.
-func (s *Supervisor[TObserved, TDesired]) clearShutdownRequested(ctx context.Context, workerID string) error {
+// clearIsBeingRemoved clears the IsBeingRemoved flag in storage for restart.
+func (s *Supervisor[TObserved, TDesired]) clearIsBeingRemoved(ctx context.Context, workerID string) error {
 	// Load current desired state
 	var desired TDesired
 	if err := s.store.LoadDesiredTyped(ctx, s.workerType, workerID, &desired); err != nil {
@@ -781,12 +781,12 @@ func (s *Supervisor[TObserved, TDesired]) clearShutdownRequested(ctx context.Con
 	}
 
 	// Clear shutdown flag via interface
-	if sr, ok := any(desired).(fsmv2.ShutdownRequestable); ok {
-		sr.SetShutdownRequested(false)
-	} else if sr, ok := any(&desired).(fsmv2.ShutdownRequestable); ok {
-		sr.SetShutdownRequested(false)
+	if sr, ok := any(desired).(fsmv2.RemovalRequestable); ok {
+		sr.SetBeingRemoved(false)
+	} else if sr, ok := any(&desired).(fsmv2.RemovalRequestable); ok {
+		sr.SetBeingRemoved(false)
 	} else {
-		return fmt.Errorf("desired state type %T does not implement ShutdownRequestable", desired)
+		return fmt.Errorf("desired state type %T does not implement RemovalRequestable", desired)
 	}
 
 	// Save back - need to convert to Document

--- a/umh-core/pkg/fsmv2/supervisor/lifecycle.go
+++ b/umh-core/pkg/fsmv2/supervisor/lifecycle.go
@@ -671,6 +671,104 @@ func (s *Supervisor[TObserved, TDesired]) ClearShutdownRequest(ctx context.Conte
 	return nil
 }
 
+// SetDisabled writes the IsDisabled flag on all workers in this supervisor.
+// Used by the CHANGE-19 reducer to translate ChildSpec.Enabled=false into a
+// transient stop. Distinct from RequestShutdown (permanent removal):
+// IsDisabled drives ShouldStop but does NOT signal NeedsRemoval, so the child
+// stays resident in its Stopped state and can resume when re-enabled.
+func (s *Supervisor[TObserved, TDesired]) SetDisabled(ctx context.Context, reason string, disabled bool) error {
+	s.mu.RLock()
+
+	workerIDs := make([]string, 0, len(s.workers))
+	for id := range s.workers {
+		workerIDs = append(workerIDs, id)
+	}
+
+	s.mu.RUnlock()
+
+	for _, id := range workerIDs {
+		if err := s.setDisabled(ctx, id, reason, disabled); err != nil {
+			s.logger.SentryWarn(deps.FeatureFSMv2, s.GetHierarchyPath(), "set_disabled_failed",
+				deps.Err(err),
+				deps.String("worker_id", id),
+				deps.Bool("disabled", disabled))
+		}
+	}
+
+	return nil
+}
+
+// setDisabled writes the IsDisabled flag in storage for a single worker.
+// Mirrors requestShutdown but targets the IsDisabled signal via the Disablable
+// interface instead of IsShutdownRequested via ShutdownRequestable.
+//
+//nolint:cyclop // mirrors requestShutdown structure
+func (s *Supervisor[TObserved, TDesired]) setDisabled(ctx context.Context, workerID string, reason string, disabled bool) error {
+	s.mu.RLock()
+	_, exists := s.workers[workerID]
+	s.mu.RUnlock()
+
+	if !exists {
+		return errors.New("worker not found")
+	}
+
+	// Load current desired state from database
+	var desired TDesired
+
+	err := s.store.LoadDesiredTyped(ctx, s.workerType, workerID, &desired)
+	if err != nil {
+		if !errors.Is(err, persistence.ErrNotFound) {
+			return fmt.Errorf("failed to load desired state: %w", err)
+		}
+		// No desired state in DB yet, nothing to update
+		return nil
+	}
+
+	// Guard against log flood and no-op writes: return early if the flag is
+	// already at the requested value. The reducer calls this every tick for
+	// every child; logging unconditionally would produce ~100 lines/sec per
+	// child.
+	if d, ok := any(desired).(fsmv2.Disablable); ok && d.IsDisabled() == disabled {
+		return nil
+	} else if d, ok := any(&desired).(fsmv2.Disablable); ok && d.IsDisabled() == disabled {
+		return nil
+	}
+
+	s.logger.Info("disabled_set",
+		deps.String("worker_id", workerID),
+		deps.Bool("disabled", disabled),
+		deps.Reason(reason))
+
+	// Set IsDisabled via the Disablable interface
+	if d, ok := any(desired).(fsmv2.Disablable); ok {
+		d.SetDisabled(disabled)
+	} else if d, ok := any(&desired).(fsmv2.Disablable); ok {
+		d.SetDisabled(disabled)
+	} else {
+		return fmt.Errorf("desired state type %T does not implement Disablable", desired)
+	}
+
+	desiredJSON, err := json.Marshal(desired)
+	if err != nil {
+		return fmt.Errorf("failed to marshal desired state: %w", err)
+	}
+
+	desiredDoc := make(persistence.Document)
+	if err := json.Unmarshal(desiredJSON, &desiredDoc); err != nil {
+		return fmt.Errorf("failed to unmarshal to document: %w", err)
+	}
+
+	// Add 'id' field required by TriangularStore validation.
+	desiredDoc[FieldID] = workerID
+
+	// Save updated desired state back to database
+	if _, err := s.store.SaveDesired(ctx, s.workerType, workerID, desiredDoc); err != nil {
+		return fmt.Errorf("failed to save desired state with disabled flag: %w", err)
+	}
+
+	return nil
+}
+
 // clearShutdownRequested clears the ShutdownRequested flag in storage for restart.
 func (s *Supervisor[TObserved, TDesired]) clearShutdownRequested(ctx context.Context, workerID string) error {
 	// Load current desired state

--- a/umh-core/pkg/fsmv2/supervisor/lifecycle.go
+++ b/umh-core/pkg/fsmv2/supervisor/lifecycle.go
@@ -256,7 +256,7 @@ func (s *Supervisor[TObserved, TDesired]) Shutdown() {
 
 		// Request graceful shutdown on all workers
 		for _, workerID := range workerIDs {
-			if err := s.requestShutdown(gracefulCtx, workerID, "supervisor_shutdown"); err != nil {
+			if err := s.requestRemoval(gracefulCtx, workerID, "supervisor_shutdown"); err != nil {
 				s.logger.SentryWarn(deps.FeatureFSMv2, s.GetHierarchyPath(), "graceful_shutdown_request_failed",
 					deps.Err(err))
 			}
@@ -425,7 +425,7 @@ func (s *Supervisor[TObserved, TDesired]) logTrace(msg string, fields ...deps.Fi
 	}
 }
 
-func (s *Supervisor[TObserved, TDesired]) requestShutdown(ctx context.Context, workerID string, reason string) error {
+func (s *Supervisor[TObserved, TDesired]) requestRemoval(ctx context.Context, workerID string, reason string) error {
 	s.mu.RLock()
 	_, exists := s.workers[workerID]
 	s.mu.RUnlock()
@@ -455,7 +455,7 @@ func (s *Supervisor[TObserved, TDesired]) requestShutdown(ctx context.Context, w
 		return nil
 	}
 
-	s.logger.Info("shutdown_requested",
+	s.logger.Info("removal_requested",
 		deps.String("worker_id", workerID),
 		deps.Reason(reason))
 
@@ -489,13 +489,13 @@ func (s *Supervisor[TObserved, TDesired]) requestShutdown(ctx context.Context, w
 	return nil
 }
 
-// RequestShutdown sets IsBeingRemoved=true on all workers in this supervisor.
+// RequestRemoval sets IsBeingRemoved=true on all workers in this supervisor.
 // Workers continue ticking and can complete their FSM shutdown transitions.
 // This does NOT cancel the context - use Shutdown() for forced stop.
 //
 // This method is used by parent supervisors to request graceful shutdown of
 // child supervisors when children are removed from ChildrenSpecs.
-func (s *Supervisor[TObserved, TDesired]) RequestShutdown(ctx context.Context, reason string) error {
+func (s *Supervisor[TObserved, TDesired]) RequestRemoval(ctx context.Context, reason string) error {
 	s.mu.RLock()
 
 	workerIDs := make([]string, 0, len(s.workers))
@@ -507,7 +507,7 @@ func (s *Supervisor[TObserved, TDesired]) RequestShutdown(ctx context.Context, r
 	s.mu.RUnlock()
 
 	for _, workerID := range workerIDs {
-		if err := s.requestShutdown(ctx, workerID, reason); err != nil {
+		if err := s.requestRemoval(ctx, workerID, reason); err != nil {
 			s.logger.SentryWarn(deps.FeatureFSMv2, s.GetHierarchyPath(), "shutdown_request_failed",
 				deps.Err(err))
 		}
@@ -572,7 +572,7 @@ func (s *Supervisor[TObserved, TDesired]) handleWorkerRestart(ctx context.Contex
 		deps.HierarchyPath(identity.HierarchyPath))
 
 	// 2. Clear shutdown flag in storage BEFORE creating new worker.
-	if err := s.clearIsBeingRemoved(ctx, workerID); err != nil {
+	if err := s.clearRemoval(ctx, workerID); err != nil {
 		s.logger.SentryWarn(deps.FeatureFSMv2, identity.HierarchyPath, "restart_clear_shutdown_failed",
 			deps.Err(err))
 		// Continue anyway - the new worker might still work
@@ -649,10 +649,10 @@ func (s *Supervisor[TObserved, TDesired]) handleWorkerRestart(ctx context.Contex
 	return nil
 }
 
-// ClearShutdownRequest clears IsBeingRemoved on all workers in this supervisor.
-// Sibling of RequestShutdown. Used by the CHANGE-19 reducer to flip a
+// ClearRemoval clears IsBeingRemoved on all workers in this supervisor.
+// Sibling of RequestRemoval. Used by the CHANGE-19 reducer to flip a
 // previously-disabled child back to enabled state.
-func (s *Supervisor[TObserved, TDesired]) ClearShutdownRequest(ctx context.Context) error {
+func (s *Supervisor[TObserved, TDesired]) ClearRemoval(ctx context.Context) error {
 	s.mu.RLock()
 
 	workerIDs := make([]string, 0, len(s.workers))
@@ -663,8 +663,8 @@ func (s *Supervisor[TObserved, TDesired]) ClearShutdownRequest(ctx context.Conte
 	s.mu.RUnlock()
 
 	for _, id := range workerIDs {
-		if err := s.clearIsBeingRemoved(ctx, id); err != nil {
-			return fmt.Errorf("clear shutdown request for %s: %w", id, err)
+		if err := s.clearRemoval(ctx, id); err != nil {
+			return fmt.Errorf("clear removal for %s: %w", id, err)
 		}
 	}
 
@@ -673,7 +673,7 @@ func (s *Supervisor[TObserved, TDesired]) ClearShutdownRequest(ctx context.Conte
 
 // SetDisabled writes the IsDisabled flag on all workers in this supervisor.
 // Used by the CHANGE-19 reducer to translate ChildSpec.Enabled=false into a
-// transient stop. Distinct from RequestShutdown (permanent removal):
+// transient stop. Distinct from RequestRemoval (permanent removal):
 // IsDisabled drives ShouldStop but does NOT signal NeedsRemoval, so the child
 // stays resident in its Stopped state and can resume when re-enabled.
 func (s *Supervisor[TObserved, TDesired]) SetDisabled(ctx context.Context, reason string, disabled bool) error {
@@ -699,10 +699,10 @@ func (s *Supervisor[TObserved, TDesired]) SetDisabled(ctx context.Context, reaso
 }
 
 // setDisabled writes the IsDisabled flag in storage for a single worker.
-// Mirrors requestShutdown but targets the IsDisabled signal via the Disablable
+// Mirrors requestRemoval but targets the IsDisabled signal via the Disablable
 // interface instead of IsBeingRemoved via RemovalRequestable.
 //
-//nolint:cyclop // mirrors requestShutdown structure
+//nolint:cyclop // mirrors requestRemoval structure
 func (s *Supervisor[TObserved, TDesired]) setDisabled(ctx context.Context, workerID string, reason string, disabled bool) error {
 	s.mu.RLock()
 	_, exists := s.workers[workerID]
@@ -769,18 +769,18 @@ func (s *Supervisor[TObserved, TDesired]) setDisabled(ctx context.Context, worke
 	return nil
 }
 
-// clearIsBeingRemoved clears the IsBeingRemoved flag in storage for restart.
-func (s *Supervisor[TObserved, TDesired]) clearIsBeingRemoved(ctx context.Context, workerID string) error {
+// clearRemoval clears the IsBeingRemoved flag in storage for restart.
+func (s *Supervisor[TObserved, TDesired]) clearRemoval(ctx context.Context, workerID string) error {
 	// Load current desired state
 	var desired TDesired
 	if err := s.store.LoadDesiredTyped(ctx, s.workerType, workerID, &desired); err != nil {
 		if errors.Is(err, persistence.ErrNotFound) {
 			return nil
 		}
-		return fmt.Errorf("load desired for clear shutdown: %w", err)
+		return fmt.Errorf("load desired for clear removal: %w", err)
 	}
 
-	// Clear shutdown flag via interface
+	// Clear removal flag via interface
 	if sr, ok := any(desired).(fsmv2.RemovalRequestable); ok {
 		sr.SetBeingRemoved(false)
 	} else if sr, ok := any(&desired).(fsmv2.RemovalRequestable); ok {

--- a/umh-core/pkg/fsmv2/supervisor/lifecycle_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/lifecycle_test.go
@@ -61,7 +61,7 @@ var _ = Describe("Supervisor Lifecycle", func() {
 	})
 
 	Describe("Tick with shutdown request error", func() {
-		Context("when RequestShutdown fails during timeout handling", func() {
+		Context("when RequestRemoval fails during timeout handling", func() {
 			It("should still return error about unresponsive collector", func() {
 				store := newMockTriangularStore()
 

--- a/umh-core/pkg/fsmv2/supervisor/lifecycle_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/lifecycle_test.go
@@ -212,7 +212,7 @@ var _ = Describe("Supervisor Lifecycle", func() {
 				var desiredState mockDesiredState
 				loadErr := store.LoadDesiredTyped(context.Background(), "test", identity.ID, &desiredState)
 				Expect(loadErr).ToNot(HaveOccurred())
-				Expect(desiredState.ShutdownRequested).To(BeTrue())
+				Expect(desiredState.IsBeingRemoved()).To(BeTrue())
 			})
 		})
 
@@ -247,7 +247,7 @@ var _ = Describe("Supervisor Lifecycle", func() {
 				var desiredState mockDesiredState
 				loadErr := store.LoadDesiredTyped(context.Background(), "test", identity.ID, &desiredState)
 				Expect(loadErr).ToNot(HaveOccurred())
-				Expect(desiredState.ShutdownRequested).To(BeFalse())
+				Expect(desiredState.IsBeingRemoved()).To(BeFalse())
 			})
 		})
 

--- a/umh-core/pkg/fsmv2/supervisor/pending_removal_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/pending_removal_test.go
@@ -79,7 +79,7 @@ var _ = Describe("PendingRemoval Flag Clearing", func() {
 
 			desiredDoc := persistence.Document{
 				"id":                identity.ID,
-				"ShutdownRequested": false,
+				"isBeingRemoved": false,
 			}
 			_, err = mockStore.SaveDesired(ctx, "parent", identity.ID, desiredDoc)
 			Expect(err).NotTo(HaveOccurred())

--- a/umh-core/pkg/fsmv2/supervisor/reconciliation.go
+++ b/umh-core/pkg/fsmv2/supervisor/reconciliation.go
@@ -73,7 +73,7 @@ func (s *Supervisor[TObserved, TDesired]) tickWorker(ctx context.Context, worker
 		// Worker was removed via SignalNeedsRemoval during concurrent tick.
 		// This race can happen during:
 		// 1. Shutdown() (s.started == false)
-		// 2. RequestShutdown() from reconcileChildren (s.started == true)
+		// 2. RequestRemoval() from reconcileChildren (s.started == true)
 		// WorkerIDs are always obtained from iterating s.workers, so
 		// "not found" is only possible due to this benign race condition.
 		s.logger.Debug("tick_worker_skip",
@@ -211,7 +211,7 @@ func (s *Supervisor[TObserved, TDesired]) tickWorker(ctx context.Context, worker
 				s.logger.SentryError(deps.FeatureForWorker(s.workerType), s.GetHierarchyPathUnlocked(), maxAttemptsErr, "collector_unresponsive_max_attempts",
 					deps.Attempts(s.collectorHealth.maxRestartAttempts))
 
-				if shutdownErr := s.requestShutdown(ctx, workerID, maxAttemptsErr.Error()); shutdownErr != nil {
+				if shutdownErr := s.requestRemoval(ctx, workerID, maxAttemptsErr.Error()); shutdownErr != nil {
 					s.logger.SentryError(deps.FeatureForWorker(s.workerType), workerCtx.identity.HierarchyPath, shutdownErr, "shutdown_request_failed")
 				}
 
@@ -1169,7 +1169,7 @@ func (s *Supervisor[TObserved, TDesired]) processSignal(ctx context.Context, wor
 		s.mu.Unlock()
 
 		// Request graceful shutdown - worker will go through cleanup states
-		if err := s.requestShutdown(ctx, workerID, "restart_requested"); err != nil {
+		if err := s.requestRemoval(ctx, workerID, "restart_requested"); err != nil {
 			s.logger.SentryWarn(deps.FeatureFSMv2, s.GetHierarchyPathUnlocked(), "restart_shutdown_request_failed",
 				deps.Err(err),
 				deps.String("target_worker_id", workerID))
@@ -1728,7 +1728,7 @@ func (s *Supervisor[TObserved, TDesired]) reconcileChildren(specs []config.Child
 				// Request shutdown - sets IsBeingRemoved=true on child's workers
 				// Child continues ticking and will emit SignalNeedsRemoval when ready
 				ctx := context.Background()
-				if err := child.RequestShutdown(ctx, "removed_from_specs"); err != nil {
+				if err := child.RequestRemoval(ctx, "removed_from_specs"); err != nil {
 					s.logger.SentryWarn(deps.FeatureFSMv2, s.GetHierarchyPathUnlocked(), "child_shutdown_request_failed",
 						deps.Err(err),
 						deps.String("child_name", name))

--- a/umh-core/pkg/fsmv2/supervisor/reconciliation.go
+++ b/umh-core/pkg/fsmv2/supervisor/reconciliation.go
@@ -187,16 +187,16 @@ func (s *Supervisor[TObserved, TDesired]) tickWorker(ctx context.Context, worker
 	// Shutdown bypass: Allow FSM to process shutdown even with stale data.
 	// During graceful shutdown, child supervisors shut down first (correct order),
 	// which causes parent's observation to become stale (collectors can't observe gone children).
-	// The shutdown transition only needs the ShutdownRequested flag, not fresh observation data.
-	var isShutdownRequested bool
+	// The shutdown transition only needs the IsBeingRemoved flag, not fresh observation data.
+	var isBeingRemoved bool
 	if ds, ok := snapshot.Desired.(fsmv2.DesiredState); ok {
-		isShutdownRequested = ds.IsShutdownRequested()
+		isBeingRemoved = ds.IsBeingRemoved()
 	}
 
 	// I3: Check data freshness BEFORE calling state.Next()
 	// This is the trust boundary: states assume data is always fresh
 	// EXCEPT when shutdown is requested - shutdown doesn't need fresh observation
-	if !isShutdownRequested && !s.checkDataFreshness(snapshot) {
+	if !isBeingRemoved && !s.checkDataFreshness(snapshot) {
 		if s.freshnessChecker.IsTimeout(snapshot) {
 			// I4: Check if we've exhausted restart attempts
 			// Acquire lock to read mutable collectorHealth fields (restartCount)
@@ -803,8 +803,12 @@ func (s *Supervisor[TObserved, TDesired]) tick(ctx context.Context) (err error) 
 	var existingDesiredTyped TDesired
 	if err := s.store.LoadDesiredTyped(ctx, s.workerType, firstWorkerID, &existingDesiredTyped); err == nil {
 		if ds, ok := any(existingDesiredTyped).(fsmv2.DesiredState); ok {
-			if ds.IsShutdownRequested() {
-				desiredDoc[FieldShutdownRequested] = true
+			if ds.IsBeingRemoved() {
+				desiredDoc[FieldIsBeingRemoved] = true
+			}
+		} else if ds, ok := any(&existingDesiredTyped).(fsmv2.DesiredState); ok {
+			if ds.IsBeingRemoved() {
+				desiredDoc[FieldIsBeingRemoved] = true
 			}
 		}
 		if d, ok := any(existingDesiredTyped).(fsmv2.Disablable); ok {
@@ -875,7 +879,7 @@ func (s *Supervisor[TObserved, TDesired]) tick(ctx context.Context) (err error) 
 	// PR2 boundary caveat (pr2_issues #8 — empty-string ParentMappedState):
 	// Migrated state files use `!ShouldStop()` as a start-check. The
 	// FRAMEWORK ShouldStop body (worker_snapshot.go) is
-	// `IsShutdownRequested || ParentMappedState == "stopped"` and returns
+	// `IsBeingRemoved || ParentMappedState == "stopped"` and returns
 	// FALSE for empty-string ParentMappedState — so `!ShouldStop()` returns
 	// TRUE (fail-OPEN start). The pre-migration form `== DesiredStateRunning`
 	// returned FALSE for empty string (fail-SAFE stay-stopped). Production
@@ -885,7 +889,7 @@ func (s *Supervisor[TObserved, TDesired]) tick(ctx context.Context) (err error) 
 	// code has no defense if that ordering is ever broken — exactly the F7
 	// premature-start failure mode the cascade is meant to prevent. Note
 	// the asymmetry: workers with a worker-local ShouldStop override (e.g.
-	// examplechild's snapshot.ShouldStop = `IsShutdownRequested ||
+	// examplechild's snapshot.ShouldStop = `IsBeingRemoved ||
 	// !ShouldBeRunning`) fail-SAFE on empty string. transport / communicator
 	// inherit the framework body and so inherit the fail-OPEN polarity.
 	// Proper fix is harmonization at framework level (P3.x scope).
@@ -974,7 +978,7 @@ func (s *Supervisor[TObserved, TDesired]) tick(ctx context.Context) (err error) 
 	}
 
 	// When shutting down, pass nil to trigger graceful child shutdown instead of re-creation
-	if desiredDoc[FieldShutdownRequested] == true {
+	if desiredDoc[FieldIsBeingRemoved] == true {
 		childrenSpecs = nil
 	}
 
@@ -1525,7 +1529,7 @@ func (s *Supervisor[TObserved, TDesired]) reconcileChildren(specs []config.Child
 			// from cold boot (e.g., the parent's Stopped state has not yet
 			// emitted Enabled=true). Without this guard, the supervisor would
 			// allocate dependencies, construct the worker, then on the very
-			// next tick the reducer would flip IsShutdownRequested=true and
+			// next tick the reducer would flip IsBeingRemoved=true and
 			// the child's StoppedState would signal NeedsRemoval — a full
 			// create-and-destroy round-trip just to honor "this should be off."
 			//
@@ -1649,7 +1653,7 @@ func (s *Supervisor[TObserved, TDesired]) reconcileChildren(specs []config.Child
 
 			desiredDoc := persistence.Document{
 				FieldID:                childIdentity.ID,
-				FieldShutdownRequested: false,
+				FieldIsBeingRemoved: false,
 			}
 			if _, err := s.store.SaveDesired(childDesiredCtx, spec.WorkerType, childIdentity.ID, desiredDoc); err != nil {
 				s.logger.SentryWarn(deps.FeatureFSMv2, childPath, "child_initial_desired_state_save_failed",
@@ -1683,8 +1687,8 @@ func (s *Supervisor[TObserved, TDesired]) reconcileChildren(specs []config.Child
 	// CHANGE-19 reducer: translate Enabled → IsDisabled for resident children.
 	// This runs before Phase 1 (pendingRemoval) so Enabled=false children are NOT
 	// despawned — they stay in s.children with IsDisabled=true. ShouldStop() ORs
-	// IsDisabled with IsShutdownRequested + Config.GetState()=="stopped", so the
-	// child still enters its Stopped state machine. But because IsShutdownRequested
+	// IsDisabled with IsBeingRemoved + Config.GetState()=="stopped", so the
+	// child still enters its Stopped state machine. But because IsBeingRemoved
 	// stays false, the child's StoppedState does NOT signal NeedsRemoval, leaving
 	// the child resident and ready to resume on Enabled=true.
 	//
@@ -1721,7 +1725,7 @@ func (s *Supervisor[TObserved, TDesired]) reconcileChildren(specs []config.Child
 
 			child := s.children[name]
 			if child != nil {
-				// Request shutdown - sets ShutdownRequested=true on child's workers
+				// Request shutdown - sets IsBeingRemoved=true on child's workers
 				// Child continues ticking and will emit SignalNeedsRemoval when ready
 				ctx := context.Background()
 				if err := child.RequestShutdown(ctx, "removed_from_specs"); err != nil {

--- a/umh-core/pkg/fsmv2/supervisor/reconciliation.go
+++ b/umh-core/pkg/fsmv2/supervisor/reconciliation.go
@@ -797,13 +797,23 @@ func (s *Supervisor[TObserved, TDesired]) tick(ctx context.Context) (err error) 
 
 	desiredDoc[FieldID] = firstWorkerID
 
-	// Preserve ShutdownRequested: shutdown is a supervisor operation that overrides DeriveDesiredState
+	// Preserve supervisor-managed flags: shutdown and disabled are supervisor
+	// operations that override DeriveDesiredState. Without this, the per-tick
+	// derivation would clobber the reducer's writes.
 	var existingDesiredTyped TDesired
 	if err := s.store.LoadDesiredTyped(ctx, s.workerType, firstWorkerID, &existingDesiredTyped); err == nil {
-		// Check if existing state had shutdown requested via interface
 		if ds, ok := any(existingDesiredTyped).(fsmv2.DesiredState); ok {
 			if ds.IsShutdownRequested() {
 				desiredDoc[FieldShutdownRequested] = true
+			}
+		}
+		if d, ok := any(existingDesiredTyped).(fsmv2.Disablable); ok {
+			if d.IsDisabled() {
+				desiredDoc[FieldIsDisabled] = true
+			}
+		} else if d, ok := any(&existingDesiredTyped).(fsmv2.Disablable); ok {
+			if d.IsDisabled() {
+				desiredDoc[FieldIsDisabled] = true
 			}
 		}
 	}
@@ -1670,9 +1680,13 @@ func (s *Supervisor[TObserved, TDesired]) reconcileChildren(specs []config.Child
 		}
 	}
 
-	// CHANGE-19 reducer: translate Enabled → IsShutdownRequested for resident children.
+	// CHANGE-19 reducer: translate Enabled → IsDisabled for resident children.
 	// This runs before Phase 1 (pendingRemoval) so Enabled=false children are NOT
-	// despawned — they stay in s.children but have IsShutdownRequested=true.
+	// despawned — they stay in s.children with IsDisabled=true. ShouldStop() ORs
+	// IsDisabled with IsShutdownRequested + Config.GetState()=="stopped", so the
+	// child still enters its Stopped state machine. But because IsShutdownRequested
+	// stays false, the child's StoppedState does NOT signal NeedsRemoval, leaving
+	// the child resident and ready to resume on Enabled=true.
 	//
 	// context.Background() is used here because reconcileChildren does not accept a ctx
 	// parameter. If reconcileChildren is ever refactored to propagate context, replace
@@ -1683,15 +1697,9 @@ func (s *Supervisor[TObserved, TDesired]) reconcileChildren(specs []config.Child
 		if !exists {
 			continue
 		}
-		var reducerErr error
-		if !spec.Enabled {
-			reducerErr = child.RequestShutdown(reducerCtx, "reducer: enabled=false")
-		} else {
-			reducerErr = child.ClearShutdownRequest(reducerCtx)
-		}
-		if reducerErr != nil {
-			s.logger.SentryWarn(deps.FeatureFSMv2, s.GetHierarchyPathUnlocked(), "reducer_set_enabled_failed",
-				deps.Err(reducerErr),
+		if err := child.SetDisabled(reducerCtx, "reducer: enabled=false", !spec.Enabled); err != nil {
+			s.logger.SentryWarn(deps.FeatureFSMv2, s.GetHierarchyPathUnlocked(), "reducer_set_disabled_failed",
+				deps.Err(err),
 				deps.String("child_name", spec.Name),
 				deps.Bool("enabled", spec.Enabled))
 		}

--- a/umh-core/pkg/fsmv2/supervisor/reconciliation_pause_resume_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/reconciliation_pause_resume_test.go
@@ -97,7 +97,7 @@ var _ = Describe("CHANGE-19 Pause/Resume", func() {
 		// Setup: parent with one child spec, Enabled=false from the start.
 		// PR3-I skip-on-create: reconcileChildren must NOT create the child
 		// when its first appearance in the spec list is Enabled=false. The
-		// reducer-on-resident path that writes IsShutdownRequested=true is
+		// reducer-on-resident path that writes IsDisabled=true is
 		// covered separately by TestPauseResume_ResidentChildEnabledFalse_…
 		initialSpecs := []config.ChildSpec{
 			{
@@ -121,12 +121,13 @@ var _ = Describe("CHANGE-19 Pause/Resume", func() {
 			"skip-on-create must not write pendingRemoval; only spec omission does")
 	})
 
-	It("TestPauseResume_ResidentChildEnabledFalse_ReducerSetsIsShutdownRequested", func() {
+	It("TestPauseResume_ResidentChildEnabledFalse_ReducerSetsIsDisabled", func() {
 		// Resident-child reducer path: when Enabled flips from true to false
 		// on a child that already exists in s.children, the reducer must
-		// write IsShutdownRequested=true on the child's worker desired
-		// state, and the child must stay resident (no pendingRemoval, no
-		// despawn).
+		// write IsDisabled=true on the child's worker desired state (NOT
+		// IsShutdownRequested — that signals permanent removal). The child
+		// stays resident (no pendingRemoval, no despawn) and ShouldStop()
+		// drives it into Stopped state via the OR with IsDisabled.
 		initialSpecs := []config.ChildSpec{
 			{
 				Name:       "child-a",
@@ -153,7 +154,7 @@ var _ = Describe("CHANGE-19 Pause/Resume", func() {
 		}
 		parentSuper.TestUpdateUserSpec(config.UserSpec{Config: "parent-config-disable"})
 
-		// Tick 2: reducer must write IsShutdownRequested=true; PR3-I's
+		// Tick 2: reducer must write IsDisabled=true; PR3-I's
 		// skip-on-create branch must NOT remove the resident child.
 		Expect(parentSuper.TestTick(ctx)).To(Succeed())
 
@@ -165,12 +166,17 @@ var _ = Describe("CHANGE-19 Pause/Resume", func() {
 		Expect(parentSuper.TestIsPendingRemoval("child-a")).To(BeFalse(),
 			"Enabled=false must not write pendingRemoval; only omitting the name from specs triggers despawn")
 
-		// Assert 3: reducer wrote IsShutdownRequested=true on child's worker desired state.
+		// Assert 3: reducer wrote IsDisabled=true on child's worker desired state.
 		var childDesired supervisor.TestDesiredState
 		err := mockStore.LoadDesiredTyped(ctx, "child", "child-a-001", &childDesired)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(childDesired.IsShutdownRequested()).To(BeTrue(),
-			"reducer must write IsShutdownRequested=true on resident child's desired state when Enabled=false")
+		Expect(childDesired.IsDisabled()).To(BeTrue(),
+			"reducer must write IsDisabled=true on resident child's desired state when Enabled=false")
+
+		// Assert 4: IsShutdownRequested stays false — that signal is reserved
+		// for permanent removal, not transient parent-disable.
+		Expect(childDesired.IsShutdownRequested()).To(BeFalse(),
+			"reducer must NOT write IsShutdownRequested=true on Enabled=false; that signal is for permanent removal")
 	})
 
 	It("TestPauseResume_ReenableFromStopped_ChildRestartsTryingToStart", func() {
@@ -203,13 +209,13 @@ var _ = Describe("CHANGE-19 Pause/Resume", func() {
 		}
 		parentSuper.TestUpdateUserSpec(config.UserSpec{Config: "parent-config-disable"})
 
-		// Tick 2: reducer writes IsShutdownRequested=true on resident child.
+		// Tick 2: reducer writes IsDisabled=true on resident child.
 		Expect(parentSuper.TestTick(ctx)).To(Succeed())
 
 		var childDesired supervisor.TestDesiredState
 		err := mockStore.LoadDesiredTyped(ctx, "child", "child-a-001", &childDesired)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(childDesired.IsShutdownRequested()).To(BeTrue(),
+		Expect(childDesired.IsDisabled()).To(BeTrue(),
 			"precondition: child must be paused before re-enable")
 
 		// Re-enable: flip the spec to Enabled=true.
@@ -227,9 +233,10 @@ var _ = Describe("CHANGE-19 Pause/Resume", func() {
 		// the cache and reconcileChildren would reuse the Enabled=false DDS from tick 2.
 		parentSuper.TestUpdateUserSpec(config.UserSpec{Config: "parent-config-reenable"})
 
-		// Tick 3: reducer calls ClearShutdownRequest → IsShutdownRequested=false;
-		// the child's state machine will transition from Stopped to TryingToStart on
-		// subsequent worker ticks.
+		// Tick 3: reducer writes IsDisabled=false; the child's state machine
+		// will transition from Stopped to TryingToStart on subsequent worker
+		// ticks (ShouldStop now returns false because all three signals are
+		// false).
 		Expect(parentSuper.TestTick(ctx)).To(Succeed())
 
 		// Assert 1: child is still resident (never despawned during the pause/resume cycle).
@@ -240,11 +247,16 @@ var _ = Describe("CHANGE-19 Pause/Resume", func() {
 		Expect(parentSuper.TestIsPendingRemoval("child-a")).To(BeFalse(),
 			"re-enabling must not affect pendingRemoval — only spec omission triggers despawn")
 
-		// Assert 3: IsShutdownRequested is now false so the worker can restart.
-		err = mockStore.LoadDesiredTyped(ctx, "child", "child-a-001", &childDesired)
+		// Assert 3: IsDisabled is now false so the worker can restart.
+		// Use a fresh variable: IsDisabled has json:"isDisabled,omitempty", so when
+		// the flag is false the JSON document omits the key entirely. Reusing the
+		// previous childDesired (Disabled=true) would leave the field untouched on
+		// unmarshal and produce a stale read.
+		var childDesiredAfter supervisor.TestDesiredState
+		err = mockStore.LoadDesiredTyped(ctx, "child", "child-a-001", &childDesiredAfter)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(childDesired.IsShutdownRequested()).To(BeFalse(),
-			"reducer must write IsShutdownRequested=false when Enabled flips back to true, "+
+		Expect(childDesiredAfter.IsDisabled()).To(BeFalse(),
+			"reducer must write IsDisabled=false when Enabled flips back to true, "+
 				"allowing the child's state machine to transition from Stopped to TryingToStart")
 	})
 
@@ -255,9 +267,9 @@ var _ = Describe("CHANGE-19 Pause/Resume", func() {
 		// last Enabled value.
 		//
 		// The one-way stop trajectory (TryingToStop→Stopped before accepting the new
-		// IsShutdownRequested=false) is enforced by the child worker's state machine, not
+		// IsDisabled=false) is enforced by the child worker's state machine, not
 		// by the supervisor. At the supervisor level, the reducer is stateless: it reads
-		// the current spec's Enabled field and writes IsShutdownRequested each tick.
+		// the current spec's Enabled field and writes IsDisabled each tick.
 		initialSpecs := []config.ChildSpec{
 			{
 				Name:       "child-a",
@@ -268,7 +280,7 @@ var _ = Describe("CHANGE-19 Pause/Resume", func() {
 		}
 		parentSuper, worker := newPauseResumeFixture(ctx, mockStore, initialSpecs)
 
-		// Tick 1: create child with Enabled=true → reducer writes IsShutdownRequested=false
+		// Tick 1: create child with Enabled=true → reducer writes IsDisabled=false
 		err := parentSuper.TestTick(ctx)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -290,7 +302,7 @@ var _ = Describe("CHANGE-19 Pause/Resume", func() {
 		// Bust the DDS cache so reconcileChildren picks up the Enabled=false spec.
 		parentSuper.TestUpdateUserSpec(config.UserSpec{Config: "parent-config-disable"})
 
-		// Tick 2: reducer writes IsShutdownRequested=true (child enters TryingToStop in worker FSM)
+		// Tick 2: reducer writes IsDisabled=true (child enters TryingToStop in worker FSM via ShouldStop)
 		err = parentSuper.TestTick(ctx)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -310,7 +322,7 @@ var _ = Describe("CHANGE-19 Pause/Resume", func() {
 		// Bust the DDS cache again so the Enabled=true is picked up on tick 3.
 		parentSuper.TestUpdateUserSpec(config.UserSpec{Config: "parent-config-reenable"})
 
-		// Tick 3: reducer writes IsShutdownRequested=false; child stays resident
+		// Tick 3: reducer writes IsDisabled=false; child stays resident
 		err = parentSuper.TestTick(ctx)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -322,11 +334,11 @@ var _ = Describe("CHANGE-19 Pause/Resume", func() {
 		Expect(children).To(HaveKey("child-a"),
 			"child must remain resident after the rapid disable/re-enable cycle")
 
-		// Assert 2: IsShutdownRequested reflects the final Enabled=true value
+		// Assert 2: IsDisabled reflects the final Enabled=true value
 		var childDesired supervisor.TestDesiredState
 		err = mockStore.LoadDesiredTyped(ctx, "child", "child-a-001", &childDesired)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(childDesired.IsShutdownRequested()).To(BeFalse(),
-			"after re-enable, IsShutdownRequested must be false regardless of prior mid-flight disable")
+		Expect(childDesired.IsDisabled()).To(BeFalse(),
+			"after re-enable, IsDisabled must be false regardless of prior mid-flight disable")
 	})
 })

--- a/umh-core/pkg/fsmv2/supervisor/reconciliation_pause_resume_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/reconciliation_pause_resume_test.go
@@ -67,7 +67,7 @@ func newPauseResumeFixture(
 
 	desiredDoc := persistence.Document{
 		"id":                identity.ID,
-		"ShutdownRequested": false,
+		"isBeingRemoved": false,
 	}
 	_, err = mockStore.SaveDesired(ctx, "parent", identity.ID, desiredDoc)
 	Expect(err).NotTo(HaveOccurred())
@@ -125,7 +125,7 @@ var _ = Describe("CHANGE-19 Pause/Resume", func() {
 		// Resident-child reducer path: when Enabled flips from true to false
 		// on a child that already exists in s.children, the reducer must
 		// write IsDisabled=true on the child's worker desired state (NOT
-		// IsShutdownRequested — that signals permanent removal). The child
+		// IsBeingRemoved — that signals permanent removal). The child
 		// stays resident (no pendingRemoval, no despawn) and ShouldStop()
 		// drives it into Stopped state via the OR with IsDisabled.
 		initialSpecs := []config.ChildSpec{
@@ -173,10 +173,10 @@ var _ = Describe("CHANGE-19 Pause/Resume", func() {
 		Expect(childDesired.IsDisabled()).To(BeTrue(),
 			"reducer must write IsDisabled=true on resident child's desired state when Enabled=false")
 
-		// Assert 4: IsShutdownRequested stays false — that signal is reserved
+		// Assert 4: IsBeingRemoved stays false — that signal is reserved
 		// for permanent removal, not transient parent-disable.
-		Expect(childDesired.IsShutdownRequested()).To(BeFalse(),
-			"reducer must NOT write IsShutdownRequested=true on Enabled=false; that signal is for permanent removal")
+		Expect(childDesired.IsBeingRemoved()).To(BeFalse(),
+			"reducer must NOT write IsBeingRemoved=true on Enabled=false; that signal is for permanent removal")
 	})
 
 	It("TestPauseResume_ReenableFromStopped_ChildRestartsTryingToStart", func() {

--- a/umh-core/pkg/fsmv2/supervisor/supervisor_suite_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/supervisor_suite_test.go
@@ -130,7 +130,7 @@ type mockWorker struct {
 	observed            fsmv2.ObservedState
 	initialState        fsmv2.State[any, any]
 	collectFunc         func(ctx context.Context) (fsmv2.ObservedState, error)
-	requestShutdownFunc func() // Callback for when RequestShutdown is called
+	requestRemovalFunc func() // Callback for when RequestRemoval is called
 }
 
 func (m *mockWorker) CollectObservedState(ctx context.Context, _ fsmv2.DesiredState) (fsmv2.ObservedState, error) {

--- a/umh-core/pkg/fsmv2/supervisor/supervisor_suite_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/supervisor_suite_test.go
@@ -109,12 +109,12 @@ func (m *mockObservedState) GetTimestamp() time.Time {
 }
 
 type mockDesiredState struct {
-	ShutdownRequested bool
-	State             string
+	BeingRemoved bool   `json:"isBeingRemoved"`
+	State        string `json:"state"`
 }
 
-func (m *mockDesiredState) IsShutdownRequested() bool {
-	return m.ShutdownRequested
+func (m *mockDesiredState) IsBeingRemoved() bool {
+	return m.BeingRemoved
 }
 
 func (m *mockDesiredState) GetState() string {
@@ -438,7 +438,7 @@ func newSupervisorWithWorker(worker *mockWorker, customStore storage.TriangularS
 
 	desiredDoc := persistence.Document{
 		"id":                identity.ID,
-		"ShutdownRequested": false,
+		"isBeingRemoved": false,
 	}
 	if _, err := triangularStore.SaveDesired(ctx, workerType, identity.ID, desiredDoc); err != nil {
 		panic(fmt.Sprintf("failed to save initial desired state: %v", err))

--- a/umh-core/pkg/fsmv2/supervisor/supervisor_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/supervisor_test.go
@@ -119,11 +119,11 @@ type mockDesiredState struct {
 	State string
 }
 
-func (m *mockDesiredState) IsShutdownRequested() bool {
+func (m *mockDesiredState) IsBeingRemoved() bool {
 	return false
 }
 
-func (m *mockDesiredState) SetShutdownRequested(_ bool) {
+func (m *mockDesiredState) SetBeingRemoved(_ bool) {
 }
 
 func (m *mockDesiredState) GetState() string {

--- a/umh-core/pkg/fsmv2/supervisor/test_accessors.go
+++ b/umh-core/pkg/fsmv2/supervisor/test_accessors.go
@@ -47,9 +47,9 @@ func (s *Supervisor[TObserved, TDesired]) TestTick(ctx context.Context) error {
 	return s.tick(ctx)
 }
 
-// TestRequestShutdown exposes requestShutdown() for testing. DO NOT USE in production code.
-func (s *Supervisor[TObserved, TDesired]) TestRequestShutdown(ctx context.Context, workerID string, reason string) error {
-	return s.requestShutdown(ctx, workerID, reason)
+// TestRequestRemoval exposes requestRemoval() for testing. DO NOT USE in production code.
+func (s *Supervisor[TObserved, TDesired]) TestRequestRemoval(ctx context.Context, workerID string, reason string) error {
+	return s.requestRemoval(ctx, workerID, reason)
 }
 
 // TestGetRestartCount returns collectorHealth.restartCount for testing. DO NOT USE in production code.

--- a/umh-core/pkg/fsmv2/supervisor/testutil/helpers.go
+++ b/umh-core/pkg/fsmv2/supervisor/testutil/helpers.go
@@ -38,17 +38,17 @@ func (t *ObservedState) GetTimestamp() time.Time {
 }
 
 type DesiredState struct {
-	State       string `json:"state"`
-	ShutdownReq bool   `json:"ShutdownRequested"`
-	Disabled    bool   `json:"isDisabled,omitempty"`
+	State        string `json:"state"`
+	BeingRemoved bool   `json:"isBeingRemoved"`
+	Disabled     bool   `json:"isDisabled,omitempty"`
 }
 
-func (t *DesiredState) IsShutdownRequested() bool {
-	return t.ShutdownReq
+func (t *DesiredState) IsBeingRemoved() bool {
+	return t.BeingRemoved
 }
 
-func (t *DesiredState) SetShutdownRequested(requested bool) {
-	t.ShutdownReq = requested
+func (t *DesiredState) SetBeingRemoved(requested bool) {
+	t.BeingRemoved = requested
 }
 
 func (t *DesiredState) IsDisabled() bool {

--- a/umh-core/pkg/fsmv2/supervisor/testutil/helpers.go
+++ b/umh-core/pkg/fsmv2/supervisor/testutil/helpers.go
@@ -40,6 +40,7 @@ func (t *ObservedState) GetTimestamp() time.Time {
 type DesiredState struct {
 	State       string `json:"state"`
 	ShutdownReq bool   `json:"ShutdownRequested"`
+	Disabled    bool   `json:"isDisabled,omitempty"`
 }
 
 func (t *DesiredState) IsShutdownRequested() bool {
@@ -48,6 +49,14 @@ func (t *DesiredState) IsShutdownRequested() bool {
 
 func (t *DesiredState) SetShutdownRequested(requested bool) {
 	t.ShutdownReq = requested
+}
+
+func (t *DesiredState) IsDisabled() bool {
+	return t.Disabled
+}
+
+func (t *DesiredState) SetDisabled(disabled bool) {
+	t.Disabled = disabled
 }
 
 type Worker struct {

--- a/umh-core/pkg/fsmv2/supervisor/types.go
+++ b/umh-core/pkg/fsmv2/supervisor/types.go
@@ -53,7 +53,7 @@ type SupervisorInterface interface {
 	StartAsChild(ctx context.Context)
 	Shutdown()
 	RequestShutdown(ctx context.Context, reason string) error
-	// ClearShutdownRequest clears IsShutdownRequested on all workers in this supervisor.
+	// ClearShutdownRequest clears IsBeingRemoved on all workers in this supervisor.
 	// Sibling of RequestShutdown. Used by the CHANGE-19 reducer to flip a
 	// previously-disabled child back to enabled state.
 	ClearShutdownRequest(ctx context.Context) error

--- a/umh-core/pkg/fsmv2/supervisor/types.go
+++ b/umh-core/pkg/fsmv2/supervisor/types.go
@@ -57,6 +57,13 @@ type SupervisorInterface interface {
 	// Sibling of RequestShutdown. Used by the CHANGE-19 reducer to flip a
 	// previously-disabled child back to enabled state.
 	ClearShutdownRequest(ctx context.Context) error
+	// SetDisabled writes the IsDisabled signal on all workers' WrappedDesiredState
+	// in this supervisor. Called by the CHANGE-19 reducer to translate
+	// ChildSpec.Enabled=false into a transient stop. Distinct from RequestShutdown
+	// (permanent removal): IsDisabled drives ShouldStop without signalling
+	// NeedsRemoval, so the child stays resident in its Stopped state and can
+	// resume when re-enabled.
+	SetDisabled(ctx context.Context, reason string, disabled bool) error
 	ListWorkers() []string
 	tick(ctx context.Context) error
 	updateUserSpec(spec config.UserSpec)

--- a/umh-core/pkg/fsmv2/supervisor/types.go
+++ b/umh-core/pkg/fsmv2/supervisor/types.go
@@ -52,14 +52,14 @@ type SupervisorInterface interface {
 	// Collectors and executors still run in goroutines (they handle async I/O).
 	StartAsChild(ctx context.Context)
 	Shutdown()
-	RequestShutdown(ctx context.Context, reason string) error
-	// ClearShutdownRequest clears IsBeingRemoved on all workers in this supervisor.
-	// Sibling of RequestShutdown. Used by the CHANGE-19 reducer to flip a
+	RequestRemoval(ctx context.Context, reason string) error
+	// ClearRemoval clears IsBeingRemoved on all workers in this supervisor.
+	// Sibling of RequestRemoval. Used by the CHANGE-19 reducer to flip a
 	// previously-disabled child back to enabled state.
-	ClearShutdownRequest(ctx context.Context) error
+	ClearRemoval(ctx context.Context) error
 	// SetDisabled writes the IsDisabled signal on all workers' WrappedDesiredState
 	// in this supervisor. Called by the CHANGE-19 reducer to translate
-	// ChildSpec.Enabled=false into a transient stop. Distinct from RequestShutdown
+	// ChildSpec.Enabled=false into a transient stop. Distinct from RequestRemoval
 	// (permanent removal): IsDisabled drives ShouldStop without signalling
 	// NeedsRemoval, so the child stays resident in its Stopped state and can
 	// resume when re-enabled.

--- a/umh-core/pkg/fsmv2/testutil_test.go
+++ b/umh-core/pkg/fsmv2/testutil_test.go
@@ -42,7 +42,7 @@ func (r *testStateReader) LoadObservedTyped(_ context.Context, _ string, _ strin
 // mockDesiredState satisfies fsmv2.DesiredState for tests.
 type mockDesiredState struct{}
 
-func (d *mockDesiredState) IsShutdownRequested() bool { return false }
+func (d *mockDesiredState) IsBeingRemoved() bool      { return false }
 func (d *mockDesiredState) GetState() string          { return "running" }
 
 // configurableStateReader satisfies deps.StateReader with configurable responses.

--- a/umh-core/pkg/fsmv2/worker_base_test.go
+++ b/umh-core/pkg/fsmv2/worker_base_test.go
@@ -199,7 +199,7 @@ port: 8080`,
 			ds, err := wb.DeriveDesiredState(nil)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(ds).NotTo(BeNil())
-			Expect(ds.IsShutdownRequested()).To(BeFalse())
+			Expect(ds.(interface{ IsBeingRemoved() bool }).IsBeingRemoved()).To(BeFalse())
 		})
 
 		It("sets configReady=true even for nil spec", func() {

--- a/umh-core/pkg/fsmv2/worker_snapshot.go
+++ b/umh-core/pkg/fsmv2/worker_snapshot.go
@@ -43,7 +43,7 @@ type WorkerSnapshot[TConfig any, TStatus any] struct {
 
 	// Desired is the wrapped desired state (BaseDesiredState + TConfig +
 	// ChildrenSpecs). Use Desired.Config for typed config and
-	// Desired.IsShutdownRequested() for the merged shutdown signal.
+	// Desired.IsBeingRemoved for the merged shutdown signal.
 	Desired WrappedDesiredState[TConfig]
 
 	// Observed is the full typed observation captured by the supervisor on
@@ -54,8 +54,8 @@ type WorkerSnapshot[TConfig any, TStatus any] struct {
 
 // ShouldStop reports whether the worker should be in (or transitioning to) a stopped state.
 // It is the umbrella check for all three stop signals:
-//   - IsShutdownRequested (permanent removal — Phase 1 absent-from-specs, SignalNeedsRestart,
-//     graceful shutdown, supervisor self-protection). Renamed to IsBeingRemoved in PR5.3.
+//   - IsBeingRemoved (permanent removal — Phase 1 absent-from-specs, SignalNeedsRestart,
+//     graceful shutdown, supervisor self-protection). Renamed from IsShutdownRequested in PR5.3.
 //   - IsDisabled (transient parent-disable — ChildSpec.Enabled=false set by CHANGE-19 reducer).
 //   - Config.GetState() == DesiredStateStopped (user-driven stop via YAML).
 //
@@ -63,7 +63,7 @@ type WorkerSnapshot[TConfig any, TStatus any] struct {
 // In StoppedState, distinguish IsBeingRemoved (signal NeedsRemoval) from the others
 // (stay resident); see helpers.StoppedNext (PR5.9) for the canonical pattern.
 func (s WorkerSnapshot[TConfig, TStatus]) ShouldStop() bool {
-	if s.Desired.IsShutdownRequested() {
+	if s.Desired.IsBeingRemoved() {
 		return true
 	}
 	if s.Desired.IsDisabled() {

--- a/umh-core/pkg/fsmv2/worker_snapshot.go
+++ b/umh-core/pkg/fsmv2/worker_snapshot.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/config"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
 )
 
@@ -51,15 +52,27 @@ type WorkerSnapshot[TConfig any, TStatus any] struct {
 	Observed Observation[TStatus]
 }
 
-// ShouldStop returns true when the worker should transition to stopped.
-// Returns the user-shutdown signal (Desired.IsShutdownRequested()).
+// ShouldStop reports whether the worker should be in (or transitioning to) a stopped state.
+// It is the umbrella check for all three stop signals:
+//   - IsShutdownRequested (permanent removal — Phase 1 absent-from-specs, SignalNeedsRestart,
+//     graceful shutdown, supervisor self-protection). Renamed to IsBeingRemoved in PR5.3.
+//   - IsDisabled (transient parent-disable — ChildSpec.Enabled=false set by CHANGE-19 reducer).
+//   - Config.GetState() == DesiredStateStopped (user-driven stop via YAML).
 //
-// Parent-driven stop intent now flows through the same flag: a parent that
-// wants a child stopped marks the child's ChildSpec Enabled=false, which the
-// reducer translates into IsShutdownRequested=true on the child. There is no
-// longer a separate parent-mapped-state path.
+// Use ShouldStop in non-Stopped state files where the source doesn't matter ("just stop").
+// In StoppedState, distinguish IsBeingRemoved (signal NeedsRemoval) from the others
+// (stay resident); see helpers.StoppedNext (PR5.9) for the canonical pattern.
 func (s WorkerSnapshot[TConfig, TStatus]) ShouldStop() bool {
-	return s.Desired.IsShutdownRequested()
+	if s.Desired.IsShutdownRequested() {
+		return true
+	}
+	if s.Desired.IsDisabled() {
+		return true
+	}
+	if cfg, ok := any(&s.Desired.Config).(interface{ GetState() string }); ok {
+		return cfg.GetState() == config.DesiredStateStopped
+	}
+	return false
 }
 
 // ConvertWorkerSnapshot type-asserts the raw snapshot from State.Next() into a

--- a/umh-core/pkg/fsmv2/worker_snapshot.go
+++ b/umh-core/pkg/fsmv2/worker_snapshot.go
@@ -53,15 +53,20 @@ type WorkerSnapshot[TConfig any, TStatus any] struct {
 }
 
 // ShouldStop reports whether the worker should be in (or transitioning to) a stopped state.
-// It is the umbrella check for all three stop signals:
-//   - IsBeingRemoved (permanent removal — Phase 1 absent-from-specs, SignalNeedsRestart,
-//     graceful shutdown, supervisor self-protection). Renamed from IsShutdownRequested in PR5.3.
-//   - IsDisabled (transient parent-disable — ChildSpec.Enabled=false set by CHANGE-19 reducer).
-//   - Config.GetState() == DesiredStateStopped (user-driven stop via YAML).
+// It is the umbrella OR over the three stop signals PR5 disambiguated:
 //
-// Use ShouldStop in non-Stopped state files where the source doesn't matter ("just stop").
-// In StoppedState, distinguish IsBeingRemoved (signal NeedsRemoval) from the others
-// (stay resident); see helpers.StoppedNext (PR5.9) for the canonical pattern.
+//   - IsBeingRemoved (permanent: cases C, D, E, F — Phase 1 absent-from-specs,
+//     SignalNeedsRestart, graceful process shutdown, supervisor self-protection).
+//   - IsDisabled (transient parent-disable: case B — ChildSpec.Enabled=false set
+//     by the CHANGE-19 reducer).
+//   - Config.GetState() == DesiredStateStopped (transient user-driven stop:
+//     case A — user writes state: stopped in YAML).
+//
+// Use ShouldStop in non-Stopped state files where the source doesn't matter
+// ("just stop"). In StoppedState, discriminate IsBeingRemoved (emit
+// SignalNeedsRemoval, tear down) from the transient signals (stay resident);
+// see helpers.StoppedNext for the canonical three-branch pattern. Full case
+// table in pkg/fsmv2/CLAUDE.md "Stopping a worker — six cases, three signals".
 func (s WorkerSnapshot[TConfig, TStatus]) ShouldStop() bool {
 	if s.Desired.IsBeingRemoved() {
 		return true

--- a/umh-core/pkg/fsmv2/worker_snapshot_test.go
+++ b/umh-core/pkg/fsmv2/worker_snapshot_test.go
@@ -65,7 +65,7 @@ var _ = Describe("ConvertWorkerSnapshot", func() {
 		Expect(snap.Observed.Status.LatencyMs).To(Equal(int64(42)))
 		Expect(snap.Identity).To(Equal(identity))
 		Expect(snap.CollectedAt).To(Equal(now))
-		Expect(snap.Desired.IsShutdownRequested()).To(BeFalse())
+		Expect(snap.Desired.IsBeingRemoved()).To(BeFalse())
 	})
 
 	It("copies framework fields from observed state", func() {
@@ -90,7 +90,7 @@ var _ = Describe("ConvertWorkerSnapshot", func() {
 		wds := &fsmv2.WrappedDesiredState[workerTestConfig]{
 			BaseDesiredState: config.BaseDesiredState{},
 		}
-		wds.SetShutdownRequested(true)
+		wds.SetBeingRemoved(true)
 
 		raw := fsmv2.Snapshot{
 			Observed: obs,
@@ -105,7 +105,7 @@ var _ = Describe("ConvertWorkerSnapshot", func() {
 		Expect(snap.Observed.ChildrenHealthy).To(Equal(3))
 		Expect(snap.Observed.ChildrenUnhealthy).To(Equal(1))
 		Expect(snap.Observed.ChildrenView).To(Equal(mockView))
-		Expect(snap.Desired.IsShutdownRequested()).To(BeTrue())
+		Expect(snap.Desired.IsBeingRemoved()).To(BeTrue())
 	})
 
 	It("panics with descriptive message on non-Snapshot input", func() {
@@ -138,9 +138,9 @@ var _ = Describe("ConvertWorkerSnapshot", func() {
 })
 
 var _ = Describe("ShouldStop", func() {
-	It("returns true when Desired.IsShutdownRequested() is true (other signals false)", func() {
+	It("returns true when Desired.IsBeingRemoved is true (other signals false)", func() {
 		wds := fsmv2.WrappedDesiredState[workerTestConfig]{}
-		wds.SetShutdownRequested(true)
+		wds.SetBeingRemoved(true)
 		snap := fsmv2.WorkerSnapshot[workerTestConfig, workerTestStatus]{
 			Desired: wds,
 		}
@@ -180,9 +180,9 @@ var _ = Describe("ShouldStop", func() {
 		Expect(snap.ShouldStop()).To(BeFalse())
 	})
 
-	It("returns true via IsShutdownRequested when Config does not implement GetState()", func() {
+	It("returns true via IsBeingRemoved when Config does not implement GetState()", func() {
 		wds := fsmv2.WrappedDesiredState[workerTestConfig]{}
-		wds.SetShutdownRequested(true)
+		wds.SetBeingRemoved(true)
 		snap := fsmv2.WorkerSnapshot[workerTestConfig, workerTestStatus]{
 			Desired: wds,
 		}

--- a/umh-core/pkg/fsmv2/worker_snapshot_test.go
+++ b/umh-core/pkg/fsmv2/worker_snapshot_test.go
@@ -138,7 +138,7 @@ var _ = Describe("ConvertWorkerSnapshot", func() {
 })
 
 var _ = Describe("ShouldStop", func() {
-	It("returns true when Desired.IsShutdownRequested() is true", func() {
+	It("returns true when Desired.IsShutdownRequested() is true (other signals false)", func() {
 		wds := fsmv2.WrappedDesiredState[workerTestConfig]{}
 		wds.SetShutdownRequested(true)
 		snap := fsmv2.WorkerSnapshot[workerTestConfig, workerTestStatus]{
@@ -147,7 +147,49 @@ var _ = Describe("ShouldStop", func() {
 		Expect(snap.ShouldStop()).To(BeTrue())
 	})
 
-	It("returns false when Desired.IsShutdownRequested() is false", func() {
+	It("returns true when Desired.IsDisabled() is true (other signals false)", func() {
+		wds := fsmv2.WrappedDesiredState[workerTestConfig]{}
+		wds.SetDisabled(true)
+		snap := fsmv2.WorkerSnapshot[workerTestConfig, workerTestStatus]{
+			Desired: wds,
+		}
+		Expect(snap.ShouldStop()).To(BeTrue())
+	})
+
+	It("returns true when Config.GetState() == \"stopped\" (other signals false)", func() {
+		wds := fsmv2.WrappedDesiredState[userSpecConfig]{
+			Config: userSpecConfig{
+				BaseUserSpec: config.BaseUserSpec{State: config.DesiredStateStopped},
+			},
+		}
+		snap := fsmv2.WorkerSnapshot[userSpecConfig, workerTestStatus]{
+			Desired: wds,
+		}
+		Expect(snap.ShouldStop()).To(BeTrue())
+	})
+
+	It("returns false when all three signals are negative", func() {
+		wds := fsmv2.WrappedDesiredState[userSpecConfig]{
+			Config: userSpecConfig{
+				BaseUserSpec: config.BaseUserSpec{State: config.DesiredStateRunning},
+			},
+		}
+		snap := fsmv2.WorkerSnapshot[userSpecConfig, workerTestStatus]{
+			Desired: wds,
+		}
+		Expect(snap.ShouldStop()).To(BeFalse())
+	})
+
+	It("returns true via IsShutdownRequested when Config does not implement GetState()", func() {
+		wds := fsmv2.WrappedDesiredState[workerTestConfig]{}
+		wds.SetShutdownRequested(true)
+		snap := fsmv2.WorkerSnapshot[workerTestConfig, workerTestStatus]{
+			Desired: wds,
+		}
+		Expect(snap.ShouldStop()).To(BeTrue())
+	})
+
+	It("returns false when Config does not implement GetState() and other signals are false", func() {
 		snap := fsmv2.WorkerSnapshot[workerTestConfig, workerTestStatus]{
 			Desired: fsmv2.WrappedDesiredState[workerTestConfig]{},
 		}

--- a/umh-core/pkg/fsmv2/workers/application/README.md
+++ b/umh-core/pkg/fsmv2/workers/application/README.md
@@ -118,7 +118,7 @@ Represents the desired state with child specifications:
 
 ```go
 type ApplicationDesiredState struct {
-    config.BaseDesiredState `json:",inline"`  // Embeds State and ShutdownRequested
+    config.BaseDesiredState `json:",inline"`  // Embeds IsBeingRemoved
     Name          string                       `json:"name"`
     ChildrenSpecs []config.ChildSpec           `json:"childrenSpecs,omitempty"`
 }

--- a/umh-core/pkg/fsmv2/workers/application/children.go
+++ b/umh-core/pkg/fsmv2/workers/application/children.go
@@ -30,7 +30,7 @@ import (
 // §4-C exception: the regular zero-value-false rule is opted out of here in
 // favor of "every declared child runs" — the load-bearing semantic for the
 // application worker (see the §4-C exception block in DeriveDesiredState).
-// Callers that want a stopped child must use ShutdownRequested, not Enabled.
+// Callers that want a stopped child must use IsBeingRemoved, not Enabled.
 //
 // Pure, deterministic, idempotent: same snapshot input yields the same
 // ChildSpec values across repeated calls. Per §4-C LOCKED, Enabled is set

--- a/umh-core/pkg/fsmv2/workers/application/snapshot/snapshot.go
+++ b/umh-core/pkg/fsmv2/workers/application/snapshot/snapshot.go
@@ -38,7 +38,7 @@ type ApplicationConfig struct {
 
 // ApplicationStatus holds the runtime observation data for the application
 // supervisor. Framework fields (CollectedAt, State, LastActionResults,
-// MetricsEmbedder, ShutdownRequested, ChildrenHealthy, ChildrenUnhealthy,
+// MetricsEmbedder, IsBeingRemoved, ChildrenHealthy, ChildrenUnhealthy,
 // ChildrenView) are carried by fsmv2.Observation[ApplicationStatus] and are
 // not duplicated here.
 //

--- a/umh-core/pkg/fsmv2/workers/application/worker.go
+++ b/umh-core/pkg/fsmv2/workers/application/worker.go
@@ -145,7 +145,7 @@ func (w *ApplicationWorker) DeriveDesiredState(spec interface{}) (fsmv2.DesiredS
 	// contract is "every child the user declared runs". Default-on is the
 	// load-bearing semantic for this worker; the regular §4-C zero-value-
 	// false rule is opted out of here. Callers that explicitly want a
-	// stopped child must use the worker-specific ShutdownRequested signal,
+	// stopped child must use the worker-specific IsBeingRemoved signal,
 	// not the per-tick Enabled flag. RenderChildren (children.go) emits
 	// the same default-on result so the legacy DDS path and the post-P2.2
 	// renderChildren-in-state.Next path stay bit-for-bit identical.
@@ -167,7 +167,7 @@ func (w *ApplicationWorker) DeriveDesiredState(spec interface{}) (fsmv2.DesiredS
 		}
 		for i, raw := range rawCfg.Children {
 			if _, hasEnabled := raw["enabled"]; hasEnabled {
-				return nil, fmt.Errorf("application children[%d] has user-supplied `enabled:` field; not permitted (§4-C YAML-passthrough exception): the application worker forces all declared children to run. Remove the `enabled:` key from your YAML, or use the ShutdownRequested signal at runtime if you need to stop a specific child", i)
+				return nil, fmt.Errorf("application children[%d] has user-supplied `enabled:` field; not permitted (§4-C YAML-passthrough exception): the application worker forces all declared children to run. Remove the `enabled:` key from your YAML, or use the IsBeingRemoved signal at runtime if you need to stop a specific child", i)
 			}
 		}
 	}

--- a/umh-core/pkg/fsmv2/workers/application/worker_test.go
+++ b/umh-core/pkg/fsmv2/workers/application/worker_test.go
@@ -76,7 +76,7 @@ children:
 			desiredIface, err := worker.DeriveDesiredState(userSpec)
 			Expect(err).ToNot(HaveOccurred())
 			desired := desiredIface.(*fsmv2.WrappedDesiredState[snapshot.ApplicationConfig])
-			Expect(desired.IsShutdownRequested()).To(BeFalse())
+			Expect(desired.IsBeingRemoved()).To(BeFalse())
 
 			children := RenderChildren(fsmv2.WorkerSnapshot[snapshot.ApplicationConfig, snapshot.ApplicationStatus]{
 				Desired: *desired,
@@ -97,7 +97,7 @@ children:
 			desiredIface, err := worker.DeriveDesiredState(userSpec)
 			Expect(err).ToNot(HaveOccurred())
 			desired := desiredIface.(*fsmv2.WrappedDesiredState[snapshot.ApplicationConfig])
-			Expect(desired.IsShutdownRequested()).To(BeFalse())
+			Expect(desired.IsBeingRemoved()).To(BeFalse())
 
 			children := RenderChildren(fsmv2.WorkerSnapshot[snapshot.ApplicationConfig, snapshot.ApplicationStatus]{
 				Desired: *desired,
@@ -118,7 +118,7 @@ children:
 			desiredIface, err := worker.DeriveDesiredState(userSpec)
 			Expect(err).ToNot(HaveOccurred())
 			desired := desiredIface.(*fsmv2.WrappedDesiredState[snapshot.ApplicationConfig])
-			Expect(desired.IsShutdownRequested()).To(BeFalse())
+			Expect(desired.IsBeingRemoved()).To(BeFalse())
 
 			children := RenderChildren(fsmv2.WorkerSnapshot[snapshot.ApplicationConfig, snapshot.ApplicationStatus]{
 				Desired: *desired,
@@ -135,7 +135,7 @@ children:
 			desiredIface, err := worker.DeriveDesiredState(nil)
 			Expect(err).ToNot(HaveOccurred())
 			desired := desiredIface.(*fsmv2.WrappedDesiredState[snapshot.ApplicationConfig])
-			Expect(desired.IsShutdownRequested()).To(BeFalse())
+			Expect(desired.IsBeingRemoved()).To(BeFalse())
 			Expect(desired.Config.Name).To(Equal("test-root"))
 
 			children := RenderChildren(fsmv2.WorkerSnapshot[snapshot.ApplicationConfig, snapshot.ApplicationStatus]{

--- a/umh-core/pkg/fsmv2/workers/communicator/state/state_recovering_test.go
+++ b/umh-core/pkg/fsmv2/workers/communicator/state/state_recovering_test.go
@@ -98,7 +98,7 @@ var _ = Describe("RecoveringState Transitions", func() {
 					ChildrenUnhealthy: 1,
 				},
 				Desired: &fsmv2.WrappedDesiredState[communicator.CommunicatorConfig]{
-					BaseDesiredState: config.BaseDesiredState{ShutdownRequested: true},
+					BaseDesiredState: config.BaseDesiredState{BeingRemoved: true},
 				},
 			}
 
@@ -117,7 +117,7 @@ var _ = Describe("RecoveringState Transitions", func() {
 					ChildrenUnhealthy: 0,
 				},
 				Desired: &fsmv2.WrappedDesiredState[communicator.CommunicatorConfig]{
-					BaseDesiredState: config.BaseDesiredState{ShutdownRequested: true},
+					BaseDesiredState: config.BaseDesiredState{BeingRemoved: true},
 				},
 			}
 

--- a/umh-core/pkg/fsmv2/workers/communicator/state/state_stopped.go
+++ b/umh-core/pkg/fsmv2/workers/communicator/state/state_stopped.go
@@ -30,7 +30,7 @@ type StoppedState struct {
 func (s *StoppedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[communicator.CommunicatorConfig, communicator.CommunicatorStatus](snapAny)
 
-	if snap.Desired.IsShutdownRequested() {
+	if snap.Desired.IsBeingRemoved() {
 		return fsmv2.Transition(s, fsmv2.SignalNeedsRemoval, nil, "Communicator is stopped and shutdown was requested", nil)
 	}
 

--- a/umh-core/pkg/fsmv2/workers/communicator/state/state_stopped_test.go
+++ b/umh-core/pkg/fsmv2/workers/communicator/state/state_stopped_test.go
@@ -96,7 +96,7 @@ var _ = Describe("StoppedState Transitions", func() {
 				Identity: deps.Identity{ID: "comm-1", Name: "communicator", WorkerType: "communicator"},
 				Observed: fsmv2.Observation[communicator.CommunicatorStatus]{},
 				Desired: &fsmv2.WrappedDesiredState[communicator.CommunicatorConfig]{
-					BaseDesiredState: config.BaseDesiredState{ShutdownRequested: false},
+					BaseDesiredState: config.BaseDesiredState{BeingRemoved: false},
 				},
 			}
 
@@ -114,7 +114,7 @@ var _ = Describe("StoppedState Transitions", func() {
 				Identity: deps.Identity{ID: "test", Name: "test", WorkerType: "communicator"},
 				Observed: fsmv2.Observation[communicator.CommunicatorStatus]{},
 				Desired: &fsmv2.WrappedDesiredState[communicator.CommunicatorConfig]{
-					BaseDesiredState: config.BaseDesiredState{ShutdownRequested: true},
+					BaseDesiredState: config.BaseDesiredState{BeingRemoved: true},
 				},
 			}
 
@@ -130,7 +130,7 @@ var _ = Describe("StoppedState Transitions", func() {
 				Identity: deps.Identity{ID: "comm-shutdown", Name: "communicator", WorkerType: "communicator"},
 				Observed: fsmv2.Observation[communicator.CommunicatorStatus]{},
 				Desired: &fsmv2.WrappedDesiredState[communicator.CommunicatorConfig]{
-					BaseDesiredState: config.BaseDesiredState{ShutdownRequested: true},
+					BaseDesiredState: config.BaseDesiredState{BeingRemoved: true},
 				},
 			}
 

--- a/umh-core/pkg/fsmv2/workers/communicator/state/state_syncing_test.go
+++ b/umh-core/pkg/fsmv2/workers/communicator/state/state_syncing_test.go
@@ -62,7 +62,7 @@ var _ = Describe("SyncingState Transitions", func() {
 					ChildrenUnhealthy: 0,
 				},
 				Desired: &fsmv2.WrappedDesiredState[communicator.CommunicatorConfig]{
-					BaseDesiredState: config.BaseDesiredState{ShutdownRequested: true},
+					BaseDesiredState: config.BaseDesiredState{BeingRemoved: true},
 				},
 			}
 
@@ -81,7 +81,7 @@ var _ = Describe("SyncingState Transitions", func() {
 					ChildrenUnhealthy: 1,
 				},
 				Desired: &fsmv2.WrappedDesiredState[communicator.CommunicatorConfig]{
-					BaseDesiredState: config.BaseDesiredState{ShutdownRequested: true},
+					BaseDesiredState: config.BaseDesiredState{BeingRemoved: true},
 				},
 			}
 

--- a/umh-core/pkg/fsmv2/workers/communicator/worker_test.go
+++ b/umh-core/pkg/fsmv2/workers/communicator/worker_test.go
@@ -130,7 +130,7 @@ var _ = Describe("CommunicatorWorker", func() {
 				desired, ok := desiredIface.(*fsmv2.WrappedDesiredState[communicator.CommunicatorConfig])
 				Expect(ok).To(BeTrue(), "expected *fsmv2.WrappedDesiredState[CommunicatorConfig]")
 				Expect(desired.Config.GetState()).To(Equal("running"))
-				Expect(desired.IsShutdownRequested()).To(BeFalse())
+				Expect(desired.IsBeingRemoved()).To(BeFalse())
 			})
 
 			It("should include TransportWorker child via RenderChildren", func() {

--- a/umh-core/pkg/fsmv2/workers/example/examplechild/state/state_stopped.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplechild/state/state_stopped.go
@@ -32,11 +32,11 @@ type StoppedState struct {
 func (s *StoppedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[examplechild.ExamplechildConfig, examplechild.ExamplechildStatus](snapAny)
 
-	if snap.Desired.IsShutdownRequested() {
+	if snap.Desired.IsBeingRemoved() {
 		return fsmv2.Transition(s, fsmv2.SignalNeedsRemoval, nil, "Shutdown requested", nil)
 	}
 
-	// Parent disable propagates via ChildSpec.Enabled=false → IsShutdownRequested
+	// Parent disable propagates via ChildSpec.Enabled=false → IsBeingRemoved
 	// (handled by the shutdown check above). When neither user nor parent has
 	// requested stop, advance to TryingToConnect.
 	if !snap.ShouldStop() {

--- a/umh-core/pkg/fsmv2/workers/example/examplechild/state/state_stopped.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplechild/state/state_stopped.go
@@ -32,18 +32,7 @@ type StoppedState struct {
 func (s *StoppedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[examplechild.ExamplechildConfig, examplechild.ExamplechildStatus](snapAny)
 
-	if snap.Desired.IsBeingRemoved() {
-		return fsmv2.Transition(s, fsmv2.SignalNeedsRemoval, nil, "Shutdown requested", nil)
-	}
-
-	// Parent disable propagates via ChildSpec.Enabled=false → IsBeingRemoved
-	// (handled by the shutdown check above). When neither user nor parent has
-	// requested stop, advance to TryingToConnect.
-	if !snap.ShouldStop() {
-		return fsmv2.Transition(&TryingToConnectState{}, fsmv2.SignalNone, nil, "attempting to connect", nil)
-	}
-
-	return fsmv2.Transition(s, fsmv2.SignalNone, nil, "Child is stopped, no connection", nil)
+	return helpers.StoppedNext(s, snap, &TryingToConnectState{}, "attempting to connect")
 }
 
 func (s *StoppedState) String() string {

--- a/umh-core/pkg/fsmv2/workers/example/examplechild/state/state_stopped_test.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplechild/state/state_stopped_test.go
@@ -34,7 +34,7 @@ import (
 func makeChildSnapshot(shutdownRequested bool) fsmv2.Snapshot {
 	desired := &fsmv2.WrappedDesiredState[examplechild.ExamplechildConfig]{
 		BaseDesiredState: config.BaseDesiredState{
-			ShutdownRequested: shutdownRequested,
+			BeingRemoved: shutdownRequested,
 		},
 	}
 	observed := fsmv2.Observation[examplechild.ExamplechildStatus]{}

--- a/umh-core/pkg/fsmv2/workers/example/examplechild/state/state_stopped_test.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplechild/state/state_stopped_test.go
@@ -26,9 +26,11 @@ import (
 )
 
 // makeChildSnapshot constructs an examplechild snapshot for state-machine
-// behavioral tests. shutdownRequested mirrors what the parent sets when it
-// disables the child via ChildSpec.Enabled=false (the reducer translates
-// Enabled=false into IsShutdownRequested=true).
+// behavioral tests. shutdownRequested models the permanent-removal signal
+// (Phase 1 absent-from-specs path, SignalNeedsRestart, graceful shutdown).
+// Transient parent-disable flows through IsDisabled (set by the CHANGE-19
+// reducer) — that signal does NOT cause StoppedState to signal NeedsRemoval,
+// so the child stays resident. See PR5 signal disambiguation.
 func makeChildSnapshot(shutdownRequested bool) fsmv2.Snapshot {
 	desired := &fsmv2.WrappedDesiredState[examplechild.ExamplechildConfig]{
 		BaseDesiredState: config.BaseDesiredState{

--- a/umh-core/pkg/fsmv2/workers/example/examplechild/worker_test.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplechild/worker_test.go
@@ -88,7 +88,7 @@ var _ = Describe("ChildWorker", func() {
 
 			desired, ok := desiredIface.(*fsmv2.WrappedDesiredState[examplechild.ExamplechildConfig])
 			Expect(ok).To(BeTrue(), "expected *WrappedDesiredState[ExamplechildConfig], got %T", desiredIface)
-			Expect(desired.IsShutdownRequested()).To(BeFalse())
+			Expect(desired.IsBeingRemoved()).To(BeFalse())
 		})
 	})
 

--- a/umh-core/pkg/fsmv2/workers/example/examplefailing/state/state_stopped.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplefailing/state/state_stopped.go
@@ -32,18 +32,7 @@ type StoppedState struct {
 func (s *StoppedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[examplefailing.ExamplefailingConfig, examplefailing.ExamplefailingStatus](snapAny)
 
-	if snap.Desired.IsBeingRemoved() {
-		return fsmv2.Transition(s, fsmv2.SignalNeedsRemoval, nil, "shutdown requested, signaling removal", nil)
-	}
-
-	// Parent disable propagates via ChildSpec.Enabled=false → IsBeingRemoved
-	// (handled by the shutdown check above). When neither user nor parent has
-	// requested stop, advance to TryingToConnect.
-	if !snap.ShouldStop() {
-		return fsmv2.Transition(&TryingToConnectState{}, fsmv2.SignalNone, nil, "attempting to connect", nil)
-	}
-
-	return fsmv2.Transition(s, fsmv2.SignalNone, nil, "worker is stopped, no connection", nil)
+	return helpers.StoppedNext(s, snap, &TryingToConnectState{}, "attempting to connect")
 }
 
 func (s *StoppedState) String() string {

--- a/umh-core/pkg/fsmv2/workers/example/examplefailing/state/state_stopped.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplefailing/state/state_stopped.go
@@ -32,11 +32,11 @@ type StoppedState struct {
 func (s *StoppedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[examplefailing.ExamplefailingConfig, examplefailing.ExamplefailingStatus](snapAny)
 
-	if snap.Desired.IsShutdownRequested() {
+	if snap.Desired.IsBeingRemoved() {
 		return fsmv2.Transition(s, fsmv2.SignalNeedsRemoval, nil, "shutdown requested, signaling removal", nil)
 	}
 
-	// Parent disable propagates via ChildSpec.Enabled=false → IsShutdownRequested
+	// Parent disable propagates via ChildSpec.Enabled=false → IsBeingRemoved
 	// (handled by the shutdown check above). When neither user nor parent has
 	// requested stop, advance to TryingToConnect.
 	if !snap.ShouldStop() {

--- a/umh-core/pkg/fsmv2/workers/example/examplepanic/state/state_stopped.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplepanic/state/state_stopped.go
@@ -31,11 +31,11 @@ type StoppedState struct {
 func (s *StoppedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[example_panic.ExamplepanicConfig, example_panic.ExamplepanicStatus](snapAny)
 
-	if snap.Desired.IsShutdownRequested() {
+	if snap.Desired.IsBeingRemoved() {
 		return fsmv2.Transition(s, fsmv2.SignalNeedsRemoval, nil, "Shutdown requested, signaling removal", nil)
 	}
 
-	// Parent disable propagates via ChildSpec.Enabled=false → IsShutdownRequested
+	// Parent disable propagates via ChildSpec.Enabled=false → IsBeingRemoved
 	// (handled by the shutdown check above). When neither user nor parent has
 	// requested stop, advance to TryingToConnect.
 	if !snap.ShouldStop() {

--- a/umh-core/pkg/fsmv2/workers/example/exampleparent/state/state_degraded.go
+++ b/umh-core/pkg/fsmv2/workers/example/exampleparent/state/state_degraded.go
@@ -29,7 +29,7 @@ type DegradedState struct {
 func (s *DegradedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[exampleparent.ExampleparentConfig, exampleparent.ExampleparentStatus](snapAny)
 
-	if snap.Desired.IsShutdownRequested() {
+	if snap.Desired.IsBeingRemoved() {
 		return fsmv2.Transition(&TryingToStopState{}, fsmv2.SignalNone, nil, "Shutdown requested, transitioning to TryingToStop", []config.ChildSpec{})
 	}
 

--- a/umh-core/pkg/fsmv2/workers/example/exampleparent/state/state_running.go
+++ b/umh-core/pkg/fsmv2/workers/example/exampleparent/state/state_running.go
@@ -35,7 +35,7 @@ type RunningState struct {
 func (s *RunningState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[exampleparent.ExampleparentConfig, exampleparent.ExampleparentStatus](snapAny)
 
-	if snap.Desired.IsShutdownRequested() {
+	if snap.Desired.IsBeingRemoved() {
 		return fsmv2.Transition(&TryingToStopState{}, fsmv2.SignalNone, nil, "Shutdown requested, transitioning to TryingToStop", []config.ChildSpec{})
 	}
 

--- a/umh-core/pkg/fsmv2/workers/example/exampleparent/state/state_stopped.go
+++ b/umh-core/pkg/fsmv2/workers/example/exampleparent/state/state_stopped.go
@@ -40,13 +40,13 @@ type StoppedState struct {
 func (s *StoppedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[exampleparent.ExampleparentConfig, exampleparent.ExampleparentStatus](snapAny)
 
-	if snap.Desired.IsShutdownRequested() {
+	if snap.Desired.IsBeingRemoved() {
 		return fsmv2.Transition(s, fsmv2.SignalNeedsRemoval, nil, "Shutdown requested, signaling removal", []config.ChildSpec{})
 	}
 
 	// Top-level parent gate: advance only if the user-configured State is
 	// "running". exampleparent has no parent of its own; child workers use
-	// IsShutdownRequested propagated from ChildSpec.Enabled instead.
+	// IsBeingRemoved propagated from ChildSpec.Enabled instead.
 	if snap.Desired.Config.GetState() == config.DesiredStateRunning {
 		elapsed := time.Duration(snap.Observed.Metrics.Framework.TimeInCurrentStateMs) * time.Millisecond
 		if elapsed >= StoppedWaitDuration {

--- a/umh-core/pkg/fsmv2/workers/example/exampleparent/state/state_trying_to_start.go
+++ b/umh-core/pkg/fsmv2/workers/example/exampleparent/state/state_trying_to_start.go
@@ -32,7 +32,7 @@ type TryingToStartState struct {
 func (s *TryingToStartState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[exampleparent.ExampleparentConfig, exampleparent.ExampleparentStatus](snapAny)
 
-	if snap.Desired.IsShutdownRequested() {
+	if snap.Desired.IsBeingRemoved() {
 		return fsmv2.Transition(&TryingToStopState{}, fsmv2.SignalNone, nil, "Shutdown requested, transitioning to TryingToStop", []config.ChildSpec{})
 	}
 

--- a/umh-core/pkg/fsmv2/workers/example/exampleparent/state/state_trying_to_stop.go
+++ b/umh-core/pkg/fsmv2/workers/example/exampleparent/state/state_trying_to_stop.go
@@ -25,7 +25,7 @@ import (
 // TryingToStopState represents the state during graceful shutdown. While in
 // this state the parent emits an empty ChildSpec slice so the supervisor calls
 // RequestShutdown on every existing child; children absent from the emitted
-// specs receive ShutdownRequested=true and stop on their own.
+// specs receive IsBeingRemoved=true and stop on their own.
 // Waits for all children to stop before transitioning to StoppedState.
 type TryingToStopState struct {
 	helpers.StoppingBase

--- a/umh-core/pkg/fsmv2/workers/example/exampleparent/state/state_trying_to_stop.go
+++ b/umh-core/pkg/fsmv2/workers/example/exampleparent/state/state_trying_to_stop.go
@@ -24,7 +24,7 @@ import (
 
 // TryingToStopState represents the state during graceful shutdown. While in
 // this state the parent emits an empty ChildSpec slice so the supervisor calls
-// RequestShutdown on every existing child; children absent from the emitted
+// RequestRemoval on every existing child; children absent from the emitted
 // specs receive IsBeingRemoved=true and stop on their own.
 // Waits for all children to stop before transitioning to StoppedState.
 type TryingToStopState struct {

--- a/umh-core/pkg/fsmv2/workers/example/exampleparent/worker_test.go
+++ b/umh-core/pkg/fsmv2/workers/example/exampleparent/worker_test.go
@@ -75,7 +75,7 @@ var _ = Describe("ParentWorker", func() {
 
 			Expect(err).ToNot(HaveOccurred())
 			desired := desiredIface.(*fsmv2.WrappedDesiredState[exampleparent.ExampleparentConfig])
-			Expect(desired.IsShutdownRequested()).To(BeFalse())
+			Expect(desired.IsBeingRemoved()).To(BeFalse())
 			// ChildrenCount == 0 -> non-nil empty slice (worker.go: spec parse with ChildrenCount=0).
 			Expect(desired.ChildrenSpecs).To(BeEmpty())
 			Expect(desired.ChildrenSpecs).NotTo(BeNil())
@@ -98,7 +98,7 @@ var _ = Describe("ParentWorker", func() {
 
 			Expect(err).ToNot(HaveOccurred())
 			desired := desiredIface.(*fsmv2.WrappedDesiredState[exampleparent.ExampleparentConfig])
-			Expect(desired.IsShutdownRequested()).To(BeFalse())
+			Expect(desired.IsBeingRemoved()).To(BeFalse())
 			Expect(desired.ChildrenSpecs).To(HaveLen(3))
 			Expect(desired.ChildrenSpecs[0].Name).To(Equal("child-0"))
 			Expect(desired.ChildrenSpecs[0].Enabled).To(BeTrue(), "ChildSpec.Enabled must be true (§4-C/F4⊕G1 invariant)")

--- a/umh-core/pkg/fsmv2/workers/example/exampleslow/state/state_stopped.go
+++ b/umh-core/pkg/fsmv2/workers/example/exampleslow/state/state_stopped.go
@@ -31,11 +31,11 @@ type StoppedState struct {
 func (s *StoppedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[exampleslow.ExampleslowConfig, exampleslow.ExampleslowStatus](snapAny)
 
-	if snap.Desired.IsShutdownRequested() {
+	if snap.Desired.IsBeingRemoved() {
 		return fsmv2.Transition(s, fsmv2.SignalNeedsRemoval, nil, "shutdown requested, needs removal", nil)
 	}
 
-	// Parent disable propagates via ChildSpec.Enabled=false → IsShutdownRequested
+	// Parent disable propagates via ChildSpec.Enabled=false → IsBeingRemoved
 	// (handled by the shutdown check above). When neither user nor parent has
 	// requested stop, advance to TryingToConnect.
 	if !snap.ShouldStop() {

--- a/umh-core/pkg/fsmv2/workers/example/helloworld/state/state_degraded_test.go
+++ b/umh-core/pkg/fsmv2/workers/example/helloworld/state/state_degraded_test.go
@@ -104,7 +104,7 @@ var _ = Describe("DegradedState", func() {
 						Status: hello_world.HelloworldStatus{Mood: "sad", HelloSaid: true},
 					},
 					Desired: &fsmv2.WrappedDesiredState[hello_world.HelloworldConfig]{
-						BaseDesiredState: config.BaseDesiredState{ShutdownRequested: true},
+						BaseDesiredState: config.BaseDesiredState{BeingRemoved: true},
 					},
 				}
 			})
@@ -185,7 +185,7 @@ var _ = Describe("DegradedState Transitions", func() {
 					Status: hello_world.HelloworldStatus{Mood: "sad", HelloSaid: true},
 				},
 				Desired: &fsmv2.WrappedDesiredState[hello_world.HelloworldConfig]{
-					BaseDesiredState: config.BaseDesiredState{ShutdownRequested: true},
+					BaseDesiredState: config.BaseDesiredState{BeingRemoved: true},
 				},
 			}
 
@@ -203,7 +203,7 @@ var _ = Describe("DegradedState Transitions", func() {
 					Status: hello_world.HelloworldStatus{Mood: "happy", HelloSaid: true},
 				},
 				Desired: &fsmv2.WrappedDesiredState[hello_world.HelloworldConfig]{
-					BaseDesiredState: config.BaseDesiredState{ShutdownRequested: true},
+					BaseDesiredState: config.BaseDesiredState{BeingRemoved: true},
 				},
 			}
 

--- a/umh-core/pkg/fsmv2/workers/example/helloworld/state/state_running_test.go
+++ b/umh-core/pkg/fsmv2/workers/example/helloworld/state/state_running_test.go
@@ -74,7 +74,7 @@ var _ = Describe("RunningState", func() {
 						Status: hello_world.HelloworldStatus{HelloSaid: true},
 					},
 					Desired: &fsmv2.WrappedDesiredState[hello_world.HelloworldConfig]{
-						BaseDesiredState: config.BaseDesiredState{ShutdownRequested: true},
+						BaseDesiredState: config.BaseDesiredState{BeingRemoved: true},
 					},
 				}
 			})
@@ -121,7 +121,7 @@ var _ = Describe("RunningState Transitions", func() {
 					Status: hello_world.HelloworldStatus{HelloSaid: true},
 				},
 				Desired: &fsmv2.WrappedDesiredState[hello_world.HelloworldConfig]{
-					BaseDesiredState: config.BaseDesiredState{ShutdownRequested: true},
+					BaseDesiredState: config.BaseDesiredState{BeingRemoved: true},
 				},
 			}
 
@@ -157,7 +157,7 @@ var _ = Describe("RunningState Transitions", func() {
 					Status: hello_world.HelloworldStatus{HelloSaid: true},
 				},
 				Desired: &fsmv2.WrappedDesiredState[hello_world.HelloworldConfig]{
-					BaseDesiredState: config.BaseDesiredState{ShutdownRequested: false},
+					BaseDesiredState: config.BaseDesiredState{BeingRemoved: false},
 				},
 			}
 

--- a/umh-core/pkg/fsmv2/workers/example/helloworld/state/state_stopped_test.go
+++ b/umh-core/pkg/fsmv2/workers/example/helloworld/state/state_stopped_test.go
@@ -70,7 +70,7 @@ var _ = Describe("StoppedState", func() {
 					Identity: deps.Identity{ID: "test", Name: "test", WorkerType: "helloworld"},
 					Observed: fsmv2.Observation[hello_world.HelloworldStatus]{},
 					Desired: &fsmv2.WrappedDesiredState[hello_world.HelloworldConfig]{
-						BaseDesiredState: config.BaseDesiredState{ShutdownRequested: true},
+						BaseDesiredState: config.BaseDesiredState{BeingRemoved: true},
 					},
 				}
 			})
@@ -129,7 +129,7 @@ var _ = Describe("StoppedState Transitions", func() {
 				Identity: deps.Identity{ID: "hello-1", Name: "helloworld", WorkerType: "helloworld"},
 				Observed: fsmv2.Observation[hello_world.HelloworldStatus]{},
 				Desired: &fsmv2.WrappedDesiredState[hello_world.HelloworldConfig]{
-					BaseDesiredState: config.BaseDesiredState{ShutdownRequested: false},
+					BaseDesiredState: config.BaseDesiredState{BeingRemoved: false},
 				},
 			}
 
@@ -147,7 +147,7 @@ var _ = Describe("StoppedState Transitions", func() {
 				Identity: deps.Identity{ID: "test", Name: "test", WorkerType: "helloworld"},
 				Observed: fsmv2.Observation[hello_world.HelloworldStatus]{},
 				Desired: &fsmv2.WrappedDesiredState[hello_world.HelloworldConfig]{
-					BaseDesiredState: config.BaseDesiredState{ShutdownRequested: true},
+					BaseDesiredState: config.BaseDesiredState{BeingRemoved: true},
 				},
 			}
 
@@ -165,7 +165,7 @@ var _ = Describe("StoppedState Transitions", func() {
 					Status: hello_world.HelloworldStatus{HelloSaid: true},
 				},
 				Desired: &fsmv2.WrappedDesiredState[hello_world.HelloworldConfig]{
-					BaseDesiredState: config.BaseDesiredState{ShutdownRequested: true},
+					BaseDesiredState: config.BaseDesiredState{BeingRemoved: true},
 				},
 			}
 

--- a/umh-core/pkg/fsmv2/workers/example/helloworld/state/state_trying_to_start_test.go
+++ b/umh-core/pkg/fsmv2/workers/example/helloworld/state/state_trying_to_start_test.go
@@ -105,7 +105,7 @@ var _ = Describe("TryingToStartState", func() {
 						Status: hello_world.HelloworldStatus{HelloSaid: false},
 					},
 					Desired: &fsmv2.WrappedDesiredState[hello_world.HelloworldConfig]{
-						BaseDesiredState: config.BaseDesiredState{ShutdownRequested: true},
+						BaseDesiredState: config.BaseDesiredState{BeingRemoved: true},
 					},
 				}
 			})
@@ -137,7 +137,7 @@ var _ = Describe("TryingToStartState", func() {
 						Status: hello_world.HelloworldStatus{HelloSaid: true},
 					},
 					Desired: &fsmv2.WrappedDesiredState[hello_world.HelloworldConfig]{
-						BaseDesiredState: config.BaseDesiredState{ShutdownRequested: true},
+						BaseDesiredState: config.BaseDesiredState{BeingRemoved: true},
 					},
 				}
 
@@ -190,7 +190,7 @@ var _ = Describe("TryingToStartState Transitions", func() {
 					Status: hello_world.HelloworldStatus{HelloSaid: false},
 				},
 				Desired: &fsmv2.WrappedDesiredState[hello_world.HelloworldConfig]{
-					BaseDesiredState: config.BaseDesiredState{ShutdownRequested: true},
+					BaseDesiredState: config.BaseDesiredState{BeingRemoved: true},
 				},
 			}
 

--- a/umh-core/pkg/fsmv2/workers/persistence/snapshot/snapshot.go
+++ b/umh-core/pkg/fsmv2/workers/persistence/snapshot/snapshot.go
@@ -73,7 +73,7 @@ func (c PersistenceConfig) GetMaintenanceInterval() time.Duration {
 
 // PersistenceStatus holds the runtime observation data for the persistence worker.
 // Framework fields (CollectedAt, State, LastActionResults, MetricsEmbedder,
-// ShutdownRequested, children counts) are carried by fsmv2.Observation[PersistenceStatus]
+// IsBeingRemoved, children counts) are carried by fsmv2.Observation[PersistenceStatus]
 // and are not duplicated here.
 type PersistenceStatus struct {
 	// LastCompactionAt records the most recent successful compaction timestamp.

--- a/umh-core/pkg/fsmv2/workers/persistence/state/state_degraded_test.go
+++ b/umh-core/pkg/fsmv2/workers/persistence/state/state_degraded_test.go
@@ -48,7 +48,7 @@ var _ = Describe("DegradedState", func() {
 					},
 					Desired: &fsmv2.WrappedDesiredState[snapshot.PersistenceConfig]{
 						BaseDesiredState: fsmv2config.BaseDesiredState{
-							ShutdownRequested: true,
+							BeingRemoved: true,
 						},
 						Config: snapshot.PersistenceConfig{
 							CompactionInterval:  5 * time.Minute,

--- a/umh-core/pkg/fsmv2/workers/persistence/state/state_running_test.go
+++ b/umh-core/pkg/fsmv2/workers/persistence/state/state_running_test.go
@@ -45,7 +45,7 @@ var _ = Describe("RunningState", func() {
 					},
 					Desired: &fsmv2.WrappedDesiredState[snapshot.PersistenceConfig]{
 						BaseDesiredState: fsmv2config.BaseDesiredState{
-							ShutdownRequested: true,
+							BeingRemoved: true,
 						},
 						Config: snapshot.PersistenceConfig{
 							CompactionInterval:  5 * time.Minute,

--- a/umh-core/pkg/fsmv2/workers/persistence/state/state_stopped_test.go
+++ b/umh-core/pkg/fsmv2/workers/persistence/state/state_stopped_test.go
@@ -44,7 +44,7 @@ var _ = Describe("StoppedState", func() {
 					},
 					Desired: &fsmv2.WrappedDesiredState[snapshot.PersistenceConfig]{
 						BaseDesiredState: fsmv2config.BaseDesiredState{
-							ShutdownRequested: true,
+							BeingRemoved: true,
 						},
 						Config: snapshot.PersistenceConfig{
 							CompactionInterval:  5 * time.Minute,

--- a/umh-core/pkg/fsmv2/workers/persistence/state/state_stopping_test.go
+++ b/umh-core/pkg/fsmv2/workers/persistence/state/state_stopping_test.go
@@ -48,7 +48,7 @@ var _ = Describe("StoppingState", func() {
 					},
 					Desired: &fsmv2.WrappedDesiredState[snapshot.PersistenceConfig]{
 						BaseDesiredState: fsmv2config.BaseDesiredState{
-							ShutdownRequested: true,
+							BeingRemoved: true,
 						},
 						Config: snapshot.PersistenceConfig{
 							CompactionInterval:  5 * time.Minute,
@@ -74,7 +74,7 @@ var _ = Describe("StoppingState", func() {
 					},
 					Desired: &fsmv2.WrappedDesiredState[snapshot.PersistenceConfig]{
 						BaseDesiredState: fsmv2config.BaseDesiredState{
-							ShutdownRequested: true,
+							BeingRemoved: true,
 						},
 						Config: snapshot.PersistenceConfig{
 							CompactionInterval:  5 * time.Minute,
@@ -103,7 +103,7 @@ var _ = Describe("StoppingState", func() {
 					},
 					Desired: &fsmv2.WrappedDesiredState[snapshot.PersistenceConfig]{
 						BaseDesiredState: fsmv2config.BaseDesiredState{
-							ShutdownRequested: true,
+							BeingRemoved: true,
 						},
 						Config: snapshot.PersistenceConfig{
 							CompactionInterval:  5 * time.Minute,
@@ -132,7 +132,7 @@ var _ = Describe("StoppingState", func() {
 					},
 					Desired: &fsmv2.WrappedDesiredState[snapshot.PersistenceConfig]{
 						BaseDesiredState: fsmv2config.BaseDesiredState{
-							ShutdownRequested: true,
+							BeingRemoved: true,
 						},
 						Config: snapshot.PersistenceConfig{
 							CompactionInterval:  5 * time.Minute,

--- a/umh-core/pkg/fsmv2/workers/persistence/state/state_trying_to_start_test.go
+++ b/umh-core/pkg/fsmv2/workers/persistence/state/state_trying_to_start_test.go
@@ -45,7 +45,7 @@ var _ = Describe("TryingToStartState", func() {
 					},
 					Desired: &fsmv2.WrappedDesiredState[snapshot.PersistenceConfig]{
 						BaseDesiredState: fsmv2config.BaseDesiredState{
-							ShutdownRequested: true,
+							BeingRemoved: true,
 						},
 						Config: snapshot.PersistenceConfig{
 							CompactionInterval:  5 * time.Minute,
@@ -155,7 +155,7 @@ var _ = Describe("TryingToStartState", func() {
 					},
 					Desired: &fsmv2.WrappedDesiredState[snapshot.PersistenceConfig]{
 						BaseDesiredState: fsmv2config.BaseDesiredState{
-							ShutdownRequested: true,
+							BeingRemoved: true,
 						},
 						Config: snapshot.PersistenceConfig{
 							CompactionInterval:  5 * time.Minute,

--- a/umh-core/pkg/fsmv2/workers/transport/pull/state/state_stopped.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/state/state_stopped.go
@@ -33,7 +33,7 @@ type StoppedState struct {
 func (s *StoppedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[pull_pkg.PullConfig, pull_pkg.PullStatus](snapAny)
 
-	if snap.Desired.IsShutdownRequested() {
+	if snap.Desired.IsBeingRemoved() {
 		return fsmv2.Transition(s, fsmv2.SignalNeedsRemoval, nil, "shutdown requested, signaling removal", nil)
 	}
 

--- a/umh-core/pkg/fsmv2/workers/transport/pull/state/state_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/state/state_test.go
@@ -72,7 +72,7 @@ func makeSnapshotWithBackoff(
 
 	desired := &fsmv2.WrappedDesiredState[pull_pkg.PullConfig]{
 		BaseDesiredState: config.BaseDesiredState{
-			ShutdownRequested: effectiveShutdown,
+			BeingRemoved: effectiveShutdown,
 		},
 	}
 

--- a/umh-core/pkg/fsmv2/workers/transport/pull/state/state_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/state/state_test.go
@@ -61,10 +61,12 @@ func makeSnapshotWithBackoff(
 	degradedEnteredAt time.Time,
 	lastErrorAt time.Time,
 ) fsmv2.Snapshot {
-	// Parent-driven stop now flows through IsShutdownRequested via the
-	// CHANGE-19 reducer. Translate the legacy parentMappedState=stopped test
-	// input into shutdownRequested=true so existing scenarios still exercise
-	// the parent-stop code path. Callers that intentionally probe the
+	// Legacy parentMappedState=stopped test input is translated into
+	// shutdownRequested=true so existing scenarios still exercise the
+	// permanent-removal code path (Phase-1 absent-from-specs). Transient
+	// parent-disable (Enabled=false → IsDisabled, added in PR5) is not
+	// modelled here; callers exercising disable-without-removal must wait
+	// for PR5.7 helper updates. Callers that intentionally probe the
 	// "stopped, no shutdown" combination must pass parentMappedState=running.
 	effectiveShutdown := shutdownRequested || parentMappedState == config.DesiredStateStopped
 
@@ -122,11 +124,11 @@ var _ = Describe("StoppedState", func() {
 		Expect(result.State).To(BeAssignableToTypeOf(&state.RunningState{}))
 	})
 
-	It("should signal NeedsRemoval when parent has stopped (Enabled=false → shutdown)", func() {
-		// Under PR3 semantics, parent-driven stop flows through
-		// IsShutdownRequested via the CHANGE-19 reducer. The helper
-		// translates parentMappedState=stopped → shutdownRequested=true,
-		// so this case behaves like the explicit-shutdown case above.
+	It("should signal NeedsRemoval when parent has stopped (legacy mapping → shutdown)", func() {
+		// The makeSnapshot helper translates parentMappedState=stopped into
+		// shutdownRequested=true to exercise the permanent-removal path
+		// (Phase-1 absent-from-specs). Transient parent-disable (PR5
+		// IsDisabled signal) is not modelled here yet — see PR5.7.
 		snap := makeSnapshot(config.DesiredStateStopped, false, 0, false, false)
 		result := s.Next(snap)
 		Expect(result.State).To(BeAssignableToTypeOf(&state.StoppedState{}))

--- a/umh-core/pkg/fsmv2/workers/transport/push/state/state_stopped.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/state/state_stopped.go
@@ -32,7 +32,7 @@ type StoppedState struct {
 func (s *StoppedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[push_pkg.PushConfig, push_pkg.PushStatus](snapAny)
 
-	if snap.Desired.IsShutdownRequested() {
+	if snap.Desired.IsBeingRemoved() {
 		return fsmv2.Transition(s, fsmv2.SignalNeedsRemoval, nil, "shutdown requested, signaling removal", nil)
 	}
 

--- a/umh-core/pkg/fsmv2/workers/transport/push/state/state_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/state/state_test.go
@@ -70,7 +70,7 @@ func makeSnapshotWithBackoff(
 
 	desired := &fsmv2.WrappedDesiredState[push_pkg.PushConfig]{
 		BaseDesiredState: config.BaseDesiredState{
-			ShutdownRequested: effectiveShutdown,
+			BeingRemoved: effectiveShutdown,
 		},
 	}
 

--- a/umh-core/pkg/fsmv2/workers/transport/push/state/state_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/state/state_test.go
@@ -61,10 +61,11 @@ func makeSnapshotWithBackoff(
 	degradedEnteredAt time.Time,
 	lastErrorAt time.Time,
 ) fsmv2.Snapshot {
-	// Parent-driven stop now flows through IsShutdownRequested via the
-	// CHANGE-19 reducer. Translate the legacy parentMappedState=stopped test
-	// input into shutdownRequested=true so existing scenarios still exercise
-	// the parent-stop code path.
+	// Legacy parentMappedState=stopped test input is translated into
+	// shutdownRequested=true so existing scenarios still exercise the
+	// permanent-removal code path (Phase-1 absent-from-specs). Transient
+	// parent-disable (Enabled=false → IsDisabled, added in PR5) is not
+	// modelled here; see PR5.7.
 	effectiveShutdown := shutdownRequested || parentMappedState == config.DesiredStateStopped
 
 	desired := &fsmv2.WrappedDesiredState[push_pkg.PushConfig]{
@@ -121,11 +122,11 @@ var _ = Describe("StoppedState", func() {
 		Expect(result.State).To(BeAssignableToTypeOf(&state.RunningState{}))
 	})
 
-	It("should signal NeedsRemoval when parent has stopped (Enabled=false → shutdown)", func() {
-		// Under PR3 semantics, parent-driven stop flows through
-		// IsShutdownRequested via the CHANGE-19 reducer. The helper
-		// translates parentMappedState=stopped → shutdownRequested=true,
-		// so this case behaves like the explicit-shutdown case above.
+	It("should signal NeedsRemoval when parent has stopped (legacy mapping → shutdown)", func() {
+		// The makeSnapshot helper translates parentMappedState=stopped into
+		// shutdownRequested=true to exercise the permanent-removal path
+		// (Phase-1 absent-from-specs). Transient parent-disable (PR5
+		// IsDisabled signal) is not modelled here yet — see PR5.7.
 		snap := makeSnapshot(config.DesiredStateStopped, false, 0, false, false)
 		result := s.Next(snap)
 		Expect(result.State).To(BeAssignableToTypeOf(&state.StoppedState{}))

--- a/umh-core/pkg/fsmv2/workers/transport/state/state_stopped.go
+++ b/umh-core/pkg/fsmv2/workers/transport/state/state_stopped.go
@@ -46,7 +46,7 @@ func (s *StoppedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	}
 
 	// Stay stopped: keep children resident but disabled. The CHANGE-19 reducer
-	// (supervisor/reconciliation.go) translates Enabled=false into RequestShutdown
+	// (supervisor/reconciliation.go) translates Enabled=false into RequestRemoval
 	// while leaving the child in supervisor's children map, so flipping Enabled
 	// back to true on transition resumes cleanly without losing internal state.
 	return fsmv2.Transition(s, fsmv2.SignalNone, nil, "Transport is stopped, waiting for running request", config.DisableAll(children))

--- a/umh-core/pkg/fsmv2/workers/transport/state/state_stopped.go
+++ b/umh-core/pkg/fsmv2/workers/transport/state/state_stopped.go
@@ -32,6 +32,12 @@ type StoppedState struct {
 }
 
 // Next evaluates the current snapshot and returns the next state or action.
+//
+// Diverges from the canonical helpers.StoppedNext pattern because Transport is
+// a parent worker: its StoppedState renders children explicitly (resident but
+// disabled via config.DisableAll) so internal state survives a stop/start
+// cycle. helpers.StoppedNext does not emit children and so is not a fit here;
+// the three-branch shape below mirrors it for the leaf concerns.
 func (s *StoppedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[transport_pkg.TransportConfig, transport_pkg.TransportStatus](snapAny)
 

--- a/umh-core/pkg/fsmv2/workers/transport/state/state_stopped.go
+++ b/umh-core/pkg/fsmv2/workers/transport/state/state_stopped.go
@@ -35,7 +35,7 @@ type StoppedState struct {
 func (s *StoppedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[transport_pkg.TransportConfig, transport_pkg.TransportStatus](snapAny)
 
-	if snap.Desired.IsShutdownRequested() {
+	if snap.Desired.IsBeingRemoved() {
 		return fsmv2.Transition(s, fsmv2.SignalNeedsRemoval, nil, "Shutdown requested, signaling removal", nil)
 	}
 

--- a/umh-core/pkg/fsmv2/workers/transport/state/state_stopping.go
+++ b/umh-core/pkg/fsmv2/workers/transport/state/state_stopping.go
@@ -36,7 +36,7 @@ func (s *StoppingState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[transport_pkg.TransportConfig, transport_pkg.TransportStatus](snapAny)
 
 	// Stopping: keep children resident but disabled so the CHANGE-19 reducer
-	// drives RequestShutdown without despawning. Children resume cleanly when
+	// drives RequestRemoval without despawning. Children resume cleanly when
 	// the parent re-enters a running path and emits Enabled=true again.
 
 	return fsmv2.Transition(&StoppedState{}, fsmv2.SignalNone, nil,

--- a/umh-core/pkg/fsmv2/workers/transport/state/state_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/state/state_test.go
@@ -40,7 +40,7 @@ func makeSnapshotFull(shutdownRequested bool, desiredState string, jwtToken stri
 func makeSnapshotWithBackoff(shutdownRequested bool, desiredState string, jwtToken string, jwtExpiry time.Time, childrenHealthy, childrenUnhealthy int, consecutiveErrors int, lastErrorType httpTransport.ErrorType, lastAuthAttemptAt time.Time, lastRetryAfter time.Duration) fsmv2.Snapshot {
 	desired := &fsmv2.WrappedDesiredState[transport_pkg.TransportConfig]{
 		BaseDesiredState: config.BaseDesiredState{
-			ShutdownRequested: shutdownRequested,
+			BeingRemoved: shutdownRequested,
 		},
 		Config: transport_pkg.TransportConfig{
 			BaseUserSpec: config.BaseUserSpec{State: desiredState},
@@ -83,7 +83,7 @@ func makeSnapshotWithBackoff(shutdownRequested bool, desiredState string, jwtTok
 func makeAuthFailedSnapshot(authToken, relayURL, instanceUUID string, shutdownRequested bool) fsmv2.Snapshot {
 	desired := &fsmv2.WrappedDesiredState[transport_pkg.TransportConfig]{
 		BaseDesiredState: config.BaseDesiredState{
-			ShutdownRequested: shutdownRequested,
+			BeingRemoved: shutdownRequested,
 		},
 		Config: transport_pkg.TransportConfig{
 			BaseUserSpec: config.BaseUserSpec{State: config.DesiredStateRunning},

--- a/umh-core/pkg/fsmv2/wrapped_desired_state.go
+++ b/umh-core/pkg/fsmv2/wrapped_desired_state.go
@@ -37,19 +37,31 @@ func (d *WrappedDesiredState[TConfig]) GetChildrenSpecs() []config.ChildSpec {
 	return d.ChildrenSpecs
 }
 
-// IsDisabled reports whether this child is currently disabled by its parent.
-// Set by the CHANGE-19 reducer when ChildSpec.Enabled=false. Transient — the
-// parent may flip Enabled=true to resume the child without removing it.
+// IsDisabled reports whether this child is currently transient-paused by its
+// parent (case B in the six-cases enumeration). Set by the CHANGE-19 reducer
+// in supervisor/reconciliation.go when the parent's ChildSpec.Enabled=false
+// for this child; cleared when the parent flips back to Enabled=true. The
+// reducer runs at the start of reconcileChildren, before the child's tick,
+// so child state files see a consistent value for the whole tick.
 //
-// Compare with IsBeingRemoved (permanent removal — renamed from
-// IsShutdownRequested in PR5.3) and Config.GetState()=="stopped"
-// (user-driven stop). See WorkerSnapshot.ShouldStop for the umbrella
-// semantic.
+// Transient: the worker stays resident in s.children. ShouldStop returns true
+// (the umbrella OR), so non-Stopped states route to Stopping → Stopped via
+// the standard stop path. The Stopped state stays put (helpers.StoppedNext
+// "stay resident" branch) and resumes to TryingToStart when IsDisabled clears.
+//
+// Distinct from IsBeingRemoved (permanent removal — cases C, D, E, F: parent
+// omits spec, SignalNeedsRestart, graceful process shutdown, supervisor
+// self-protection) and Config.GetState()=="stopped" (transient user-driven
+// stop — case A). See WorkerSnapshot.ShouldStop for the umbrella OR over all
+// three, and pkg/fsmv2/CLAUDE.md "Stopping a worker — six cases, three
+// signals" for the case table.
 func (d *WrappedDesiredState[TConfig]) IsDisabled() bool {
 	return d.Disabled
 }
 
-// SetDisabled sets the disabled flag. Called by the supervisor reducer.
+// SetDisabled sets the transient-disable flag. Called by the CHANGE-19 reducer
+// in supervisor/reconciliation.go from the parent's ChildSpec.Enabled flag.
+// Worker code should not call this directly.
 func (d *WrappedDesiredState[TConfig]) SetDisabled(v bool) {
 	d.Disabled = v
 }

--- a/umh-core/pkg/fsmv2/wrapped_desired_state.go
+++ b/umh-core/pkg/fsmv2/wrapped_desired_state.go
@@ -28,10 +28,27 @@ type WrappedDesiredState[TConfig any] struct {
 	config.BaseDesiredState
 	Config        TConfig            `json:"config"`
 	ChildrenSpecs []config.ChildSpec `json:"childrenSpecs,omitempty"`
+	Disabled      bool               `json:"isDisabled,omitempty"`
 }
 
 // GetChildrenSpecs returns the children specifications.
 // Implements config.ChildSpecProvider interface.
 func (d *WrappedDesiredState[TConfig]) GetChildrenSpecs() []config.ChildSpec {
 	return d.ChildrenSpecs
+}
+
+// IsDisabled reports whether this child is currently disabled by its parent.
+// Set by the CHANGE-19 reducer when ChildSpec.Enabled=false. Transient — the
+// parent may flip Enabled=true to resume the child without removing it.
+//
+// Compare with IsShutdownRequested (permanent removal; renamed IsBeingRemoved
+// in PR5.3) and Config.GetState()=="stopped" (user-driven stop). See
+// WorkerSnapshot.ShouldStop for the umbrella semantic.
+func (d *WrappedDesiredState[TConfig]) IsDisabled() bool {
+	return d.Disabled
+}
+
+// SetDisabled sets the disabled flag. Called by the supervisor reducer.
+func (d *WrappedDesiredState[TConfig]) SetDisabled(v bool) {
+	d.Disabled = v
 }

--- a/umh-core/pkg/fsmv2/wrapped_desired_state.go
+++ b/umh-core/pkg/fsmv2/wrapped_desired_state.go
@@ -20,7 +20,7 @@ import (
 
 // WrappedDesiredState wraps a developer's TConfig into the full DesiredState
 // required by the supervisor. BaseDesiredState promotion provides
-// IsShutdownRequested and SetShutdownRequested for free.
+// IsBeingRemoved and SetBeingRemoved for free.
 //
 // The framework constructs this internally during DeriveDesiredState;
 // developers only provide TConfig via WorkerBase helpers.
@@ -41,9 +41,10 @@ func (d *WrappedDesiredState[TConfig]) GetChildrenSpecs() []config.ChildSpec {
 // Set by the CHANGE-19 reducer when ChildSpec.Enabled=false. Transient — the
 // parent may flip Enabled=true to resume the child without removing it.
 //
-// Compare with IsShutdownRequested (permanent removal; renamed IsBeingRemoved
-// in PR5.3) and Config.GetState()=="stopped" (user-driven stop). See
-// WorkerSnapshot.ShouldStop for the umbrella semantic.
+// Compare with IsBeingRemoved (permanent removal — renamed from
+// IsShutdownRequested in PR5.3) and Config.GetState()=="stopped"
+// (user-driven stop). See WorkerSnapshot.ShouldStop for the umbrella
+// semantic.
 func (d *WrappedDesiredState[TConfig]) IsDisabled() bool {
 	return d.Disabled
 }

--- a/umh-core/pkg/fsmv2/wrapped_desired_state_test.go
+++ b/umh-core/pkg/fsmv2/wrapped_desired_state_test.go
@@ -27,6 +27,7 @@ import (
 // Compile-time assertions: WrappedDesiredState satisfies framework interfaces.
 var _ fsmv2.DesiredState = &fsmv2.WrappedDesiredState[testConfig]{}
 var _ fsmv2.ShutdownRequestable = &fsmv2.WrappedDesiredState[testConfig]{}
+var _ fsmv2.Disablable = &fsmv2.WrappedDesiredState[testConfig]{}
 var _ config.ChildSpecProvider = &fsmv2.WrappedDesiredState[testConfig]{}
 
 // testConfig is a minimal worker configuration for testing.
@@ -94,6 +95,49 @@ var _ = Describe("WrappedDesiredState", func() {
 			Expect(restored.Config.Host).To(Equal("localhost"))
 			Expect(restored.Config.Port).To(Equal(8080))
 			Expect(restored.IsShutdownRequested()).To(BeTrue())
+		})
+	})
+
+	Describe("IsDisabled", func() {
+		It("returns false by default", func() {
+			ds := &fsmv2.WrappedDesiredState[testConfig]{}
+			Expect(ds.IsDisabled()).To(BeFalse())
+		})
+
+		It("returns true after SetDisabled(true)", func() {
+			ds := &fsmv2.WrappedDesiredState[testConfig]{}
+			ds.SetDisabled(true)
+			Expect(ds.IsDisabled()).To(BeTrue())
+		})
+
+		It("returns false after SetDisabled(false)", func() {
+			ds := &fsmv2.WrappedDesiredState[testConfig]{Disabled: true}
+			Expect(ds.IsDisabled()).To(BeTrue())
+			ds.SetDisabled(false)
+			Expect(ds.IsDisabled()).To(BeFalse())
+		})
+	})
+
+	Describe("Disabled JSON serialization", func() {
+		It("omits the field when false (omitempty)", func() {
+			ds := &fsmv2.WrappedDesiredState[testConfig]{}
+			data, err := json.Marshal(ds)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(data)).NotTo(ContainSubstring("isDisabled"))
+		})
+
+		It("includes the field when true", func() {
+			ds := &fsmv2.WrappedDesiredState[testConfig]{Disabled: true}
+			data, err := json.Marshal(ds)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(data)).To(ContainSubstring(`"isDisabled":true`))
+		})
+
+		It("unmarshals isDisabled into Disabled field", func() {
+			raw := `{"config":{"host":"","port":0},"isDisabled":true}`
+			var ds fsmv2.WrappedDesiredState[testConfig]
+			Expect(json.Unmarshal([]byte(raw), &ds)).To(Succeed())
+			Expect(ds.IsDisabled()).To(BeTrue())
 		})
 	})
 

--- a/umh-core/pkg/fsmv2/wrapped_desired_state_test.go
+++ b/umh-core/pkg/fsmv2/wrapped_desired_state_test.go
@@ -26,7 +26,7 @@ import (
 
 // Compile-time assertions: WrappedDesiredState satisfies framework interfaces.
 var _ fsmv2.DesiredState = &fsmv2.WrappedDesiredState[testConfig]{}
-var _ fsmv2.ShutdownRequestable = &fsmv2.WrappedDesiredState[testConfig]{}
+var _ fsmv2.RemovalRequestable = &fsmv2.WrappedDesiredState[testConfig]{}
 var _ fsmv2.Disablable = &fsmv2.WrappedDesiredState[testConfig]{}
 var _ config.ChildSpecProvider = &fsmv2.WrappedDesiredState[testConfig]{}
 
@@ -37,35 +37,35 @@ type testConfig struct {
 }
 
 var _ = Describe("WrappedDesiredState", func() {
-	Describe("IsShutdownRequested", func() {
+	Describe("IsBeingRemoved", func() {
 		It("returns false when not requested", func() {
 			ds := &fsmv2.WrappedDesiredState[testConfig]{}
-			Expect(ds.IsShutdownRequested()).To(BeFalse())
+			Expect(ds.IsBeingRemoved()).To(BeFalse())
 		})
 
 		It("returns true when requested", func() {
 			ds := &fsmv2.WrappedDesiredState[testConfig]{
-				BaseDesiredState: config.BaseDesiredState{ShutdownRequested: true},
+				BaseDesiredState: config.BaseDesiredState{BeingRemoved: true},
 			}
-			Expect(ds.IsShutdownRequested()).To(BeTrue())
+			Expect(ds.IsBeingRemoved()).To(BeTrue())
 		})
 	})
 
-	Describe("SetShutdownRequested", func() {
+	Describe("SetBeingRemoved", func() {
 		It("sets shutdown to true", func() {
 			ds := &fsmv2.WrappedDesiredState[testConfig]{}
-			Expect(ds.IsShutdownRequested()).To(BeFalse())
+			Expect(ds.IsBeingRemoved()).To(BeFalse())
 
-			ds.SetShutdownRequested(true)
-			Expect(ds.IsShutdownRequested()).To(BeTrue())
+			ds.SetBeingRemoved(true)
+			Expect(ds.IsBeingRemoved()).To(BeTrue())
 		})
 
 		It("sets shutdown back to false", func() {
 			ds := &fsmv2.WrappedDesiredState[testConfig]{
-				BaseDesiredState: config.BaseDesiredState{ShutdownRequested: true},
+				BaseDesiredState: config.BaseDesiredState{BeingRemoved: true},
 			}
-			ds.SetShutdownRequested(false)
-			Expect(ds.IsShutdownRequested()).To(BeFalse())
+			ds.SetBeingRemoved(false)
+			Expect(ds.IsBeingRemoved()).To(BeFalse())
 		})
 	})
 
@@ -85,7 +85,7 @@ var _ = Describe("WrappedDesiredState", func() {
 			original := &fsmv2.WrappedDesiredState[testConfig]{
 				Config: testConfig{Host: "localhost", Port: 8080},
 			}
-			original.SetShutdownRequested(true)
+			original.SetBeingRemoved(true)
 
 			data, err := json.Marshal(original)
 			Expect(err).NotTo(HaveOccurred())
@@ -94,7 +94,7 @@ var _ = Describe("WrappedDesiredState", func() {
 			Expect(json.Unmarshal(data, &restored)).To(Succeed())
 			Expect(restored.Config.Host).To(Equal("localhost"))
 			Expect(restored.Config.Port).To(Equal(8080))
-			Expect(restored.IsShutdownRequested()).To(BeTrue())
+			Expect(restored.IsBeingRemoved()).To(BeTrue())
 		})
 	})
 


### PR DESCRIPTION
## Summary

Disambiguates the conflated `IsShutdownRequested` flag into three primitive stop signals so the framework can distinguish *transient parent-disable* from *permanent removal*. Lays the groundwork for future retain/hydrate (state-preservation across pause).

5th in the worker-api-v2 stack: #2536 → #2537 → #2538 → #2561 → this PR.

## The new model — six cases, three signals

A worker can be wanted-stopped for SIX semantically distinct reasons; PR5 maps them to THREE primitives:

| # | Case | Source | Permanence | Mapped signal |
|---|---|---|---|---|
| A | user `state: stopped` (YAML) | user config | Transient | `Config.GetState() == DesiredStateStopped` |
| B | parent disable (`ChildSpec.Enabled=false`) | parent renderChildren | Transient | `Desired.IsDisabled()` (NEW) |
| C | parent remove (omit from spec list) | renderChildren returns `[]ChildSpec{}` | Permanent | `Desired.IsBeingRemoved()` |
| D | self-driven restart (`SignalNeedsRestart`) | worker self | Permanent | `Desired.IsBeingRemoved()` |
| E | graceful process shutdown | process exit | Permanent | `Desired.IsBeingRemoved()` |
| F | supervisor self-protection (collector unresponsive) | Layer-3 escalation | Permanent | `Desired.IsBeingRemoved()` |

`WorkerSnapshot.ShouldStop()` ORs all three primitives — the umbrella check for non-Stopped state files. `helpers.StoppedNext()` (new helper) discriminates `IsBeingRemoved` (permanent → emit `NeedsRemoval`) from the others (transient → stay resident).

## Commits (7)

| | Subject |
|---|---|
| 1 | `PR5.1` add `IsDisabled` field to `WrappedDesiredState` |
| 2 | `PR5.4` `ShouldStop` ORs all three signals |
| 3 | `PR5.2` wire `SetDisabled` into CHANGE-19 reducer |
| 4 | `PR5.3` rename `ShutdownRequested` → `IsBeingRemoved` (79 files) |
| 5 | `PR5.5` rename `RequestShutdown` → `RequestRemoval` (and Clear*) |
| 6 | `PR5.9` add `helpers.StoppedNext()` framework helper |
| 7 | `PR5.10` docs: replace two-options framing with 6-cases enumeration |

## Renames (clean rename, wire format also changed)

- `BaseDesiredState.ShutdownRequested` field → `BeingRemoved`
- `IsShutdownRequested()` method → `IsBeingRemoved()`
- `SetShutdownRequested()` → `SetBeingRemoved()`
- `ShutdownRequestable` interface → `RemovalRequestable`
- `FieldShutdownRequested` constant → `FieldIsBeingRemoved`
- `Supervisor.{requestShutdown,RequestShutdown,clearShutdownRequested,ClearShutdownRequest}` → `{requestRemoval,RequestRemoval,clearRemoval,ClearRemoval}`
- JSON tag `"ShutdownRequested"` → `"isBeingRemoved"` (no on-disk state in production yet)

## What this enables (future work, not in PR5)

Pre-PR5: `Enabled=false` and `[]ChildSpec{}` both converged to "child gone" because both wrote `IsShutdownRequested=true`. State (counters, connection handles, pending buffers) lost in both cases.

Post-PR5: `Enabled=false` writes `IsDisabled=true` (transient — child stays resident in StoppedState, ready to resume). `[]ChildSpec{}` writes `IsBeingRemoved=true` (permanent — full teardown). The `cse:"retain"` + `DependencyHydrator` design (`003_klaus/artifacts/2026-04-09_fsmv2_state_recovery_design.md`) can now be wired on top — IsDisabled is the natural seam for state preservation.

## Verification

- `go build ./...` clean
- `go vet ./...` clean
- Supervisor tests pass per-package (281s)
- 2 of 3 example workers' `StoppedState` migrated to `helpers.StoppedNext()`; transport's parent-worker StoppedState left as-is with comment (different shape — renders children, not leaf semantic)
- Failing/Restart Scenario integration tests: **net improvement** vs PR4 baseline (was 100% deterministic fail; now passes ~95% with rare scenario hang)

## Known follow-ups (deferred, to be filed as separate Linear tickets post-merge)

- **Residual ~5% Failing/Restart Scenario hang**: architect's `pendingRestart` guard hypothesis was falsified during 5.8 investigation (proposed fix broke Restart deterministically). Real cause is a scenario hang, not stuck-in-shutdown — needs goroutine-dump-driven investigation. Not gating this PR (PR5 strictly improved this test class).
- **Parallel-test pollution** in `go test ./pkg/fsmv2/supervisor/...`: tests pass per-package but flake when the suite runs in parallel. Pre-existing pattern.
- **retain/hydrate implementation** (`cse:"retain"` + `DependencyHydrator`): designed but out of scope for PR5. PR5 lays the semantic groundwork only.

## Test plan

- [ ] CI green on this branch
- [ ] CodeRabbit pass
- [ ] Reviewer to verify Pattern A consistency between `IsDisabled`/`Disabled` and `IsBeingRemoved`/`BeingRemoved`
- [ ] Reviewer to verify the 6×3 mapping table matches the actual reducer/lifecycle code
- [ ] Reviewer to confirm `helpers.StoppedNext()` semantic matches the pattern most StoppedState files want (transport's divergence documented inline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)