### PR TITLE
feat(fsmv2/L3): Transition() replaces Result() — 56 state files / 173 callsites; foundation for children declared inside State.Next()

### DIFF
--- a/umh-core/pkg/fsmv2/CLAUDE.md
+++ b/umh-core/pkg/fsmv2/CLAUDE.md
@@ -75,27 +75,28 @@ func (s *RunningState) Next(snapAny any) fsmv2.NextResult[any, any] {
     if snap.ShouldStop() {
         reason := fmt.Sprintf("stop required: shutdown=%t, parentState=%q",
             snap.IsShutdownRequested(), snap.Observed.ParentMappedState)
-        return fsmv2.Result[any, any](&ShuttingDownState{}, fsmv2.SignalNone, nil, reason)
+        return fsmv2.Transition(&ShuttingDownState{}, fsmv2.SignalNone, nil, reason, nil)
     }
 
     // Business logic.
     if needsWork {
         reason := fmt.Sprintf("dispatching %s (queue=%d)", MyActionName, snap.Status.QueueDepth)
-        return fsmv2.Result[any, any](s, fsmv2.SignalNone, &MyAction{}, reason)
+        return fsmv2.Transition(s, fsmv2.SignalNone, &MyAction{}, reason, nil)
     }
 
     // Catch-all return: include the conditions that kept the worker here so
     // operators can identify which precondition is still missing.
     reason := fmt.Sprintf("running: queue=%d, hasWork=%t", snap.Status.QueueDepth, needsWork)
-    return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil, reason)
+    return fsmv2.Transition(s, fsmv2.SignalNone, nil, reason, nil)
 }
 ```
 
-`fsmv2.Result[any, any]` is the canonical return shape for state files.
+`fsmv2.Transition()` is the canonical return shape for state files. Never use the generic
+`fsmv2.Result[any, any](...)` form — the architecture gate rejects it.
 
 ## Reason Strings in State Transitions
 
-The `Reason` parameter in `fsmv2.Result()` is visible in structured JSON logs (every state transition), supervisor heartbeats (every ~100 ticks), and parent supervisor's `ChildInfo.StateReason`. Write reasons that help operators troubleshoot without reading code.
+The `Reason` parameter in `fsmv2.Transition()` is visible in structured JSON logs (every state transition), supervisor heartbeats (every ~100 ticks), and parent supervisor's `ChildInfo.StateReason`. Write reasons that help operators troubleshoot without reading code.
 
 **Rules:**
 - Include dynamic snapshot values via `fmt.Sprintf` — never hardcode values that exist in the snapshot
@@ -112,6 +113,39 @@ fmt.Sprintf("sync recovering: %d consecutive errors (%s), backoff %s",
 
 **Bad**: `"Stop required"`, `"Waiting for transport or token"`, `"Degraded, still pushing"`
 **Good**: `"stop required: shutdown=false, parentState=stopped"`, `"waiting: hasTransport=true, hasValidToken=false"`, `"degraded (5 consecutive errors), still pushing"`
+
+## Children-in-Next Pattern
+
+Parent state files can express child sets directly in `Next()` via the fifth argument of
+`fsmv2.Transition()`. This is the path toward moving child lifecycle decisions out of
+`DeriveDesiredState` and into the state machine where they are visible to operators.
+
+**Nil = no opinion** (supervisor uses the `ChildrenSpecs` from `DeriveDesiredState`):
+
+```go
+return fsmv2.Transition(s, fsmv2.SignalNone, nil, "no change to children", nil)
+```
+
+**Empty slice = zero children** (supervisor tears down all children):
+
+```go
+return fsmv2.Transition(&TryingToStopState{}, fsmv2.SignalNone, nil, "stopping, no children needed",
+    []config.ChildSpec{})
+```
+
+**Populated slice = exact desired child set** (supervisor reconciles to match):
+
+```go
+return fsmv2.Transition(s, fsmv2.SignalNone, nil, "running with children",
+    []config.ChildSpec{
+        {Name: "child1", WorkerType: "examplechild", UserSpec: spec1},
+        {Name: "child2", WorkerType: "examplechild", UserSpec: spec2},
+    })
+```
+
+Until a parent state returns a non-nil `Children` value, the supervisor continues using
+the legacy `ChildrenSpecs` path from `DeriveDesiredState`. Both paths coexist safely
+during migration.
 
 ## Worker Struct Pattern (WorkerBase embed)
 

--- a/umh-core/pkg/fsmv2/api.go
+++ b/umh-core/pkg/fsmv2/api.go
@@ -148,9 +148,6 @@ type NextResult[TSnapshot any, TDeps any] struct {
 	// Example: "sync degraded: 5 consecutive errors (authentication_failure)"
 	Reason string
 
-	// Signal indicates framework-level events (shutdown, restart, etc.).
-	Signal Signal
-
 	// Children is the parent's intended children-set for this tick.
 	// The supervisor reads this field in L5 and reconciles spawn / despawn /
 	// config-update against its own children registry. Until then, nil signals
@@ -173,6 +170,9 @@ type NextResult[TSnapshot any, TDeps any] struct {
 	// State authors should construct the explicit empty slice when they mean
 	// "no children" and reserve nil for "no opinion" / unmigrated paths.
 	Children []config.ChildSpec
+
+	// Signal indicates framework-level events (shutdown, restart, etc.).
+	Signal Signal
 }
 
 // State represents a single state in the FSM lifecycle (stateless).
@@ -322,6 +322,7 @@ func wrapTypedAction(action any) Action[any] {
 	// Validate Execute signature: func(context.Context, <TDeps>) error.
 	execType := execMethod.Type()
 	ctxType := reflect.TypeOf((*context.Context)(nil)).Elem()
+
 	errType := reflect.TypeOf((*error)(nil)).Elem()
 	if execType.NumIn() != 2 || execType.NumOut() != 1 ||
 		!execType.In(0).Implements(ctxType) ||
@@ -332,6 +333,7 @@ func wrapTypedAction(action any) Action[any] {
 
 	// Validate Name signature: func() string.
 	nameType := nameMethod.Type()
+
 	stringType := reflect.TypeOf("")
 	if nameType.NumIn() != 0 || nameType.NumOut() != 1 || nameType.Out(0) != stringType {
 		panic(fmt.Sprintf("fsmv2.Transition auto-wrap: action of type %T has wrong Name signature %s — "+
@@ -345,7 +347,9 @@ func wrapTypedAction(action any) Action[any] {
 		name: cachedName,
 		execute: func(ctx context.Context, deps any) error {
 			depsVal := reflect.ValueOf(deps)
-			if !depsVal.IsValid() {
+
+			switch {
+			case !depsVal.IsValid():
 				// nil deps: only valid if expectedDepsType is nilable (ptr, iface, map, chan, func, slice).
 				switch expectedDepsType.Kind() {
 				case reflect.Ptr, reflect.Interface, reflect.Map, reflect.Chan, reflect.Func, reflect.Slice:
@@ -354,10 +358,10 @@ func wrapTypedAction(action any) Action[any] {
 					return fmt.Errorf("fsmv2.Transition auto-wrap: nil deps not assignable to %s (action %q)",
 						expectedDepsType, cachedName)
 				}
-			} else if !depsVal.Type().AssignableTo(expectedDepsType) {
+			case !depsVal.Type().AssignableTo(expectedDepsType):
 				return fmt.Errorf("fsmv2.Transition auto-wrap: deps type %T not assignable to %s (action %q)",
 					deps, expectedDepsType, cachedName)
-			} else {
+			default:
 				depsVal = depsVal.Convert(expectedDepsType)
 			}
 
@@ -365,6 +369,7 @@ func wrapTypedAction(action any) Action[any] {
 			if errIface := out[0].Interface(); errIface != nil {
 				return errIface.(error)
 			}
+
 			return nil
 		},
 	}

--- a/umh-core/pkg/fsmv2/api.go
+++ b/umh-core/pkg/fsmv2/api.go
@@ -208,23 +208,29 @@ type State[TSnapshot any, TDeps any] interface {
 // Result creates a NextResult with the given components.
 // This is a convenience function to reduce boilerplate when returning from Next().
 //
+// The children argument is the parent's intended children-set for this tick.
+// Pass nil when the state is not managing children. See NextResult.Children
+// godoc for discriminator semantics.
+//
 // Usage:
 //
-//	return fsmv2.Result(s, fsmv2.SignalNone, nil, "Worker is stopped")
+//	return fsmv2.Result(s, fsmv2.SignalNone, nil, "Worker is stopped", nil)
 //
 //	reason := fmt.Sprintf("degraded: %d errors (%s)", errors, errorType)
-//	return fsmv2.Result(&DegradedState{}, fsmv2.SignalNone, nil, reason)
+//	return fsmv2.Result(&DegradedState{}, fsmv2.SignalNone, nil, reason, nil)
 func Result[TSnapshot any, TDeps any](
 	state State[TSnapshot, TDeps],
 	signal Signal,
 	action Action[TDeps],
 	reason string,
+	children []config.ChildSpec,
 ) NextResult[TSnapshot, TDeps] {
 	return NextResult[TSnapshot, TDeps]{
-		State:  state,
-		Signal: signal,
-		Action: action,
-		Reason: reason,
+		State:    state,
+		Signal:   signal,
+		Action:   action,
+		Reason:   reason,
+		Children: children,
 	}
 }
 
@@ -272,13 +278,7 @@ func Transition(
 		wrapped = wrapTypedAction(a)
 	}
 
-	return NextResult[any, any]{
-		State:    state,
-		Signal:   signal,
-		Action:   wrapped,
-		Reason:   reason,
-		Children: children,
-	}
+	return Result[any, any](state, signal, wrapped, reason, children)
 }
 
 // reflectedAction adapts an Action[TDeps] for some concrete TDeps into an

--- a/umh-core/pkg/fsmv2/api.go
+++ b/umh-core/pkg/fsmv2/api.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"sync"
 	"time"
 
@@ -149,6 +150,29 @@ type NextResult[TSnapshot any, TDeps any] struct {
 
 	// Signal indicates framework-level events (shutdown, restart, etc.).
 	Signal Signal
+
+	// Children is the parent's intended children-set for this tick.
+	// The supervisor reads this field in L5 and reconciles spawn / despawn /
+	// config-update against its own children registry. Until then, nil signals
+	// 'no opinion' and the supervisor falls back to the legacy ChildrenSpecs path.
+	//
+	// Discriminator (Go-level, unambiguous):
+	//   - nil sentinel       → "no opinion" — supervisor falls back to the
+	//                          `WrappedDesiredState.ChildrenSpecs` path (legacy
+	//                          parents that populate ChildrenSpecs directly in
+	//                          DeriveDesiredState).
+	//   - non-nil (any len)  → "use this exact set" — including the explicit
+	//                          empty form []config.ChildSpec{} which means
+	//                          "I am a parent and I want zero children right
+	//                          now." The supervisor will despawn any children
+	//                          not in the set.
+	//
+	// CSE JSON round-trip note: nil and [] collapse ambiguously across some
+	// JSON encoders. The discriminator above is enforced at the Go API
+	// boundary (state.Next return value) BEFORE serialization, never after.
+	// State authors should construct the explicit empty slice when they mean
+	// "no children" and reserve nil for "no opinion" / unmigrated paths.
+	Children []config.ChildSpec
 }
 
 // State represents a single state in the FSM lifecycle (stateless).
@@ -201,6 +225,148 @@ func Result[TSnapshot any, TDeps any](
 		Signal: signal,
 		Action: action,
 		Reason: reason,
+	}
+}
+
+// Transition is a non-generic convenience wrapper for worker state files.
+// It lets state implementations drop the explicit [any, any] type parameters
+// when returning from Next(), reducing boilerplate.
+//
+// The action argument is `any` so that typed Action[TDeps] values can be
+// passed without a caller-visible WrapAction. The function accepts:
+//   - nil: no action
+//   - Action[any]: passed through unchanged (fast path)
+//   - Action[TDeps] for any concrete TDeps: auto-wrapped via reflection
+//     so Execute asserts deps into TDeps before delegating
+//
+// Values that don't structurally match an Action (missing Execute/Name or
+// wrong signatures) cause a panic with a diagnostic message; this is a
+// programmer error, not a runtime condition.
+//
+// The children argument is the parent's intended children-set for this tick.
+// Pass nil when the state is not managing children. See NextResult.Children
+// godoc for discriminator semantics.
+//
+// Prefer Action[any] over Transition for hot-path actions to avoid the
+// ~8.5% reflection auto-wrap overhead (see transition_test.go benchmark).
+// For state-machine callbacks this overhead is negligible.
+//
+// Usage:
+//
+//	return fsmv2.Transition(s, fsmv2.SignalNone, nil, "Worker is stopped", nil)
+//	return fsmv2.Transition(&RunningState{}, fsmv2.SignalNone, &MyAction{}, reason, nil)
+func Transition(
+	state State[any, any],
+	signal Signal,
+	action any,
+	reason string,
+	children []config.ChildSpec,
+) NextResult[any, any] {
+	var wrapped Action[any]
+	switch a := action.(type) {
+	case nil:
+		// wrapped stays nil
+	case Action[any]:
+		wrapped = a
+	default:
+		wrapped = wrapTypedAction(a)
+	}
+
+	return NextResult[any, any]{
+		State:    state,
+		Signal:   signal,
+		Action:   wrapped,
+		Reason:   reason,
+		Children: children,
+	}
+}
+
+// reflectedAction adapts an Action[TDeps] for some concrete TDeps into an
+// Action[any]. The adapter asserts deps into TDeps via reflection before
+// delegating to the inner action's Execute method.
+type reflectedAction struct {
+	execute func(ctx context.Context, deps any) error
+	name    string
+}
+
+// Execute delegates to the reflection-built closure.
+func (r *reflectedAction) Execute(ctx context.Context, deps any) error {
+	return r.execute(ctx, deps)
+}
+
+// Name returns the cached name captured at wrap time.
+func (r *reflectedAction) Name() string { return r.name }
+
+// wrapTypedAction builds an Action[any] adapter for a typed Action[TDeps]
+// discovered via reflection. Panics if the value does not structurally match
+// an Action interface (Execute(context.Context, TDeps) error + Name() string).
+func wrapTypedAction(action any) Action[any] {
+	v := reflect.ValueOf(action)
+	if !v.IsValid() {
+		panic(fmt.Sprintf("fsmv2.Transition auto-wrap: action is nil or invalid; "+
+			"requires Execute(context.Context, TDeps) error and Name() string (got %T)", action))
+	}
+
+	if v.Kind() == reflect.Ptr && v.IsNil() {
+		panic(fmt.Sprintf("fsmv2.Transition auto-wrap: typed nil action (%T)", action))
+	}
+
+	execMethod := v.MethodByName("Execute")
+	nameMethod := v.MethodByName("Name")
+
+	if !execMethod.IsValid() || !nameMethod.IsValid() {
+		panic(fmt.Sprintf("fsmv2.Transition auto-wrap: action of type %T is not a valid Action[TDeps] — "+
+			"requires Execute(context.Context, TDeps) error and Name() string", action))
+	}
+
+	// Validate Execute signature: func(context.Context, <TDeps>) error.
+	execType := execMethod.Type()
+	ctxType := reflect.TypeOf((*context.Context)(nil)).Elem()
+	errType := reflect.TypeOf((*error)(nil)).Elem()
+	if execType.NumIn() != 2 || execType.NumOut() != 1 ||
+		!execType.In(0).Implements(ctxType) ||
+		!execType.Out(0).Implements(errType) {
+		panic(fmt.Sprintf("fsmv2.Transition auto-wrap: action of type %T has wrong Execute signature %s — "+
+			"requires Execute(context.Context, TDeps) error", action, execType))
+	}
+
+	// Validate Name signature: func() string.
+	nameType := nameMethod.Type()
+	stringType := reflect.TypeOf("")
+	if nameType.NumIn() != 0 || nameType.NumOut() != 1 || nameType.Out(0) != stringType {
+		panic(fmt.Sprintf("fsmv2.Transition auto-wrap: action of type %T has wrong Name signature %s — "+
+			"requires Name() string", action, nameType))
+	}
+
+	expectedDepsType := execType.In(1)
+	cachedName := nameMethod.Call(nil)[0].String()
+
+	return &reflectedAction{
+		name: cachedName,
+		execute: func(ctx context.Context, deps any) error {
+			depsVal := reflect.ValueOf(deps)
+			if !depsVal.IsValid() {
+				// nil deps: only valid if expectedDepsType is nilable (ptr, iface, map, chan, func, slice).
+				switch expectedDepsType.Kind() {
+				case reflect.Ptr, reflect.Interface, reflect.Map, reflect.Chan, reflect.Func, reflect.Slice:
+					depsVal = reflect.Zero(expectedDepsType)
+				default:
+					return fmt.Errorf("fsmv2.Transition auto-wrap: nil deps not assignable to %s (action %q)",
+						expectedDepsType, cachedName)
+				}
+			} else if !depsVal.Type().AssignableTo(expectedDepsType) {
+				return fmt.Errorf("fsmv2.Transition auto-wrap: deps type %T not assignable to %s (action %q)",
+					deps, expectedDepsType, cachedName)
+			} else {
+				depsVal = depsVal.Convert(expectedDepsType)
+			}
+
+			out := execMethod.Call([]reflect.Value{reflect.ValueOf(ctx), depsVal})
+			if errIface := out[0].Interface(); errIface != nil {
+				return errIface.(error)
+			}
+			return nil
+		},
 	}
 }
 

--- a/umh-core/pkg/fsmv2/architecture_test.go
+++ b/umh-core/pkg/fsmv2/architecture_test.go
@@ -540,6 +540,20 @@ var _ = Describe("FSMv2 Architecture Validation", func() {
 				}
 			})
 		})
+
+		Describe("No Legacy Result Calls (Invariant: Use fsmv2.Transition)", func() {
+			It("should use fsmv2.Transition() not fsmv2.Result[any,any]() in state files", func() {
+				violations := validator.ValidateNoLegacyResultCalls(getFsmv2Dir())
+				if len(violations) > 0 {
+					message := validator.FormatViolationsWithPattern(
+						"Legacy Result Call Violations",
+						violations,
+						"LEGACY_RESULT_CALL",
+					)
+					Fail(message)
+				}
+			})
+		})
 	})
 })
 

--- a/umh-core/pkg/fsmv2/internal/validator/state.go
+++ b/umh-core/pkg/fsmv2/internal/validator/state.go
@@ -349,7 +349,7 @@ func extractResultArgs(expr ast.Expr) (state, action ast.Expr) {
 		}
 	}
 
-	if funcName != "Result" || len(callExpr.Args) < 3 {
+	if (funcName != "Result" && funcName != "Transition") || len(callExpr.Args) < 3 {
 		return nil, nil
 	}
 
@@ -382,7 +382,7 @@ func extractResultArgsWithSignal(expr ast.Expr) (state, signal, action ast.Expr)
 		}
 	}
 
-	if funcName != "Result" || len(callExpr.Args) < 3 {
+	if (funcName != "Result" && funcName != "Transition") || len(callExpr.Args) < 3 {
 		return nil, nil, nil
 	}
 
@@ -688,7 +688,7 @@ func checkTryingToStatesReturnActions(filename string) []Violation {
 				}
 			}
 
-			if funcName != "Result" {
+			if funcName != "Result" && funcName != "Transition" {
 				return true
 			}
 

--- a/umh-core/pkg/fsmv2/internal/validator/transition_alias.go
+++ b/umh-core/pkg/fsmv2/internal/validator/transition_alias.go
@@ -49,8 +49,8 @@ var legacyResultSymbols = map[string]struct{}{
 // rendered using the alias actually used in the source file (e.g. "fsmv2.Result"
 // or "v2.Result").
 type LegacyResultCall struct {
-	Pos    token.Position
 	Symbol string
+	Pos    token.Position
 }
 
 // FindLegacyResultCalls scans the parsed Go AST of a single file and returns

--- a/umh-core/pkg/fsmv2/internal/validator/transition_alias.go
+++ b/umh-core/pkg/fsmv2/internal/validator/transition_alias.go
@@ -1,0 +1,215 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validator
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"strconv"
+	"strings"
+)
+
+// Transition alias matcher.
+//
+// Scans worker state files for call expressions of the form
+// `fsmv2.Result[T1, T2](...)` and `fsmv2.WrapAction[T](...)`, which L3
+// migrates mechanically to `fsmv2.Transition(...)` and framework-wrapped
+// actions. FindLegacyResultCalls is the per-file leaf; ValidateNoLegacyResultCalls
+// is the conventional Validate* wrapper that architecture_test.go calls.
+
+// fsmv2ImportPathSuffix identifies the fsmv2 package import regardless of
+// module path, so the matcher works in-tree and from downstream forks.
+const fsmv2ImportPathSuffix = "/pkg/fsmv2"
+
+// legacyResultSymbols enumerates the unqualified names that, when called with
+// explicit type parameters via a SelectorExpr on the fsmv2 alias, constitute a
+// legacy form to be migrated.
+var legacyResultSymbols = map[string]struct{}{
+	"Result":     {},
+	"WrapAction": {},
+}
+
+// LegacyResultCall describes a single call expression that should migrate to
+// `fsmv2.Transition` (for Result) or a framework-wrapped action helper (for
+// WrapAction). Pos is the file:line:column of the call expression; Symbol is
+// rendered using the alias actually used in the source file (e.g. "fsmv2.Result"
+// or "v2.Result").
+type LegacyResultCall struct {
+	Pos    token.Position
+	Symbol string
+}
+
+// FindLegacyResultCalls scans the parsed Go AST of a single file and returns
+// token positions of every call expression of the form `fsmv2.Result[...](...)`
+// or `fsmv2.WrapAction[...](...)`. These are the forms that L3 migrates to
+// `fsmv2.Transition(...)` / framework-wrapped actions.
+//
+// The returned slice is empty if the file has no violations. The package alias
+// is resolved from the file's import list: if the file imports the fsmv2
+// package under a custom alias, that alias is what the matcher looks for.
+// Files that do not import fsmv2 return nil.
+//
+// Only the explicit-generic form (IndexExpr / IndexListExpr) is flagged; plain
+// calls like `fsmv2.Result(...)` (type-parameter inference, which should not
+// occur in practice) are intentionally left alone, as are calls to
+// `fsmv2.Transition(...)` (the non-generic alias that this matcher exists to
+// drive workers toward).
+func FindLegacyResultCalls(file *ast.File, fset *token.FileSet) []LegacyResultCall {
+	if file == nil || fset == nil {
+		return nil
+	}
+
+	alias, ok := resolveFsmv2Alias(file)
+	if !ok {
+		return nil
+	}
+
+	var hits []LegacyResultCall
+
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+
+		symbol, matched := matchLegacySelector(call.Fun, alias)
+		if !matched {
+			return true
+		}
+
+		hits = append(hits, LegacyResultCall{
+			Pos:    fset.Position(call.Pos()),
+			Symbol: symbol,
+		})
+
+		return true
+	})
+
+	return hits
+}
+
+// ValidateNoLegacyResultCalls walks all worker state files under baseDir and
+// returns violations for any file that still contains fsmv2.Result[...] or
+// fsmv2.WrapAction[...] call expressions. These are the forms that L3 migrates
+// to fsmv2.Transition().
+func ValidateNoLegacyResultCalls(baseDir string) []Violation {
+	var violations []Violation
+
+	stateFiles := FindStateFiles(baseDir)
+	fset := token.NewFileSet()
+
+	for _, path := range stateFiles {
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			continue
+		}
+
+		hits := FindLegacyResultCalls(file, fset)
+		for _, h := range hits {
+			violations = append(violations, Violation{
+				File:    path,
+				Line:    h.Pos.Line,
+				Type:    "LEGACY_RESULT_CALL",
+				Message: fmt.Sprintf("use fsmv2.Transition() instead of %s[...](...)", h.Symbol),
+			})
+		}
+	}
+
+	return violations
+}
+
+// resolveFsmv2Alias returns the identifier used to reference the fsmv2 package
+// in this file. The second return value is false when the file does not import
+// fsmv2 at all. Explicit aliases (e.g. `v2 "…/pkg/fsmv2"`) take precedence over
+// the default last-path-segment alias.
+func resolveFsmv2Alias(file *ast.File) (string, bool) {
+	for _, imp := range file.Imports {
+		if imp.Path == nil {
+			continue
+		}
+
+		path, err := strconv.Unquote(imp.Path.Value)
+		if err != nil {
+			continue
+		}
+
+		if !isFsmv2ImportPath(path) {
+			continue
+		}
+
+		if imp.Name != nil && imp.Name.Name != "" && imp.Name.Name != "_" && imp.Name.Name != "." {
+			return imp.Name.Name, true
+		}
+
+		return lastPathSegment(path), true
+	}
+
+	return "", false
+}
+
+// isFsmv2ImportPath reports whether the given import path refers to the
+// fsmv2 package. The comparison uses a path-component suffix match so forks
+// under different module roots still validate.
+func isFsmv2ImportPath(path string) bool {
+	return path == "pkg/fsmv2" || strings.HasSuffix(path, fsmv2ImportPathSuffix)
+}
+
+// lastPathSegment returns the final path component of an import path, which is
+// Go's default identifier for an unaliased import.
+func lastPathSegment(path string) string {
+	if idx := strings.LastIndex(path, "/"); idx >= 0 {
+		return path[idx+1:]
+	}
+
+	return path
+}
+
+// matchLegacySelector inspects a CallExpr.Fun expression and reports whether
+// it is `<alias>.Result[...]` or `<alias>.WrapAction[...]`. The rendered symbol
+// uses the caller-supplied alias so error messages reflect the source verbatim.
+func matchLegacySelector(fun ast.Expr, alias string) (string, bool) {
+	var inner ast.Expr
+
+	switch e := fun.(type) {
+	case *ast.IndexExpr:
+		inner = e.X
+	case *ast.IndexListExpr:
+		inner = e.X
+	default:
+		return "", false
+	}
+
+	sel, ok := inner.(*ast.SelectorExpr)
+	if !ok {
+		return "", false
+	}
+
+	if _, legacy := legacyResultSymbols[sel.Sel.Name]; !legacy {
+		return "", false
+	}
+
+	ident, ok := sel.X.(*ast.Ident)
+	if !ok {
+		return "", false
+	}
+
+	if ident.Name != alias {
+		return "", false
+	}
+
+	return fmt.Sprintf("%s.%s", alias, sel.Sel.Name), true
+}

--- a/umh-core/pkg/fsmv2/internal/validator/transition_alias_test.go
+++ b/umh-core/pkg/fsmv2/internal/validator/transition_alias_test.go
@@ -1,0 +1,172 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validator_test
+
+import (
+	"go/parser"
+	"go/token"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/internal/validator"
+)
+
+var _ = Describe("FindLegacyResultCalls (TransitionAlias matcher)", func() {
+
+	It("flags fsmv2.Result[any, any](...) as a legacy call", func() {
+		src := `package sample
+
+import "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
+
+func Next() any {
+	return fsmv2.Result[any, any](nil, fsmv2.SignalNone, nil, "reason", nil)
+}
+`
+
+		fset := token.NewFileSet()
+
+		file, err := parser.ParseFile(fset, "test.go", src, 0)
+		Expect(err).NotTo(HaveOccurred())
+
+		hits := validator.FindLegacyResultCalls(file, fset)
+		Expect(hits).To(HaveLen(1))
+		Expect(hits[0].Symbol).To(Equal("fsmv2.Result"))
+		Expect(hits[0].Pos.Line).To(Equal(6))
+	})
+
+	It("flags fsmv2.WrapAction[MyDeps](...) as a legacy call", func() {
+		src := `package sample
+
+import "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
+
+type MyDeps struct{}
+
+func Wrap() any {
+	return fsmv2.WrapAction[MyDeps](nil)
+}
+`
+
+		fset := token.NewFileSet()
+
+		file, err := parser.ParseFile(fset, "test.go", src, 0)
+		Expect(err).NotTo(HaveOccurred())
+
+		hits := validator.FindLegacyResultCalls(file, fset)
+		Expect(hits).To(HaveLen(1))
+		Expect(hits[0].Symbol).To(Equal("fsmv2.WrapAction"))
+	})
+
+	It("respects custom import aliases and renders the alias in Symbol", func() {
+		src := `package sample
+
+import v2 "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
+
+func Next() any {
+	return v2.Result[any, any](nil, v2.SignalNone, nil, "reason", nil)
+}
+`
+
+		fset := token.NewFileSet()
+
+		file, err := parser.ParseFile(fset, "test.go", src, 0)
+		Expect(err).NotTo(HaveOccurred())
+
+		hits := validator.FindLegacyResultCalls(file, fset)
+		Expect(hits).To(HaveLen(1))
+		Expect(hits[0].Symbol).To(Equal("v2.Result"))
+	})
+
+	It("does not flag fsmv2.Transition(...) calls", func() {
+		src := `package sample
+
+import "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
+
+func Next() any {
+	return fsmv2.Transition(nil, fsmv2.SignalNone, nil, "reason", nil)
+}
+`
+
+		fset := token.NewFileSet()
+
+		file, err := parser.ParseFile(fset, "test.go", src, 0)
+		Expect(err).NotTo(HaveOccurred())
+
+		hits := validator.FindLegacyResultCalls(file, fset)
+		Expect(hits).To(BeEmpty())
+	})
+
+	It("does not flag fsmv2.Result(...) without explicit type parameters", func() {
+		src := `package sample
+
+import "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
+
+func Next() any {
+	return fsmv2.Result(nil, fsmv2.SignalNone, nil, "reason", nil)
+}
+`
+
+		fset := token.NewFileSet()
+
+		file, err := parser.ParseFile(fset, "test.go", src, 0)
+		Expect(err).NotTo(HaveOccurred())
+
+		hits := validator.FindLegacyResultCalls(file, fset)
+		Expect(hits).To(BeEmpty())
+	})
+
+	It("returns nil for files that do not import fsmv2", func() {
+		src := `package sample
+
+import "fmt"
+
+func Print() {
+	fmt.Println("hello")
+}
+`
+
+		fset := token.NewFileSet()
+
+		file, err := parser.ParseFile(fset, "test.go", src, 0)
+		Expect(err).NotTo(HaveOccurred())
+
+		hits := validator.FindLegacyResultCalls(file, fset)
+		Expect(hits).To(BeNil())
+	})
+
+	It("returns multiple hits with distinct positions", func() {
+		src := `package sample
+
+import "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
+
+func Next() any {
+	_ = fsmv2.Result[any, any](nil, fsmv2.SignalNone, nil, "first", nil)
+	_ = fsmv2.WrapAction[struct{}](nil)
+	return nil
+}
+`
+
+		fset := token.NewFileSet()
+
+		file, err := parser.ParseFile(fset, "test.go", src, 0)
+		Expect(err).NotTo(HaveOccurred())
+
+		hits := validator.FindLegacyResultCalls(file, fset)
+		Expect(hits).To(HaveLen(2))
+		Expect(hits[0].Symbol).To(Equal("fsmv2.Result"))
+		Expect(hits[1].Symbol).To(Equal("fsmv2.WrapAction"))
+		Expect(hits[0].Pos.Line).NotTo(Equal(hits[1].Pos.Line))
+	})
+})

--- a/umh-core/pkg/fsmv2/internal/validator/validator_suite_test.go
+++ b/umh-core/pkg/fsmv2/internal/validator/validator_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validator_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestValidator(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Validator Suite")
+}

--- a/umh-core/pkg/fsmv2/supervisor/immutability_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/immutability_test.go
@@ -140,7 +140,7 @@ func (s *snapshotMutatingState) Next(snapshot any) fsmv2.NextResult[any, any] {
 	snap := snapshot.(fsmv2.Snapshot)
 	snap.Observed = nil
 
-	return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil, "testing snapshot immutability")
+	return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil, "testing snapshot immutability", nil)
 }
 
 func (s *snapshotMutatingState) String() string { return "SnapshotMutatingState" }
@@ -155,7 +155,7 @@ func (s *identityMutatingState) Next(snapshot any) fsmv2.NextResult[any, any] {
 	snap := snapshot.(fsmv2.Snapshot)
 	snap.Identity.Name = "Modified"
 
-	return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil, "testing identity immutability")
+	return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil, "testing identity immutability", nil)
 }
 
 func (s *identityMutatingState) String() string { return "IdentityMutatingState" }
@@ -172,7 +172,7 @@ func (s *aggressiveMutatingState) Next(snapshot any) fsmv2.NextResult[any, any] 
 	snap.Identity.Name = "Modified"
 	snap.Desired = nil
 
-	return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil, "testing complete snapshot immutability")
+	return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil, "testing complete snapshot immutability", nil)
 }
 
 func (s *aggressiveMutatingState) String() string { return "AggressiveMutatingState" }

--- a/umh-core/pkg/fsmv2/supervisor/panic_recovery_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/panic_recovery_test.go
@@ -535,7 +535,7 @@ type panickingState struct {
 func (s *panickingState) Next(snapshot any) fsmv2.NextResult[any, any] {
 	if s.worker.panicOnTick {
 		if s.worker.panicOnlyOnce && s.worker.panicTriggered {
-			return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil, "staying in state")
+			return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil, "staying in state", nil)
 		}
 
 		s.worker.panicTriggered = true
@@ -547,7 +547,7 @@ func (s *panickingState) Next(snapshot any) fsmv2.NextResult[any, any] {
 		panic(s.worker.panicMessage)
 	}
 
-	return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil, "staying in state")
+	return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil, "staying in state", nil)
 }
 
 func (s *panickingState) String() string { return "PanickingState" }

--- a/umh-core/pkg/fsmv2/supervisor/supervisor_suite_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/supervisor_suite_test.go
@@ -171,7 +171,7 @@ type mockState struct {
 
 func (m *mockState) Next(snapshot any) fsmv2.NextResult[any, any] {
 	if m.nextState == nil {
-		return fsmv2.Result[any, any](m, fsmv2.SignalNone, nil, "mock state")
+		return fsmv2.Result[any, any](m, fsmv2.SignalNone, nil, "mock state", nil)
 	}
 
 	reason := m.reason
@@ -179,7 +179,7 @@ func (m *mockState) Next(snapshot any) fsmv2.NextResult[any, any] {
 		reason = "mock state"
 	}
 
-	return fsmv2.Result[any, any](m.nextState, m.signal, m.action, reason)
+	return fsmv2.Result[any, any](m.nextState, m.signal, m.action, reason, nil)
 }
 
 func (m *mockState) String() string { return "MockState" }

--- a/umh-core/pkg/fsmv2/supervisor/supervisor_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/supervisor_test.go
@@ -126,7 +126,7 @@ func (m *mockState) String() string {
 }
 
 func (m *mockState) Next(_ any) fsmv2.NextResult[any, any] {
-	return fsmv2.Result[any, any](m, fsmv2.SignalNone, nil, m.reason)
+	return fsmv2.Result[any, any](m, fsmv2.SignalNone, nil, m.reason, nil)
 }
 
 func (m *mockState) LifecyclePhase() config.LifecyclePhase { return config.PhaseRunningHealthy }

--- a/umh-core/pkg/fsmv2/supervisor/testutil/helpers.go
+++ b/umh-core/pkg/fsmv2/supervisor/testutil/helpers.go
@@ -136,7 +136,7 @@ type State struct {
 
 func (m *State) Next(snapshot any) fsmv2.NextResult[any, any] {
 	if m.NextState == nil {
-		return fsmv2.Result[any, any](m, fsmv2.SignalNone, nil, "test state")
+		return fsmv2.Result[any, any](m, fsmv2.SignalNone, nil, "test state", nil)
 	}
 
 	reason := m.Reason
@@ -144,7 +144,7 @@ func (m *State) Next(snapshot any) fsmv2.NextResult[any, any] {
 		reason = "test state"
 	}
 
-	return fsmv2.Result[any, any](m.NextState, m.Signal, m.Action, reason)
+	return fsmv2.Result[any, any](m.NextState, m.Signal, m.Action, reason, nil)
 }
 
 func (m *State) String() string { return "State" }

--- a/umh-core/pkg/fsmv2/supervisor/variable_injection_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/variable_injection_test.go
@@ -84,7 +84,7 @@ func (t *TestState) Next(snapshot any) fsmv2.NextResult[any, any] {
 		reason = t.name
 	}
 
-	return fsmv2.Result[any, any](t, fsmv2.SignalNone, nil, reason)
+	return fsmv2.Result[any, any](t, fsmv2.SignalNone, nil, reason, nil)
 }
 
 func (t *TestState) String() string {

--- a/umh-core/pkg/fsmv2/transition_test.go
+++ b/umh-core/pkg/fsmv2/transition_test.go
@@ -1,0 +1,227 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fsmv2_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/config"
+)
+
+type fakeTransitionState struct{}
+
+func (s *fakeTransitionState) Next(_ any) fsmv2.NextResult[any, any] {
+	return fsmv2.NextResult[any, any]{State: s}
+}
+
+func (s *fakeTransitionState) String() string { return "fake" }
+
+func (s *fakeTransitionState) LifecyclePhase() config.LifecyclePhase {
+	return config.PhaseStopped
+}
+
+type fakeTransitionAction struct {
+	name string
+}
+
+func (a *fakeTransitionAction) Execute(_ context.Context, _ any) error { return nil }
+func (a *fakeTransitionAction) Name() string                           { return a.name }
+
+type fakeTypedDeps struct {
+	marker string
+}
+
+type fakeTypedAction struct {
+	returnError error
+	called      *bool
+	name        string
+	wantMarker  string
+}
+
+func (a *fakeTypedAction) Execute(_ context.Context, deps fakeTypedDeps) error {
+	if a.called != nil {
+		*a.called = true
+	}
+	if a.wantMarker != "" && deps.marker != a.wantMarker {
+		return fmt.Errorf("unexpected marker: got %q, want %q", deps.marker, a.wantMarker)
+	}
+	return a.returnError
+}
+
+func (a *fakeTypedAction) Name() string { return a.name }
+
+type fakeNonAction struct{}
+
+type fakePtrDepsAction struct {
+	sawNil *bool
+	name   string
+}
+
+func (a *fakePtrDepsAction) Execute(_ context.Context, deps *fakeTypedDeps) error {
+	if a.sawNil != nil {
+		*a.sawNil = (deps == nil)
+	}
+	return nil
+}
+
+func (a *fakePtrDepsAction) Name() string { return a.name }
+
+type fakeIntDepsAction struct {
+	name string
+}
+
+func (a *fakeIntDepsAction) Execute(_ context.Context, _ int) error { return nil }
+func (a *fakeIntDepsAction) Name() string                           { return a.name }
+
+var _ = Describe("Transition", func() {
+	It("returns a NextResult with matching fields for a simple transition", func() {
+		state := &fakeTransitionState{}
+
+		result := fsmv2.Transition(state, fsmv2.SignalNone, nil, "reason", nil)
+
+		Expect(result.State).To(BeIdenticalTo(state))
+		Expect(result.Signal).To(Equal(fsmv2.SignalNone))
+		Expect(result.Action).To(BeNil())
+		Expect(result.Reason).To(Equal("reason"))
+		Expect(result.Children).To(BeNil())
+	})
+
+	It("propagates the action instance through to NextResult", func() {
+		state := &fakeTransitionState{}
+		action := &fakeTransitionAction{name: "noop"}
+
+		result := fsmv2.Transition(state, fsmv2.SignalNone, action, "with-action", nil)
+
+		Expect(result.Action).To(BeIdenticalTo(action))
+	})
+
+	It("propagates SignalNeedsRestart to NextResult", func() {
+		state := &fakeTransitionState{}
+
+		result := fsmv2.Transition(state, fsmv2.SignalNeedsRestart, nil, "restart", nil)
+
+		Expect(result.Signal).To(Equal(fsmv2.SignalNeedsRestart))
+	})
+
+	It("panics with an auto-wrap diagnostic for non-Action values", func() {
+		state := &fakeTransitionState{}
+
+		Expect(func() {
+			fsmv2.Transition(state, fsmv2.SignalNone, 42, "wrong-type", nil)
+		}).To(PanicWith(And(
+			ContainSubstring("fsmv2.Transition auto-wrap"),
+			ContainSubstring("int"),
+		)))
+	})
+
+	It("panics when a struct lacks Execute/Name methods", func() {
+		state := &fakeTransitionState{}
+
+		Expect(func() {
+			fsmv2.Transition(state, fsmv2.SignalNone, &fakeNonAction{}, "no-methods", nil)
+		}).To(PanicWith(And(
+			ContainSubstring("fsmv2.Transition auto-wrap"),
+			ContainSubstring("fakeNonAction"),
+		)))
+	})
+
+	It("auto-wraps a typed Action[TDeps] and delegates Execute", func() {
+		state := &fakeTransitionState{}
+		called := false
+		action := &fakeTypedAction{
+			name:       "typed",
+			wantMarker: "hello",
+			called:     &called,
+		}
+
+		result := fsmv2.Transition(state, fsmv2.SignalNone, action, "typed-ok", nil)
+
+		Expect(result.Action).NotTo(BeNil())
+		Expect(result.Action.Name()).To(Equal("typed"))
+
+		err := result.Action.Execute(context.Background(), fakeTypedDeps{marker: "hello"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(called).To(BeTrue())
+	})
+
+	It("propagates errors from the inner typed Action", func() {
+		state := &fakeTransitionState{}
+		sentinel := errors.New("inner boom")
+		action := &fakeTypedAction{
+			name:        "typed-err",
+			returnError: sentinel,
+		}
+
+		result := fsmv2.Transition(state, fsmv2.SignalNone, action, "typed-err", nil)
+
+		err := result.Action.Execute(context.Background(), fakeTypedDeps{})
+		Expect(err).To(MatchError(sentinel))
+	})
+
+	It("returns a descriptive error when deps type is not assignable to TDeps", func() {
+		state := &fakeTransitionState{}
+		called := false
+		action := &fakeTypedAction{name: "typed-mismatch", called: &called}
+
+		result := fsmv2.Transition(state, fsmv2.SignalNone, action, "deps-mismatch", nil)
+
+		err := result.Action.Execute(context.Background(), 42)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("not assignable"))
+		Expect(err.Error()).To(ContainSubstring("typed-mismatch"))
+		Expect(called).To(BeFalse())
+	})
+
+	It("panics with a typed-nil diagnostic when a typed nil action is passed", func() {
+		state := &fakeTransitionState{}
+		var a *fakeTypedAction = nil
+
+		Expect(func() {
+			fsmv2.Transition(state, fsmv2.SignalNone, a, "typed-nil", nil)
+		}).To(PanicWith(And(
+			ContainSubstring("typed nil action"),
+			ContainSubstring("fakeTypedAction"),
+		)))
+	})
+
+	It("accepts a nil deps value when TDeps is a nilable pointer kind", func() {
+		state := &fakeTransitionState{}
+		sawNil := false
+		action := &fakePtrDepsAction{name: "ptr-deps", sawNil: &sawNil}
+
+		result := fsmv2.Transition(state, fsmv2.SignalNone, action, "ptr-nil-ok", nil)
+
+		err := result.Action.Execute(context.Background(), nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(sawNil).To(BeTrue())
+	})
+
+	It("returns an error when nil deps is passed to a non-nilable TDeps", func() {
+		state := &fakeTransitionState{}
+		action := &fakeIntDepsAction{name: "int-deps"}
+
+		result := fsmv2.Transition(state, fsmv2.SignalNone, action, "int-nil-fail", nil)
+
+		err := result.Action.Execute(context.Background(), nil)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("nil deps not assignable"))
+	})
+})

--- a/umh-core/pkg/fsmv2/transition_test.go
+++ b/umh-core/pkg/fsmv2/transition_test.go
@@ -60,9 +60,11 @@ func (a *fakeTypedAction) Execute(_ context.Context, deps fakeTypedDeps) error {
 	if a.called != nil {
 		*a.called = true
 	}
+
 	if a.wantMarker != "" && deps.marker != a.wantMarker {
 		return fmt.Errorf("unexpected marker: got %q, want %q", deps.marker, a.wantMarker)
 	}
+
 	return a.returnError
 }
 
@@ -79,6 +81,7 @@ func (a *fakePtrDepsAction) Execute(_ context.Context, deps *fakeTypedDeps) erro
 	if a.sawNil != nil {
 		*a.sawNil = (deps == nil)
 	}
+
 	return nil
 }
 

--- a/umh-core/pkg/fsmv2/workers/application/state/state_degraded.go
+++ b/umh-core/pkg/fsmv2/workers/application/state/state_degraded.go
@@ -30,7 +30,7 @@ func (s *DegradedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[snapshot.ApplicationConfig, snapshot.ApplicationStatus](snapAny)
 
 	if snap.ShouldStop() {
-		return fsmv2.Result[any, any](&StoppedState{}, fsmv2.SignalNone, nil, "Shutdown requested")
+		return fsmv2.Transition(&StoppedState{}, fsmv2.SignalNone, nil, "Shutdown requested", nil)
 	}
 
 	circuitOpen, stale := snapshot.ChildrenViewToStatus(snap.ChildrenView)
@@ -40,10 +40,10 @@ func (s *DegradedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	}
 
 	if !status.HasInfrastructureIssues() {
-		return fsmv2.Result[any, any](&RunningState{}, fsmv2.SignalNone, nil, "Recovered from infrastructure issues")
+		return fsmv2.Transition(&RunningState{}, fsmv2.SignalNone, nil, "Recovered from infrastructure issues", nil)
 	}
 
-	return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil, status.InfrastructureReason())
+	return fsmv2.Transition(s, fsmv2.SignalNone, nil, status.InfrastructureReason(), nil)
 }
 
 func (s *DegradedState) String() string {

--- a/umh-core/pkg/fsmv2/workers/application/state/state_running.go
+++ b/umh-core/pkg/fsmv2/workers/application/state/state_running.go
@@ -29,7 +29,7 @@ func (s *RunningState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[snapshot.ApplicationConfig, snapshot.ApplicationStatus](snapAny)
 
 	if snap.ShouldStop() {
-		return fsmv2.Result[any, any](&StoppedState{}, fsmv2.SignalNone, nil, "Shutdown requested")
+		return fsmv2.Transition(&StoppedState{}, fsmv2.SignalNone, nil, "Shutdown requested", nil)
 	}
 
 	circuitOpen, stale := snapshot.ChildrenViewToStatus(snap.ChildrenView)
@@ -39,10 +39,10 @@ func (s *RunningState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	}
 
 	if status.HasInfrastructureIssues() {
-		return fsmv2.Result[any, any](&DegradedState{}, fsmv2.SignalNone, nil, status.InfrastructureReason())
+		return fsmv2.Transition(&DegradedState{}, fsmv2.SignalNone, nil, status.InfrastructureReason(), nil)
 	}
 
-	return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil, "Application supervisor is running and managing children")
+	return fsmv2.Transition(s, fsmv2.SignalNone, nil, "Application supervisor is running and managing children", nil)
 }
 
 func (s *RunningState) String() string {

--- a/umh-core/pkg/fsmv2/workers/application/state/state_stopped.go
+++ b/umh-core/pkg/fsmv2/workers/application/state/state_stopped.go
@@ -38,10 +38,10 @@ func (s *StoppedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[snapshot.ApplicationConfig, snapshot.ApplicationStatus](snapAny)
 
 	if snap.IsShutdownRequested {
-		return fsmv2.Result[any, any](s, fsmv2.SignalNeedsRemoval, nil, "Application supervisor is stopped and shutdown requested")
+		return fsmv2.Transition(s, fsmv2.SignalNeedsRemoval, nil, "Application supervisor is stopped and shutdown requested", nil)
 	}
 
-	return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil, "Application supervisor is stopped")
+	return fsmv2.Transition(s, fsmv2.SignalNone, nil, "Application supervisor is stopped", nil)
 }
 
 func (s *StoppedState) String() string {

--- a/umh-core/pkg/fsmv2/workers/communicator/state/state_recovering.go
+++ b/umh-core/pkg/fsmv2/workers/communicator/state/state_recovering.go
@@ -33,18 +33,18 @@ func (s *RecoveringState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[communicator.CommunicatorConfig, communicator.CommunicatorStatus](snapAny)
 
 	if snap.IsShutdownRequested {
-		return fsmv2.Result[any, any](&StoppedState{}, fsmv2.SignalNone, nil, "Shutdown requested during recovering state")
+		return fsmv2.Transition(&StoppedState{}, fsmv2.SignalNone, nil, "Shutdown requested during recovering state", nil)
 	}
 
 	if snap.ChildrenHealthy > 0 && snap.ChildrenUnhealthy == 0 {
-		return fsmv2.Result[any, any](&SyncingState{}, fsmv2.SignalNone, nil,
+		return fsmv2.Transition(&SyncingState{}, fsmv2.SignalNone, nil,
 			fmt.Sprintf("recovered: healthy=%d, unhealthy=%d",
-				snap.ChildrenHealthy, snap.ChildrenUnhealthy))
+				snap.ChildrenHealthy, snap.ChildrenUnhealthy), nil)
 	}
 
-	return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil,
+	return fsmv2.Transition(s, fsmv2.SignalNone, nil,
 		fmt.Sprintf("recovering: healthy=%d, unhealthy=%d",
-			snap.ChildrenHealthy, snap.ChildrenUnhealthy))
+			snap.ChildrenHealthy, snap.ChildrenUnhealthy), nil)
 }
 
 func (s *RecoveringState) String() string {

--- a/umh-core/pkg/fsmv2/workers/communicator/state/state_stopped.go
+++ b/umh-core/pkg/fsmv2/workers/communicator/state/state_stopped.go
@@ -35,10 +35,10 @@ func (s *StoppedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[communicator.CommunicatorConfig, communicator.CommunicatorStatus](snapAny)
 
 	if snap.IsShutdownRequested {
-		return fsmv2.Result[any, any](s, fsmv2.SignalNeedsRemoval, nil, "Communicator is stopped and shutdown was requested")
+		return fsmv2.Transition(s, fsmv2.SignalNeedsRemoval, nil, "Communicator is stopped and shutdown was requested", nil)
 	}
 
-	return fsmv2.Result[any, any](&SyncingState{}, fsmv2.SignalNone, nil, "Starting sync orchestration")
+	return fsmv2.Transition(&SyncingState{}, fsmv2.SignalNone, nil, "Starting sync orchestration", nil)
 }
 
 func (s *StoppedState) String() string {

--- a/umh-core/pkg/fsmv2/workers/communicator/state/state_syncing.go
+++ b/umh-core/pkg/fsmv2/workers/communicator/state/state_syncing.go
@@ -39,18 +39,18 @@ func (s *SyncingState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[communicator.CommunicatorConfig, communicator.CommunicatorStatus](snapAny)
 
 	if snap.IsShutdownRequested {
-		return fsmv2.Result[any, any](&StoppedState{}, fsmv2.SignalNone, nil, "Shutdown requested during sync")
+		return fsmv2.Transition(&StoppedState{}, fsmv2.SignalNone, nil, "Shutdown requested during sync", nil)
 	}
 
 	if snap.ChildrenHealthy == 0 || snap.ChildrenUnhealthy > 0 {
-		return fsmv2.Result[any, any](&RecoveringState{}, fsmv2.SignalNone, nil,
+		return fsmv2.Transition(&RecoveringState{}, fsmv2.SignalNone, nil,
 			fmt.Sprintf("children unhealthy: healthy=%d, unhealthy=%d",
-				snap.ChildrenHealthy, snap.ChildrenUnhealthy))
+				snap.ChildrenHealthy, snap.ChildrenUnhealthy), nil)
 	}
 
-	return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil,
+	return fsmv2.Transition(s, fsmv2.SignalNone, nil,
 		fmt.Sprintf("syncing: healthy=%d, unhealthy=%d",
-			snap.ChildrenHealthy, snap.ChildrenUnhealthy))
+			snap.ChildrenHealthy, snap.ChildrenUnhealthy), nil)
 }
 
 func (s *SyncingState) String() string {

--- a/umh-core/pkg/fsmv2/workers/example/examplechild/state/state_connected.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplechild/state/state_connected.go
@@ -31,16 +31,16 @@ func (s *ConnectedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[example_child.ExamplechildConfig, example_child.ExamplechildStatus](snapAny)
 
 	if snap.ShouldStop() {
-		return fsmv2.Result[any, any](&TryingToStopState{}, fsmv2.SignalNone, nil,
+		return fsmv2.Transition(&TryingToStopState{}, fsmv2.SignalNone, nil,
 			fmt.Sprintf("stop required: shutdown=%t, parentState=%s",
-				snap.IsShutdownRequested, snap.ParentMappedState))
+				snap.IsShutdownRequested, snap.ParentMappedState), nil)
 	}
 
 	if snap.Status.ConnectionHealth != "healthy" {
-		return fsmv2.Result[any, any](&DisconnectedState{}, fsmv2.SignalNone, nil, "Connection lost, transitioning to disconnected")
+		return fsmv2.Transition(&DisconnectedState{}, fsmv2.SignalNone, nil, "Connection lost, transitioning to disconnected", nil)
 	}
 
-	return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil, "Active connection established")
+	return fsmv2.Transition(s, fsmv2.SignalNone, nil, "Active connection established", nil)
 }
 
 func (s *ConnectedState) String() string {

--- a/umh-core/pkg/fsmv2/workers/example/examplechild/state/state_disconnected.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplechild/state/state_disconnected.go
@@ -32,15 +32,15 @@ func (s *DisconnectedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[example_child.ExamplechildConfig, example_child.ExamplechildStatus](snapAny)
 
 	if snap.ShouldStop() {
-		return fsmv2.Result[any, any](&TryingToStopState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: shutdown=%t, parentState=%s", snap.IsShutdownRequested, snap.ParentMappedState))
+		return fsmv2.Transition(&TryingToStopState{}, fsmv2.SignalNone, nil,
+			fmt.Sprintf("stop required: shutdown=%t, parentState=%s", snap.IsShutdownRequested, snap.ParentMappedState), nil)
 	}
 
 	if !snap.IsShutdownRequested && snap.ParentMappedState == config.DesiredStateRunning {
-		return fsmv2.Result[any, any](&TryingToConnectState{}, fsmv2.SignalNone, nil, "Attempting to reconnect")
+		return fsmv2.Transition(&TryingToConnectState{}, fsmv2.SignalNone, nil, "Attempting to reconnect", nil)
 	}
 
-	return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil, "Connection lost, will retry")
+	return fsmv2.Transition(s, fsmv2.SignalNone, nil, "Connection lost, will retry", nil)
 }
 
 func (s *DisconnectedState) String() string {

--- a/umh-core/pkg/fsmv2/workers/example/examplechild/state/state_stopped.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplechild/state/state_stopped.go
@@ -15,6 +15,8 @@
 package state
 
 import (
+	"fmt"
+
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/config"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/internal/helpers"
@@ -34,14 +36,14 @@ func (s *StoppedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[example_child.ExamplechildConfig, example_child.ExamplechildStatus](snapAny)
 
 	if snap.IsShutdownRequested {
-		return fsmv2.Result[any, any](s, fsmv2.SignalNeedsRemoval, nil, "shutdown requested, stopping: parentState="+snap.ParentMappedState)
+		return fsmv2.Transition(s, fsmv2.SignalNeedsRemoval, nil, fmt.Sprintf("shutdown requested, stopping: parentState=%s", snap.ParentMappedState), nil)
 	}
 
 	if snap.ParentMappedState == config.DesiredStateRunning {
-		return fsmv2.Result[any, any](&TryingToConnectState{}, fsmv2.SignalNone, nil, "parent wants running, attempting to connect: parentState="+snap.ParentMappedState)
+		return fsmv2.Transition(&TryingToConnectState{}, fsmv2.SignalNone, nil, fmt.Sprintf("parent wants running, attempting to connect: parentState=%s", snap.ParentMappedState), nil)
 	}
 
-	return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil, "Child is stopped, no connection")
+	return fsmv2.Transition(s, fsmv2.SignalNone, nil, "Child is stopped, no connection", nil)
 }
 
 func (s *StoppedState) String() string {

--- a/umh-core/pkg/fsmv2/workers/example/examplechild/state/state_stopped.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplechild/state/state_stopped.go
@@ -15,8 +15,6 @@
 package state
 
 import (
-	"fmt"
-
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/config"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/internal/helpers"
@@ -36,11 +34,11 @@ func (s *StoppedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[example_child.ExamplechildConfig, example_child.ExamplechildStatus](snapAny)
 
 	if snap.IsShutdownRequested {
-		return fsmv2.Transition(s, fsmv2.SignalNeedsRemoval, nil, fmt.Sprintf("shutdown requested, stopping: parentState=%s", snap.ParentMappedState), nil)
+		return fsmv2.Transition(s, fsmv2.SignalNeedsRemoval, nil, "shutdown requested, stopping: parentState="+snap.ParentMappedState, nil)
 	}
 
 	if snap.ParentMappedState == config.DesiredStateRunning {
-		return fsmv2.Transition(&TryingToConnectState{}, fsmv2.SignalNone, nil, fmt.Sprintf("parent wants running, attempting to connect: parentState=%s", snap.ParentMappedState), nil)
+		return fsmv2.Transition(&TryingToConnectState{}, fsmv2.SignalNone, nil, "parent wants running, attempting to connect: parentState="+snap.ParentMappedState, nil)
 	}
 
 	return fsmv2.Transition(s, fsmv2.SignalNone, nil, "Child is stopped, no connection", nil)

--- a/umh-core/pkg/fsmv2/workers/example/examplechild/state/state_trying_to_connect.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplechild/state/state_trying_to_connect.go
@@ -30,14 +30,14 @@ func (s *TryingToConnectState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[example_child.ExamplechildConfig, example_child.ExamplechildStatus](snapAny)
 
 	if snap.ShouldStop() {
-		return fsmv2.Result[any, any](&TryingToStopState{}, fsmv2.SignalNone, nil, "Stop required, initiating shutdown")
+		return fsmv2.Transition(&TryingToStopState{}, fsmv2.SignalNone, nil, "Stop required, initiating shutdown", nil)
 	}
 
 	if snap.Status.ConnectionHealth == "healthy" {
-		return fsmv2.Result[any, any](&ConnectedState{}, fsmv2.SignalNone, nil, "Connection established successfully")
+		return fsmv2.Transition(&ConnectedState{}, fsmv2.SignalNone, nil, "Connection established successfully", nil)
 	}
 
-	return fsmv2.Result[any, any](s, fsmv2.SignalNone, &action.ConnectAction{}, "Attempting to establish connection")
+	return fsmv2.Transition(s, fsmv2.SignalNone, &action.ConnectAction{}, "Attempting to establish connection", nil)
 }
 
 func (s *TryingToConnectState) String() string {

--- a/umh-core/pkg/fsmv2/workers/example/examplechild/state/state_trying_to_stop.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplechild/state/state_trying_to_stop.go
@@ -32,10 +32,10 @@ func (s *TryingToStopState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[example_child.ExamplechildConfig, example_child.ExamplechildStatus](snapAny)
 
 	if snap.Status.ConnectionHealth != "healthy" {
-		return fsmv2.Result[any, any](&StoppedState{}, fsmv2.SignalNone, nil, fmt.Sprintf("disconnection complete: connectionHealth=%q parentState=%q", snap.Status.ConnectionHealth, snap.ParentMappedState))
+		return fsmv2.Transition(&StoppedState{}, fsmv2.SignalNone, nil, fmt.Sprintf("disconnection complete: connectionHealth=%q parentState=%q", snap.Status.ConnectionHealth, snap.ParentMappedState), nil)
 	}
 
-	return fsmv2.Result[any, any](s, fsmv2.SignalNone, &action.DisconnectAction{}, "Closing connections gracefully")
+	return fsmv2.Transition(s, fsmv2.SignalNone, &action.DisconnectAction{}, "Closing connections gracefully", nil)
 }
 
 func (s *TryingToStopState) String() string {

--- a/umh-core/pkg/fsmv2/workers/example/examplefailing/state/state_connected.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplefailing/state/state_connected.go
@@ -48,25 +48,25 @@ func (s *ConnectedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[examplefailing.ExamplefailingConfig, examplefailing.ExamplefailingStatus](snapAny)
 
 	if snap.ShouldStop() {
-		return fsmv2.Result[any, any](&TryingToStopState{}, fsmv2.SignalNone, nil,
+		return fsmv2.Transition(&TryingToStopState{}, fsmv2.SignalNone, nil,
 			fmt.Sprintf("stop required: shutdown=%t, parentState=%s",
-				snap.IsShutdownRequested, snap.ParentMappedState))
+				snap.IsShutdownRequested, snap.ParentMappedState), nil)
 	}
 
 	if snap.Status.ConnectionHealth == "no connection" {
-		return fsmv2.Result[any, any](&DisconnectedState{}, fsmv2.SignalNone, nil, "connection lost unexpectedly")
+		return fsmv2.Transition(&DisconnectedState{}, fsmv2.SignalNone, nil, "connection lost unexpectedly", nil)
 	}
 
 	if snap.Config.ShouldFail && !snap.Status.AllCyclesComplete {
 		timeInStateMs := snap.Metrics.Metrics.Framework.TimeInCurrentStateMs
 		if timeInStateMs >= healthyDurationMsBeforeNextCycle {
-			return fsmv2.Result[any, any](&TriggeringNextCycleState{}, fsmv2.SignalNone, nil, "reached healthy duration threshold, triggering next failure cycle")
+			return fsmv2.Transition(&TriggeringNextCycleState{}, fsmv2.SignalNone, nil, "reached healthy duration threshold, triggering next failure cycle", nil)
 		}
 
-		return fsmv2.Result[any, any](s, fsmv2.SignalNone, &action.TriggerObservationAction{}, "waiting for healthy duration, triggering observation")
+		return fsmv2.Transition(s, fsmv2.SignalNone, &action.TriggerObservationAction{}, "waiting for healthy duration, triggering observation", nil)
 	}
 
-	return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil, "connected and ready, no action needed")
+	return fsmv2.Transition(s, fsmv2.SignalNone, nil, "connected and ready, no action needed", nil)
 }
 
 func (s *ConnectedState) String() string {

--- a/umh-core/pkg/fsmv2/workers/example/examplefailing/state/state_disconnected.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplefailing/state/state_disconnected.go
@@ -32,16 +32,16 @@ func (s *DisconnectedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[examplefailing.ExamplefailingConfig, examplefailing.ExamplefailingStatus](snapAny)
 
 	if snap.ShouldStop() {
-		return fsmv2.Result[any, any](&TryingToStopState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: shutdown=%t, parentState=%s", snap.IsShutdownRequested, snap.ParentMappedState))
+		return fsmv2.Transition(&TryingToStopState{}, fsmv2.SignalNone, nil,
+			fmt.Sprintf("stop required: shutdown=%t, parentState=%s", snap.IsShutdownRequested, snap.ParentMappedState), nil)
 	}
 
 	if !snap.IsShutdownRequested && snap.ParentMappedState == config.DesiredStateRunning {
-		return fsmv2.Result[any, any](&TryingToConnectState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("parentState=%q: worker should be running, attempting to reconnect", snap.ParentMappedState))
+		return fsmv2.Transition(&TryingToConnectState{}, fsmv2.SignalNone, nil,
+			fmt.Sprintf("parentState=%q: worker should be running, attempting to reconnect", snap.ParentMappedState), nil)
 	}
 
-	return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil, "connection lost, waiting for reconnect conditions")
+	return fsmv2.Transition(s, fsmv2.SignalNone, nil, "connection lost, waiting for reconnect conditions", nil)
 }
 
 func (s *DisconnectedState) String() string {

--- a/umh-core/pkg/fsmv2/workers/example/examplefailing/state/state_stopped.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplefailing/state/state_stopped.go
@@ -34,14 +34,14 @@ func (s *StoppedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[examplefailing.ExamplefailingConfig, examplefailing.ExamplefailingStatus](snapAny)
 
 	if snap.IsShutdownRequested {
-		return fsmv2.Result[any, any](s, fsmv2.SignalNeedsRemoval, nil, "shutdown requested, signaling removal")
+		return fsmv2.Transition(s, fsmv2.SignalNeedsRemoval, nil, "shutdown requested, signaling removal", nil)
 	}
 
 	if !snap.IsShutdownRequested && snap.ParentMappedState == config.DesiredStateRunning {
-		return fsmv2.Result[any, any](&TryingToConnectState{}, fsmv2.SignalNone, nil, "worker should be running, transitioning to connect")
+		return fsmv2.Transition(&TryingToConnectState{}, fsmv2.SignalNone, nil, "worker should be running, transitioning to connect", nil)
 	}
 
-	return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil, "worker is stopped, no connection")
+	return fsmv2.Transition(s, fsmv2.SignalNone, nil, "worker is stopped, no connection", nil)
 }
 
 func (s *StoppedState) String() string {

--- a/umh-core/pkg/fsmv2/workers/example/examplefailing/state/state_triggering_next_cycle.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplefailing/state/state_triggering_next_cycle.go
@@ -33,20 +33,20 @@ func (s *TriggeringNextCycleState) Next(snapAny any) fsmv2.NextResult[any, any] 
 	snap := fsmv2.ConvertWorkerSnapshot[examplefailing.ExamplefailingConfig, examplefailing.ExamplefailingStatus](snapAny)
 
 	if snap.ShouldStop() {
-		return fsmv2.Result[any, any](&TryingToStopState{}, fsmv2.SignalNone, nil,
+		return fsmv2.Transition(&TryingToStopState{}, fsmv2.SignalNone, nil,
 			fmt.Sprintf("stop required: shutdown=%t, parentState=%s",
-				snap.IsShutdownRequested, snap.ParentMappedState))
+				snap.IsShutdownRequested, snap.ParentMappedState), nil)
 	}
 
 	if snap.Status.ConnectionHealth == "healthy" {
-		return fsmv2.Result[any, any](s, fsmv2.SignalNone, &action.DisconnectAction{}, "disconnecting to trigger next failure cycle")
+		return fsmv2.Transition(s, fsmv2.SignalNone, &action.DisconnectAction{}, "disconnecting to trigger next failure cycle", nil)
 	}
 
 	if snap.Status.ConnectionHealth == "no connection" {
-		return fsmv2.Result[any, any](&DisconnectedState{}, fsmv2.SignalNone, nil, "cycle triggered, connection lost")
+		return fsmv2.Transition(&DisconnectedState{}, fsmv2.SignalNone, nil, "cycle triggered, connection lost", nil)
 	}
 
-	return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil, "waiting for disconnect to complete")
+	return fsmv2.Transition(s, fsmv2.SignalNone, nil, "waiting for disconnect to complete", nil)
 }
 
 func (s *TriggeringNextCycleState) String() string {

--- a/umh-core/pkg/fsmv2/workers/example/examplefailing/state/state_trying_to_connect.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplefailing/state/state_trying_to_connect.go
@@ -32,26 +32,26 @@ func (s *TryingToConnectState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[examplefailing.ExamplefailingConfig, examplefailing.ExamplefailingStatus](snapAny)
 
 	if snap.ShouldStop() {
-		return fsmv2.Result[any, any](&TryingToStopState{}, fsmv2.SignalNone, nil,
+		return fsmv2.Transition(&TryingToStopState{}, fsmv2.SignalNone, nil,
 			fmt.Sprintf("stop required: shutdown=%t, parentState=%s",
-				snap.IsShutdownRequested, snap.ParentMappedState))
+				snap.IsShutdownRequested, snap.ParentMappedState), nil)
 	}
 
 	if snap.Status.RestartAfterFailures > 0 &&
 		snap.Status.ConnectAttempts >= snap.Status.RestartAfterFailures {
-		return fsmv2.Result[any, any](s, fsmv2.SignalNeedsRestart, nil, "max connection attempts reached, signaling restart")
+		return fsmv2.Transition(s, fsmv2.SignalNeedsRestart, nil, "max connection attempts reached, signaling restart", nil)
 	}
 
 	if snap.Status.ConnectionHealth == "healthy" {
-		return fsmv2.Result[any, any](&ConnectedState{}, fsmv2.SignalNone, nil, "connection established successfully")
+		return fsmv2.Transition(&ConnectedState{}, fsmv2.SignalNone, nil, "connection established successfully", nil)
 	}
 
 	if snap.Status.RecoveryDelayActive {
-		return fsmv2.Result[any, any](s, fsmv2.SignalNone, &action.TriggerObservationAction{},
-			"waiting for recovery delay (triggering observation)")
+		return fsmv2.Transition(s, fsmv2.SignalNone, &action.TriggerObservationAction{},
+			"waiting for recovery delay (triggering observation)", nil)
 	}
 
-	return fsmv2.Result[any, any](s, fsmv2.SignalNone, &action.ConnectAction{}, "attempting to establish connection")
+	return fsmv2.Transition(s, fsmv2.SignalNone, &action.ConnectAction{}, "attempting to establish connection", nil)
 }
 
 func (s *TryingToConnectState) String() string {

--- a/umh-core/pkg/fsmv2/workers/example/examplefailing/state/state_trying_to_stop.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplefailing/state/state_trying_to_stop.go
@@ -15,6 +15,8 @@
 package state
 
 import (
+	"fmt"
+
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/internal/helpers"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/examplefailing/action"
@@ -30,11 +32,11 @@ func (s *TryingToStopState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[examplefailing.ExamplefailingConfig, examplefailing.ExamplefailingStatus](snapAny)
 
 	if snap.Status.ConnectionHealth == "no connection" {
-		return fsmv2.Result[any, any](&StoppedState{}, fsmv2.SignalNone, nil,
-			"disconnected successfully: connectionHealth="+snap.Status.ConnectionHealth)
+		return fsmv2.Transition(&StoppedState{}, fsmv2.SignalNone, nil,
+			fmt.Sprintf("disconnected successfully: connectionHealth=%s", snap.Status.ConnectionHealth), nil)
 	}
 
-	return fsmv2.Result[any, any](s, fsmv2.SignalNone, &action.DisconnectAction{}, "attempting to disconnect cleanly")
+	return fsmv2.Transition(s, fsmv2.SignalNone, &action.DisconnectAction{}, "attempting to disconnect cleanly", nil)
 }
 
 func (s *TryingToStopState) String() string {

--- a/umh-core/pkg/fsmv2/workers/example/examplefailing/state/state_trying_to_stop.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplefailing/state/state_trying_to_stop.go
@@ -15,12 +15,10 @@
 package state
 
 import (
-	"fmt"
-
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/internal/helpers"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/examplefailing/action"
 	examplefailing "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/examplefailing"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/examplefailing/action"
 )
 
 // TryingToStopState represents the state where the worker is attempting to disconnect cleanly.
@@ -33,7 +31,7 @@ func (s *TryingToStopState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.Status.ConnectionHealth == "no connection" {
 		return fsmv2.Transition(&StoppedState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("disconnected successfully: connectionHealth=%s", snap.Status.ConnectionHealth), nil)
+			"disconnected successfully: connectionHealth="+snap.Status.ConnectionHealth, nil)
 	}
 
 	return fsmv2.Transition(s, fsmv2.SignalNone, &action.DisconnectAction{}, "attempting to disconnect cleanly", nil)

--- a/umh-core/pkg/fsmv2/workers/example/examplepanic/state/state_connected.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplepanic/state/state_connected.go
@@ -28,14 +28,14 @@ func (s *ConnectedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[example_panic.ExamplepanicConfig, example_panic.ExamplepanicStatus](snapAny)
 
 	if snap.ShouldStop() {
-		return fsmv2.Result[any, any](&TryingToStopState{}, fsmv2.SignalNone, nil, "Stop required, transitioning to TryingToStop")
+		return fsmv2.Transition(&TryingToStopState{}, fsmv2.SignalNone, nil, "Stop required, transitioning to TryingToStop", nil)
 	}
 
 	if snap.Status.ConnectionHealth == "no connection" {
-		return fsmv2.Result[any, any](&DisconnectedState{}, fsmv2.SignalNone, nil, "Connection lost, transitioning to Disconnected")
+		return fsmv2.Transition(&DisconnectedState{}, fsmv2.SignalNone, nil, "Connection lost, transitioning to Disconnected", nil)
 	}
 
-	return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil, "Active connection established")
+	return fsmv2.Transition(s, fsmv2.SignalNone, nil, "Active connection established", nil)
 }
 
 func (s *ConnectedState) String() string {

--- a/umh-core/pkg/fsmv2/workers/example/examplepanic/state/state_disconnected.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplepanic/state/state_disconnected.go
@@ -31,16 +31,16 @@ func (s *DisconnectedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[example_panic.ExamplepanicConfig, example_panic.ExamplepanicStatus](snapAny)
 
 	if snap.ShouldStop() {
-		return fsmv2.Result[any, any](&TryingToStopState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: shutdown=%t, parentState=%s", snap.IsShutdownRequested, snap.ParentMappedState))
+		return fsmv2.Transition(&TryingToStopState{}, fsmv2.SignalNone, nil,
+			fmt.Sprintf("stop required: shutdown=%t, parentState=%s", snap.IsShutdownRequested, snap.ParentMappedState), nil)
 	}
 
 	if !snap.IsShutdownRequested && snap.ParentMappedState == config.DesiredStateRunning {
-		return fsmv2.Result[any, any](&TryingToConnectState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("parentState=%q: should be running, transitioning to TryingToConnect", snap.ParentMappedState))
+		return fsmv2.Transition(&TryingToConnectState{}, fsmv2.SignalNone, nil,
+			fmt.Sprintf("parentState=%q: should be running, transitioning to TryingToConnect", snap.ParentMappedState), nil)
 	}
 
-	return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil, "Connection lost, will retry")
+	return fsmv2.Transition(s, fsmv2.SignalNone, nil, "Connection lost, will retry", nil)
 }
 
 func (s *DisconnectedState) String() string {

--- a/umh-core/pkg/fsmv2/workers/example/examplepanic/state/state_stopped.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplepanic/state/state_stopped.go
@@ -35,15 +35,15 @@ func (s *StoppedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[example_panic.ExamplepanicConfig, example_panic.ExamplepanicStatus](snapAny)
 
 	if snap.IsShutdownRequested {
-		return fsmv2.Result[any, any](s, fsmv2.SignalNeedsRemoval, nil, "Shutdown requested, signaling removal")
+		return fsmv2.Transition(s, fsmv2.SignalNeedsRemoval, nil, "Shutdown requested, signaling removal", nil)
 	}
 
 	if !snap.IsShutdownRequested && snap.ParentMappedState == config.DesiredStateRunning {
-		return fsmv2.Result[any, any](&TryingToConnectState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("parentState=%q: should be running, transitioning to TryingToConnect", snap.ParentMappedState))
+		return fsmv2.Transition(&TryingToConnectState{}, fsmv2.SignalNone, nil,
+			fmt.Sprintf("parentState=%q: should be running, transitioning to TryingToConnect", snap.ParentMappedState), nil)
 	}
 
-	return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil, "Panic worker is stopped, no connection")
+	return fsmv2.Transition(s, fsmv2.SignalNone, nil, "Panic worker is stopped, no connection", nil)
 }
 
 func (s *StoppedState) String() string {

--- a/umh-core/pkg/fsmv2/workers/example/examplepanic/state/state_trying_to_connect.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplepanic/state/state_trying_to_connect.go
@@ -29,14 +29,14 @@ func (s *TryingToConnectState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[example_panic.ExamplepanicConfig, example_panic.ExamplepanicStatus](snapAny)
 
 	if snap.ShouldStop() {
-		return fsmv2.Result[any, any](&TryingToStopState{}, fsmv2.SignalNone, nil, "Stop required, transitioning to TryingToStop")
+		return fsmv2.Transition(&TryingToStopState{}, fsmv2.SignalNone, nil, "Stop required, transitioning to TryingToStop", nil)
 	}
 
 	if snap.Status.ConnectionHealth == "healthy" {
-		return fsmv2.Result[any, any](&ConnectedState{}, fsmv2.SignalNone, nil, "Connection healthy, transitioning to Connected")
+		return fsmv2.Transition(&ConnectedState{}, fsmv2.SignalNone, nil, "Connection healthy, transitioning to Connected", nil)
 	}
 
-	return fsmv2.Result[any, any](s, fsmv2.SignalNone, &action.ConnectAction{}, "Attempting to establish connection")
+	return fsmv2.Transition(s, fsmv2.SignalNone, &action.ConnectAction{}, "Attempting to establish connection", nil)
 }
 
 func (s *TryingToConnectState) String() string {

--- a/umh-core/pkg/fsmv2/workers/example/examplepanic/state/state_trying_to_stop.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplepanic/state/state_trying_to_stop.go
@@ -29,10 +29,10 @@ func (s *TryingToStopState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[example_panic.ExamplepanicConfig, example_panic.ExamplepanicStatus](snapAny)
 
 	if snap.Status.ConnectionHealth == "no connection" {
-		return fsmv2.Result[any, any](&StoppedState{}, fsmv2.SignalNone, nil, "Connection closed, transitioning to Stopped")
+		return fsmv2.Transition(&StoppedState{}, fsmv2.SignalNone, nil, "Connection closed, transitioning to Stopped", nil)
 	}
 
-	return fsmv2.Result[any, any](s, fsmv2.SignalNone, &action.DisconnectAction{}, "Closing connections gracefully")
+	return fsmv2.Transition(s, fsmv2.SignalNone, &action.DisconnectAction{}, "Closing connections gracefully", nil)
 }
 
 func (s *TryingToStopState) String() string {

--- a/umh-core/pkg/fsmv2/workers/example/exampleparent/state/state_degraded.go
+++ b/umh-core/pkg/fsmv2/workers/example/exampleparent/state/state_degraded.go
@@ -29,14 +29,14 @@ func (s *DegradedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[exampleparent.ExampleparentConfig, exampleparent.ExampleparentStatus](snapAny)
 
 	if snap.IsShutdownRequested {
-		return fsmv2.Result[any, any](&TryingToStopState{}, fsmv2.SignalNone, nil, "Shutdown requested, transitioning to TryingToStop")
+		return fsmv2.Transition(&TryingToStopState{}, fsmv2.SignalNone, nil, "Shutdown requested, transitioning to TryingToStop", nil)
 	}
 
 	if snap.ChildrenUnhealthy == 0 {
-		return fsmv2.Result[any, any](&RunningState{}, fsmv2.SignalNone, nil, "All children now healthy, transitioning to Running")
+		return fsmv2.Transition(&RunningState{}, fsmv2.SignalNone, nil, "All children now healthy, transitioning to Running", nil)
 	}
 
-	return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil, "Some children are unhealthy")
+	return fsmv2.Transition(s, fsmv2.SignalNone, nil, "Some children are unhealthy", nil)
 }
 
 func (s *DegradedState) String() string {

--- a/umh-core/pkg/fsmv2/workers/example/exampleparent/state/state_running.go
+++ b/umh-core/pkg/fsmv2/workers/example/exampleparent/state/state_running.go
@@ -35,19 +35,19 @@ func (s *RunningState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[exampleparent.ExampleparentConfig, exampleparent.ExampleparentStatus](snapAny)
 
 	if snap.IsShutdownRequested {
-		return fsmv2.Result[any, any](&TryingToStopState{}, fsmv2.SignalNone, nil, "Shutdown requested, transitioning to TryingToStop")
+		return fsmv2.Transition(&TryingToStopState{}, fsmv2.SignalNone, nil, "Shutdown requested, transitioning to TryingToStop", nil)
 	}
 
 	if snap.ChildrenUnhealthy > 0 {
-		return fsmv2.Result[any, any](&DegradedState{}, fsmv2.SignalNone, nil, "Some children are unhealthy, transitioning to Degraded")
+		return fsmv2.Transition(&DegradedState{}, fsmv2.SignalNone, nil, "Some children are unhealthy, transitioning to Degraded", nil)
 	}
 
 	elapsed := time.Duration(snap.Metrics.Metrics.Framework.TimeInCurrentStateMs) * time.Millisecond
 	if elapsed >= RunningDuration {
-		return fsmv2.Result[any, any](&TryingToStopState{}, fsmv2.SignalNone, nil, "Running duration elapsed, transitioning to TryingToStop")
+		return fsmv2.Transition(&TryingToStopState{}, fsmv2.SignalNone, nil, "Running duration elapsed, transitioning to TryingToStop", nil)
 	}
 
-	return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil, "All children healthy and running")
+	return fsmv2.Transition(s, fsmv2.SignalNone, nil, "All children healthy and running", nil)
 }
 
 func (s *RunningState) String() string {

--- a/umh-core/pkg/fsmv2/workers/example/exampleparent/state/state_stopped.go
+++ b/umh-core/pkg/fsmv2/workers/example/exampleparent/state/state_stopped.go
@@ -40,17 +40,17 @@ func (s *StoppedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[exampleparent.ExampleparentConfig, exampleparent.ExampleparentStatus](snapAny)
 
 	if snap.IsShutdownRequested {
-		return fsmv2.Result[any, any](s, fsmv2.SignalNeedsRemoval, nil, "Shutdown requested, signaling removal")
+		return fsmv2.Transition(s, fsmv2.SignalNeedsRemoval, nil, "Shutdown requested, signaling removal", nil)
 	}
 
 	if !snap.IsShutdownRequested {
 		elapsed := time.Duration(snap.Metrics.Metrics.Framework.TimeInCurrentStateMs) * time.Millisecond
 		if elapsed >= StoppedWaitDuration {
-			return fsmv2.Result[any, any](&TryingToStartState{}, fsmv2.SignalNone, nil, "Wait duration elapsed, transitioning to TryingToStart")
+			return fsmv2.Transition(&TryingToStartState{}, fsmv2.SignalNone, nil, "Wait duration elapsed, transitioning to TryingToStart", nil)
 		}
 	}
 
-	return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil, "Parent is stopped, no children spawned")
+	return fsmv2.Transition(s, fsmv2.SignalNone, nil, "Parent is stopped, no children spawned", nil)
 }
 
 func (s *StoppedState) String() string {

--- a/umh-core/pkg/fsmv2/workers/example/exampleparent/state/state_trying_to_start.go
+++ b/umh-core/pkg/fsmv2/workers/example/exampleparent/state/state_trying_to_start.go
@@ -32,18 +32,18 @@ func (s *TryingToStartState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[exampleparent.ExampleparentConfig, exampleparent.ExampleparentStatus](snapAny)
 
 	if snap.IsShutdownRequested {
-		return fsmv2.Result[any, any](&TryingToStopState{}, fsmv2.SignalNone, nil, "Shutdown requested, transitioning to TryingToStop")
+		return fsmv2.Transition(&TryingToStopState{}, fsmv2.SignalNone, nil, "Shutdown requested, transitioning to TryingToStop", nil)
 	}
 
 	if snap.Status.ID == "" {
-		return fsmv2.Result[any, any](s, fsmv2.SignalNone, &action.StartAction{}, "ID not set, executing StartAction")
+		return fsmv2.Transition(s, fsmv2.SignalNone, &action.StartAction{}, "ID not set, executing StartAction", nil)
 	}
 
 	if snap.ChildrenHealthy > 0 && snap.ChildrenUnhealthy == 0 {
-		return fsmv2.Result[any, any](&RunningState{}, fsmv2.SignalNone, nil, "All children healthy, transitioning to Running")
+		return fsmv2.Transition(&RunningState{}, fsmv2.SignalNone, nil, "All children healthy, transitioning to Running", nil)
 	}
 
-	return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil, "Waiting for all children to become healthy")
+	return fsmv2.Transition(s, fsmv2.SignalNone, nil, "Waiting for all children to become healthy", nil)
 }
 
 func (s *TryingToStartState) String() string {

--- a/umh-core/pkg/fsmv2/workers/example/exampleparent/state/state_trying_to_stop.go
+++ b/umh-core/pkg/fsmv2/workers/example/exampleparent/state/state_trying_to_stop.go
@@ -32,14 +32,14 @@ func (s *TryingToStopState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[exampleparent.ExampleparentConfig, exampleparent.ExampleparentStatus](snapAny)
 
 	if snap.Status.ID == "" {
-		return fsmv2.Result[any, any](s, fsmv2.SignalNone, &action.StopAction{}, "ID not set, executing StopAction")
+		return fsmv2.Transition(s, fsmv2.SignalNone, &action.StopAction{}, "ID not set, executing StopAction", nil)
 	}
 
 	if snap.ChildrenHealthy == 0 && snap.ChildrenUnhealthy == 0 {
-		return fsmv2.Result[any, any](&StoppedState{}, fsmv2.SignalNone, nil, "All children stopped, transitioning to Stopped")
+		return fsmv2.Transition(&StoppedState{}, fsmv2.SignalNone, nil, "All children stopped, transitioning to Stopped", nil)
 	}
 
-	return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil, "Gracefully stopping all children")
+	return fsmv2.Transition(s, fsmv2.SignalNone, nil, "Gracefully stopping all children", nil)
 }
 
 func (s *TryingToStopState) String() string {

--- a/umh-core/pkg/fsmv2/workers/example/exampleslow/state/state_connected.go
+++ b/umh-core/pkg/fsmv2/workers/example/exampleslow/state/state_connected.go
@@ -28,14 +28,14 @@ func (s *ConnectedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[example_slow.ExampleslowConfig, example_slow.ExampleslowStatus](snapAny)
 
 	if snap.ShouldStop() {
-		return fsmv2.Result[any, any](&TryingToStopState{}, fsmv2.SignalNone, nil, "stop required, transitioning to trying to stop")
+		return fsmv2.Transition(&TryingToStopState{}, fsmv2.SignalNone, nil, "stop required, transitioning to trying to stop", nil)
 	}
 
 	if snap.Status.ConnectionHealth == "no connection" {
-		return fsmv2.Result[any, any](&DisconnectedState{}, fsmv2.SignalNone, nil, "connection lost, transitioning to disconnected")
+		return fsmv2.Transition(&DisconnectedState{}, fsmv2.SignalNone, nil, "connection lost, transitioning to disconnected", nil)
 	}
 
-	return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil, "active connection established")
+	return fsmv2.Transition(s, fsmv2.SignalNone, nil, "active connection established", nil)
 }
 
 func (s *ConnectedState) String() string {

--- a/umh-core/pkg/fsmv2/workers/example/exampleslow/state/state_disconnected.go
+++ b/umh-core/pkg/fsmv2/workers/example/exampleslow/state/state_disconnected.go
@@ -31,16 +31,16 @@ func (s *DisconnectedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[example_slow.ExampleslowConfig, example_slow.ExampleslowStatus](snapAny)
 
 	if snap.ShouldStop() {
-		return fsmv2.Result[any, any](&TryingToStopState{}, fsmv2.SignalNone, nil,
+		return fsmv2.Transition(&TryingToStopState{}, fsmv2.SignalNone, nil,
 			fmt.Sprintf("stop required: shutdown=%t, parentState=%s",
-				snap.IsShutdownRequested, snap.ParentMappedState))
+				snap.IsShutdownRequested, snap.ParentMappedState), nil)
 	}
 
 	if !snap.IsShutdownRequested && snap.ParentMappedState == config.DesiredStateRunning {
-		return fsmv2.Result[any, any](&TryingToConnectState{}, fsmv2.SignalNone, nil, "should be running, attempting reconnection")
+		return fsmv2.Transition(&TryingToConnectState{}, fsmv2.SignalNone, nil, "should be running, attempting reconnection", nil)
 	}
 
-	return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil, "connection lost, will retry")
+	return fsmv2.Transition(s, fsmv2.SignalNone, nil, "connection lost, will retry", nil)
 }
 
 func (s *DisconnectedState) String() string {

--- a/umh-core/pkg/fsmv2/workers/example/exampleslow/state/state_stopped.go
+++ b/umh-core/pkg/fsmv2/workers/example/exampleslow/state/state_stopped.go
@@ -15,6 +15,8 @@
 package state
 
 import (
+	"fmt"
+
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/config"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/internal/helpers"
@@ -33,15 +35,15 @@ func (s *StoppedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[example_slow.ExampleslowConfig, example_slow.ExampleslowStatus](snapAny)
 
 	if snap.IsShutdownRequested {
-		return fsmv2.Result[any, any](s, fsmv2.SignalNeedsRemoval, nil,
-			"shutdown requested, stopping: parentState="+snap.ParentMappedState)
+		return fsmv2.Transition(s, fsmv2.SignalNeedsRemoval, nil,
+			fmt.Sprintf("shutdown requested, stopping: parentState=%s", snap.ParentMappedState), nil)
 	}
 
 	if snap.ParentMappedState == config.DesiredStateRunning {
-		return fsmv2.Result[any, any](&TryingToConnectState{}, fsmv2.SignalNone, nil, "should be running, transitioning to trying to connect")
+		return fsmv2.Transition(&TryingToConnectState{}, fsmv2.SignalNone, nil, "should be running, transitioning to trying to connect", nil)
 	}
 
-	return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil, "slow worker is stopped, no connection")
+	return fsmv2.Transition(s, fsmv2.SignalNone, nil, "slow worker is stopped, no connection", nil)
 }
 
 func (s *StoppedState) String() string {

--- a/umh-core/pkg/fsmv2/workers/example/exampleslow/state/state_stopped.go
+++ b/umh-core/pkg/fsmv2/workers/example/exampleslow/state/state_stopped.go
@@ -15,8 +15,6 @@
 package state
 
 import (
-	"fmt"
-
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/config"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/internal/helpers"
@@ -36,7 +34,7 @@ func (s *StoppedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.IsShutdownRequested {
 		return fsmv2.Transition(s, fsmv2.SignalNeedsRemoval, nil,
-			fmt.Sprintf("shutdown requested, stopping: parentState=%s", snap.ParentMappedState), nil)
+			"shutdown requested, stopping: parentState="+snap.ParentMappedState, nil)
 	}
 
 	if snap.ParentMappedState == config.DesiredStateRunning {

--- a/umh-core/pkg/fsmv2/workers/example/exampleslow/state/state_trying_to_connect.go
+++ b/umh-core/pkg/fsmv2/workers/example/exampleslow/state/state_trying_to_connect.go
@@ -31,16 +31,16 @@ func (s *TryingToConnectState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[example_slow.ExampleslowConfig, example_slow.ExampleslowStatus](snapAny)
 
 	if snap.ShouldStop() {
-		return fsmv2.Result[any, any](&TryingToStopState{}, fsmv2.SignalNone, nil,
+		return fsmv2.Transition(&TryingToStopState{}, fsmv2.SignalNone, nil,
 			fmt.Sprintf("stop required: shutdown=%t, parentState=%s",
-				snap.IsShutdownRequested, snap.ParentMappedState))
+				snap.IsShutdownRequested, snap.ParentMappedState), nil)
 	}
 
 	if snap.Status.ConnectionHealth == "healthy" {
-		return fsmv2.Result[any, any](&ConnectedState{}, fsmv2.SignalNone, nil, "connection healthy, transitioning to connected")
+		return fsmv2.Transition(&ConnectedState{}, fsmv2.SignalNone, nil, "connection healthy, transitioning to connected", nil)
 	}
 
-	return fsmv2.Result[any, any](s, fsmv2.SignalNone, &action.ConnectAction{}, "attempting to establish connection with delay")
+	return fsmv2.Transition(s, fsmv2.SignalNone, &action.ConnectAction{}, "attempting to establish connection with delay", nil)
 }
 
 func (s *TryingToConnectState) String() string {

--- a/umh-core/pkg/fsmv2/workers/example/exampleslow/state/state_trying_to_stop.go
+++ b/umh-core/pkg/fsmv2/workers/example/exampleslow/state/state_trying_to_stop.go
@@ -29,10 +29,10 @@ func (s *TryingToStopState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[example_slow.ExampleslowConfig, example_slow.ExampleslowStatus](snapAny)
 
 	if snap.Status.ConnectionHealth == "no connection" {
-		return fsmv2.Result[any, any](&StoppedState{}, fsmv2.SignalNone, nil, "connection closed, transitioning to stopped")
+		return fsmv2.Transition(&StoppedState{}, fsmv2.SignalNone, nil, "connection closed, transitioning to stopped", nil)
 	}
 
-	return fsmv2.Result[any, any](s, fsmv2.SignalNone, &action.DisconnectAction{}, "closing connections gracefully")
+	return fsmv2.Transition(s, fsmv2.SignalNone, &action.DisconnectAction{}, "closing connections gracefully", nil)
 }
 
 func (s *TryingToStopState) String() string {

--- a/umh-core/pkg/fsmv2/workers/example/helloworld/state/state_degraded.go
+++ b/umh-core/pkg/fsmv2/workers/example/helloworld/state/state_degraded.go
@@ -35,18 +35,18 @@ func (s *DegradedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	// 1. Check shutdown
 	if snap.ShouldStop() {
-		return fsmv2.Result[any, any](&StoppedState{}, fsmv2.SignalNone, nil,
+		return fsmv2.Transition(&StoppedState{}, fsmv2.SignalNone, nil,
 			fmt.Sprintf("stop required: shutdown=%t, parentState=%s",
-				snap.IsShutdownRequested, snap.ParentMappedState))
+				snap.IsShutdownRequested, snap.ParentMappedState), nil)
 	}
 
 	// 2. Check if mood has recovered (no longer "sad")
 	if snap.Status.Mood != "sad" {
-		return fsmv2.Result[any, any](&RunningState{}, fsmv2.SignalNone, nil, "Mood recovered, transitioning to running")
+		return fsmv2.Transition(&RunningState{}, fsmv2.SignalNone, nil, "Mood recovered, transitioning to running", nil)
 	}
 
 	// 3. Stay degraded
-	return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil, "Mood is still sad")
+	return fsmv2.Transition(s, fsmv2.SignalNone, nil, "Mood is still sad", nil)
 }
 
 // String returns the state name for logging and metrics.

--- a/umh-core/pkg/fsmv2/workers/example/helloworld/state/state_running.go
+++ b/umh-core/pkg/fsmv2/workers/example/helloworld/state/state_running.go
@@ -34,18 +34,18 @@ func (s *RunningState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	// 1. Check shutdown - transition back to stopped
 	if snap.ShouldStop() {
-		return fsmv2.Result[any, any](&StoppedState{}, fsmv2.SignalNone, nil,
+		return fsmv2.Transition(&StoppedState{}, fsmv2.SignalNone, nil,
 			fmt.Sprintf("stop required: shutdown=%t, parentState=%s",
-				snap.IsShutdownRequested, snap.ParentMappedState))
+				snap.IsShutdownRequested, snap.ParentMappedState), nil)
 	}
 
 	// 2. Check mood from mood file (read in CollectObservedState)
 	if snap.Status.Mood == "sad" {
-		return fsmv2.Result[any, any](&DegradedState{}, fsmv2.SignalNone, nil, "Mood is sad, transitioning to degraded")
+		return fsmv2.Transition(&DegradedState{}, fsmv2.SignalNone, nil, "Mood is sad, transitioning to degraded", nil)
 	}
 
 	// 3. Stay in running state
-	return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil, "Worker is running and has said hello")
+	return fsmv2.Transition(s, fsmv2.SignalNone, nil, "Worker is running and has said hello", nil)
 }
 
 // String returns the state name for logging and metrics.

--- a/umh-core/pkg/fsmv2/workers/example/helloworld/state/state_stopped.go
+++ b/umh-core/pkg/fsmv2/workers/example/helloworld/state/state_stopped.go
@@ -36,10 +36,10 @@ func (s *StoppedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[hello_world.HelloworldConfig, hello_world.HelloworldStatus](snapAny)
 
 	if snap.IsShutdownRequested {
-		return fsmv2.Result[any, any](s, fsmv2.SignalNeedsRemoval, nil, "Shutdown requested, signaling removal")
+		return fsmv2.Transition(s, fsmv2.SignalNeedsRemoval, nil, "Shutdown requested, signaling removal", nil)
 	}
 
-	return fsmv2.Result[any, any](&TryingToStartState{}, fsmv2.SignalNone, nil, "Starting worker")
+	return fsmv2.Transition(&TryingToStartState{}, fsmv2.SignalNone, nil, "Starting worker", nil)
 }
 
 // String returns the state name for logging and metrics.

--- a/umh-core/pkg/fsmv2/workers/example/helloworld/state/state_trying_to_start.go
+++ b/umh-core/pkg/fsmv2/workers/example/helloworld/state/state_trying_to_start.go
@@ -34,21 +34,21 @@ func (s *TryingToStartState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	// 1. Check shutdown first
 	if snap.ShouldStop() {
-		return fsmv2.Result[any, any](&StoppedState{}, fsmv2.SignalNone, nil,
+		return fsmv2.Transition(&StoppedState{}, fsmv2.SignalNone, nil,
 			fmt.Sprintf("stop required: shutdown=%t, parentState=%s",
-				snap.IsShutdownRequested, snap.ParentMappedState))
+				snap.IsShutdownRequested, snap.ParentMappedState), nil)
 	}
 
 	// 2. Check if action has already completed (observe the effect)
 	// This makes the state machine resilient to action replay
 	if snap.Status.HelloSaid {
-		return fsmv2.Result[any, any](&RunningState{}, fsmv2.SignalNone, nil, "Hello has been said, transitioning to running")
+		return fsmv2.Transition(&RunningState{}, fsmv2.SignalNone, nil, "Hello has been said, transitioning to running", nil)
 	}
 
 	// 3. Emit action and stay in this state
-	return fsmv2.Result[any, any](s, fsmv2.SignalNone,
+	return fsmv2.Transition(s, fsmv2.SignalNone,
 		fsmv2.SimpleAction[*hello_world.HelloworldDependencies](hello_world.SayHelloActionName, hello_world.SayHello),
-		"Saying hello to the world")
+		"Saying hello to the world", nil)
 }
 
 // String returns the state name for logging and metrics.

--- a/umh-core/pkg/fsmv2/workers/persistence/state/base.go
+++ b/umh-core/pkg/fsmv2/workers/persistence/state/base.go
@@ -28,16 +28,16 @@ func emitActionIfDue(
 ) fsmv2.NextResult[any, any] {
 	timeSinceCompaction := snap.CollectedAt.Sub(snap.Status.LastCompactionAt)
 	if timeSinceCompaction >= snap.Config.GetCompactionInterval() {
-		return fsmv2.Result[any, any](currentState, fsmv2.SignalNone,
-			action.NewCompactDeltasAction(snap.Config.GetRetentionWindow()), "Running compaction")
+		return fsmv2.Transition(currentState, fsmv2.SignalNone,
+			action.NewCompactDeltasAction(snap.Config.GetRetentionWindow()), "Running compaction", nil)
 	}
 
 	if isMaintenanceDue(snap) {
-		return fsmv2.Result[any, any](currentState, fsmv2.SignalNone,
-			action.NewRunMaintenanceAction(), "Running maintenance")
+		return fsmv2.Transition(currentState, fsmv2.SignalNone,
+			action.NewRunMaintenanceAction(), "Running maintenance", nil)
 	}
 
-	return fsmv2.Result[any, any](currentState, fsmv2.SignalNone, nil, "Monitoring for cleanup needs")
+	return fsmv2.Transition(currentState, fsmv2.SignalNone, nil, "Monitoring for cleanup needs", nil)
 }
 
 const shortIntervalThreshold = 3 * 24 * time.Hour

--- a/umh-core/pkg/fsmv2/workers/persistence/state/state_degraded.go
+++ b/umh-core/pkg/fsmv2/workers/persistence/state/state_degraded.go
@@ -30,13 +30,13 @@ func (s *RunningDegradedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[snapshot.PersistenceConfig, snapshot.PersistenceStatus](snapAny)
 
 	if snap.ShouldStop() {
-		return fsmv2.Result[any, any](&ShuttingDownState{}, fsmv2.SignalNone, nil,
+		return fsmv2.Transition(&ShuttingDownState{}, fsmv2.SignalNone, nil,
 			fmt.Sprintf("stop required: shutdown=%t, parentState=%s",
-				snap.IsShutdownRequested, snap.ParentMappedState))
+				snap.IsShutdownRequested, snap.ParentMappedState), nil)
 	}
 
 	if snap.Status.IsHealthy() {
-		return fsmv2.Result[any, any](&RunningState{}, fsmv2.SignalNone, nil, "Action succeeded, recovered to healthy")
+		return fsmv2.Transition(&RunningState{}, fsmv2.SignalNone, nil, "Action succeeded, recovered to healthy", nil)
 	}
 
 	return emitActionIfDue(s, snap)

--- a/umh-core/pkg/fsmv2/workers/persistence/state/state_running.go
+++ b/umh-core/pkg/fsmv2/workers/persistence/state/state_running.go
@@ -30,13 +30,13 @@ func (s *RunningState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[snapshot.PersistenceConfig, snapshot.PersistenceStatus](snapAny)
 
 	if snap.ShouldStop() {
-		return fsmv2.Result[any, any](&ShuttingDownState{}, fsmv2.SignalNone, nil,
+		return fsmv2.Transition(&ShuttingDownState{}, fsmv2.SignalNone, nil,
 			fmt.Sprintf("stop required: shutdown=%t, parentState=%s",
-				snap.IsShutdownRequested, snap.ParentMappedState))
+				snap.IsShutdownRequested, snap.ParentMappedState), nil)
 	}
 
 	if !snap.Status.IsHealthy() {
-		return fsmv2.Result[any, any](&RunningDegradedState{}, fsmv2.SignalNone, nil, "Action failed, entering degraded state")
+		return fsmv2.Transition(&RunningDegradedState{}, fsmv2.SignalNone, nil, "Action failed, entering degraded state", nil)
 	}
 
 	return emitActionIfDue(s, snap)

--- a/umh-core/pkg/fsmv2/workers/persistence/state/state_stopped.go
+++ b/umh-core/pkg/fsmv2/workers/persistence/state/state_stopped.go
@@ -32,10 +32,10 @@ func (s *StoppedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[snapshot.PersistenceConfig, snapshot.PersistenceStatus](snapAny)
 
 	if snap.IsShutdownRequested {
-		return fsmv2.Result[any, any](s, fsmv2.SignalNeedsRemoval, nil, "Persistence worker stopped and shutdown requested")
+		return fsmv2.Transition(s, fsmv2.SignalNeedsRemoval, nil, "Persistence worker stopped and shutdown requested", nil)
 	}
 
-	return fsmv2.Result[any, any](&TryingToStartState{}, fsmv2.SignalNone, nil, "Starting persistence worker")
+	return fsmv2.Transition(&TryingToStartState{}, fsmv2.SignalNone, nil, "Starting persistence worker", nil)
 }
 
 func (s *StoppedState) String() string {

--- a/umh-core/pkg/fsmv2/workers/persistence/state/state_stopping.go
+++ b/umh-core/pkg/fsmv2/workers/persistence/state/state_stopping.go
@@ -30,12 +30,12 @@ func (s *ShuttingDownState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	for _, result := range snap.LastActionResults {
 		if result.ActionType == action.NewRunMaintenanceAction().Name() && result.Success {
-			return fsmv2.Result[any, any](&StoppedState{}, fsmv2.SignalNone, nil, "Shutdown maintenance completed")
+			return fsmv2.Transition(&StoppedState{}, fsmv2.SignalNone, nil, "Shutdown maintenance completed", nil)
 		}
 	}
 
-	return fsmv2.Result[any, any](s, fsmv2.SignalNone,
-		action.NewRunMaintenanceAction(), "Running shutdown maintenance")
+	return fsmv2.Transition(s, fsmv2.SignalNone,
+		action.NewRunMaintenanceAction(), "Running shutdown maintenance", nil)
 }
 
 func (s *ShuttingDownState) String() string {

--- a/umh-core/pkg/fsmv2/workers/persistence/state/state_trying_to_start.go
+++ b/umh-core/pkg/fsmv2/workers/persistence/state/state_trying_to_start.go
@@ -31,8 +31,8 @@ func (s *TryingToStartState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[snapshot.PersistenceConfig, snapshot.PersistenceStatus](snapAny)
 
 	if snap.ShouldStop() {
-		return fsmv2.Result[any, any](&StoppedState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: shutdown=%t, parentState=%s", snap.IsShutdownRequested, snap.ParentMappedState))
+		return fsmv2.Transition(&StoppedState{}, fsmv2.SignalNone, nil,
+			fmt.Sprintf("stop required: shutdown=%t, parentState=%s", snap.IsShutdownRequested, snap.ParentMappedState), nil)
 	}
 
 	maintenanceActionName := action.NewRunMaintenanceAction().Name()
@@ -44,14 +44,14 @@ func (s *TryingToStartState) Next(snapAny any) fsmv2.NextResult[any, any] {
 		}
 
 		if result.Success {
-			return fsmv2.Result[any, any](&RunningState{}, fsmv2.SignalNone, nil, "Startup maintenance completed")
+			return fsmv2.Transition(&RunningState{}, fsmv2.SignalNone, nil, "Startup maintenance completed", nil)
 		}
 
 		break
 	}
 
-	return fsmv2.Result[any, any](s, fsmv2.SignalNone,
-		action.NewRunMaintenanceAction(), "Running startup maintenance")
+	return fsmv2.Transition(s, fsmv2.SignalNone,
+		action.NewRunMaintenanceAction(), "Running startup maintenance", nil)
 }
 
 func (s *TryingToStartState) String() string {

--- a/umh-core/pkg/fsmv2/workers/transport/pull/state/state_degraded.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/state/state_degraded.go
@@ -35,14 +35,14 @@ func (s *DegradedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[snapshot.PullDesiredState, snapshot.PullStatus](snapAny)
 
 	if snap.ShouldStop() {
-		return fsmv2.Result[any, any](&StoppingState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: shutdown=%t, parentState(observed)=%s", snap.IsShutdownRequested, snap.ParentMappedState))
+		return fsmv2.Transition(&StoppingState{}, fsmv2.SignalNone, nil,
+			fmt.Sprintf("stop required: shutdown=%t, parentState(observed)=%s", snap.IsShutdownRequested, snap.ParentMappedState), nil)
 	}
 
 	if snap.Status.ConsecutiveErrors == 0 && snap.Status.PendingMessageCount < pendingDegradedThreshold {
-		return fsmv2.Result[any, any](&RunningState{}, fsmv2.SignalNone, nil,
+		return fsmv2.Transition(&RunningState{}, fsmv2.SignalNone, nil,
 			fmt.Sprintf("recovering to Running: consecutiveErrors=0, pendingMessages=%d (threshold=%d)",
-				snap.Status.PendingMessageCount, pendingDegradedThreshold))
+				snap.Status.PendingMessageCount, pendingDegradedThreshold), nil)
 	}
 
 	if snap.Status.HasTransport && snap.Status.HasValidToken {
@@ -60,21 +60,21 @@ func (s *DegradedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 		}
 
 		if shouldWait {
-			return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil,
+			return fsmv2.Transition(s, fsmv2.SignalNone, nil,
 				fmt.Sprintf("degraded (%d errors, %d pending), backoff %s",
 					snap.Status.ConsecutiveErrors, snap.Status.PendingMessageCount,
-					backoffDelay.Round(time.Second)))
+					backoffDelay.Round(time.Second)), nil)
 		}
 
-		return fsmv2.Result[any, any](s, fsmv2.SignalNone, &action.PullAction{},
+		return fsmv2.Transition(s, fsmv2.SignalNone, &action.PullAction{},
 			fmt.Sprintf("degraded (%d consecutive errors, %d pending), still pulling",
-				snap.Status.ConsecutiveErrors, snap.Status.PendingMessageCount))
+				snap.Status.ConsecutiveErrors, snap.Status.PendingMessageCount), nil)
 	}
 
-	return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil,
+	return fsmv2.Transition(s, fsmv2.SignalNone, nil,
 		fmt.Sprintf("degraded (%d consecutive errors, %d pending), waiting: hasTransport=%t, hasValidToken=%t",
 			snap.Status.ConsecutiveErrors, snap.Status.PendingMessageCount,
-			snap.Status.HasTransport, snap.Status.HasValidToken))
+			snap.Status.HasTransport, snap.Status.HasValidToken), nil)
 }
 
 func (s *DegradedState) String() string {

--- a/umh-core/pkg/fsmv2/workers/transport/pull/state/state_running.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/state/state_running.go
@@ -42,27 +42,27 @@ func (s *RunningState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[snapshot.PullDesiredState, snapshot.PullStatus](snapAny)
 
 	if snap.ShouldStop() {
-		return fsmv2.Result[any, any](&StoppingState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: shutdown=%t, parentState(observed)=%s", snap.IsShutdownRequested, snap.ParentMappedState))
+		return fsmv2.Transition(&StoppingState{}, fsmv2.SignalNone, nil,
+			fmt.Sprintf("stop required: shutdown=%t, parentState(observed)=%s", snap.IsShutdownRequested, snap.ParentMappedState), nil)
 	}
 
 	if snap.Status.ConsecutiveErrors >= errorDegradedThreshold {
-		return fsmv2.Result[any, any](&DegradedState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("degrading: %d consecutive errors (threshold=%d)", snap.Status.ConsecutiveErrors, errorDegradedThreshold))
+		return fsmv2.Transition(&DegradedState{}, fsmv2.SignalNone, nil,
+			fmt.Sprintf("degrading: %d consecutive errors (threshold=%d)", snap.Status.ConsecutiveErrors, errorDegradedThreshold), nil)
 	}
 
 	if snap.Status.PendingMessageCount >= pendingDegradedThreshold {
-		return fsmv2.Result[any, any](&DegradedState{}, fsmv2.SignalNone, nil,
+		return fsmv2.Transition(&DegradedState{}, fsmv2.SignalNone, nil,
 			fmt.Sprintf("degrading: %d pending messages (threshold=%d)",
-				snap.Status.PendingMessageCount, pendingDegradedThreshold))
+				snap.Status.PendingMessageCount, pendingDegradedThreshold), nil)
 	}
 
 	if snap.Status.HasTransport && snap.Status.HasValidToken {
-		return fsmv2.Result[any, any](s, fsmv2.SignalNone, &action.PullAction{}, "pulling messages (transport and token available)")
+		return fsmv2.Transition(s, fsmv2.SignalNone, &action.PullAction{}, "pulling messages (transport and token available)", nil)
 	}
 
-	return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil,
-		fmt.Sprintf("waiting: hasTransport=%t, hasValidToken=%t", snap.Status.HasTransport, snap.Status.HasValidToken))
+	return fsmv2.Transition(s, fsmv2.SignalNone, nil,
+		fmt.Sprintf("waiting: hasTransport=%t, hasValidToken=%t", snap.Status.HasTransport, snap.Status.HasValidToken), nil)
 }
 
 func (s *RunningState) String() string {

--- a/umh-core/pkg/fsmv2/workers/transport/pull/state/state_stopped.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/state/state_stopped.go
@@ -33,16 +33,16 @@ func (s *StoppedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[snapshot.PullDesiredState, snapshot.PullStatus](snapAny)
 
 	if snap.IsShutdownRequested {
-		return fsmv2.Result[any, any](s, fsmv2.SignalNeedsRemoval, nil, "shutdown requested, signaling removal")
+		return fsmv2.Transition(s, fsmv2.SignalNeedsRemoval, nil, "shutdown requested, signaling removal", nil)
 	}
 
 	if snap.ParentMappedState == config.DesiredStateRunning && !snap.IsShutdownRequested {
-		return fsmv2.Result[any, any](&RunningState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("parent mapped state is %q, transitioning to Running", snap.ParentMappedState))
+		return fsmv2.Transition(&RunningState{}, fsmv2.SignalNone, nil,
+			fmt.Sprintf("parent mapped state is %q, transitioning to Running", snap.ParentMappedState), nil)
 	}
 
-	return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil,
-		fmt.Sprintf("stopped, parent mapped state is %q", snap.ParentMappedState))
+	return fsmv2.Transition(s, fsmv2.SignalNone, nil,
+		fmt.Sprintf("stopped, parent mapped state is %q", snap.ParentMappedState), nil)
 }
 
 func (s *StoppedState) String() string {

--- a/umh-core/pkg/fsmv2/workers/transport/pull/state/state_stopping.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/state/state_stopping.go
@@ -34,9 +34,9 @@ func (s *StoppingState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	// Self-return is valid during cleanup but MUST carry an action  -  never nil.
 	// See CLAUDE.md "State Transition Traps" for the full pattern.
 
-	return fsmv2.Result[any, any](&StoppedState{}, fsmv2.SignalNone, nil,
+	return fsmv2.Transition(&StoppedState{}, fsmv2.SignalNone, nil,
 		fmt.Sprintf("stop complete: shutdown=%t, parentState(observed)=%s",
-			snap.IsShutdownRequested, snap.ParentMappedState))
+			snap.IsShutdownRequested, snap.ParentMappedState), nil)
 }
 
 func (s *StoppingState) String() string {

--- a/umh-core/pkg/fsmv2/workers/transport/push/state/state_degraded.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/state/state_degraded.go
@@ -34,12 +34,12 @@ func (s *DegradedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[snapshot.PushDesiredState, snapshot.PushStatus](snapAny)
 
 	if snap.ShouldStop() {
-		return fsmv2.Result[any, any](&StoppingState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: shutdown=%t, parentState(observed)=%s", snap.IsShutdownRequested, snap.ParentMappedState))
+		return fsmv2.Transition(&StoppingState{}, fsmv2.SignalNone, nil,
+			fmt.Sprintf("stop required: shutdown=%t, parentState(observed)=%s", snap.IsShutdownRequested, snap.ParentMappedState), nil)
 	}
 
 	if snap.Status.ConsecutiveErrors == 0 {
-		return fsmv2.Result[any, any](&RunningState{}, fsmv2.SignalNone, nil, "errors cleared (consecutiveErrors=0), recovering to Running")
+		return fsmv2.Transition(&RunningState{}, fsmv2.SignalNone, nil, "errors cleared (consecutiveErrors=0), recovering to Running", nil)
 	}
 
 	if snap.Status.HasTransport && snap.Status.HasValidToken {
@@ -57,21 +57,21 @@ func (s *DegradedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 		}
 
 		if shouldWait {
-			return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil,
+			return fsmv2.Transition(s, fsmv2.SignalNone, nil,
 				fmt.Sprintf("degraded (%d errors, %d pending), backoff %s",
 					snap.Status.ConsecutiveErrors, snap.Status.PendingMessageCount,
-					backoffDelay.Round(time.Second)))
+					backoffDelay.Round(time.Second)), nil)
 		}
 
-		return fsmv2.Result[any, any](s, fsmv2.SignalNone, &action.PushAction{},
+		return fsmv2.Transition(s, fsmv2.SignalNone, &action.PushAction{},
 			fmt.Sprintf("degraded (%d consecutive errors, %d pending), still pushing",
-				snap.Status.ConsecutiveErrors, snap.Status.PendingMessageCount))
+				snap.Status.ConsecutiveErrors, snap.Status.PendingMessageCount), nil)
 	}
 
-	return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil,
+	return fsmv2.Transition(s, fsmv2.SignalNone, nil,
 		fmt.Sprintf("degraded (%d consecutive errors, %d pending), waiting: hasTransport=%t, hasValidToken=%t",
 			snap.Status.ConsecutiveErrors, snap.Status.PendingMessageCount,
-			snap.Status.HasTransport, snap.Status.HasValidToken))
+			snap.Status.HasTransport, snap.Status.HasValidToken), nil)
 }
 
 func (s *DegradedState) String() string {

--- a/umh-core/pkg/fsmv2/workers/transport/push/state/state_running.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/state/state_running.go
@@ -37,27 +37,27 @@ func (s *RunningState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[snapshot.PushDesiredState, snapshot.PushStatus](snapAny)
 
 	if snap.ShouldStop() {
-		return fsmv2.Result[any, any](&StoppingState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: shutdown=%t, parentState(observed)=%s", snap.IsShutdownRequested, snap.ParentMappedState))
+		return fsmv2.Transition(&StoppingState{}, fsmv2.SignalNone, nil,
+			fmt.Sprintf("stop required: shutdown=%t, parentState(observed)=%s", snap.IsShutdownRequested, snap.ParentMappedState), nil)
 	}
 
 	if snap.Status.ConsecutiveErrors >= errorDegradedThreshold {
-		return fsmv2.Result[any, any](&DegradedState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("degrading: %d consecutive errors", snap.Status.ConsecutiveErrors))
+		return fsmv2.Transition(&DegradedState{}, fsmv2.SignalNone, nil,
+			fmt.Sprintf("degrading: %d consecutive errors", snap.Status.ConsecutiveErrors), nil)
 	}
 
 	if snap.Status.PendingMessageCount >= pendingDegradedThreshold {
-		return fsmv2.Result[any, any](&DegradedState{}, fsmv2.SignalNone, nil,
+		return fsmv2.Transition(&DegradedState{}, fsmv2.SignalNone, nil,
 			fmt.Sprintf("degrading: %d pending messages (threshold=%d)",
-				snap.Status.PendingMessageCount, pendingDegradedThreshold))
+				snap.Status.PendingMessageCount, pendingDegradedThreshold), nil)
 	}
 
 	if snap.Status.HasTransport && snap.Status.HasValidToken {
-		return fsmv2.Result[any, any](s, fsmv2.SignalNone, &action.PushAction{}, "pushing messages (transport and token available)")
+		return fsmv2.Transition(s, fsmv2.SignalNone, &action.PushAction{}, "pushing messages (transport and token available)", nil)
 	}
 
-	return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil,
-		fmt.Sprintf("waiting: hasTransport=%t, hasValidToken=%t", snap.Status.HasTransport, snap.Status.HasValidToken))
+	return fsmv2.Transition(s, fsmv2.SignalNone, nil,
+		fmt.Sprintf("waiting: hasTransport=%t, hasValidToken=%t", snap.Status.HasTransport, snap.Status.HasValidToken), nil)
 }
 
 func (s *RunningState) String() string {

--- a/umh-core/pkg/fsmv2/workers/transport/push/state/state_stopped.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/state/state_stopped.go
@@ -32,16 +32,16 @@ func (s *StoppedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[snapshot.PushDesiredState, snapshot.PushStatus](snapAny)
 
 	if snap.IsShutdownRequested {
-		return fsmv2.Result[any, any](s, fsmv2.SignalNeedsRemoval, nil, "shutdown requested, signaling removal")
+		return fsmv2.Transition(s, fsmv2.SignalNeedsRemoval, nil, "shutdown requested, signaling removal", nil)
 	}
 
 	if snap.ParentMappedState == config.DesiredStateRunning {
-		return fsmv2.Result[any, any](&RunningState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("parent mapped state is %q, transitioning to Running", snap.ParentMappedState))
+		return fsmv2.Transition(&RunningState{}, fsmv2.SignalNone, nil,
+			fmt.Sprintf("parent mapped state is %q, transitioning to Running", snap.ParentMappedState), nil)
 	}
 
-	return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil,
-		fmt.Sprintf("stopped, parent mapped state is %q", snap.ParentMappedState))
+	return fsmv2.Transition(s, fsmv2.SignalNone, nil,
+		fmt.Sprintf("stopped, parent mapped state is %q", snap.ParentMappedState), nil)
 }
 
 func (s *StoppedState) String() string {

--- a/umh-core/pkg/fsmv2/workers/transport/push/state/state_stopping.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/state/state_stopping.go
@@ -34,9 +34,9 @@ func (s *StoppingState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	// Self-return is valid during cleanup but MUST carry an action  -  never nil.
 	// See CLAUDE.md "State Transition Traps" for the full pattern.
 
-	return fsmv2.Result[any, any](&StoppedState{}, fsmv2.SignalNone, nil,
+	return fsmv2.Transition(&StoppedState{}, fsmv2.SignalNone, nil,
 		fmt.Sprintf("stop complete: shutdown=%t, parentState(observed)=%s",
-			snap.IsShutdownRequested, snap.ParentMappedState))
+			snap.IsShutdownRequested, snap.ParentMappedState), nil)
 }
 
 func (s *StoppingState) String() string {

--- a/umh-core/pkg/fsmv2/workers/transport/state/state_auth_failed.go
+++ b/umh-core/pkg/fsmv2/workers/transport/state/state_auth_failed.go
@@ -38,7 +38,7 @@ func (s *AuthFailedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[snapshot.TransportDesiredState, snapshot.TransportStatus](snapAny)
 
 	if snap.IsShutdownRequested {
-		return fsmv2.Result[any, any](&StoppingState{}, fsmv2.SignalNone, nil, "Shutdown requested, transitioning to Stopping")
+		return fsmv2.Transition(&StoppingState{}, fsmv2.SignalNone, nil, "Shutdown requested, transitioning to Stopping", nil)
 	}
 
 	// FailedAuthConfig is guaranteed populated here because only permanent errors
@@ -49,14 +49,14 @@ func (s *AuthFailedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	uuidChanged := snap.Config.InstanceUUID != snap.Status.FailedAuthConfig.InstanceUUID
 
 	if tokenChanged || relayChanged || uuidChanged {
-		return fsmv2.Result[any, any](&StartingState{}, fsmv2.SignalNone, nil,
+		return fsmv2.Transition(&StartingState{}, fsmv2.SignalNone, nil,
 			fmt.Sprintf("config changed (token=%t, relay=%t, uuid=%t), retrying auth",
-				tokenChanged, relayChanged, uuidChanged))
+				tokenChanged, relayChanged, uuidChanged), nil)
 	}
 
-	return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil,
+	return fsmv2.Transition(s, fsmv2.SignalNone, nil,
 		fmt.Sprintf("auth failed (%s), waiting for config change",
-			snap.Status.LastErrorType))
+			snap.Status.LastErrorType), nil)
 }
 
 // String returns the state name derived from the type.

--- a/umh-core/pkg/fsmv2/workers/transport/state/state_degraded.go
+++ b/umh-core/pkg/fsmv2/workers/transport/state/state_degraded.go
@@ -35,29 +35,29 @@ func (s *DegradedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[snapshot.TransportDesiredState, snapshot.TransportStatus](snapAny)
 
 	if snap.IsShutdownRequested {
-		return fsmv2.Result[any, any](&StoppingState{}, fsmv2.SignalNone, nil, "Shutdown requested, transitioning to Stopping")
+		return fsmv2.Transition(&StoppingState{}, fsmv2.SignalNone, nil, "Shutdown requested, transitioning to Stopping", nil)
 	}
 
 	// If token is expired, need to re-authenticate (mirrors RunningState)
 	if snap.Status.IsTokenExpired() {
-		return fsmv2.Result[any, any](&StartingState{}, fsmv2.SignalNone, nil, "Token expired, transitioning to Starting for re-authentication")
+		return fsmv2.Transition(&StartingState{}, fsmv2.SignalNone, nil, "Token expired, transitioning to Starting for re-authentication", nil)
 	}
 
 	// Nuclear fallback: reset transport on prolonged child failures
 	if backoff.ShouldResetTransport(snap.Status.LastErrorType, snap.Status.ConsecutiveErrors) {
-		return fsmv2.Result[any, any](s, fsmv2.SignalNone, action.NewResetTransportAction(),
+		return fsmv2.Transition(s, fsmv2.SignalNone, action.NewResetTransportAction(),
 			fmt.Sprintf("resetting transport: %d consecutive errors (type=%d)",
-				snap.Status.ConsecutiveErrors, snap.Status.LastErrorType))
+				snap.Status.ConsecutiveErrors, snap.Status.LastErrorType), nil)
 	}
 
 	// If all children are now healthy, transition back to Running
 	if snap.ChildrenUnhealthy == 0 {
-		return fsmv2.Result[any, any](&RunningState{}, fsmv2.SignalNone, nil, "All children now healthy, transitioning to Running")
+		return fsmv2.Transition(&RunningState{}, fsmv2.SignalNone, nil, "All children now healthy, transitioning to Running", nil)
 	}
 
-	return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil,
+	return fsmv2.Transition(s, fsmv2.SignalNone, nil,
 		fmt.Sprintf("degraded: %d unhealthy children, %d consecutive errors",
-			snap.ChildrenUnhealthy, snap.Status.ConsecutiveErrors))
+			snap.ChildrenUnhealthy, snap.Status.ConsecutiveErrors), nil)
 }
 
 // String returns the state name derived from the type.

--- a/umh-core/pkg/fsmv2/workers/transport/state/state_running.go
+++ b/umh-core/pkg/fsmv2/workers/transport/state/state_running.go
@@ -40,28 +40,28 @@ func (s *RunningState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[snapshot.TransportDesiredState, snapshot.TransportStatus](snapAny)
 
 	if snap.IsShutdownRequested {
-		return fsmv2.Result[any, any](&StoppingState{}, fsmv2.SignalNone, nil, "Shutdown requested, transitioning to Stopping")
+		return fsmv2.Transition(&StoppingState{}, fsmv2.SignalNone, nil, "Shutdown requested, transitioning to Stopping", nil)
 	}
 
 	// If token is expired, need to re-authenticate
 	if snap.Status.IsTokenExpired() {
-		return fsmv2.Result[any, any](&StartingState{}, fsmv2.SignalNone, nil, "Token expired, transitioning to Starting for re-authentication")
+		return fsmv2.Transition(&StartingState{}, fsmv2.SignalNone, nil, "Token expired, transitioning to Starting for re-authentication", nil)
 	}
 
 	// Proactive night re-auth: if token would expire during business hours, re-auth at 3 AM
 	if ShouldProactivelyReauth(snap.Status.JWTExpiry, time.Now()) {
-		return fsmv2.Result[any, any](&StartingState{}, fsmv2.SignalNone, nil,
+		return fsmv2.Transition(&StartingState{}, fsmv2.SignalNone, nil,
 			fmt.Sprintf("proactive night re-auth: token expires at %s (business hours), re-authing now",
-				snap.Status.JWTExpiry.Local().Format("15:04")))
+				snap.Status.JWTExpiry.Local().Format("15:04")), nil)
 	}
 
 	// If any children are unhealthy, transition to degraded
 	if snap.ChildrenUnhealthy > 0 {
-		return fsmv2.Result[any, any](&DegradedState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("children unhealthy (%d), transitioning to Degraded", snap.ChildrenUnhealthy))
+		return fsmv2.Transition(&DegradedState{}, fsmv2.SignalNone, nil,
+			fmt.Sprintf("children unhealthy (%d), transitioning to Degraded", snap.ChildrenUnhealthy), nil)
 	}
 
-	return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil, "All children healthy, transport running")
+	return fsmv2.Transition(s, fsmv2.SignalNone, nil, "All children healthy, transport running", nil)
 }
 
 // ShouldProactivelyReauth returns true if the token would expire during business

--- a/umh-core/pkg/fsmv2/workers/transport/state/state_starting.go
+++ b/umh-core/pkg/fsmv2/workers/transport/state/state_starting.go
@@ -40,7 +40,7 @@ func (s *StartingState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[snapshot.TransportDesiredState, snapshot.TransportStatus](snapAny)
 
 	if snap.IsShutdownRequested {
-		return fsmv2.Result[any, any](&StoppingState{}, fsmv2.SignalNone, nil, "Shutdown requested, transitioning to Stopping")
+		return fsmv2.Transition(&StoppingState{}, fsmv2.SignalNone, nil, "Shutdown requested, transitioning to Stopping", nil)
 	}
 
 	// If we don't have a valid token, authenticate (with backoff on repeated failures)
@@ -51,9 +51,9 @@ func (s *StartingState) Next(snapAny any) fsmv2.NextResult[any, any] {
 		// If config changed, stale errors and backoff are irrelevant: go straight to auth dispatch.
 		if !configChanged && snap.Status.ConsecutiveErrors > 0 && !snap.Status.LastAuthAttemptAt.IsZero() {
 			if isPermanentAuthError(snap.Status.LastErrorType) {
-				return fsmv2.Result[any, any](&AuthFailedState{}, fsmv2.SignalNone, nil,
+				return fsmv2.Transition(&AuthFailedState{}, fsmv2.SignalNone, nil,
 					fmt.Sprintf("permanent auth failure (%s after %d errors), entering AuthFailed",
-						snap.Status.LastErrorType, snap.Status.ConsecutiveErrors))
+						snap.Status.LastErrorType, snap.Status.ConsecutiveErrors), nil)
 			}
 
 			delay := backoff.CalculateDelayForErrorType(
@@ -62,9 +62,9 @@ func (s *StartingState) Next(snapAny any) fsmv2.NextResult[any, any] {
 				snap.Status.LastRetryAfter,
 			)
 			if time.Since(snap.Status.LastAuthAttemptAt) < delay {
-				return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil,
+				return fsmv2.Transition(s, fsmv2.SignalNone, nil,
 					fmt.Sprintf("auth backoff: %d errors (%s), delay %s",
-						snap.Status.ConsecutiveErrors, snap.Status.LastErrorType, delay.Round(time.Second)))
+						snap.Status.ConsecutiveErrors, snap.Status.LastErrorType, delay.Round(time.Second)), nil)
 			}
 		}
 
@@ -75,20 +75,20 @@ func (s *StartingState) Next(snapAny any) fsmv2.NextResult[any, any] {
 			snap.Config.Timeout,
 		)
 
-		return fsmv2.Result[any, any](s, fsmv2.SignalNone, authAction, "No valid token, authenticating with relay")
+		return fsmv2.Transition(s, fsmv2.SignalNone, authAction, "No valid token, authenticating with relay", nil)
 	}
 
 	// Authenticated; transition to Running. Children start via ChildStartStates
 	// once parent enters Running; RunningState handles unhealthy children.
 	if snap.Status.HasValidToken() {
-		return fsmv2.Result[any, any](&RunningState{}, fsmv2.SignalNone, nil, "Authenticated, transitioning to Running")
+		return fsmv2.Transition(&RunningState{}, fsmv2.SignalNone, nil, "Authenticated, transitioning to Running", nil)
 	}
 
 	// Unreachable: the !HasValidToken() block above returns in all paths, so
 	// control only reaches here when HasValidToken() is true. The catch-all is
 	// required by the architecture validator's MISSING_CATCHALL_RETURN rule.
-	return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil,
-		fmt.Sprintf("starting: awaiting token (hasValidToken=%t)", snap.Status.HasValidToken()))
+	return fsmv2.Transition(s, fsmv2.SignalNone, nil,
+		fmt.Sprintf("starting: awaiting token (hasValidToken=%t)", snap.Status.HasValidToken()), nil)
 }
 
 // isPermanentAuthError returns true for error types that indicate a configuration

--- a/umh-core/pkg/fsmv2/workers/transport/state/state_stopped.go
+++ b/umh-core/pkg/fsmv2/workers/transport/state/state_stopped.go
@@ -31,14 +31,14 @@ func (s *StoppedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[snapshot.TransportDesiredState, snapshot.TransportStatus](snapAny)
 
 	if snap.IsShutdownRequested {
-		return fsmv2.Result[any, any](s, fsmv2.SignalNeedsRemoval, nil, "Shutdown requested, signaling removal")
+		return fsmv2.Transition(s, fsmv2.SignalNeedsRemoval, nil, "Shutdown requested, signaling removal", nil)
 	}
 
 	if snap.Config.ShouldBeRunning() {
-		return fsmv2.Result[any, any](&StartingState{}, fsmv2.SignalNone, nil, "Desired state is running, transitioning to Starting")
+		return fsmv2.Transition(&StartingState{}, fsmv2.SignalNone, nil, "Desired state is running, transitioning to Starting", nil)
 	}
 
-	return fsmv2.Result[any, any](s, fsmv2.SignalNone, nil, "Transport is stopped, waiting for running request")
+	return fsmv2.Transition(s, fsmv2.SignalNone, nil, "Transport is stopped, waiting for running request", nil)
 }
 
 // String returns the state name derived from the type.

--- a/umh-core/pkg/fsmv2/workers/transport/state/state_stopped.go
+++ b/umh-core/pkg/fsmv2/workers/transport/state/state_stopped.go
@@ -15,6 +15,8 @@
 package state
 
 import (
+	"fmt"
+
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/internal/helpers"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/snapshot"
@@ -22,6 +24,10 @@ import (
 
 // StoppedState represents the initial state where the transport worker is not running.
 // The worker is not authenticated and no children are spawned.
+//
+// Transport is a top-level worker, not a child. Reason strings show
+// snap.Config.ShouldBeRunning() and snap.IsShutdownRequested directly;
+// snap.Observed.ParentMappedState is not applicable here (and is deleted in L5b).
 type StoppedState struct {
 	helpers.StoppedBase
 }
@@ -31,14 +37,18 @@ func (s *StoppedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[snapshot.TransportDesiredState, snapshot.TransportStatus](snapAny)
 
 	if snap.IsShutdownRequested {
-		return fsmv2.Transition(s, fsmv2.SignalNeedsRemoval, nil, "Shutdown requested, signaling removal", nil)
+		return fsmv2.Transition(s, fsmv2.SignalNeedsRemoval, nil,
+			fmt.Sprintf("removal signaled: shouldBeRunning=%t", snap.Config.ShouldBeRunning()), nil)
 	}
 
 	if snap.Config.ShouldBeRunning() {
-		return fsmv2.Transition(&StartingState{}, fsmv2.SignalNone, nil, "Desired state is running, transitioning to Starting", nil)
+		return fsmv2.Transition(&StartingState{}, fsmv2.SignalNone, nil,
+			fmt.Sprintf("transitioning to Starting: shutdown=%t", snap.IsShutdownRequested), nil)
 	}
 
-	return fsmv2.Transition(s, fsmv2.SignalNone, nil, "Transport is stopped, waiting for running request", nil)
+	return fsmv2.Transition(s, fsmv2.SignalNone, nil,
+		fmt.Sprintf("stopped, waiting: shouldBeRunning=%t, shutdown=%t",
+			snap.Config.ShouldBeRunning(), snap.IsShutdownRequested), nil)
 }
 
 // String returns the state name derived from the type.

--- a/umh-core/pkg/fsmv2/workers/transport/state/state_stopping.go
+++ b/umh-core/pkg/fsmv2/workers/transport/state/state_stopping.go
@@ -37,9 +37,9 @@ func (s *StoppingState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	// Cleanup hook: add resource cleanup here if needed.
 	// Self-return during cleanup MUST carry an action: never nil.
 
-	return fsmv2.Result[any, any](&StoppedState{}, fsmv2.SignalNone, nil,
+	return fsmv2.Transition(&StoppedState{}, fsmv2.SignalNone, nil,
 		fmt.Sprintf("stop complete: children healthy=%d, unhealthy=%d",
-			snap.ChildrenHealthy, snap.ChildrenUnhealthy))
+			snap.ChildrenHealthy, snap.ChildrenUnhealthy), nil)
 }
 
 // String returns the state name derived from the type.


### PR DESCRIPTION
## Why

Currently children are defined in `DeriveDesiredState` — parents return a `WrappedDesiredState` with a `ChildrenSpecs` field, and the supervisor reads `ChildrenSpecs` independently of `State.Next()`. `RenderChildren`, `GetChildrenSpecs`, and `ChildSpecProvider` are the helpers that sit on top of this split.

This PR is the first of several that replace that API piece by piece. Parents now declare children directly in each `State.Next()` call, alongside the next state and action. The new function is `Transition(state, signal, action, reason, children)` — no type parameters, takes the children-set as the fifth arg.

L3 introduces the new function and converts all 56 state files / 173 callsites onto it. Parents still emit children via the existing `ChildrenSpecs` route. L5 implements the supervisor read path and migrates the four parents.

## Scale

56 state files / 173 callsites migrate from `Result()` to `Transition()`. Two new framework files (`transition_test.go`, `internal/validator/transition_alias.go`). ~60 lines added to `api.go`. A new architecture test (`internal/validator/transition_alias.go`) runs in CI from L3 onwards, failing any callsite that uses legacy `Result()` or `WrapAction[T]` in worker state files.

## What's in this PR

- **New return helper `Transition()` for state files** — no type parameters, takes children as the 5th argument. Replaces every `Result[T, T](...)` callsite in worker code.
- **`Result()` now takes 5 args** — kept as the framework-internal function `Transition()` delegates into. Only framework code calls it directly.
- **State files no longer specify generic type parameters when returning actions.** A reflection wrapper handles typed `Action[TDeps]` inside `Transition()`. The reflection wrap costs ~8.5% per tick when an action is involved; most ticks have no action, so net cost is small.
- **New `NextResult.Children` field for parents to emit their child-set.** L3 introduces the field; L5 connects the supervisor to read it. All L3 callsites pass `nil`; the supervisor treats `nil` `Children` as "use the existing `ChildrenSpecs` route" — the fallback is explicit, not an uninitialized field.
- **CI rejects legacy `Result()` and `WrapAction[T](...)` in worker state files** via a new AST validator. Future regressions fail the architecture test.
- **56 state files migrated, 173 callsites converted** from `Result[any, any](...)` to `Transition(..., nil)`.

## Symbols deprecated in earlier PRs (deletion target listed)

| Symbol | Deprecated since | Target layer |
|--------|-----------------|--------------|
| `WorkerSnapshot.IsShutdownRequested` | L1 | renamed `IsBeingRemoved` in L9 |
| `WorkerSnapshot.ParentMappedState` | L1 | deleted in L5 |
| `MappedParentStateProvider`, `setMappedParentState()`, `applyStateMapping()` | L1 | deleted in L5 |

## Deferred

| Item | Target | Reason deferred |
|------|--------|-----------------|
| Supervisor reads `NextResult.Children` (with `WrappedDesiredState.ChildrenSpecs` fallback) | L5 | The supervisor's reconcile loop is rewritten in L5; reading `NextResult.Children` and migrating the four parents must land in the same PR |
| `exampleparent`, `application`, `transport`, `communicator`: move `RenderChildren` from `DeriveDesiredState` into `State.Next()` | L5 | Per-parent migration; lands alongside the supervisor change |
| `config.NewChildSpec` factory | L5 | Used by migrated parents |
| `ChildSpec.Enabled` (the `Enabled` flag skips child creation when false) | L5 | Same reconcile pass that reads `Children` |
| `Supervisor.Reducer`: when `Enabled=false`, set `IsShutdownRequested` | L5 | When `Enabled=false`, `Supervisor.Reducer` sets `IsShutdownRequested` on the child, triggering its removal lifecycle |
| `ParentMappedState` removal (Observation field + supervisor wiring) | L5 | Replaced by the `Enabled` flag |
| `ChildStartStates` deletion | L5 | `ChildStartStates` defined per-parent initial states for children; replaced by `ChildSpec.Enabled` which gates child creation without per-parent startup state tables |
| `wrap_action.go` + `wrap_action_test.go` introduction | never | None of the 173 migrated callsites used `WrapAction[T](&Foo{})`, so `wrap_action.go` is unnecessary and can be skipped. No PR in the stack ends up calling it. |

## Stack position

```
origin/staging
   ↓
feature/wapi-L0-strip-arch-validators  (PR #2565 — L0, MERGED)
   ↓
feature/wapi-L1-clean  (PR #2566 — L1, MERGED)
   ↓
feature/wapi-L1.5-shutdown  (PR #2571 — L1.5, MERGED)
   ↓
feature/wapi-L2a  (PR #2570 — L2a)
   ↓
feature/wapi-L3  (THIS PR)
```
