### PR TITLE
ci: add Linear Release sync workflow for umh-core

### DIFF
--- a/.github/workflows/linear-release.yml
+++ b/.github/workflows/linear-release.yml
@@ -1,0 +1,56 @@
+# Copyright 2025 UMH Systems GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Syncs each stable GitHub Release to a Linear release (continuous pipeline).
+# Skips pre-release tags (v*-pre.*) so the Linear release attribution lives
+# on the version that actually shipped to customers. The commit range from
+# the previous stable release captures every issue that landed during soak.
+
+name: Linear Release
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing stable release tag to (re)sync (e.g., v0.44.20).'
+        required: true
+        type: string
+
+jobs:
+  sync:
+    # Gate: only stable semver tags (v*), excludes pre-releases and non-semver tags.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (startsWith(github.event.release.tag_name, 'v') && !github.event.release.prerelease)
+    name: Sync to Linear
+    runs-on: depot-ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.tag || github.event.release.tag_name }}
+          # Required: the CLI walks the commit range from the previous release.
+          fetch-depth: 0
+
+      - uses: linear/linear-release-action@0917777589db006387af296dde440385f88d6ac4 # v0.10.0
+        with:
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY_UMH_CORE }}
+          version: ${{ inputs.tag || github.event.release.tag_name }}
+          name: ${{ inputs.tag || github.event.release.tag_name }}
+          # Monorepo: scope to umh-core; ignore helm chart and classic commits.
+          include_paths: umh-core/**


### PR DESCRIPTION
## Summary

Wires umh-core to a Linear continuous release pipeline so each stable umh-core release attaches its issues (`ENG-XXXX`) to a Linear release.

## What we get

In Linear, every issue that shipped in a release will show that release in its sidebar. So opening ENG-4862 will tell us "shipped in v0.44.20" without leaving Linear. The release page lists every issue carried by that version, so we can answer "what's in v0.44.20?" or "which release fixed this?" from inside Linear instead of cross-referencing CHANGELOG, GitHub tags, and Sentry releases.

## How it works

- Trigger: `on: release: published` (same hook as `update-github-release.yml`) plus `workflow_dispatch` for backfill.
- The CLI scans commits in the range `[previous stable release SHA .. tag SHA]` for `ENG-XXXX` identifiers in branch names, commit messages, and PR-merge trailers. Every issue that landed during nightly soak is captured at the stable release.
- Gate: `startsWith(tag, 'v')` AND NOT `prerelease`. Pre-release tags (`v*-pre.*`) and non-`v*` tags result in a skipped workflow run.
- Monorepo path filter `umh-core/**` keeps helm chart and Classic deployment commits out of umh-core's release attribution.

## Targets

- Base branch: `staging`
- Action SHA-pinned to `linear/linear-release-action@v0.10.0`, matching repo convention
- Separate workflow file (not bolted onto `update-github-release.yml`) so Linear sync runs with `contents: read` only and stays independent of the release-body update's failure modes

## Pre-merge prerequisites

- [x] Secret `LINEAR_ACCESS_KEY_UMH_CORE` added to repo secrets
- [x] Linear pipeline "umh-core" (Continuous) created

## Test plan

- [ ] After merge, cut the next stable umh-core release as usual (tag `v0.44.XX`, publish GitHub Release without `prerelease=true`)
- [ ] Workflow run is green; preceding `-pre.*` tag releases show as skipped
- [ ] In Linear → Releases → umh-core, the new entry exists

**First-run expectation**: per the linear-release CLI README, on the first sync only the tag commit itself is scanned. Expect 0-1 issues on the first stable release after merge. The second stable release after merge is the real test of the commit-range walk.

## Notes

- No CHANGELOG entry (`skip-changelog-guard`): CI plumbing, no user-visible behavior change
- See companion PR in ManagementConsole for the matching MC pipeline
