### PR TITLE
docs: prepare v0.44.21 release changelog

### DIFF
--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## [0.44.21]
+
 ### Fixes
 
 - Editing or deploying a bridge with an invalid config could hang the Management Console in "executing" indefinitely — umh-core's rollback path crashed mid-execution, the instance restarted, and the UI never received a final reply. The bridge often ended up needing delete + recreate to recover. The edit/deploy now ends with a clear failure when the rollback succeeds. Affects v0.44.19


### PR DESCRIPTION
## Summary

Renames `## Unreleased` to `## [0.44.21]` in `umh-core/CHANGELOG.md` and adds a fresh empty `## Unreleased` above it, per [umh-core/RELEASING.md](./umh-core/RELEASING.md). No code changes.

v0.44.21 ships the ENG-4959 hotfix (#2572) — bridge edit/deploy panic recovery — that landed on staging after v0.44.20 was tagged.

## Release plan (per RELEASING.md)

1. Merge this PR to staging
2. Open staging → main PR, merge
3. Draft GitHub Release on main, tag `v0.44.21`, title `v0.44.21 - Bridge Edit Hotfix` (or similar), publish

## Test plan

- [x] `## [0.44.21]` section contains only the two ENG-4959 fix bullets
- [x] `## Unreleased` above is empty (next development cycle)
- [x] `## [0.44.20]` block unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)