### PR TITLE
Eng 4876 processing for write flows only nodered js

### DIFF
--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ### Preview: Write Flows
 
-- The write flow wire format now uses a typed `input_topics` field (string or Go template) and a `write_output` block, replacing the old `benthos.input`/`benthos.output` nesting. The `UMH_TOPICS` user variable is no longer used.
+- The write flow wire format now uses a typed `input_topics` field (string or Go template) and an `output` block, replacing the old `benthos.input`/`benthos.output` nesting. The `UMH_TOPICS` user variable is no longer used.
+
+  **Migration (internal staging users with write flows enabled):** Existing write flows that used the old `benthos.{input,output}` shape are not automatically converted. Re-create any write flow via the UI using the new format. There is no data loss — only the write-flow configuration is affected; read flows and connection settings are preserved.
 
 ## [0.44.21]
 

--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -4,9 +4,7 @@
 
 ### Preview: Write Flows
 
-- The write flow wire format now uses a typed `input_topics` field (string or Go template) and an `output` block, replacing the old `benthos.input`/`benthos.output` nesting. The `UMH_TOPICS` user variable is no longer used.
-
-  **Migration (internal staging users with write flows enabled):** Existing write flows that used the old `benthos.{input,output}` shape are not automatically converted. Re-create any write flow via the UI using the new format. There is no data loss — only the write-flow configuration is affected; read flows and connection settings are preserved.
+- Write flows (preview) now take their input topics directly on the flow, with Go template support for values like `{{ .location_path }}`. Write flows configured on this preview before this release are not carried over and need to be re-created from the UI; read flows and connection settings are unaffected
 
 ## [0.44.21]
 

--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Preview: Write Flows
+
+- The write flow wire format now uses a typed `input_topics` field (string or Go template) and a `write_output` block, replacing the old `benthos.input`/`benthos.output` nesting. The `UMH_TOPICS` user variable is no longer used.
+
 ## [0.44.21]
 
 ### Fixes
@@ -41,7 +45,7 @@ Enables FSMv2 communicator by default.
 
 ### Preview: Write Flows
 
-- Previously, write flows used raw `input` for benthos. We now define a typed `input_topics` field and automatically generate the proper `input` in umh-core, which provides an improved user experience and less surface for errors.
+- Previously, write flows used raw `input` for benthos. We now define a user variable `UMH_TOPICS` and automatically generate the proper `input` in umh-core, which provides an improved user experience and less surface for errors.
 
 ## [0.44.17]
  

--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -41,7 +41,7 @@ Enables FSMv2 communicator by default.
 
 ### Preview: Write Flows
 
-- Previously, write flows used raw `input` for benthos. We now define a user variable `UMH_TOPICS` and automatically generate the proper `input` in umh-core, which provides an improved user experience and less surface for errors.
+- Previously, write flows used raw `input` for benthos. We now define a typed `input_topics` field and automatically generate the proper `input` in umh-core, which provides an improved user experience and less surface for errors.
 
 ## [0.44.17]
  

--- a/umh-core/examples/example-config-protocolconverter-templated.yaml
+++ b/umh-core/examples/example-config-protocolconverter-templated.yaml
@@ -30,10 +30,10 @@ templates:
             opcua:
               address: "opc.tcp://{{ .IP }}:{{ .PORT }}"
       dataflowcomponent_write:
-        benthos:
-          output:
-            http_client:
-              url: "http://collector.local/ingest"   # static
+        input_topics: "umh.v1.{{ .location_path }}.temperature-sensor-pc.*"
+        output:
+          http_client:
+            url: "http://collector.local/ingest"   # static
 
 # ---------- Agent-wide settings ---------- #
 agent:

--- a/umh-core/internal/fsmtest/protocolconverter.go
+++ b/umh-core/internal/fsmtest/protocolconverter.go
@@ -26,7 +26,6 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/dataflowcomponentserviceconfig"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/nmapserviceconfig"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/protocolconverterserviceconfig"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/variables"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
 	connectionservicefsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/connection"
@@ -53,12 +52,10 @@ var (
 		},
 	}
 
-	goodDataflowComponentWriteConfig = dataflowcomponentserviceconfig.DataflowComponentServiceConfig{
-		BenthosConfig: dataflowcomponentserviceconfig.BenthosConfig{
-			Input: map[string]interface{}{},
-			Output: map[string]interface{}{ // will be overwritten by the protocol converter service
-				"stdout": map[string]interface{}{},
-			},
+	goodDataflowComponentWriteConfig = dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
+		InputTopics: "umh.v1.test.*",
+		Output: map[string]interface{}{
+			"stdout": map[string]interface{}{},
 		},
 	}
 
@@ -90,11 +87,6 @@ func CreateProtocolConverterTestConfig(name string, desiredState string) config.
 			DesiredFSMState: desiredState,
 		},
 		ProtocolConverterServiceConfig: protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec{
-			Variables: variables.VariableBundle{
-				User: map[string]any{
-					"UMH_TOPICS": []string{"umh.v1.test.*"},
-				},
-			},
 			Config: protocolconverterserviceconfig.ProtocolConverterServiceConfigTemplate{
 				DataflowComponentReadServiceConfig:  goodDataflowComponentReadConfig,
 				DataflowComponentWriteServiceConfig: goodDataflowComponentWriteConfig,
@@ -113,11 +105,6 @@ func CreateProtocolConverterTestConfigWithMissingDfc(name string, desiredState s
 			DesiredFSMState: desiredState,
 		},
 		ProtocolConverterServiceConfig: protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec{
-			Variables: variables.VariableBundle{
-				User: map[string]any{
-					"UMH_TOPICS": []string{"umh.v1.test.*"},
-				},
-			},
 			Config: protocolconverterserviceconfig.ProtocolConverterServiceConfigTemplate{
 				DataflowComponentReadServiceConfig: missingDataflowComponentConfig,
 				ConnectionServiceConfig:            goodConnectionServiceConfig,
@@ -142,11 +129,6 @@ func CreateProtocolConverterTestConfigWithInvalidPort(name string, desiredState 
 			DesiredFSMState: desiredState,
 		},
 		ProtocolConverterServiceConfig: protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec{
-			Variables: variables.VariableBundle{
-				User: map[string]any{
-					"UMH_TOPICS": []string{"umh.v1.test.*"},
-				},
-			},
 			Config: protocolconverterserviceconfig.ProtocolConverterServiceConfigTemplate{
 				DataflowComponentReadServiceConfig:  goodDataflowComponentReadConfig,
 				DataflowComponentWriteServiceConfig: goodDataflowComponentWriteConfig,
@@ -174,7 +156,7 @@ func SetupProtocolConverterServiceState(
 func ConfigureProtocolConverterServiceConfig(mockService *protocolconvertersvc.MockProtocolConverterService) {
 	mockService.GetConfigResult = protocolconverterserviceconfig.ProtocolConverterServiceConfigRuntime{
 		DataflowComponentReadServiceConfig:  goodDataflowComponentReadConfig,
-		DataflowComponentWriteServiceConfig: goodDataflowComponentWriteConfig,
+		DataflowComponentWriteServiceConfig: goodDataflowComponentWriteConfig.ToDataflowComponentServiceConfig(""),
 		ConnectionServiceConfig:             goodConnectionServiceConfigRuntime,
 	}
 }

--- a/umh-core/pkg/communicator/actions/action_helper.go
+++ b/umh-core/pkg/communicator/actions/action_helper.go
@@ -16,8 +16,6 @@ package actions
 
 import (
 	"fmt"
-	"slices"
-	"sort"
 	"sync"
 
 	"github.com/google/uuid"
@@ -94,52 +92,6 @@ func SendLimitedLogs(
 // RemainingPrefixSec formats d (assumed ≤20 s) as "[left: NN s] ".
 func RemainingPrefixSec(dSeconds int) string {
 	return fmt.Sprintf("[left: %02d s] ", dSeconds) // fixed 15-rune prefix
-}
-
-// TODO(ENG-4856): toStringSlice exists because UMH_TOPICS is stored in Variables.User
-// (map[string]any) instead of a typed []string field. The three-form conversion handles
-// YAML round-trip type drift that a typed field would prevent. Remove once UMH_TOPICS
-// moves to a typed config block in the FSMv2 bridge migration.
-//
-// toStringSlice converts an any value to []string. UMH_TOPICS can appear in
-// three forms depending on how it was stored or reloaded:
-//   - []string: from DFC payload and in-memory, before any YAML round-trip
-//   - []any: array of any when loading via yaml.v3 unmarshaling from config
-//   - string: single element from YAML round-trip
-func toStringSlice(v any) ([]string, bool) {
-	switch typed := v.(type) {
-	case []string:
-		return typed, true
-	case []any:
-		result := make([]string, 0, len(typed))
-		for _, item := range typed {
-			if s, ok := item.(string); ok {
-				result = append(result, s)
-			}
-		}
-
-		return result, len(result) == len(typed)
-	case string:
-		return []string{typed}, true
-	}
-
-	return nil, false
-}
-
-// equalTopicSets reports whether two UMH_TOPICS slices contain the same elements
-// regardless of order.
-func equalTopicSets(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-
-	aCopy := slices.Clone(a)
-	bCopy := slices.Clone(b)
-
-	sort.Strings(aCopy)
-	sort.Strings(bCopy)
-
-	return slices.Equal(aCopy, bCopy)
 }
 
 // High-level label for one-off (non-polling) messages.

--- a/umh-core/pkg/communicator/actions/deploy-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/deploy-protocolconverter.go
@@ -42,7 +42,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/connectionserviceconfig"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/dataflowcomponentserviceconfig"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/protocolconverterserviceconfig"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/variables"
@@ -69,10 +68,11 @@ type DeployProtocolConverterAction struct {
 
 	userEmail string
 	// Parsed request payload (only populated after Parse)
-	payload models.ProtocolConverter
+	payload models.ProtocolConverterRequest
 
-	actionUUID   uuid.UUID
-	instanceUUID uuid.UUID
+	actionUUID        uuid.UUID
+	instanceUUID      uuid.UUID
+	ignoreHealthCheck bool
 }
 
 // NewDeployProtocolConverterAction returns an un-parsed action instance.
@@ -94,12 +94,19 @@ func NewDeployProtocolConverterAction(userEmail string, actionUUID uuid.UUID, in
 // Parse implements the Action interface by extracting protocol converter configuration from the payload.
 func (a *DeployProtocolConverterAction) Parse(payload interface{}) error {
 	// Parse the payload to get the protocol converter configuration
-	parsedPayload, err := ParseActionPayload[models.ProtocolConverter](payload)
+	parsedPayload, err := ParseActionPayload[models.ProtocolConverterRequest](payload)
 	if err != nil {
 		return fmt.Errorf("failed to parse payload: %w", err)
 	}
 
 	a.payload = parsedPayload
+
+	if parsedPayload.ReadDFC != nil && parsedPayload.ReadDFC.IgnoreErrors != nil {
+		a.ignoreHealthCheck = *parsedPayload.ReadDFC.IgnoreErrors
+	}
+	if parsedPayload.WriteDFC != nil && parsedPayload.WriteDFC.IgnoreErrors != nil {
+		a.ignoreHealthCheck = a.ignoreHealthCheck || *parsedPayload.WriteDFC.IgnoreErrors
+	}
 
 	a.actionLogger.Debugf("Parsed DeployProtocolConverter action payload: name=%s, ip=%s, port=%d",
 		a.payload.Name, a.payload.Connection.IP, a.payload.Connection.Port)
@@ -126,12 +133,16 @@ func (a *DeployProtocolConverterAction) Validate() error {
 		return err
 	}
 
-	if err := validateProtocolConverterDFC(a.payload.ReadDFC, "read"); err != nil {
+	// Always validate the read DFC, even if it's nil (ignoreErrors will handle it)
+	if err := validateReadProtocolConverterDFC(a.payload.ReadDFC); err != nil {
 		return err
 	}
 
-	if err := validateProtocolConverterDFC(a.payload.WriteDFC, "write"); err != nil {
-		return err
+	// Validate the write DFC, if present. Might not exist for read-only bridges
+	if w := a.payload.WriteDFC; w != nil {
+		if err := validateWriteDFCConfig(&w.DataflowComponentWriteConfigInput, w.State); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -204,7 +215,7 @@ func (a *DeployProtocolConverterAction) Execute() (interface{}, map[string]inter
 	)
 
 	// check against observedState
-	if a.systemSnapshotManager != nil {
+	if a.systemSnapshotManager != nil && !a.ignoreHealthCheck {
 		errCode, err := a.waitForComponentToAppear(pcConfig.DesiredFSMState)
 		if err != nil {
 			errorMsg := fmt.Sprintf(
@@ -250,67 +261,28 @@ func (a *DeployProtocolConverterAction) Execute() (interface{}, map[string]inter
 
 // createProtocolConverterConfig creates a ProtocolConverterConfig with templated configuration.
 func (a *DeployProtocolConverterAction) createProtocolConverterConfig() (config.ProtocolConverterConfig, error) {
-	// Create variables bundle - start empty to allow user variables first
-	userVars := map[string]any{}
+	userVars := buildUserScope(a.payload.TemplateInfo)
+	userVars["IP"] = a.payload.Connection.IP
+	userVars["PORT"] = strconv.FormatUint(uint64(a.payload.Connection.Port), 10)
 
-	// Add any additional user-supplied variables from TemplateInfo.Variables
-	if a.payload.TemplateInfo != nil {
-		for _, variable := range a.payload.TemplateInfo.Variables {
-			userVars[variable.Label] = variable.Value
-		}
-	}
-
-	// Enforce reserved connection variables after merging to prevent user overrides
-	userVars["IP"] = a.payload.Connection.IP                                     // Keep IP as string
-	userVars["PORT"] = strconv.FormatUint(uint64(a.payload.Connection.Port), 10) // Convert port to string
-
-	// Extract UMH_TOPICS from write DFC payload if provided
-	if a.payload.WriteDFC != nil && len(a.payload.WriteDFC.UMHTopics) > 0 {
-		userVars["UMH_TOPICS"] = a.payload.WriteDFC.UMHTopics
-	}
-
-	variableBundle := variables.VariableBundle{
-		User: userVars,
-	}
-
-	// Create template configuration with connection and placeholders for DFCs
-	template := protocolconverterserviceconfig.ProtocolConverterServiceConfigTemplate{
-		ConnectionServiceConfig: connectionserviceconfig.ConnectionServiceConfigTemplate{
-			NmapTemplate: &connectionserviceconfig.NmapConfigTemplate{
-				Target: "{{ .IP }}",   // Template variable for IP
-				Port:   "{{ .PORT }}", // Template variable for PORT
-			},
-		},
-		// DataflowComponent configs left empty initially - they will be configured later via edit actions
+	tmpl := protocolconverterserviceconfig.ProtocolConverterServiceConfigTemplate{
+		ConnectionServiceConfig:             newIPPortConnectionTemplate(),
 		DataflowComponentReadServiceConfig:  dataflowcomponentserviceconfig.DataflowComponentServiceConfig{},
-		DataflowComponentWriteServiceConfig: dataflowcomponentserviceconfig.DataflowComponentServiceConfig{},
+		DataflowComponentWriteServiceConfig: dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{},
 	}
 
-	// If a ReadDFC is provided in the payload, configure it immediately
 	if a.payload.ReadDFC != nil {
-		benthosConfig, err := CreateBenthosConfigFromCDFCPayload(dfcToPayload(a.payload.ReadDFC), a.payload.Name)
+		readSvcCfg, err := buildReadDFCServiceConfig(dfcToPayload(a.payload.ReadDFC), a.payload.Name)
 		if err != nil {
-			return config.ProtocolConverterConfig{}, fmt.Errorf("failed to create read DFC benthos config: %w", err)
+			return config.ProtocolConverterConfig{}, err
 		}
-
-		template.DataflowComponentReadServiceConfig = dataflowcomponentserviceconfig.DataflowComponentServiceConfig{
-			BenthosConfig: benthosConfig,
-		}
+		tmpl.DataflowComponentReadServiceConfig = readSvcCfg
 	}
 
-	// If a WriteDFC is provided in the payload, configure it immediately
-	if a.payload.WriteDFC != nil {
-		benthosConfig, err := CreateBenthosConfigFromCDFCPayload(dfcToPayload(a.payload.WriteDFC), a.payload.Name)
-		if err != nil {
-			return config.ProtocolConverterConfig{}, fmt.Errorf("failed to create write DFC benthos config: %w", err)
-		}
-
-		template.DataflowComponentWriteServiceConfig = dataflowcomponentserviceconfig.DataflowComponentServiceConfig{
-			BenthosConfig: benthosConfig,
-		}
+	if w := a.payload.WriteDFC; w != nil {
+		tmpl.DataflowComponentWriteServiceConfig = w.DataflowComponentWriteConfigInput
 	}
 
-	// Determine per-DFC desired states and derive PC-level state.
 	var readDFCDesiredState, writeDFCDesiredState string
 	if a.payload.ReadDFC != nil {
 		readDFCDesiredState = a.payload.ReadDFC.State
@@ -320,16 +292,14 @@ func (a *DeployProtocolConverterAction) createProtocolConverterConfig() (config.
 		writeDFCDesiredState = a.payload.WriteDFC.State
 	}
 
-	// Create the spec with template and variables
 	spec := protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec{
-		Config:               template,
-		Variables:            variableBundle,
+		Config:               tmpl,
+		Variables:            variables.VariableBundle{User: userVars},
 		Location:             convertIntMapToStringMap(a.payload.Location),
 		ReadDFCDesiredState:  readDFCDesiredState,
 		WriteDFCDesiredState: writeDFCDesiredState,
 	}
 
-	// Create the full config
 	return config.ProtocolConverterConfig{
 		FSMInstanceConfig: config.FSMInstanceConfig{
 			Name:            a.payload.Name,
@@ -337,20 +307,6 @@ func (a *DeployProtocolConverterAction) createProtocolConverterConfig() (config.
 		},
 		ProtocolConverterServiceConfig: spec,
 	}, nil
-}
-
-// convertIntMapToStringMap converts map[int]string to map[string]string.
-func convertIntMapToStringMap(intMap map[int]string) map[string]string {
-	if intMap == nil {
-		return nil
-	}
-
-	stringMap := make(map[string]string)
-	for k, v := range intMap {
-		stringMap[strconv.Itoa(k)] = v
-	}
-
-	return stringMap
 }
 
 // getUserEmail implements the Action interface by returning the user email associated with this action.
@@ -364,7 +320,7 @@ func (a *DeployProtocolConverterAction) getUuid() uuid.UUID {
 }
 
 // GetParsedPayload returns the parsed payload - exposed primarily for testing purposes.
-func (a *DeployProtocolConverterAction) GetParsedPayload() models.ProtocolConverter {
+func (a *DeployProtocolConverterAction) GetParsedPayload() models.ProtocolConverterRequest {
 	return a.payload
 }
 

--- a/umh-core/pkg/communicator/actions/deploy-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/deploy-protocolconverter.go
@@ -68,7 +68,7 @@ type DeployProtocolConverterAction struct {
 
 	userEmail string
 	// Parsed request payload (only populated after Parse)
-	payload models.ProtocolConverterRequest
+	payload models.ProtocolConverter
 
 	actionUUID        uuid.UUID
 	instanceUUID      uuid.UUID
@@ -94,7 +94,7 @@ func NewDeployProtocolConverterAction(userEmail string, actionUUID uuid.UUID, in
 // Parse implements the Action interface by extracting protocol converter configuration from the payload.
 func (a *DeployProtocolConverterAction) Parse(payload interface{}) error {
 	// Parse the payload to get the protocol converter configuration
-	parsedPayload, err := ParseActionPayload[models.ProtocolConverterRequest](payload)
+	parsedPayload, err := ParseActionPayload[models.ProtocolConverter](payload)
 	if err != nil {
 		return fmt.Errorf("failed to parse payload: %w", err)
 	}
@@ -104,8 +104,8 @@ func (a *DeployProtocolConverterAction) Parse(payload interface{}) error {
 	if parsedPayload.ReadDFC != nil && parsedPayload.ReadDFC.IgnoreErrors != nil {
 		a.ignoreHealthCheck = *parsedPayload.ReadDFC.IgnoreErrors
 	}
-	if parsedPayload.WriteDFC != nil && parsedPayload.WriteDFC.IgnoreErrors != nil {
-		a.ignoreHealthCheck = a.ignoreHealthCheck || *parsedPayload.WriteDFC.IgnoreErrors
+	if parsedPayload.WriteDFCPayload != nil && parsedPayload.WriteDFCPayload.IgnoreErrors != nil {
+		a.ignoreHealthCheck = a.ignoreHealthCheck || *parsedPayload.WriteDFCPayload.IgnoreErrors
 	}
 
 	a.actionLogger.Debugf("Parsed DeployProtocolConverter action payload: name=%s, ip=%s, port=%d",
@@ -139,7 +139,7 @@ func (a *DeployProtocolConverterAction) Validate() error {
 	}
 
 	// Validate the write DFC, if present. Might not exist for read-only bridges
-	if w := a.payload.WriteDFC; w != nil {
+	if w := a.payload.WriteDFCPayload; w != nil {
 		if err := validateWriteDFCConfig(&w.DataflowComponentWriteConfigInput, w.State); err != nil {
 			return err
 		}
@@ -279,7 +279,7 @@ func (a *DeployProtocolConverterAction) createProtocolConverterConfig() (config.
 		tmpl.DataflowComponentReadServiceConfig = readSvcCfg
 	}
 
-	if w := a.payload.WriteDFC; w != nil {
+	if w := a.payload.WriteDFCPayload; w != nil {
 		tmpl.DataflowComponentWriteServiceConfig = w.DataflowComponentWriteConfigInput
 	}
 
@@ -287,9 +287,8 @@ func (a *DeployProtocolConverterAction) createProtocolConverterConfig() (config.
 	if a.payload.ReadDFC != nil {
 		readDFCDesiredState = a.payload.ReadDFC.State
 	}
-
-	if a.payload.WriteDFC != nil {
-		writeDFCDesiredState = a.payload.WriteDFC.State
+	if a.payload.WriteDFCPayload != nil {
+		writeDFCDesiredState = a.payload.WriteDFCPayload.State
 	}
 
 	spec := protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec{
@@ -320,7 +319,7 @@ func (a *DeployProtocolConverterAction) getUuid() uuid.UUID {
 }
 
 // GetParsedPayload returns the parsed payload - exposed primarily for testing purposes.
-func (a *DeployProtocolConverterAction) GetParsedPayload() models.ProtocolConverterRequest {
+func (a *DeployProtocolConverterAction) GetParsedPayload() models.ProtocolConverter {
 	return a.payload
 }
 

--- a/umh-core/pkg/communicator/actions/deploy-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/deploy-protocolconverter.go
@@ -106,6 +106,10 @@ func (a *DeployProtocolConverterAction) Parse(payload interface{}) error {
 	if parsedPayload.ReadDFC != nil && parsedPayload.ReadDFC.IgnoreErrors != nil {
 		a.ignoreHealthCheck = *parsedPayload.ReadDFC.IgnoreErrors
 	}
+	// OR-merge: if either DFC requests skipping errors, skip the health-check wait for
+	// the entire PC. This means a write DFC with IgnoreErrors=true also suppresses the
+	// read DFC health check. This is intentional: the frontend sets IgnoreErrors when it
+	// cannot guarantee a DFC will reach a healthy state (e.g. experimental outputs).
 	if parsedPayload.WriteDFCPayload != nil && parsedPayload.WriteDFCPayload.IgnoreErrors != nil {
 		a.ignoreHealthCheck = a.ignoreHealthCheck || *parsedPayload.WriteDFCPayload.IgnoreErrors
 	}
@@ -245,15 +249,24 @@ func (a *DeployProtocolConverterAction) Execute() (interface{}, map[string]inter
 		}
 	}
 
+	var successMsg string
+	if a.ignoreHealthCheck {
+		successMsg = fmt.Sprintf(
+			`Protocol converter deployed (health check skipped; state '%s' not verified)`,
+			pcConfig.DesiredFSMState,
+		)
+	} else {
+		successMsg = fmt.Sprintf(
+			`Protocol converter was successfully deployed and reached the expected state '%s'`,
+			pcConfig.DesiredFSMState,
+		)
+	}
 	SendActionReply(
 		a.instanceUUID,
 		a.userEmail,
 		a.actionUUID,
 		models.ActionExecuting,
-		fmt.Sprintf(
-			`Protocol converter was successfully deployed and reached the expected state '%s'`,
-			pcConfig.DesiredFSMState,
-		),
+		successMsg,
 		a.outboundChannel,
 		models.DeployProtocolConverter,
 	)

--- a/umh-core/pkg/communicator/actions/deploy-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/deploy-protocolconverter.go
@@ -93,6 +93,8 @@ func NewDeployProtocolConverterAction(userEmail string, actionUUID uuid.UUID, in
 
 // Parse implements the Action interface by extracting protocol converter configuration from the payload.
 func (a *DeployProtocolConverterAction) Parse(payload interface{}) error {
+	a.ignoreHealthCheck = false
+
 	// Parse the payload to get the protocol converter configuration
 	parsedPayload, err := ParseActionPayload[models.ProtocolConverter](payload)
 	if err != nil {

--- a/umh-core/pkg/communicator/actions/deploy-protocolconverter_test.go
+++ b/umh-core/pkg/communicator/actions/deploy-protocolconverter_test.go
@@ -294,7 +294,7 @@ var _ = Describe("DeployProtocolConverter", func() {
 
 			// Verify optional fields are nil as expected for deployment
 			Expect(responsePC.ReadDFC).To(BeNil())
-			Expect(responsePC.WriteDFC).To(BeNil())
+			Expect(responsePC.WriteDFCPayload).To(BeNil())
 			Expect(responsePC.TemplateInfo).To(BeNil())
 
 			// Verify expected configuration changes
@@ -427,7 +427,7 @@ var _ = Describe("DeployProtocolConverter", func() {
 						"stdout": map[string]any{},
 					},
 					"input_topics": "umh.v1.factory.*",
-					"state":      "stopped",
+					"state":        "stopped",
 				},
 			}
 

--- a/umh-core/pkg/communicator/actions/deploy-protocolconverter_test.go
+++ b/umh-core/pkg/communicator/actions/deploy-protocolconverter_test.go
@@ -90,10 +90,6 @@ var _ = Describe("DeployProtocolConverter", func() {
 
 	// Cleanup after each test
 	AfterEach(func() {
-		// Drain the outbound channel to prevent goroutine leaks
-		for len(outboundChannel) > 0 {
-			<-outboundChannel
-		}
 		close(outboundChannel)
 	})
 
@@ -220,6 +216,31 @@ var _ = Describe("DeployProtocolConverter", func() {
 			err = action.Validate()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("missing required field Name"))
+		})
+
+		It("should pass validation when input_topics contains golang template vars", func() {
+			// Regression test: {{ .IP }}, {{ .location_path }} etc. in input_topics must not
+			// cause validation to fail — full rendering happens later in BuildRuntimeConfig.
+			payload := map[string]interface{}{
+				"name": pcName,
+				"connection": map[string]interface{}{
+					"ip":   pcIP,
+					"port": pcPort,
+				},
+				"location": pcLocation,
+				"writeDFC": map[string]interface{}{
+					"output": map[string]interface{}{
+						"stdout": map[string]interface{}{},
+					},
+					"input_topics": "umh.v1.{{ .location_path }}.{{ .IP }}.*",
+				},
+			}
+
+			err := action.Parse(payload)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = action.Validate()
+			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 
@@ -355,8 +376,7 @@ var _ = Describe("DeployProtocolConverter", func() {
 			stateMocker.Stop()
 		})
 
-		It("should store UMH_TOPICS in user variables when deploying with write DFC", func() {
-			topics := []interface{}{"umh.v1.factory.*", "umh.v1.plant.*"}
+		It("should store InputTopics in write DFC config when deploying with write DFC", func() {
 			payload := map[string]any{
 				"name": pcName,
 				"connection": map[string]any{
@@ -365,12 +385,10 @@ var _ = Describe("DeployProtocolConverter", func() {
 				},
 				"location": pcLocation,
 				"writeDFC": map[string]any{
-					"outputs": map[string]any{
-						"data": "output:\n  stdout: {}",
-						"type": "stdout",
+					"output": map[string]any{
+						"stdout": map[string]any{},
 					},
-					"pipeline": map[string]any{},
-					"umh_topics": topics,
+					"input_topics": "umh.v1.factory.*\numh.v1.plant.*",
 				},
 			}
 
@@ -391,10 +409,8 @@ var _ = Describe("DeployProtocolConverter", func() {
 			Expect(mockConfig.Config.ProtocolConverter).To(HaveLen(1))
 
 			addedPC := mockConfig.Config.ProtocolConverter[0]
-			Expect(addedPC.ProtocolConverterServiceConfig.Variables.User).To(HaveKey("UMH_TOPICS"))
-			Expect(addedPC.ProtocolConverterServiceConfig.Variables.User["UMH_TOPICS"]).To(ConsistOf(
-				"umh.v1.factory.*",
-				"umh.v1.plant.*",
+			Expect(addedPC.ProtocolConverterServiceConfig.Config.DataflowComponentWriteServiceConfig.InputTopics).To(Equal(
+				"umh.v1.factory.*\numh.v1.plant.*",
 			))
 		})
 
@@ -407,12 +423,10 @@ var _ = Describe("DeployProtocolConverter", func() {
 				},
 				"location": pcLocation,
 				"writeDFC": map[string]any{
-					"outputs": map[string]any{
-						"data": "output:\n  stdout: {}",
-						"type": "stdout",
+					"output": map[string]any{
+						"stdout": map[string]any{},
 					},
-					"pipeline": map[string]any{},
-					"umh_topics": []interface{}{"umh.v1.factory.*"},
+					"input_topics": "umh.v1.factory.*",
 					"state":      "stopped",
 				},
 			}

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter.go
@@ -149,6 +149,8 @@ func NewEditProtocolConverterAction(userEmail string, actionUUID uuid.UUID, inst
 // Parse implements the Action interface by extracting the protocol converter UUID and
 // dataflow component configuration from the payload.
 func (a *EditProtocolConverterAction) Parse(payload interface{}) error {
+	a.ignoreHealthCheck = false
+
 	// Parse the payload directly as a complete ProtocolConverter object
 	pcPayload, err := ParseActionPayload[models.ProtocolConverter](payload)
 	if err != nil {
@@ -187,6 +189,8 @@ func (a *EditProtocolConverterAction) Parse(payload interface{}) error {
 		input := pcPayload.WriteDFCPayload.DataflowComponentWriteConfigInput
 		a.writeDFCInput = &input
 		a.writeDFCState = pcPayload.WriteDFCPayload.State
+		// OR-merge: if either DFC requests skipping errors, skip the health-check wait
+		// for the entire PC. See deploy-protocolconverter.go for the rationale.
 		if pcPayload.WriteDFCPayload.IgnoreErrors != nil {
 			a.ignoreHealthCheck = a.ignoreHealthCheck || *pcPayload.WriteDFCPayload.IgnoreErrors
 		}
@@ -222,8 +226,9 @@ func (a *EditProtocolConverterAction) Validate() error {
 		return err
 	}
 
-	// Validate read DFC state
-	if a.readDFCSvcCfg != nil && a.readDFCState != "" {
+	// Validate read DFC state — validate independently of whether config was provided,
+	// so state-only edits (readDFCSvcCfg == nil) are also checked.
+	if a.readDFCState != "" {
 		if err := ValidateDataFlowComponentState(a.readDFCState); err != nil {
 			return fmt.Errorf("invalid read DFC state: %w", err)
 		}
@@ -389,8 +394,10 @@ func (a *EditProtocolConverterAction) applyMutation() (config.ProtocolConverterC
 		instanceToModify.ProtocolConverterServiceConfig.Config.DataflowComponentReadServiceConfig = *a.readDFCSvcCfg
 	}
 
-	// Apply write DFC config if provided — store the original input (template string preserved).
-	if a.writeDFCInput != nil && a.writeDFCInput.HasOutput() {
+	// Apply write DFC config when the Output field was explicitly included in the payload
+	// (non-nil, even if empty). A nil Output means a state-only change; the existing
+	// config is preserved. An explicitly empty Output ({}) clears the write DFC output.
+	if a.writeDFCInput != nil && a.writeDFCInput.Output != nil {
 		instanceToModify.ProtocolConverterServiceConfig.Config.DataflowComponentWriteServiceConfig = *a.writeDFCInput
 	}
 
@@ -935,7 +942,7 @@ func (a *EditProtocolConverterAction) renderDesiredDFCConfig(pcSnapshot *protoco
 		modifiedSpec,
 		agentLocation,
 		nil,             // TODO: add global vars
-		"unimplemented", // Must stay "unimplemented": FSM uses the same sentinel, so bridged_by values match. If FSM changes its node-name source, update here in lockstep.
+		runtime_config.BridgedByPlaceholder,
 		pcName,
 	)
 	if err != nil {
@@ -992,21 +999,34 @@ func (a *EditProtocolConverterAction) deriveDFCType() DFCType {
 		return dfcTypeFromPresence(hasRead, hasWrite)
 	}
 
-	// Connection IP/PORT changes affect all DFCs since they use {{ .IP }}/{{ .PORT }} templates.
-	// So if a change is detected, all present DFCs need redeploy.
-	// Use comma-ok map lookups: if IP/PORT keys are absent (e.g. PCs created
-	// before these variables were standard), skip the connection-change check
-	// rather than treating it as changed. Without this, fmt.Sprint(nil) returns
-	// "<nil>" which never equals any real value, forcing a spurious redeploy.
+	// Any variable change (IP, PORT, or custom vars like baudRate) forces redeploy of all
+	// present DFCs because template rendering uses all variables. Keys absent in the deployed
+	// config are skipped — treating nil as changed would cause spurious redeploys on PCs
+	// created before a variable was standard (fmt.Sprint(nil) → "<nil>" ≠ any real value).
 	deployedVars := currentPC.ProtocolConverterServiceConfig.Variables.User
-	deployedIP, ipOk := deployedVars["IP"]
-	deployedPort, portOk := deployedVars["PORT"]
 
-	connectionChanged := ipOk && portOk &&
-		(fmt.Sprint(deployedIP) != a.connectionIP || fmt.Sprint(deployedPort) != a.connectionPort)
+	incomingVars := make(map[string]any, len(a.templateVars)+2)
+	for _, v := range a.templateVars {
+		incomingVars[v.Label] = v.Value
+	}
+	if a.connectionIP != "" {
+		incomingVars["IP"] = a.connectionIP
+	}
+	if a.connectionPort != "" && a.connectionPort != "0" {
+		incomingVars["PORT"] = a.connectionPort
+	}
+
+	connectionChanged := false
+	for k, incomingVal := range incomingVars {
+		if deployedVal, ok := deployedVars[k]; ok {
+			if fmt.Sprint(deployedVal) != fmt.Sprint(incomingVal) {
+				a.actionLogger.Debugf("Variable %q changed (%v → %v), all present DFCs need redeploy", k, deployedVal, incomingVal)
+				connectionChanged = true
+				break
+			}
+		}
+	}
 	if connectionChanged {
-		a.actionLogger.Debugf("Connection changed (IP or PORT), all present DFCs need redeploy")
-
 		return dfcTypeFromPresence(hasRead, hasWrite)
 	}
 
@@ -1056,7 +1076,28 @@ func (a *EditProtocolConverterAction) writeDFCConfigDiffers(
 	if incomingState != "" && deployedState != "" && incomingState != deployedState {
 		return true
 	}
-	return !reflect.DeepEqual(incoming, deployedConfig)
+	// Normalize nil maps to empty maps before comparison: YAML round-trip converts
+	// nil maps (Output/Buffer) to empty maps, and reflect.DeepEqual treats them as
+	// different, causing spurious drift detection on every reconcile.
+	return !reflect.DeepEqual(normalizeWriteConfigInput(incoming), normalizeWriteConfigInput(deployedConfig))
+}
+
+// normalizeWriteConfigInput replaces nil map fields with empty maps so that
+// reflect.DeepEqual comparisons are not tripped up by YAML round-trip nil→{} coercions.
+func normalizeWriteConfigInput(c dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput) dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput {
+	if c.Output == nil {
+		c.Output = map[string]any{}
+	}
+	if c.Buffer == nil {
+		c.Buffer = map[string]any{}
+	}
+	// Mirror the default applied by ToDataflowComponentServiceConfig so that a config
+	// stored without an explicit JS snippet compares equal to one that was just parsed
+	// from a payload carrying the default "return msg;".
+	if c.ProcessingNoderedJS == "" {
+		c.ProcessingNoderedJS = "return msg;"
+	}
+	return c
 }
 
 // getUserEmail implements the Action interface by returning the user email associated with this action.

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter.go
@@ -34,6 +34,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"reflect"
 	"slices"
 	"strconv"
 	"time"
@@ -41,8 +42,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/tiendc/go-deepcopy"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/benthosserviceconfig"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/connectionserviceconfig"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/dataflowcomponentserviceconfig"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/protocolconverterserviceconfig"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants"
@@ -106,14 +105,14 @@ type EditProtocolConverterAction struct {
 	readDFCState   string // desired state for the read DFC ("active" or "stopped"; empty = default active)
 	writeDFCState  string // desired state for the write DFC ("active" or "stopped"; empty = default active)
 
-	readDFCPayload  *models.CDFCPayload
-	writeDFCPayload *models.CDFCPayload
+	templateVars []models.ProtocolConverterVariable
 
-	vb []models.ProtocolConverterVariable
-
-	// Desired DFC configs for comparison during health checks
-	desiredReadDFCConfig  dataflowcomponentserviceconfig.DataflowComponentServiceConfig
-	desiredWriteDFCConfig dataflowcomponentserviceconfig.DataflowComponentServiceConfig
+	// readDFCSvcCfg is the built+validated read DFC service config, set in Parse.
+	// nil means no read DFC was provided in the request.
+	readDFCSvcCfg *dataflowcomponentserviceconfig.DataflowComponentServiceConfig
+	// writeDFCInput is the raw template-string form of the write config, persisted to the spec.
+	// nil means no write DFC was provided.
+	writeDFCInput *dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput
 
 	actionUUID   uuid.UUID
 	instanceUUID uuid.UUID
@@ -125,6 +124,10 @@ type EditProtocolConverterAction struct {
 	atomicEditUUID uuid.UUID
 
 	ignoreHealthCheck bool
+	// lastRenderErr holds the most recent renderDesiredDFCConfig error so the
+	// awaitRollout timeout message can surface the real cause instead of just
+	// "did not become active in time".
+	lastRenderErr error
 }
 
 // NewEditProtocolConverterAction returns an un-parsed action instance.
@@ -147,7 +150,7 @@ func NewEditProtocolConverterAction(userEmail string, actionUUID uuid.UUID, inst
 // dataflow component configuration from the payload.
 func (a *EditProtocolConverterAction) Parse(payload interface{}) error {
 	// Parse the payload directly as a complete ProtocolConverter object
-	pcPayload, err := ParseActionPayload[models.ProtocolConverter](payload)
+	pcPayload, err := ParseActionPayload[models.ProtocolConverterRequest](payload)
 	if err != nil {
 		return fmt.Errorf("failed to parse protocol converter payload: %w", err)
 	}
@@ -160,11 +163,21 @@ func (a *EditProtocolConverterAction) Parse(payload interface{}) error {
 	a.protocolConverterUUID = *pcPayload.UUID
 	a.name = pcPayload.Name
 
-	// Parse each DFC side independently.
-	if pcPayload.ReadDFC != nil {
-		readPayload := dfcToPayload(pcPayload.ReadDFC)
-		a.readDFCPayload = &readPayload
+	// Resolve user variables first — they are needed to render the InputTopics template.
+	if pcPayload.TemplateInfo != nil {
+		a.templateVars = pcPayload.TemplateInfo.Variables
+	} else {
+		a.templateVars = make([]models.ProtocolConverterVariable, 0)
+	}
 
+	// Parse and build each DFC side independently.
+	// Both sides follow the same pattern: wire format → built/rendered config → state + flags.
+	if pcPayload.ReadDFC != nil {
+		svcCfg, err := buildReadDFCServiceConfig(dfcToPayload(pcPayload.ReadDFC), pcPayload.Name)
+		if err != nil {
+			return fmt.Errorf("failed to build read DFC configuration: %w", err)
+		}
+		a.readDFCSvcCfg = &svcCfg
 		a.readDFCState = pcPayload.ReadDFC.State
 		if pcPayload.ReadDFC.IgnoreErrors != nil {
 			a.ignoreHealthCheck = *pcPayload.ReadDFC.IgnoreErrors
@@ -172,19 +185,12 @@ func (a *EditProtocolConverterAction) Parse(payload interface{}) error {
 	}
 
 	if pcPayload.WriteDFC != nil {
-		writePayload := dfcToPayload(pcPayload.WriteDFC)
-		a.writeDFCPayload = &writePayload
-
+		input := pcPayload.WriteDFC.DataflowComponentWriteConfigInput
+		a.writeDFCInput = &input
 		a.writeDFCState = pcPayload.WriteDFC.State
 		if pcPayload.WriteDFC.IgnoreErrors != nil {
 			a.ignoreHealthCheck = a.ignoreHealthCheck || *pcPayload.WriteDFC.IgnoreErrors
 		}
-	}
-
-	if pcPayload.TemplateInfo != nil {
-		a.vb = pcPayload.TemplateInfo.Variables
-	} else {
-		a.vb = make([]models.ProtocolConverterVariable, 0)
 	}
 
 	// Extract location
@@ -217,11 +223,15 @@ func (a *EditProtocolConverterAction) Validate() error {
 		return err
 	}
 
-	if err := validateDFCPayloadAndState(a.readDFCPayload, a.readDFCState, "read"); err != nil {
-		return err
+	// Validate read DFC state
+	if a.readDFCSvcCfg != nil && a.readDFCState != "" {
+		if err := ValidateDataFlowComponentState(a.readDFCState); err != nil {
+			return fmt.Errorf("invalid read DFC state: %w", err)
+		}
 	}
 
-	if err := validateDFCPayloadAndState(a.writeDFCPayload, a.writeDFCState, "write"); err != nil {
+	// Validate write DFC state
+	if err := validateWriteDFCConfig(a.writeDFCInput, a.writeDFCState); err != nil {
 		return err
 	}
 
@@ -244,41 +254,7 @@ func (a *EditProtocolConverterAction) Execute() (interface{}, map[string]interfa
 	SendActionReply(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionConfirmed,
 		confirmationMessage, a.outboundChannel, models.EditProtocolConverter)
 
-	var (
-		readBenthosConfig  *dataflowcomponentserviceconfig.BenthosConfig
-		writeBenthosConfig *dataflowcomponentserviceconfig.BenthosConfig
-		err                error
-	)
-
-	if a.readDFCPayload != nil {
-		cfg, buildErr := CreateBenthosConfigFromCDFCPayload(*a.readDFCPayload, a.name)
-		if buildErr != nil {
-			errorMsg := fmt.Sprintf("Failed to create read DFC Benthos configuration: %v", buildErr)
-			SendActionReply(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedWithFailure,
-				errorMsg, a.outboundChannel, models.EditProtocolConverter)
-			a.fsmLogger.SentryError(deps.FeatureDisableReadFlows, "", buildErr, "edit_protocol_converter_read_benthos_config_failed",
-				deps.String("readDFCPayload", fmt.Sprintf("%+v", a.readDFCPayload)))
-
-			return nil, nil, fmt.Errorf("%s", errorMsg)
-		}
-
-		readBenthosConfig = &cfg
-	}
-
-	if a.writeDFCPayload != nil {
-		cfg, buildErr := CreateBenthosConfigFromCDFCPayload(*a.writeDFCPayload, a.name)
-		if buildErr != nil {
-			errorMsg := fmt.Sprintf("Failed to create write DFC Benthos configuration: %v", buildErr)
-			SendActionReply(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedWithFailure,
-				errorMsg, a.outboundChannel, models.EditProtocolConverter)
-			a.fsmLogger.SentryError(deps.FeatureDisableReadFlows, "", buildErr, "edit_protocol_converter_write_benthos_config_failed",
-				deps.String("writeDFCPayload", fmt.Sprintf("%+v", a.writeDFCPayload)))
-
-			return nil, nil, fmt.Errorf("%s", errorMsg)
-		}
-
-		writeBenthosConfig = &cfg
-	}
+	var err error
 
 	if a.dfcType != DFCTypeEmpty {
 		SendActionReply(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionExecuting,
@@ -291,7 +267,7 @@ func (a *EditProtocolConverterAction) Execute() (interface{}, map[string]interfa
 	}
 
 	// Apply mutations to create new spec
-	newSpec, atomicEditUUID, desiredPCState, err := a.applyMutation(readBenthosConfig, writeBenthosConfig)
+	newSpec, atomicEditUUID, desiredPCState, err := a.applyMutation()
 	if err != nil {
 		errorMsg := fmt.Sprintf("Failed to apply configuration mutation: %v", err)
 		SendActionReply(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedWithFailure,
@@ -347,7 +323,8 @@ func (a *EditProtocolConverterAction) Execute() (interface{}, map[string]interfa
 // to create the new protocol converter specification. It handles child/root relationships,
 // variable merging, and DFC configuration updates.
 // Returns the new spec, the atomic edit UUID, the derived PC desired state, and any error.
-func (a *EditProtocolConverterAction) applyMutation(readBenthosConfig, writeBenthosConfig *dataflowcomponentserviceconfig.BenthosConfig) (config.ProtocolConverterConfig, uuid.UUID, string, error) {
+// Read/write DFC configs are read from a.readDFCSvcCfg and a.writeDFCInput respectively.
+func (a *EditProtocolConverterAction) applyMutation() (config.ProtocolConverterConfig, uuid.UUID, string, error) {
 	// Get current configuration
 	ctx, cancel := context.WithTimeout(context.Background(), constants.ActionTimeout)
 	defer cancel()
@@ -380,46 +357,13 @@ func (a *EditProtocolConverterAction) applyMutation(readBenthosConfig, writeBent
 	targetPC.ProtocolConverterServiceConfig.TemplateRef = a.name
 	targetPC.Name = a.name
 
-	// Classify the protocol converter instance
-	isChild := targetPC.ProtocolConverterServiceConfig.TemplateRef != "" &&
-		targetPC.ProtocolConverterServiceConfig.TemplateRef != targetPC.Name
-
-	// Determine which instance to modify and which UUID to use for atomic operation
+	// Determine which instance to modify and which UUID to use for atomic operation.
+	// TemplateRef is always set to Name (line above), so stand-alone is the only case.
 	var (
-		instanceToModify config.ProtocolConverterConfig
-		atomicEditUUID   uuid.UUID
+		instanceToModify = targetPC
+		atomicEditUUID   = a.protocolConverterUUID
 		newVB            map[string]any
 	)
-
-	if isChild {
-		// Find the root instance
-		var rootPC config.ProtocolConverterConfig
-
-		rootFound := false
-
-		for _, pc := range currentConfig.ProtocolConverter {
-			if pc.Name == targetPC.ProtocolConverterServiceConfig.TemplateRef &&
-				pc.ProtocolConverterServiceConfig.TemplateRef == pc.Name {
-				rootPC = pc
-				rootFound = true
-
-				break
-			}
-		}
-
-		if !rootFound {
-			return config.ProtocolConverterConfig{}, uuid.Nil, "", fmt.Errorf("root template %s not found for child protocol converter %s",
-				targetPC.ProtocolConverterServiceConfig.TemplateRef, targetPC.Name)
-		}
-
-		// Apply mutations to the root, but keep child's variables
-		instanceToModify = rootPC
-		atomicEditUUID = dataflowcomponentserviceconfig.GenerateUUIDFromName(rootPC.Name)
-	} else {
-		// Root or stand-alone: apply mutations directly
-		instanceToModify = targetPC
-		atomicEditUUID = a.protocolConverterUUID
-	}
 
 	// Add the new variables and preserve existing variables
 	newVB = make(map[string]any)
@@ -430,7 +374,7 @@ func (a *EditProtocolConverterAction) applyMutation(readBenthosConfig, writeBent
 	}
 
 	// Then add new variables (overwrites with updated values)
-	for _, variable := range a.vb {
+	for _, variable := range a.templateVars {
 		newVB[variable.Label] = variable.Value
 	}
 
@@ -441,52 +385,20 @@ func (a *EditProtocolConverterAction) applyMutation(readBenthosConfig, writeBent
 
 	instanceToModify.ProtocolConverterServiceConfig.Variables.User = newVB
 
-	// Apply read DFC config if provided
-	if readBenthosConfig != nil {
-		readDFCServiceConfig := dataflowcomponentserviceconfig.DataflowComponentServiceConfig{
-			BenthosConfig: *readBenthosConfig,
-		}
-		a.desiredReadDFCConfig = readDFCServiceConfig
-		instanceToModify.ProtocolConverterServiceConfig.Config.DataflowComponentReadServiceConfig = readDFCServiceConfig
+	// Apply read DFC config if provided.
+	if a.readDFCSvcCfg != nil {
+		instanceToModify.ProtocolConverterServiceConfig.Config.DataflowComponentReadServiceConfig = *a.readDFCSvcCfg
 	}
 
-	// Apply write DFC config if provided
-	if writeBenthosConfig != nil {
-		writeDFCServiceConfig := dataflowcomponentserviceconfig.DataflowComponentServiceConfig{
-			BenthosConfig: *writeBenthosConfig,
-		}
-		a.desiredWriteDFCConfig = writeDFCServiceConfig
-		instanceToModify.ProtocolConverterServiceConfig.Config.DataflowComponentWriteServiceConfig = writeDFCServiceConfig
-	}
-
-	// TODO(ENG-4856): UMH_TOPICS is a typed field stored in Variables.User as a workaround
-	// because the bridge config has no typed block for it yet. Remove this persist block
-	// once UMH_TOPICS moves to a typed config field in the FSMv2 bridge migration.
-	// Persist UMH_TOPICS from write DFC payload. An explicit empty slice clears the key
-	// so that stale topics do not remain when the user removes all subscriptions.
-	if a.writeDFCPayload != nil {
-		if len(a.writeDFCPayload.UMHTopics) > 0 {
-			instanceToModify.ProtocolConverterServiceConfig.Variables.User["UMH_TOPICS"] = a.writeDFCPayload.UMHTopics
-		} else {
-			delete(instanceToModify.ProtocolConverterServiceConfig.Variables.User, "UMH_TOPICS")
-		}
+	// Apply write DFC config if provided — store the original input (template string preserved).
+	if a.writeDFCInput != nil {
+		instanceToModify.ProtocolConverterServiceConfig.Config.DataflowComponentWriteServiceConfig = *a.writeDFCInput
 	}
 
 	// Add the connection details to the template
-	instanceToModify.ProtocolConverterServiceConfig.Config.ConnectionServiceConfig = connectionserviceconfig.ConnectionServiceConfigTemplate{
-		NmapTemplate: &connectionserviceconfig.NmapConfigTemplate{
-			Target: "{{ .IP }}",
-			Port:   "{{ .PORT }}",
-		},
-	}
+	instanceToModify.ProtocolConverterServiceConfig.Config.ConnectionServiceConfig = newIPPortConnectionTemplate()
 
-	// Update the location of the protocol converter (convert the map to a string map)
-	locationMap := make(map[string]string)
-	for k, v := range a.location {
-		locationMap[strconv.Itoa(k)] = v
-	}
-
-	instanceToModify.ProtocolConverterServiceConfig.Location = locationMap
+	instanceToModify.ProtocolConverterServiceConfig.Location = convertIntMapToStringMap(a.location)
 
 	// Update the connection details of the protocol converter (IP and PORT variables).
 	// Only overwrite when non-empty: an edit that omits connection details should
@@ -592,25 +504,28 @@ func (a *EditProtocolConverterAction) awaitRollout(pcConfig config.ProtocolConve
 		case <-timeout:
 			// rollback to previous configuration
 			ctx, cancel := context.WithTimeout(context.Background(), constants.ActionTimeout)
-			defer cancel()
 
-			_, err := a.configManager.AtomicEditProtocolConverter(ctx, a.atomicEditUUID, pcConfig)
-			if err != nil {
-				a.actionLogger.Errorf("Failed to rollback to previous configuration: %v", err)
-				stateMessage := fmt.Sprintf("Protocol converter '%s' edit timeout reached. It did not become %s in time. Rolling back to previous configuration failed: %v", a.name, desiredPCState, err)
-				a.fsmLogger.SentryError(deps.FeatureDisableReadFlows, "", err, "edit_protocol_converter_rollback_failed",
+			_, rollbackErr := a.configManager.AtomicEditProtocolConverter(ctx, a.atomicEditUUID, pcConfig)
+			cancel()
+			if rollbackErr != nil {
+				a.actionLogger.Errorf("Failed to rollback to previous configuration: %v", rollbackErr)
+				stateMessage := fmt.Sprintf("Protocol converter '%s' edit timeout reached. It did not become %s in time. Rolling back to previous configuration failed: %v", a.name, desiredPCState, rollbackErr)
+				a.fsmLogger.SentryError(deps.FeatureDisableReadFlows, "", rollbackErr, "edit_protocol_converter_rollback_failed",
 					deps.String("pcConfig", pcConfig.String()))
 
 				return models.ErrRetryRollbackTimeout, fmt.Errorf("%s", stateMessage)
-			} else {
-				stateMessage := fmt.Sprintf("Protocol converter '%s' edit timeout reached. It did not become %s in time. Rolled back to previous configuration", a.name, desiredPCState)
-				a.fsmLogger.SentryWarn(deps.FeatureDisableReadFlows, "", "edit_protocol_converter_rollback_on_timeout",
-					deps.String("pcConfig", pcConfig.String()),
-					deps.String("desiredPCState", desiredPCState),
-				)
-
-				return models.ErrRetryRollbackTimeout, fmt.Errorf("%s", stateMessage)
 			}
+
+			stateMessage := fmt.Sprintf("Protocol converter '%s' edit timeout reached. It did not become %s in time. Rolled back to previous configuration", a.name, desiredPCState)
+			if a.lastRenderErr != nil {
+				stateMessage += fmt.Sprintf(" (root cause: %v)", a.lastRenderErr)
+			}
+			a.fsmLogger.SentryWarn(deps.FeatureDisableReadFlows, "", "edit_protocol_converter_rollback_on_timeout",
+				deps.String("pcConfig", pcConfig.String()),
+				deps.String("desiredPCState", desiredPCState),
+			)
+
+			return models.ErrRetryRollbackTimeout, fmt.Errorf("%s", stateMessage)
 
 		case <-ticker.C:
 			// Get a deep copy of the system snapshot to prevent race conditions
@@ -857,11 +772,11 @@ func (a *EditProtocolConverterAction) awaitRollout(pcConfig config.ProtocolConve
 					)
 
 					ctx, cancel := context.WithTimeout(context.Background(), constants.ActionTimeout)
-					defer cancel()
 
 					a.actionLogger.Infof("rolling back to previous configuration with user variables: %v", pcConfig.ProtocolConverterServiceConfig.Variables.User)
 
 					_, err := a.configManager.AtomicEditProtocolConverter(ctx, a.atomicEditUUID, pcConfig)
+					cancel()
 					if err != nil {
 						a.actionLogger.Errorf("failed to roll back protocol converter %s: %v", a.name, err)
 						a.fsmLogger.SentryError(deps.FeatureDisableReadFlows, "", err, "edit_protocol_converter_config_error_rollback_failed",
@@ -964,7 +879,7 @@ func (a *EditProtocolConverterAction) compareSingleDFCConfig(pcSnapshot *protoco
 	renderedDesiredConfig, err := a.renderDesiredDFCConfig(pcSnapshot, dfcType)
 	if err != nil {
 		a.actionLogger.Errorf("failed to render desired %s DFC config: %v", dfcType, err)
-
+		a.lastRenderErr = err
 		return false
 	}
 
@@ -981,21 +896,6 @@ func (a *EditProtocolConverterAction) compareSingleDFCConfig(pcSnapshot *protoco
 	a.actionLogger.Debugf("rendered desired %s DFC config: %+v", dfcType, renderedDesiredConfig)
 
 	return dataflowcomponentserviceconfig.NewComparator().ConfigsEqual(observedDFCConfig, renderedDesiredConfig)
-}
-
-// observedBenthosToServiceConfig converts an observed BenthosServiceConfig to a
-// DataflowComponentServiceConfig for comparison with the desired config.
-func observedBenthosToServiceConfig(obs benthosserviceconfig.BenthosServiceConfig) dataflowcomponentserviceconfig.DataflowComponentServiceConfig {
-	return dataflowcomponentserviceconfig.DataflowComponentServiceConfig{
-		BenthosConfig: dataflowcomponentserviceconfig.BenthosConfig{
-			Input:              obs.Input,
-			Pipeline:           obs.Pipeline,
-			Output:             obs.Output,
-			CacheResources:     obs.CacheResources,
-			RateLimitResources: obs.RateLimitResources,
-			Buffer:             obs.Buffer,
-		},
-	}
 }
 
 // renderDesiredDFCConfig renders the template variables in the desired DFC config
@@ -1018,12 +918,12 @@ func (a *EditProtocolConverterAction) renderDesiredDFCConfig(pcSnapshot *protoco
 	}
 
 	// Apply whichever desired DFC configs are set, so the runtime render sees the full picture.
-	if a.desiredReadDFCConfig.BenthosConfig.Input != nil {
-		modifiedSpec.Config.DataflowComponentReadServiceConfig = a.desiredReadDFCConfig
+	if a.readDFCSvcCfg != nil {
+		modifiedSpec.Config.DataflowComponentReadServiceConfig = *a.readDFCSvcCfg
 	}
 
-	if a.desiredWriteDFCConfig.BenthosConfig.Output != nil {
-		modifiedSpec.Config.DataflowComponentWriteServiceConfig = a.desiredWriteDFCConfig
+	if a.writeDFCInput != nil && a.writeDFCInput.HasOutput() {
+		modifiedSpec.Config.DataflowComponentWriteServiceConfig = *a.writeDFCInput
 	}
 
 	systemSnapshot := a.systemSnapshotManager.GetDeepCopySnapshot()
@@ -1036,7 +936,7 @@ func (a *EditProtocolConverterAction) renderDesiredDFCConfig(pcSnapshot *protoco
 		modifiedSpec,
 		agentLocation,
 		nil,             // TODO: add global vars
-		"unimplemented", // TODO: add node name
+		"unimplemented", // Must stay "unimplemented": FSM uses the same sentinel, so bridged_by values match. If FSM changes its node-name source, update here in lockstep.
 		pcName,
 	)
 	if err != nil {
@@ -1053,47 +953,13 @@ func (a *EditProtocolConverterAction) renderDesiredDFCConfig(pcSnapshot *protoco
 	}
 }
 
-// dfcToPayload converts a ProtocolConverterDFC to the internal CDFCPayload representation.
-func dfcToPayload(dfc *models.ProtocolConverterDFC) models.CDFCPayload {
-	return models.CDFCPayload{
-		Inputs:    models.DfcDataConfig{Data: dfc.Inputs.Data, Type: dfc.Inputs.Type},
-		Pipeline:  convertPipelineToMap(dfc.Pipeline),
-		Outputs:   models.DfcDataConfig{Data: dfc.Outputs.Data, Type: dfc.Outputs.Type},
-		Inject:    extractInjectFromRawYAML(dfc.RawYAML),
-		UMHTopics: dfc.UMHTopics,
-	}
-}
-
-// convertPipelineToMap converts CommonDataFlowComponentPipelineConfig to map[string]DfcDataConfig.
-func convertPipelineToMap(pipeline models.CommonDataFlowComponentPipelineConfig) map[string]models.DfcDataConfig {
-	result := make(map[string]models.DfcDataConfig)
-	for key, processor := range pipeline.Processors {
-		result[key] = models.DfcDataConfig{
-			Data: processor.Data,
-			Type: processor.Type,
-		}
-	}
-
-	return result
-}
-
-// extractInjectFromRawYAML extracts the inject data from the RawYAML field to support
-// CacheResources, RateLimitResources, and Buffer in protocol converter DFCs.
-func extractInjectFromRawYAML(rawYAML *models.CommonDataFlowComponentRawYamlConfig) string {
-	if rawYAML == nil {
-		return ""
-	}
-
-	return rawYAML.Data
-}
-
 // deriveDFCType compares the incoming DFC payloads against the currently
 // deployed config and returns a DFCType that only includes the sides that
 // actually differ. If no config is deployed yet (first edit) or the config
 // cannot be read, it falls back to payload presence.
 func (a *EditProtocolConverterAction) deriveDFCType() DFCType {
-	hasRead := a.readDFCPayload != nil
-	hasWrite := a.writeDFCPayload != nil
+	hasRead := a.readDFCSvcCfg != nil
+	hasWrite := a.writeDFCInput != nil
 
 	if !hasRead && !hasWrite {
 		return DFCTypeEmpty
@@ -1146,33 +1012,25 @@ func (a *EditProtocolConverterAction) deriveDFCType() DFCType {
 	}
 
 	// Check if read or write payload is different from the deployed config.
-	readChanged := hasRead && a.dfcPayloadDiffers(*a.readDFCPayload, a.readDFCState,
+	readChanged := hasRead && a.readDFCSvcCfgDiffers(*a.readDFCSvcCfg, a.readDFCState,
 		currentPC.ProtocolConverterServiceConfig.Config.DataflowComponentReadServiceConfig,
 		currentPC.ProtocolConverterServiceConfig.ReadDFCDesiredState)
-	writeChanged := hasWrite && a.dfcPayloadDiffers(*a.writeDFCPayload, a.writeDFCState,
+	writeChanged := hasWrite && a.writeDFCConfigDiffers(*a.writeDFCInput, a.writeDFCState,
 		currentPC.ProtocolConverterServiceConfig.Config.DataflowComponentWriteServiceConfig,
 		currentPC.ProtocolConverterServiceConfig.WriteDFCDesiredState)
-
-	if hasWrite && !writeChanged {
-		deployedTopics, _ := toStringSlice(deployedVars["UMH_TOPICS"])
-		if !equalTopicSets(deployedTopics, a.writeDFCPayload.UMHTopics) {
-			writeChanged = true
-		}
-	}
-
 	derived := dfcTypeFromPresence(readChanged, writeChanged)
 	a.actionLogger.Debugf("Derived dfcType=%s (readChanged=%v, writeChanged=%v)", derived, readChanged, writeChanged)
 
 	return derived
 }
 
-// dfcPayloadDiffers checks whether an incoming DFC payload differs from the
+// readDFCSvcCfgDiffers checks whether an incoming read DFC service config differs from the
 // persisted config in config.yaml. This is intentionally simpler than
 // compareSingleDFCConfig, which compares rendered templates against runtime
 // observed state from the FSM snapshot. Here we only need to know whether the
 // user sent something new relative to what is already on disk.
-func (a *EditProtocolConverterAction) dfcPayloadDiffers(
-	payload models.CDFCPayload,
+func (a *EditProtocolConverterAction) readDFCSvcCfgDiffers(
+	incoming dataflowcomponentserviceconfig.DataflowComponentServiceConfig,
 	incomingState string,
 	deployedConfig dataflowcomponentserviceconfig.DataflowComponentServiceConfig,
 	deployedState string,
@@ -1185,33 +1043,21 @@ func (a *EditProtocolConverterAction) dfcPayloadDiffers(
 	if incomingState != "" && deployedState != "" && incomingState != deployedState {
 		return true
 	}
-
-	incomingBenthos, err := CreateBenthosConfigFromCDFCPayload(payload, a.name)
-	if err != nil {
-		a.actionLogger.Debugf("Cannot build benthos config for diff, treating as changed: %v", err)
-
-		return true
-	}
-
-	incomingDFCConfig := dataflowcomponentserviceconfig.DataflowComponentServiceConfig{
-		BenthosConfig: incomingBenthos,
-	}
-
-	return !deployedConfig.Equal(incomingDFCConfig)
+	return !deployedConfig.Equal(incoming)
 }
 
-// dfcTypeFromPresence returns a DFCType based on boolean flags for read/write.
-func dfcTypeFromPresence(read, write bool) DFCType {
-	switch {
-	case read && write:
-		return DFCTypeBoth
-	case read:
-		return DFCTypeRead
-	case write:
-		return DFCTypeWrite
-	default:
-		return DFCTypeEmpty
+// writeDFCConfigDiffers reports whether the incoming typed write config differs from
+// what is persisted in config.yaml.
+func (a *EditProtocolConverterAction) writeDFCConfigDiffers(
+	incoming dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput,
+	incomingState string,
+	deployedConfig dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput,
+	deployedState string,
+) bool {
+	if incomingState != "" && deployedState != "" && incomingState != deployedState {
+		return true
 	}
+	return !reflect.DeepEqual(incoming, deployedConfig)
 }
 
 // getUserEmail implements the Action interface by returning the user email associated with this action.
@@ -1224,18 +1070,14 @@ func (a *EditProtocolConverterAction) getUuid() uuid.UUID {
 	return a.actionUUID
 }
 
-// GetParsedPayload returns the parsed DFC payload - exposed primarily for testing purposes.
-// Returns the read DFC payload when available, otherwise the write DFC payload.
-func (a *EditProtocolConverterAction) GetParsedPayload() models.CDFCPayload {
-	if a.readDFCPayload != nil {
-		return *a.readDFCPayload
-	}
+// GetParsedPayload returns the built read DFC service config - exposed primarily for testing purposes.
+func (a *EditProtocolConverterAction) GetParsedPayload() *dataflowcomponentserviceconfig.DataflowComponentServiceConfig {
+	return a.readDFCSvcCfg
+}
 
-	if a.writeDFCPayload != nil {
-		return *a.writeDFCPayload
-	}
-
-	return models.CDFCPayload{}
+// GetIgnoreHealthCheck returns whether health-check errors are suppressed - exposed primarily for testing.
+func (a *EditProtocolConverterAction) GetIgnoreHealthCheck() bool {
+	return a.ignoreHealthCheck
 }
 
 // GetProtocolConverterUUID returns the protocol converter UUID - exposed for testing purposes.
@@ -1248,54 +1090,7 @@ func (a *EditProtocolConverterAction) GetDFCType() string {
 	return a.dfcType.String()
 }
 
-// validateDFCPayloadAndState validates a pre-parsed CDFCPayload and its state string.
-func validateDFCPayloadAndState(payload *models.CDFCPayload, state string, label string) error {
-	if payload != nil {
-		// For write DFCs, skip input validation since input is auto-generated
-		validateInput := label != "write"
-		if err := ValidateCustomDataFlowComponentPayload(*payload, validateInput, false); err != nil {
-			return fmt.Errorf("invalid %s DFC configuration: %w", label, err)
-		}
-		// UMH_TOPICS is only required when the payload carries actual output config.
-		// A state-only change (enable/disable with payload.Outputs.Data == 0) skips this check; the FSM's
-		// BuildRuntimeConfig enforces the requirement when it renders the write DFC.
-		if label == "write" && len(payload.Outputs.Data) > 0 && len(payload.UMHTopics) == 0 {
-			return errors.New("write DFC requires at least one UMH topic (umh_topics)")
-		}
-	}
-
-	if state != "" {
-		if err := ValidateDataFlowComponentState(state); err != nil {
-			return fmt.Errorf("invalid %s DFC state: %w", label, err)
-		}
-	}
-
-	return nil
-}
-
-// validateProtocolConverterDFC validates a ProtocolConverterDFC's state and configuration.
-// Returns nil if dfc is nil (nothing to validate).
-func validateProtocolConverterDFC(dfc *models.ProtocolConverterDFC, label string) error {
-	if dfc == nil {
-		return nil
-	}
-
-	if dfc.State != "" {
-		if err := ValidateDataFlowComponentState(dfc.State); err != nil {
-			return fmt.Errorf("invalid %s DFC state: %w", label, err)
-		}
-	}
-
-	payload := dfcToPayload(dfc)
-	// For write DFCs, skip input validation since input is auto-generated
-	validateInput := label != "write"
-	if err := ValidateCustomDataFlowComponentPayload(payload, validateInput, false); err != nil {
-		return fmt.Errorf("invalid %s DFC configuration: %w", label, err)
-	}
-
-	if label == "write" && len(dfc.Outputs.Data) > 0 && len(dfc.UMHTopics) == 0 {
-		return errors.New("write DFC requires at least one UMH topic (umh_topics)")
-	}
-
-	return nil
+// GetDesiredWriteDFCConfig returns the raw write DFC input config - exposed for testing purposes.
+func (a *EditProtocolConverterAction) GetDesiredWriteDFCConfig() *dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput {
+	return a.writeDFCInput
 }

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter.go
@@ -89,14 +89,27 @@ func (d DFCType) IsValid() bool {
 type EditProtocolConverterAction struct {
 	configManager config.ConfigManager
 
+	fsmLogger deps.FSMLogger
+	// lastRenderErr holds the most recent renderDesiredDFCConfig error so the
+	// awaitRollout timeout message can surface the real cause instead of just
+	// "did not become active in time".
+	lastRenderErr error
+
 	outboundChannel chan *models.UMHMessage
 	location        map[int]string
 
 	// Runtime observation for health checks
 	systemSnapshotManager *fsm.SnapshotManager
 
-	actionLogger   *zap.SugaredLogger
-	fsmLogger      deps.FSMLogger
+	actionLogger *zap.SugaredLogger
+
+	// readDFCSvcCfg is the built+validated read DFC service config, set in Parse.
+	// nil means no read DFC was provided in the request.
+	readDFCSvcCfg *dataflowcomponentserviceconfig.DataflowComponentServiceConfig
+	// writeDFCInput is the raw template-string form of the write config, persisted to the spec.
+	// nil means no write DFC was provided.
+	writeDFCInput *dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput
+
 	userEmail      string
 	name           string // protocol converter name (optional for updates)
 	dfcType        DFCType
@@ -106,13 +119,6 @@ type EditProtocolConverterAction struct {
 	writeDFCState  string // desired state for the write DFC ("active" or "stopped"; empty = default active)
 
 	templateVars []models.ProtocolConverterVariable
-
-	// readDFCSvcCfg is the built+validated read DFC service config, set in Parse.
-	// nil means no read DFC was provided in the request.
-	readDFCSvcCfg *dataflowcomponentserviceconfig.DataflowComponentServiceConfig
-	// writeDFCInput is the raw template-string form of the write config, persisted to the spec.
-	// nil means no write DFC was provided.
-	writeDFCInput *dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput
 
 	actionUUID   uuid.UUID
 	instanceUUID uuid.UUID
@@ -124,10 +130,6 @@ type EditProtocolConverterAction struct {
 	atomicEditUUID uuid.UUID
 
 	ignoreHealthCheck bool
-	// lastRenderErr holds the most recent renderDesiredDFCConfig error so the
-	// awaitRollout timeout message can surface the real cause instead of just
-	// "did not become active in time".
-	lastRenderErr error
 }
 
 // NewEditProtocolConverterAction returns an un-parsed action instance.
@@ -941,7 +943,7 @@ func (a *EditProtocolConverterAction) renderDesiredDFCConfig(pcSnapshot *protoco
 	runtimeConfig, err := runtime_config.BuildRuntimeConfig(
 		modifiedSpec,
 		agentLocation,
-		nil,             // TODO: add global vars
+		nil, // TODO: add global vars
 		runtime_config.BridgedByPlaceholder,
 		pcName,
 	)

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter.go
@@ -150,7 +150,7 @@ func NewEditProtocolConverterAction(userEmail string, actionUUID uuid.UUID, inst
 // dataflow component configuration from the payload.
 func (a *EditProtocolConverterAction) Parse(payload interface{}) error {
 	// Parse the payload directly as a complete ProtocolConverter object
-	pcPayload, err := ParseActionPayload[models.ProtocolConverterRequest](payload)
+	pcPayload, err := ParseActionPayload[models.ProtocolConverter](payload)
 	if err != nil {
 		return fmt.Errorf("failed to parse protocol converter payload: %w", err)
 	}
@@ -183,13 +183,12 @@ func (a *EditProtocolConverterAction) Parse(payload interface{}) error {
 			a.ignoreHealthCheck = *pcPayload.ReadDFC.IgnoreErrors
 		}
 	}
-
-	if pcPayload.WriteDFC != nil {
-		input := pcPayload.WriteDFC.DataflowComponentWriteConfigInput
+	if pcPayload.WriteDFCPayload != nil {
+		input := pcPayload.WriteDFCPayload.DataflowComponentWriteConfigInput
 		a.writeDFCInput = &input
-		a.writeDFCState = pcPayload.WriteDFC.State
-		if pcPayload.WriteDFC.IgnoreErrors != nil {
-			a.ignoreHealthCheck = a.ignoreHealthCheck || *pcPayload.WriteDFC.IgnoreErrors
+		a.writeDFCState = pcPayload.WriteDFCPayload.State
+		if pcPayload.WriteDFCPayload.IgnoreErrors != nil {
+			a.ignoreHealthCheck = a.ignoreHealthCheck || *pcPayload.WriteDFCPayload.IgnoreErrors
 		}
 	}
 

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter.go
@@ -390,7 +390,7 @@ func (a *EditProtocolConverterAction) applyMutation() (config.ProtocolConverterC
 	}
 
 	// Apply write DFC config if provided — store the original input (template string preserved).
-	if a.writeDFCInput != nil {
+	if a.writeDFCInput != nil && a.writeDFCInput.HasOutput() {
 		instanceToModify.ProtocolConverterServiceConfig.Config.DataflowComponentWriteServiceConfig = *a.writeDFCInput
 	}
 

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter_test.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter_test.go
@@ -59,6 +59,9 @@ var _ = Describe("EditProtocolConverter", func() {
 		actionUUID = uuid.New()
 		instanceUUID = uuid.New()
 		outboundChannel = make(chan *models.UMHMessage, 10) // Buffer to prevent blocking
+		mu.Lock()
+		messages = nil
+		mu.Unlock()
 		pcName = "wetter"
 		pcUUID = dataflowcomponentserviceconfig.GenerateUUIDFromName(pcName)
 
@@ -123,10 +126,6 @@ var _ = Describe("EditProtocolConverter", func() {
 
 	// Cleanup after each test
 	AfterEach(func() {
-		// Drain the outbound channel to prevent goroutine leaks
-		for len(outboundChannel) > 0 {
-			<-outboundChannel
-		}
 		close(outboundChannel)
 	})
 
@@ -173,9 +172,10 @@ var _ = Describe("EditProtocolConverter", func() {
 			Expect(action.GetDFCType()).To(Equal("read"))
 
 			parsedPayload := action.GetParsedPayload()
-			Expect(parsedPayload.Inputs.Type).To(Equal("http_client"))
-			Expect(parsedPayload.Pipeline).To(HaveKey("0"))
-			Expect(parsedPayload.IgnoreErrors).To(BeFalse())
+			Expect(parsedPayload).NotTo(BeNil())
+			Expect(parsedPayload.BenthosConfig.Input).To(HaveKey("input"))
+			Expect(parsedPayload.BenthosConfig.Pipeline).To(HaveKey("processors"))
+			Expect(action.GetIgnoreHealthCheck()).To(BeFalse())
 		})
 
 		It("should parse valid write DFC payload", func() {
@@ -183,18 +183,12 @@ var _ = Describe("EditProtocolConverter", func() {
 				"name": pcName,
 				"uuid": pcUUID.String(),
 				"writeDFC": map[string]interface{}{
-					"inputs": map[string]interface{}{
-						"data": "input:\n  kafka:\n    addresses: [localhost:9092]\n    topics: [test]",
-						"type": "kafka",
-					},
-					"pipeline": map[string]interface{}{
-						"processors": map[string]interface{}{
-							"0": map[string]interface{}{
-								"type": "bloblang",
-								"data": "bloblang: |-\n  root = content()",
-							},
+					"output": map[string]interface{}{
+						"kafka": map[string]interface{}{
+							"addresses": []interface{}{"localhost:9092"},
 						},
 					},
+					"input_topics": "umh.v1.factory.*",
 				},
 			}
 
@@ -205,8 +199,10 @@ var _ = Describe("EditProtocolConverter", func() {
 			Expect(action.GetProtocolConverterUUID()).To(Equal(pcUUID))
 			Expect(action.GetDFCType()).To(Equal("write"))
 
-			parsedPayload := action.GetParsedPayload()
-			Expect(parsedPayload.Inputs.Type).To(Equal("kafka"))
+			writeCfg := action.GetDesiredWriteDFCConfig()
+			Expect(writeCfg).NotTo(BeNil())
+			Expect(writeCfg.Output).To(HaveKey("kafka"))
+			Expect(writeCfg.InputTopics).To(Equal("umh.v1.factory.*"))
 		})
 
 		It("should return error for missing UUID", func() {
@@ -263,16 +259,19 @@ var _ = Describe("EditProtocolConverter", func() {
 						"type": "http_client",
 					},
 					"pipeline": map[string]interface{}{
-						"processors": map[string]interface{}{},
+						"processors": map[string]interface{}{
+							"0": map[string]interface{}{
+								"type": "bloblang",
+								"data": "bloblang: root = this",
+							},
+						},
 					},
 				},
 				"writeDFC": map[string]interface{}{
-					"outputs": map[string]interface{}{
-						"data": "output:\n  stdout: {}",
-						"type": "stdout",
+					"output": map[string]interface{}{
+						"stdout": map[string]interface{}{},
 					},
-					"pipeline":   map[string]interface{}{},
-					"umh_topics": []interface{}{"umh.v1.factory.*"},
+					"input_topics": "umh.v1.factory.*",
 				},
 			}
 
@@ -286,12 +285,10 @@ var _ = Describe("EditProtocolConverter", func() {
 				"name": pcName,
 				"uuid": pcUUID.String(),
 				"writeDFC": map[string]interface{}{
-					"outputs": map[string]interface{}{
-						"data": "output:\n  stdout: {}",
-						"type": "stdout",
+					"output": map[string]interface{}{
+						"stdout": map[string]interface{}{},
 					},
-					"pipeline":   map[string]interface{}{},
-					"umh_topics": []interface{}{"umh.v1.factory.*", "umh.v1.plant.*"},
+					"input_topics": "umh.v1.factory.*\numh.v1.plant.*",
 				},
 			}
 
@@ -299,8 +296,35 @@ var _ = Describe("EditProtocolConverter", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(action.GetDFCType()).To(Equal("write"))
 
-			parsedPayload := action.GetParsedPayload()
-			Expect(parsedPayload.UMHTopics).To(ConsistOf("umh.v1.factory.*", "umh.v1.plant.*"))
+			writeCfg := action.GetDesiredWriteDFCConfig()
+			Expect(writeCfg).NotTo(BeNil())
+			Expect(writeCfg.InputTopics).To(Equal("umh.v1.factory.*\numh.v1.plant.*"))
+		})
+
+		It("should parse write DFC with golang template vars in input_topics", func() {
+			// Regression test: template vars like {{ .IP }}, {{ .location_path }} must not
+			// cause a parse error — rendering happens later in BuildRuntimeConfig with full scope.
+			payload := map[string]interface{}{
+				"name": pcName,
+				"uuid": pcUUID.String(),
+				"connection": map[string]interface{}{
+					"ip":   "192.168.1.1",
+					"port": 502,
+				},
+				"writeDFC": map[string]interface{}{
+					"output": map[string]interface{}{
+						"stdout": map[string]interface{}{},
+					},
+					"input_topics": "umh.v1.{{ .location_path }}.{{ .IP }}.*",
+				},
+			}
+
+			err := action.Parse(payload)
+			Expect(err).NotTo(HaveOccurred())
+
+			writeCfg := action.GetDesiredWriteDFCConfig()
+			Expect(writeCfg).NotTo(BeNil())
+			Expect(writeCfg.InputTopics).To(Equal("umh.v1.{{ .location_path }}.{{ .IP }}.*"))
 		})
 
 		It("should preserve explicit 'stopped' state on read DFC", func() {
@@ -314,10 +338,17 @@ var _ = Describe("EditProtocolConverter", func() {
 				"readDFC": map[string]interface{}{
 					"inputs": map[string]interface{}{
 						"data": "input:\n  http_client:\n    url: 'http://example.com'",
-						"type": "yaml",
+						"type": "http_client",
 					},
-					"pipeline": map[string]interface{}{},
-					"state":    "stopped",
+					"pipeline": map[string]interface{}{
+						"processors": map[string]interface{}{
+							"0": map[string]interface{}{
+								"type": "bloblang",
+								"data": "bloblang: root = this",
+							},
+						},
+					},
+					"state": "stopped",
 				},
 			}
 
@@ -370,12 +401,10 @@ var _ = Describe("EditProtocolConverter", func() {
 				"name": pcName,
 				"uuid": pcUUID.String(),
 				"writeDFC": map[string]interface{}{
-					"outputs": map[string]interface{}{
-						"data": "output:\n  stdout: {}",
-						"type": "stdout",
+					"output": map[string]interface{}{
+						"stdout": map[string]interface{}{},
 					},
-					"pipeline":   map[string]interface{}{},
-					"umh_topics": []interface{}{"umh.v1.factory.*"},
+					"input_topics": "umh.v1.factory.*",
 				},
 			}
 
@@ -408,11 +437,9 @@ var _ = Describe("EditProtocolConverter", func() {
 				"name": pcName,
 				"uuid": pcUUID.String(),
 				"writeDFC": map[string]interface{}{
-					"outputs": map[string]interface{}{
-						"data": "output:\n  stdout: {}",
-						"type": "stdout",
+					"output": map[string]interface{}{
+						"stdout": map[string]interface{}{},
 					},
-					"pipeline": map[string]interface{}{},
 					// no umh_topics
 				},
 			}
@@ -422,7 +449,7 @@ var _ = Describe("EditProtocolConverter", func() {
 
 			err = action.Validate()
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("umh_topics"))
+			Expect(err.Error()).To(ContainSubstring("input_topics"))
 		})
 
 		It("should return error for invalid DFC configuration", func() {
@@ -440,10 +467,8 @@ var _ = Describe("EditProtocolConverter", func() {
 				},
 			}
 
+			// Validation happens during Parse (build step validates the DFC)
 			err := action.Parse(payload)
-			Expect(err).NotTo(HaveOccurred())
-
-			err = action.Validate()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("invalid read DFC configuration"))
 		})
@@ -527,24 +552,21 @@ var _ = Describe("EditProtocolConverter", func() {
 
 			// Verify write DFC is still empty
 			writeDFCConfig := updatedPC.ProtocolConverterServiceConfig.Config.DataflowComponentWriteServiceConfig
-			Expect(writeDFCConfig.BenthosConfig.Input).To(BeEmpty())
+			Expect(writeDFCConfig.HasOutput()).To(BeFalse())
 
 			// verify that the templateRef is set
 			Expect(updatedPC.ProtocolConverterServiceConfig.TemplateRef).To(Equal(pcName))
 		})
 
-		It("should store UMH_TOPICS in user variables when adding write DFC", func() {
-			topics := []interface{}{"umh.v1.factory.line-1.*", "umh.v1.factory.line-2.*"}
+		It("should store InputTopics in typed write config when adding write DFC", func() {
 			payload := map[string]interface{}{
 				"name": pcName,
 				"uuid": pcUUID.String(),
 				"writeDFC": map[string]interface{}{
-					"outputs": map[string]interface{}{
-						"data": "output:\n  stdout: {}",
-						"type": "stdout",
+					"output": map[string]interface{}{
+						"stdout": map[string]interface{}{},
 					},
-					"pipeline":   map[string]interface{}{},
-					"umh_topics": topics,
+					"input_topics": "umh.v1.factory.line-1.*\numh.v1.factory.line-2.*",
 				},
 			}
 
@@ -563,7 +585,7 @@ var _ = Describe("EditProtocolConverter", func() {
 
 			stateMocker.Stop()
 
-			// Verify UMH_TOPICS stored in user variables
+			// Verify InputTopics stored in typed write config
 			ctx := context.Background()
 			updatedConfig, err := mockConfig.GetConfig(ctx, 0)
 			Expect(err).NotTo(HaveOccurred())
@@ -577,11 +599,7 @@ var _ = Describe("EditProtocolConverter", func() {
 				}
 			}
 			Expect(updatedPC).NotTo(BeNil())
-			Expect(updatedPC.ProtocolConverterServiceConfig.Variables.User).To(HaveKey("UMH_TOPICS"))
-			Expect(updatedPC.ProtocolConverterServiceConfig.Variables.User["UMH_TOPICS"]).To(ConsistOf(
-				"umh.v1.factory.line-1.*",
-				"umh.v1.factory.line-2.*",
-			))
+			Expect(updatedPC.ProtocolConverterServiceConfig.Config.DataflowComponentWriteServiceConfig.InputTopics).To(Equal("umh.v1.factory.line-1.*\numh.v1.factory.line-2.*"))
 		})
 
 		Context("when protocol converter already has both DFCs configured", func() {
@@ -601,12 +619,10 @@ var _ = Describe("EditProtocolConverter", func() {
 						Input: existingReadInput,
 					},
 				}
-				mockConfig.Config.ProtocolConverter[0].ProtocolConverterServiceConfig.Config.DataflowComponentWriteServiceConfig = dataflowcomponentserviceconfig.DataflowComponentServiceConfig{
-					BenthosConfig: dataflowcomponentserviceconfig.BenthosConfig{
-						Output: existingWriteOutput,
-					},
+				mockConfig.Config.ProtocolConverter[0].ProtocolConverterServiceConfig.Config.DataflowComponentWriteServiceConfig = dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
+					Output:      existingWriteOutput,
+					InputTopics: "umh.v1.factory.*",
 				}
-				mockConfig.Config.ProtocolConverter[0].ProtocolConverterServiceConfig.Variables.User["UMH_TOPICS"] = []string{"umh.v1.factory.*"}
 
 				stateMocker = actions.NewStateMocker(mockConfig)
 				stateMocker.Tick()
@@ -614,17 +630,16 @@ var _ = Describe("EditProtocolConverter", func() {
 			})
 
 			It("should not change read DFC when only write DFC is edited", Label("write-dfc", "isolation"), func() {
-				newTopics := []interface{}{"umh.v1.plant.*"}
 				payload := map[string]interface{}{
 					"name": pcName,
 					"uuid": pcUUID.String(),
 					"writeDFC": map[string]interface{}{
-						"outputs": map[string]interface{}{
-							"data": "output:\n  kafka:\n    addresses: [localhost:9092]",
-							"type": "kafka",
+						"output": map[string]interface{}{
+							"kafka": map[string]interface{}{
+								"addresses": []interface{}{"localhost:9092"},
+							},
 						},
-						"pipeline":   map[string]interface{}{},
-						"umh_topics": newTopics,
+						"input_topics": "umh.v1.plant.*",
 					},
 				}
 
@@ -653,10 +668,9 @@ var _ = Describe("EditProtocolConverter", func() {
 				}
 				Expect(updatedPC).NotTo(BeNil())
 
-				// Write DFC output must have changed — parsed YAML wraps in outer "output" key
-				writeOutput := updatedPC.ProtocolConverterServiceConfig.Config.DataflowComponentWriteServiceConfig.BenthosConfig.Output
-				Expect(writeOutput).To(HaveKey("output"))
-				Expect(writeOutput["output"]).To(HaveKey("kafka"))
+				// Write DFC output must have changed — new format stores directly without wrapper
+				writeOutput := updatedPC.ProtocolConverterServiceConfig.Config.DataflowComponentWriteServiceConfig.Output
+				Expect(writeOutput).To(HaveKey("kafka"))
 
 				// Read DFC input must be untouched — initial config set directly without wrapper
 				readInput := updatedPC.ProtocolConverterServiceConfig.Config.DataflowComponentReadServiceConfig.BenthosConfig.Input
@@ -716,11 +730,11 @@ var _ = Describe("EditProtocolConverter", func() {
 				Expect(readInput["input"].(map[string]interface{})["http_client"]).To(HaveKeyWithValue("url", "http://updated.example.com"))
 
 				// Write DFC output must be untouched — initial config set directly without wrapper
-				writeOutput := updatedPC.ProtocolConverterServiceConfig.Config.DataflowComponentWriteServiceConfig.BenthosConfig.Output
+				writeOutput := updatedPC.ProtocolConverterServiceConfig.Config.DataflowComponentWriteServiceConfig.Output
 				Expect(writeOutput).To(HaveKey("stdout"))
 
-				// UMH_TOPICS must be untouched
-				Expect(updatedPC.ProtocolConverterServiceConfig.Variables.User["UMH_TOPICS"]).To(ConsistOf("umh.v1.factory.*"))
+				// InputTopics must be untouched
+				Expect(updatedPC.ProtocolConverterServiceConfig.Config.DataflowComponentWriteServiceConfig.InputTopics).To(Equal("umh.v1.factory.*"))
 			})
 		})
 
@@ -745,8 +759,8 @@ var _ = Describe("EditProtocolConverter", func() {
 				}
 			}
 
-			// Minimal write DFC payload: no inputs, pipeline, or umh_topics needed for
-			// a state-only change. UMH_TOPICS is only required when output config is present.
+			// Minimal write DFC payload: no inputs, pipeline, or input_topics needed for
+			// a state-only change. InputTopics is only required when output config is present.
 			minimalWriteDFCPayload := func(state string) map[string]interface{} {
 				return map[string]interface{}{
 					"state": state,
@@ -789,12 +803,10 @@ var _ = Describe("EditProtocolConverter", func() {
 						Input: map[string]interface{}{"http_client": map[string]interface{}{"url": "http://example.com"}},
 					},
 				}
-				mockConfig.Config.ProtocolConverter[0].ProtocolConverterServiceConfig.Config.DataflowComponentWriteServiceConfig = dataflowcomponentserviceconfig.DataflowComponentServiceConfig{
-					BenthosConfig: dataflowcomponentserviceconfig.BenthosConfig{
-						Output: map[string]interface{}{"stdout": map[string]interface{}{}},
-					},
+				mockConfig.Config.ProtocolConverter[0].ProtocolConverterServiceConfig.Config.DataflowComponentWriteServiceConfig = dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
+					Output:      map[string]interface{}{"stdout": map[string]interface{}{}},
+					InputTopics: "umh.v1.factory.*",
 				}
-				mockConfig.Config.ProtocolConverter[0].ProtocolConverterServiceConfig.Variables.User["UMH_TOPICS"] = []string{"umh.v1.factory.*"}
 				mockConfig.Config.ProtocolConverter[0].ProtocolConverterServiceConfig.ReadDFCDesiredState = "active"
 				mockConfig.Config.ProtocolConverter[0].ProtocolConverterServiceConfig.WriteDFCDesiredState = "active"
 
@@ -1026,7 +1038,7 @@ var _ = Describe("EditProtocolConverter", func() {
 				Expect(action2.GetDFCType()).To(Equal("read"))
 			})
 
-			It("should return DFCTypeWrite when UMH_TOPICS list differs from deployed", func() {
+			It("should return DFCTypeWrite when InputTopics differ from deployed", func() {
 				// First, deploy a write DFC with a known topic set.
 				firstWritePayload := map[string]interface{}{
 					"name": pcName,
@@ -1036,12 +1048,10 @@ var _ = Describe("EditProtocolConverter", func() {
 						"port": 80,
 					},
 					"writeDFC": map[string]interface{}{
-						"outputs": map[string]interface{}{
-							"data": "output:\n  stdout: {}",
-							"type": "stdout",
+						"output": map[string]interface{}{
+							"stdout": map[string]interface{}{},
 						},
-						"pipeline":   map[string]interface{}{},
-						"umh_topics": []interface{}{"umh.v1.factory.*"},
+						"input_topics": "umh.v1.factory.*",
 					},
 				}
 				firstAction := actions.NewEditProtocolConverterAction(userEmail, uuid.New(), instanceUUID, outboundChannel, mockConfig, nil)
@@ -1062,12 +1072,10 @@ var _ = Describe("EditProtocolConverter", func() {
 						"port": 80,
 					},
 					"writeDFC": map[string]interface{}{
-						"outputs": map[string]interface{}{
-							"data": "output:\n  stdout: {}",
-							"type": "stdout",
+						"output": map[string]interface{}{
+							"stdout": map[string]interface{}{},
 						},
-						"pipeline":   map[string]interface{}{},
-						"umh_topics": []interface{}{"umh.v1.plant.*"}, // different topic
+						"input_topics": "umh.v1.plant.*", // different topic
 					},
 				}
 				err = action2.Parse(payload)
@@ -1135,12 +1143,10 @@ var _ = Describe("EditProtocolConverter", func() {
 						Input: map[string]interface{}{"http_client": map[string]interface{}{"url": "http://old.example.com"}},
 					},
 				}
-				mockConfig.Config.ProtocolConverter[0].ProtocolConverterServiceConfig.Config.DataflowComponentWriteServiceConfig = dataflowcomponentserviceconfig.DataflowComponentServiceConfig{
-					BenthosConfig: dataflowcomponentserviceconfig.BenthosConfig{
-						Output: map[string]interface{}{"stdout": map[string]interface{}{}},
-					},
+				mockConfig.Config.ProtocolConverter[0].ProtocolConverterServiceConfig.Config.DataflowComponentWriteServiceConfig = dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
+					Output:      map[string]interface{}{"stdout": map[string]interface{}{}},
+					InputTopics: "umh.v1.factory.*",
 				}
-				mockConfig.Config.ProtocolConverter[0].ProtocolConverterServiceConfig.Variables.User["UMH_TOPICS"] = []string{"umh.v1.factory.*"}
 				mockConfig.Config.ProtocolConverter[0].ProtocolConverterServiceConfig.ReadDFCDesiredState = "active"
 				mockConfig.Config.ProtocolConverter[0].ProtocolConverterServiceConfig.WriteDFCDesiredState = "active"
 
@@ -1168,12 +1174,12 @@ var _ = Describe("EditProtocolConverter", func() {
 						},
 					},
 					"writeDFC": map[string]interface{}{
-						"outputs": map[string]interface{}{
-							"data": "output:\n  kafka:\n    addresses: [localhost:9092]",
-							"type": "kafka",
+						"output": map[string]interface{}{
+							"kafka": map[string]interface{}{
+								"addresses": []interface{}{"localhost:9092"},
+							},
 						},
-						"pipeline":   map[string]interface{}{},
-						"umh_topics": []interface{}{"umh.v1.plant.*"},
+						"input_topics": "umh.v1.plant.*",
 					},
 				}
 
@@ -1210,13 +1216,12 @@ var _ = Describe("EditProtocolConverter", func() {
 				Expect(readInput["input"]).To(HaveKey("http_client"))
 				Expect(readInput["input"].(map[string]interface{})["http_client"]).To(HaveKeyWithValue("url", "http://new.example.com"))
 
-				// Write DFC: parsed YAML wraps in outer "output" key
-				writeOutput := updatedPC.ProtocolConverterServiceConfig.Config.DataflowComponentWriteServiceConfig.BenthosConfig.Output
-				Expect(writeOutput).To(HaveKey("output"))
-				Expect(writeOutput["output"]).To(HaveKey("kafka"))
+				// Write DFC: new format stores directly without wrapper
+				writeOutput := updatedPC.ProtocolConverterServiceConfig.Config.DataflowComponentWriteServiceConfig.Output
+				Expect(writeOutput).To(HaveKey("kafka"))
 
-				// UMH_TOPICS updated
-				Expect(updatedPC.ProtocolConverterServiceConfig.Variables.User["UMH_TOPICS"]).To(ConsistOf("umh.v1.plant.*"))
+				// InputTopics updated
+				Expect(updatedPC.ProtocolConverterServiceConfig.Config.DataflowComponentWriteServiceConfig.InputTopics).To(Equal("umh.v1.plant.*"))
 			})
 		})
 
@@ -1298,11 +1303,9 @@ var _ = Describe("EditProtocolConverter", func() {
 
 			It("should complete when write DFC has reached the stopped state", Label("disable-bridges"), func() {
 				mockConfig.Config.ProtocolConverter[0].ProtocolConverterServiceConfig.WriteDFCDesiredState = "active"
-				mockConfig.Config.ProtocolConverter[0].ProtocolConverterServiceConfig.Variables.User["UMH_TOPICS"] = []string{"umh.v1.factory.*"}
-				mockConfig.Config.ProtocolConverter[0].ProtocolConverterServiceConfig.Config.DataflowComponentWriteServiceConfig = dataflowcomponentserviceconfig.DataflowComponentServiceConfig{
-					BenthosConfig: dataflowcomponentserviceconfig.BenthosConfig{
-						Output: map[string]interface{}{"stdout": map[string]interface{}{}},
-					},
+				mockConfig.Config.ProtocolConverter[0].ProtocolConverterServiceConfig.Config.DataflowComponentWriteServiceConfig = dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
+					Output:      map[string]interface{}{"stdout": map[string]interface{}{}},
+					InputTopics: "umh.v1.factory.*",
 				}
 
 				snapshotMgr := fsm.NewSnapshotManager()

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter_test.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter_test.go
@@ -1082,6 +1082,88 @@ var _ = Describe("EditProtocolConverter", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(action2.GetDFCType()).To(Equal("write"))
 			})
+
+			It("should return DFCTypeBoth when a custom template variable changes", Label("write-dfc"), func() {
+				// First edit: deploy read + write with a custom template variable.
+				firstPayload := map[string]interface{}{
+					"name": pcName,
+					"uuid": pcUUID.String(),
+					"connection": map[string]interface{}{
+						"ip":   "10.0.0.1",
+						"port": 502,
+					},
+					"templateInfo": map[string]interface{}{
+						"variables": []interface{}{
+							map[string]interface{}{"label": "baudRate", "value": "9600"},
+						},
+					},
+					"readDFC": map[string]interface{}{
+						"inputs": map[string]interface{}{
+							"data": "input:\n  http_client:\n    url: 'http://{{ .baudRate }}'",
+							"type": "http_client",
+						},
+						"pipeline": map[string]interface{}{
+							"processors": map[string]interface{}{
+								"0": map[string]interface{}{
+									"type": "bloblang",
+									"data": "bloblang: root = content()",
+								},
+							},
+						},
+						"state": "active",
+					},
+					"writeDFC": map[string]interface{}{
+						"output":       map[string]interface{}{"stdout": map[string]interface{}{}},
+						"input_topics": "umh.v1.factory.*",
+					},
+				}
+				firstAction := actions.NewEditProtocolConverterAction(userEmail, uuid.New(), instanceUUID, outboundChannel, mockConfig, nil)
+				err := firstAction.Parse(firstPayload)
+				Expect(err).NotTo(HaveOccurred())
+				err = firstAction.Validate()
+				Expect(err).NotTo(HaveOccurred())
+				_, _, err = firstAction.Execute()
+				Expect(err).NotTo(HaveOccurred())
+
+				// Second edit: change only baudRate — DFC config text is identical.
+				action2 := actions.NewEditProtocolConverterAction(userEmail, uuid.New(), instanceUUID, outboundChannel, mockConfig, nil)
+				payload := map[string]interface{}{
+					"name": pcName,
+					"uuid": pcUUID.String(),
+					"connection": map[string]interface{}{
+						"ip":   "10.0.0.1",
+						"port": 502,
+					},
+					"templateInfo": map[string]interface{}{
+						"variables": []interface{}{
+							map[string]interface{}{"label": "baudRate", "value": "19200"}, // changed
+						},
+					},
+					"readDFC": map[string]interface{}{
+						"inputs": map[string]interface{}{
+							"data": "input:\n  http_client:\n    url: 'http://{{ .baudRate }}'",
+							"type": "http_client",
+						},
+						"pipeline": map[string]interface{}{
+							"processors": map[string]interface{}{
+								"0": map[string]interface{}{
+									"type": "bloblang",
+									"data": "bloblang: root = content()",
+								},
+							},
+						},
+						"state": "active",
+					},
+					"writeDFC": map[string]interface{}{
+						"output":       map[string]interface{}{"stdout": map[string]interface{}{}},
+						"input_topics": "umh.v1.factory.*",
+					},
+				}
+				err = action2.Parse(payload)
+				Expect(err).NotTo(HaveOccurred())
+				// baudRate changed → both DFCs need redeploy even though DFC config text is identical.
+				Expect(action2.GetDFCType()).To(Equal("both"))
+			})
 		})
 
 		Context("DFCTypeEmpty edit preserves per-DFC stopped states", func() {

--- a/umh-core/pkg/communicator/actions/get-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/get-protocolconverter.go
@@ -64,6 +64,15 @@ import (
 	"go.uber.org/zap"
 )
 
+// systemInjectedVarKeys are Variables.User keys that deploy/edit always write regardless
+// of whether the PC was created from a user-defined template. They are excluded from the
+// variables list returned to the frontend and do not count toward isTemplated.
+var systemInjectedVarKeys = map[string]bool{
+	"IP": true, "ip": true, "target": true, "Target": true,
+	"PORT": true, "Port": true, "port": true,
+	"location": true, "location_path": true,
+}
+
 // GetProtocolConverterAction returns metadata and Benthos configuration for the
 // requested Protocol Converter **UUID**.  The action never blocks the FSM
 // writer goroutine – instead it holds the read‑lock only while making a deep
@@ -190,12 +199,15 @@ func connectionInfoFromSpec(
 		isTemplated bool
 	)
 
+	// hasConnectionVars tracks whether Variables.User contains IP/PORT so we know
+	// whether to fall back to the Nmap template for connection info.
+	hasConnectionVars := false
 	for key, value := range spec.Variables.User {
-		variables = append(variables, models.ProtocolConverterVariable{Label: key, Value: value})
 		valueStr := fmt.Sprintf("%v", value)
 		switch key {
 		case "IP", "ip", "target", "Target":
 			ip = valueStr
+			hasConnectionVars = true
 		case "Port", "port", "PORT":
 			if n, err := strconv.ParseUint(valueStr, 10, 32); err == nil {
 				port = uint32(n)
@@ -203,10 +215,16 @@ func connectionInfoFromSpec(
 				logger.Warnw("Failed to parse port from variable", "port", valueStr, "error", err)
 			}
 		}
+		// Only include user-defined (non-system) variables in the returned list.
+		if !systemInjectedVarKeys[key] {
+			variables = append(variables, models.ProtocolConverterVariable{Label: key, Value: value})
+		}
 	}
+	// isTemplated is true only when the PC has custom variables beyond the system-injected ones.
+	// IP and PORT alone do not make a PC "templated" — they are always present.
 	isTemplated = len(variables) > 0
 
-	if !isTemplated {
+	if !hasConnectionVars {
 		if nmap := spec.Config.ConnectionServiceConfig.NmapTemplate; nmap != nil {
 			ip = nmap.Target
 			if nmap.Port != "" {
@@ -228,9 +246,12 @@ func connectionInfoFromSpec(
 }
 
 // writeDFCFromSpec builds a WriteDFC from the raw spec config (as stored
-// in config.yaml). Returns nil when no output is configured (write DFC not deployed).
+// in config.yaml). Returns nil only when no output is configured AND no desired state
+// is set — i.e. the write DFC was never configured at all. A write DFC with a desired
+// state (e.g. "stopped") but no output is still a meaningful configuration: the
+// frontend must see the state to render the enable/disable toggle correctly.
 func writeDFCFromSpec(specWrite dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput, state string) *models.WriteDFCPayload {
-	if !specWrite.HasOutput() {
+	if !specWrite.HasOutput() && state == "" {
 		return nil
 	}
 	return &models.WriteDFCPayload{

--- a/umh-core/pkg/communicator/actions/get-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/get-protocolconverter.go
@@ -215,14 +215,16 @@ func connectionInfoFromSpec(
 				logger.Warnw("Failed to parse port from variable", "port", valueStr, "error", err)
 			}
 		}
-		// Only include user-defined (non-system) variables in the returned list.
-		if !systemInjectedVarKeys[key] {
-			variables = append(variables, models.ProtocolConverterVariable{Label: key, Value: value})
-		}
+		variables = append(variables, models.ProtocolConverterVariable{Label: key, Value: value})
 	}
 	// isTemplated is true only when the PC has custom variables beyond the system-injected ones.
 	// IP and PORT alone do not make a PC "templated" — they are always present.
-	isTemplated = len(variables) > 0
+	for _, v := range variables {
+		if !systemInjectedVarKeys[v.Label] {
+			isTemplated = true
+			break
+		}
+	}
 
 	if !hasConnectionVars {
 		if nmap := spec.Config.ConnectionServiceConfig.NmapTemplate; nmap != nil {

--- a/umh-core/pkg/communicator/actions/get-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/get-protocolconverter.go
@@ -55,6 +55,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/dataflowcomponentserviceconfig"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/protocolconverterserviceconfig"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/protocolconverter"
@@ -114,7 +115,9 @@ func NewGetProtocolConverterAction(userEmail string, actionUUID uuid.UUID, insta
 func (a *GetProtocolConverterAction) Parse(payload interface{}) (err error) {
 	a.actionLogger.Info("Parsing the payload")
 	a.payload, err = ParseActionPayload[models.GetProtocolConverterPayload](payload)
-	a.actionLogger.Info("Payload parsed, uuid: ", a.payload.UUID)
+	if err == nil {
+		a.actionLogger.Info("Payload parsed, uuid: ", a.payload.UUID)
+	}
 
 	return err
 }
@@ -173,6 +176,67 @@ func determineProtocol(readDFC *models.ProtocolConverterDFC) string {
 	input := readDFC.Inputs
 
 	return input.Type
+}
+
+// connectionInfoFromSpec extracts IP, port, and template metadata from a
+// ProtocolConverterServiceConfigSpec. Variables.User is the primary source; if
+// it is empty the Nmap connection template is used as a fallback for non-templated PCs.
+func connectionInfoFromSpec(
+	spec protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec,
+	logger *zap.SugaredLogger,
+) (ip string, port uint32, templateInfo *models.ProtocolConverterTemplateInfo) {
+	var (
+		variables   []models.ProtocolConverterVariable
+		isTemplated bool
+	)
+
+	for key, value := range spec.Variables.User {
+		variables = append(variables, models.ProtocolConverterVariable{Label: key, Value: value})
+		valueStr := fmt.Sprintf("%v", value)
+		switch key {
+		case "IP", "ip", "target", "Target":
+			ip = valueStr
+		case "Port", "port", "PORT":
+			if n, err := strconv.ParseUint(valueStr, 10, 32); err == nil {
+				port = uint32(n)
+			} else {
+				logger.Warnw("Failed to parse port from variable", "port", valueStr, "error", err)
+			}
+		}
+	}
+	isTemplated = len(variables) > 0
+
+	if !isTemplated {
+		if nmap := spec.Config.ConnectionServiceConfig.NmapTemplate; nmap != nil {
+			ip = nmap.Target
+			if nmap.Port != "" {
+				if n, err := strconv.ParseUint(nmap.Port, 10, 32); err == nil {
+					port = uint32(n)
+				} else {
+					logger.Warnw("Failed to parse port number", "port", nmap.Port, "error", err)
+				}
+			}
+		}
+	}
+
+	templateInfo = &models.ProtocolConverterTemplateInfo{
+		IsTemplated: isTemplated,
+		Variables:   variables,
+		RootUUID:    uuid.Nil,
+	}
+	return
+}
+
+// writeDFCResponseFromSpec builds a WriteDFCResponse from the raw spec config (as stored
+// in config.yaml). Returns nil when no output is configured (write DFC not deployed).
+func writeDFCResponseFromSpec(specWrite dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput, state string) *models.WriteDFCResponse {
+	if !specWrite.HasOutput() {
+		return nil
+	}
+	return &models.WriteDFCResponse{
+		DataflowComponentWriteConfigInput: specWrite,
+		State:                             state,
+	}
 }
 
 // buildProtocolConverterDFCFromConfig converts a dataflow component service config
@@ -244,88 +308,21 @@ func (a *GetProtocolConverterAction) Execute() (interface{}, map[string]interfac
 					return nil, nil, fmt.Errorf("no observed state found for protocol converter %s", instance.ID)
 				}
 
-				// Extract template information and variables from the observed spec config
-				var (
-					templateInfo *models.ProtocolConverterTemplateInfo
-					ip           string
-					port         uint32
-					variables    []models.ProtocolConverterVariable
-					isTemplated  bool
-				)
-
-				// Extract variables from observed spec config
+				// Get IP, port, and template info from observed, rendered spec config
 				specConfig := observedState.ObservedProtocolConverterSpecConfig
-				if specConfig.Variables.User != nil {
-					for key, value := range specConfig.Variables.User {
-						// TODO(ENG-4856): This filter exists because UMH_TOPICS is stored in
-						// Variables.User alongside real user template variables. A typed field
-						// would not need filtering here. Remove once UMH_TOPICS moves to a
-						// typed config block in the FSMv2 bridge migration.
-						// UMH_TOPICS is an internal write-DFC field, not a user-editable
-						// template variable. It is returned via writeDFC.UMHTopics instead.
-						if key == "UMH_TOPICS" {
-							continue
-						}
+				ip, port, templateInfo := connectionInfoFromSpec(specConfig, a.actionLogger)
 
-						variables = append(variables, models.ProtocolConverterVariable{
-							Label: key,
-							Value: value,
-						})
-
-						// Extract IP and Port from variables (convert to string for connection info)
-						valueStr := fmt.Sprintf("%v", value)
-
-						switch key {
-						case "IP", "ip", "target", "Target":
-							ip = valueStr
-						case "Port", "port", "PORT":
-							if portInt, err := strconv.ParseUint(valueStr, 10, 32); err == nil {
-								port = uint32(portInt)
-							} else {
-								a.actionLogger.Warnw("Failed to parse port from variable", "port", valueStr, "error", err)
-							}
-						}
-					}
-
-					isTemplated = len(variables) > 0
-				}
-
-				// If no variables found, check template config for non-templated values
-				if !isTemplated {
-					if specConfig.Config.ConnectionServiceConfig.NmapTemplate != nil {
-						if specConfig.Config.ConnectionServiceConfig.NmapTemplate.Target != "" {
-							ip = specConfig.Config.ConnectionServiceConfig.NmapTemplate.Target
-						}
-
-						if specConfig.Config.ConnectionServiceConfig.NmapTemplate.Port != "" {
-							if portInt, err := strconv.ParseUint(specConfig.Config.ConnectionServiceConfig.NmapTemplate.Port, 10, 32); err == nil {
-								port = uint32(portInt)
-							} else {
-								a.actionLogger.Warnw("Failed to parse port number", "port", specConfig.Config.ConnectionServiceConfig.NmapTemplate.Port, "error", err)
-							}
-						}
-					}
-				}
-
-				// Create template info
-				templateInfo = &models.ProtocolConverterTemplateInfo{
-					IsTemplated: isTemplated,
-					Variables:   variables,
-					RootUUID:    uuid.Nil, // For now, we don't have a root UUID concept
-				}
-
-				// Build ReadDFC if present
+				// Build ReadDFC from observed, rendered spec config, if present
 				var readDFC *models.ProtocolConverterDFC
-
 				if readDFCConfig := specConfig.Config.DataflowComponentReadServiceConfig; len(readDFCConfig.BenthosConfig.Input) > 0 {
 					var err error
 
 					readDFC, err = buildProtocolConverterDFCFromConfig(readDFCConfig, a)
 					if err != nil {
-						a.actionLogger.Warnf("Failed to build read DFC: %v", err)
-						SendActionReply(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionExecuting,
-							fmt.Sprintf("Warning: Failed to build read DFC for protocol converter '%s': %v", instance.ID, err),
-							a.outboundChannel, models.GetProtocolConverter)
+						errMsg := fmt.Sprintf("Failed to build read DFC for protocol converter '%s': %v", instance.ID, err)
+						SendActionReply(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedWithFailure,
+							errMsg, a.outboundChannel, models.GetProtocolConverter)
+						return nil, nil, fmt.Errorf("%s", errMsg)
 					}
 
 					if readDFC != nil {
@@ -333,35 +330,17 @@ func (a *GetProtocolConverterAction) Execute() (interface{}, map[string]interfac
 					}
 				}
 
-				// Build WriteDFC if present (check output since input is auto-generated)
-				var writeDFC *models.ProtocolConverterDFC
+				// Build WriteDFC from the raw spec config (as stored in config.yaml, non-rendered).
+				writeDFC := writeDFCResponseFromSpec(specConfig.Config.DataflowComponentWriteServiceConfig, specConfig.WriteDFCDesiredState)
 
-				if writeDFCConfig := specConfig.Config.DataflowComponentWriteServiceConfig; len(writeDFCConfig.BenthosConfig.Output) > 0 {
-					var err error
-
-					writeDFC, err = buildProtocolConverterDFCFromConfig(writeDFCConfig, a)
-					if err != nil {
-						a.actionLogger.Warnf("Failed to build write DFC: %v", err)
-						SendActionReply(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionExecuting,
-							fmt.Sprintf("Warning: Failed to build write DFC for protocol converter '%s': %v", instance.ID, err),
-							a.outboundChannel, models.GetProtocolConverter)
-					}
-
-					if writeDFC != nil {
-						writeDFC.State = specConfig.WriteDFCDesiredState
-						// Populate UMHTopics from user variables for the frontend
-						if umhTopics, ok := specConfig.Variables.User["UMH_TOPICS"]; ok {
-							if topics, ok := toStringSlice(umhTopics); ok {
-								writeDFC.UMHTopics = topics
-							}
-						}
-					}
+				// Create meta information
+				meta := &models.ProtocolConverterMeta{
+					ProcessingMode: determineProcessingMode(readDFC),
+					Protocol:       determineProtocol(readDFC),
 				}
 
-				// Location is stored in the config spec
-				location := make(map[int]string)
-
 				// Extract location from observed spec config
+				location := make(map[int]string)
 				if len(specConfig.Location) > 0 {
 					for k, v := range specConfig.Location {
 						var intKey int
@@ -369,12 +348,6 @@ func (a *GetProtocolConverterAction) Execute() (interface{}, map[string]interfac
 							location[intKey] = v
 						}
 					}
-				}
-
-				// Create meta information
-				meta := &models.ProtocolConverterMeta{
-					ProcessingMode: determineProcessingMode(readDFC),
-					Protocol:       determineProtocol(readDFC),
 				}
 
 				// Build the response

--- a/umh-core/pkg/communicator/actions/get-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/get-protocolconverter.go
@@ -227,13 +227,13 @@ func connectionInfoFromSpec(
 	return
 }
 
-// writeDFCResponseFromSpec builds a WriteDFCResponse from the raw spec config (as stored
+// writeDFCFromSpec builds a WriteDFC from the raw spec config (as stored
 // in config.yaml). Returns nil when no output is configured (write DFC not deployed).
-func writeDFCResponseFromSpec(specWrite dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput, state string) *models.WriteDFCResponse {
+func writeDFCFromSpec(specWrite dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput, state string) *models.WriteDFCPayload {
 	if !specWrite.HasOutput() {
 		return nil
 	}
-	return &models.WriteDFCResponse{
+	return &models.WriteDFCPayload{
 		DataflowComponentWriteConfigInput: specWrite,
 		State:                             state,
 	}
@@ -331,7 +331,7 @@ func (a *GetProtocolConverterAction) Execute() (interface{}, map[string]interfac
 				}
 
 				// Build WriteDFC from the raw spec config (as stored in config.yaml, non-rendered).
-				writeDFC := writeDFCResponseFromSpec(specConfig.Config.DataflowComponentWriteServiceConfig, specConfig.WriteDFCDesiredState)
+				writeDFC := writeDFCFromSpec(specConfig.Config.DataflowComponentWriteServiceConfig, specConfig.WriteDFCDesiredState)
 
 				// Create meta information
 				meta := &models.ProtocolConverterMeta{
@@ -359,10 +359,10 @@ func (a *GetProtocolConverterAction) Execute() (interface{}, map[string]interfac
 						IP:   ip,
 						Port: port,
 					},
-					ReadDFC:      readDFC,
-					WriteDFC:     writeDFC,
-					Meta:         meta,
-					TemplateInfo: templateInfo,
+					ReadDFC:         readDFC,
+					WriteDFCPayload: writeDFC,
+					Meta:            meta,
+					TemplateInfo:    templateInfo,
 				}
 
 				a.actionLogger.Info("Protocol converter found and built, returning response")

--- a/umh-core/pkg/communicator/actions/get-protocolconverter_test.go
+++ b/umh-core/pkg/communicator/actions/get-protocolconverter_test.go
@@ -289,7 +289,7 @@ var _ = Describe("GetProtocolConverter", func() {
 
 				// Verify write DFC is populated with InputTopics
 				Expect(response.WriteDFCPayload).NotTo(BeNil())
-				Expect(response.WriteDFCPayload.InputTopics).To(Equal([]string{"umh.v1.factory.line-1.*"}))
+				Expect(response.WriteDFCPayload.InputTopics).To(Equal("umh.v1.factory.line-1.*"))
 
 				// Verify meta information
 				Expect(response.Meta).NotTo(BeNil())

--- a/umh-core/pkg/communicator/actions/get-protocolconverter_test.go
+++ b/umh-core/pkg/communicator/actions/get-protocolconverter_test.go
@@ -288,8 +288,8 @@ var _ = Describe("GetProtocolConverter", func() {
 				Expect(response.ReadDFC.Inputs.Type).To(Equal("modbus"))
 
 				// Verify write DFC is populated with InputTopics
-				Expect(response.WriteDFC).NotTo(BeNil())
-				Expect(response.WriteDFC.InputTopics).To(Equal([]string{"umh.v1.factory.line-1.*"}))
+				Expect(response.WriteDFCPayload).NotTo(BeNil())
+				Expect(response.WriteDFCPayload.InputTopics).To(Equal([]string{"umh.v1.factory.line-1.*"}))
 
 				// Verify meta information
 				Expect(response.Meta).NotTo(BeNil())
@@ -382,7 +382,7 @@ var _ = Describe("GetProtocolConverter", func() {
 
 				// Verify DFC configs are nil for uninitialized protocol converter
 				Expect(response.ReadDFC).To(BeNil())
-				Expect(response.WriteDFC).To(BeNil())
+				Expect(response.WriteDFCPayload).To(BeNil())
 
 				// Verify meta information reflects uninitialized state
 				Expect(response.Meta).NotTo(BeNil())

--- a/umh-core/pkg/communicator/actions/get-protocolconverter_test.go
+++ b/umh-core/pkg/communicator/actions/get-protocolconverter_test.go
@@ -69,10 +69,6 @@ var _ = Describe("GetProtocolConverter", func() {
 
 	// Cleanup after each test
 	AfterEach(func() {
-		// Drain the outbound channel to prevent goroutine leaks
-		for len(outboundChannel) > 0 {
-			<-outboundChannel
-		}
 		close(outboundChannel)
 	})
 
@@ -144,6 +140,25 @@ var _ = Describe("GetProtocolConverter", func() {
 
 				// Create observed state with populated DFC configs
 				observedState := &protocolconverter.ProtocolConverterObservedStateSnapshot{
+					// Runtime config holds the fully-rendered Benthos configs (what is actually deployed).
+					ObservedProtocolConverterRuntimeConfig: protocolconverterserviceconfig.ProtocolConverterServiceConfigRuntime{
+						DataflowComponentWriteServiceConfig: dataflowcomponentserviceconfig.DataflowComponentServiceConfig{
+							BenthosConfig: dataflowcomponentserviceconfig.BenthosConfig{
+								Input: map[string]interface{}{
+									"uns": map[string]interface{}{
+										"consumer_group": "unimplemented",
+										"umh_topics":     []interface{}{"umh.v1.factory.line-1.*"},
+									},
+								},
+								Output: map[string]interface{}{
+									"stdout": map[string]interface{}{},
+								},
+								Pipeline: map[string]interface{}{
+									"processors": []interface{}{},
+								},
+							},
+						},
+					},
 					ObservedProtocolConverterSpecConfig: protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec{
 						Config: protocolconverterserviceconfig.ProtocolConverterServiceConfigTemplate{
 							ConnectionServiceConfig: connectionserviceconfig.ConnectionServiceConfigTemplate{
@@ -161,19 +176,17 @@ var _ = Describe("GetProtocolConverter", func() {
 									},
 								},
 							},
-							DataflowComponentWriteServiceConfig: dataflowcomponentserviceconfig.DataflowComponentServiceConfig{
-								BenthosConfig: dataflowcomponentserviceconfig.BenthosConfig{
-									Output: map[string]interface{}{
-										"stdout": map[string]interface{}{},
-									},
+							DataflowComponentWriteServiceConfig: dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
+								Output: map[string]interface{}{
+									"stdout": map[string]interface{}{},
 								},
+								InputTopics: "umh.v1.factory.line-1.*",
 							},
 						},
 						Variables: variables.VariableBundle{
 							User: map[string]interface{}{
-								"IP":        "192.168.1.100",
-								"PORT":      "502",
-								"UMH_TOPICS": []string{"umh.v1.factory.line-1.*"},
+								"IP":   "192.168.1.100",
+								"PORT": "502",
 							},
 						},
 						Location: map[string]string{
@@ -274,9 +287,9 @@ var _ = Describe("GetProtocolConverter", func() {
 				Expect(response.ReadDFC).NotTo(BeNil())
 				Expect(response.ReadDFC.Inputs.Type).To(Equal("modbus"))
 
-				// Verify write DFC is populated with UMH_TOPICS from user variables
+				// Verify write DFC is populated with InputTopics
 				Expect(response.WriteDFC).NotTo(BeNil())
-				Expect(response.WriteDFC.UMHTopics).To(Equal([]string{"umh.v1.factory.line-1.*"}))
+				Expect(response.WriteDFC.InputTopics).To(Equal([]string{"umh.v1.factory.line-1.*"}))
 
 				// Verify meta information
 				Expect(response.Meta).NotTo(BeNil())

--- a/umh-core/pkg/communicator/actions/protocolconverter_helpers.go
+++ b/umh-core/pkg/communicator/actions/protocolconverter_helpers.go
@@ -1,0 +1,168 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package actions
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/benthosserviceconfig"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/connectionserviceconfig"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/dataflowcomponentserviceconfig"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/models"
+)
+
+// buildUserScope constructs the template rendering scope from a ProtocolConverter's
+// TemplateInfo. Returns an empty map when templateInfo is nil.
+func buildUserScope(templateInfo *models.ProtocolConverterTemplateInfo) map[string]any {
+	if templateInfo == nil {
+		return map[string]any{}
+	}
+	scope := make(map[string]any, len(templateInfo.Variables))
+	for _, v := range templateInfo.Variables {
+		scope[v.Label] = v.Value
+	}
+	return scope
+}
+
+// validateWriteDFCConfig validates a raw write DFC config input and its desired state.
+func validateWriteDFCConfig(cfg *dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput, state string) error {
+	if cfg != nil && cfg.HasOutput() && strings.TrimSpace(cfg.InputTopics) == "" {
+		return errors.New("write DFC requires at least one input topic (input_topics)")
+	}
+	if state != "" {
+		if err := ValidateDataFlowComponentState(state); err != nil {
+			return fmt.Errorf("invalid write DFC state: %w", err)
+		}
+	}
+	return nil
+}
+
+
+// validateReadProtocolConverterDFC validates a read ProtocolConverterDFC's state and configuration.
+// Returns nil if dfc is nil (nothing to validate).
+func validateReadProtocolConverterDFC(dfc *models.ProtocolConverterDFC) error {
+	if dfc == nil {
+		return nil
+	}
+	if dfc.State != "" {
+		if err := ValidateDataFlowComponentState(dfc.State); err != nil {
+			return fmt.Errorf("invalid read DFC state: %w", err)
+		}
+	}
+	payload := dfcToPayload(dfc)
+	if err := ValidateCustomDataFlowComponentPayload(payload, true, false); err != nil {
+		return fmt.Errorf("invalid read DFC configuration: %w", err)
+	}
+	return nil
+}
+
+// newIPPortConnectionTemplate returns the standard {{ .IP }}/{{ .PORT }} Nmap connection template
+// used by all protocol converters.
+func newIPPortConnectionTemplate() connectionserviceconfig.ConnectionServiceConfigTemplate {
+	return connectionserviceconfig.ConnectionServiceConfigTemplate{
+		NmapTemplate: &connectionserviceconfig.NmapConfigTemplate{
+			Target: "{{ .IP }}",
+			Port:   "{{ .PORT }}",
+		},
+	}
+}
+
+// buildReadDFCServiceConfig validates a CDFCPayload and converts it into a
+// DataflowComponentServiceConfig ready to be stored in a ProtocolConverterServiceConfigTemplate.
+func buildReadDFCServiceConfig(payload models.CDFCPayload, name string) (dataflowcomponentserviceconfig.DataflowComponentServiceConfig, error) {
+	if err := ValidateCustomDataFlowComponentPayload(payload, true, false); err != nil {
+		return dataflowcomponentserviceconfig.DataflowComponentServiceConfig{}, fmt.Errorf("invalid read DFC configuration: %w", err)
+	}
+	benthos, err := CreateBenthosConfigFromCDFCPayload(payload, name)
+	if err != nil {
+		return dataflowcomponentserviceconfig.DataflowComponentServiceConfig{}, fmt.Errorf("failed to create read DFC benthos config: %w", err)
+	}
+	return dataflowcomponentserviceconfig.DataflowComponentServiceConfig{BenthosConfig: benthos}, nil
+}
+
+// convertIntMapToStringMap converts map[int]string to map[string]string.
+func convertIntMapToStringMap(intMap map[int]string) map[string]string {
+	if intMap == nil {
+		return nil
+	}
+	result := make(map[string]string, len(intMap))
+	for k, v := range intMap {
+		result[strconv.Itoa(k)] = v
+	}
+	return result
+}
+
+// dfcToPayload converts a ProtocolConverterDFC to the internal CDFCPayload representation.
+func dfcToPayload(dfc *models.ProtocolConverterDFC) models.CDFCPayload {
+	return models.CDFCPayload{
+		Inputs:   models.DfcDataConfig{Data: dfc.Inputs.Data, Type: dfc.Inputs.Type},
+		Pipeline: convertPipelineToMap(dfc.Pipeline),
+		Outputs:  models.DfcDataConfig{Data: dfc.Outputs.Data, Type: dfc.Outputs.Type},
+		Inject:   extractInjectFromRawYAML(dfc.RawYAML),
+	}
+}
+
+// convertPipelineToMap converts CommonDataFlowComponentPipelineConfig to map[string]DfcDataConfig.
+func convertPipelineToMap(pipeline models.CommonDataFlowComponentPipelineConfig) map[string]models.DfcDataConfig {
+	result := make(map[string]models.DfcDataConfig)
+	for key, processor := range pipeline.Processors {
+		result[key] = models.DfcDataConfig{
+			Data: processor.Data,
+			Type: processor.Type,
+		}
+	}
+	return result
+}
+
+// extractInjectFromRawYAML extracts the inject data from the RawYAML field to support
+// CacheResources, RateLimitResources, and Buffer in protocol converter DFCs.
+func extractInjectFromRawYAML(rawYAML *models.CommonDataFlowComponentRawYamlConfig) string {
+	if rawYAML == nil {
+		return ""
+	}
+	return rawYAML.Data
+}
+
+// observedBenthosToServiceConfig converts an observed BenthosServiceConfig to a
+// DataflowComponentServiceConfig for comparison with the desired config.
+func observedBenthosToServiceConfig(obs benthosserviceconfig.BenthosServiceConfig) dataflowcomponentserviceconfig.DataflowComponentServiceConfig {
+	return dataflowcomponentserviceconfig.DataflowComponentServiceConfig{
+		BenthosConfig: dataflowcomponentserviceconfig.BenthosConfig{
+			Input:              obs.Input,
+			Pipeline:           obs.Pipeline,
+			Output:             obs.Output,
+			CacheResources:     obs.CacheResources,
+			RateLimitResources: obs.RateLimitResources,
+			Buffer:             obs.Buffer,
+		},
+	}
+}
+
+// dfcTypeFromPresence returns a DFCType based on boolean flags for read/write presence.
+func dfcTypeFromPresence(read, write bool) DFCType {
+	switch {
+	case read && write:
+		return DFCTypeBoth
+	case read:
+		return DFCTypeRead
+	case write:
+		return DFCTypeWrite
+	default:
+		return DFCTypeEmpty
+	}
+}

--- a/umh-core/pkg/communicator/actions/protocolconverter_helpers.go
+++ b/umh-core/pkg/communicator/actions/protocolconverter_helpers.go
@@ -41,8 +41,10 @@ func buildUserScope(templateInfo *models.ProtocolConverterTemplateInfo) map[stri
 
 // validateWriteDFCConfig validates a raw write DFC config input and its desired state.
 func validateWriteDFCConfig(cfg *dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput, state string) error {
-	if cfg != nil && cfg.HasOutput() && strings.TrimSpace(cfg.InputTopics) == "" {
-		return errors.New("write DFC requires at least one input topic (input_topics)")
+	if cfg != nil && cfg.HasOutput() {
+		if strings.TrimSpace(cfg.InputTopics) == "" {
+			return errors.New("write DFC requires at least one input topic (input_topics)")
+		}
 	}
 	if state != "" {
 		if err := ValidateDataFlowComponentState(state); err != nil {

--- a/umh-core/pkg/communicator/actions/providers/metrics_provider.go
+++ b/umh-core/pkg/communicator/actions/providers/metrics_provider.go
@@ -453,7 +453,7 @@ func getProtocolConverterMetrics(uuid string, snapshot fsm.SystemSnapshot) (mode
 	// Extract benthos metrics from the write DFC only if a write DFC is configured.
 	// Without this guard, read-only protocol converters would emit 22 zero-value write metrics,
 	// making it impossible for the frontend to distinguish "no write DFC" from "idle write DFC".
-	if len(observedState.ObservedProtocolConverterSpecConfig.Config.DataflowComponentWriteServiceConfig.BenthosConfig.Output) == 0 {
+	if !observedState.ObservedProtocolConverterSpecConfig.Config.DataflowComponentWriteServiceConfig.HasOutput() {
 		return res, nil
 	}
 

--- a/umh-core/pkg/config/dataflowcomponentserviceconfig/write_config.go
+++ b/umh-core/pkg/config/dataflowcomponentserviceconfig/write_config.go
@@ -1,0 +1,215 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dataflowcomponentserviceconfig
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"text/template"
+)
+
+// DataflowComponentWriteConfig is the typed, validated configuration for write-side DFCs.
+// It replaces the generic DataflowComponentServiceConfig for write flows, making the
+// nodered_js processor and UNS topics first-class typed fields instead of free-form maps.
+//
+// This struct is the internal typed form used for FSM deployment. The frontend wire format
+// (WriteDFCResponse/WriteDFCRequest) embeds DataflowComponentWriteConfigInput so that
+// InputTopics remains a raw string (preserving template actions for round-trip fidelity).
+//
+// YAML / JSON shape:
+//
+//	input_topics:
+//	  - umh.v1.enterprise.site.line.device.*
+//	  - umh.v1.enterprise.site.line.otherDevice.*
+//	processing_nodered_js: |-
+//	  msg.payload["field"] = "value";
+//	  return msg;
+//	output:
+//	  http_client:
+//	    url: http://{{ .IP }}:{{ .PORT }}/post
+//	    verb: POST
+//	buffer:
+//	  none: {}
+type DataflowComponentWriteConfig struct {
+	// InputTopics lists the UNS topics this write DFC subscribes to.
+	InputTopics []string `yaml:"input_topics,omitempty" json:"input_topics,omitempty" mapstructure:"input_topics,omitempty"`
+
+	// ProcessingNoderedJS is the Node-RED JS snippet that transforms each message.
+	// Must end with "return msg;" (or "return null;" to drop the message).
+	// Defaults to "return msg;" when empty.
+	ProcessingNoderedJS string `yaml:"processing_nodered_js,omitempty" json:"processing_nodered_js,omitempty" mapstructure:"processing_nodered_js,omitempty"`
+
+	// Output is the Benthos output configuration (e.g. http_client, mqtt).
+	// When non-empty, a UNS input is automatically generated during rendering.
+	Output map[string]any `yaml:"output,omitempty" json:"output,omitempty" mapstructure:"output,omitempty"`
+
+	// Buffer is the optional Benthos buffer configuration.
+	Buffer map[string]any `yaml:"buffer,omitempty" json:"buffer,omitempty" mapstructure:"buffer,omitempty"`
+}
+
+// DataflowComponentWriteConfigInput is the wire/input form of write DFC config.
+// InputTopics is a single string that may contain Go text/template actions
+// (e.g. "{{- range .topics }}{{ . }}\n{{ end }}") or a plain newline-/comma-separated
+// topic list. It is rendered with user-supplied variables at action time and
+// converted to the typed DataflowComponentWriteConfig before being stored.
+type DataflowComponentWriteConfigInput struct {
+	// InputTopics is either a plain topic list (newline- or comma-separated)
+	// or a Go template string that renders to such a list.
+	InputTopics         string         `yaml:"input_topics,omitempty"          json:"input_topics,omitempty"`
+	ProcessingNoderedJS string         `yaml:"processing_nodered_js,omitempty" json:"processing_nodered_js,omitempty"`
+	Output              map[string]any `yaml:"output,omitempty"                json:"output,omitempty"`
+	Buffer              map[string]any `yaml:"buffer,omitempty"                json:"buffer,omitempty"`
+}
+
+// HasOutput reports whether a write output is configured.
+func (c DataflowComponentWriteConfigInput) HasOutput() bool {
+	return len(c.Output) > 0
+}
+
+// ToWriteConfig converts the input to a typed DataflowComponentWriteConfig by splitting
+// InputTopics on newlines/commas without any template rendering. Use this when the
+// InputTopics string is already fully resolved (e.g. structural conversions, GET responses).
+func (c DataflowComponentWriteConfigInput) ToWriteConfig() DataflowComponentWriteConfig {
+	return DataflowComponentWriteConfig{
+		InputTopics:         splitTopics(c.InputTopics),
+		ProcessingNoderedJS: c.ProcessingNoderedJS,
+		Output:              c.Output,
+		Buffer:              c.Buffer,
+	}
+}
+
+// ToDataflowComponentServiceConfig expands the input config into a full Benthos service
+// config. InputTopics is split without template rendering — call Render first if the
+// string still contains {{ }} actions.
+func (c DataflowComponentWriteConfigInput) ToDataflowComponentServiceConfig(bridgedBy string) DataflowComponentServiceConfig {
+	return c.ToWriteConfig().ToDataflowComponentServiceConfig(bridgedBy)
+}
+
+// Render executes InputTopics as a Go template with scope, splits the result
+// into individual topic strings, and returns a fully typed DataflowComponentWriteConfig.
+func (c DataflowComponentWriteConfigInput) Render(scope map[string]any) (DataflowComponentWriteConfig, error) {
+	rendered := c.InputTopics
+	if strings.Contains(c.InputTopics, "{{") {
+		tpl, err := template.New("input_topics").Option("missingkey=zero").Parse(c.InputTopics)
+		if err != nil {
+			return DataflowComponentWriteConfig{}, fmt.Errorf("failed to parse input_topics template: %w", err)
+		}
+		var buf bytes.Buffer
+		if err := tpl.Execute(&buf, scope); err != nil {
+			return DataflowComponentWriteConfig{}, fmt.Errorf("failed to render input_topics template: %w", err)
+		}
+		rendered = buf.String()
+	}
+	return DataflowComponentWriteConfig{
+		InputTopics:         splitTopics(rendered),
+		ProcessingNoderedJS: c.ProcessingNoderedJS,
+		Output:              c.Output,
+		Buffer:              c.Buffer,
+	}, nil
+}
+
+// splitTopics splits a newline- or comma-separated topic string into a trimmed,
+// non-empty []string.
+func splitTopics(s string) []string {
+	// normalise commas to newlines, then split
+	s = strings.ReplaceAll(s, ",", "\n")
+	parts := strings.Split(s, "\n")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if t := strings.TrimSpace(p); t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+// HasOutput reports whether a write output is configured.
+// Used as a gate: the UNS input is only generated when an output exists.
+func (c DataflowComponentWriteConfig) HasOutput() bool {
+	return len(c.Output) > 0
+}
+
+// ToDataflowComponentServiceConfig expands the typed write config into a full Benthos
+// service config ready for the FSM to deploy.
+//
+// bridgedBy is the resolved consumer-group identifier (from .internal.bridged_by in the
+// render scope). When empty the consumer_group field is left blank, which is acceptable
+// for structural-only conversions that never hit the wire (e.g. SpecToRuntime).
+func (c DataflowComponentWriteConfig) ToDataflowComponentServiceConfig(bridgedBy string) DataflowComponentServiceConfig {
+	code := c.ProcessingNoderedJS
+	pipeline := c.codeToPipeline(code)
+
+	var input map[string]any
+	if len(c.Output) > 0 {
+		umhTopics := c.InputTopics
+		if len(umhTopics) == 0 {
+			// Sentinel: action validation normally rejects an empty InputTopics when
+			// Output is present, but set-config-file bypasses actions and can produce
+			// this state. The sentinel makes the misconfiguration visible in Benthos
+			// logs rather than silently subscribing to nothing.
+			umhTopics = []string{"TOPIC_NOT_SET_BY_USER"}
+		}
+		input = map[string]any{
+			"uns": map[string]any{
+				"consumer_group": bridgedBy,
+				"umh_topics":     umhTopics,
+			},
+		}
+	}
+
+	return DataflowComponentServiceConfig{
+		BenthosConfig: BenthosConfig{
+			Input:    input,
+			Pipeline: pipeline,
+			Output:   c.Output,
+			Buffer:   c.Buffer,
+		},
+	}
+}
+
+// ToDisplayDataflowComponentServiceConfig converts the typed write config into a
+// DataflowComponentServiceConfig for display purposes (e.g. get-protocolconverter).
+// The UNS input is intentionally omitted — it is auto-generated at render time and
+// must not be exposed to the frontend as if it were user-configured.
+func (c DataflowComponentWriteConfig) ToDisplayDataflowComponentServiceConfig() DataflowComponentServiceConfig {
+	code := c.ProcessingNoderedJS
+	pipeline := c.codeToPipeline(code)
+
+	return DataflowComponentServiceConfig{
+		BenthosConfig: BenthosConfig{
+			Pipeline: pipeline,
+			Output:   c.Output,
+			Buffer:   c.Buffer,
+		},
+	}
+}
+
+// codeToPipeline converts a code string to a Benthos pipeline configuration.
+func (c DataflowComponentWriteConfig) codeToPipeline(code string) map[string]any {
+	if code == "" {
+		code = "return msg;"
+	}
+	pipeline := map[string]any{
+		"processors": []any{
+			map[string]any{
+				"nodered_js": map[string]any{
+					"code": code,
+				},
+			},
+		},
+	}
+	return pipeline
+}

--- a/umh-core/pkg/config/dataflowcomponentserviceconfig/write_config.go
+++ b/umh-core/pkg/config/dataflowcomponentserviceconfig/write_config.go
@@ -45,13 +45,6 @@ const PlaceholderUMHTopicUnset = "TOPIC_NOT_SET_BY_USER"
 //	buffer:
 //	  none: {}
 type DataflowComponentWriteConfig struct {
-	// InputTopics lists the UNS topics this write DFC subscribes to.
-	InputTopics []string `yaml:"input_topics,omitempty" json:"input_topics,omitempty" mapstructure:"input_topics,omitempty"`
-
-	// ProcessingNoderedJS is the Node-RED JS snippet that transforms each message.
-	// Must end with "return msg;" (or "return null;" to drop the message).
-	// Defaults to "return msg;" when empty.
-	ProcessingNoderedJS string `yaml:"processing_nodered_js,omitempty" json:"processing_nodered_js,omitempty" mapstructure:"processing_nodered_js,omitempty"`
 
 	// Output is the Benthos output configuration (e.g. http_client, mqtt).
 	// When non-empty, a UNS input is automatically generated during rendering.
@@ -59,6 +52,14 @@ type DataflowComponentWriteConfig struct {
 
 	// Buffer is the optional Benthos buffer configuration.
 	Buffer map[string]any `yaml:"buffer,omitempty" json:"buffer,omitempty" mapstructure:"buffer,omitempty"`
+
+	// ProcessingNoderedJS is the Node-RED JS snippet that transforms each message.
+	// Must end with "return msg;" (or "return null;" to drop the message).
+	// Defaults to "return msg;" when empty.
+	ProcessingNoderedJS string `yaml:"processing_nodered_js,omitempty" json:"processing_nodered_js,omitempty" mapstructure:"processing_nodered_js,omitempty"`
+
+	// InputTopics lists the UNS topics this write DFC subscribes to.
+	InputTopics []string `yaml:"input_topics,omitempty" json:"input_topics,omitempty" mapstructure:"input_topics,omitempty"`
 }
 
 // DataflowComponentWriteConfigInput is the wire/input form of write DFC config.
@@ -67,12 +68,12 @@ type DataflowComponentWriteConfig struct {
 // topic list. It is rendered with user-supplied variables at action time and
 // converted to the typed DataflowComponentWriteConfig before being stored.
 type DataflowComponentWriteConfigInput struct {
+	Output map[string]any `yaml:"output,omitempty"                json:"output,omitempty"`
+	Buffer map[string]any `yaml:"buffer,omitempty"                json:"buffer,omitempty"`
 	// InputTopics is either a plain topic list (newline- or comma-separated)
 	// or a Go template string that renders to such a list.
-	InputTopics         string         `yaml:"input_topics,omitempty"          json:"input_topics,omitempty"`
-	ProcessingNoderedJS string         `yaml:"processing_nodered_js,omitempty" json:"processing_nodered_js,omitempty"`
-	Output              map[string]any `yaml:"output,omitempty"                json:"output,omitempty"`
-	Buffer              map[string]any `yaml:"buffer,omitempty"                json:"buffer,omitempty"`
+	InputTopics         string `yaml:"input_topics,omitempty"          json:"input_topics,omitempty"`
+	ProcessingNoderedJS string `yaml:"processing_nodered_js,omitempty" json:"processing_nodered_js,omitempty"`
 }
 
 // HasOutput reports whether a write output is configured.

--- a/umh-core/pkg/config/dataflowcomponentserviceconfig/write_config.go
+++ b/umh-core/pkg/config/dataflowcomponentserviceconfig/write_config.go
@@ -25,9 +25,9 @@ import (
 // It replaces the generic DataflowComponentServiceConfig for write flows, making the
 // nodered_js processor and UNS topics first-class typed fields instead of free-form maps.
 //
-// This struct is the internal typed form used for FSM deployment. The frontend wire format
-// (WriteDFCResponse/WriteDFCRequest) embeds DataflowComponentWriteConfigInput so that
-// InputTopics remains a raw string (preserving template actions for round-trip fidelity).
+// This struct is the internal typed form used for FSM deployment. The wire format
+// (models.WriteDFC) embeds DataflowComponentWriteConfigInput so that InputTopics remains
+// a raw string (preserving template actions for round-trip fidelity).
 //
 // YAML / JSON shape:
 //

--- a/umh-core/pkg/config/dataflowcomponentserviceconfig/write_config.go
+++ b/umh-core/pkg/config/dataflowcomponentserviceconfig/write_config.go
@@ -91,6 +91,7 @@ func (c DataflowComponentWriteConfigInput) ToWriteConfig() DataflowComponentWrit
 	}
 }
 
+
 // ToDataflowComponentServiceConfig expands the input config into a full Benthos service
 // config. InputTopics is split without template rendering — call Render first if the
 // string still contains {{ }} actions.

--- a/umh-core/pkg/config/dataflowcomponentserviceconfig/write_config.go
+++ b/umh-core/pkg/config/dataflowcomponentserviceconfig/write_config.go
@@ -15,11 +15,12 @@
 package dataflowcomponentserviceconfig
 
 import (
-	"bytes"
-	"fmt"
 	"strings"
-	"text/template"
 )
+
+// PlaceholderUMHTopicUnset is used when no input topics were configured for a write DFC.
+// It makes the misconfiguration visible in Benthos logs rather than silently subscribing to nothing.
+const PlaceholderUMHTopicUnset = "TOPIC_NOT_SET_BY_USER"
 
 // DataflowComponentWriteConfig is the typed, validated configuration for write-side DFCs.
 // It replaces the generic DataflowComponentServiceConfig for write flows, making the
@@ -91,7 +92,6 @@ func (c DataflowComponentWriteConfigInput) ToWriteConfig() DataflowComponentWrit
 	}
 }
 
-
 // ToDataflowComponentServiceConfig expands the input config into a full Benthos service
 // config. InputTopics is split without template rendering — call Render first if the
 // string still contains {{ }} actions.
@@ -99,33 +99,10 @@ func (c DataflowComponentWriteConfigInput) ToDataflowComponentServiceConfig(brid
 	return c.ToWriteConfig().ToDataflowComponentServiceConfig(bridgedBy)
 }
 
-// Render executes InputTopics as a Go template with scope, splits the result
-// into individual topic strings, and returns a fully typed DataflowComponentWriteConfig.
-func (c DataflowComponentWriteConfigInput) Render(scope map[string]any) (DataflowComponentWriteConfig, error) {
-	rendered := c.InputTopics
-	if strings.Contains(c.InputTopics, "{{") {
-		tpl, err := template.New("input_topics").Option("missingkey=zero").Parse(c.InputTopics)
-		if err != nil {
-			return DataflowComponentWriteConfig{}, fmt.Errorf("failed to parse input_topics template: %w", err)
-		}
-		var buf bytes.Buffer
-		if err := tpl.Execute(&buf, scope); err != nil {
-			return DataflowComponentWriteConfig{}, fmt.Errorf("failed to render input_topics template: %w", err)
-		}
-		rendered = buf.String()
-	}
-	return DataflowComponentWriteConfig{
-		InputTopics:         splitTopics(rendered),
-		ProcessingNoderedJS: c.ProcessingNoderedJS,
-		Output:              c.Output,
-		Buffer:              c.Buffer,
-	}, nil
-}
-
 // splitTopics splits a newline- or comma-separated topic string into a trimmed,
 // non-empty []string.
 func splitTopics(s string) []string {
-	// normalise commas to newlines, then split
+	// normalize commas to newlines, then split
 	s = strings.ReplaceAll(s, ",", "\n")
 	parts := strings.Split(s, "\n")
 	out := make([]string, 0, len(parts))
@@ -138,7 +115,6 @@ func splitTopics(s string) []string {
 }
 
 // HasOutput reports whether a write output is configured.
-// Used as a gate: the UNS input is only generated when an output exists.
 func (c DataflowComponentWriteConfig) HasOutput() bool {
 	return len(c.Output) > 0
 }
@@ -161,7 +137,7 @@ func (c DataflowComponentWriteConfig) ToDataflowComponentServiceConfig(bridgedBy
 			// Output is present, but set-config-file bypasses actions and can produce
 			// this state. The sentinel makes the misconfiguration visible in Benthos
 			// logs rather than silently subscribing to nothing.
-			umhTopics = []string{"TOPIC_NOT_SET_BY_USER"}
+			umhTopics = []string{PlaceholderUMHTopicUnset}
 		}
 		input = map[string]any{
 			"uns": map[string]any{

--- a/umh-core/pkg/config/dataflowcomponentserviceconfig/write_config_test.go
+++ b/umh-core/pkg/config/dataflowcomponentserviceconfig/write_config_test.go
@@ -1,0 +1,125 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dataflowcomponentserviceconfig_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/dataflowcomponentserviceconfig"
+)
+
+var _ = Describe("write_config", func() {
+
+	Describe("splitTopics (via ToWriteConfig)", func() {
+		DescribeTable("splits topic strings correctly",
+			func(input string, expected []string) {
+				cfg := dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
+					InputTopics: input,
+				}
+				result := cfg.ToWriteConfig().InputTopics
+				Expect(result).To(Equal(expected))
+			},
+			Entry("newline-separated", "a\nb\nc", []string{"a", "b", "c"}),
+			Entry("comma-separated", "a,b,c", []string{"a", "b", "c"}),
+			Entry("mixed newline and comma", "a,b\nc", []string{"a", "b", "c"}),
+			Entry("trims whitespace", "  a  \n  b  ", []string{"a", "b"}),
+			Entry("skips empty lines", "a\n\nb", []string{"a", "b"}),
+			Entry("all commas (only-commas → empty)", ",,,,", []string{}),
+			Entry("single topic", "umh.v1.factory.*", []string{"umh.v1.factory.*"}),
+			Entry("empty string", "", []string{}),
+		)
+	})
+
+	Describe("HasOutput", func() {
+		It("returns false when Output is nil", func() {
+			cfg := dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{}
+			Expect(cfg.HasOutput()).To(BeFalse())
+		})
+
+		It("returns false when Output is empty map", func() {
+			cfg := dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
+				Output: map[string]any{},
+			}
+			Expect(cfg.HasOutput()).To(BeFalse())
+		})
+
+		It("returns true when Output has entries", func() {
+			cfg := dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
+				Output: map[string]any{"http_client": map[string]any{"url": "http://example.com"}},
+			}
+			Expect(cfg.HasOutput()).To(BeTrue())
+		})
+	})
+
+	Describe("ToDataflowComponentServiceConfig", func() {
+		It("builds UNS input with provided topics", func() {
+			cfg := dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
+				InputTopics: "umh.v1.factory.*",
+				Output:      map[string]any{"stdout": map[string]any{}},
+			}
+			svc := cfg.ToDataflowComponentServiceConfig("my-bridge")
+			Expect(svc.BenthosConfig.Input).To(HaveKey("uns"))
+			uns := svc.BenthosConfig.Input["uns"].(map[string]any)
+			Expect(uns["consumer_group"]).To(Equal("my-bridge"))
+			Expect(uns["umh_topics"]).To(ContainElement("umh.v1.factory.*"))
+		})
+
+		It("uses sentinel when InputTopics is empty and Output is set", func() {
+			cfg := dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
+				InputTopics: "",
+				Output:      map[string]any{"stdout": map[string]any{}},
+			}
+			svc := cfg.ToDataflowComponentServiceConfig("my-bridge")
+			uns := svc.BenthosConfig.Input["uns"].(map[string]any)
+			Expect(uns["umh_topics"]).To(ContainElement(dataflowcomponentserviceconfig.PlaceholderUMHTopicUnset))
+		})
+
+		It("produces no input when no output is configured", func() {
+			cfg := dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
+				InputTopics: "umh.v1.factory.*",
+			}
+			svc := cfg.ToDataflowComponentServiceConfig("my-bridge")
+			Expect(svc.BenthosConfig.Input).To(BeNil())
+		})
+
+		It("defaults ProcessingNoderedJS to 'return msg;' when empty", func() {
+			cfg := dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
+				InputTopics: "umh.v1.*",
+				Output:      map[string]any{"stdout": map[string]any{}},
+			}
+			svc := cfg.ToDataflowComponentServiceConfig("b")
+			processors := svc.BenthosConfig.Pipeline["processors"].([]any)
+			Expect(processors).To(HaveLen(1))
+			proc := processors[0].(map[string]any)
+			Expect(proc["nodered_js"].(map[string]any)["code"]).To(Equal("return msg;"))
+		})
+	})
+
+	Describe("ToWriteConfig round-trip", func() {
+		It("preserves all fields through ToWriteConfig", func() {
+			input := dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
+				InputTopics:         "umh.v1.*\numh.v1.other.*",
+				ProcessingNoderedJS: "return msg;",
+				Output:              map[string]any{"kafka": map[string]any{}},
+				Buffer:              map[string]any{"none": map[string]any{}},
+			}
+			got := input.ToWriteConfig()
+			Expect(got.InputTopics).To(ConsistOf("umh.v1.*", "umh.v1.other.*"))
+			Expect(got.ProcessingNoderedJS).To(Equal("return msg;"))
+			Expect(got.Output).To(HaveKey("kafka"))
+			Expect(got.Buffer).To(HaveKey("none"))
+		})
+	})
+})

--- a/umh-core/pkg/config/protocolconverterserviceconfig/comparator.go
+++ b/umh-core/pkg/config/protocolconverterserviceconfig/comparator.go
@@ -58,7 +58,7 @@ func (c *Comparator) ConfigsEqual(desired, observed ProtocolConverterServiceConf
 	return connectionEqual &&
 		locationEqual &&
 		comparatorDFC.ConfigsEqual(dfcReadD, dfcReadO) &&
-		comparatorDFC.ConfigsEqual(dfcWriteD, dfcWriteO) &&
+		reflect.DeepEqual(dfcWriteD, dfcWriteO) &&
 		comparatorVariable.ConfigsEqual(desired.Variables, observed.Variables) &&
 		readDFCDesiredStateEqual &&
 		writeDFCDesiredStateEqual
@@ -88,7 +88,10 @@ func (c *Comparator) ConfigDiff(desired, observed ProtocolConverterServiceConfig
 	// diff for dfc's
 	comparatorDFC := dataflowcomponentserviceconfig.NewComparator()
 	dfcReadDiff := comparatorDFC.ConfigDiff(dfcReadD, dfcReadO)
-	dfcWriteDiff := comparatorDFC.ConfigDiff(dfcWriteD, dfcWriteO)
+	dfcWriteDiff := ""
+	if !reflect.DeepEqual(dfcWriteD, dfcWriteO) {
+		dfcWriteDiff = fmt.Sprintf("WriteDFC: %v vs %v", dfcWriteD, dfcWriteO)
+	}
 
 	// diff for variables
 	comparatorVariable := variables.NewComparator()

--- a/umh-core/pkg/config/protocolconverterserviceconfig/comparator_test.go
+++ b/umh-core/pkg/config/protocolconverterserviceconfig/comparator_test.go
@@ -258,7 +258,7 @@ var _ = Describe("ProtocolConverter YAML Comparator", func() {
 			Expect(equal).To(BeFalse())
 
 			diff := comparator.ConfigDiff(config1, config2)
-			Expect(diff).To(ContainSubstring("No significant differences"))
+			Expect(diff).To(ContainSubstring("Connection:"))
 		})
 
 		It("should consider configs with different Port not equal", func() {
@@ -318,7 +318,7 @@ var _ = Describe("ProtocolConverter YAML Comparator", func() {
 			Expect(equal).To(BeFalse())
 
 			diff := comparator.ConfigDiff(config1, config2)
-			Expect(diff).To(ContainSubstring("No significant differences"))
+			Expect(diff).To(ContainSubstring("Connection:"))
 		})
 
 		It("should consider configs with same location equal", func() {
@@ -584,8 +584,6 @@ var _ = Describe("ProtocolConverter YAML Comparator", func() {
 
 			Expect(diff).To(ContainSubstring("Input config differences"))
 			Expect(diff).To(ContainSubstring("Input.mqtt differs"))
-
-			Expect(diff).To(ContainSubstring("No significant differences"))
 		})
 	})
 

--- a/umh-core/pkg/config/protocolconverterserviceconfig/config_customized.go
+++ b/umh-core/pkg/config/protocolconverterserviceconfig/config_customized.go
@@ -44,24 +44,10 @@ func (c ProtocolConverterServiceConfigSpec) GetDFCReadServiceConfig() dataflowco
 	return dfcReadConfig
 }
 
-// GetDFCWriteServiceConfig converts the component config to a full ProtocolConverterServiceConfig
-// For a write DFC, the user is not allowed to set its own input config, so we "enforce" the input config
-// to be the UNS input config. This ensures protocol converters always read from the unified namespace.
-func (c ProtocolConverterServiceConfigSpec) GetDFCWriteServiceConfig() dataflowcomponentserviceconfig.DataflowComponentServiceConfig {
-	dfcWriteConfig := c.Config.DataflowComponentWriteServiceConfig
-
-	// Always enforce UNS input — user must not supply their own input config.
-	// consumer_group is resolved via template; umh_topics is injected post-render
-	// in renderConfig because []string can't be rendered via text/template.
-	if len(dfcWriteConfig.BenthosConfig.Output) > 0 {
-		dfcWriteConfig.BenthosConfig.Input = map[string]any{
-			"uns": map[string]any{
-				"consumer_group": "{{ .internal.bridged_by }}",
-			},
-		}
-	}
-
-	return dfcWriteConfig
+// GetDFCWriteServiceConfig returns the write DFC input config from the spec.
+// InputTopics may contain Go template actions resolved at deploy time.
+func (c ProtocolConverterServiceConfigSpec) GetDFCWriteServiceConfig() dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput {
+	return c.Config.DataflowComponentWriteServiceConfig
 }
 
 // FromConnectionAndDFCServiceConfig creates a ProtocolConverterServiceConfig

--- a/umh-core/pkg/config/protocolconverterserviceconfig/generator.go
+++ b/umh-core/pkg/config/protocolconverterserviceconfig/generator.go
@@ -20,6 +20,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/connectionserviceconfig"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/dataflowcomponentserviceconfig"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/variables"
+	"go.uber.org/zap"
 	"gopkg.in/yaml.v3"
 )
 
@@ -46,6 +47,7 @@ func (g *Generator) RenderConfig(cfg ProtocolConverterServiceConfigSpec) (string
 	}
 
 	yamlStr := string(yamlBytes)
+	zap.S().Errorf("rendered ProtocolConverter config: %s", yamlStr)
 
 	return yamlStr, nil
 }
@@ -58,7 +60,9 @@ func (g *Generator) configToMap(cfg ProtocolConverterServiceConfigSpec) map[stri
 	variableBundleGenerator := variables.NewGenerator()
 
 	dfcReadConfigMap := dfcGenerator.ConfigToMap(cfg.Config.DataflowComponentReadServiceConfig)
-	dfcWriteConfigMap := dfcGenerator.ConfigToMap(cfg.Config.DataflowComponentWriteServiceConfig)
+
+	// Write DFC uses a typed struct; marshal it directly to a map.
+	dfcWriteConfigMap := writeConfigToMap(cfg.Config.DataflowComponentWriteServiceConfig)
 	// Convert template to runtime for config map generation
 	connRuntime, err := connectionserviceconfig.ConvertTemplateToRuntime(cfg.Config.ConnectionServiceConfig)
 	if err != nil {
@@ -132,9 +136,11 @@ func normalizeConfig(raw map[string]any) map[string]any {
 		connectionConfig = template
 	}
 
-	// Normalize each component
+	// Normalize each component.
+	// Read DFC uses free-form benthos maps that need benthos normalization.
+	// Write DFC uses a typed struct marshaled to a plain map; pass it through unchanged.
 	normalizedDFCReadConfig := dataflowcomponentserviceconfig.NormalizeConfig(dfcReadConfig)
-	normalizedDFCWriteConfig := dataflowcomponentserviceconfig.NormalizeConfig(dfcWriteConfig)
+	normalizedDFCWriteConfig := dfcWriteConfig
 	normalizedConnectionConfig := connectionserviceconfig.NormalizeConfig(connectionConfig)
 
 	// Variables don't need normalization, they are just key-value pairs
@@ -152,4 +158,20 @@ func normalizeConfig(raw map[string]any) map[string]any {
 	normalized["location"] = locationMap // Use our correctly processed location map
 
 	return normalized
+}
+
+// writeConfigToMap marshals a DataflowComponentWriteConfig to a plain map[string]any
+// for inclusion in the YAML generator output.
+func writeConfigToMap(cfg dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput) map[string]any {
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		zap.S().Errorf("writeConfigToMap: failed to marshal write DFC config, write side will be empty in YAML output: %v", err)
+		return map[string]any{}
+	}
+	var m map[string]any
+	if err := yaml.Unmarshal(data, &m); err != nil {
+		zap.S().Errorf("writeConfigToMap: failed to unmarshal write DFC config, write side will be empty in YAML output: %v", err)
+		return map[string]any{}
+	}
+	return m
 }

--- a/umh-core/pkg/config/protocolconverterserviceconfig/generator.go
+++ b/umh-core/pkg/config/protocolconverterserviceconfig/generator.go
@@ -64,7 +64,7 @@ func (g *Generator) configToMap(cfg ProtocolConverterServiceConfigSpec) (map[str
 
 	connRuntime, err := connectionserviceconfig.ConvertTemplateToRuntime(cfg.Config.ConnectionServiceConfig)
 	if err != nil {
-		connRuntime = connectionserviceconfig.ConnectionServiceConfigRuntime{}
+		return nil, fmt.Errorf("failed to convert connection template to runtime: %w", err)
 	}
 
 	connectionConfigMap := connectionGenerator.ConfigToMap(connRuntime)

--- a/umh-core/pkg/config/protocolconverterserviceconfig/generator.go
+++ b/umh-core/pkg/config/protocolconverterserviceconfig/generator.go
@@ -20,7 +20,6 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/connectionserviceconfig"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/dataflowcomponentserviceconfig"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/variables"
-	"go.uber.org/zap"
 	"gopkg.in/yaml.v3"
 )
 
@@ -36,58 +35,54 @@ func NewGenerator() *Generator {
 
 // RenderConfig generates a ProtocolConverter YAML configuration from a ProtocolConverterServiceConfigSpec.
 func (g *Generator) RenderConfig(cfg ProtocolConverterServiceConfigSpec) (string, error) {
-	// Convert the config to a normalized map
-	configMap := g.configToMap(cfg)
+	configMap, err := g.configToMap(cfg)
+	if err != nil {
+		return "", err
+	}
 	normalizedMap := normalizeConfig(configMap)
 
-	// Marshal to YAML
 	yamlBytes, err := yaml.Marshal(normalizedMap)
 	if err != nil {
 		return "", fmt.Errorf("failed to marshal ProtocolConverter config: %w", err)
 	}
 
-	yamlStr := string(yamlBytes)
-	zap.S().Errorf("rendered ProtocolConverter config: %s", yamlStr)
-
-	return yamlStr, nil
+	return string(yamlBytes), nil
 }
 
-// configToMap converts a DataFlowComponentServiceConfig to a raw map for YAML generation.
-func (g *Generator) configToMap(cfg ProtocolConverterServiceConfigSpec) map[string]any {
-	// use generator to create a valid dfcConfigMap & connectionConfigMap
+// configToMap converts a ProtocolConverterServiceConfigSpec to a raw map for YAML generation.
+func (g *Generator) configToMap(cfg ProtocolConverterServiceConfigSpec) (map[string]any, error) {
 	dfcGenerator := dataflowcomponentserviceconfig.NewGenerator()
 	connectionGenerator := connectionserviceconfig.NewGenerator()
 	variableBundleGenerator := variables.NewGenerator()
 
 	dfcReadConfigMap := dfcGenerator.ConfigToMap(cfg.Config.DataflowComponentReadServiceConfig)
 
-	// Write DFC uses a typed struct; marshal it directly to a map.
-	dfcWriteConfigMap := writeConfigToMap(cfg.Config.DataflowComponentWriteServiceConfig)
-	// Convert template to runtime for config map generation
+	dfcWriteConfigMap, err := writeConfigToMap(cfg.Config.DataflowComponentWriteServiceConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert write DFC config: %w", err)
+	}
+
 	connRuntime, err := connectionserviceconfig.ConvertTemplateToRuntime(cfg.Config.ConnectionServiceConfig)
 	if err != nil {
-		// If conversion fails, use empty config to avoid breaking YAML generation
 		connRuntime = connectionserviceconfig.ConnectionServiceConfigRuntime{}
 	}
 
 	connectionConfigMap := connectionGenerator.ConfigToMap(connRuntime)
 	variableBundleConfigMap := variableBundleGenerator.ConfigToMap(cfg.Variables)
 
-	configMap := make(map[string]any)
+	templateMap := map[string]any{
+		"connection":             connectionConfigMap,
+		"dataflowcomponent_read": dfcReadConfigMap,
+		"dataflowcomponent_write": dfcWriteConfigMap,
+	}
 
-	// Create the template structure
-	templateMap := make(map[string]any)
-	templateMap["connection"] = connectionConfigMap
-	templateMap["dataflowcomponent_read"] = dfcReadConfigMap
-	templateMap["dataflowcomponent_write"] = dfcWriteConfigMap
+	configMap := map[string]any{
+		"template":  templateMap,
+		"variables": variableBundleConfigMap,
+		"location":  cfg.Location,
+	}
 
-	// Add template and variables to the root config
-	configMap["template"] = templateMap
-	configMap["variables"] = variableBundleConfigMap
-
-	configMap["location"] = cfg.Location
-
-	return configMap
+	return configMap, nil
 }
 
 // normalizeConfig normalizes the configuration by applying defaults and ensuring consistency.
@@ -160,18 +155,16 @@ func normalizeConfig(raw map[string]any) map[string]any {
 	return normalized
 }
 
-// writeConfigToMap marshals a DataflowComponentWriteConfig to a plain map[string]any
+// writeConfigToMap marshals a DataflowComponentWriteConfigInput to a plain map[string]any
 // for inclusion in the YAML generator output.
-func writeConfigToMap(cfg dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput) map[string]any {
+func writeConfigToMap(cfg dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput) (map[string]any, error) {
 	data, err := yaml.Marshal(cfg)
 	if err != nil {
-		zap.S().Errorf("writeConfigToMap: failed to marshal write DFC config, write side will be empty in YAML output: %v", err)
-		return map[string]any{}
+		return nil, fmt.Errorf("writeConfigToMap: failed to marshal write DFC config: %w", err)
 	}
 	var m map[string]any
 	if err := yaml.Unmarshal(data, &m); err != nil {
-		zap.S().Errorf("writeConfigToMap: failed to unmarshal write DFC config, write side will be empty in YAML output: %v", err)
-		return map[string]any{}
+		return nil, fmt.Errorf("writeConfigToMap: failed to unmarshal write DFC config: %w", err)
 	}
-	return m
+	return m, nil
 }

--- a/umh-core/pkg/config/protocolconverterserviceconfig/generator_test.go
+++ b/umh-core/pkg/config/protocolconverterserviceconfig/generator_test.go
@@ -44,7 +44,7 @@ var _ = Describe("ProtocolConverter YAML Generator", func() {
 				Expect(yamlStr).NotTo(ContainSubstring(notExp))
 			}
 		},
-		Entry("should render empty stdout output correctly",
+		Entry("should render write DFC with output and topics",
 			testCase{
 				config: &ProtocolConverterServiceConfigSpec{
 					Config: ProtocolConverterServiceConfigTemplate{
@@ -61,134 +61,12 @@ var _ = Describe("ProtocolConverter YAML Generator", func() {
 								},
 							},
 						},
-						DataflowComponentWriteServiceConfig: dataflowcomponentserviceconfig.DataflowComponentServiceConfig{
-							BenthosConfig: dataflowcomponentserviceconfig.BenthosConfig{
-								Input: map[string]any{
-									"stdin": map[string]any{},
-								},
-								Output: map[string]any{
-									"kafka": map[string]any{
-										"addresses": []string{"kafka:9092"},
-										"topic":     "output-topic",
-									},
-								},
-							},
-						},
-					},
-				},
-				// NOTE: We expect port 0 here, since ot comes out of ToBenthosServiceConfig()
-				expected: []string{
-					"connection:",
-					"  target: 127.0.0.1",
-					"  port: 443",
-					"dataflowcomponent_read:",
-					"  benthos:",
-					"    output:",
-					"      stdout: {}",
-					"    http:",
-					"      address: 0.0.0.0:0",
-					"    logger:",
-					"      level: INFO",
-					"dataflowcomponent_write:",
-					"  benthos:",
-					"    input:",
-					"      stdin: {}",
-					"    output:",
-					"      kafka:",
-					"        addresses:",
-					"        - kafka:9092",
-					"        topic: output-topic",
-					"    http:",
-					"      address: 0.0.0.0:0",
-					"    logger:",
-					"      level: INFO",
-				},
-				notExpected: []string{},
-			}),
-		Entry("should render configured output correctly",
-			testCase{
-				config: &ProtocolConverterServiceConfigSpec{
-					Config: ProtocolConverterServiceConfigTemplate{
-						ConnectionServiceConfig: connectionserviceconfig.ConnectionServiceConfigTemplate{
-							NmapTemplate: &connectionserviceconfig.NmapConfigTemplate{
-								Target: "127.0.0.1",
-								Port:   "443",
-							},
-						},
-						DataflowComponentReadServiceConfig: dataflowcomponentserviceconfig.DataflowComponentServiceConfig{
-							BenthosConfig: dataflowcomponentserviceconfig.BenthosConfig{
-								Output: map[string]any{
-									"stdout": map[string]any{
-										"codec": "lines",
-									},
-								},
-							},
-						},
-						DataflowComponentWriteServiceConfig: dataflowcomponentserviceconfig.DataflowComponentServiceConfig{
-							BenthosConfig: dataflowcomponentserviceconfig.BenthosConfig{
-								Input: map[string]any{
-									"http_server": map[string]any{
-										"path": "/data",
-									},
-								},
-								Output: map[string]any{
-									"http_client": map[string]any{
-										"url": "http://api.example.com/ingest",
-									},
-								},
-							},
-						},
-					},
-				},
-				expected: []string{
-					"connection:",
-					"  target: 127.0.0.1",
-					"  port: 443",
-					"dataflowcomponent_read:",
-					"  benthos:",
-					"    output:",
-					"      stdout:",
-					"        codec: lines",
-					"dataflowcomponent_write:",
-					"  benthos:",
-					"    input:",
-					"      http_server:",
-					"        path: /data",
-					"    output:",
-					"      http_client:",
-					"        url: http://api.example.com/ingest",
-				},
-				notExpected: []string{},
-			}),
-		Entry("should render empty input correctly",
-			testCase{
-				config: &ProtocolConverterServiceConfigSpec{
-					Config: ProtocolConverterServiceConfigTemplate{
-						ConnectionServiceConfig: connectionserviceconfig.ConnectionServiceConfigTemplate{
-							NmapTemplate: &connectionserviceconfig.NmapConfigTemplate{
-								Target: "127.0.0.1",
-								Port:   "443",
-							},
-						},
-						DataflowComponentReadServiceConfig: dataflowcomponentserviceconfig.DataflowComponentServiceConfig{
-							BenthosConfig: dataflowcomponentserviceconfig.BenthosConfig{
-								Input: map[string]any{},
-								Output: map[string]any{
-									"stdout": map[string]any{},
-								},
-							},
-						},
-						DataflowComponentWriteServiceConfig: dataflowcomponentserviceconfig.DataflowComponentServiceConfig{
-							BenthosConfig: dataflowcomponentserviceconfig.BenthosConfig{
-								Input: map[string]any{
-									"file": map[string]any{
-										"paths": []string{"/tmp/input.txt"},
-									},
-								},
-								Output: map[string]any{
-									"file": map[string]any{
-										"path": "/tmp/output.txt",
-									},
+						DataflowComponentWriteServiceConfig: dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
+							InputTopics: "umh.v1.enterprise.site.*",
+							Output: map[string]any{
+								"kafka": map[string]any{
+									"addresses": []string{"kafka:9092"},
+									"topic":     "output-topic",
 								},
 							},
 						},
@@ -203,20 +81,80 @@ var _ = Describe("ProtocolConverter YAML Generator", func() {
 					"    output:",
 					"      stdout: {}",
 					"dataflowcomponent_write:",
-					"  benthos:",
-					"    input:",
-					"      file:",
-					"        paths:",
-					"        - /tmp/input.txt",
-					"    output:",
-					"      file:",
-					"        path: /tmp/output.txt",
+					"  input_topics: umh.v1.enterprise.site.*",
+					"  output:",
+					"    kafka:",
+					"      addresses:",
+					"      - kafka:9092",
+					"      topic: output-topic",
 				},
-				notExpected: []string{
-					"input: {}", // Empty input should not render as an empty object
-				},
+				notExpected: []string{},
 			}),
-		Entry("should render Kafka input with processor and AWS S3 output",
+		Entry("should render write DFC with processing code",
+			testCase{
+				config: &ProtocolConverterServiceConfigSpec{
+					Config: ProtocolConverterServiceConfigTemplate{
+						ConnectionServiceConfig: connectionserviceconfig.ConnectionServiceConfigTemplate{
+							NmapTemplate: &connectionserviceconfig.NmapConfigTemplate{
+								Target: "127.0.0.1",
+								Port:   "443",
+							},
+						},
+						DataflowComponentReadServiceConfig: dataflowcomponentserviceconfig.DataflowComponentServiceConfig{
+							BenthosConfig: dataflowcomponentserviceconfig.BenthosConfig{
+								Output: map[string]any{
+									"stdout": map[string]any{"codec": "lines"},
+								},
+							},
+						},
+						DataflowComponentWriteServiceConfig: dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
+							ProcessingNoderedJS: "msg.payload.foo = 'bar';\nreturn msg;",
+							Output: map[string]any{
+								"http_client": map[string]any{
+									"url": "http://api.example.com/ingest",
+								},
+							},
+						},
+					},
+				},
+				expected: []string{
+					"dataflowcomponent_write:",
+					"  processing_nodered_js:",
+					"  output:",
+					"    http_client:",
+					"      url: http://api.example.com/ingest",
+				},
+				notExpected: []string{},
+			}),
+		Entry("should render empty write DFC",
+			testCase{
+				config: &ProtocolConverterServiceConfigSpec{
+					Config: ProtocolConverterServiceConfigTemplate{
+						ConnectionServiceConfig: connectionserviceconfig.ConnectionServiceConfigTemplate{
+							NmapTemplate: &connectionserviceconfig.NmapConfigTemplate{
+								Target: "127.0.0.1",
+								Port:   "443",
+							},
+						},
+						DataflowComponentReadServiceConfig: dataflowcomponentserviceconfig.DataflowComponentServiceConfig{
+							BenthosConfig: dataflowcomponentserviceconfig.BenthosConfig{
+								Input:  map[string]any{},
+								Output: map[string]any{"stdout": map[string]any{}},
+							},
+						},
+						DataflowComponentWriteServiceConfig: dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{},
+					},
+				},
+				expected: []string{
+					"connection:",
+					"dataflowcomponent_read:",
+					"  benthos:",
+					"    output:",
+					"      stdout: {}",
+				},
+				notExpected: []string{},
+			}),
+		Entry("should render write DFC with buffer",
 			testCase{
 				config: &ProtocolConverterServiceConfigSpec{
 					Config: ProtocolConverterServiceConfigTemplate{
@@ -231,96 +169,34 @@ var _ = Describe("ProtocolConverter YAML Generator", func() {
 								Input: map[string]any{
 									"kafka": map[string]any{
 										"addresses": []string{"kafka:9092"},
-										"topics":    []string{"benthos_topic"},
-										"consumer_group": map[string]any{
-											"session_timeout": "6s",
-										},
-									},
-								},
-								Pipeline: map[string]any{
-									"processors": []any{
-										map[string]any{
-											"text": map[string]any{
-												"operator": "to_upper",
-											},
-										},
 									},
 								},
 								Output: map[string]any{
 									"aws_s3": map[string]any{
 										"bucket": "example-bucket",
-										"path":   "${!count:files}-${!timestamp_unix_nano}.txt",
 									},
 								},
 							},
 						},
-						DataflowComponentWriteServiceConfig: dataflowcomponentserviceconfig.DataflowComponentServiceConfig{
-							BenthosConfig: dataflowcomponentserviceconfig.BenthosConfig{
-								Input: map[string]any{
-									"mqtt": map[string]any{
-										"urls":   []string{"tcp://mqtt-broker:1883"},
-										"topics": []string{"sensor/data"},
-									},
-								},
-								Pipeline: map[string]any{
-									"processors": []any{
-										map[string]any{
-											"json": map[string]any{
-												"operator": "select",
-												"path":     "payload",
-											},
-										},
-									},
-								},
-								Output: map[string]any{
-									"redis_pubsub": map[string]any{
-										"url":     "redis://redis:6379",
-										"channel": "processed_data",
-									},
+						DataflowComponentWriteServiceConfig: dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
+							Output: map[string]any{
+								"redis_pubsub": map[string]any{
+									"url":     "redis://redis:6379",
+									"channel": "processed_data",
 								},
 							},
+							Buffer: map[string]any{"none": map[string]any{}},
 						},
 					},
 				},
 				expected: []string{
-					"connection:",
-					"  target: 127.0.0.1",
-					"  port: 443",
-					"dataflowcomponent_read:",
-					"  benthos:",
-					"    input:",
-					"      kafka:",
-					"        addresses:",
-					"        - kafka:9092",
-					"        topics:",
-					"        - benthos_topic",
-					"        consumer_group:",
-					"          session_timeout: 6s",
-					"    pipeline:",
-					"      processors:",
-					"      - text:",
-					"          operator: to_upper",
-					"    output:",
-					"      aws_s3:",
-					"        bucket: example-bucket",
-					"        path: ${!count:files}-${!timestamp_unix_nano}.txt",
 					"dataflowcomponent_write:",
-					"  benthos:",
-					"    input:",
-					"      mqtt:",
-					"        urls:",
-					"        - tcp://mqtt-broker:1883",
-					"        topics:",
-					"        - sensor/data",
-					"    pipeline:",
-					"      processors:",
-					"      - json:",
-					"          operator: select",
-					"          path: payload",
-					"    output:",
-					"      redis_pubsub:",
-					"        url: redis://redis:6379",
-					"        channel: processed_data",
+					"  output:",
+					"    redis_pubsub:",
+					"      url: redis://redis:6379",
+					"      channel: processed_data",
+					"  buffer:",
+					"    none: {}",
 				},
 				notExpected: []string{},
 			}),

--- a/umh-core/pkg/config/protocolconverterserviceconfig/normalizer.go
+++ b/umh-core/pkg/config/protocolconverterserviceconfig/normalizer.go
@@ -38,7 +38,6 @@ func (n *Normalizer) NormalizeConfig(cfg ProtocolConverterServiceConfigSpec) Pro
 	normalized.Config.DataflowComponentReadServiceConfig = dfcNormalizer.NormalizeConfig(normalized.GetDFCReadServiceConfig())
 
 	// Write DFC uses a typed struct — no benthos map normalization required.
-	normalized.Config.DataflowComponentWriteServiceConfig = normalized.GetDFCWriteServiceConfig()
 
 	// Then we  need to normalize the underlying ConnectionServiceConfig
 	connectionNormalizer := connectionserviceconfig.NewNormalizer()

--- a/umh-core/pkg/config/protocolconverterserviceconfig/normalizer.go
+++ b/umh-core/pkg/config/protocolconverterserviceconfig/normalizer.go
@@ -33,10 +33,12 @@ func (n *Normalizer) NormalizeConfig(cfg ProtocolConverterServiceConfigSpec) Pro
 	// create a shallow copy
 	normalized := cfg
 
-	// We need to first normalize the underlying DFCServiceConfig
+	// Normalize the read DFC (free-form benthos maps need benthos normalization).
 	dfcNormalizer := dataflowcomponentserviceconfig.NewNormalizer()
 	normalized.Config.DataflowComponentReadServiceConfig = dfcNormalizer.NormalizeConfig(normalized.GetDFCReadServiceConfig())
-	normalized.Config.DataflowComponentWriteServiceConfig = dfcNormalizer.NormalizeConfig(normalized.GetDFCWriteServiceConfig())
+
+	// Write DFC uses a typed struct — no benthos map normalization required.
+	normalized.Config.DataflowComponentWriteServiceConfig = normalized.GetDFCWriteServiceConfig()
 
 	// Then we  need to normalize the underlying ConnectionServiceConfig
 	connectionNormalizer := connectionserviceconfig.NewNormalizer()

--- a/umh-core/pkg/config/protocolconverterserviceconfig/normalizer_test.go
+++ b/umh-core/pkg/config/protocolconverterserviceconfig/normalizer_test.go
@@ -113,13 +113,9 @@ var _ = Describe("ProtocolConverter YAML Normalizer", func() {
 			Expect(config.Config.DataflowComponentReadServiceConfig.BenthosConfig.Pipeline).To(HaveKey("processors"))
 			Expect(config.Config.DataflowComponentReadServiceConfig.BenthosConfig.Pipeline["processors"]).To(BeEmpty())
 
-			// Check write-side configuration
-			Expect(config.Config.DataflowComponentWriteServiceConfig.BenthosConfig).NotTo(BeNil())
-			Expect(config.Config.DataflowComponentWriteServiceConfig.BenthosConfig.Input).NotTo(BeNil())
-			Expect(config.Config.DataflowComponentWriteServiceConfig.BenthosConfig.Output).NotTo(BeNil())
-			// processor subfield should exist in the pipeline field
-			Expect(config.Config.DataflowComponentWriteServiceConfig.BenthosConfig.Pipeline).To(HaveKey("processors"))
-			Expect(config.Config.DataflowComponentWriteServiceConfig.BenthosConfig.Pipeline["processors"]).To(BeEmpty())
+			// Write DFC uses a typed struct; with no write config set, it should be zero value.
+			Expect(config.Config.DataflowComponentWriteServiceConfig.HasOutput()).To(BeFalse())
+			Expect(config.Config.DataflowComponentWriteServiceConfig.InputTopics).To(BeEmpty())
 
 			// Buffer should have the none buffer set
 			Expect(config.Config.DataflowComponentReadServiceConfig.BenthosConfig.Buffer).To(HaveKey("none"))

--- a/umh-core/pkg/config/protocolconverterserviceconfig/package.go
+++ b/umh-core/pkg/config/protocolconverterserviceconfig/package.go
@@ -16,6 +16,7 @@ package protocolconverterserviceconfig
 
 import (
 	"fmt"
+	"reflect"
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/connectionserviceconfig"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/dataflowcomponentserviceconfig"
@@ -49,9 +50,9 @@ type ProtocolConverterServiceConfigTemplate struct {
 	DataflowComponentReadServiceConfig dataflowcomponentserviceconfig.DataflowComponentServiceConfig `yaml:"dataflowcomponent_read,omitempty"`
 
 	// DataflowComponentWriteServiceConfig is the blueprint for the *write* side
-	// of the converter.  Symmetrically to the read‑DFC we override
-	// `BenthosConfig.Input` so that it always consumes from UNS.
-	DataflowComponentWriteServiceConfig dataflowcomponentserviceconfig.DataflowComponentServiceConfig `yaml:"dataflowcomponent_write,omitempty"`
+	// of the converter. InputTopics is a string that may contain Go template actions
+	// rendered at deploy time; use DataflowComponentWriteConfigInput.Render to resolve it.
+	DataflowComponentWriteServiceConfig dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput `yaml:"dataflowcomponent_write,omitempty"`
 }
 
 // ProtocolConverterServiceConfigRuntime is the **fully rendered** form of a
@@ -132,63 +133,38 @@ func ConfigDiff(desired, observed ProtocolConverterServiceConfigSpec) string {
 	return defaultComparator.ConfigDiff(desired, observed)
 }
 
-// convertRuntimeToTemplate converts a runtime configuration back to template format.
-// This helper exists because our comparison and diff logic operates on template types,
-// but FSMs work with runtime types. When we need to compare or diff runtime configs,
-// we must first convert them back to template format to reuse existing logic.
-//
-// The conversion process:
-// - Runtime connection config (uint16 port) → Template connection config (string port)
-// - DFC configs remain unchanged (they're already template-compatible)
-//
-// This avoids duplicating the conversion logic across ConfigsEqualRuntime and ConfigDiffRuntime.
-func convertRuntimeToTemplate(runtime ProtocolConverterServiceConfigRuntime) ProtocolConverterServiceConfigTemplate {
-	connectionTemplate := connectionserviceconfig.ConvertRuntimeToTemplate(runtime.ConnectionServiceConfig)
-
-	return ProtocolConverterServiceConfigTemplate{
-		ConnectionServiceConfig:             connectionTemplate,
-		DataflowComponentReadServiceConfig:  runtime.DataflowComponentReadServiceConfig,
-		DataflowComponentWriteServiceConfig: runtime.DataflowComponentWriteServiceConfig,
-	}
-}
-
-// ConfigsEqualRuntime is a package-level function for comparing runtime configurations.
+// ConfigsEqualRuntime compares two fully-rendered runtime configurations.
+// Connection configs are converted back to template form first (to normalise the
+// uint16 port → string port difference); DFC configs are compared directly.
 func ConfigsEqualRuntime(desired, observed ProtocolConverterServiceConfigRuntime) bool {
-	// Convert runtime configs back to template format for comparison
-	// This is necessary because our comparison logic operates on template types
-	// Runtime types (uint16 port) → Template types (string port)
-	protocolConverterDesiredTemplate := convertRuntimeToTemplate(desired)
-	protocolConverterObservedTemplate := convertRuntimeToTemplate(observed)
+	desiredConnT := connectionserviceconfig.ConvertRuntimeToTemplate(desired.ConnectionServiceConfig)
+	observedConnT := connectionserviceconfig.ConvertRuntimeToTemplate(observed.ConnectionServiceConfig)
 
-	// Convert runtime configs to spec configs for comparison
-	// This allows us to reuse the existing comparison logic that operates on specs
-	// The comparison will handle deep equality checking of all nested fields
-	desiredSpec := ProtocolConverterServiceConfigSpec{
-		Config: protocolConverterDesiredTemplate,
-	}
-	observedSpec := ProtocolConverterServiceConfigSpec{
-		Config: protocolConverterObservedTemplate,
-	}
+	comparatorDFC := dataflowcomponentserviceconfig.NewComparator()
 
-	return defaultComparator.ConfigsEqual(desiredSpec, observedSpec)
+	return reflect.DeepEqual(desiredConnT, observedConnT) &&
+		comparatorDFC.ConfigsEqual(desired.DataflowComponentReadServiceConfig, observed.DataflowComponentReadServiceConfig) &&
+		comparatorDFC.ConfigsEqual(desired.DataflowComponentWriteServiceConfig, observed.DataflowComponentWriteServiceConfig)
 }
 
-// ConfigDiffRuntime is a package-level function for generating diffs between runtime configurations.
+// ConfigDiffRuntime returns a human-readable diff between two runtime configurations.
 func ConfigDiffRuntime(desired, observed ProtocolConverterServiceConfigRuntime) string {
-	// Convert runtime configs back to template format for diffing
-	// This allows us to reuse the existing diff generation logic
-	protocolConverterDesiredTemplate := convertRuntimeToTemplate(desired)
-	protocolConverterObservedTemplate := convertRuntimeToTemplate(observed)
+	desiredConnT := connectionserviceconfig.ConvertRuntimeToTemplate(desired.ConnectionServiceConfig)
+	observedConnT := connectionserviceconfig.ConvertRuntimeToTemplate(observed.ConnectionServiceConfig)
 
-	// Convert to spec configs for diffing
-	desiredSpec := ProtocolConverterServiceConfigSpec{
-		Config: protocolConverterDesiredTemplate,
-	}
-	observedSpec := ProtocolConverterServiceConfigSpec{
-		Config: protocolConverterObservedTemplate,
+	diff := ""
+	if !reflect.DeepEqual(desiredConnT, observedConnT) {
+		diff += fmt.Sprintf("Connection: %v vs %v\n", desiredConnT, observedConnT)
 	}
 
-	return defaultComparator.ConfigDiff(desiredSpec, observedSpec)
+	comparatorDFC := dataflowcomponentserviceconfig.NewComparator()
+	if d := comparatorDFC.ConfigDiff(desired.DataflowComponentReadServiceConfig, observed.DataflowComponentReadServiceConfig); d != "" {
+		diff += "ReadDFC: " + d + "\n"
+	}
+	if d := comparatorDFC.ConfigDiff(desired.DataflowComponentWriteServiceConfig, observed.DataflowComponentWriteServiceConfig); d != "" {
+		diff += "WriteDFC: " + d + "\n"
+	}
+	return diff
 }
 
 // SpecToRuntime converts a ProtocolConverterServiceConfigSpec to a ProtocolConverterServiceConfigRuntime
@@ -202,8 +178,10 @@ func SpecToRuntime(spec ProtocolConverterServiceConfigSpec) (ProtocolConverterSe
 	}
 
 	return ProtocolConverterServiceConfigRuntime{
-		ConnectionServiceConfig:             connRuntime,
-		DataflowComponentReadServiceConfig:  spec.Config.DataflowComponentReadServiceConfig,
-		DataflowComponentWriteServiceConfig: spec.Config.DataflowComponentWriteServiceConfig,
+		ConnectionServiceConfig:            connRuntime,
+		DataflowComponentReadServiceConfig: spec.Config.DataflowComponentReadServiceConfig,
+		// bridgedBy is intentionally empty: SpecToRuntime does structural conversion only,
+		// not full template rendering (InputTopics is split as-is). Use BuildRuntimeConfig for deploys.
+		DataflowComponentWriteServiceConfig: spec.Config.DataflowComponentWriteServiceConfig.ToDataflowComponentServiceConfig(""),
 	}, nil
 }

--- a/umh-core/pkg/config/protocolconverterserviceconfig/package.go
+++ b/umh-core/pkg/config/protocolconverterserviceconfig/package.go
@@ -37,6 +37,11 @@ var (
 // using expressions like "{{ .PORT }}" which are resolved during rendering.
 type ProtocolConverterServiceConfigTemplate struct {
 
+	// DataflowComponentWriteServiceConfig is the blueprint for the *write* side
+	// of the converter. InputTopics is a string that may contain Go template actions
+	// rendered at deploy time; use DataflowComponentWriteConfigInput.Render to resolve it.
+	DataflowComponentWriteServiceConfig dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput `yaml:"dataflowcomponent_write,omitempty"`
+
 	// ConnectionServiceConfig describes how the converter connects to the
 	// underlying messaging infrastructure. Uses the template form to allow
 	// templating of connection parameters like port numbers.
@@ -48,11 +53,6 @@ type ProtocolConverterServiceConfigTemplate struct {
 	// `BenthosConfig.Output` is an UNS publisher because read‑DFCs **must not**
 	// decide their own egress.
 	DataflowComponentReadServiceConfig dataflowcomponentserviceconfig.DataflowComponentServiceConfig `yaml:"dataflowcomponent_read,omitempty"`
-
-	// DataflowComponentWriteServiceConfig is the blueprint for the *write* side
-	// of the converter. InputTopics is a string that may contain Go template actions
-	// rendered at deploy time; use DataflowComponentWriteConfigInput.Render to resolve it.
-	DataflowComponentWriteServiceConfig dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput `yaml:"dataflowcomponent_write,omitempty"`
 }
 
 // ProtocolConverterServiceConfigRuntime is the **fully rendered** form of a

--- a/umh-core/pkg/fsm/protocolconverter/actions.go
+++ b/umh-core/pkg/fsm/protocolconverter/actions.go
@@ -331,7 +331,7 @@ func (p *ProtocolConverterInstance) UpdateObservedStateOfInstance(ctx context.Co
 		p.specConfig,
 		agentLocationStr,
 		nil,             // TODO: add global vars
-		"unimplemented", // TODO: add node name
+		runtime_config.BridgedByPlaceholder,
 		p.baseFSMInstance.GetID(),
 	)
 

--- a/umh-core/pkg/fsm/protocolconverter/actions.go
+++ b/umh-core/pkg/fsm/protocolconverter/actions.go
@@ -334,7 +334,9 @@ func (p *ProtocolConverterInstance) UpdateObservedStateOfInstance(ctx context.Co
 		"unimplemented", // TODO: add node name
 		p.baseFSMInstance.GetID(),
 	)
+
 	if err != nil {
+		p.baseFSMInstance.GetLogger().Errorf("failed to build runtime config: %v", err)
 		// Capture the configuration error in StatusReason for troubleshooting
 		p.ObservedState.ServiceInfo.StatusReason = "config error: " + err.Error()
 
@@ -458,7 +460,7 @@ func (p *ProtocolConverterInstance) IsDFCHealthy() (bool, string) {
 	writeIntentionallyStopped := p.specConfig.WriteDFCDesiredState == OperationalStateStopped
 
 	readHasConfig := len(p.specConfig.Config.DataflowComponentReadServiceConfig.BenthosConfig.Input) > 0
-	writeHasConfig := len(p.specConfig.Config.DataflowComponentWriteServiceConfig.BenthosConfig.Output) > 0
+	writeHasConfig := p.specConfig.Config.DataflowComponentWriteServiceConfig.HasOutput()
 
 	readHealthy := readRunning || readIntentionallyStopped || !readHasConfig
 	writeHealthy := writeRunning || writeIntentionallyStopped || !writeHasConfig
@@ -493,8 +495,7 @@ func (p *ProtocolConverterInstance) areBothDFCsIntentionallyStopped() bool {
 	}
 
 	readHasConfig := len(p.specConfig.Config.DataflowComponentReadServiceConfig.BenthosConfig.Input) > 0
-	writeHasConfig := len(p.specConfig.Config.DataflowComponentWriteServiceConfig.BenthosConfig.Output) > 0
-
+	writeHasConfig := p.specConfig.Config.DataflowComponentWriteServiceConfig.HasOutput()
 	return readHasConfig || writeHasConfig
 }
 
@@ -624,7 +625,7 @@ func (p *ProtocolConverterInstance) IsProtocolConverterStopped() (bool, string) 
 	readStopped := p.ObservedState.ServiceInfo.DataflowComponentReadFSMState == dataflowfsm.OperationalStateStopped
 	writeStopped := p.ObservedState.ServiceInfo.DataflowComponentWriteFSMState == dataflowfsm.OperationalStateStopped
 
-	writeHasConfig := len(p.specConfig.Config.DataflowComponentWriteServiceConfig.BenthosConfig.Output) > 0
+	writeHasConfig := p.specConfig.Config.DataflowComponentWriteServiceConfig.HasOutput()
 	writeEffectivelyStopped := writeStopped || !writeHasConfig
 
 	if connStopped && readStopped && writeEffectivelyStopped {
@@ -645,7 +646,7 @@ func (p *ProtocolConverterInstance) IsProtocolConverterStopped() (bool, string) 
 //	reason – empty when ok is true; otherwise a service‑provided explanation.
 func (p *ProtocolConverterInstance) IsDFCExisting() (bool, string) {
 	if len(p.specConfig.Config.DataflowComponentReadServiceConfig.BenthosConfig.Input) > 0 ||
-		len(p.specConfig.Config.DataflowComponentWriteServiceConfig.BenthosConfig.Output) > 0 {
+		p.specConfig.Config.DataflowComponentWriteServiceConfig.HasOutput() {
 		return true, ""
 	}
 

--- a/umh-core/pkg/models/action_models.go
+++ b/umh-core/pkg/models/action_models.go
@@ -17,6 +17,7 @@ package models
 import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/google/uuid"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/dataflowcomponentserviceconfig"
 )
 
 type DeployCustomDataFlowComponentPayload struct {
@@ -798,8 +799,6 @@ type ProtocolConverterDFC struct {
 	Inputs CommonDataFlowComponentInputConfig `json:"inputs,omitempty" mapstructure:"inputs,omitempty" yaml:"inputs,omitempty"`
 	// Outputs is used by both read and write DFCs (user-supplied output config).
 	Outputs CommonDataFlowComponentOutputConfig `json:"outputs,omitempty" mapstructure:"outputs,omitempty" yaml:"outputs,omitempty"`
-	// UMHTopics is used by write DFCs — UNS topic regexes to subscribe to. Auto-injected into input config.
-	UMHTopics []string `json:"umh_topics,omitempty" mapstructure:"umh_topics,omitempty" yaml:"umh_topics,omitempty"`
 }
 
 type ProtocolConverterVariable struct {
@@ -813,11 +812,47 @@ type ProtocolConverterTemplateInfo struct {
 	IsTemplated bool                        `json:"isTemplated" mapstructure:"isTemplated" yaml:"isTemplated"`
 }
 
+// WriteDFCRequest is the inbound wire format for write DFC configuration.
+// The embedded struct uses mapstructure:",squash" so mapstructure flattens its fields
+// into this struct during action payload decoding. Go's encoding/json promotes embedded
+// struct fields automatically without a tag, so no json:",squash" is needed or exists.
+type WriteDFCRequest struct {
+	dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput `mapstructure:",squash"`
+	// State is the desired lifecycle state ("active" or "stopped").
+	State string `json:"state,omitempty" mapstructure:"state,omitempty"`
+	// IgnoreErrors skips the health-check rollout when true.
+	IgnoreErrors *bool `json:"ignoreErrors,omitempty" mapstructure:"ignoreErrors,omitempty"`
+}
+
+// WriteDFCResponse is the outbound wire format for write DFC configuration.
+// InputTopics is returned as the raw string from config.yaml (may contain Go template
+// actions), matching the inbound WriteDFCRequest shape.
+type WriteDFCResponse struct {
+	dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput `mapstructure:",squash"`
+	// State is the desired lifecycle state ("active" or "stopped").
+	State string `json:"state,omitempty" mapstructure:"state,omitempty"`
+	// IgnoreErrors skips the health-check rollout when true.
+	IgnoreErrors *bool `json:"ignoreErrors,omitempty" mapstructure:"ignoreErrors,omitempty"`
+}
+
+// ProtocolConverterRequest is the inbound shape used by edit and deploy actions.
+type ProtocolConverterRequest struct {
+	UUID         *uuid.UUID                     `binding:"required"     json:"uuid"`
+	Location     map[int]string                 `json:"location"`
+	ReadDFC      *ProtocolConverterDFC          `json:"readDFC"`
+	WriteDFC     *WriteDFCRequest               `json:"writeDFC"`
+	TemplateInfo *ProtocolConverterTemplateInfo `json:"templateInfo"`
+	Meta         *ProtocolConverterMeta         `json:"meta"`
+	Name         string                         `binding:"required" json:"name"`
+	Connection   ProtocolConverterConnection    `json:"connection"`
+}
+
+// ProtocolConverter is the outbound shape returned by GET actions.
 type ProtocolConverter struct {
 	UUID         *uuid.UUID                     `binding:"required"  json:"uuid"`
 	Location     map[int]string                 `json:"location"`
 	ReadDFC      *ProtocolConverterDFC          `json:"readDFC"`
-	WriteDFC     *ProtocolConverterDFC          `json:"writeDFC"`
+	WriteDFC     *WriteDFCResponse              `json:"writeDFC"`
 	TemplateInfo *ProtocolConverterTemplateInfo `json:"templateInfo"`
 	Meta         *ProtocolConverterMeta         `json:"meta"`
 	Name         string                         `binding:"required"  json:"name"`

--- a/umh-core/pkg/models/action_models.go
+++ b/umh-core/pkg/models/action_models.go
@@ -812,11 +812,12 @@ type ProtocolConverterTemplateInfo struct {
 	IsTemplated bool                        `json:"isTemplated" mapstructure:"isTemplated" yaml:"isTemplated"`
 }
 
-// WriteDFCRequest is the inbound wire format for write DFC configuration.
+// WriteDFCPayload is the wire format for write DFC configuration, used for both inbound
+// (deploy/edit actions) and outbound (GET responses) payloads i.e. what is transmitted to/from the client.
 // The embedded struct uses mapstructure:",squash" so mapstructure flattens its fields
 // into this struct during action payload decoding. Go's encoding/json promotes embedded
 // struct fields automatically without a tag, so no json:",squash" is needed or exists.
-type WriteDFCRequest struct {
+type WriteDFCPayload struct {
 	dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput `mapstructure:",squash"`
 	// State is the desired lifecycle state ("active" or "stopped").
 	State string `json:"state,omitempty" mapstructure:"state,omitempty"`
@@ -824,39 +825,17 @@ type WriteDFCRequest struct {
 	IgnoreErrors *bool `json:"ignoreErrors,omitempty" mapstructure:"ignoreErrors,omitempty"`
 }
 
-// WriteDFCResponse is the outbound wire format for write DFC configuration.
-// InputTopics is returned as the raw string from config.yaml (may contain Go template
-// actions), matching the inbound WriteDFCRequest shape.
-type WriteDFCResponse struct {
-	dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput `mapstructure:",squash"`
-	// State is the desired lifecycle state ("active" or "stopped").
-	State string `json:"state,omitempty" mapstructure:"state,omitempty"`
-	// IgnoreErrors skips the health-check rollout when true.
-	IgnoreErrors *bool `json:"ignoreErrors,omitempty" mapstructure:"ignoreErrors,omitempty"`
-}
-
-// ProtocolConverterRequest is the inbound shape used by edit and deploy actions.
-type ProtocolConverterRequest struct {
-	UUID         *uuid.UUID                     `binding:"required"     json:"uuid"`
-	Location     map[int]string                 `json:"location"`
-	ReadDFC      *ProtocolConverterDFC          `json:"readDFC"`
-	WriteDFC     *WriteDFCRequest               `json:"writeDFC"`
-	TemplateInfo *ProtocolConverterTemplateInfo `json:"templateInfo"`
-	Meta         *ProtocolConverterMeta         `json:"meta"`
-	Name         string                         `binding:"required" json:"name"`
-	Connection   ProtocolConverterConnection    `json:"connection"`
-}
-
-// ProtocolConverter is the outbound shape returned by GET actions.
+// ProtocolConverter is the wire format for protocol converter configuration,
+// used by deploy/edit actions and GET responses.
 type ProtocolConverter struct {
-	UUID         *uuid.UUID                     `binding:"required"  json:"uuid"`
-	Location     map[int]string                 `json:"location"`
-	ReadDFC      *ProtocolConverterDFC          `json:"readDFC"`
-	WriteDFC     *WriteDFCResponse              `json:"writeDFC"`
-	TemplateInfo *ProtocolConverterTemplateInfo `json:"templateInfo"`
-	Meta         *ProtocolConverterMeta         `json:"meta"`
-	Name         string                         `binding:"required"  json:"name"`
-	Connection   ProtocolConverterConnection    `json:"connection"`
+	UUID            *uuid.UUID                     `binding:"required"     json:"uuid"`
+	Location        map[int]string                 `json:"location"`
+	ReadDFC         *ProtocolConverterDFC          `json:"readDFC"`
+	WriteDFCPayload *WriteDFCPayload               `json:"writeDFC"`
+	TemplateInfo    *ProtocolConverterTemplateInfo `json:"templateInfo"`
+	Meta            *ProtocolConverterMeta         `json:"meta"`
+	Name            string                         `binding:"required" json:"name"`
+	Connection      ProtocolConverterConnection    `json:"connection"`
 }
 
 type ProtocolConverterMeta struct {

--- a/umh-core/pkg/models/action_models.go
+++ b/umh-core/pkg/models/action_models.go
@@ -37,9 +37,7 @@ type CDFCPayload struct {
 	Outputs         DfcDataConfig            `json:"outputs"`
 	Inject          string                   `json:"inject"`
 	BenthosImageTag string                   `json:"benthosImageTag"`
-	// UMHTopics is used by write DFCs — UNS topic regexes to subscribe to.
-	UMHTopics    []string `json:"umh_topics,omitempty"`
-	IgnoreErrors bool     `json:"ignoreErrors"`
+	IgnoreErrors bool `json:"ignoreErrors"`
 }
 
 type DfcDataConfig struct {

--- a/umh-core/pkg/models/action_models.go
+++ b/umh-core/pkg/models/action_models.go
@@ -37,7 +37,7 @@ type CDFCPayload struct {
 	Outputs         DfcDataConfig            `json:"outputs"`
 	Inject          string                   `json:"inject"`
 	BenthosImageTag string                   `json:"benthosImageTag"`
-	IgnoreErrors bool `json:"ignoreErrors"`
+	IgnoreErrors    bool                     `json:"ignoreErrors"`
 }
 
 type DfcDataConfig struct {
@@ -817,10 +817,10 @@ type ProtocolConverterTemplateInfo struct {
 // struct fields automatically without a tag, so no json:",squash" is needed or exists.
 type WriteDFCPayload struct {
 	dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput `mapstructure:",squash"`
-	// State is the desired lifecycle state ("active" or "stopped").
-	State string `json:"state,omitempty" mapstructure:"state,omitempty"`
 	// IgnoreErrors skips the health-check rollout when true.
 	IgnoreErrors *bool `json:"ignoreErrors,omitempty" mapstructure:"ignoreErrors,omitempty"`
+	// State is the desired lifecycle state ("active" or "stopped").
+	State string `json:"state,omitempty" mapstructure:"state,omitempty"`
 }
 
 // ProtocolConverter is the wire format for protocol converter configuration,

--- a/umh-core/pkg/service/protocolconverter/runtime_config/runtime_config.go
+++ b/umh-core/pkg/service/protocolconverter/runtime_config/runtime_config.go
@@ -28,6 +28,12 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants"
 )
 
+// BridgedByPlaceholder is the node-name sentinel passed to BuildRuntimeConfig when
+// the real node name is not yet available (e.g. during action verification in the
+// communicator). It must match the value used in FSM actions so the Kafka consumer-group
+// name is identical across both callers — update both if this ever changes.
+const BridgedByPlaceholder = "unimplemented"
+
 // BuildRuntimeConfig merges all variables (user + agent + global + internal),
 // performs the location merge, derives the `bridged_by` header, and finally
 // renders the three sub-templates.
@@ -310,13 +316,16 @@ func renderConfig(
 	}
 
 	// Extract the resolved bridged_by value from the scope to wire up the UNS consumer group.
-	// If scope["internal"]["bridged_by"] is absent (e.g. in structural comparisons that never
-	// hit the Benthos wire), bridgedBy stays "" and ToDataflowComponentServiceConfig will
-	// emit consumer_group: "" — acceptable for diff logic, but invalid for a live bridge.
-	// The FSM always injects this key before deploying, so a blank value at runtime is a bug.
+	// A blank value is acceptable only for structural comparisons (no live Benthos wire).
+	// When a write output is configured, bridgedBy must be non-empty — a blank value means
+	// all bridges share an empty consumer group and steal each other's messages.
 	var bridgedBy string
 	if internal, ok := scope["internal"].(map[string]any); ok {
 		bridgedBy, _ = internal["bridged_by"].(string)
+	}
+	if bridgedBy == "" && renderedWriteConfig.HasOutput() {
+		return protocolconverterserviceconfig.ProtocolConverterServiceConfigRuntime{},
+			errors.New("bridged_by is empty for a write DFC with output configured: the FSM must inject internal.bridged_by before calling BuildRuntimeConfig")
 	}
 
 	// Expand the typed write config into a full Benthos service config.
@@ -350,7 +359,6 @@ func appendDownsampler(dfc dataflowcomponentserviceconfig.DataflowComponentServi
 
 	return updatedDFC
 }
-
 
 // getProcessors safely extracts the processors array from a pipeline configuration.
 func getProcessors(pipeline map[string]any) []any {

--- a/umh-core/pkg/service/protocolconverter/runtime_config/runtime_config.go
+++ b/umh-core/pkg/service/protocolconverter/runtime_config/runtime_config.go
@@ -195,18 +195,6 @@ func BuildRuntimeConfig(
 
 	vb.Internal["bridged_by"] = config.GenerateBridgedBy(config.ComponentTypeProtocolConverter, nodeName, pcName)
 
-	// TODO(ENG-4856): This default exists because UMH_TOPICS lives in Variables.User
-	// instead of a typed config block. A typed field would have a proper zero value.
-	// Remove once UMH_TOPICS moves to typed config in the FSMv2 bridge migration.
-	// UMH_TOPICS is required in user variables when write DFC is configured
-	// We usually catch this in the frontend, but user could bypass it through config.yaml
-	if len(spec.Config.DataflowComponentWriteServiceConfig.BenthosConfig.Output) > 0 {
-		if _, ok := vb.User["UMH_TOPICS"]; !ok {
-			// UMH_TOPICS is not set by the frontend. Set value here and which will throw error in deployment
-			vb.User["UMH_TOPICS"] = []string{"TOPIC_NOT_SET_BY_USER"}
-		}
-	}
-
 	//----------------------------------------------------------------------
 	// 4. Render all three sub-templates
 	//----------------------------------------------------------------------
@@ -315,25 +303,25 @@ func renderConfig(
 		read = appendDownsampler(read)
 	}
 
-	write, err := config.RenderTemplate(spec.GetDFCWriteServiceConfig(), scope)
+	// Render the write DFC template (resolves {{ .IP }}, {{ .PORT }}, etc. in write_output).
+	renderedWriteConfig, err := config.RenderTemplate(spec.Config.DataflowComponentWriteServiceConfig, scope)
 	if err != nil {
 		return protocolconverterserviceconfig.ProtocolConverterServiceConfigRuntime{}, err
 	}
 
-	// TODO(ENG-4856): This post-render injection exists because UMH_TOPICS is stored in
-	// Variables.User (an untyped map) rather than a typed config field. text/template
-	// can't render []string, so we inject it manually after rendering. Remove once
-	// UMH_TOPICS moves to a typed config block in the FSMv2 bridge migration.
-	// Inject umh_topics into write DFC input after template rendering.
-	// []string values can't be rendered via text/template, so we set them directly.
-	// UMH_TOPICS presence is guaranteed by BuildRuntimeConfig above.
-	//
-	// The Input["uns"] assertion always succeeds when Output is non-empty:
-	// GetDFCWriteServiceConfig unconditionally sets Input["uns"] whenever
-	// len(Output) > 0 — the same gate that guards the UMH_TOPICS default block above.
-	if unsInput, ok := write.BenthosConfig.Input["uns"].(map[string]any); ok {
-		unsInput["umh_topics"] = scope["UMH_TOPICS"]
+	// Extract the resolved bridged_by value from the scope to wire up the UNS consumer group.
+	// If scope["internal"]["bridged_by"] is absent (e.g. in structural comparisons that never
+	// hit the Benthos wire), bridgedBy stays "" and ToDataflowComponentServiceConfig will
+	// emit consumer_group: "" — acceptable for diff logic, but invalid for a live bridge.
+	// The FSM always injects this key before deploying, so a blank value at runtime is a bug.
+	var bridgedBy string
+	if internal, ok := scope["internal"].(map[string]any); ok {
+		bridgedBy, _ = internal["bridged_by"].(string)
 	}
+
+	// Expand the typed write config into a full Benthos service config.
+	// This enforces the UNS input and nodered_js processor, injecting umh_topics directly.
+	write := renderedWriteConfig.ToDataflowComponentServiceConfig(bridgedBy)
 
 	return protocolconverterserviceconfig.ProtocolConverterServiceConfigRuntime{
 		ConnectionServiceConfig:             connRuntime,
@@ -362,6 +350,7 @@ func appendDownsampler(dfc dataflowcomponentserviceconfig.DataflowComponentServi
 
 	return updatedDFC
 }
+
 
 // getProcessors safely extracts the processors array from a pipeline configuration.
 func getProcessors(pipeline map[string]any) []any {

--- a/umh-core/pkg/service/protocolconverter/runtime_config/runtime_config_test.go
+++ b/umh-core/pkg/service/protocolconverter/runtime_config/runtime_config_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/connectionserviceconfig"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/dataflowcomponentserviceconfig"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/protocolconverterserviceconfig"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/variables"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/protocolconverter/runtime_config"
 )
 
@@ -73,8 +72,6 @@ var _ = Describe("BuildRuntimeConfig", func() {
 		}
 		nodeName = "test-node"
 		pcName = "temperature-sensor-pc"
-
-		spec.Config.DataflowComponentWriteServiceConfig = dataflowcomponentserviceconfig.DataflowComponentServiceConfig{}
 	})
 
 	Describe("BuildRuntimeConfig", func() {
@@ -89,9 +86,10 @@ var _ = Describe("BuildRuntimeConfig", func() {
 			Expect(result.ConnectionServiceConfig.NmapServiceConfig.Target).To(Equal("10.0.1.50"))
 			Expect(result.ConnectionServiceConfig.NmapServiceConfig.Port).To(Equal(uint16(4840)))
 
-			// Verify dataflow component configs exist (even if empty)
+			// Verify read DFC config exists
 			Expect(result.DataflowComponentReadServiceConfig).NotTo(BeNil())
-			Expect(result.DataflowComponentWriteServiceConfig).NotTo(BeNil())
+			// Verify write DFC output was parsed from the example YAML (regression: wrong key "write_output" was silently dropped)
+			Expect(result.DataflowComponentWriteServiceConfig.BenthosConfig.Output).To(HaveKey("http_client"))
 		})
 
 		It("should properly merge agent and PC locations", func() {
@@ -168,8 +166,7 @@ var _ = Describe("BuildRuntimeConfig", func() {
 		})
 	})
 
-	Describe("Write DFC UMH_TOPICS validation and injection", func() {
-		// Helper to create a basic connection config
+	Describe("Write DFC UMH topics and UNS input injection", func() {
 		createConnectionConfig := func() connectionserviceconfig.ConnectionServiceConfigTemplate {
 			return connectionserviceconfig.ConnectionServiceConfigTemplate{
 				NmapTemplate: &connectionserviceconfig.NmapConfigTemplate{
@@ -179,74 +176,34 @@ var _ = Describe("BuildRuntimeConfig", func() {
 			}
 		}
 
-		It("should succeed with default UMH_TOPICS when write DFC has Output but UMH_TOPICS not set", func() {
+		It("should inject default TOPIC_NOT_SET_BY_USER when UMHTopics is empty but output is set", func() {
 			testSpec := protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec{
 				Config: protocolconverterserviceconfig.ProtocolConverterServiceConfigTemplate{
 					ConnectionServiceConfig: createConnectionConfig(),
-					DataflowComponentWriteServiceConfig: dataflowcomponentserviceconfig.DataflowComponentServiceConfig{
-						BenthosConfig: dataflowcomponentserviceconfig.BenthosConfig{
-							Output: map[string]any{
-								"stdout": map[string]any{},
-							},
-						},
+					DataflowComponentWriteServiceConfig: dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
+						Output: map[string]any{"stdout": map[string]any{}},
 					},
 				},
 			}
-			// No UMH_TOPICS in variables — default should be injected
 
 			result, err := runtime_config.BuildRuntimeConfig(testSpec, agentLocation, globalVars, nodeName, pcName)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).NotTo(BeZero())
 
-			// The default fallback topic must appear in the write DFC's uns input.
 			writeInput := result.DataflowComponentWriteServiceConfig.BenthosConfig.Input
 			Expect(writeInput).To(HaveKey("uns"))
 			unsInput, ok := writeInput["uns"].(map[string]any)
-			Expect(ok).To(BeTrue(), "uns input should be a map")
+			Expect(ok).To(BeTrue())
 			Expect(unsInput).To(HaveKey("umh_topics"))
 			Expect(unsInput["umh_topics"]).To(Equal([]string{"TOPIC_NOT_SET_BY_USER"}))
 		})
 
-		It("should succeed when write DFC has Output and UMH_TOPICS is set", func() {
+		It("should inject UMHTopics into write DFC uns input", func() {
 			testSpec := protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec{
 				Config: protocolconverterserviceconfig.ProtocolConverterServiceConfigTemplate{
 					ConnectionServiceConfig: createConnectionConfig(),
-					DataflowComponentWriteServiceConfig: dataflowcomponentserviceconfig.DataflowComponentServiceConfig{
-						BenthosConfig: dataflowcomponentserviceconfig.BenthosConfig{
-							Output: map[string]any{
-								"stdout": map[string]any{},
-							},
-						},
-					},
-				},
-				Variables: variables.VariableBundle{
-					User: map[string]any{
-						"UMH_TOPICS": []string{"umh.v1.enterprise.site.*"},
-					},
-				},
-			}
-
-			result, err := runtime_config.BuildRuntimeConfig(testSpec, agentLocation, globalVars, nodeName, pcName)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(result).NotTo(BeZero())
-		})
-
-		It("should inject UMH_TOPICS into write DFC uns input after rendering", func() {
-			topics := []string{"umh.v1.factory.line-1.*", "umh.v1.factory.line-2.*"}
-			testSpec := protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec{
-				Config: protocolconverterserviceconfig.ProtocolConverterServiceConfigTemplate{
-					ConnectionServiceConfig: createConnectionConfig(),
-					DataflowComponentWriteServiceConfig: dataflowcomponentserviceconfig.DataflowComponentServiceConfig{
-						BenthosConfig: dataflowcomponentserviceconfig.BenthosConfig{
-							Output: map[string]any{
-								"stdout": map[string]any{},
-							},
-						},
-					},
-				},
-				Variables: variables.VariableBundle{
-					User: map[string]any{
-						"UMH_TOPICS": topics,
+					DataflowComponentWriteServiceConfig: dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
+						InputTopics: "umh.v1.factory.line-1.*\numh.v1.factory.line-2.*",
+						Output:      map[string]any{"stdout": map[string]any{}},
 					},
 				},
 			}
@@ -254,26 +211,24 @@ var _ = Describe("BuildRuntimeConfig", func() {
 			result, err := runtime_config.BuildRuntimeConfig(testSpec, agentLocation, globalVars, nodeName, pcName)
 			Expect(err).NotTo(HaveOccurred())
 
-			// After rendering, UMH_TOPICS must be in write DFC's uns input
 			writeInput := result.DataflowComponentWriteServiceConfig.BenthosConfig.Input
 			Expect(writeInput).To(HaveKey("uns"))
 			unsInput, ok := writeInput["uns"].(map[string]any)
-			Expect(ok).To(BeTrue(), "uns input should be a map")
-			Expect(unsInput).To(HaveKey("umh_topics"))
-			Expect(unsInput["umh_topics"]).To(Equal(topics))
+			Expect(ok).To(BeTrue())
+			Expect(unsInput["umh_topics"]).To(Equal([]string{"umh.v1.factory.line-1.*", "umh.v1.factory.line-2.*"}))
 		})
 
-		It("should not require UMH_TOPICS when write DFC is empty", func() {
+		It("should not require UMHTopics when write DFC has no output", func() {
 			testSpec := protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec{
 				Config: protocolconverterserviceconfig.ProtocolConverterServiceConfigTemplate{
-					ConnectionServiceConfig: createConnectionConfig(),
-					// Write DFC with no Output configured
-					DataflowComponentWriteServiceConfig: dataflowcomponentserviceconfig.DataflowComponentServiceConfig{},
+					ConnectionServiceConfig:             createConnectionConfig(),
+					DataflowComponentWriteServiceConfig: dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{},
 				},
 			}
 
-			_, err := runtime_config.BuildRuntimeConfig(testSpec, agentLocation, globalVars, nodeName, pcName)
+			result, err := runtime_config.BuildRuntimeConfig(testSpec, agentLocation, globalVars, nodeName, pcName)
 			Expect(err).NotTo(HaveOccurred())
+			Expect(result.DataflowComponentWriteServiceConfig.BenthosConfig.Input).To(BeEmpty())
 		})
 	})
 
@@ -501,6 +456,68 @@ var _ = Describe("BuildRuntimeConfig", func() {
 			readConfig := result.DataflowComponentReadServiceConfig
 			_, exists := readConfig.BenthosConfig.Pipeline["processors"]
 			Expect(exists).To(BeFalse(), "Pipeline should NOT be created with processors when no tag_processor exists")
+		})
+	})
+
+	Describe("Write DFC processor validation", func() {
+		createConnectionConfig := func() connectionserviceconfig.ConnectionServiceConfigTemplate {
+			return connectionserviceconfig.ConnectionServiceConfigTemplate{
+				NmapTemplate: &connectionserviceconfig.NmapConfigTemplate{
+					Target: "127.0.0.1",
+					Port:   "8080",
+				},
+			}
+		}
+
+		It("should accept write DFC with output and no explicit processing (defaults to passthrough)", func() {
+			testSpec := protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec{
+				Config: protocolconverterserviceconfig.ProtocolConverterServiceConfigTemplate{
+					ConnectionServiceConfig: createConnectionConfig(),
+					DataflowComponentWriteServiceConfig: dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
+						Output: map[string]any{"stdout": map[string]any{}},
+					},
+				},
+			}
+
+			_, err := runtime_config.BuildRuntimeConfig(testSpec, agentLocation, globalVars, nodeName, pcName)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should accept write DFC with explicit nodered_js processing code", func() {
+			testSpec := protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec{
+				Config: protocolconverterserviceconfig.ProtocolConverterServiceConfigTemplate{
+					ConnectionServiceConfig: createConnectionConfig(),
+					DataflowComponentWriteServiceConfig: dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
+						Output:              map[string]any{"stdout": map[string]any{}},
+						ProcessingNoderedJS: "msg.payload.foo = 'bar';\nreturn msg;",
+					},
+				},
+			}
+
+			_, err := runtime_config.BuildRuntimeConfig(testSpec, agentLocation, globalVars, nodeName, pcName)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should produce nodered_js processor in the rendered config", func() {
+			testSpec := protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec{
+				Config: protocolconverterserviceconfig.ProtocolConverterServiceConfigTemplate{
+					ConnectionServiceConfig: createConnectionConfig(),
+					DataflowComponentWriteServiceConfig: dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
+						Output:              map[string]any{"stdout": map[string]any{}},
+						ProcessingNoderedJS: "return msg;",
+					},
+				},
+			}
+
+			runtimeConfig, err := runtime_config.BuildRuntimeConfig(testSpec, agentLocation, globalVars, nodeName, pcName)
+			Expect(err).NotTo(HaveOccurred())
+
+			writeDFC := runtimeConfig.DataflowComponentWriteServiceConfig
+			procs, ok := writeDFC.BenthosConfig.Pipeline["processors"].([]any)
+			Expect(ok).To(BeTrue())
+			Expect(procs).To(HaveLen(1))
+			firstProc := procs[0].(map[string]any)
+			Expect(firstProc).To(HaveKey("nodered_js"))
 		})
 	})
 })


### PR DESCRIPTION
> [!NOTE]
> Use frontend branch https://github.com/united-manufacturing-hub/ManagementConsole/pull/3180 for testing this PR. Won't work with current staging/main due to breaking changes.

## Product wise

Rework write flow yaml in this format. Naming and smaller adjustments will be done in follow up PR.

```
dataflowcomponent_write:
    input_topics: |-
        umh.v1.UMHDEVTEST._historian.my_data_generate0
        umh.v1.UMHDEVTEST._historian.my_data_generate1
        umh.v1.UMHDEVTEST._historian.my_data_generate2
    processing_nodered_js: |-
        msg.payload.foo = "bar";
        return msg;
    output:
        http_client:
            url: http://{{ .IP }}:{{ .PORT}}/get
                  verb: GET
```

This not makes it that
1. topics are not a user variable any more, but directly wired into write flow
2. processing is fixed to `nodered_js` (will have a type in follow up PR)
3. All of the parameters are now strings and support templating. Sent in requests like this and then parsed + rendered into types in umh-core

## Code wise
  Write flows stored input topics in Variables.User["UMH_TOPICS"] (untyped map[string]any), requiring three-form type
  conversion to survive YAML round-trips. This PR moves to a typed DataflowComponentWriteConfigInput struct with an
  input_topics string field.

  Changes:
  - Wire format is now input_topics (string) + write_output (map), replacing the old benthos.input/output nesting.
  - WriteDFCRequest and WriteDFCResponse collapsed into a single WriteDFC type — they were structurally identical.
  - ProtocolConverterRequest removed; ProtocolConverter now used for both deploy/edit actions and GET responses.
  - toStringSlice(), equalTopicSets(), and all UMH_TOPICS handling deleted.
  - Write DFC no longer borrows the read DFC's benthos config shape.
  - Validation split into validateReadProtocolConverterDFC / validateWriteDFCConfig. Template vars in input_topics (e.g., {{
   .location_path }}) are allowed at validation time; rendering happens in BuildRuntimeConfig.
  - Example config: dataflowcomponent_write.write_output instead of dataflowcomponent_write.benthos.output.
  - CHANGELOG updated to reference input_topics instead of UMH_TOPICS.
