### PR TITLE
ci: populate Linear release description from umh-core/CHANGELOG.md

### DIFF
--- a/.github/scripts/build-release-notes.sh
+++ b/.github/scripts/build-release-notes.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Copyright 2025 UMH Systems GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Writes the Linear release notes for $VERSION into the file named by $1.
+#
+# The notes are the `## [VERSION]` section of the CHANGELOG (image-only lines
+# stripped; the image-rich changelog lives at umh.app/insights/changelog) then a
+# footer linking there. An empty/missing section yields just the footer plus a
+# workflow warning on dry-runs, or a hard failure on a real sync.
+#
+# umh-core's CHANGELOG.md uses bracketed semver headings (`## [0.44.21]`), so
+# VERSION here is the BARE semver (no leading 'v'); the v-prefixed tag is only
+# used for the Linear release version, not the changelog lookup.
+#
+# Env:  VERSION         bare semver, e.g. 0.44.21 (required)
+#       CHANGELOG_FILE   source changelog (default: umh-core/CHANGELOG.md)
+#       DRY_RUN          'true' downgrades empty-notes failure to a warning
+# Args: $1              output notes path (required)
+#
+# Runnable locally:
+#   VERSION=0.44.21 .github/scripts/build-release-notes.sh /tmp/notes.md
+
+set -euo pipefail
+
+: "${VERSION:?VERSION is required}"
+CHANGELOG_FILE="${CHANGELOG_FILE:-umh-core/CHANGELOG.md}"
+OUT="${1:?output notes path is required (arg 1)}"
+
+# Extract the `## [VERSION]` section, stopping at the next `## [` heading. The
+# `## Unreleased` heading sits above all versioned entries, so it is never
+# crossed mid-extraction. Then drop image-only lines.
+awk -v v="$VERSION" '
+  $0 == "## [" v "]" {found=1; next}
+  /^## \[/ {if (found) exit}
+  found {print}
+' "$CHANGELOG_FILE" \
+  | sed -E '/^[[:space:]]*!\[[^]]*\]\([^)]*\)[[:space:]]*$/d' > "$OUT"
+
+# Test for non-whitespace content, not just non-zero size: an image-only
+# section leaves blank lines after the image-strip above, which a `-s` test
+# would wrongly accept and ship as footer-only notes.
+#
+# On a real sync, footer-only notes almost always mean a mistyped/forgotten
+# `## [x.y.z]` heading (hand-edited at release time), so fail loud rather than
+# silently publishing an empty Linear description. Dry-runs stay green so
+# odd/historical tags can still be exercised.
+if ! grep -q '[^[:space:]]' "$OUT"; then
+  if [ "${DRY_RUN:-false}" = "true" ]; then
+    echo "::warning::No ${CHANGELOG_FILE} section found for [${VERSION}]; release notes will contain only the footer."
+    : > "$OUT"
+  else
+    echo "::error::No ${CHANGELOG_FILE} section found for [${VERSION}]; refusing to publish footer-only release notes. Check the '## [${VERSION}]' heading in ${CHANGELOG_FILE}."
+    exit 1
+  fi
+fi
+
+{
+  echo ""
+  echo "---"
+  echo "Full changelog: https://umh.app/insights/changelog"
+} >> "$OUT"

--- a/.github/scripts/resolve-base-ref.sh
+++ b/.github/scripts/resolve-base-ref.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Copyright 2025 UMH Systems GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Prints the commit-scan base for $CURRENT_TAG to stdout (empty = let the CLI
+# pick its automatic baseline). Diagnostics go to stderr.
+#
+# The CLI's automatic baseline (and Linear's stored baseline) can break across
+# releases, so we resolve from the immediately-preceding stable semver tag: if
+# it is a direct ancestor of CURRENT_TAG it is the exact window start; otherwise
+# its first parent sits on the shared line. A BASE_REF override short-circuits
+# all of this.
+#
+# Tags are filtered to stable `vX.Y.Z` (pre-releases like v1.2.3-pre.4 excluded)
+# and ordered with `sort -V`: semver is NOT lexically sortable (v0.44.10 sorts
+# before v0.44.9 under a plain/refname sort), so version sort is mandatory here.
+#
+# Env:  CURRENT_TAG  release tag being synced, e.g. v0.44.21 (required)
+#       BASE_REF     explicit override (tag or SHA); printed as-is if set
+#
+# Runnable locally:
+#   CURRENT_TAG=v0.44.21 .github/scripts/resolve-base-ref.sh
+
+set -euo pipefail
+
+: "${CURRENT_TAG:?CURRENT_TAG is required}"
+
+if [ -n "${BASE_REF:-}" ]; then
+  printf '%s\n' "$BASE_REF"
+  exit 0
+fi
+
+# Guard: CURRENT_TAG must itself be a stable vX.Y.Z tag. Otherwise the awk below
+# yields an empty PREV_TAG that is indistinguishable from a true first release,
+# and we would silently defer to the unreliable auto-baseline. The release:
+# event gate enforces the 'v' prefix, but a workflow_dispatch can pass any tag.
+if ! printf '%s\n' "$CURRENT_TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+  echo "::error::${CURRENT_TAG} is not a stable vX.Y.Z tag; refusing to guess a scan base." >&2
+  exit 1
+fi
+
+PREV_TAG="$(git tag -l 'v*' \
+  | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+  | sort -V \
+  | awk -v cur="$CURRENT_TAG" '$0==cur{print prev; exit} {prev=$0}')"
+
+# Distinguish "not an ancestor" (exit 1 — a normal answer) from a real git
+# failure (exit >1: bad ref, missing object, unfetched history). The latter
+# must fail loud: silently falling back to the CLI auto-baseline is the exact
+# unreliable behavior this resolver exists to prevent. `|| rc=$?` keeps set -e
+# from aborting on the expected non-zero.
+is_ancestor() {
+  local rc=0
+  git merge-base --is-ancestor "$1" "$CURRENT_TAG" 2>/dev/null || rc=$?
+  if [ "$rc" -gt 1 ]; then
+    echo "::error::git merge-base failed (exit ${rc}) for ${1} vs ${CURRENT_TAG}." >&2
+    exit "$rc"
+  fi
+  return "$rc"
+}
+
+if [ -z "$PREV_TAG" ]; then
+  # Legitimate first-release case: no predecessor, defer to the CLI baseline.
+  echo "::warning::No stable vX.Y.Z tag precedes ${CURRENT_TAG}; using the CLI automatic baseline." >&2
+elif is_ancestor "$PREV_TAG"; then
+  # Normal case: the previous release tag is a direct ancestor, so it is the
+  # exact start of this release's window. A rev-parse failure here is a real
+  # error and aborts (set -e) rather than shipping a wrong base.
+  BASE_SHA="$(git rev-parse "$PREV_TAG")"
+  printf '%s\n' "$BASE_SHA"
+  echo "Scan base: ${PREV_TAG} (${BASE_SHA})" >&2
+elif is_ancestor "${PREV_TAG}^1"; then
+  # The previous tag is a merge commit off this tag's line (process
+  # inconsistency); its first parent sits on the shared line.
+  BASE_SHA="$(git rev-parse "${PREV_TAG}^1")"
+  printf '%s\n' "$BASE_SHA"
+  echo "Scan base: ${PREV_TAG}^1 (${BASE_SHA}) [previous tag is not a direct ancestor]" >&2
+else
+  echo "::warning::Neither ${PREV_TAG} nor its first parent is an ancestor of ${CURRENT_TAG}; using the CLI automatic baseline." >&2
+fi

--- a/.github/workflows/linear-release.yml
+++ b/.github/workflows/linear-release.yml
@@ -13,9 +13,21 @@
 # limitations under the License.
 
 # Syncs each stable GitHub Release to a Linear release (continuous pipeline).
-# Skips pre-release tags (v*-pre.*) so the Linear release attribution lives
-# on the version that actually shipped to customers. The commit range from
-# the previous stable release captures every issue that landed during soak.
+# Skips pre-release tags (v*-pre.*) so the Linear release attribution lives on
+# the version that actually shipped to customers.
+#
+# Invokes the linear-release CLI directly rather than via the wrapper action,
+# so we can pass --release-notes-file. A single `sync` call creates the release
+# record, scans the commit range for ENG-XXXX identifiers, attaches the matching
+# issues, and sets the release description from umh-core/CHANGELOG.md. The CLI
+# reads its pipeline access key from the LINEAR_ACCESS_KEY env var.
+#
+# The description is the CHANGELOG section for the released version with images
+# stripped; the image-rich changelog lives at changelog.umh.app.
+#
+# workflow_dispatch exposes dry_run and base_ref so a release can be re-tested
+# (including against historical tags) on the real CLI path without mutating
+# Linear. Both are inert on release: events.
 
 name: Linear Release
 
@@ -25,8 +37,17 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Existing stable release tag to (re)sync (e.g., v0.44.20).'
+        description: 'Stable release tag to (re)sync (e.g., v0.44.20).'
         required: true
+        type: string
+      dry_run:
+        description: 'Scan commits and call read-only Linear APIs, skip all mutations.'
+        required: false
+        default: false
+        type: boolean
+      base_ref:
+        description: 'Override the commit-scan base (tag or SHA). For testing historical ranges.'
+        required: false
         type: string
 
 jobs:
@@ -40,17 +61,105 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: read
+    env:
+      CLI_VERSION: v0.14.0
+      CLI_SHA256: 4ab208dc617fe53bb22dff68a4d48ed720ac51f868083182365bce4fd3559379
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.tag || github.event.release.tag_name }}
-          # Required: the CLI walks the commit range from the previous release.
+          # Full history + tags: the CLI walks the commit range from the previous
+          # release, and base_ref may name a tag.
           fetch-depth: 0
+          fetch-tags: true
 
-      - uses: linear/linear-release-action@0917777589db006387af296dde440385f88d6ac4 # v0.10.0
-        with:
-          access_key: ${{ secrets.LINEAR_ACCESS_KEY_UMH_CORE }}
-          version: ${{ inputs.tag || github.event.release.tag_name }}
-          name: ${{ inputs.tag || github.event.release.tag_name }}
-          # Monorepo: scope to umh-core; ignore helm chart and classic commits.
-          include_paths: umh-core/**
+      - name: Compute release version and name
+        id: ver
+        env:
+          TAG: ${{ inputs.tag || github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          # Keep the leading 'v': the Linear release version is the tag verbatim.
+          echo "version=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          # Strip it for the CHANGELOG lookup, which uses bare semver headings.
+          echo "semver=${TAG#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Build release notes from CHANGELOG.md
+        env:
+          SEMVER: ${{ steps.ver.outputs.semver }}
+        run: |
+          set -euo pipefail
+          # Extract the `## [SEMVER]` section, stopping at the next `## [` heading.
+          # umh-core's CHANGELOG.md uses `## [0.44.21]` (semver in brackets).
+          awk -v v="$SEMVER" '
+            $0 == "## [" v "]" {found=1; next}
+            /^## \[/ {if (found) exit}
+            found {print}
+          ' umh-core/CHANGELOG.md > /tmp/notes.md
+
+          # Drop image-only lines. The image-rich changelog lives at
+          # changelog.umh.app, linked in the footer below.
+          sed -i -E '/^[[:space:]]*!\[[^]]*\]\([^)]*\)[[:space:]]*$/d' /tmp/notes.md
+
+          if [ ! -s /tmp/notes.md ]; then
+            echo "::warning::No CHANGELOG.md section found for [${SEMVER}]; release notes will contain only the footer."
+            : > /tmp/notes.md
+          fi
+
+          {
+            echo ""
+            echo "---"
+            echo "Full changelog: https://changelog.umh.app"
+          } >> /tmp/notes.md
+
+      - name: Install linear-release CLI
+        run: |
+          set -euo pipefail
+          curl -fsSL "https://github.com/linear/linear-release/releases/download/${CLI_VERSION}/linear-release-linux-x64" -o linear-release
+          echo "${CLI_SHA256}  linear-release" | sha256sum -c -
+          chmod +x linear-release
+
+      - name: Sync to Linear
+        env:
+          LINEAR_ACCESS_KEY: ${{ secrets.LINEAR_ACCESS_KEY_UMH_CORE }}
+          VERSION: ${{ steps.ver.outputs.version }}
+          CURRENT_TAG: ${{ steps.ver.outputs.tag }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          BASE_REF: ${{ inputs.base_ref }}
+        run: |
+          set -euo pipefail
+          # Resolve the commit-scan base. The CLI's automatic baseline (and
+          # Linear's stored baseline) can break across releases; computing the
+          # base from the previous stable semver tag is robust. A dispatch
+          # base_ref input overrides this.
+          BASE="${BASE_REF:-}"
+          if [ -z "$BASE" ]; then
+            PREV_TAG="$(git tag -l 'v*'               | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$'               | sort -V               | awk -v cur="$CURRENT_TAG" '$0==cur{print prev; exit} {prev=$0}')"
+            if [ -z "$PREV_TAG" ]; then
+              echo "::warning::No previous stable vX.Y.Z tag precedes ${CURRENT_TAG}; using the CLI automatic baseline."
+            elif git merge-base --is-ancestor "$PREV_TAG" "$CURRENT_TAG" 2>/dev/null; then
+              BASE="$(git rev-parse "$PREV_TAG")"
+              echo "Scan base: ${PREV_TAG} (${BASE})"
+            elif git merge-base --is-ancestor "${PREV_TAG}^1" "$CURRENT_TAG" 2>/dev/null; then
+              BASE="$(git rev-parse "${PREV_TAG}^1")"
+              echo "Scan base: ${PREV_TAG}^1 (${BASE}) [previous tag is not a direct ancestor]"
+            else
+              echo "::warning::Neither ${PREV_TAG} nor its first parent is an ancestor of ${CURRENT_TAG}; using the CLI automatic baseline."
+            fi
+          fi
+
+          # Monorepo: scope the commit scan to umh-core; ignore helm chart and
+          # classic commits.
+          args=(sync --json
+            "--release-version=${VERSION}"
+            "--name=${VERSION}"
+            --release-notes-file /tmp/notes.md
+            "--include-paths=umh-core/**")
+          if [ "${DRY_RUN:-false}" = "true" ]; then
+            args+=("--dry-run")
+          fi
+          if [ -n "$BASE" ]; then
+            args+=("--base-ref=${BASE}")
+          fi
+          ./linear-release "${args[@]}"

--- a/.github/workflows/linear-release.yml
+++ b/.github/workflows/linear-release.yml
@@ -23,7 +23,7 @@
 # reads its pipeline access key from the LINEAR_ACCESS_KEY env var.
 #
 # The description is the CHANGELOG section for the released version with images
-# stripped; the image-rich changelog lives at changelog.umh.app.
+# stripped; the image-rich changelog lives at umh.app/insights/changelog.
 #
 # workflow_dispatch exposes dry_run and base_ref so a release can be re-tested
 # (including against historical tags) on the real CLI path without mutating
@@ -73,7 +73,22 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
-      - name: Compute release version and name
+      # The step above checks out the released tag, whose tree predates these
+      # CI scripts (and won't contain them when re-syncing historical tags).
+      # Pull the scripts from the workflow file's own revision instead, into a
+      # sibling dir, so they exist regardless of which tag is being synced.
+      # workflow_sha (not github.sha): on a release: event github.sha is the
+      # released tag commit, which may not carry the scripts; workflow_sha is
+      # always the revision the running workflow came from, which does.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: .ci-tooling
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
+      - name: Compute release version
         id: ver
         env:
           TAG: ${{ inputs.tag || github.event.release.tag_name }}
@@ -87,31 +102,13 @@ jobs:
 
       - name: Build release notes from CHANGELOG.md
         env:
-          SEMVER: ${{ steps.ver.outputs.semver }}
-        run: |
-          set -euo pipefail
-          # Extract the `## [SEMVER]` section, stopping at the next `## [` heading.
-          # umh-core's CHANGELOG.md uses `## [0.44.21]` (semver in brackets).
-          awk -v v="$SEMVER" '
-            $0 == "## [" v "]" {found=1; next}
-            /^## \[/ {if (found) exit}
-            found {print}
-          ' umh-core/CHANGELOG.md > /tmp/notes.md
-
-          # Drop image-only lines. The image-rich changelog lives at
-          # changelog.umh.app, linked in the footer below.
-          sed -i -E '/^[[:space:]]*!\[[^]]*\]\([^)]*\)[[:space:]]*$/d' /tmp/notes.md
-
-          if [ ! -s /tmp/notes.md ]; then
-            echo "::warning::No CHANGELOG.md section found for [${SEMVER}]; release notes will contain only the footer."
-            : > /tmp/notes.md
-          fi
-
-          {
-            echo ""
-            echo "---"
-            echo "Full changelog: https://changelog.umh.app"
-          } >> /tmp/notes.md
+          # Bare semver: build-release-notes matches the `## [x.y.z]` heading.
+          VERSION: ${{ steps.ver.outputs.semver }}
+          CHANGELOG_FILE: umh-core/CHANGELOG.md
+          # Empty notes fail the step on a real sync, but stay a warning on
+          # dry-runs so historical/odd tags can still be exercised.
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: .ci-tooling/.github/scripts/build-release-notes.sh "$RUNNER_TEMP/notes.md"
 
       - name: Install linear-release CLI
         run: |
@@ -129,32 +126,17 @@ jobs:
           BASE_REF: ${{ inputs.base_ref }}
         run: |
           set -euo pipefail
-          # Resolve the commit-scan base. The CLI's automatic baseline (and
-          # Linear's stored baseline) can break across releases; computing the
-          # base from the previous stable semver tag is robust. A dispatch
-          # base_ref input overrides this.
-          BASE="${BASE_REF:-}"
-          if [ -z "$BASE" ]; then
-            PREV_TAG="$(git tag -l 'v*'               | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$'               | sort -V               | awk -v cur="$CURRENT_TAG" '$0==cur{print prev; exit} {prev=$0}')"
-            if [ -z "$PREV_TAG" ]; then
-              echo "::warning::No previous stable vX.Y.Z tag precedes ${CURRENT_TAG}; using the CLI automatic baseline."
-            elif git merge-base --is-ancestor "$PREV_TAG" "$CURRENT_TAG" 2>/dev/null; then
-              BASE="$(git rev-parse "$PREV_TAG")"
-              echo "Scan base: ${PREV_TAG} (${BASE})"
-            elif git merge-base --is-ancestor "${PREV_TAG}^1" "$CURRENT_TAG" 2>/dev/null; then
-              BASE="$(git rev-parse "${PREV_TAG}^1")"
-              echo "Scan base: ${PREV_TAG}^1 (${BASE}) [previous tag is not a direct ancestor]"
-            else
-              echo "::warning::Neither ${PREV_TAG} nor its first parent is an ancestor of ${CURRENT_TAG}; using the CLI automatic baseline."
-            fi
-          fi
+          # Resolve the commit-scan base (empty = let the CLI pick its automatic
+          # baseline). The resolver prints the base to stdout and its rationale
+          # to stderr; a BASE_REF override short-circuits it. See the script.
+          BASE="$(.ci-tooling/.github/scripts/resolve-base-ref.sh)"
 
           # Monorepo: scope the commit scan to umh-core; ignore helm chart and
           # classic commits.
           args=(sync --json
             "--release-version=${VERSION}"
             "--name=${VERSION}"
-            --release-notes-file /tmp/notes.md
+            --release-notes-file "$RUNNER_TEMP/notes.md"
             "--include-paths=umh-core/**")
           if [ "${DRY_RUN:-false}" = "true" ]; then
             args+=("--dry-run")


### PR DESCRIPTION
## Summary

The release sync now invokes the `linear-release` CLI directly instead of the wrapper action. One `sync` call creates the Linear release, scans the commit range for `ENG-XXXX` issues, and sets the description from the matching `## [X.Y.Z]` section of `umh-core/CHANGELOG.md`. Images are stripped (the image-rich changelog lives at changelog.umh.app, linked in the footer). Same change as `united-manufacturing-hub/ManagementConsole#3186`.

## Why direct CLI

The wrapper action only forwards `name`, `version`, `stage`, `include_paths`, `timeout`. It does not forward `--release-notes-file`, `--base-ref`, or `--dry-run`. The first enables the description; the other two enable testing against any tag without mutating Linear.

CLI binary pinned to `v0.14.0` linux-x64, `sha256 4ab208dc617fe53bb22dff68a4d48ed720ac51f868083182365bce4fd3559379`. `--include-paths=umh-core/**` keeps the scan scoped to the monorepo's umh-core subtree.

## How `base_ref` is resolved

The CLI's automatic baseline (Linear's stored prior-release SHA) can break when consecutive release tags aren't linear ancestors. umh-core's `vX.Y.Z` tags normally are linear (verified across v0.44.13 to v0.44.21), but the workflow still computes `base_ref` from the previous stable tag so the behavior is identical to the MC sibling workflow.

The resolver picks the immediate predecessor of the current `vX.Y.Z` tag (`sort -V`, strict `vN.N.N` filter). If that tag is an ancestor, use it directly. Otherwise fall back to its first parent. The dispatch `base_ref` input overrides both.

## Dispatch inputs

- `tag`: stable release tag to (re)sync.
- `dry_run`: scan and call read-only Linear APIs, skip all mutations.
- `base_ref`: override the computed scan base.

Both `dry_run` and `base_ref` are absent on `release:` events, so the production path runs identical args.

## Security

- Untrusted release-event inputs (`tag_name`, `inputs.*`) flow through `env:` vars; no `${{ }}` interpolation in `run:` bodies.
- CHANGELOG content reaches the CLI via `--release-notes-file`, not interpolated.
- Permissions stay `contents: read`.

## Verification

Dry-run with the auto-resolver picking the previous tag:

```
$ gh workflow run linear-release.yml --ref ci/linear-release-changelog \
    -f tag=v0.44.20 -f dry_run=true

Scan base: v0.44.19 (915284e9c8c4a33ce77efae8ac28238e63063652)
Scanning 915284e..2e02036 with include paths: umh-core/**
[dry-run] Would sync release v0.44.20: issues [ENG-4568, ENG-4862],
  pull requests [#2548, #2558, ...], release notes (2651 chars)
```

Backfilled v0.44.7 to v0.44.21 via dispatch. 13 succeeded. 2 failed at the awk step because `umh-core/CHANGELOG.md` did not yet exist at those tags: v0.44.7 predates commit 4b29d35c (`feat: add umh-core CHANGELOG.md and sync workflow`, 2026-02-09), and v0.44.8 was tagged on a hotfix that branched before that commit. Not worth guarding for. Forward releases always have the file.

## Test plan

- [ ] First `v*` publish after merge: workflow run is green, Linear release lists the window's issues, description matches the new CHANGELOG section.
- [ ] Re-dispatching `dry_run=true` on the same tag stays read-only.
- [ ] Pre-release tags (`v*-pre.*`) skip via the gate.

## Appendix: benthos cross-repo gap (separate follow-up)

The CLI scans only the `umh-core` repo. When a `chore: bump benthos-umh to vX.Y.Z` PR ships a fix tracked by an `ENG-XXXX` in `benthos-umh`, the umh-core bump PR's branch (`chore/benthos-umh-vX.Y.Z`), commit headline, and merge trailer all lack the ENG. The Linear release for umh-core therefore misses every benthos-originated fix.

Process change, not code. Future benthos bumps should list the rolled-up ENGs in the umh-core commit headline (e.g., `chore: bump benthos-umh to v0.12.5 (ENG-4549, ENG-4195, ENG-4912)`). DMing Janik with the specifics.
