### PR TITLE
L5b: remove the legacy child-control mechanism

### DIFF
--- a/umh-core/cmd/main.go
+++ b/umh-core/cmd/main.go
@@ -25,6 +25,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"go.uber.org/zap"
+
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/internal/pprof"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/communicator/actions"
 	v2 "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/communicator/api/v2"
@@ -60,7 +62,6 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/models"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/sentry"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/version"
-	"go.uber.org/zap"
 )
 
 func main() {
@@ -605,6 +606,7 @@ children:
 	fsmv2Logger = fsmv2Logger.Desugar().WithOptions(zap.WrapCore(fsmv2Hook.Wrap)).Sugar()
 
 	fsmv2Deps := map[string]any{}
+
 	if configData.Agent.UseFSMv2MemoryCleanup {
 		register.SetDeps[*persistenceWorker.PersistenceDependencies](persistenceWorker.WorkerTypeName, persistenceWorker.NewStoreOnlyDependencies(store))
 	}

--- a/umh-core/pkg/communicator/actions/actions_recovery_test.go
+++ b/umh-core/pkg/communicator/actions/actions_recovery_test.go
@@ -25,6 +25,8 @@ import (
 
 	"github.com/google/uuid"
 
+	"go.uber.org/zap"
+
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/communicator/pkg/encoding"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
@@ -32,7 +34,6 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/logger"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/metrics"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/models"
-	"go.uber.org/zap"
 )
 
 // panickingAction is a minimal Action used in tests to drive HandleActionMessage
@@ -88,7 +89,9 @@ func captureStderr(t *testing.T, fn func()) string {
 	// blocking forever on io.ReadAll. t.Cleanup belt-and-braces for the
 	// case where the panic kills the test process before defer fires.
 	os.Stderr = w
+
 	t.Cleanup(func() { os.Stderr = orig })
+
 	defer func() {
 		os.Stderr = orig
 		_ = w.Close()
@@ -312,7 +315,9 @@ func TestRecoverActionPanicDoublePanicGuardFiresWhenMetricPanics(t *testing.T) {
 	log := logger.For(logger.ComponentCommunicator)
 
 	prev := recordActionPanicFn
+
 	t.Cleanup(func() { recordActionPanicFn = prev })
+
 	recordActionPanicFn = func(string, string) { panic("metric boom") }
 
 	stderr := captureStderr(t, func() {
@@ -526,6 +531,7 @@ func TestHandleActionMessageRecoversFromPanic(t *testing.T) {
 
 		if state, _ := reply["actionReplyState"].(string); state == string(models.ActionFinishedWithFailure) {
 			sawFailureReply = true
+
 			break
 		}
 	}

--- a/umh-core/pkg/communicator/actions/actions_sentry_wiring_test.go
+++ b/umh-core/pkg/communicator/actions/actions_sentry_wiring_test.go
@@ -19,9 +19,10 @@ import (
 	"strings"
 	"testing"
 
+	"go.uber.org/zap/zapcore"
+
 	deps "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
 	fsmv2sentry "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/sentry"
-	"go.uber.org/zap/zapcore"
 )
 
 // TestCommunicatorFSMLoggerWiredToSentryHook locks the invariant that the
@@ -38,6 +39,7 @@ import (
 // the debouncer's lastSeen map was updated for the expected fingerprint.
 func TestCommunicatorFSMLoggerWiredToSentryHook(t *testing.T) {
 	logger := communicatorFSMLogger()
+
 	if communicatorSentryHook == nil {
 		t.Fatal("communicatorSentryHook nil after communicatorFSMLogger() — Once.Do did not run")
 	}

--- a/umh-core/pkg/communicator/actions/deploy-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/deploy-protocolconverter.go
@@ -41,6 +41,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"go.uber.org/zap"
+
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/dataflowcomponentserviceconfig"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/protocolconverterserviceconfig"
@@ -52,7 +54,6 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/logger"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/models"
-	"go.uber.org/zap"
 )
 
 // DeployProtocolConverterAction implements the Action interface for deploying a
@@ -261,6 +262,7 @@ func (a *DeployProtocolConverterAction) Execute() (interface{}, map[string]inter
 			pcConfig.DesiredFSMState,
 		)
 	}
+
 	SendActionReply(
 		a.instanceUUID,
 		a.userEmail,
@@ -291,6 +293,7 @@ func (a *DeployProtocolConverterAction) createProtocolConverterConfig() (config.
 		if err != nil {
 			return config.ProtocolConverterConfig{}, err
 		}
+
 		tmpl.DataflowComponentReadServiceConfig = readSvcCfg
 	}
 
@@ -302,6 +305,7 @@ func (a *DeployProtocolConverterAction) createProtocolConverterConfig() (config.
 	if a.payload.ReadDFC != nil {
 		readDFCDesiredState = a.payload.ReadDFC.State
 	}
+
 	if a.payload.WriteDFCPayload != nil {
 		writeDFCDesiredState = a.payload.WriteDFCPayload.State
 	}

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter.go
@@ -42,6 +42,8 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/tiendc/go-deepcopy"
+	"go.uber.org/zap"
+
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/dataflowcomponentserviceconfig"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/protocolconverterserviceconfig"
@@ -53,7 +55,6 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/models"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/protocolconverter/runtime_config"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/s6"
-	"go.uber.org/zap"
 )
 
 // DFCType represents the type of dataflow component configuration.
@@ -222,12 +223,15 @@ func (a *EditProtocolConverterAction) Parse(payload interface{}) error {
 		if err != nil {
 			return fmt.Errorf("failed to build read DFC configuration: %w", err)
 		}
+
 		a.readDFCSvcCfg = &svcCfg
+
 		a.readDFCState = pcPayload.ReadDFC.State
 		if pcPayload.ReadDFC.IgnoreErrors != nil {
 			a.ignoreHealthCheck = *pcPayload.ReadDFC.IgnoreErrors
 		}
 	}
+
 	if pcPayload.WriteDFCPayload != nil {
 		input := pcPayload.WriteDFCPayload.DataflowComponentWriteConfigInput
 		a.writeDFCInput = &input
@@ -563,6 +567,7 @@ func (a *EditProtocolConverterAction) awaitRollout(pcConfig config.ProtocolConve
 			if a.lastRenderErr != nil {
 				stateMessage += fmt.Sprintf(" (root cause: %v)", a.lastRenderErr)
 			}
+
 			a.fsmLogger.SentryWarn(deps.FeatureDisableReadFlows, "", "edit_protocol_converter_rollback_on_timeout",
 				deps.String("pcConfig", pcConfig.String()),
 				deps.String("desiredPCState", desiredPCState),
@@ -769,6 +774,7 @@ func (a *EditProtocolConverterAction) awaitRollout(pcConfig config.ProtocolConve
 
 								flowName := a.lastFailedDFCType.flowName()
 								detail := renderErrUserDetail(renderErr)
+
 								return models.ErrRetryRollbackTimeout, fmt.Errorf(
 									"bridge '%s' couldn't be updated and the automatic rollback also failed, so it may need manual recovery. The new %s isn't valid YAML. Fix the highlighted line and try again.\n\n%s",
 									a.name, flowName, detail,
@@ -784,6 +790,7 @@ func (a *EditProtocolConverterAction) awaitRollout(pcConfig config.ProtocolConve
 
 							flowName := a.lastFailedDFCType.flowName()
 							detail := renderErrUserDetail(renderErr)
+
 							return models.ErrConfigFileInvalid, fmt.Errorf(
 								"bridge '%s' was restored to its previous working configuration because the new %s isn't valid YAML. Fix the highlighted line and try again.\n\n%s",
 								a.name, flowName, detail,
@@ -1216,23 +1223,29 @@ func (a *EditProtocolConverterAction) deriveDFCType() DFCType {
 	for _, v := range a.templateVars {
 		incomingVars[v.Label] = v.Value
 	}
+
 	if a.connectionIP != "" {
 		incomingVars["IP"] = a.connectionIP
 	}
+
 	if a.connectionPort != "" && a.connectionPort != "0" {
 		incomingVars["PORT"] = a.connectionPort
 	}
 
 	connectionChanged := false
+
 	for k, incomingVal := range incomingVars {
 		if deployedVal, ok := deployedVars[k]; ok {
 			if fmt.Sprint(deployedVal) != fmt.Sprint(incomingVal) {
 				a.actionLogger.Debugf("Variable %q changed (%v → %v), all present DFCs need redeploy", k, deployedVal, incomingVal)
+
 				connectionChanged = true
+
 				break
 			}
 		}
 	}
+
 	if connectionChanged {
 		return dfcTypeFromPresence(hasRead, hasWrite)
 	}
@@ -1269,6 +1282,7 @@ func (a *EditProtocolConverterAction) readDFCSvcCfgDiffers(
 	if incomingState != "" && deployedState != "" && incomingState != deployedState {
 		return true
 	}
+
 	return !deployedConfig.Equal(incoming)
 }
 
@@ -1296,9 +1310,11 @@ func normalizeWriteConfigInput(c dataflowcomponentserviceconfig.DataflowComponen
 	if c.Processing.Code == "" {
 		c.Processing.Code = "return msg;"
 	}
+
 	if c.Processing.Type == "" {
 		c.Processing.Type = "nodered_js"
 	}
+
 	return c
 }
 

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter_test.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/communicator/actions"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/communicator/pkg/encoding"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
@@ -2036,6 +2037,7 @@ var _ = Describe("EditProtocolConverter", func() {
 			It("aborts on writeDFC-only render failure, rolls back, and reports ErrConfigFileInvalid", func() {
 				observedStateWithWriteInject := func(inject string) *protocolconverter.ProtocolConverterObservedStateSnapshot {
 					output := map[string]interface{}{"http_client": map[string]interface{}{}}
+
 					return &protocolconverter.ProtocolConverterObservedStateSnapshot{
 						ObservedProtocolConverterSpecConfig: protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec{
 							Config: protocolconverterserviceconfig.ProtocolConverterServiceConfigTemplate{
@@ -2128,9 +2130,11 @@ var _ = Describe("EditProtocolConverter", func() {
 					for _, r := range privateReplies {
 						if r.state == string(models.ActionFinishedWithFailure) {
 							final = r
+
 							return true
 						}
 					}
+
 					return false
 				}, "2s").Should(BeTrue(), "expected a final ActionFinishedWithFailure reply")
 				Expect(final.errorCode).To(Equal(models.ErrConfigFileInvalid))
@@ -2151,6 +2155,7 @@ var _ = Describe("EditProtocolConverter", func() {
 							count++
 						}
 					}
+
 					return count
 				}
 
@@ -2308,6 +2313,7 @@ var _ = Describe("EditProtocolConverter", func() {
 						},
 					},
 				}
+
 				return &protocolconverter.ProtocolConverterObservedStateSnapshot{
 					ObservedProtocolConverterSpecConfig: protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec{
 						Config: protocolconverterserviceconfig.ProtocolConverterServiceConfigTemplate{
@@ -2363,6 +2369,7 @@ var _ = Describe("EditProtocolConverter", func() {
 						"url": "http://example.com",
 					},
 				}
+
 				return &protocolconverter.ProtocolConverterObservedStateSnapshot{
 					ObservedProtocolConverterSpecConfig: protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec{
 						Config: protocolconverterserviceconfig.ProtocolConverterServiceConfigTemplate{
@@ -2438,6 +2445,7 @@ var _ = Describe("EditProtocolConverter", func() {
 						"variables": extraVars,
 					}
 				}
+
 				return payload
 			}
 

--- a/umh-core/pkg/communicator/actions/get-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/get-protocolconverter.go
@@ -53,6 +53,8 @@ import (
 	"strconv"
 
 	"github.com/google/uuid"
+	"go.uber.org/zap"
+
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/dataflowcomponentserviceconfig"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/protocolconverterserviceconfig"
@@ -61,7 +63,6 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/protocolconverter"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/logger"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/models"
-	"go.uber.org/zap"
 )
 
 // systemInjectedVarKeys are Variables.User keys that deploy/edit always write regardless
@@ -123,6 +124,7 @@ func NewGetProtocolConverterAction(userEmail string, actionUUID uuid.UUID, insta
 // happens later in Execute.
 func (a *GetProtocolConverterAction) Parse(payload interface{}) (err error) {
 	a.actionLogger.Info("Parsing the payload")
+
 	a.payload, err = ParseActionPayload[models.GetProtocolConverterPayload](payload)
 	if err == nil {
 		a.actionLogger.Info("Payload parsed, uuid: ", a.payload.UUID)
@@ -202,8 +204,10 @@ func connectionInfoFromSpec(
 	// hasConnectionVars tracks whether Variables.User contains IP/PORT so we know
 	// whether to fall back to the Nmap template for connection info.
 	hasConnectionVars := false
+
 	for key, value := range spec.Variables.User {
 		valueStr := fmt.Sprintf("%v", value)
+
 		switch key {
 		case "IP", "ip", "target", "Target":
 			ip = valueStr
@@ -215,6 +219,7 @@ func connectionInfoFromSpec(
 				logger.Warnw("Failed to parse port from variable", "port", valueStr, "error", err)
 			}
 		}
+
 		variables = append(variables, models.ProtocolConverterVariable{Label: key, Value: value})
 	}
 	// isTemplated is true only when the PC has custom variables beyond the system-injected ones.
@@ -222,6 +227,7 @@ func connectionInfoFromSpec(
 	for _, v := range variables {
 		if !systemInjectedVarKeys[v.Label] {
 			isTemplated = true
+
 			break
 		}
 	}
@@ -244,7 +250,8 @@ func connectionInfoFromSpec(
 		Variables:   variables,
 		RootUUID:    uuid.Nil,
 	}
-	return
+
+	return ip, port, templateInfo
 }
 
 // writeDFCFromSpec builds a WriteDFC from the raw spec config (as stored
@@ -256,6 +263,7 @@ func writeDFCFromSpec(specWrite dataflowcomponentserviceconfig.DataflowComponent
 	if !specWrite.HasOutput() && state == "" {
 		return nil
 	}
+
 	return &models.WriteDFCPayload{
 		DataflowComponentWriteConfigInput: specWrite,
 		State:                             state,
@@ -337,6 +345,7 @@ func (a *GetProtocolConverterAction) Execute() (interface{}, map[string]interfac
 
 				// Build ReadDFC from observed, rendered spec config, if present
 				var readDFC *models.ProtocolConverterDFC
+
 				if readDFCConfig := specConfig.Config.DataflowComponentReadServiceConfig; len(readDFCConfig.BenthosConfig.Input) > 0 {
 					var err error
 
@@ -345,6 +354,7 @@ func (a *GetProtocolConverterAction) Execute() (interface{}, map[string]interfac
 						errMsg := fmt.Sprintf("Failed to build read DFC for protocol converter '%s': %v", instance.ID, err)
 						SendActionReply(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedWithFailure,
 							errMsg, a.outboundChannel, models.GetProtocolConverter)
+
 						return nil, nil, fmt.Errorf("%s", errMsg)
 					}
 
@@ -364,6 +374,7 @@ func (a *GetProtocolConverterAction) Execute() (interface{}, map[string]interfac
 
 				// Extract location from observed spec config
 				location := make(map[int]string)
+
 				if len(specConfig.Location) > 0 {
 					for k, v := range specConfig.Location {
 						var intKey int

--- a/umh-core/pkg/communicator/actions/protocolconverter_helpers.go
+++ b/umh-core/pkg/communicator/actions/protocolconverter_helpers.go
@@ -31,10 +31,12 @@ func buildUserScope(templateInfo *models.ProtocolConverterTemplateInfo) map[stri
 	if templateInfo == nil {
 		return map[string]any{}
 	}
+
 	scope := make(map[string]any, len(templateInfo.Variables))
 	for _, v := range templateInfo.Variables {
 		scope[v.Label] = v.Value
 	}
+
 	return scope
 }
 
@@ -43,11 +45,13 @@ func validateWriteDFCConfig(cfg *dataflowcomponentserviceconfig.DataflowComponen
 	if cfg != nil && cfg.HasOutput() && len(cfg.ToWriteConfig().Topics) == 0 {
 		return errors.New("write DFC requires at least one input topic (source.topics)")
 	}
+
 	if state != "" {
 		if err := ValidateDataFlowComponentState(state); err != nil {
 			return fmt.Errorf("invalid write DFC state: %w", err)
 		}
 	}
+
 	return nil
 }
 
@@ -57,15 +61,18 @@ func validateReadProtocolConverterDFC(dfc *models.ProtocolConverterDFC) error {
 	if dfc == nil {
 		return nil
 	}
+
 	if dfc.State != "" {
 		if err := ValidateDataFlowComponentState(dfc.State); err != nil {
 			return fmt.Errorf("invalid read DFC state: %w", err)
 		}
 	}
+
 	payload := dfcToPayload(dfc)
 	if err := ValidateCustomDataFlowComponentPayload(payload, true, false); err != nil {
 		return fmt.Errorf("invalid read DFC configuration: %w", err)
 	}
+
 	return nil
 }
 
@@ -86,10 +93,12 @@ func buildReadDFCServiceConfig(payload models.CDFCPayload, name string) (dataflo
 	if err := ValidateCustomDataFlowComponentPayload(payload, true, false); err != nil {
 		return dataflowcomponentserviceconfig.DataflowComponentServiceConfig{}, fmt.Errorf("invalid read DFC configuration: %w", err)
 	}
+
 	benthos, err := CreateBenthosConfigFromCDFCPayload(payload, name)
 	if err != nil {
 		return dataflowcomponentserviceconfig.DataflowComponentServiceConfig{}, fmt.Errorf("failed to create read DFC benthos config: %w", err)
 	}
+
 	return dataflowcomponentserviceconfig.DataflowComponentServiceConfig{BenthosConfig: benthos}, nil
 }
 
@@ -98,10 +107,12 @@ func convertIntMapToStringMap(intMap map[int]string) map[string]string {
 	if intMap == nil {
 		return nil
 	}
+
 	result := make(map[string]string, len(intMap))
 	for k, v := range intMap {
 		result[strconv.Itoa(k)] = v
 	}
+
 	return result
 }
 
@@ -124,6 +135,7 @@ func convertPipelineToMap(pipeline models.CommonDataFlowComponentPipelineConfig)
 			Type: processor.Type,
 		}
 	}
+
 	return result
 }
 
@@ -133,6 +145,7 @@ func extractInjectFromRawYAML(rawYAML *models.CommonDataFlowComponentRawYamlConf
 	if rawYAML == nil {
 		return ""
 	}
+
 	return rawYAML.Data
 }
 

--- a/umh-core/pkg/config/dataflowcomponentserviceconfig/write_config.go
+++ b/umh-core/pkg/config/dataflowcomponentserviceconfig/write_config.go
@@ -28,26 +28,26 @@ const PlaceholderUMHTopicUnset = "TOPIC_NOT_SET_BY_USER"
 type WriteConfigSource struct {
 	// Topics is either a plain topic list (newline- or comma-separated, each line
 	// optionally prefixed with "- ") or a Go template string that renders to such a list.
-	Topics string `yaml:"topics,omitempty" json:"topics,omitempty" mapstructure:"topics,omitempty"`
+	Topics string `json:"topics,omitempty" mapstructure:"topics,omitempty" yaml:"topics,omitempty"`
 }
 
 // WriteConfigProcessing holds the processing configuration for a write DFC.
 type WriteConfigProcessing struct {
 	// Type is the processor type. Currently hardcoded to "nodered_js".
-	Type string `yaml:"type,omitempty" json:"type,omitempty" mapstructure:"type,omitempty"`
+	Type string `json:"type,omitempty" mapstructure:"type,omitempty" yaml:"type,omitempty"`
 	// Code is the processor code snippet (e.g. Node-RED JS).
 	// Might contain a Go template string that renders to a processor code snippet.
-	Code string `yaml:"code,omitempty" json:"code,omitempty" mapstructure:"code,omitempty"`
+	Code string `json:"code,omitempty" mapstructure:"code,omitempty" yaml:"code,omitempty"`
 }
 
 // WriteConfigDestination holds the destination (output) configuration for a write DFC.
 type WriteConfigDestination struct {
 	// Protocol is the Benthos output plugin name (e.g. "http_client", "kafka").
 	// Currently hardcoded to "http_client".
-	Protocol string `yaml:"protocol,omitempty" json:"protocol,omitempty" mapstructure:"protocol,omitempty"`
+	Protocol string `json:"protocol,omitempty" mapstructure:"protocol,omitempty" yaml:"protocol,omitempty"`
 	// Code is the YAML body of the Benthos output plugin config.
 	// Might contain a Go template string that renders to a YAML body.
-	Code string `yaml:"code,omitempty" json:"code,omitempty" mapstructure:"code,omitempty"`
+	Code string `json:"code,omitempty" mapstructure:"code,omitempty" yaml:"code,omitempty"`
 }
 
 // toOutputMap builds the Benthos output map for this destination.
@@ -71,6 +71,7 @@ func (d WriteConfigDestination) toOutputMap() map[string]any {
 	} else {
 		destConfig = map[string]any{}
 	}
+
 	return map[string]any{d.Protocol: destConfig}
 }
 
@@ -80,7 +81,7 @@ type WriteConfigExtra struct {
 	// Code is any extra Benthos YAML that is inlined verbatim into the generated
 	// Benthos service config.
 	// Might contain a Go template string that renders to a YAML body.
-	Code string `yaml:"code,omitempty" json:"code,omitempty" mapstructure:"code,omitempty"`
+	Code string `json:"code,omitempty" mapstructure:"code,omitempty" yaml:"code,omitempty"`
 }
 
 // DataflowComponentWriteConfig is the typed, validated configuration for write-side DFCs.
@@ -122,12 +123,12 @@ type DataflowComponentWriteConfig struct {
 // (e.g. fields from an older config format). They are round-tripped transparently
 // so that a config written in an older format is never silently erased on read/write.
 type DataflowComponentWriteConfigInput struct {
-	Extra *WriteConfigExtra `yaml:"extra,omitempty"       json:"extra,omitempty"       mapstructure:"extra,omitempty"`
+	Extra *WriteConfigExtra `json:"extra,omitempty" mapstructure:"extra,omitempty" yaml:"extra,omitempty"`
 	// UnrecognizedFields preserves unknown YAML keys for round-trip fidelity.
-	UnrecognizedFields map[string]any         `yaml:",inline" json:"-" mapstructure:"-"`
-	Processing         WriteConfigProcessing  `yaml:"processing,omitempty"  json:"processing,omitempty"  mapstructure:"processing,omitempty"`
-	Destination        WriteConfigDestination `yaml:"destination,omitempty" json:"destination,omitempty" mapstructure:"destination,omitempty"`
-	Source             WriteConfigSource      `yaml:"source,omitempty"      json:"source,omitempty"      mapstructure:"source,omitempty"`
+	UnrecognizedFields map[string]any         `json:"-"                     mapstructure:"-"                     yaml:",inline"`
+	Processing         WriteConfigProcessing  `json:"processing,omitempty"  mapstructure:"processing,omitempty"  yaml:"processing,omitempty"`
+	Destination        WriteConfigDestination `json:"destination,omitempty" mapstructure:"destination,omitempty" yaml:"destination,omitempty"`
+	Source             WriteConfigSource      `json:"source,omitempty"      mapstructure:"source,omitempty"      yaml:"source,omitempty"`
 }
 
 // HasOutput reports whether a write output is configured.
@@ -158,15 +159,18 @@ func (c DataflowComponentWriteConfigInput) ToDataflowComponentServiceConfig(brid
 // non-empty []string. YAML list entries prefixed with "- " are also handled.
 func splitTopics(s string) []string {
 	parts := strings.Split(s, "\n")
+
 	out := make([]string, 0, len(parts))
 	for _, p := range parts {
 		t := strings.TrimSpace(p)
 		t = strings.TrimPrefix(t, "- ")
+
 		t = strings.TrimSpace(t)
 		if t != "" {
 			out = append(out, t)
 		}
 	}
+
 	return out
 }
 
@@ -185,16 +189,20 @@ func (c DataflowComponentWriteConfig) ToDataflowComponentServiceConfig(bridgedBy
 	if processorType == "" {
 		processorType = "nodered_js"
 	}
+
 	pipeline := c.codeToPipeline(c.Processing.Code, processorType)
 
-	var input map[string]any
-	var output map[string]any
+	var (
+		input  map[string]any
+		output map[string]any
+	)
 
 	if c.HasOutput() {
 		topics := c.Topics
 		if len(topics) == 0 {
 			topics = []string{PlaceholderUMHTopicUnset}
 		}
+
 		input = map[string]any{
 			"uns": map[string]any{
 				"consumer_group": bridgedBy,
@@ -208,6 +216,7 @@ func (c DataflowComponentWriteConfig) ToDataflowComponentServiceConfig(bridgedBy
 	}
 
 	cacheResources, rateLimitResources, buffer := c.parseExtra()
+
 	return DataflowComponentServiceConfig{
 		BenthosConfig: BenthosConfig{
 			Input:              input,
@@ -228,6 +237,7 @@ func (c DataflowComponentWriteConfig) ToDisplayDataflowComponentServiceConfig() 
 	if processorType == "" {
 		processorType = "nodered_js"
 	}
+
 	pipeline := c.codeToPipeline(c.Processing.Code, processorType)
 
 	var output map[string]any
@@ -236,6 +246,7 @@ func (c DataflowComponentWriteConfig) ToDisplayDataflowComponentServiceConfig() 
 	}
 
 	cacheResources, rateLimitResources, buffer := c.parseExtra()
+
 	return DataflowComponentServiceConfig{
 		BenthosConfig: BenthosConfig{
 			Pipeline:           pipeline,
@@ -254,10 +265,12 @@ func (c DataflowComponentWriteConfig) parseExtra() (cacheResources []map[string]
 	if c.Extra == nil || c.Extra.Code == "" {
 		return nil, nil, nil
 	}
+
 	var parsed map[string]any
 	if err := yaml.Unmarshal([]byte(c.Extra.Code), &parsed); err != nil {
 		return nil, nil, nil
 	}
+
 	if raw, ok := parsed["cache_resources"].([]any); ok {
 		for _, item := range raw {
 			if m, ok := item.(map[string]any); ok {
@@ -265,6 +278,7 @@ func (c DataflowComponentWriteConfig) parseExtra() (cacheResources []map[string]
 			}
 		}
 	}
+
 	if raw, ok := parsed["rate_limit_resources"].([]any); ok {
 		for _, item := range raw {
 			if m, ok := item.(map[string]any); ok {
@@ -272,9 +286,11 @@ func (c DataflowComponentWriteConfig) parseExtra() (cacheResources []map[string]
 			}
 		}
 	}
+
 	if m, ok := parsed["buffer"].(map[string]any); ok {
 		buffer = m
 	}
+
 	return cacheResources, rateLimitResources, buffer
 }
 
@@ -283,6 +299,7 @@ func (c DataflowComponentWriteConfig) codeToPipeline(code, processorType string)
 	if code == "" {
 		code = "return msg;"
 	}
+
 	return map[string]any{
 		"processors": []any{
 			map[string]any{

--- a/umh-core/pkg/config/protocolconverterserviceconfig/comparator.go
+++ b/umh-core/pkg/config/protocolconverterserviceconfig/comparator.go
@@ -88,6 +88,7 @@ func (c *Comparator) ConfigDiff(desired, observed ProtocolConverterServiceConfig
 	// diff for dfc's
 	comparatorDFC := dataflowcomponentserviceconfig.NewComparator()
 	dfcReadDiff := comparatorDFC.ConfigDiff(dfcReadD, dfcReadO)
+
 	dfcWriteDiff := ""
 	if !reflect.DeepEqual(dfcWriteD, dfcWriteO) {
 		dfcWriteDiff = fmt.Sprintf("WriteDFC: %v vs %v", dfcWriteD, dfcWriteO)

--- a/umh-core/pkg/config/protocolconverterserviceconfig/generator.go
+++ b/umh-core/pkg/config/protocolconverterserviceconfig/generator.go
@@ -17,10 +17,11 @@ package protocolconverterserviceconfig
 import (
 	"fmt"
 
+	"gopkg.in/yaml.v3"
+
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/connectionserviceconfig"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/dataflowcomponentserviceconfig"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/variables"
-	"gopkg.in/yaml.v3"
 )
 
 // Generator handles the generation of DFC YAML configurations
@@ -39,6 +40,7 @@ func (g *Generator) RenderConfig(cfg ProtocolConverterServiceConfigSpec) (string
 	if err != nil {
 		return "", err
 	}
+
 	normalizedMap := normalizeConfig(configMap)
 
 	yamlBytes, err := yaml.Marshal(normalizedMap)
@@ -71,8 +73,8 @@ func (g *Generator) configToMap(cfg ProtocolConverterServiceConfigSpec) (map[str
 	variableBundleConfigMap := variableBundleGenerator.ConfigToMap(cfg.Variables)
 
 	templateMap := map[string]any{
-		"connection":             connectionConfigMap,
-		"dataflowcomponent_read": dfcReadConfigMap,
+		"connection":              connectionConfigMap,
+		"dataflowcomponent_read":  dfcReadConfigMap,
 		"dataflowcomponent_write": dfcWriteConfigMap,
 	}
 
@@ -162,9 +164,11 @@ func writeConfigToMap(cfg dataflowcomponentserviceconfig.DataflowComponentWriteC
 	if err != nil {
 		return nil, fmt.Errorf("writeConfigToMap: failed to marshal write DFC config: %w", err)
 	}
+
 	var m map[string]any
 	if err := yaml.Unmarshal(data, &m); err != nil {
 		return nil, fmt.Errorf("writeConfigToMap: failed to unmarshal write DFC config: %w", err)
 	}
+
 	return m, nil
 }

--- a/umh-core/pkg/config/protocolconverterserviceconfig/package.go
+++ b/umh-core/pkg/config/protocolconverterserviceconfig/package.go
@@ -161,9 +161,11 @@ func ConfigDiffRuntime(desired, observed ProtocolConverterServiceConfigRuntime) 
 	if d := comparatorDFC.ConfigDiff(desired.DataflowComponentReadServiceConfig, observed.DataflowComponentReadServiceConfig); d != "" {
 		diff += "ReadDFC: " + d + "\n"
 	}
+
 	if d := comparatorDFC.ConfigDiff(desired.DataflowComponentWriteServiceConfig, observed.DataflowComponentWriteServiceConfig); d != "" {
 		diff += "WriteDFC: " + d + "\n"
 	}
+
 	return diff
 }
 

--- a/umh-core/pkg/config/templating.go
+++ b/umh-core/pkg/config/templating.go
@@ -269,7 +269,7 @@ func RenderTemplate[T any](tmpl T, scope map[string]any) (T, error) {
 
 	// D. sanity-check – no {{ left over
 	if bytes.Contains(buf.Bytes(), []byte("{{")) {
-		return *new(T), fmt.Errorf("unresolved template markers in rendered output")
+		return *new(T), errors.New("unresolved template markers in rendered output")
 	}
 
 	return out, nil

--- a/umh-core/pkg/fsm/base_manager_test.go
+++ b/umh-core/pkg/fsm/base_manager_test.go
@@ -54,22 +54,25 @@ func (f *fakeFSMInstance) GetCurrentFSMState() string { return f.currentState }
 func (f *fakeFSMInstance) GetDesiredFSMState() string { return f.desiredState }
 func (f *fakeFSMInstance) SetDesiredFSMState(s string) error {
 	f.setDesiredCalls++
+
 	f.desiredState = s
 	if f.flapDesired != "" {
 		f.desiredState = f.flapDesired
 	}
+
 	return nil
 }
 func (f *fakeFSMInstance) IsTransientStreakCounterMaxed() bool { return false }
 func (f *fakeFSMInstance) Reconcile(ctx context.Context, _ publicfsm.SystemSnapshot, _ serviceregistry.Provider) (error, bool) {
 	f.reconcileCalls++
+
 	return nil, false
 }
 func (f *fakeFSMInstance) Remove(_ context.Context) error                { return nil }
 func (f *fakeFSMInstance) GetLastObservedState() publicfsm.ObservedState { return nil }
 func (f *fakeFSMInstance) GetMinimumRequiredTime() time.Duration         { return 0 }
 
-// FSMInstanceActions
+// FSMInstanceActions.
 func (f *fakeFSMInstance) CreateInstance(_ context.Context, _ filesystem.Service) error { return nil }
 func (f *fakeFSMInstance) RemoveInstance(_ context.Context, _ filesystem.Service) error { return nil }
 func (f *fakeFSMInstance) StartInstance(_ context.Context, _ filesystem.Service) error  { return nil }
@@ -110,12 +113,14 @@ func newFix4cManager(initial map[string]*fakeFSMInstance, configs []fix4cTestCon
 	for name, inst := range initial {
 		mgr.AddInstanceForTest(name, inst)
 	}
+
 	return mgr
 }
 
 func runFix4cReconcile(mgr *publicfsm.BaseFSMManager[fix4cTestConfig]) (error, bool) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
+
 	return mgr.Reconcile(ctx, publicfsm.SystemSnapshot{}, nil)
 }
 
@@ -135,6 +140,7 @@ var _ = Describe("BaseFSMManager fix 4c — manager-recreate guard (ENG-4862)", 
 
 			Eventually(func() int {
 				_, _ = runFix4cReconcile(mgr)
+
 				return len(mgr.GetInstances())
 			}, "2s", "10ms").Should(Equal(0), "Removed instance should be deleted by Step 3 even with continuous desired-state flapping")
 
@@ -180,6 +186,7 @@ var _ = Describe("BaseFSMManager fix 4c — manager-recreate guard (ENG-4862)", 
 			Eventually(func() bool {
 				_, _ = runFix4cReconcile(mgr)
 				_, hasWedged := mgr.GetInstances()["bridge-3"]
+
 				return !hasWedged || mgr.GetInstances()["bridge-3"] != publicfsm.FSMInstance(wedged)
 			}, "2s", "10ms").Should(BeTrue(), "wedged Removed instance must be cleaned out")
 
@@ -189,6 +196,7 @@ var _ = Describe("BaseFSMManager fix 4c — manager-recreate guard (ENG-4862)", 
 				if !ok {
 					return ""
 				}
+
 				return inst.GetCurrentFSMState()
 			}, "2s", "10ms").Should(Equal("to_be_created"), "manager must recreate the instance from config after deletion")
 

--- a/umh-core/pkg/fsm/protocolconverter/actions.go
+++ b/umh-core/pkg/fsm/protocolconverter/actions.go
@@ -330,11 +330,10 @@ func (p *ProtocolConverterInstance) UpdateObservedStateOfInstance(ctx context.Co
 	p.runtimeConfig, err = runtime_config.BuildRuntimeConfig(
 		p.specConfig,
 		agentLocationStr,
-		nil,             // TODO: add global vars
+		nil, // TODO: add global vars
 		runtime_config.BridgedByPlaceholder,
 		p.baseFSMInstance.GetID(),
 	)
-
 	if err != nil {
 		p.baseFSMInstance.GetLogger().Errorf("failed to build runtime config: %v", err)
 		// Capture the configuration error in StatusReason for troubleshooting
@@ -496,6 +495,7 @@ func (p *ProtocolConverterInstance) areBothDFCsIntentionallyStopped() bool {
 
 	readHasConfig := len(p.specConfig.Config.DataflowComponentReadServiceConfig.BenthosConfig.Input) > 0
 	writeHasConfig := p.specConfig.Config.DataflowComponentWriteServiceConfig.HasOutput()
+
 	return readHasConfig || writeHasConfig
 }
 

--- a/umh-core/pkg/fsmv2/CLAUDE.md
+++ b/umh-core/pkg/fsmv2/CLAUDE.md
@@ -11,7 +11,7 @@ The `architecture_test.go` validates ALL workers via file-system scanning (not r
 | Rule | Description |
 |------|-------------|
 | Empty State Structs | States have no fields (except embedded base) |
-| Shutdown Check First | Check `IsShutdownRequested()` as FIRST conditional in `Next()` |
+| Shutdown Check First | Check `ShouldStop()` as FIRST conditional in `Next()` |
 | State XOR Action | Return state OR action, never both |
 | Single Type Assertion | `Next()` has exactly one type assertion at entry |
 | Pure DeriveDesiredState | No dependency access - only use `spec` parameter |
@@ -70,11 +70,10 @@ type RunningState struct {
 func (s *RunningState) Next(snapAny any) fsmv2.NextResult[any, any] {
     snap := fsmv2.ConvertWorkerSnapshot[MyConfig, MyStatus](snapAny)
 
-    // Shutdown check FIRST. Build the reason from snapshot fields so operators
-    // can see why the worker stopped without reading code.
+    // Stop check FIRST. Use snap.StopReason() so operators see why the worker
+    // stopped (shutdown vs disable) without reading code.
     if snap.ShouldStop() {
-        reason := fmt.Sprintf("stop required: shutdown=%t, parentState=%q",
-            snap.IsShutdownRequested(), snap.Observed.ParentMappedState)
+        reason := fmt.Sprintf("stop required: %s", snap.StopReason())
         return fsmv2.Transition(&ShuttingDownState{}, fsmv2.SignalNone, nil, reason, nil)
     }
 
@@ -100,10 +99,9 @@ The `Reason` parameter in `fsmv2.Transition()` is visible in structured JSON log
 
 **Rules:**
 - Include dynamic snapshot values via `fmt.Sprintf` — never hardcode values that exist in the snapshot
-- For "stop required" transitions: `fmt.Sprintf("stop required: shutdown=%t, parentState=%s", ...)`
+- For "stop required"/"stop complete" transitions: `fmt.Sprintf("stop required: %s", snap.StopReason())` — names both stop causes (shutdown + disabled)
 - For "waiting" catch-alls: include which preconditions are missing (`hasTransport=%t, hasValidToken=%t`)
 - For degraded/error states: include the consecutive error count
-- For child lifecycle: include the parent mapped state (`parentState=%q`)
 
 **Gold standard** — communicator worker's `buildRecoveringReason()` in `state_recovering.go`:
 ```go
@@ -112,7 +110,7 @@ fmt.Sprintf("sync recovering: %d consecutive errors (%s), backoff %s",
 ```
 
 **Bad**: `"Stop required"`, `"Waiting for transport or token"`, `"Degraded, still pushing"`
-**Good**: `"stop required: shutdown=false, parentState=stopped"`, `"waiting: hasTransport=true, hasValidToken=false"`, `"degraded (5 consecutive errors), still pushing"`
+**Good**: `"stop required: shutdown=false disabled=true"`, `"waiting: hasTransport=true, hasValidToken=false"`, `"degraded (5 consecutive errors), still pushing"`
 
 ## Children-in-Next Pattern
 
@@ -467,7 +465,3 @@ This prevents failure rate dilution: if idle ticks feed phantom "successes" into
 - Self-return WITH an action (e.g., `&FlushAction{}`) is allowed (active cleanup)
 - CI enforced: `ValidateStoppingStateNoCatchAllSelfReturn` in `internal/validator/state.go`
 - See any `state_stopping.go` for the pattern
-
-### Observed vs Desired ParentMappedState
-
-`ParentMappedState` is only populated on the **observed** state (via `SetParentMappedState()`). The **desired** state copy is always empty. Use `snap.Observed.ParentMappedState` in reason strings, never `snap.Desired.ParentMappedState`.

--- a/umh-core/pkg/fsmv2/api.go
+++ b/umh-core/pkg/fsmv2/api.go
@@ -504,6 +504,14 @@ func (s WorkerSnapshot[TConfig, TStatus]) ShouldStop() bool {
 	return s.IsShutdownRequested || s.IsDisabled
 }
 
+// StopReason names every active cause behind ShouldStop() for use in transition
+// reason strings. ShouldStop() is true on either a shutdown request or an admin
+// disable, so a bare "shutdown=%t" reason misreports a disable-driven stop as
+// shutdown=false; this reports both terms so operators see the real cause.
+func (s WorkerSnapshot[TConfig, TStatus]) StopReason() string {
+	return fmt.Sprintf("shutdown=%t disabled=%t", s.IsShutdownRequested, s.IsDisabled)
+}
+
 // ConvertWorkerSnapshot type-asserts the raw snapshot from State.Next() into a
 // fully typed WorkerSnapshot. Panics with a descriptive message if the snapshot
 // contains unexpected types.

--- a/umh-core/pkg/fsmv2/api.go
+++ b/umh-core/pkg/fsmv2/api.go
@@ -416,8 +416,7 @@ type DependencyProvider interface {
 
 // BaseUserSpec is satisfied by config types that embed config.BaseUserSpec.
 // WorkerBase.DeriveDesiredState uses this interface to read and validate the
-// desired lifecycle state ("running" or "stopped") from TConfig, then propagate
-// it into WrappedDesiredState.State.
+// desired lifecycle state ("running" or "stopped") from TConfig.
 type BaseUserSpec interface {
 	GetState() string
 }
@@ -462,26 +461,14 @@ type ChildrenViewConsumer interface {
 
 // WrappedDesiredState wraps a developer's TConfig into the full DesiredState
 // required by the supervisor. BaseDesiredState promotion provides
-// IsShutdownRequested and SetShutdownRequested for free. The State field
-// carries the desired lifecycle state ("running"/"stopped") set by
-// DeriveDesiredState from the user spec's BaseUserSpec.GetState().
+// IsShutdownRequested and SetShutdownRequested for free.
 //
 // The framework constructs this during DeriveDesiredState. Developers define
 // their TConfig type and call the typed DeriveDesiredState helpers to produce it.
 type WrappedDesiredState[TConfig any] struct {
 	Config        TConfig            `json:"config"`
-	State         string             `json:"state"                   yaml:"state"` // "stopped" or "running" - desired lifecycle state
 	ChildrenSpecs []config.ChildSpec `json:"childrenSpecs,omitempty"`
 	config.BaseDesiredState
-}
-
-// GetState returns the desired lifecycle state, defaulting to "running" if empty.
-func (d *WrappedDesiredState[TConfig]) GetState() string {
-	if d.State == "" {
-		return config.DesiredStateRunning
-	}
-
-	return d.State
 }
 
 // GetChildrenSpecs returns the children specifications.
@@ -500,7 +487,6 @@ type WorkerSnapshot[TConfig any, TStatus any] struct {
 	Status              TStatus
 	ChildrenView        config.ChildrenView
 	Identity            deps.Identity
-	ParentMappedState   string
 	LastActionResults   []deps.ActionResult
 	Metrics             deps.MetricsEmbedder
 	ChildrenHealthy     int
@@ -513,9 +499,9 @@ type WorkerSnapshot[TConfig any, TStatus any] struct {
 }
 
 // ShouldStop returns true when the worker should transition to stopped,
-// whether from an explicit shutdown request, an admin disable, or a parent-driven stop signal.
+// whether from an explicit shutdown request or an admin disable.
 func (s WorkerSnapshot[TConfig, TStatus]) ShouldStop() bool {
-	return s.IsShutdownRequested || s.IsDisabled || s.ParentMappedState == config.DesiredStateStopped
+	return s.IsShutdownRequested || s.IsDisabled
 }
 
 // ConvertWorkerSnapshot type-asserts the raw snapshot from State.Next() into a
@@ -543,7 +529,6 @@ func ConvertWorkerSnapshot[TConfig any, TStatus any](snapAny any) WorkerSnapshot
 		Identity:            snap.Identity,
 		IsShutdownRequested: des.IsShutdownRequested(),
 		IsDisabled:          des.IsDisabled(),
-		ParentMappedState:   obs.ParentMappedState,
 		CollectedAt:         obs.CollectedAt,
 		LastActionResults:   obs.LastActionResults,
 		Metrics:             obs.MetricsEmbedder,

--- a/umh-core/pkg/fsmv2/architecture_test.go
+++ b/umh-core/pkg/fsmv2/architecture_test.go
@@ -281,16 +281,6 @@ var _ = Describe("FSMv2 Architecture Validation", func() {
 			})
 		})
 
-		Describe("Exhaustive Transition Coverage (Invariant: Complete State Handling)", func() {
-			It("should end with catch-all return: return s, SignalNone, nil", func() {
-				violations := validator.ValidateExhaustiveTransitionCoverage(getFsmv2Dir())
-				if len(violations) > 0 {
-					message := validator.FormatViolationsWithPattern("Catch-All Return Violations", violations, "MISSING_CATCHALL_RETURN")
-					Fail(message)
-				}
-			})
-		})
-
 		Describe("Base State Type Embedding (Invariant: Type Hierarchy)", func() {
 			It("should embed exactly one Base*State type", func() {
 				violations := validator.ValidateBaseStateEmbedding(getFsmv2Dir())

--- a/umh-core/pkg/fsmv2/config/childspec.go
+++ b/umh-core/pkg/fsmv2/config/childspec.go
@@ -46,11 +46,11 @@ import (
 //   - Disabled: Inherited from this type. Set by the supervisor's disable-mapping pass
 //     from the parent's ChildSpec.Enabled; child workers stay resident in Stopped.
 //
-// The desired lifecycle state ("running"/"stopped") is read from the user spec
-// via BaseUserSpec.GetState() in DeriveDesiredState and stored directly on the
-// outer DesiredState type (not on BaseDesiredState). Callers that used to set
-// BaseDesiredState{State: x} should instead set the State field on the embedding
-// struct (e.g., MyDesiredState{State: x, ...}).
+// The desired lifecycle state ("running"/"stopped") lives on the user spec, not
+// on the DesiredState. Embed BaseUserSpec in your UserSpec config type to inherit
+// GetState(); DeriveDesiredState reads and validates it. As stated above, do not
+// add a State field to your DesiredState — the supervisor drives lifecycle through
+// ShutdownRequested and Disabled and never populates a custom State field.
 //
 // Correct ShouldBeRunning() implementation:
 //

--- a/umh-core/pkg/fsmv2/config/childspec.go
+++ b/umh-core/pkg/fsmv2/config/childspec.go
@@ -43,7 +43,8 @@ import (
 //
 // Correct lifecycle control:
 //   - ShutdownRequested: Inherited from this type. Set by supervisor for graceful shutdown.
-//   - ParentMappedState: For child workers only. Injected by supervisor from parent's ChildStartStates.
+//   - Disabled: Inherited from this type. Set by the supervisor's disable-mapping pass
+//     from the parent's ChildSpec.Enabled; child workers stay resident in Stopped.
 //
 // The desired lifecycle state ("running"/"stopped") is read from the user spec
 // via BaseUserSpec.GetState() in DeriveDesiredState and stored directly on the
@@ -51,17 +52,15 @@ import (
 // BaseDesiredState{State: x} should instead set the State field on the embedding
 // struct (e.g., MyDesiredState{State: x, ...}).
 //
-// Correct ShouldBeRunning() implementations:
+// Correct ShouldBeRunning() implementation:
 //
-//	// Root/leaf workers (no parent):
 //	func (s *MyDesiredState) ShouldBeRunning() bool {
 //	    return !s.ShutdownRequested
 //	}
 //
-//	// Child workers (have parent):
-//	func (s *MyDesiredState) ShouldBeRunning() bool {
-//	    return !s.ShutdownRequested && s.ParentMappedState == config.DesiredStateRunning
-//	}
+// Child workers do not gate on a parent-supplied field: the supervisor's
+// disable-mapping pass sets Disabled from the parent's ChildSpec.Enabled, and
+// state files route lifecycle through snap.ShouldStop().
 //
 // See ValidateNoCustomLifecycleFields in pkg/fsmv2/internal/validator/snapshot.go for enforcement.
 type BaseDesiredState struct {
@@ -166,31 +165,13 @@ func (u UserSpec) Clone() UserSpec {
 //   - Supervisor handles "how to make it exist"
 //   - Children run independently in their own FSMs
 //
-// # Child Start States
+// # Child Lifecycle Gating
 //
-// ChildStartStates coordinates parent state with child lifecycle.
-//
-// ChildStartStates specifies which parent FSM states cause children to run.
-// When the parent is in a listed state, children run. Otherwise, they stop.
-//
-// INVARIANT: If a parent state checks ChildrenHealthy/ChildrenUnhealthy to gate
-// its own transitions, that state MUST be listed in ChildStartStates. Otherwise,
-// children are mapped to "stopped" and can never satisfy the health check,
-// creating a permanent deadlock.
-//
-// Example use case: Children should only run when parent is in "Running" or "TryingToStart" states.
-//
-// Format:
-//
-//	ChildStartStates: []string{"Running", "TryingToStart"}
-//
-// When to use:
-// - Parent lifecycle controls child lifecycle (children run only in certain parent states)
-// - Simple "run when parent is active" patterns
-//
-// When not to use:
-// - Passing data between states (use VariableBundle instead)
-// - Triggering actions (use signals instead)
+// A child runs while the parent sets ChildSpec.Enabled=true for it. The
+// supervisor's disable-mapping pass translates Enabled into the child's
+// Disabled bit, and state files route lifecycle through snap.ShouldStop().
+// Setting Enabled=false leaves the child resident in Stopped (not despawned);
+// flipping it back to true resumes the child on the next tick.
 //
 // # Dependency Inheritance
 //
@@ -206,7 +187,7 @@ func (u UserSpec) Clone() UserSpec {
 //	    Name:       "mqtt-connection",
 //	    WorkerType: "mqtt_client",
 //	    UserSpec:   UserSpec{Config: "url: tcp://localhost:1883"},
-//	    ChildStartStates: []string{"Running", "TryingToStart"}, // Child runs when parent is active
+//	    Enabled:    true, // Parent wants this child running
 //	}
 //
 // Example - Benthos managing connections and data flows:
@@ -217,25 +198,20 @@ func (u UserSpec) Clone() UserSpec {
 //	        Name:       "modbus-connection",
 //	        WorkerType: "modbus_client",
 //	        UserSpec:   UserSpec{Config: "address: 192.168.1.100:502"},
-//	        // Empty ChildStartStates = child always runs (follows parent's DesiredState.State)
+//	        Enabled:    true,
 //	    },
 //	    {
 //	        Name:       "source-flow",
 //	        WorkerType: "benthos_flow",
 //	        UserSpec:   UserSpec{Config: "input: {...}"},
-//	        ChildStartStates: []string{"Running"}, // Child only runs when parent is Running
+//	        Enabled:    true,
 //	    },
 //	}
 type ChildSpec struct {
-	Dependencies map[string]any `json:"dependencies,omitempty"     yaml:"dependencies,omitempty"` // Additional deps to merge with parent's deps (child overrides parent)
-	UserSpec     UserSpec       `json:"userSpec"                   yaml:"userSpec"`               // Raw user config (input to DeriveDesiredState)
-	Name         string         `json:"name"                       yaml:"name"`                   // Unique name for this child (within parent scope)
-	WorkerType   string         `json:"workerType"                 yaml:"workerType"`             // Type of worker to create (registered worker factory key)
-	// Deprecated. Only the application worker still consumes ChildStartStates
-	// (via computeMappedState in reconciliation.go). Other workers leave it
-	// empty. Remove together with computeMappedState when the application
-	// worker moves to RenderChildren.
-	ChildStartStates []string `json:"childStartStates,omitempty" yaml:"childStartStates,omitempty"` // Parent FSM states where child should run (empty = always run)
+	Dependencies map[string]any `json:"dependencies,omitempty" yaml:"dependencies,omitempty"` // Additional deps to merge with parent's deps (child overrides parent)
+	UserSpec     UserSpec       `json:"userSpec"               yaml:"userSpec"`               // Raw user config (input to DeriveDesiredState)
+	Name         string         `json:"name"                   yaml:"name"`                   // Unique name for this child (within parent scope)
+	WorkerType   string         `json:"workerType"             yaml:"workerType"`             // Type of worker to create (registered worker factory key)
 
 	// Enabled is the parent's per-tick request for this child to run. Zero
 	// value (false) means "stopped but resident" — children stay in Stopped
@@ -258,11 +234,6 @@ func (c ChildSpec) Clone() ChildSpec {
 
 	clone.UserSpec = c.UserSpec.Clone()
 
-	if c.ChildStartStates != nil {
-		clone.ChildStartStates = make([]string, len(c.ChildStartStates))
-		copy(clone.ChildStartStates, c.ChildStartStates)
-	}
-
 	if c.Dependencies != nil {
 		clone.Dependencies = make(map[string]any, len(c.Dependencies))
 		for k, v := range c.Dependencies {
@@ -278,7 +249,7 @@ func (c ChildSpec) Clone() ChildSpec {
 // enabling incremental validation (only re-validate specs whose hash changed).
 //
 // The hash is computed from all relevant fields: Name, WorkerType, UserSpec,
-// ChildStartStates, Enabled, and Dependencies (excluding any unexported fields).
+// Enabled, and Dependencies (excluding any unexported fields).
 //
 // Returns a hex-encoded FNV-1a 64-bit hash string (16 characters) and an error
 // if Variables cannot be marshaled to JSON.
@@ -305,52 +276,18 @@ func (c ChildSpec) Hash() (string, error) {
 	h.Write(varsBytes)
 	h.Write([]byte{0}) // separator
 
-	// Hash ChildStartStates
-	for _, state := range c.ChildStartStates {
-		h.Write([]byte(state))
-		h.Write([]byte{0}) // separator
-	}
-
 	if c.Enabled {
 		h.Write([]byte{1})
 	} else {
 		h.Write([]byte{0})
 	}
+
 	h.Write([]byte{0}) // separator
 
 	// Dependencies contain runtime objects (channels, etc.) that can't be meaningfully hashed,
 	// so we skip them. Changes to dependencies don't require re-validation anyway.
 
 	return fmt.Sprintf("%016x", h.Sum64()), nil
-}
-
-// GetMappedChildState returns the desired state for this child based on the parent's current FSM state.
-//
-// Logic:
-//   - If ChildStartStates is empty: child always runs (returns "running")
-//   - If parentState is in ChildStartStates: child should run (returns "running")
-//   - Otherwise: child should stop (returns "stopped")
-//
-// Example:
-//
-//	spec := ChildSpec{ChildStartStates: []string{"Running", "TryingToStart"}}
-//	spec.GetMappedChildState("Running")        // returns "running"
-//	spec.GetMappedChildState("TryingToStop")   // returns "stopped"
-//	spec.GetMappedChildState("Stopped")        // returns "stopped"
-//
-// Note: This replaces the deprecated StateMapping approach with direct state checks.
-func (c *ChildSpec) GetMappedChildState(parentState string) string {
-	if len(c.ChildStartStates) == 0 {
-		return DesiredStateRunning
-	}
-
-	for _, state := range c.ChildStartStates {
-		if state == parentState {
-			return DesiredStateRunning
-		}
-	}
-
-	return DesiredStateStopped
 }
 
 // ChildInfo provides a read-only snapshot of a child worker's current state.
@@ -381,19 +318,19 @@ type ChildInfo struct {
 //
 // 1. Add fields to your ObservedState to store children info:
 //
-//	type MyObservedState struct {
-//	    ChildrenHealthy   int
-//	    ChildrenUnhealthy int
-//	}
+//			type MyObservedState struct {
+//			    ChildrenHealthy   int
+//			    ChildrenUnhealthy int
+//			}
 //
-//  2. Implement SetChildrenView on your ObservedState (the supervisor calls it
-//     automatically through the ChildrenViewConsumer capability interface):
+//	 2. Implement SetChildrenView on your ObservedState (the supervisor calls it
+//	    automatically through the ChildrenViewConsumer capability interface):
 //
-//     func (o MyObservedState) SetChildrenView(view config.ChildrenView) fsmv2.ObservedState {
-//     o.ChildrenHealthy = view.HealthyCount
-//     o.ChildrenUnhealthy = view.UnhealthyCount
-//     return o
-//     }
+//	    func (o MyObservedState) SetChildrenView(view config.ChildrenView) fsmv2.ObservedState {
+//	    o.ChildrenHealthy = view.HealthyCount
+//	    o.ChildrenUnhealthy = view.UnhealthyCount
+//	    return o
+//	    }
 //
 // 3. Access children info in State.Next() via the snapshot:
 //
@@ -551,8 +488,8 @@ func (d *DesiredState) GetChildrenSpecs() []ChildSpec {
 
 // NewChildSpec creates a typed ChildSpec by marshalling cfg into UserSpec.Config (YAML).
 // Returns an error if YAML marshalling fails (unexpected for static struct types).
-// The ChildStartStates and Dependencies fields are left at their zero values; callers
-// that need them should set them on the returned spec.
+// The Dependencies field is left at its zero value; callers that need it should
+// set it on the returned spec.
 //
 // Use NewChildSpec to build typed child specs from a parent's RenderChildren body:
 //

--- a/umh-core/pkg/fsmv2/config/childspec_test.go
+++ b/umh-core/pkg/fsmv2/config/childspec_test.go
@@ -33,15 +33,14 @@ var _ = Describe("ChildSpec", func() {
 				UserSpec: config.UserSpec{
 					Config: "mqtt:\n  url: tcp://localhost:1883",
 				},
-				ChildStartStates: []string{"Running", "TryingToStart"},
+				Enabled: true,
 			}
 
 			data, err := yaml.Marshal(spec)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(string(data)).To(ContainSubstring("name: connection"))
 			Expect(string(data)).To(ContainSubstring("workerType: mqtt_connection"))
-			Expect(string(data)).To(ContainSubstring("childStartStates:"))
-			Expect(string(data)).To(ContainSubstring("- Running"))
+			Expect(string(data)).To(ContainSubstring("enabled: true"))
 		})
 
 		It("should deserialize from YAML correctly", func() {
@@ -50,9 +49,7 @@ name: connection
 workerType: mqtt_connection
 userSpec:
   config: "mqtt:\n  url: tcp://localhost:1883"
-childStartStates:
-  - Running
-  - TryingToStart
+enabled: true
 `
 			var spec config.ChildSpec
 			err := yaml.Unmarshal([]byte(yamlData), &spec)
@@ -61,10 +58,10 @@ childStartStates:
 			Expect(spec.Name).To(Equal("connection"))
 			Expect(spec.WorkerType).To(Equal("mqtt_connection"))
 			Expect(spec.UserSpec.Config).To(ContainSubstring("tcp://localhost:1883"))
-			Expect(spec.ChildStartStates).To(ConsistOf("Running", "TryingToStart"))
+			Expect(spec.Enabled).To(BeTrue())
 		})
 
-		It("should handle optional ChildStartStates correctly", func() {
+		It("should handle missing optional fields correctly", func() {
 			yamlData := `
 name: simple-worker
 workerType: basic
@@ -76,7 +73,7 @@ userSpec:
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(spec.Name).To(Equal("simple-worker"))
-			Expect(spec.ChildStartStates).To(BeNil())
+			Expect(spec.Enabled).To(BeFalse())
 		})
 	})
 
@@ -101,7 +98,7 @@ userSpec:
 var _ = Describe("ChildSpec Clone", func() {
 	Describe("Clone()", func() {
 		It("should create a deep copy that is independent from the original", func() {
-			// Create original ChildSpec with UserSpec and ChildStartStates
+			// Create original ChildSpec with a UserSpec carrying Variables.
 			original := config.ChildSpec{
 				Name:       "original-worker",
 				WorkerType: "mqtt_connection",
@@ -113,7 +110,7 @@ var _ = Describe("ChildSpec Clone", func() {
 						},
 					},
 				},
-				ChildStartStates: []string{"Running", "TryingToStart"},
+				Enabled: true,
 			}
 
 			// Clone it
@@ -123,41 +120,13 @@ var _ = Describe("ChildSpec Clone", func() {
 			Expect(cloned.Name).To(Equal(original.Name))
 			Expect(cloned.WorkerType).To(Equal(original.WorkerType))
 			Expect(cloned.UserSpec.Config).To(Equal(original.UserSpec.Config))
-			Expect(cloned.ChildStartStates).To(Equal(original.ChildStartStates))
+			Expect(cloned.Enabled).To(Equal(original.Enabled))
 
-			// Modify the clone's ChildStartStates slice
-			cloned.ChildStartStates[0] = "Modified"
-			cloned.ChildStartStates = append(cloned.ChildStartStates, "NewState")
+			// Modify the clone's deep-copied UserSpec variables
+			cloned.UserSpec.Variables.User["key1"] = "modified"
 
 			// Verify the original is NOT affected
-			Expect(original.ChildStartStates).To(Equal([]string{"Running", "TryingToStart"}))
-			Expect(original.ChildStartStates).ToNot(ContainElement("Modified"))
-			Expect(original.ChildStartStates).ToNot(ContainElement("NewState"))
-		})
-
-		It("should handle nil ChildStartStates", func() {
-			original := config.ChildSpec{
-				Name:             "worker-no-states",
-				WorkerType:       "basic",
-				ChildStartStates: nil,
-			}
-
-			cloned := original.Clone()
-
-			Expect(cloned.ChildStartStates).To(BeNil())
-		})
-
-		It("should handle empty ChildStartStates slice", func() {
-			original := config.ChildSpec{
-				Name:             "worker-empty-states",
-				WorkerType:       "basic",
-				ChildStartStates: []string{},
-			}
-
-			cloned := original.Clone()
-
-			Expect(cloned.ChildStartStates).ToNot(BeNil())
-			Expect(cloned.ChildStartStates).To(BeEmpty())
+			Expect(original.UserSpec.Variables.User["key1"]).To(Equal("value1"))
 		})
 	})
 })
@@ -176,7 +145,7 @@ var _ = Describe("ChildSpec Hash", func() {
 						},
 					},
 				},
-				ChildStartStates: []string{"Running", "TryingToStart"},
+				Enabled: true,
 			}
 
 			spec2 := config.ChildSpec{
@@ -190,7 +159,7 @@ var _ = Describe("ChildSpec Hash", func() {
 						},
 					},
 				},
-				ChildStartStates: []string{"Running", "TryingToStart"},
+				Enabled: true,
 			}
 
 			hash1, err1 := spec1.Hash()
@@ -260,19 +229,19 @@ var _ = Describe("ChildSpec Hash", func() {
 			Expect(hash1).NotTo(Equal(hash2))
 		})
 
-		It("should produce different hashes when ChildStartStates changes", func() {
+		It("should produce different hashes when Enabled changes", func() {
 			spec1 := config.ChildSpec{
-				Name:             "child-1",
-				WorkerType:       "mqtt_connection",
-				UserSpec:         config.UserSpec{Config: "config"},
-				ChildStartStates: []string{"Running"},
+				Name:       "child-1",
+				WorkerType: "mqtt_connection",
+				UserSpec:   config.UserSpec{Config: "config"},
+				Enabled:    false,
 			}
 
 			spec2 := config.ChildSpec{
-				Name:             "child-1",
-				WorkerType:       "mqtt_connection",
-				UserSpec:         config.UserSpec{Config: "config"},
-				ChildStartStates: []string{"Running", "TryingToStart"},
+				Name:       "child-1",
+				WorkerType: "mqtt_connection",
+				UserSpec:   config.UserSpec{Config: "config"},
+				Enabled:    true,
 			}
 
 			hash1, err1 := spec1.Hash()

--- a/umh-core/pkg/fsmv2/config/childspec_validation.go
+++ b/umh-core/pkg/fsmv2/config/childspec_validation.go
@@ -54,23 +54,6 @@ func ValidateChildSpec(spec ChildSpec, registry WorkerTypeChecker) error {
 		return fmt.Errorf("child spec validation failed: invalid user spec: %w", err)
 	}
 
-	// Validate ChildStartStates
-	if len(spec.ChildStartStates) > 0 {
-		seenStates := make(map[string]bool)
-
-		for _, state := range spec.ChildStartStates {
-			if state == "" {
-				return errors.New("child spec validation failed: ChildStartStates entry cannot be empty")
-			}
-
-			if seenStates[state] {
-				return errors.New("child spec validation failed: duplicate state in ChildStartStates")
-			}
-
-			seenStates[state] = true
-		}
-	}
-
 	return nil
 }
 

--- a/umh-core/pkg/fsmv2/config/childspec_validation_test.go
+++ b/umh-core/pkg/fsmv2/config/childspec_validation_test.go
@@ -58,20 +58,6 @@ var _ = Describe("ChildSpec Validation", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("should pass validation for a ChildSpec with ChildStartStates", func() {
-			spec := config.ChildSpec{
-				Name:       "valid-child-with-states",
-				WorkerType: "test-worker",
-				UserSpec: config.UserSpec{
-					Config: "config-data",
-				},
-				ChildStartStates: []string{"Running", "TryingToStart"},
-			}
-
-			err := config.ValidateChildSpec(spec, registry)
-			Expect(err).NotTo(HaveOccurred())
-		})
-
 		It("should fail when Name is empty", func() {
 			spec := config.ChildSpec{
 				Name:       "",
@@ -143,71 +129,16 @@ var _ = Describe("ChildSpec Validation", func() {
 			Expect(err.Error()).To(ContainSubstring("invalid user spec"))
 		})
 
-		It("should validate even with nil ChildStartStates", func() {
+		It("should validate a spec with Enabled set", func() {
 			spec := config.ChildSpec{
-				Name:       "no-states",
+				Name:       "enabled-child",
 				WorkerType: "test-worker",
 				UserSpec: config.UserSpec{
 					Config: "config",
 				},
-				ChildStartStates: nil,
+				Enabled: true,
 			}
 
-			err := config.ValidateChildSpec(spec, registry)
-			Expect(err).NotTo(HaveOccurred())
-		})
-
-		It("should validate with empty ChildStartStates", func() {
-			spec := config.ChildSpec{
-				Name:       "empty-states",
-				WorkerType: "test-worker",
-				UserSpec: config.UserSpec{
-					Config: "config",
-				},
-				ChildStartStates: []string{},
-			}
-
-			err := config.ValidateChildSpec(spec, registry)
-			Expect(err).NotTo(HaveOccurred())
-		})
-
-		It("should reject ChildStartStates with empty state name", func() {
-			spec := config.ChildSpec{
-				Name:             "test-child",
-				WorkerType:       "test-worker",
-				ChildStartStates: []string{"Running", ""},
-				UserSpec: config.UserSpec{
-					Config: "config",
-				},
-			}
-			err := config.ValidateChildSpec(spec, registry)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("cannot be empty"))
-		})
-
-		It("should reject ChildStartStates with duplicate state names", func() {
-			spec := config.ChildSpec{
-				Name:             "test-child",
-				WorkerType:       "test-worker",
-				ChildStartStates: []string{"Running", "Running"},
-				UserSpec: config.UserSpec{
-					Config: "config",
-				},
-			}
-			err := config.ValidateChildSpec(spec, registry)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("duplicate"))
-		})
-
-		It("should accept valid ChildStartStates with multiple unique states", func() {
-			spec := config.ChildSpec{
-				Name:             "test-child",
-				WorkerType:       "test-worker",
-				ChildStartStates: []string{"Running", "TryingToStart", "Degraded"},
-				UserSpec: config.UserSpec{
-					Config: "config",
-				},
-			}
 			err := config.ValidateChildSpec(spec, registry)
 			Expect(err).NotTo(HaveOccurred())
 		})
@@ -428,18 +359,18 @@ var _ = Describe("ChildSpec Validation", func() {
 			Expect(err.Error()).To(ContainSubstring("duplicate name"))
 		})
 
-		It("should pass validation with multiple specs having different ChildStartStates", func() {
+		It("should pass validation with multiple specs having different Enabled values", func() {
 			specs := []config.ChildSpec{
 				{
-					Name:       "child-with-states",
+					Name:       "child-enabled",
 					WorkerType: "communicator",
 					UserSpec: config.UserSpec{
 						Config: "config",
 					},
-					ChildStartStates: []string{"Running"},
+					Enabled: true,
 				},
 				{
-					Name:       "child-without-states",
+					Name:       "child-disabled",
 					WorkerType: "test-worker",
 					UserSpec: config.UserSpec{
 						Config: "config",

--- a/umh-core/pkg/fsmv2/config/doc.go
+++ b/umh-core/pkg/fsmv2/config/doc.go
@@ -96,7 +96,7 @@
 //	        Variables: config.VariableBundle{
 //	            User: map[string]any{"URL": "tcp://localhost:1883"},
 //	        },
-//	        ChildStartStates: []string{"Running", "TryingToStart"},
+//	        Enabled: true,
 //	    },
 //	}
 //
@@ -104,18 +104,14 @@
 // how to create them. The supervisor handles creation, deletion, and updates.
 // Children can be added or removed by changing ChildrenSpecs in DeriveDesiredState().
 //
-// # ChildStartStates
+// # Child lifecycle gating
 //
-// ChildStartStates specifies which parent FSM states cause the child to run:
+// A parent gates each child's lifecycle through ChildSpec.Enabled. The
+// supervisor's disable-mapping pass translates Enabled into the child's
+// Disabled bit, and state files route lifecycle through snap.ShouldStop().
+// Setting Enabled=false leaves the child resident in Stopped; flipping it back
+// to true resumes the child on the next tick.
 //
-//	ChildStartStates: []string{"Running", "TryingToStart"}
-//	// Child runs when parent is in "Running" or "TryingToStart"
-//	// Child stops when parent is in any other state
-//
-// The child runs if the parent state is in the list, stops otherwise.
-// An empty list means the child always runs.
-//
-// ChildStartStates handles lifecycle coordination, not data passing.
 // Use VariableBundle to pass data from parent to child.
 //
 // # DesiredState and shutdown control

--- a/umh-core/pkg/fsmv2/integration/cascade_scenario_test.go
+++ b/umh-core/pkg/fsmv2/integration/cascade_scenario_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Cascade Scenario Integration", func() {
 		// 25s allows time for two complete failure cycles:
 		// Cycle 1 (startup):
 		// - Parent starts and creates children
-		// - Children wait for ParentMappedState before starting (slight delay)
+		// - Children wait for the parent to enable them before starting (slight delay)
 		// - Children fail (3 times each) - Parent stays in TryingToStart (expected)
 		// - Children recover - Parent goes to Running
 		// Cycle 2 (runtime):
@@ -185,7 +185,7 @@ func verifyCascadeChildrenFailed(t *integration.TestLogger) {
 
 	// Children should fail at least once to verify failure behavior
 	// Note: The exact failure count depends on timing - children wait for
-	// ParentMappedState before starting, which affects how many failures
+	// the parent to enable them before starting, which affects how many failures
 	// occur within the test duration. The important thing is that failures DO happen.
 	Expect(childFailures).To(BeNumerically(">=", 1),
 		fmt.Sprintf("Expected children to fail at least once, got %d", childFailures))

--- a/umh-core/pkg/fsmv2/integration/despawn_discriminator_test.go
+++ b/umh-core/pkg/fsmv2/integration/despawn_discriminator_test.go
@@ -49,11 +49,10 @@ func (s *despawnPhaseState) Next(_ any) fsmv2.NextResult[any, any] {
 		return fsmv2.Transition(s, fsmv2.SignalNone, nil, "spawning child-0",
 			[]fsmconfig.ChildSpec{
 				{
-					Name:             "child-0",
-					WorkerType:       "examplechild",
-					UserSpec:         fsmconfig.UserSpec{},
-					Enabled:          true,
-					ChildStartStates: []string{"TryingToStart", "Running"},
+					Name:       "child-0",
+					WorkerType: "examplechild",
+					UserSpec:   fsmconfig.UserSpec{},
+					Enabled:    true,
 				},
 			})
 	}
@@ -77,14 +76,12 @@ func (w *despawnParentWorker) CollectObservedState(_ context.Context, _ fsmv2.De
 
 func (w *despawnParentWorker) DeriveDesiredState(_ interface{}) (fsmv2.DesiredState, error) {
 	return &fsmv2.WrappedDesiredState[exampleparent.ExampleparentConfig]{
-		State: fsmconfig.DesiredStateRunning,
 		ChildrenSpecs: []fsmconfig.ChildSpec{
 			{
-				Name:             "child-0",
-				WorkerType:       "examplechild",
-				UserSpec:         fsmconfig.UserSpec{},
-				Enabled:          true,
-				ChildStartStates: []string{"TryingToStart", "Running"},
+				Name:       "child-0",
+				WorkerType: "examplechild",
+				UserSpec:   fsmconfig.UserSpec{},
+				Enabled:    true,
 			},
 		},
 	}, nil

--- a/umh-core/pkg/fsmv2/integration/despawn_discriminator_test.go
+++ b/umh-core/pkg/fsmv2/integration/despawn_discriminator_test.go
@@ -46,6 +46,7 @@ func (s *despawnPhaseState) LifecyclePhase() fsmconfig.LifecyclePhase {
 func (s *despawnPhaseState) Next(_ any) fsmv2.NextResult[any, any] {
 	if !s.spawned {
 		s.spawned = true
+
 		return fsmv2.Transition(s, fsmv2.SignalNone, nil, "spawning child-0",
 			[]fsmconfig.ChildSpec{
 				{
@@ -126,6 +127,7 @@ var _ = Describe("Despawn discriminator: non-nil empty ChildSpec slice despawns 
 		// discriminator falls through to legacy and child-0 is never removed.
 		Eventually(func() bool {
 			_ = parentSup.TestTick(ctx)
+
 			return len(parentSup.GetChildren()) == 0
 		}, "5s", "100ms").Should(BeTrue(),
 			"child-0 must be removed once state machine emits non-nil empty ChildSpec slice — "+

--- a/umh-core/pkg/fsmv2/integration/disabled_child_test.go
+++ b/umh-core/pkg/fsmv2/integration/disabled_child_test.go
@@ -103,7 +103,7 @@ var _ = Describe("Resident-disabled child stays in Stopped, not removed", func()
 		err := parentSup.AddWorker(identity, &residentDisabledParentWorker{})
 		Expect(err).ToNot(HaveOccurred())
 
-		for i := 0; i < 3; i++ {
+		for range 3 {
 			Expect(parentSup.TestTick(ctx)).To(Succeed())
 		}
 

--- a/umh-core/pkg/fsmv2/internal/validator/registry.go
+++ b/umh-core/pkg/fsmv2/internal/validator/registry.go
@@ -322,20 +322,6 @@ func (s *TryingToConnectState) Next(snap any) (...) {
 }`,
 		ReferenceFile: "example-child/state/state_trying_to_connect.go",
 	},
-	"MISSING_CATCHALL_RETURN": {
-		Name: "Exhaustive Transition Coverage",
-		Why: `Next() methods should end with a catch-all return: "return s, SignalNone, nil".
-WHY: The FSM always has a valid transition. Without a catch-all,
-edge cases may cause undefined behavior. The catch-all is a safety net that
-maintains the current state when no explicit transition matches.`,
-		CorrectCode: `func (s *MyState) Next(snap any) (...) {
-    if condition1 { return &State1{}, ... }
-    if condition2 { return &State2{}, ... }
-    // Catch-all: stay in current state
-    return s, SignalNone, nil
-}`,
-		ReferenceFile: "example-child/state/state_connected.go",
-	},
 	"MISSING_BASE_STATE": {
 		Name: "Base State Type Embedding",
 		Why: `State structs should embed exactly one Base*State type.

--- a/umh-core/pkg/fsmv2/internal/validator/snapshot.go
+++ b/umh-core/pkg/fsmv2/internal/validator/snapshot.go
@@ -322,9 +322,10 @@ func ValidateStateFieldExists(baseDir string) []Violation {
 // checkStateFieldExists parses a snapshot file and checks for State string field.
 // Both DesiredState and ObservedState types must have an explicit State string field.
 // BaseDesiredState no longer carries State (F4 refactor); each embedding type owns it.
-// Child worker desired states (PushDesiredState, PullDesiredState) that are controlled
-// entirely by ParentMappedState are exempt: they embed BaseDesiredState only for
-// ShutdownRequested and do not participate in the running/stopped lifecycle transition.
+// Child worker desired states (PushDesiredState, PullDesiredState) whose lifecycle
+// is driven by the supervisor (ShutdownRequested/Disabled) are exempt: they embed
+// BaseDesiredState only for ShutdownRequested and do not participate in the
+// running/stopped lifecycle transition through their own State field.
 func checkStateFieldExists(filename string) []Violation {
 	var violations []Violation
 
@@ -376,7 +377,7 @@ func checkStateFieldExists(filename string) []Violation {
 		}
 
 		// Child worker DesiredState types that embed only BaseDesiredState (for
-		// ShutdownRequested) and rely solely on ParentMappedState for lifecycle
+		// ShutdownRequested) and have their lifecycle driven by the supervisor
 		// are exempt from the State field requirement. They are identified by
 		// embedding BaseDesiredState without having a State string field of their own.
 		// This is a valid pattern for push/pull child workers.
@@ -629,7 +630,7 @@ func checkFolderMatchesWorkerType(filename string) []Violation {
 }
 
 // ValidateNoCustomLifecycleFields checks that DesiredState structs do NOT have custom lifecycle fields.
-// Lifecycle is controlled by BaseDesiredState.ShutdownRequested and ParentMappedState.
+// Lifecycle is controlled by BaseDesiredState.ShutdownRequested and Disabled.
 func ValidateNoCustomLifecycleFields(baseDir string) []Violation {
 	var violations []Violation
 
@@ -684,8 +685,8 @@ func checkNoCustomLifecycleFields(filename string) []Violation {
 							Line: pos.Line,
 							Type: "CUSTOM_LIFECYCLE_FIELD",
 							Message: fmt.Sprintf("DesiredState %s has forbidden lifecycle field '%s' - "+
-								"lifecycle is controlled by ShutdownRequested (from BaseDesiredState) "+
-								"and ParentMappedState (for child workers). "+
+								"lifecycle is controlled by ShutdownRequested and Disabled "+
+								"(from BaseDesiredState). "+
 								"Custom lifecycle fields are never populated correctly and break parent-child coordination.",
 								typeSpec.Name.Name, name.Name),
 						})

--- a/umh-core/pkg/fsmv2/internal/validator/state.go
+++ b/umh-core/pkg/fsmv2/internal/validator/state.go
@@ -737,91 +737,6 @@ func checkTryingToStatesReturnActions(filename string) []Violation {
 	return violations
 }
 
-// ValidateExhaustiveTransitionCoverage checks that Next() methods end with catch-all return.
-func ValidateExhaustiveTransitionCoverage(baseDir string) []Violation {
-	var violations []Violation
-
-	stateFiles := FindStateFiles(baseDir)
-
-	for _, file := range stateFiles {
-		fileViolations := checkExhaustiveTransitionCoverage(file)
-		violations = append(violations, fileViolations...)
-	}
-
-	return violations
-}
-
-// checkExhaustiveTransitionCoverage checks for catch-all return (TryingTo states exempt).
-// This now checks for fsmv2.Result(s, fsmv2.SignalNone, nil, "reason") pattern.
-func checkExhaustiveTransitionCoverage(filename string) []Violation {
-	var violations []Violation
-
-	baseName := filepath.Base(filename)
-	// TryingTo and stopping states are active-transition states exempt from the catch-all rule.
-	// Stopped states are also exempt because they legitimately transition out when desired state
-	// changes (e.g., StoppedState -> TryingToStartState).
-	if strings.Contains(baseName, "trying_to") || strings.Contains(baseName, "stopping") || strings.Contains(baseName, "stopped") {
-		return violations
-	}
-
-	fset := token.NewFileSet()
-
-	node, err := parser.ParseFile(fset, filename, nil, parser.ParseComments)
-	if err != nil {
-		return violations
-	}
-
-	ast.Inspect(node, func(n ast.Node) bool {
-		funcDecl, ok := n.(*ast.FuncDecl)
-		if !ok || funcDecl.Name.Name != "Next" {
-			return true
-		}
-
-		if funcDecl.Body == nil || len(funcDecl.Body.List) == 0 {
-			return true
-		}
-
-		lastStmt := funcDecl.Body.List[len(funcDecl.Body.List)-1]
-
-		retStmt, ok := lastStmt.(*ast.ReturnStmt)
-		if !ok || len(retStmt.Results) != 1 {
-			return true
-		}
-
-		// Extract state, signal, action from fsmv2.Result() call
-		stateResult, signalResult, actionResult := extractResultArgsWithSignal(retStmt.Results[0])
-		if stateResult == nil || signalResult == nil || actionResult == nil {
-			return true
-		}
-
-		isCatchAll := false
-
-		if ident, ok := stateResult.(*ast.Ident); ok && ident.Name == "s" {
-			if selExpr, ok := signalResult.(*ast.SelectorExpr); ok {
-				if selExpr.Sel.Name == "SignalNone" {
-					if nilIdent, ok := actionResult.(*ast.Ident); ok && nilIdent.Name == "nil" {
-						isCatchAll = true
-					}
-				}
-			}
-		}
-
-		if !isCatchAll {
-			pos := fset.Position(retStmt.Pos())
-			violations = append(violations, Violation{
-				File:    filename,
-				Line:    pos.Line,
-				Type:    "MISSING_CATCHALL_RETURN",
-				Message: "Next() should end with catch-all: fsmv2.Result(s, fsmv2.SignalNone, nil, reason)",
-			})
-		}
-
-		return true
-	})
-
-	return violations
-}
-
 // ValidateBaseStateEmbedding checks that state structs embed Base*State.
 func ValidateBaseStateEmbedding(baseDir string) []Violation {
 	var violations []Violation
@@ -849,11 +764,11 @@ func checkBaseStateEmbedding(filename string) []Violation {
 
 	// Valid phase-specific base types from helpers package
 	validPhaseBaseTypes := map[string]bool{
-		"StartingBase":       true,
-		"RunningHealthyBase": true,
+		"StartingBase":        true,
+		"RunningHealthyBase":  true,
 		"RunningDegradedBase": true,
-		"StoppingBase":       true,
-		"StoppedBase":        true,
+		"StoppingBase":        true,
+		"StoppedBase":         true,
 	}
 
 	ast.Inspect(node, func(n ast.Node) bool {

--- a/umh-core/pkg/fsmv2/internal/validator/worker.go
+++ b/umh-core/pkg/fsmv2/internal/validator/worker.go
@@ -181,7 +181,7 @@ func ValidateNilSpecHandling(baseDir string) []Violation {
 	return violations
 }
 
-// checkNilSpecHandling checks for nil spec check or use of nil-safe helpers (DeriveLeafState, ParseUserSpec).
+// checkNilSpecHandling checks for nil spec check or use of nil-safe helpers (ParseUserSpec).
 func checkNilSpecHandling(filename string) []Violation {
 	var violations []Violation
 
@@ -256,8 +256,7 @@ func checkNilSpecHandling(filename string) []Violation {
 // usesNilSafeHelper checks if the function body uses helpers that handle nil internally.
 func usesNilSafeHelper(body *ast.BlockStmt) bool {
 	nilSafeHelpers := map[string]bool{
-		"DeriveLeafState": true,
-		"ParseUserSpec":   true,
+		"ParseUserSpec": true,
 	}
 
 	found := false

--- a/umh-core/pkg/fsmv2/observation.go
+++ b/umh-core/pkg/fsmv2/observation.go
@@ -167,8 +167,6 @@ type Observation[TStatus any] struct {
 	Status TStatus `json:"-"`
 	// State is the current FSM state name (set by supervisor via SetState).
 	State string `json:"state"`
-	// ParentMappedState is the desired state mapped from the parent's current state.
-	ParentMappedState string `json:"parent_mapped_state"`
 	// LastActionResults contains action history (managed by supervisor).
 	LastActionResults []deps.ActionResult `json:"last_action_results,omitempty"`
 	// MetricsEmbedder provides framework and worker metrics (anonymous embed, inline in JSON).
@@ -192,7 +190,6 @@ type observationFrameworkFields struct {
 	CollectedAt       time.Time           `json:"collected_at"`
 	ChildrenView      config.ChildrenView `json:"childrenView"`
 	State             string              `json:"state"`
-	ParentMappedState string              `json:"parent_mapped_state"`
 	LastActionResults []deps.ActionResult `json:"last_action_results,omitempty"`
 	deps.MetricsEmbedder
 	ChildrenHealthy   int  `json:"children_healthy"`
@@ -208,7 +205,6 @@ func (o Observation[TStatus]) MarshalJSON() ([]byte, error) {
 		ChildrenView:      o.ChildrenView,
 		State:             o.State,
 		ShutdownRequested: o.ShutdownRequested,
-		ParentMappedState: o.ParentMappedState,
 		LastActionResults: o.LastActionResults,
 		ChildrenHealthy:   o.ChildrenHealthy,
 		ChildrenUnhealthy: o.ChildrenUnhealthy,
@@ -257,7 +253,6 @@ func (o *Observation[TStatus]) UnmarshalJSON(data []byte) error {
 	o.ChildrenView = fw.ChildrenView
 	o.State = fw.State
 	o.ShutdownRequested = fw.ShutdownRequested
-	o.ParentMappedState = fw.ParentMappedState
 	o.LastActionResults = fw.LastActionResults
 	o.ChildrenHealthy = fw.ChildrenHealthy
 	o.ChildrenUnhealthy = fw.ChildrenUnhealthy
@@ -366,15 +361,6 @@ func (o Observation[TStatus]) SetFrameworkMetrics(fm deps.FrameworkMetrics) Obse
 //	interface{ SetActionHistory([]deps.ActionResult) fsmv2.ObservedState }
 func (o Observation[TStatus]) SetActionHistory(h []deps.ActionResult) ObservedState {
 	o.LastActionResults = h
-
-	return o
-}
-
-// SetParentMappedState sets the lifecycle state mapped from the parent worker. Matches collector pattern:
-//
-//	interface{ SetParentMappedState(string) fsmv2.ObservedState }
-func (o Observation[TStatus]) SetParentMappedState(s string) ObservedState {
-	o.ParentMappedState = s
 
 	return o
 }

--- a/umh-core/pkg/fsmv2/observation_test.go
+++ b/umh-core/pkg/fsmv2/observation_test.go
@@ -96,11 +96,6 @@ var _ = Describe("Observation", func() {
 				SetActionHistory([]deps.ActionResult) fsmv2.ObservedState
 			})
 			Expect(ok).To(BeTrue(), "must satisfy SetActionHistory duck-type")
-
-			_, ok = obs.(interface {
-				SetParentMappedState(string) fsmv2.ObservedState
-			})
-			Expect(ok).To(BeTrue(), "must satisfy SetParentMappedState duck-type")
 		})
 	})
 
@@ -113,7 +108,6 @@ var _ = Describe("Observation", func() {
 			Expect(obs.GetTimestamp()).To(Equal(ts))
 		})
 	})
-
 
 	Describe("MarshalJSON", func() {
 		It("produces flat JSON with framework and business fields at same level", func() {

--- a/umh-core/pkg/fsmv2/register/deps_registry_test.go
+++ b/umh-core/pkg/fsmv2/register/deps_registry_test.go
@@ -106,7 +106,7 @@ var _ = Describe("register deps registry", func() {
 		It("returns Go-native nil for pointer TDeps when never SetDeps", func() {
 			got := register.GetDeps[*depsRegistryDeps]("never-set")
 
-			Expect(got == nil).To(BeTrue())
+			Expect(got).To(BeNil())
 		})
 
 		It("returns struct{} zero value for register.NoDeps when never SetDeps", func() {
@@ -131,7 +131,7 @@ var _ = Describe("register deps registry", func() {
 
 			got := register.GetDeps[someIface]("never-set-iface")
 
-			Expect(got == nil).To(BeTrue())
+			Expect(got).To(BeNil())
 		})
 	})
 
@@ -143,11 +143,11 @@ var _ = Describe("register deps registry", func() {
 			var wg sync.WaitGroup
 			wg.Add(goroutines * 2)
 
-			for g := 0; g < goroutines; g++ {
+			for g := range goroutines {
 				go func(id int) {
 					defer wg.Done()
 
-					for k := 0; k < keysPerGoroutine; k++ {
+					for k := range keysPerGoroutine {
 						key := "concurrent-writer-" + strconv.Itoa(id) + "-" + strconv.Itoa(k)
 						register.SetDeps[*depsRegistryDeps](key, &depsRegistryDeps{
 							Label: key,
@@ -159,7 +159,7 @@ var _ = Describe("register deps registry", func() {
 				go func(id int) {
 					defer wg.Done()
 
-					for k := 0; k < keysPerGoroutine; k++ {
+					for k := range keysPerGoroutine {
 						key := "concurrent-reader-" + strconv.Itoa(id) + "-" + strconv.Itoa(k)
 						_ = register.GetDeps[*depsRegistryDeps](key)
 					}
@@ -186,16 +186,16 @@ var _ = Describe("register deps registry", func() {
 			go func() {
 				defer wg.Done()
 
-				for i := 0; i < iterations; i++ {
+				for range iterations {
 					register.ClearDeps(key)
 				}
 			}()
 
-			for w := 0; w < writers; w++ {
+			for w := range writers {
 				go func(id int) {
 					defer wg.Done()
 
-					for i := 0; i < iterations; i++ {
+					for i := range iterations {
 						register.SetDeps[*depsRegistryDeps](key, &depsRegistryDeps{
 							Label: key,
 							Value: id*1000 + i,
@@ -204,11 +204,11 @@ var _ = Describe("register deps registry", func() {
 				}(w)
 			}
 
-			for r := 0; r < readers; r++ {
+			for range readers {
 				go func() {
 					defer wg.Done()
 
-					for i := 0; i < iterations; i++ {
+					for range iterations {
 						_ = register.GetDeps[*depsRegistryDeps](key)
 					}
 				}()
@@ -287,7 +287,7 @@ var _ = Describe("register deps registry", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(w).NotTo(BeNil())
 			Expect(constructorRan).To(BeTrue())
-			Expect(capturedDeps == nil).To(BeTrue())
+			Expect(capturedDeps).To(BeNil())
 		})
 	})
 })

--- a/umh-core/pkg/fsmv2/register/register.go
+++ b/umh-core/pkg/fsmv2/register/register.go
@@ -78,6 +78,7 @@ func Worker[TConfig any, TStatus any, TDeps any](
 		if err != nil {
 			panic(fmt.Sprintf("register.Worker(%q): constructor failed for %s: %v", workerType, id.String(), err))
 		}
+
 		if w == nil {
 			panic(fmt.Sprintf("register.Worker(%q): constructor returned nil worker for %s", workerType, id.String()))
 		}
@@ -115,6 +116,7 @@ func SetDepsBuilder[T any](workerType string, builderFn func(deps.Identity, deps
 	if workerType == "" {
 		panic("register.SetDepsBuilder: workerType must be non-empty")
 	}
+
 	if builderFn == nil {
 		panic("register.SetDepsBuilder: builderFn must be non-nil")
 	}
@@ -141,6 +143,7 @@ func GetDepsBuilder(workerType string) (func(deps.Identity, deps.FSMLogger, deps
 func ResetDepsBuilderRegistry() {
 	depsBuilderRegistry.Range(func(key, _ any) bool {
 		depsBuilderRegistry.Delete(key)
+
 		return true
 	})
 }

--- a/umh-core/pkg/fsmv2/supervisor/api.go
+++ b/umh-core/pkg/fsmv2/supervisor/api.go
@@ -258,9 +258,6 @@ func (s *Supervisor[TObserved, TDesired]) AddWorker(identity deps.Identity, work
 
 			return healthy, unhealthy
 		},
-		MappedParentStateProvider: func() string {
-			return s.getMappedParentState()
-		},
 		ChildrenViewProvider: func() config.ChildrenView {
 			return config.NewChildrenView(s.childInfoSlice())
 		},
@@ -575,21 +572,6 @@ func (s *Supervisor[TObserved, TDesired]) GetWorkerState(workerID string) (strin
 	return workerCtx.currentState.String(), workerCtx.currentStateReason, nil
 }
 
-// GetMappedParentState returns the mapped parent state for this supervisor.
-// Returns empty string if this supervisor has no parent or no mapping has been applied.
-// This method is primarily used for testing hierarchical state mapping.
-func (s *Supervisor[TObserved, TDesired]) GetMappedParentState() string {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	return s.mappedParentState
-}
-
-// getMappedParentState implements SupervisorInterface.
-func (s *Supervisor[TObserved, TDesired]) getMappedParentState() string {
-	return s.GetMappedParentState()
-}
-
 // isCircuitOpen returns true if any circuit breaker is open for this supervisor.
 // Used by InfrastructureHealthChecker.CheckChildConsistency() to detect unhealthy children.
 func (s *Supervisor[TObserved, TDesired]) isCircuitOpen() bool {
@@ -629,37 +611,6 @@ func (s *Supervisor[TObserved, TDesired]) IsObservationStale() bool {
 	}
 
 	return true
-}
-
-// setMappedParentState implements SupervisorInterface.
-func (s *Supervisor[TObserved, TDesired]) setMappedParentState(state string) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	s.mappedParentState = state
-}
-
-// getChildStartStates implements SupervisorInterface.
-func (s *Supervisor[TObserved, TDesired]) getChildStartStates() []string {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	if s.childStartStates == nil {
-		return nil
-	}
-
-	states := make([]string, len(s.childStartStates))
-	copy(states, s.childStartStates)
-
-	return states
-}
-
-// setChildStartStates implements SupervisorInterface.
-func (s *Supervisor[TObserved, TDesired]) setChildStartStates(states []string) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	s.childStartStates = states
 }
 
 // updateUserSpec implements SupervisorInterface.
@@ -851,7 +802,6 @@ type SupervisorDebugInfo struct {
 	Children            map[string]SupervisorDebugInfo `json:"children,omitempty"`
 	WorkerType          string                         `json:"worker_type"`
 	HierarchyPath       string                         `json:"hierarchy_path"`
-	MappedParentState   string                         `json:"mapped_parent_state,omitempty"`
 	Workers             []WorkerDebugInfo              `json:"workers"`
 	CollectedAtUnixNano int64                          `json:"collected_at_unix_nano"`
 	CircuitOpen         bool                           `json:"circuit_open"`
@@ -871,7 +821,6 @@ func (s *Supervisor[TObserved, TDesired]) GetDebugInfo() interface{} {
 		HierarchyPath:       s.GetHierarchyPathUnlocked(),
 		CircuitOpen:         s.circuitOpen.Load(),
 		PanicCircuitOpen:    s.panicCircuitOpen.Load(),
-		MappedParentState:   s.mappedParentState,
 		CollectedAtUnixNano: time.Now().UnixNano(),
 		Workers:             make([]WorkerDebugInfo, 0, len(s.workers)),
 	}

--- a/umh-core/pkg/fsmv2/supervisor/api_boundary_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/api_boundary_test.go
@@ -90,7 +90,6 @@ var _ = Describe("Supervisor API Boundary", func() {
 		It("should export testing support methods", func() {
 			publicMethods := []string{
 				"GetChildren",
-				"GetMappedParentState",
 			}
 
 			for _, methodName := range publicMethods {
@@ -149,7 +148,6 @@ var _ = Describe("Supervisor API Boundary", func() {
 		It("should NOT export hierarchical composition methods", func() {
 			internalMethods := []string{
 				"reconcileChildren",
-				"applyStateMapping",
 				"UpdateUserSpec",
 			}
 

--- a/umh-core/pkg/fsmv2/supervisor/doc.go
+++ b/umh-core/pkg/fsmv2/supervisor/doc.go
@@ -419,7 +419,7 @@
 //
 // # Best practices
 //
-//   - Check IsShutdownRequested() as first condition in state.Next()
+//   - Check ShouldStop() as first condition in state.Next()
 //   - Make all actions idempotent (check if work already done)
 //   - Use ChildSpec.Enabled to coordinate child lifecycle (not data passing)
 //   - Pass data to children via VariableBundle, not direct method calls

--- a/umh-core/pkg/fsmv2/supervisor/doc.go
+++ b/umh-core/pkg/fsmv2/supervisor/doc.go
@@ -99,10 +99,9 @@
 //   - Removes children after workers complete shutdown
 //   - Propagates errors (halts reconciliation on failure)
 //
-// Apply state mapping:
-//   - Parent state influences child desired state
-//   - ChildStartStates determines when children should run
-//   - Empty ChildStartStates means child always runs
+// Apply disable mapping:
+//   - ChildSpec.Enabled determines whether each child should run
+//   - Enabled=false leaves the child resident in Stopped (not despawned)
 //
 // Recursively tick children:
 //   - Ticks all children in hierarchy order
@@ -422,7 +421,7 @@
 //
 //   - Check IsShutdownRequested() as first condition in state.Next()
 //   - Make all actions idempotent (check if work already done)
-//   - Use ChildStartStates to coordinate child lifecycle (not data passing)
+//   - Use ChildSpec.Enabled to coordinate child lifecycle (not data passing)
 //   - Pass data to children via VariableBundle, not direct method calls
 //   - Release locks before calling child methods (prevent deadlock)
 //   - Handle context cancellation in all async operations

--- a/umh-core/pkg/fsmv2/supervisor/document_fields.go
+++ b/umh-core/pkg/fsmv2/supervisor/document_fields.go
@@ -34,6 +34,12 @@ const (
 	// PascalCase matches struct tag: `json:"ShutdownRequested"`.
 	FieldShutdownRequested = "ShutdownRequested"
 
+	// FieldDisabled is the resident-disable flag set by the disable-mapping pass.
+	// Like ShutdownRequested, it is a supervisor operation that must be preserved
+	// across DeriveDesiredState re-derivation (workers always re-derive Disabled=false).
+	// PascalCase matches struct tag: `json:"Disabled"`.
+	FieldDisabled = "Disabled"
+
 	// FieldParentID is the parent supervisor ID (renamed from "bridged_by").
 	FieldParentID = "parent_id"
 )

--- a/umh-core/pkg/fsmv2/supervisor/hierarchical_tick_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/hierarchical_tick_test.go
@@ -256,69 +256,6 @@ var _ = Describe("Hierarchical Tick Propagation (Task 0.6)", func() {
 			Expect(events).To(ContainElement("DeriveDesiredState:parent"))
 		})
 
-		It("should apply state mapping before child tick", func() {
-			worker := &hierarchicalWorker{
-				id:     "parent",
-				logger: tickLog,
-				observed: &mockObservedState{
-					ID:          "parent-worker",
-					CollectedAt: time.Now(),
-					Desired:     &mockDesiredState{},
-				},
-				childrenSpecs: []config.ChildSpec{
-					{
-						Name:             "child1",
-						WorkerType:       "child",
-						UserSpec:         config.UserSpec{},
-						ChildStartStates: []string{"running"},
-					},
-				},
-			}
-
-			parentSuper = supervisor.NewSupervisor[*supervisor.TestObservedState, *supervisor.TestDesiredState](supervisor.Config{
-				WorkerType: "parent",
-				Logger:     deps.NewNopFSMLogger(),
-				Store:      mockStore,
-			})
-
-			identity := deps.Identity{
-				ID:         "parent-worker",
-				Name:       "Parent Worker",
-				WorkerType: "parent",
-			}
-			err := parentSuper.AddWorker(identity, worker)
-			Expect(err).NotTo(HaveOccurred())
-
-			parentSuper.TestUpdateUserSpec(config.UserSpec{Config: "config"})
-
-			desiredDoc := persistence.Document{
-				"id":                identity.ID,
-				"ShutdownRequested": false,
-			}
-			_, err = mockStore.SaveDesired(ctx, "parent", identity.ID, desiredDoc)
-			Expect(err).NotTo(HaveOccurred())
-
-			mockStore.Observed["parent"] = map[string]interface{}{
-				"parent-worker": persistence.Document{
-					"id":          "parent-worker",
-					"collectedAt": time.Now(),
-				},
-			}
-
-			mockStore.Observed["child"] = map[string]interface{}{
-				"child-worker": persistence.Document{
-					"id":          "child-worker",
-					"collectedAt": time.Now(),
-				},
-			}
-
-			err = parentSuper.TestTick(ctx)
-			Expect(err).NotTo(HaveOccurred())
-
-			events := tickLog.GetEvents()
-			Expect(events).To(ContainElement("DeriveDesiredState:parent"))
-		})
-
 		It("should reconcile new children in same tick cycle", func() {
 			worker := &hierarchicalWorker{
 				id:     "parent",

--- a/umh-core/pkg/fsmv2/supervisor/internal/collection/collector.go
+++ b/umh-core/pkg/fsmv2/supervisor/internal/collection/collector.go
@@ -66,8 +66,7 @@ type CollectorConfig[TObserved any] struct {
 	// consume ChildrenView instead and read HealthyCount / UnhealthyCount as fields.
 	// The collector still calls both setters during migration; counts agree because
 	// ChildrenView derives them from the same per-child Phase.
-	ChildrenCountsProvider    func() (healthy int, unhealthy int)
-	MappedParentStateProvider func() string // Returns mapped state from parent's StateMapping (injected by supervisor for child workers)
+	ChildrenCountsProvider func() (healthy int, unhealthy int)
 	// ChildrenViewProvider returns the full ChildrenView snapshot for parent
 	// workers that need per-child detail.
 	ChildrenViewProvider func() config.ChildrenView
@@ -490,16 +489,6 @@ func (c *Collector[TObserved]) collectAndSaveObservedState(ctx context.Context) 
 			SetChildrenCounts(int, int) fsmv2.ObservedState
 		}); ok {
 			observed = setter.SetChildrenCounts(healthy, unhealthy)
-		}
-	}
-
-	// Inject mapped parent state so child workers know when to start/stop via StateMapping
-	if c.config.MappedParentStateProvider != nil {
-		mappedState := c.config.MappedParentStateProvider()
-		if setter, ok := observed.(interface {
-			SetParentMappedState(string) fsmv2.ObservedState
-		}); ok {
-			observed = setter.SetParentMappedState(mappedState)
 		}
 	}
 

--- a/umh-core/pkg/fsmv2/supervisor/lifecycle.go
+++ b/umh-core/pkg/fsmv2/supervisor/lifecycle.go
@@ -477,6 +477,7 @@ func (s *Supervisor[TObserved, TDesired]) requestShutdown(ctx context.Context, w
 		if !errors.Is(err, persistence.ErrNotFound) {
 			return fmt.Errorf("failed to load desired state: %w", err)
 		}
+
 		return nil
 	}
 
@@ -699,6 +700,7 @@ func (s *Supervisor[TObserved, TDesired]) setDisabled(ctx context.Context, worke
 		if !errors.Is(err, persistence.ErrNotFound) {
 			return fmt.Errorf("failed to load desired state: %w", err)
 		}
+
 		return nil
 	}
 

--- a/umh-core/pkg/fsmv2/supervisor/lock_documentation_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/lock_documentation_test.go
@@ -391,7 +391,7 @@ var _ = Describe("Lock Documentation", func() {
 			// This test documents what good lock documentation looks like
 			expectedFormat := `
 // mu protects access to workers map, expectedObservedTypes, expectedDesiredTypes,
-// children, globalVars, and mappedParentState.
+// children, and globalVars.
 //
 // This is a sync.RWMutex to allow concurrent reads from multiple goroutines
 // while ensuring exclusive writes when modifying worker registry state.

--- a/umh-core/pkg/fsmv2/supervisor/reconciliation.go
+++ b/umh-core/pkg/fsmv2/supervisor/reconciliation.go
@@ -962,8 +962,6 @@ func (s *Supervisor[TObserved, TDesired]) tick(ctx context.Context) (err error) 
 		return fmt.Errorf("failed to reconcile children: %w", err)
 	}
 
-	s.applyStateMapping()
-
 	// Tick children; errors logged but don't fail parent
 	s.mu.RLock()
 
@@ -1484,7 +1482,6 @@ func (s *Supervisor[TObserved, TDesired]) reconcileChildren(specs []config.Child
 			childUserSpec := spec.UserSpec
 			childUserSpec.Variables = config.Merge(s.userSpec.Variables, spec.UserSpec.Variables)
 			child.updateUserSpec(childUserSpec)
-			child.setChildStartStates(spec.ChildStartStates)
 
 			updatedCount++
 		} else {
@@ -1548,7 +1545,6 @@ func (s *Supervisor[TObserved, TDesired]) reconcileChildren(specs []config.Child
 			childUserSpec := spec.UserSpec
 			childUserSpec.Variables = config.Merge(s.userSpec.Variables, spec.UserSpec.Variables)
 			childSupervisor.updateUserSpec(childUserSpec)
-			childSupervisor.setChildStartStates(spec.ChildStartStates)
 			childSupervisor.setParent(s, s.workerType)
 
 			// Compute child's hierarchy path: parent path + child segment
@@ -1752,39 +1748,6 @@ func (s *Supervisor[TObserved, TDesired]) reconcileChildren(specs []config.Child
 	return nil
 }
 
-func (s *Supervisor[TObserved, TDesired]) applyStateMapping() {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	if len(s.workers) == 0 {
-		return
-	}
-
-	var parentState string
-
-	for _, workerCtx := range s.workers {
-		workerCtx.mu.RLock()
-
-		if workerCtx.currentState != nil {
-			parentState = workerCtx.currentState.String()
-		}
-
-		workerCtx.mu.RUnlock()
-
-		break
-	}
-
-	for childName, child := range s.children {
-		mappedState := s.computeMappedState(parentState, child)
-
-		child.setMappedParentState(mappedState)
-		s.logTrace("state_mapped",
-			deps.String("child_name", childName),
-			deps.String("parent_state", parentState),
-			deps.String("mapped_state", mappedState))
-	}
-}
-
 // applyDisableMapping propagates ChildSpec.Enabled into each child's IsDisabled bit.
 // Called inside reconcileChildren (parent.mu held). Acquires per-child locks internally.
 // Nil specs are a no-op: leaf workers return nil from GetChildrenSpecs every tick.
@@ -1875,28 +1838,4 @@ func (s *Supervisor[TObserved, TDesired]) classifyDisableMappingError(err error)
 	}
 
 	return "other"
-}
-
-// computeMappedState determines the desired state for a child based on parent's current state.
-//
-// ChildStartStates logic:
-//   - If empty: child always runs (follows parent's DesiredState.State)
-//   - If parentState is in the list: child should run (returns "running")
-//   - Otherwise: child should stop (returns "stopped")
-func (s *Supervisor[TObserved, TDesired]) computeMappedState(parentState string, child SupervisorInterface) string {
-	childStartStates := child.getChildStartStates()
-
-	// Empty ChildStartStates = child always runs (follows parent's desired state)
-	if len(childStartStates) == 0 {
-		return config.DesiredStateRunning
-	}
-
-	// Check if parent state is in the list of states where child should run
-	for _, state := range childStartStates {
-		if state == parentState {
-			return config.DesiredStateRunning
-		}
-	}
-
-	return config.DesiredStateStopped
 }

--- a/umh-core/pkg/fsmv2/supervisor/reconciliation.go
+++ b/umh-core/pkg/fsmv2/supervisor/reconciliation.go
@@ -1762,7 +1762,7 @@ func (s *Supervisor[TObserved, TDesired]) applyDisableMapping(ctx context.Contex
 	}
 
 	for _, spec := range specs {
-		spec := spec // capture for closure
+		// capture for closure
 
 		// Per-iteration panic recovery: one misbehaving child must not stop all reductions.
 		func() {
@@ -1804,6 +1804,7 @@ func (s *Supervisor[TObserved, TDesired]) handleDisableMappingError(spec config.
 	now := time.Now()
 	if now.Sub(entry.lastSeen) < disableMappingErrorSuppressionWindow {
 		s.disableMappingErrors[key] = entry
+
 		return
 	}
 
@@ -1819,6 +1820,7 @@ func (s *Supervisor[TObserved, TDesired]) handleDisableMappingError(spec config.
 		s.logger.Debug("reducer_child_not_found_disabled",
 			deps.String("child_name", spec.Name),
 			deps.Int("suppressed_count", entry.count))
+
 		return
 	}
 

--- a/umh-core/pkg/fsmv2/supervisor/reconciliation.go
+++ b/umh-core/pkg/fsmv2/supervisor/reconciliation.go
@@ -833,13 +833,20 @@ func (s *Supervisor[TObserved, TDesired]) tick(ctx context.Context) (err error) 
 		}
 	}
 
-	// Preserve ShutdownRequested: shutdown is a supervisor operation that overrides DeriveDesiredState
+	// Preserve ShutdownRequested and Disabled: both are supervisor operations
+	// (shutdown request and the disable-mapping pass) that override DeriveDesiredState.
+	// Workers always re-derive these as false, so the persisted value must be carried
+	// forward or the disable bit would be clobbered every tick.
 	var existingDesiredTyped TDesired
 	if err := s.store.LoadDesiredTyped(ctx, s.workerType, firstWorkerID, &existingDesiredTyped); err == nil {
-		// Check if existing state had shutdown requested via interface
+		// Check the existing state's lifecycle flags via interface.
 		if ds, ok := any(existingDesiredTyped).(fsmv2.DesiredState); ok {
 			if ds.IsShutdownRequested() {
 				desiredDoc[FieldShutdownRequested] = true
+			}
+
+			if ds.IsDisabled() {
+				desiredDoc[FieldDisabled] = true
 			}
 		}
 	}

--- a/umh-core/pkg/fsmv2/supervisor/should_stop_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/should_stop_test.go
@@ -19,10 +19,9 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/config"
 )
 
-var _ = Describe("WorkerSnapshot.ShouldStop — 3-way discriminator", func() {
+var _ = Describe("WorkerSnapshot.ShouldStop — 2-way discriminator", func() {
 	type noConfig struct{}
 	type noStatus struct{}
 
@@ -30,7 +29,6 @@ var _ = Describe("WorkerSnapshot.ShouldStop — 3-way discriminator", func() {
 		snap := fsmv2.WorkerSnapshot[noConfig, noStatus]{
 			IsShutdownRequested: true,
 			IsDisabled:          false,
-			ParentMappedState:   config.DesiredStateRunning,
 		}
 		Expect(snap.ShouldStop()).To(BeTrue())
 	})
@@ -39,7 +37,6 @@ var _ = Describe("WorkerSnapshot.ShouldStop — 3-way discriminator", func() {
 		snap := fsmv2.WorkerSnapshot[noConfig, noStatus]{
 			IsShutdownRequested: false,
 			IsDisabled:          true,
-			ParentMappedState:   config.DesiredStateRunning,
 		}
 		Expect(snap.ShouldStop()).To(BeTrue())
 	})
@@ -48,7 +45,6 @@ var _ = Describe("WorkerSnapshot.ShouldStop — 3-way discriminator", func() {
 		snap := fsmv2.WorkerSnapshot[noConfig, noStatus]{
 			IsShutdownRequested: true,
 			IsDisabled:          true,
-			ParentMappedState:   config.DesiredStateRunning,
 		}
 		Expect(snap.ShouldStop()).To(BeTrue())
 		// Verify ordering invariant: IsShutdownRequested is checked first in state files.
@@ -57,21 +53,11 @@ var _ = Describe("WorkerSnapshot.ShouldStop — 3-way discriminator", func() {
 		Expect(snap.IsShutdownRequested).To(BeTrue(), "shutdown WINS in StoppedState discriminator")
 	})
 
-	It("neither flag, parent running → ShouldStop=false (normal resume)", func() {
+	It("neither flag → ShouldStop=false (normal resume)", func() {
 		snap := fsmv2.WorkerSnapshot[noConfig, noStatus]{
 			IsShutdownRequested: false,
 			IsDisabled:          false,
-			ParentMappedState:   config.DesiredStateRunning,
 		}
 		Expect(snap.ShouldStop()).To(BeFalse())
-	})
-
-	It("ParentMappedState=stopped → ShouldStop=true (parent-driven stop)", func() {
-		snap := fsmv2.WorkerSnapshot[noConfig, noStatus]{
-			IsShutdownRequested: false,
-			IsDisabled:          false,
-			ParentMappedState:   config.DesiredStateStopped,
-		}
-		Expect(snap.ShouldStop()).To(BeTrue())
 	})
 })

--- a/umh-core/pkg/fsmv2/supervisor/supervisor.go
+++ b/umh-core/pkg/fsmv2/supervisor/supervisor.go
@@ -143,7 +143,7 @@ type Supervisor[TObserved fsmv2.ObservedState, TDesired fsmv2.DesiredState] stru
 	logger              deps.FSMLogger
 	baseLogger          deps.FSMLogger // Un-enriched logger for child supervisors
 	workers             map[string]*WorkerContext[TObserved, TDesired]
-	// mu Protects access to workers map, children, globalVars, and mappedParentState.
+	// mu Protects access to workers map, children, and globalVars.
 	//
 	// This is a lockmanager.Lock wrapping sync.RWMutex to allow concurrent reads from multiple goroutines
 	// (e.g., GetWorker, ListWorkers) while ensuring exclusive writes when modifying
@@ -187,10 +187,8 @@ type Supervisor[TObserved fsmv2.ObservedState, TDesired fsmv2.DesiredState] stru
 	noStateMachineLoggedOnce sync.Map
 	userSpec                 config.UserSpec
 	workerType               string
-	mappedParentState        string
 	parentID                 string
 	lastUserSpecHash         string
-	childStartStates         []string
 	collectorHealth          CollectorHealth
 	metricsWg                sync.WaitGroup
 	tickInterval             time.Duration

--- a/umh-core/pkg/fsmv2/supervisor/types.go
+++ b/umh-core/pkg/fsmv2/supervisor/types.go
@@ -58,10 +58,6 @@ type SupervisorInterface interface {
 	tick(ctx context.Context) error
 	updateUserSpec(spec config.UserSpec)
 	getUserSpec() config.UserSpec
-	getChildStartStates() []string
-	setChildStartStates(states []string)
-	getMappedParentState() string
-	setMappedParentState(state string)
 	calculateHierarchySize() int
 	calculateHierarchyDepth() int
 	GetChildren() map[string]SupervisorInterface

--- a/umh-core/pkg/fsmv2/worker_base.go
+++ b/umh-core/pkg/fsmv2/worker_base.go
@@ -134,8 +134,9 @@ func (w *WorkerBase[TConfig, TStatus, TDeps]) DeriveDesiredState(spec interface{
 		}
 	}
 
-	// Duck-type: validate and propagate the desired lifecycle state when
-	// TConfig embeds config.BaseUserSpec or implements GetState() string.
+	// Duck-type: validate the desired lifecycle state when TConfig embeds
+	// config.BaseUserSpec or implements GetState() string. Validation rejects
+	// illegal user-supplied state values; lifecycle itself is driven by the FSM.
 	wds := &WrappedDesiredState[TConfig]{
 		Config: cfg,
 	}
@@ -147,8 +148,6 @@ func (w *WorkerBase[TConfig, TStatus, TDeps]) DeriveDesiredState(spec interface{
 				return nil, fmt.Errorf("invalid desired state: %w", err)
 			}
 		}
-
-		wds.State = state
 	}
 
 	w.mu.Lock()

--- a/umh-core/pkg/fsmv2/worker_base_test.go
+++ b/umh-core/pkg/fsmv2/worker_base_test.go
@@ -266,22 +266,24 @@ var _ = Describe("WorkerBase", func() {
 			Expect(wds.Config.Port).To(Equal(9090))
 		})
 
-		It("valid UserSpec with state=stopped propagates State field", func() {
+		It("valid UserSpec with state=stopped is accepted and parses config", func() {
 			spec := config.UserSpec{Config: "state: stopped\nurl: http://example.com\nport: 1234"}
 			ds, err := worker.DeriveDesiredState(spec)
 			Expect(err).NotTo(HaveOccurred())
 			wds, ok := ds.(*fsmv2.WrappedDesiredState[wbTestConfig])
 			Expect(ok).To(BeTrue())
-			Expect(wds.State).To(Equal(config.DesiredStateStopped))
+			Expect(wds.Config.URL).To(Equal("http://example.com"))
+			Expect(wds.Config.Port).To(Equal(1234))
 		})
 
-		It("valid UserSpec with state=running propagates State field", func() {
+		It("valid UserSpec with state=running is accepted and parses config", func() {
 			spec := config.UserSpec{Config: "state: running\nurl: http://example.com\nport: 5678"}
 			ds, err := worker.DeriveDesiredState(spec)
 			Expect(err).NotTo(HaveOccurred())
 			wds, ok := ds.(*fsmv2.WrappedDesiredState[wbTestConfig])
 			Expect(ok).To(BeTrue())
-			Expect(wds.State).To(Equal(config.DesiredStateRunning))
+			Expect(wds.Config.URL).To(Equal("http://example.com"))
+			Expect(wds.Config.Port).To(Equal(5678))
 		})
 
 		It("invalid spec type (non-UserSpec) returns error", func() {
@@ -306,13 +308,13 @@ var _ = Describe("WorkerBase", func() {
 			Expect(err.Error()).To(ContainSubstring("invalid desired state"))
 		})
 
-		It("nil spec returns State='' (empty; GetState() returns 'running')", func() {
+		It("nil spec returns a default WrappedDesiredState with empty config", func() {
 			ds, err := worker.DeriveDesiredState(nil)
 			Expect(err).NotTo(HaveOccurred())
 			wds, ok := ds.(*fsmv2.WrappedDesiredState[wbTestConfig])
 			Expect(ok).To(BeTrue())
-			Expect(wds.State).To(Equal(""))
-			Expect(wds.GetState()).To(Equal(config.DesiredStateRunning))
+			Expect(wds.Config).To(Equal(wbTestConfig{}))
+			Expect(wds.IsShutdownRequested()).To(BeFalse())
 		})
 
 		It("config is cached: Config() matches after DeriveDesiredState", func() {

--- a/umh-core/pkg/fsmv2/worker_snapshot_test.go
+++ b/umh-core/pkg/fsmv2/worker_snapshot_test.go
@@ -15,9 +15,7 @@
 // Tests for WorkerSnapshot construction, ShouldStop semantics, and ExtractConfig.
 // ShouldStop covers the 2-way OR:
 //
-//	ShouldStop() == IsShutdownRequested || ParentMappedState == "stopped"
-//
-// Additional ShouldStop conditions are added in later lifecycle layers.
+//	ShouldStop() == IsShutdownRequested || IsDisabled
 
 package fsmv2_test
 
@@ -28,7 +26,6 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/config"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
 )
 
@@ -102,7 +99,7 @@ var _ = Describe("ConvertWorkerSnapshot (happy paths)", func() {
 		Expect(snap.IsShutdownRequested).To(BeTrue())
 	})
 
-	It("copies framework fields (action results, children counts, ParentMappedState)", func() {
+	It("copies framework fields (action results, children counts)", func() {
 		actionResults := []deps.ActionResult{
 			{ActionType: "connect", Success: true, Timestamp: now},
 		}
@@ -112,7 +109,6 @@ var _ = Describe("ConvertWorkerSnapshot (happy paths)", func() {
 			LastActionResults: actionResults,
 			ChildrenHealthy:   3,
 			ChildrenUnhealthy: 1,
-			ParentMappedState: config.DesiredStateStopped,
 		}
 		wds := &fsmv2.WrappedDesiredState[workerTestConfig]{}
 
@@ -123,13 +119,11 @@ var _ = Describe("ConvertWorkerSnapshot (happy paths)", func() {
 		Expect(snap.LastActionResults[0].ActionType).To(Equal("connect"))
 		Expect(snap.ChildrenHealthy).To(Equal(3))
 		Expect(snap.ChildrenUnhealthy).To(Equal(1))
-		Expect(snap.ParentMappedState).To(Equal(config.DesiredStateStopped))
 	})
 })
 
 var _ = Describe("ShouldStop", func() {
-	// ShouldStop covers 2-way OR: IsShutdownRequested || ParentMappedState=="stopped".
-	// Additional conditions are added in later lifecycle layers.
+	// ShouldStop covers 2-way OR: IsShutdownRequested || IsDisabled.
 
 	It("returns false when both signals are absent", func() {
 		snap := fsmv2.WorkerSnapshot[workerTestConfig, workerTestStatus]{}
@@ -143,9 +137,9 @@ var _ = Describe("ShouldStop", func() {
 		Expect(snap.ShouldStop()).To(BeTrue())
 	})
 
-	It("returns true when ParentMappedState is 'stopped'", func() {
+	It("returns true when IsDisabled is true (resident disable)", func() {
 		snap := fsmv2.WorkerSnapshot[workerTestConfig, workerTestStatus]{
-			ParentMappedState: config.DesiredStateStopped,
+			IsDisabled: true,
 		}
 		Expect(snap.ShouldStop()).To(BeTrue())
 	})
@@ -153,16 +147,9 @@ var _ = Describe("ShouldStop", func() {
 	It("returns true when both signals are present (OR semantics)", func() {
 		snap := fsmv2.WorkerSnapshot[workerTestConfig, workerTestStatus]{
 			IsShutdownRequested: true,
-			ParentMappedState:   config.DesiredStateStopped,
+			IsDisabled:          true,
 		}
 		Expect(snap.ShouldStop()).To(BeTrue())
-	})
-
-	It("is unaffected by a non-stop ParentMappedState value", func() {
-		snap := fsmv2.WorkerSnapshot[workerTestConfig, workerTestStatus]{
-			ParentMappedState: config.DesiredStateRunning,
-		}
-		Expect(snap.ShouldStop()).To(BeFalse())
 	})
 })
 

--- a/umh-core/pkg/fsmv2/workers/application/state/state_degraded.go
+++ b/umh-core/pkg/fsmv2/workers/application/state/state_degraded.go
@@ -15,8 +15,6 @@
 package state
 
 import (
-	"fmt"
-
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/internal/helpers"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/application/snapshot"
@@ -33,7 +31,7 @@ func (s *DegradedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&StoppedState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: %s", snap.StopReason()), nil)
+			"stop required: "+snap.StopReason(), nil)
 	}
 
 	circuitOpen, stale := snapshot.ChildrenViewToStatus(snap.ChildrenView)

--- a/umh-core/pkg/fsmv2/workers/application/state/state_degraded.go
+++ b/umh-core/pkg/fsmv2/workers/application/state/state_degraded.go
@@ -15,6 +15,8 @@
 package state
 
 import (
+	"fmt"
+
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/internal/helpers"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/application/snapshot"
@@ -30,7 +32,8 @@ func (s *DegradedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[snapshot.ApplicationConfig, snapshot.ApplicationStatus](snapAny)
 
 	if snap.ShouldStop() {
-		return fsmv2.Transition(&StoppedState{}, fsmv2.SignalNone, nil, "Shutdown requested", nil)
+		return fsmv2.Transition(&StoppedState{}, fsmv2.SignalNone, nil,
+			fmt.Sprintf("stop required: %s", snap.StopReason()), nil)
 	}
 
 	circuitOpen, stale := snapshot.ChildrenViewToStatus(snap.ChildrenView)

--- a/umh-core/pkg/fsmv2/workers/application/state/state_running.go
+++ b/umh-core/pkg/fsmv2/workers/application/state/state_running.go
@@ -15,6 +15,8 @@
 package state
 
 import (
+	"fmt"
+
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/internal/helpers"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/application/snapshot"
@@ -29,7 +31,8 @@ func (s *RunningState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[snapshot.ApplicationConfig, snapshot.ApplicationStatus](snapAny)
 
 	if snap.ShouldStop() {
-		return fsmv2.Transition(&StoppedState{}, fsmv2.SignalNone, nil, "Shutdown requested", nil)
+		return fsmv2.Transition(&StoppedState{}, fsmv2.SignalNone, nil,
+			fmt.Sprintf("stop required: %s", snap.StopReason()), nil)
 	}
 
 	circuitOpen, stale := snapshot.ChildrenViewToStatus(snap.ChildrenView)

--- a/umh-core/pkg/fsmv2/workers/application/state/state_running.go
+++ b/umh-core/pkg/fsmv2/workers/application/state/state_running.go
@@ -15,8 +15,6 @@
 package state
 
 import (
-	"fmt"
-
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/internal/helpers"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/application/snapshot"
@@ -32,7 +30,7 @@ func (s *RunningState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&StoppedState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: %s", snap.StopReason()), nil)
+			"stop required: "+snap.StopReason(), nil)
 	}
 
 	circuitOpen, stale := snapshot.ChildrenViewToStatus(snap.ChildrenView)

--- a/umh-core/pkg/fsmv2/workers/communicator/worker.go
+++ b/umh-core/pkg/fsmv2/workers/communicator/worker.go
@@ -132,7 +132,6 @@ func (w *CommunicatorWorker) CollectObservedState(ctx context.Context, _ fsmv2.D
 func (w *CommunicatorWorker) DeriveDesiredState(spec interface{}) (fsmv2.DesiredState, error) {
 	if spec == nil {
 		return &fsmv2.WrappedDesiredState[CommunicatorConfig]{
-			State: fsmv2types.DesiredStateRunning,
 			Config: CommunicatorConfig{
 				Timeout: httpTransport.LongPollingDuration + httpTransport.LongPollingBuffer,
 			},
@@ -159,7 +158,6 @@ func (w *CommunicatorWorker) DeriveDesiredState(spec interface{}) (fsmv2.Desired
 	}
 
 	return &fsmv2.WrappedDesiredState[CommunicatorConfig]{
-		State:  commSpec.GetState(),
 		Config: commSpec,
 	}, nil
 }

--- a/umh-core/pkg/fsmv2/workers/communicator/worker_test.go
+++ b/umh-core/pkg/fsmv2/workers/communicator/worker_test.go
@@ -125,7 +125,6 @@ var _ = Describe("CommunicatorWorker", func() {
 
 				desired, ok := desiredIface.(*fsmv2.WrappedDesiredState[communicator.CommunicatorConfig])
 				Expect(ok).To(BeTrue(), "expected *fsmv2.WrappedDesiredState[CommunicatorConfig]")
-				Expect(desired.GetState()).To(Equal("running"))
 				Expect(desired.IsShutdownRequested()).To(BeFalse())
 			})
 
@@ -160,7 +159,6 @@ state: "running"
 				Expect(desired.Config.InstanceUUID).To(Equal("test-uuid-12345"))
 				Expect(desired.Config.AuthToken).To(Equal("test-auth-token-secret"))
 				Expect(desired.Config.Timeout).To(Equal(15 * time.Second))
-				Expect(desired.GetState()).To(Equal("running"))
 				// ChildrenSpecs is nil: transport child is declared in RenderChildren (children.go),
 				// not in DeriveDesiredState. RenderChildren is the single source of truth.
 				Expect(desired.GetChildrenSpecs()).To(BeNil())
@@ -212,7 +210,6 @@ state: "running"
 				Expect(loadedDesired.Config.InstanceUUID).To(Equal("roundtrip-uuid-test"))
 				Expect(loadedDesired.Config.AuthToken).To(Equal("roundtrip-auth-token"))
 				Expect(loadedDesired.Config.Timeout).To(Equal(30 * time.Second))
-				Expect(loadedDesired.GetState()).To(Equal("running"))
 			})
 
 			It("should return clear error on invalid spec type", func() {

--- a/umh-core/pkg/fsmv2/workers/example/examplechild/state/state_connected.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplechild/state/state_connected.go
@@ -15,8 +15,6 @@
 package state
 
 import (
-	"fmt"
-
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/internal/helpers"
 	example_child "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/examplechild"
@@ -32,7 +30,7 @@ func (s *ConnectedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&TryingToStopState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: %s", snap.StopReason()), nil)
+			"stop required: "+snap.StopReason(), nil)
 	}
 
 	if snap.Status.ConnectionHealth != "healthy" {

--- a/umh-core/pkg/fsmv2/workers/example/examplechild/state/state_connected.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplechild/state/state_connected.go
@@ -32,8 +32,7 @@ func (s *ConnectedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&TryingToStopState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: shutdown=%t, parentState=%s",
-				snap.IsShutdownRequested, snap.ParentMappedState), nil)
+			fmt.Sprintf("stop required: shutdown=%t", snap.IsShutdownRequested), nil)
 	}
 
 	if snap.Status.ConnectionHealth != "healthy" {

--- a/umh-core/pkg/fsmv2/workers/example/examplechild/state/state_connected.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplechild/state/state_connected.go
@@ -32,7 +32,7 @@ func (s *ConnectedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&TryingToStopState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: shutdown=%t", snap.IsShutdownRequested), nil)
+			fmt.Sprintf("stop required: %s", snap.StopReason()), nil)
 	}
 
 	if snap.Status.ConnectionHealth != "healthy" {

--- a/umh-core/pkg/fsmv2/workers/example/examplechild/state/state_disconnected.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplechild/state/state_disconnected.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/config"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/internal/helpers"
 	example_child "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/examplechild"
 )
@@ -33,10 +32,10 @@ func (s *DisconnectedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&TryingToStopState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: shutdown=%t, parentState=%s", snap.IsShutdownRequested, snap.ParentMappedState), nil)
+			fmt.Sprintf("stop required: shutdown=%t", snap.IsShutdownRequested), nil)
 	}
 
-	if !snap.IsShutdownRequested && snap.ParentMappedState == config.DesiredStateRunning {
+	if !snap.ShouldStop() {
 		return fsmv2.Transition(&TryingToConnectState{}, fsmv2.SignalNone, nil, "Attempting to reconnect", nil)
 	}
 

--- a/umh-core/pkg/fsmv2/workers/example/examplechild/state/state_disconnected.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplechild/state/state_disconnected.go
@@ -32,14 +32,10 @@ func (s *DisconnectedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&TryingToStopState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: shutdown=%t", snap.IsShutdownRequested), nil)
+			fmt.Sprintf("stop required: %s", snap.StopReason()), nil)
 	}
 
-	if !snap.ShouldStop() {
-		return fsmv2.Transition(&TryingToConnectState{}, fsmv2.SignalNone, nil, "Attempting to reconnect", nil)
-	}
-
-	return fsmv2.Transition(s, fsmv2.SignalNone, nil, "Connection lost, will retry", nil)
+	return fsmv2.Transition(&TryingToConnectState{}, fsmv2.SignalNone, nil, "Attempting to reconnect", nil)
 }
 
 func (s *DisconnectedState) String() string {

--- a/umh-core/pkg/fsmv2/workers/example/examplechild/state/state_disconnected.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplechild/state/state_disconnected.go
@@ -15,8 +15,6 @@
 package state
 
 import (
-	"fmt"
-
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/internal/helpers"
 	example_child "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/examplechild"
@@ -32,7 +30,7 @@ func (s *DisconnectedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&TryingToStopState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: %s", snap.StopReason()), nil)
+			"stop required: "+snap.StopReason(), nil)
 	}
 
 	return fsmv2.Transition(&TryingToConnectState{}, fsmv2.SignalNone, nil, "Attempting to reconnect", nil)

--- a/umh-core/pkg/fsmv2/workers/example/examplechild/state/state_stopped.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplechild/state/state_stopped.go
@@ -28,7 +28,7 @@ func init() {
 //
 //  1. IsShutdownRequested=true → emit SignalNeedsRemoval (removal wins).
 //  2. IsDisabled=true → stay in Stopped (preserve dependency state).
-//  3. Otherwise, when !ShouldStop() → TryingToConnect, else stay stopped.
+//  3. Otherwise → TryingToConnect (parent wants the child running).
 //
 // See also workers/transport for the production variant where stopped
 // children stay resident; workers/example/exampleparent/children.go
@@ -48,11 +48,7 @@ func (s *StoppedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 		return fsmv2.Transition(s, fsmv2.SignalNone, nil, "disabled by supervisor, staying stopped", nil)
 	}
 
-	if !snap.ShouldStop() {
-		return fsmv2.Transition(&TryingToConnectState{}, fsmv2.SignalNone, nil, "parent wants running, attempting to connect", nil)
-	}
-
-	return fsmv2.Transition(s, fsmv2.SignalNone, nil, "Child is stopped, no connection", nil)
+	return fsmv2.Transition(&TryingToConnectState{}, fsmv2.SignalNone, nil, "parent wants running, attempting to connect", nil)
 }
 
 func (s *StoppedState) String() string {

--- a/umh-core/pkg/fsmv2/workers/example/examplechild/state/state_stopped.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplechild/state/state_stopped.go
@@ -16,7 +16,6 @@ package state
 
 import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/config"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/internal/helpers"
 	example_child "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/examplechild"
 )
@@ -29,7 +28,7 @@ func init() {
 //
 //  1. IsShutdownRequested=true → emit SignalNeedsRemoval (removal wins).
 //  2. IsDisabled=true → stay in Stopped (preserve dependency state).
-//  3. Otherwise check ParentMappedState: Running → TryingToConnect, else stay stopped.
+//  3. Otherwise, when !ShouldStop() → TryingToConnect, else stay stopped.
 //
 // See also workers/transport for the production variant where stopped
 // children stay resident; workers/example/exampleparent/children.go
@@ -42,15 +41,15 @@ func (s *StoppedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[example_child.ExamplechildConfig, example_child.ExamplechildStatus](snapAny)
 
 	if snap.IsShutdownRequested {
-		return fsmv2.Transition(s, fsmv2.SignalNeedsRemoval, nil, "shutdown requested, stopping: parentState="+snap.ParentMappedState, nil)
+		return fsmv2.Transition(s, fsmv2.SignalNeedsRemoval, nil, "shutdown requested, stopping", nil)
 	}
 
 	if snap.IsDisabled {
-		return fsmv2.Transition(s, fsmv2.SignalNone, nil, "disabled by supervisor, staying stopped: parentState="+snap.ParentMappedState, nil)
+		return fsmv2.Transition(s, fsmv2.SignalNone, nil, "disabled by supervisor, staying stopped", nil)
 	}
 
-	if snap.ParentMappedState == config.DesiredStateRunning {
-		return fsmv2.Transition(&TryingToConnectState{}, fsmv2.SignalNone, nil, "parent wants running, attempting to connect: parentState="+snap.ParentMappedState, nil)
+	if !snap.ShouldStop() {
+		return fsmv2.Transition(&TryingToConnectState{}, fsmv2.SignalNone, nil, "parent wants running, attempting to connect", nil)
 	}
 
 	return fsmv2.Transition(s, fsmv2.SignalNone, nil, "Child is stopped, no connection", nil)

--- a/umh-core/pkg/fsmv2/workers/example/examplechild/state/state_trying_to_connect.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplechild/state/state_trying_to_connect.go
@@ -15,8 +15,6 @@
 package state
 
 import (
-	"fmt"
-
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/internal/helpers"
 	example_child "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/examplechild"
@@ -33,7 +31,7 @@ func (s *TryingToConnectState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&TryingToStopState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: %s", snap.StopReason()), nil)
+			"stop required: "+snap.StopReason(), nil)
 	}
 
 	if snap.Status.ConnectionHealth == "healthy" {

--- a/umh-core/pkg/fsmv2/workers/example/examplechild/state/state_trying_to_connect.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplechild/state/state_trying_to_connect.go
@@ -15,10 +15,12 @@
 package state
 
 import (
+	"fmt"
+
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/internal/helpers"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/examplechild/action"
 	example_child "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/examplechild"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/examplechild/action"
 )
 
 // TryingToConnectState represents the state where the worker is attempting to establish a connection.
@@ -30,7 +32,8 @@ func (s *TryingToConnectState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[example_child.ExamplechildConfig, example_child.ExamplechildStatus](snapAny)
 
 	if snap.ShouldStop() {
-		return fsmv2.Transition(&TryingToStopState{}, fsmv2.SignalNone, nil, "Stop required, initiating shutdown", nil)
+		return fsmv2.Transition(&TryingToStopState{}, fsmv2.SignalNone, nil,
+			fmt.Sprintf("stop required: %s", snap.StopReason()), nil)
 	}
 
 	if snap.Status.ConnectionHealth == "healthy" {

--- a/umh-core/pkg/fsmv2/workers/example/examplechild/state/state_trying_to_stop.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplechild/state/state_trying_to_stop.go
@@ -35,7 +35,7 @@ func (s *TryingToStopState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[example_child.ExamplechildConfig, example_child.ExamplechildStatus](snapAny)
 
 	if snap.Status.ConnectionHealth != "healthy" {
-		return fsmv2.Transition(&StoppedState{}, fsmv2.SignalNone, nil, fmt.Sprintf("disconnection complete: connectionHealth=%q parentState=%q", snap.Status.ConnectionHealth, snap.ParentMappedState), nil)
+		return fsmv2.Transition(&StoppedState{}, fsmv2.SignalNone, nil, fmt.Sprintf("disconnection complete: connectionHealth=%q", snap.Status.ConnectionHealth), nil)
 	}
 
 	return fsmv2.Transition(s, fsmv2.SignalNone, &action.DisconnectAction{}, "Closing connections gracefully", nil)

--- a/umh-core/pkg/fsmv2/workers/example/examplechild/worker.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplechild/worker.go
@@ -113,9 +113,7 @@ func (w *ChildWorker) CollectObservedState(ctx context.Context, _ fsmv2.DesiredS
 // DeriveDesiredState determines what state the child worker should be in.
 func (w *ChildWorker) DeriveDesiredState(spec interface{}) (fsmv2.DesiredState, error) {
 	if spec == nil {
-		return &fsmv2.WrappedDesiredState[ExamplechildConfig]{
-			State: config.DesiredStateRunning,
-		}, nil
+		return &fsmv2.WrappedDesiredState[ExamplechildConfig]{}, nil
 	}
 
 	userSpec, ok := spec.(config.UserSpec)
@@ -138,10 +136,7 @@ func (w *ChildWorker) DeriveDesiredState(spec interface{}) (fsmv2.DesiredState, 
 		return nil, fmt.Errorf("failed to parse examplechild spec: %w", err)
 	}
 
-	state := parsed.GetState()
-
 	return &fsmv2.WrappedDesiredState[ExamplechildConfig]{
-		State:  state,
 		Config: parsed,
 	}, nil
 }

--- a/umh-core/pkg/fsmv2/workers/example/examplechild/worker_test.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplechild/worker_test.go
@@ -83,7 +83,7 @@ var _ = Describe("ChildWorker", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			desired := desiredIface.(*fsmv2.WrappedDesiredState[example_child.ExamplechildConfig])
-			Expect(desired.GetState()).To(Equal(config.DesiredStateRunning))
+			Expect(desired).NotTo(BeNil())
 		})
 	})
 })

--- a/umh-core/pkg/fsmv2/workers/example/examplefailing/state/state_connected.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplefailing/state/state_connected.go
@@ -19,8 +19,8 @@ import (
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/internal/helpers"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/examplefailing/action"
 	examplefailing "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/examplefailing"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/examplefailing/action"
 )
 
 // healthyDurationMsBeforeNextCycle is wall-clock time (in ms) to stay Connected before triggering
@@ -49,8 +49,7 @@ func (s *ConnectedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&TryingToStopState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: shutdown=%t, parentState=%s",
-				snap.IsShutdownRequested, snap.ParentMappedState), nil)
+			fmt.Sprintf("stop required: shutdown=%t", snap.IsShutdownRequested), nil)
 	}
 
 	if snap.Status.ConnectionHealth == "no connection" {

--- a/umh-core/pkg/fsmv2/workers/example/examplefailing/state/state_connected.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplefailing/state/state_connected.go
@@ -49,7 +49,7 @@ func (s *ConnectedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&TryingToStopState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: shutdown=%t", snap.IsShutdownRequested), nil)
+			fmt.Sprintf("stop required: %s", snap.StopReason()), nil)
 	}
 
 	if snap.Status.ConnectionHealth == "no connection" {

--- a/umh-core/pkg/fsmv2/workers/example/examplefailing/state/state_connected.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplefailing/state/state_connected.go
@@ -15,8 +15,6 @@
 package state
 
 import (
-	"fmt"
-
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/internal/helpers"
 	examplefailing "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/examplefailing"
@@ -49,7 +47,7 @@ func (s *ConnectedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&TryingToStopState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: %s", snap.StopReason()), nil)
+			"stop required: "+snap.StopReason(), nil)
 	}
 
 	if snap.Status.ConnectionHealth == "no connection" {

--- a/umh-core/pkg/fsmv2/workers/example/examplefailing/state/state_disconnected.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplefailing/state/state_disconnected.go
@@ -32,15 +32,11 @@ func (s *DisconnectedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&TryingToStopState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: shutdown=%t", snap.IsShutdownRequested), nil)
+			fmt.Sprintf("stop required: %s", snap.StopReason()), nil)
 	}
 
-	if !snap.ShouldStop() {
-		return fsmv2.Transition(&TryingToConnectState{}, fsmv2.SignalNone, nil,
-			"worker should be running, attempting to reconnect", nil)
-	}
-
-	return fsmv2.Transition(s, fsmv2.SignalNone, nil, "connection lost, waiting for reconnect conditions", nil)
+	return fsmv2.Transition(&TryingToConnectState{}, fsmv2.SignalNone, nil,
+		"worker should be running, attempting to reconnect", nil)
 }
 
 func (s *DisconnectedState) String() string {

--- a/umh-core/pkg/fsmv2/workers/example/examplefailing/state/state_disconnected.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplefailing/state/state_disconnected.go
@@ -15,8 +15,6 @@
 package state
 
 import (
-	"fmt"
-
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/internal/helpers"
 	examplefailing "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/examplefailing"
@@ -32,7 +30,7 @@ func (s *DisconnectedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&TryingToStopState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: %s", snap.StopReason()), nil)
+			"stop required: "+snap.StopReason(), nil)
 	}
 
 	return fsmv2.Transition(&TryingToConnectState{}, fsmv2.SignalNone, nil,

--- a/umh-core/pkg/fsmv2/workers/example/examplefailing/state/state_disconnected.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplefailing/state/state_disconnected.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/config"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/internal/helpers"
 	examplefailing "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/examplefailing"
 )
@@ -33,12 +32,12 @@ func (s *DisconnectedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&TryingToStopState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: shutdown=%t, parentState=%s", snap.IsShutdownRequested, snap.ParentMappedState), nil)
+			fmt.Sprintf("stop required: shutdown=%t", snap.IsShutdownRequested), nil)
 	}
 
-	if !snap.IsShutdownRequested && snap.ParentMappedState == config.DesiredStateRunning {
+	if !snap.ShouldStop() {
 		return fsmv2.Transition(&TryingToConnectState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("parentState=%q: worker should be running, attempting to reconnect", snap.ParentMappedState), nil)
+			"worker should be running, attempting to reconnect", nil)
 	}
 
 	return fsmv2.Transition(s, fsmv2.SignalNone, nil, "connection lost, waiting for reconnect conditions", nil)

--- a/umh-core/pkg/fsmv2/workers/example/examplefailing/state/state_stopped.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplefailing/state/state_stopped.go
@@ -16,7 +16,6 @@ package state
 
 import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/config"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/internal/helpers"
 	examplefailing "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/examplefailing"
 )
@@ -37,7 +36,7 @@ func (s *StoppedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 		return fsmv2.Transition(s, fsmv2.SignalNeedsRemoval, nil, "shutdown requested, signaling removal", nil)
 	}
 
-	if !snap.IsShutdownRequested && snap.ParentMappedState == config.DesiredStateRunning {
+	if !snap.ShouldStop() {
 		return fsmv2.Transition(&TryingToConnectState{}, fsmv2.SignalNone, nil, "worker should be running, transitioning to connect", nil)
 	}
 

--- a/umh-core/pkg/fsmv2/workers/example/examplefailing/state/state_stopped.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplefailing/state/state_stopped.go
@@ -36,11 +36,11 @@ func (s *StoppedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 		return fsmv2.Transition(s, fsmv2.SignalNeedsRemoval, nil, "shutdown requested, signaling removal", nil)
 	}
 
-	if !snap.ShouldStop() {
-		return fsmv2.Transition(&TryingToConnectState{}, fsmv2.SignalNone, nil, "worker should be running, transitioning to connect", nil)
+	if snap.IsDisabled {
+		return fsmv2.Transition(s, fsmv2.SignalNone, nil, "disabled by supervisor, staying stopped", nil)
 	}
 
-	return fsmv2.Transition(s, fsmv2.SignalNone, nil, "worker is stopped, no connection", nil)
+	return fsmv2.Transition(&TryingToConnectState{}, fsmv2.SignalNone, nil, "worker should be running, transitioning to connect", nil)
 }
 
 func (s *StoppedState) String() string {

--- a/umh-core/pkg/fsmv2/workers/example/examplefailing/state/state_triggering_next_cycle.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplefailing/state/state_triggering_next_cycle.go
@@ -34,7 +34,7 @@ func (s *TriggeringNextCycleState) Next(snapAny any) fsmv2.NextResult[any, any] 
 
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&TryingToStopState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: shutdown=%t", snap.IsShutdownRequested), nil)
+			fmt.Sprintf("stop required: %s", snap.StopReason()), nil)
 	}
 
 	if snap.Status.ConnectionHealth == "healthy" {

--- a/umh-core/pkg/fsmv2/workers/example/examplefailing/state/state_triggering_next_cycle.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplefailing/state/state_triggering_next_cycle.go
@@ -19,8 +19,8 @@ import (
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/internal/helpers"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/examplefailing/action"
 	examplefailing "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/examplefailing"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/examplefailing/action"
 )
 
 // TriggeringNextCycleState is an intermediate state used to trigger the next failure cycle.
@@ -34,8 +34,7 @@ func (s *TriggeringNextCycleState) Next(snapAny any) fsmv2.NextResult[any, any] 
 
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&TryingToStopState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: shutdown=%t, parentState=%s",
-				snap.IsShutdownRequested, snap.ParentMappedState), nil)
+			fmt.Sprintf("stop required: shutdown=%t", snap.IsShutdownRequested), nil)
 	}
 
 	if snap.Status.ConnectionHealth == "healthy" {

--- a/umh-core/pkg/fsmv2/workers/example/examplefailing/state/state_triggering_next_cycle.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplefailing/state/state_triggering_next_cycle.go
@@ -15,8 +15,6 @@
 package state
 
 import (
-	"fmt"
-
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/internal/helpers"
 	examplefailing "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/examplefailing"
@@ -34,7 +32,7 @@ func (s *TriggeringNextCycleState) Next(snapAny any) fsmv2.NextResult[any, any] 
 
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&TryingToStopState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: %s", snap.StopReason()), nil)
+			"stop required: "+snap.StopReason(), nil)
 	}
 
 	if snap.Status.ConnectionHealth == "healthy" {

--- a/umh-core/pkg/fsmv2/workers/example/examplefailing/state/state_trying_to_connect.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplefailing/state/state_trying_to_connect.go
@@ -33,7 +33,7 @@ func (s *TryingToConnectState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&TryingToStopState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: shutdown=%t", snap.IsShutdownRequested), nil)
+			fmt.Sprintf("stop required: %s", snap.StopReason()), nil)
 	}
 
 	if snap.Status.RestartAfterFailures > 0 &&

--- a/umh-core/pkg/fsmv2/workers/example/examplefailing/state/state_trying_to_connect.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplefailing/state/state_trying_to_connect.go
@@ -15,8 +15,6 @@
 package state
 
 import (
-	"fmt"
-
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/internal/helpers"
 	examplefailing "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/examplefailing"
@@ -33,7 +31,7 @@ func (s *TryingToConnectState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&TryingToStopState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: %s", snap.StopReason()), nil)
+			"stop required: "+snap.StopReason(), nil)
 	}
 
 	if snap.Status.RestartAfterFailures > 0 &&

--- a/umh-core/pkg/fsmv2/workers/example/examplefailing/state/state_trying_to_connect.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplefailing/state/state_trying_to_connect.go
@@ -19,8 +19,8 @@ import (
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/internal/helpers"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/examplefailing/action"
 	examplefailing "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/examplefailing"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/examplefailing/action"
 )
 
 // TryingToConnectState represents the state where the worker is attempting to establish a connection.
@@ -33,8 +33,7 @@ func (s *TryingToConnectState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&TryingToStopState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: shutdown=%t, parentState=%s",
-				snap.IsShutdownRequested, snap.ParentMappedState), nil)
+			fmt.Sprintf("stop required: shutdown=%t", snap.IsShutdownRequested), nil)
 	}
 
 	if snap.Status.RestartAfterFailures > 0 &&

--- a/umh-core/pkg/fsmv2/workers/example/examplefailing/worker.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplefailing/worker.go
@@ -136,9 +136,7 @@ func (w *FailingWorker) CollectObservedState(ctx context.Context, desired fsmv2.
 // DeriveDesiredState determines what state the failing worker should be in.
 func (w *FailingWorker) DeriveDesiredState(spec interface{}) (fsmv2.DesiredState, error) {
 	if spec == nil {
-		return &fsmv2.WrappedDesiredState[ExamplefailingConfig]{
-			State: fsmv2types.DesiredStateRunning,
-		}, nil
+		return &fsmv2.WrappedDesiredState[ExamplefailingConfig]{}, nil
 	}
 
 	parsed, err := fsmv2types.ParseUserSpec[ExamplefailingConfig](spec)
@@ -146,10 +144,7 @@ func (w *FailingWorker) DeriveDesiredState(spec interface{}) (fsmv2.DesiredState
 		return nil, fmt.Errorf("failed to parse examplefailing spec: %w", err)
 	}
 
-	state := parsed.GetState()
-
 	return &fsmv2.WrappedDesiredState[ExamplefailingConfig]{
-		State: state,
 		Config: ExamplefailingConfig{
 			BaseUserSpec:              parsed.BaseUserSpec,
 			ShouldFail:                parsed.ShouldFail,

--- a/umh-core/pkg/fsmv2/workers/example/examplepanic/state/state_connected.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplepanic/state/state_connected.go
@@ -15,8 +15,6 @@
 package state
 
 import (
-	"fmt"
-
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/internal/helpers"
 	example_panic "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/examplepanic"
@@ -31,7 +29,7 @@ func (s *ConnectedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&TryingToStopState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: %s", snap.StopReason()), nil)
+			"stop required: "+snap.StopReason(), nil)
 	}
 
 	if snap.Status.ConnectionHealth == "no connection" {

--- a/umh-core/pkg/fsmv2/workers/example/examplepanic/state/state_connected.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplepanic/state/state_connected.go
@@ -15,6 +15,8 @@
 package state
 
 import (
+	"fmt"
+
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/internal/helpers"
 	example_panic "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/examplepanic"
@@ -28,7 +30,8 @@ func (s *ConnectedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[example_panic.ExamplepanicConfig, example_panic.ExamplepanicStatus](snapAny)
 
 	if snap.ShouldStop() {
-		return fsmv2.Transition(&TryingToStopState{}, fsmv2.SignalNone, nil, "Stop required, transitioning to TryingToStop", nil)
+		return fsmv2.Transition(&TryingToStopState{}, fsmv2.SignalNone, nil,
+			fmt.Sprintf("stop required: %s", snap.StopReason()), nil)
 	}
 
 	if snap.Status.ConnectionHealth == "no connection" {

--- a/umh-core/pkg/fsmv2/workers/example/examplepanic/state/state_disconnected.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplepanic/state/state_disconnected.go
@@ -15,8 +15,6 @@
 package state
 
 import (
-	"fmt"
-
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/internal/helpers"
 	example_panic "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/examplepanic"
@@ -31,7 +29,7 @@ func (s *DisconnectedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&TryingToStopState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: %s", snap.StopReason()), nil)
+			"stop required: "+snap.StopReason(), nil)
 	}
 
 	return fsmv2.Transition(&TryingToConnectState{}, fsmv2.SignalNone, nil,

--- a/umh-core/pkg/fsmv2/workers/example/examplepanic/state/state_disconnected.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplepanic/state/state_disconnected.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/config"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/internal/helpers"
 	example_panic "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/examplepanic"
 )
@@ -32,12 +31,12 @@ func (s *DisconnectedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&TryingToStopState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: shutdown=%t, parentState=%s", snap.IsShutdownRequested, snap.ParentMappedState), nil)
+			fmt.Sprintf("stop required: shutdown=%t", snap.IsShutdownRequested), nil)
 	}
 
-	if !snap.IsShutdownRequested && snap.ParentMappedState == config.DesiredStateRunning {
+	if !snap.ShouldStop() {
 		return fsmv2.Transition(&TryingToConnectState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("parentState=%q: should be running, transitioning to TryingToConnect", snap.ParentMappedState), nil)
+			"should be running, transitioning to TryingToConnect", nil)
 	}
 
 	return fsmv2.Transition(s, fsmv2.SignalNone, nil, "Connection lost, will retry", nil)

--- a/umh-core/pkg/fsmv2/workers/example/examplepanic/state/state_disconnected.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplepanic/state/state_disconnected.go
@@ -31,15 +31,11 @@ func (s *DisconnectedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&TryingToStopState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: shutdown=%t", snap.IsShutdownRequested), nil)
+			fmt.Sprintf("stop required: %s", snap.StopReason()), nil)
 	}
 
-	if !snap.ShouldStop() {
-		return fsmv2.Transition(&TryingToConnectState{}, fsmv2.SignalNone, nil,
-			"should be running, transitioning to TryingToConnect", nil)
-	}
-
-	return fsmv2.Transition(s, fsmv2.SignalNone, nil, "Connection lost, will retry", nil)
+	return fsmv2.Transition(&TryingToConnectState{}, fsmv2.SignalNone, nil,
+		"should be running, transitioning to TryingToConnect", nil)
 }
 
 func (s *DisconnectedState) String() string {

--- a/umh-core/pkg/fsmv2/workers/example/examplepanic/state/state_stopped.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplepanic/state/state_stopped.go
@@ -35,12 +35,12 @@ func (s *StoppedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 		return fsmv2.Transition(s, fsmv2.SignalNeedsRemoval, nil, "Shutdown requested, signaling removal", nil)
 	}
 
-	if !snap.ShouldStop() {
-		return fsmv2.Transition(&TryingToConnectState{}, fsmv2.SignalNone, nil,
-			"should be running, transitioning to TryingToConnect", nil)
+	if snap.IsDisabled {
+		return fsmv2.Transition(s, fsmv2.SignalNone, nil, "disabled by supervisor, staying stopped", nil)
 	}
 
-	return fsmv2.Transition(s, fsmv2.SignalNone, nil, "Panic worker is stopped, no connection", nil)
+	return fsmv2.Transition(&TryingToConnectState{}, fsmv2.SignalNone, nil,
+		"should be running, transitioning to TryingToConnect", nil)
 }
 
 func (s *StoppedState) String() string {

--- a/umh-core/pkg/fsmv2/workers/example/examplepanic/state/state_stopped.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplepanic/state/state_stopped.go
@@ -15,10 +15,7 @@
 package state
 
 import (
-	"fmt"
-
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/config"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/internal/helpers"
 	example_panic "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/examplepanic"
 )
@@ -38,9 +35,9 @@ func (s *StoppedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 		return fsmv2.Transition(s, fsmv2.SignalNeedsRemoval, nil, "Shutdown requested, signaling removal", nil)
 	}
 
-	if !snap.IsShutdownRequested && snap.ParentMappedState == config.DesiredStateRunning {
+	if !snap.ShouldStop() {
 		return fsmv2.Transition(&TryingToConnectState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("parentState=%q: should be running, transitioning to TryingToConnect", snap.ParentMappedState), nil)
+			"should be running, transitioning to TryingToConnect", nil)
 	}
 
 	return fsmv2.Transition(s, fsmv2.SignalNone, nil, "Panic worker is stopped, no connection", nil)

--- a/umh-core/pkg/fsmv2/workers/example/examplepanic/state/state_trying_to_connect.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplepanic/state/state_trying_to_connect.go
@@ -15,8 +15,6 @@
 package state
 
 import (
-	"fmt"
-
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/internal/helpers"
 	example_panic "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/examplepanic"
@@ -32,7 +30,7 @@ func (s *TryingToConnectState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&TryingToStopState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: %s", snap.StopReason()), nil)
+			"stop required: "+snap.StopReason(), nil)
 	}
 
 	if snap.Status.ConnectionHealth == "healthy" {

--- a/umh-core/pkg/fsmv2/workers/example/examplepanic/state/state_trying_to_connect.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplepanic/state/state_trying_to_connect.go
@@ -15,10 +15,12 @@
 package state
 
 import (
+	"fmt"
+
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/internal/helpers"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/examplepanic/action"
 	example_panic "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/examplepanic"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/examplepanic/action"
 )
 
 type TryingToConnectState struct {
@@ -29,7 +31,8 @@ func (s *TryingToConnectState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[example_panic.ExamplepanicConfig, example_panic.ExamplepanicStatus](snapAny)
 
 	if snap.ShouldStop() {
-		return fsmv2.Transition(&TryingToStopState{}, fsmv2.SignalNone, nil, "Stop required, transitioning to TryingToStop", nil)
+		return fsmv2.Transition(&TryingToStopState{}, fsmv2.SignalNone, nil,
+			fmt.Sprintf("stop required: %s", snap.StopReason()), nil)
 	}
 
 	if snap.Status.ConnectionHealth == "healthy" {

--- a/umh-core/pkg/fsmv2/workers/example/examplepanic/worker.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplepanic/worker.go
@@ -110,9 +110,7 @@ func (w *ExamplepanicWorker) CollectObservedState(ctx context.Context, desired f
 
 func (w *ExamplepanicWorker) DeriveDesiredState(spec interface{}) (fsmv2.DesiredState, error) {
 	if spec == nil {
-		return &fsmv2.WrappedDesiredState[ExamplepanicConfig]{
-			State: config.DesiredStateRunning,
-		}, nil
+		return &fsmv2.WrappedDesiredState[ExamplepanicConfig]{}, nil
 	}
 
 	userSpec, ok := spec.(config.UserSpec)
@@ -125,10 +123,7 @@ func (w *ExamplepanicWorker) DeriveDesiredState(spec interface{}) (fsmv2.Desired
 		return nil, fmt.Errorf("failed to parse examplepanic spec: %w", err)
 	}
 
-	state := parsed.GetState()
-
 	return &fsmv2.WrappedDesiredState[ExamplepanicConfig]{
-		State:  state,
 		Config: parsed,
 	}, nil
 }

--- a/umh-core/pkg/fsmv2/workers/example/exampleparent/children_test.go
+++ b/umh-core/pkg/fsmv2/workers/example/exampleparent/children_test.go
@@ -75,15 +75,6 @@ var _ = Describe("exampleparent RenderChildren", func() {
 		}
 	})
 
-	It("leaves ChildStartStates empty on each spec (Enabled-only gating)", func() {
-		specs, err := exampleparent.RenderChildren(cfg, true)
-		Expect(err).ToNot(HaveOccurred())
-		for _, spec := range specs {
-			Expect(spec.ChildStartStates).To(BeEmpty(),
-				"spec %q must not set ChildStartStates; gating is Enabled-only", spec.Name)
-		}
-	})
-
 	It("parses each child UserSpec back to BaseUserSpec without error", func() {
 		specs, err := exampleparent.RenderChildren(cfg, true)
 		Expect(err).ToNot(HaveOccurred())

--- a/umh-core/pkg/fsmv2/workers/example/exampleparent/state/state_degraded_test.go
+++ b/umh-core/pkg/fsmv2/workers/example/exampleparent/state/state_degraded_test.go
@@ -19,18 +19,15 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/config"
 	exampleparent "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/exampleparent"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/exampleparent/state"
 )
 
 // Pins the Enabled-only child-gating contract for parent Degraded:
 // exampleparent children stay running while the parent is Degraded. They are
-// emitted with Enabled=true and an empty ChildStartStates, so the supervisor's
-// computeMappedState maps them to "running" for every alive parent state
-// (computeMappedState returns DesiredStateRunning when ChildStartStates is empty).
-// Before convergence, ChildStartStates listed only TryingToStart and Running,
-// which mapped children to "stopped" during Degraded.
+// emitted with Enabled=true; the supervisor's disable-mapping pass turns that
+// into the child's IsDisabled bit, and the child's ShouldStop() reads it. An
+// enabled child therefore does not stop while the parent is Degraded.
 var _ = Describe("DegradedState child gating (Enabled-only)", func() {
 	var stateObj *state.DegradedState
 
@@ -38,7 +35,7 @@ var _ = Describe("DegradedState child gating (Enabled-only)", func() {
 		stateObj = &state.DegradedState{}
 	})
 
-	It("keeps children running through parent Degraded (Enabled=true, no ChildStartStates)", func() {
+	It("keeps children running through parent Degraded (Enabled=true)", func() {
 		snap := fsmv2.Snapshot{
 			Observed: fsmv2.Observation[exampleparent.ExampleparentStatus]{
 				ChildrenHealthy:   0,
@@ -59,21 +56,18 @@ var _ = Describe("DegradedState child gating (Enabled-only)", func() {
 		child := result.Children[0]
 		Expect(child.Enabled).To(BeTrue(),
 			"child must carry run intent (Enabled=true) during parent Degraded")
-		Expect(child.ChildStartStates).To(BeEmpty(),
-			"empty ChildStartStates makes the child run for every alive parent state, "+
-				"including Degraded — the converged Enabled-only contract")
 
-		// Pin the gating CONSEQUENCE, not just the field shape: the supervisor's
-		// mapping (GetMappedChildState mirrors supervisor.computeMappedState) must
-		// resolve this child to "running" while the parent is Degraded.
-		Expect(child.GetMappedChildState("Degraded")).To(Equal(config.DesiredStateRunning),
-			"converged gating: child maps to running during parent Degraded")
+		// Pin the gating CONSEQUENCE through live fields, not field shape: the
+		// disable-mapping pass sets IsDisabled = !Enabled, and ShouldStop() reads
+		// it. An enabled child resolves to ShouldStop()==false during Degraded.
+		runningChild := fsmv2.WorkerSnapshot[any, any]{IsDisabled: !child.Enabled}
+		Expect(runningChild.ShouldStop()).To(BeFalse(),
+			"converged gating: an enabled child does not stop during parent Degraded")
 
-		// Counter-direction: document the pre-convergence behavior this change
-		// removes — the old ChildStartStates list mapped children to "stopped"
-		// during Degraded (Degraded was not in the list).
-		oldGating := config.ChildSpec{ChildStartStates: []string{"TryingToStart", "Running"}}
-		Expect(oldGating.GetMappedChildState("Degraded")).To(Equal(config.DesiredStateStopped),
-			"pre-convergence: the old list stopped children during Degraded")
+		// Counter-direction: a disabled child (Enabled=false → IsDisabled=true)
+		// stops. This is the behavior the old parent-state mapping expressed.
+		disabledChild := fsmv2.WorkerSnapshot[any, any]{IsDisabled: true}
+		Expect(disabledChild.ShouldStop()).To(BeTrue(),
+			"a disabled child stops regardless of parent state")
 	})
 })

--- a/umh-core/pkg/fsmv2/workers/example/exampleparent/worker.go
+++ b/umh-core/pkg/fsmv2/workers/example/exampleparent/worker.go
@@ -95,9 +95,7 @@ func (w *ParentWorker) CollectObservedState(ctx context.Context, _ fsmv2.Desired
 // Must be PURE - only uses the spec parameter, never dependencies.
 func (w *ParentWorker) DeriveDesiredState(spec interface{}) (fsmv2.DesiredState, error) {
 	if spec == nil {
-		return &fsmv2.WrappedDesiredState[ExampleparentConfig]{
-			State: config.DesiredStateRunning,
-		}, nil
+		return &fsmv2.WrappedDesiredState[ExampleparentConfig]{}, nil
 	}
 
 	parentSpec, err := config.ParseUserSpec[ExampleparentConfig](spec)
@@ -106,7 +104,6 @@ func (w *ParentWorker) DeriveDesiredState(spec interface{}) (fsmv2.DesiredState,
 	}
 
 	return &fsmv2.WrappedDesiredState[ExampleparentConfig]{
-		State: parentSpec.GetState(),
 		Config: ExampleparentConfig{
 			BaseUserSpec:    parentSpec.BaseUserSpec,
 			ChildWorkerType: parentSpec.ChildWorkerType,

--- a/umh-core/pkg/fsmv2/workers/example/exampleparent/worker_test.go
+++ b/umh-core/pkg/fsmv2/workers/example/exampleparent/worker_test.go
@@ -75,7 +75,6 @@ var _ = Describe("ParentWorker", func() {
 
 			Expect(err).ToNot(HaveOccurred())
 			desired := desiredIface.(*fsmv2.WrappedDesiredState[exampleparent.ExampleparentConfig])
-			Expect(desired.GetState()).To(Equal("running"))
 			Expect(desired.ChildrenSpecs).To(BeNil())
 		})
 
@@ -89,7 +88,6 @@ var _ = Describe("ParentWorker", func() {
 
 			Expect(err).ToNot(HaveOccurred())
 			desired := desiredIface.(*fsmv2.WrappedDesiredState[exampleparent.ExampleparentConfig])
-			Expect(desired.GetState()).To(Equal("running"))
 			// ChildrenSpecs is nil: children are declared in RenderChildren (children.go),
 			// not in DeriveDesiredState. RenderChildren is the single source of truth.
 			Expect(desired.ChildrenSpecs).To(BeNil())

--- a/umh-core/pkg/fsmv2/workers/example/exampleslow/state/state_connected.go
+++ b/umh-core/pkg/fsmv2/workers/example/exampleslow/state/state_connected.go
@@ -15,8 +15,6 @@
 package state
 
 import (
-	"fmt"
-
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/internal/helpers"
 	example_slow "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/exampleslow"
@@ -31,7 +29,7 @@ func (s *ConnectedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&TryingToStopState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: %s", snap.StopReason()), nil)
+			"stop required: "+snap.StopReason(), nil)
 	}
 
 	if snap.Status.ConnectionHealth == "no connection" {

--- a/umh-core/pkg/fsmv2/workers/example/exampleslow/state/state_connected.go
+++ b/umh-core/pkg/fsmv2/workers/example/exampleslow/state/state_connected.go
@@ -15,6 +15,8 @@
 package state
 
 import (
+	"fmt"
+
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/internal/helpers"
 	example_slow "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/exampleslow"
@@ -28,7 +30,8 @@ func (s *ConnectedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[example_slow.ExampleslowConfig, example_slow.ExampleslowStatus](snapAny)
 
 	if snap.ShouldStop() {
-		return fsmv2.Transition(&TryingToStopState{}, fsmv2.SignalNone, nil, "stop required, transitioning to trying to stop", nil)
+		return fsmv2.Transition(&TryingToStopState{}, fsmv2.SignalNone, nil,
+			fmt.Sprintf("stop required: %s", snap.StopReason()), nil)
 	}
 
 	if snap.Status.ConnectionHealth == "no connection" {

--- a/umh-core/pkg/fsmv2/workers/example/exampleslow/state/state_disconnected.go
+++ b/umh-core/pkg/fsmv2/workers/example/exampleslow/state/state_disconnected.go
@@ -31,14 +31,10 @@ func (s *DisconnectedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&TryingToStopState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: shutdown=%t", snap.IsShutdownRequested), nil)
+			fmt.Sprintf("stop required: %s", snap.StopReason()), nil)
 	}
 
-	if !snap.ShouldStop() {
-		return fsmv2.Transition(&TryingToConnectState{}, fsmv2.SignalNone, nil, "should be running, attempting reconnection", nil)
-	}
-
-	return fsmv2.Transition(s, fsmv2.SignalNone, nil, "connection lost, will retry", nil)
+	return fsmv2.Transition(&TryingToConnectState{}, fsmv2.SignalNone, nil, "should be running, attempting reconnection", nil)
 }
 
 func (s *DisconnectedState) String() string {

--- a/umh-core/pkg/fsmv2/workers/example/exampleslow/state/state_disconnected.go
+++ b/umh-core/pkg/fsmv2/workers/example/exampleslow/state/state_disconnected.go
@@ -15,8 +15,6 @@
 package state
 
 import (
-	"fmt"
-
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/internal/helpers"
 	example_slow "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/exampleslow"
@@ -31,7 +29,7 @@ func (s *DisconnectedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&TryingToStopState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: %s", snap.StopReason()), nil)
+			"stop required: "+snap.StopReason(), nil)
 	}
 
 	return fsmv2.Transition(&TryingToConnectState{}, fsmv2.SignalNone, nil, "should be running, attempting reconnection", nil)

--- a/umh-core/pkg/fsmv2/workers/example/exampleslow/state/state_disconnected.go
+++ b/umh-core/pkg/fsmv2/workers/example/exampleslow/state/state_disconnected.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/config"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/internal/helpers"
 	example_slow "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/exampleslow"
 )
@@ -32,11 +31,10 @@ func (s *DisconnectedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&TryingToStopState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: shutdown=%t, parentState=%s",
-				snap.IsShutdownRequested, snap.ParentMappedState), nil)
+			fmt.Sprintf("stop required: shutdown=%t", snap.IsShutdownRequested), nil)
 	}
 
-	if !snap.IsShutdownRequested && snap.ParentMappedState == config.DesiredStateRunning {
+	if !snap.ShouldStop() {
 		return fsmv2.Transition(&TryingToConnectState{}, fsmv2.SignalNone, nil, "should be running, attempting reconnection", nil)
 	}
 

--- a/umh-core/pkg/fsmv2/workers/example/exampleslow/state/state_stopped.go
+++ b/umh-core/pkg/fsmv2/workers/example/exampleslow/state/state_stopped.go
@@ -36,11 +36,11 @@ func (s *StoppedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 			"shutdown requested, stopping", nil)
 	}
 
-	if !snap.ShouldStop() {
-		return fsmv2.Transition(&TryingToConnectState{}, fsmv2.SignalNone, nil, "should be running, transitioning to trying to connect", nil)
+	if snap.IsDisabled {
+		return fsmv2.Transition(s, fsmv2.SignalNone, nil, "disabled by supervisor, staying stopped", nil)
 	}
 
-	return fsmv2.Transition(s, fsmv2.SignalNone, nil, "slow worker is stopped, no connection", nil)
+	return fsmv2.Transition(&TryingToConnectState{}, fsmv2.SignalNone, nil, "should be running, transitioning to trying to connect", nil)
 }
 
 func (s *StoppedState) String() string {

--- a/umh-core/pkg/fsmv2/workers/example/exampleslow/state/state_stopped.go
+++ b/umh-core/pkg/fsmv2/workers/example/exampleslow/state/state_stopped.go
@@ -16,7 +16,6 @@ package state
 
 import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/config"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/internal/helpers"
 	example_slow "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/exampleslow"
 )
@@ -34,10 +33,10 @@ func (s *StoppedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.IsShutdownRequested {
 		return fsmv2.Transition(s, fsmv2.SignalNeedsRemoval, nil,
-			"shutdown requested, stopping: parentState="+snap.ParentMappedState, nil)
+			"shutdown requested, stopping", nil)
 	}
 
-	if snap.ParentMappedState == config.DesiredStateRunning {
+	if !snap.ShouldStop() {
 		return fsmv2.Transition(&TryingToConnectState{}, fsmv2.SignalNone, nil, "should be running, transitioning to trying to connect", nil)
 	}
 

--- a/umh-core/pkg/fsmv2/workers/example/exampleslow/state/state_trying_to_connect.go
+++ b/umh-core/pkg/fsmv2/workers/example/exampleslow/state/state_trying_to_connect.go
@@ -32,7 +32,7 @@ func (s *TryingToConnectState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&TryingToStopState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: shutdown=%t", snap.IsShutdownRequested), nil)
+			fmt.Sprintf("stop required: %s", snap.StopReason()), nil)
 	}
 
 	if snap.Status.ConnectionHealth == "healthy" {

--- a/umh-core/pkg/fsmv2/workers/example/exampleslow/state/state_trying_to_connect.go
+++ b/umh-core/pkg/fsmv2/workers/example/exampleslow/state/state_trying_to_connect.go
@@ -19,8 +19,8 @@ import (
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/internal/helpers"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/exampleslow/action"
 	example_slow "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/exampleslow"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/exampleslow/action"
 )
 
 type TryingToConnectState struct {
@@ -32,8 +32,7 @@ func (s *TryingToConnectState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&TryingToStopState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: shutdown=%t, parentState=%s",
-				snap.IsShutdownRequested, snap.ParentMappedState), nil)
+			fmt.Sprintf("stop required: shutdown=%t", snap.IsShutdownRequested), nil)
 	}
 
 	if snap.Status.ConnectionHealth == "healthy" {

--- a/umh-core/pkg/fsmv2/workers/example/exampleslow/state/state_trying_to_connect.go
+++ b/umh-core/pkg/fsmv2/workers/example/exampleslow/state/state_trying_to_connect.go
@@ -15,8 +15,6 @@
 package state
 
 import (
-	"fmt"
-
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/internal/helpers"
 	example_slow "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/exampleslow"
@@ -32,7 +30,7 @@ func (s *TryingToConnectState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&TryingToStopState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: %s", snap.StopReason()), nil)
+			"stop required: "+snap.StopReason(), nil)
 	}
 
 	if snap.Status.ConnectionHealth == "healthy" {

--- a/umh-core/pkg/fsmv2/workers/example/exampleslow/worker.go
+++ b/umh-core/pkg/fsmv2/workers/example/exampleslow/worker.go
@@ -112,9 +112,7 @@ func (w *ExampleslowWorker) CollectObservedState(ctx context.Context, desired fs
 
 func (w *ExampleslowWorker) DeriveDesiredState(spec interface{}) (fsmv2.DesiredState, error) {
 	if spec == nil {
-		return &fsmv2.WrappedDesiredState[ExampleslowConfig]{
-			State: config.DesiredStateRunning,
-		}, nil
+		return &fsmv2.WrappedDesiredState[ExampleslowConfig]{}, nil
 	}
 
 	userSpec, ok := spec.(config.UserSpec)
@@ -134,10 +132,7 @@ func (w *ExampleslowWorker) DeriveDesiredState(spec interface{}) (fsmv2.DesiredS
 		}
 	}
 
-	state := parsed.GetState()
-
 	return &fsmv2.WrappedDesiredState[ExampleslowConfig]{
-		State:  state,
 		Config: parsed,
 	}, nil
 }

--- a/umh-core/pkg/fsmv2/workers/example/helloworld/state/state_degraded.go
+++ b/umh-core/pkg/fsmv2/workers/example/helloworld/state/state_degraded.go
@@ -15,8 +15,6 @@
 package state
 
 import (
-	"fmt"
-
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/internal/helpers"
 	hello_world "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/helloworld"
@@ -36,7 +34,7 @@ func (s *DegradedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	// 1. Check shutdown
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&StoppedState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: %s", snap.StopReason()), nil)
+			"stop required: "+snap.StopReason(), nil)
 	}
 
 	// 2. Check if mood has recovered (no longer "sad")

--- a/umh-core/pkg/fsmv2/workers/example/helloworld/state/state_degraded.go
+++ b/umh-core/pkg/fsmv2/workers/example/helloworld/state/state_degraded.go
@@ -36,8 +36,7 @@ func (s *DegradedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	// 1. Check shutdown
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&StoppedState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: shutdown=%t, parentState=%s",
-				snap.IsShutdownRequested, snap.ParentMappedState), nil)
+			fmt.Sprintf("stop required: shutdown=%t", snap.IsShutdownRequested), nil)
 	}
 
 	// 2. Check if mood has recovered (no longer "sad")

--- a/umh-core/pkg/fsmv2/workers/example/helloworld/state/state_degraded.go
+++ b/umh-core/pkg/fsmv2/workers/example/helloworld/state/state_degraded.go
@@ -36,7 +36,7 @@ func (s *DegradedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	// 1. Check shutdown
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&StoppedState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: shutdown=%t", snap.IsShutdownRequested), nil)
+			fmt.Sprintf("stop required: %s", snap.StopReason()), nil)
 	}
 
 	// 2. Check if mood has recovered (no longer "sad")

--- a/umh-core/pkg/fsmv2/workers/example/helloworld/state/state_running.go
+++ b/umh-core/pkg/fsmv2/workers/example/helloworld/state/state_running.go
@@ -35,7 +35,7 @@ func (s *RunningState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	// 1. Check shutdown - transition back to stopped
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&StoppedState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: shutdown=%t", snap.IsShutdownRequested), nil)
+			fmt.Sprintf("stop required: %s", snap.StopReason()), nil)
 	}
 
 	// 2. Check mood from mood file (read in CollectObservedState)

--- a/umh-core/pkg/fsmv2/workers/example/helloworld/state/state_running.go
+++ b/umh-core/pkg/fsmv2/workers/example/helloworld/state/state_running.go
@@ -35,8 +35,7 @@ func (s *RunningState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	// 1. Check shutdown - transition back to stopped
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&StoppedState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: shutdown=%t, parentState=%s",
-				snap.IsShutdownRequested, snap.ParentMappedState), nil)
+			fmt.Sprintf("stop required: shutdown=%t", snap.IsShutdownRequested), nil)
 	}
 
 	// 2. Check mood from mood file (read in CollectObservedState)

--- a/umh-core/pkg/fsmv2/workers/example/helloworld/state/state_running.go
+++ b/umh-core/pkg/fsmv2/workers/example/helloworld/state/state_running.go
@@ -15,8 +15,6 @@
 package state
 
 import (
-	"fmt"
-
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/internal/helpers"
 	hello_world "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/helloworld"
@@ -35,7 +33,7 @@ func (s *RunningState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	// 1. Check shutdown - transition back to stopped
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&StoppedState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: %s", snap.StopReason()), nil)
+			"stop required: "+snap.StopReason(), nil)
 	}
 
 	// 2. Check mood from mood file (read in CollectObservedState)

--- a/umh-core/pkg/fsmv2/workers/example/helloworld/state/state_trying_to_start.go
+++ b/umh-core/pkg/fsmv2/workers/example/helloworld/state/state_trying_to_start.go
@@ -35,7 +35,7 @@ func (s *TryingToStartState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	// 1. Check shutdown first
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&StoppedState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: shutdown=%t", snap.IsShutdownRequested), nil)
+			fmt.Sprintf("stop required: %s", snap.StopReason()), nil)
 	}
 
 	// 2. Check if action has already completed (observe the effect)

--- a/umh-core/pkg/fsmv2/workers/example/helloworld/state/state_trying_to_start.go
+++ b/umh-core/pkg/fsmv2/workers/example/helloworld/state/state_trying_to_start.go
@@ -35,8 +35,7 @@ func (s *TryingToStartState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	// 1. Check shutdown first
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&StoppedState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: shutdown=%t, parentState=%s",
-				snap.IsShutdownRequested, snap.ParentMappedState), nil)
+			fmt.Sprintf("stop required: shutdown=%t", snap.IsShutdownRequested), nil)
 	}
 
 	// 2. Check if action has already completed (observe the effect)

--- a/umh-core/pkg/fsmv2/workers/example/helloworld/state/state_trying_to_start.go
+++ b/umh-core/pkg/fsmv2/workers/example/helloworld/state/state_trying_to_start.go
@@ -15,8 +15,6 @@
 package state
 
 import (
-	"fmt"
-
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/internal/helpers"
 	hello_world "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/helloworld"
@@ -35,7 +33,7 @@ func (s *TryingToStartState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	// 1. Check shutdown first
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&StoppedState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: %s", snap.StopReason()), nil)
+			"stop required: "+snap.StopReason(), nil)
 	}
 
 	// 2. Check if action has already completed (observe the effect)

--- a/umh-core/pkg/fsmv2/workers/persistence/state/state_degraded.go
+++ b/umh-core/pkg/fsmv2/workers/persistence/state/state_degraded.go
@@ -31,8 +31,7 @@ func (s *RunningDegradedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&ShuttingDownState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: shutdown=%t, parentState=%s",
-				snap.IsShutdownRequested, snap.ParentMappedState), nil)
+			fmt.Sprintf("stop required: shutdown=%t", snap.IsShutdownRequested), nil)
 	}
 
 	if snap.Status.IsHealthy() {

--- a/umh-core/pkg/fsmv2/workers/persistence/state/state_degraded.go
+++ b/umh-core/pkg/fsmv2/workers/persistence/state/state_degraded.go
@@ -15,8 +15,6 @@
 package state
 
 import (
-	"fmt"
-
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/internal/helpers"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/persistence/snapshot"
@@ -31,7 +29,7 @@ func (s *RunningDegradedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&ShuttingDownState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: %s", snap.StopReason()), nil)
+			"stop required: "+snap.StopReason(), nil)
 	}
 
 	if snap.Status.IsHealthy() {

--- a/umh-core/pkg/fsmv2/workers/persistence/state/state_degraded.go
+++ b/umh-core/pkg/fsmv2/workers/persistence/state/state_degraded.go
@@ -31,7 +31,7 @@ func (s *RunningDegradedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&ShuttingDownState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: shutdown=%t", snap.IsShutdownRequested), nil)
+			fmt.Sprintf("stop required: %s", snap.StopReason()), nil)
 	}
 
 	if snap.Status.IsHealthy() {

--- a/umh-core/pkg/fsmv2/workers/persistence/state/state_running.go
+++ b/umh-core/pkg/fsmv2/workers/persistence/state/state_running.go
@@ -15,8 +15,6 @@
 package state
 
 import (
-	"fmt"
-
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/internal/helpers"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/persistence/snapshot"
@@ -31,7 +29,7 @@ func (s *RunningState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&ShuttingDownState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: %s", snap.StopReason()), nil)
+			"stop required: "+snap.StopReason(), nil)
 	}
 
 	if !snap.Status.IsHealthy() {

--- a/umh-core/pkg/fsmv2/workers/persistence/state/state_running.go
+++ b/umh-core/pkg/fsmv2/workers/persistence/state/state_running.go
@@ -31,8 +31,7 @@ func (s *RunningState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&ShuttingDownState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: shutdown=%t, parentState=%s",
-				snap.IsShutdownRequested, snap.ParentMappedState), nil)
+			fmt.Sprintf("stop required: shutdown=%t", snap.IsShutdownRequested), nil)
 	}
 
 	if !snap.Status.IsHealthy() {

--- a/umh-core/pkg/fsmv2/workers/persistence/state/state_running.go
+++ b/umh-core/pkg/fsmv2/workers/persistence/state/state_running.go
@@ -31,7 +31,7 @@ func (s *RunningState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&ShuttingDownState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: shutdown=%t", snap.IsShutdownRequested), nil)
+			fmt.Sprintf("stop required: %s", snap.StopReason()), nil)
 	}
 
 	if !snap.Status.IsHealthy() {

--- a/umh-core/pkg/fsmv2/workers/persistence/state/state_trying_to_start.go
+++ b/umh-core/pkg/fsmv2/workers/persistence/state/state_trying_to_start.go
@@ -15,8 +15,6 @@
 package state
 
 import (
-	"fmt"
-
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/internal/helpers"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/persistence/action"
@@ -32,7 +30,7 @@ func (s *TryingToStartState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&StoppedState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: %s", snap.StopReason()), nil)
+			"stop required: "+snap.StopReason(), nil)
 	}
 
 	maintenanceActionName := action.NewRunMaintenanceAction().Name()

--- a/umh-core/pkg/fsmv2/workers/persistence/state/state_trying_to_start.go
+++ b/umh-core/pkg/fsmv2/workers/persistence/state/state_trying_to_start.go
@@ -32,7 +32,7 @@ func (s *TryingToStartState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&StoppedState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: shutdown=%t, parentState=%s", snap.IsShutdownRequested, snap.ParentMappedState), nil)
+			fmt.Sprintf("stop required: shutdown=%t", snap.IsShutdownRequested), nil)
 	}
 
 	maintenanceActionName := action.NewRunMaintenanceAction().Name()

--- a/umh-core/pkg/fsmv2/workers/persistence/state/state_trying_to_start.go
+++ b/umh-core/pkg/fsmv2/workers/persistence/state/state_trying_to_start.go
@@ -32,7 +32,7 @@ func (s *TryingToStartState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&StoppedState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: shutdown=%t", snap.IsShutdownRequested), nil)
+			fmt.Sprintf("stop required: %s", snap.StopReason()), nil)
 	}
 
 	maintenanceActionName := action.NewRunMaintenanceAction().Name()

--- a/umh-core/pkg/fsmv2/workers/persistence/worker.go
+++ b/umh-core/pkg/fsmv2/workers/persistence/worker.go
@@ -186,7 +186,6 @@ func (w *PersistenceWorker) CollectObservedState(ctx context.Context, _ fsmv2.De
 func (w *PersistenceWorker) DeriveDesiredState(spec interface{}) (fsmv2.DesiredState, error) {
 	if spec == nil {
 		return &fsmv2.WrappedDesiredState[snapshot.PersistenceConfig]{
-			State: fsmv2config.DesiredStateRunning,
 			Config: snapshot.PersistenceConfig{
 				CompactionInterval:  DefaultCompactionInterval,
 				RetentionWindow:     DefaultRetentionWindow,
@@ -224,10 +223,7 @@ func (w *PersistenceWorker) DeriveDesiredState(spec interface{}) (fsmv2.DesiredS
 		cfg.MaintenanceInterval = DefaultMaintenanceInterval
 	}
 
-	state := cfg.GetState()
-
 	return &fsmv2.WrappedDesiredState[snapshot.PersistenceConfig]{
-		State:  state,
 		Config: cfg,
 	}, nil
 }

--- a/umh-core/pkg/fsmv2/workers/persistence/worker.go
+++ b/umh-core/pkg/fsmv2/workers/persistence/worker.go
@@ -232,6 +232,7 @@ func init() {
 	register.Worker[snapshot.PersistenceConfig, snapshot.PersistenceStatus, *PersistenceDependencies](WorkerTypeName,
 		func(id deps.Identity, logger deps.FSMLogger, sr deps.StateReader) (fsmv2.Worker, error) {
 			d := register.GetDeps[*PersistenceDependencies](WorkerTypeName)
+
 			return NewPersistenceWorker(id, logger, sr, d)
 		})
 }

--- a/umh-core/pkg/fsmv2/workers/transport/pull/snapshot/snapshot.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/snapshot/snapshot.go
@@ -56,8 +56,6 @@ type PullDependencies interface {
 
 // PullDesiredState represents the target configuration for the pull worker.
 type PullDesiredState struct {
-	ParentMappedState string `json:"parent_mapped_state"`
-
 	State string `json:"state" yaml:"state"`
 	config.BaseDesiredState
 }
@@ -70,15 +68,6 @@ func (s *PullDesiredState) GetState() string {
 	}
 
 	return s.State
-}
-
-// ShouldBeRunning returns true if the pull worker should be in a running state.
-func (s *PullDesiredState) ShouldBeRunning() bool {
-	if s.ShutdownRequested {
-		return false
-	}
-
-	return s.ParentMappedState == config.DesiredStateRunning
 }
 
 // PullStatus holds the runtime observation data for the pull worker.

--- a/umh-core/pkg/fsmv2/workers/transport/pull/snapshot/snapshot_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/snapshot/snapshot_test.go
@@ -22,30 +22,17 @@ import (
 )
 
 var _ = Describe("PullDesiredState", func() {
-	Describe("ShouldBeRunning", func() {
-		It("should return true when ParentMappedState is running and shutdown is not requested", func() {
-			desired := &snapshot.PullDesiredState{
-				ParentMappedState: "running",
-			}
+	Describe("GetState", func() {
+		It("should default to running when State is empty", func() {
+			desired := &snapshot.PullDesiredState{}
 
-			Expect(desired.ShouldBeRunning()).To(BeTrue())
+			Expect(desired.GetState()).To(Equal("running"))
 		})
 
-		It("should return false when ShutdownRequested is true", func() {
-			desired := &snapshot.PullDesiredState{
-				ParentMappedState: "running",
-			}
-			desired.SetShutdownRequested(true)
+		It("should return the explicit State when set", func() {
+			desired := &snapshot.PullDesiredState{State: "stopped"}
 
-			Expect(desired.ShouldBeRunning()).To(BeFalse())
-		})
-
-		It("should return false when ParentMappedState is stopped", func() {
-			desired := &snapshot.PullDesiredState{
-				ParentMappedState: "stopped",
-			}
-
-			Expect(desired.ShouldBeRunning()).To(BeFalse())
+			Expect(desired.GetState()).To(Equal("stopped"))
 		})
 	})
 })

--- a/umh-core/pkg/fsmv2/workers/transport/pull/state/state_degraded.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/state/state_degraded.go
@@ -36,7 +36,7 @@ func (s *DegradedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&StoppingState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: %s", snap.StopReason()), nil)
+			"stop required: "+snap.StopReason(), nil)
 	}
 
 	if snap.Status.ConsecutiveErrors == 0 && snap.Status.PendingMessageCount < pendingDegradedThreshold {

--- a/umh-core/pkg/fsmv2/workers/transport/pull/state/state_degraded.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/state/state_degraded.go
@@ -36,7 +36,7 @@ func (s *DegradedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&StoppingState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: shutdown=%t", snap.IsShutdownRequested), nil)
+			fmt.Sprintf("stop required: %s", snap.StopReason()), nil)
 	}
 
 	if snap.Status.ConsecutiveErrors == 0 && snap.Status.PendingMessageCount < pendingDegradedThreshold {

--- a/umh-core/pkg/fsmv2/workers/transport/pull/state/state_degraded.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/state/state_degraded.go
@@ -36,7 +36,7 @@ func (s *DegradedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&StoppingState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: shutdown=%t, parentState(observed)=%s", snap.IsShutdownRequested, snap.ParentMappedState), nil)
+			fmt.Sprintf("stop required: shutdown=%t", snap.IsShutdownRequested), nil)
 	}
 
 	if snap.Status.ConsecutiveErrors == 0 && snap.Status.PendingMessageCount < pendingDegradedThreshold {

--- a/umh-core/pkg/fsmv2/workers/transport/pull/state/state_running.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/state/state_running.go
@@ -43,7 +43,7 @@ func (s *RunningState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&StoppingState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: shutdown=%t", snap.IsShutdownRequested), nil)
+			fmt.Sprintf("stop required: %s", snap.StopReason()), nil)
 	}
 
 	if snap.Status.ConsecutiveErrors >= errorDegradedThreshold {

--- a/umh-core/pkg/fsmv2/workers/transport/pull/state/state_running.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/state/state_running.go
@@ -43,7 +43,7 @@ func (s *RunningState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&StoppingState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: shutdown=%t, parentState(observed)=%s", snap.IsShutdownRequested, snap.ParentMappedState), nil)
+			fmt.Sprintf("stop required: shutdown=%t", snap.IsShutdownRequested), nil)
 	}
 
 	if snap.Status.ConsecutiveErrors >= errorDegradedThreshold {

--- a/umh-core/pkg/fsmv2/workers/transport/pull/state/state_running.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/state/state_running.go
@@ -43,7 +43,7 @@ func (s *RunningState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&StoppingState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: %s", snap.StopReason()), nil)
+			"stop required: "+snap.StopReason(), nil)
 	}
 
 	if snap.Status.ConsecutiveErrors >= errorDegradedThreshold {

--- a/umh-core/pkg/fsmv2/workers/transport/pull/state/state_stopped.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/state/state_stopped.go
@@ -37,12 +37,8 @@ func (s *StoppedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 		return fsmv2.Transition(s, fsmv2.SignalNone, nil, "disabled by supervisor, staying stopped", nil)
 	}
 
-	if !snap.ShouldStop() {
-		return fsmv2.Transition(&RunningState{}, fsmv2.SignalNone, nil,
-			"parent wants running, transitioning to Running", nil)
-	}
-
-	return fsmv2.Transition(s, fsmv2.SignalNone, nil, "stopped, waiting for parent", nil)
+	return fsmv2.Transition(&RunningState{}, fsmv2.SignalNone, nil,
+		"parent wants running, transitioning to Running", nil)
 }
 
 func (s *StoppedState) String() string {

--- a/umh-core/pkg/fsmv2/workers/transport/pull/state/state_stopped.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/state/state_stopped.go
@@ -15,10 +15,7 @@
 package state
 
 import (
-	"fmt"
-
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/config"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/internal/helpers"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/pull/snapshot"
 )
@@ -40,13 +37,12 @@ func (s *StoppedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 		return fsmv2.Transition(s, fsmv2.SignalNone, nil, "disabled by supervisor, staying stopped", nil)
 	}
 
-	if snap.ParentMappedState == config.DesiredStateRunning {
+	if !snap.ShouldStop() {
 		return fsmv2.Transition(&RunningState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("parent mapped state is %q, transitioning to Running", snap.ParentMappedState), nil)
+			"parent wants running, transitioning to Running", nil)
 	}
 
-	return fsmv2.Transition(s, fsmv2.SignalNone, nil,
-		fmt.Sprintf("stopped, parent mapped state is %q", snap.ParentMappedState), nil)
+	return fsmv2.Transition(s, fsmv2.SignalNone, nil, "stopped, waiting for parent", nil)
 }
 
 func (s *StoppedState) String() string {

--- a/umh-core/pkg/fsmv2/workers/transport/pull/state/state_stopping.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/state/state_stopping.go
@@ -35,7 +35,7 @@ func (s *StoppingState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	// See CLAUDE.md "State Transition Traps" for the full pattern.
 
 	return fsmv2.Transition(&StoppedState{}, fsmv2.SignalNone, nil,
-		fmt.Sprintf("stop complete: shutdown=%t", snap.IsShutdownRequested), nil)
+		fmt.Sprintf("stop complete: %s", snap.StopReason()), nil)
 }
 
 func (s *StoppingState) String() string {

--- a/umh-core/pkg/fsmv2/workers/transport/pull/state/state_stopping.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/state/state_stopping.go
@@ -15,8 +15,6 @@
 package state
 
 import (
-	"fmt"
-
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/internal/helpers"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/pull/snapshot"
@@ -35,7 +33,7 @@ func (s *StoppingState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	// See CLAUDE.md "State Transition Traps" for the full pattern.
 
 	return fsmv2.Transition(&StoppedState{}, fsmv2.SignalNone, nil,
-		fmt.Sprintf("stop complete: %s", snap.StopReason()), nil)
+		"stop complete: "+snap.StopReason(), nil)
 }
 
 func (s *StoppingState) String() string {

--- a/umh-core/pkg/fsmv2/workers/transport/pull/state/state_stopping.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/state/state_stopping.go
@@ -35,8 +35,7 @@ func (s *StoppingState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	// See CLAUDE.md "State Transition Traps" for the full pattern.
 
 	return fsmv2.Transition(&StoppedState{}, fsmv2.SignalNone, nil,
-		fmt.Sprintf("stop complete: shutdown=%t, parentState(observed)=%s",
-			snap.IsShutdownRequested, snap.ParentMappedState), nil)
+		fmt.Sprintf("stop complete: shutdown=%t", snap.IsShutdownRequested), nil)
 }
 
 func (s *StoppingState) String() string {

--- a/umh-core/pkg/fsmv2/workers/transport/pull/state/state_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/state/state_test.go
@@ -61,15 +61,21 @@ func makeSnapshotWithBackoff(
 	degradedEnteredAt time.Time,
 	lastErrorAt time.Time,
 ) fsmv2.Snapshot {
+	// L5b: parent-driven stop is now expressed via the disable-mapping pass
+	// (IsDisabled). A test that asks for a "stopped" parent maps to
+	// Disabled=true so ShouldStop() returns true.
+	disabled := parentMappedState == config.DesiredStateStopped
+
 	desired := &fsmv2.WrappedDesiredState[snapshot.PullDesiredState]{
 		Config: snapshot.PullDesiredState{
-			ParentMappedState: parentMappedState,
 			BaseDesiredState: config.BaseDesiredState{
 				ShutdownRequested: shutdownRequested,
+				Disabled:          disabled,
 			},
 		},
 		BaseDesiredState: config.BaseDesiredState{
 			ShutdownRequested: shutdownRequested,
+			Disabled:          disabled,
 		},
 	}
 
@@ -85,7 +91,6 @@ func makeSnapshotWithBackoff(
 			LastErrorAt:         lastErrorAt,
 		},
 	}
-	obs.ParentMappedState = parentMappedState
 
 	return fsmv2.Snapshot{
 		Observed: obs,
@@ -373,9 +378,9 @@ var _ = Describe("StoppingState", func() {
 	Describe("stop signal reverted during shutdown", func() {
 		It("should recover when parent transitions back to Running (token re-auth)", func() {
 			// Scenario: transport parent briefly enters Starting for JWT refresh.
-			// Children get ParentMappedState="stopped", enter Stopping.
+			// Children get disabled (IsDisabled=true), enter Stopping.
 			// Parent re-authenticates in one tick, returns to Running.
-			// Children now have ParentMappedState="running" but are in Stopping.
+			// Children are re-enabled but are in Stopping.
 
 			// Tick N: parent in Starting → child told to stop
 			snapParentStopped := makeSnapshot(config.DesiredStateStopped, false, 0, true, true)

--- a/umh-core/pkg/fsmv2/workers/transport/pull/worker.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/worker.go
@@ -128,14 +128,14 @@ func (w *PullWorker) DeriveDesiredState(spec interface{}) (fsmv2.DesiredState, e
 		Variables: userSpec.Variables,
 	}
 
-	parsed, err := config.ParseUserSpec[PullUserSpec](renderedSpec)
-	if err != nil {
+	// Parse to validate the rendered config. The pull worker carries no
+	// lifecycle State of its own: it is a leaf child gated by the parent via
+	// Enabled/IsDisabled and routes lifecycle through snap.ShouldStop().
+	if _, err := config.ParseUserSpec[PullUserSpec](renderedSpec); err != nil {
 		return nil, err
 	}
 
-	return &fsmv2.WrappedDesiredState[snapshot.PullDesiredState]{
-		State: parsed.GetState(),
-	}, nil
+	return &fsmv2.WrappedDesiredState[snapshot.PullDesiredState]{}, nil
 }
 
 // GetInitialState returns StoppedState as the pull worker's initial FSM state.

--- a/umh-core/pkg/fsmv2/workers/transport/pull/worker_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/worker_test.go
@@ -190,7 +190,7 @@ var _ = Describe("PullWorker", func() {
 			Expect(typed).NotTo(BeNil())
 		})
 
-		It("should return correct state for valid spec", func() {
+		It("parses a valid spec into a PullDesiredState wrapper without error", func() {
 			spec := fsmv2config.UserSpec{
 				Config:    `state: stopped`,
 				Variables: fsmv2config.VariableBundle{},
@@ -199,13 +199,11 @@ var _ = Describe("PullWorker", func() {
 			desired, err := worker.DeriveDesiredState(spec)
 
 			Expect(err).ToNot(HaveOccurred())
-			Expect(desired).NotTo(BeNil())
-			typedStopped, okStopped := desired.(*fsmv2.WrappedDesiredState[snapshot.PullDesiredState])
-			Expect(okStopped).To(BeTrue())
-			Expect(typedStopped).NotTo(BeNil())
+			_, ok := desired.(*fsmv2.WrappedDesiredState[snapshot.PullDesiredState])
+			Expect(ok).To(BeTrue())
 		})
 
-		It("should return running state for empty config", func() {
+		It("parses empty config into a PullDesiredState wrapper without error", func() {
 			spec := fsmv2config.UserSpec{
 				Config:    "",
 				Variables: fsmv2config.VariableBundle{},
@@ -214,9 +212,8 @@ var _ = Describe("PullWorker", func() {
 			desired, err := worker.DeriveDesiredState(spec)
 
 			Expect(err).ToNot(HaveOccurred())
-			typedRunning, okRunning := desired.(*fsmv2.WrappedDesiredState[snapshot.PullDesiredState])
-			Expect(okRunning).To(BeTrue())
-			Expect(typedRunning).NotTo(BeNil())
+			_, ok := desired.(*fsmv2.WrappedDesiredState[snapshot.PullDesiredState])
+			Expect(ok).To(BeTrue())
 		})
 
 		It("should be deterministic", func() {

--- a/umh-core/pkg/fsmv2/workers/transport/pull/worker_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/worker_test.go
@@ -187,7 +187,7 @@ var _ = Describe("PullWorker", func() {
 			Expect(desired).NotTo(BeNil())
 			typed, ok := desired.(*fsmv2.WrappedDesiredState[snapshot.PullDesiredState])
 			Expect(ok).To(BeTrue())
-			Expect(typed.GetState()).To(Equal("running"))
+			Expect(typed).NotTo(BeNil())
 		})
 
 		It("should return correct state for valid spec", func() {
@@ -202,7 +202,7 @@ var _ = Describe("PullWorker", func() {
 			Expect(desired).NotTo(BeNil())
 			typedStopped, okStopped := desired.(*fsmv2.WrappedDesiredState[snapshot.PullDesiredState])
 			Expect(okStopped).To(BeTrue())
-			Expect(typedStopped.GetState()).To(Equal("stopped"))
+			Expect(typedStopped).NotTo(BeNil())
 		})
 
 		It("should return running state for empty config", func() {
@@ -216,7 +216,7 @@ var _ = Describe("PullWorker", func() {
 			Expect(err).ToNot(HaveOccurred())
 			typedRunning, okRunning := desired.(*fsmv2.WrappedDesiredState[snapshot.PullDesiredState])
 			Expect(okRunning).To(BeTrue())
-			Expect(typedRunning.GetState()).To(Equal("running"))
+			Expect(typedRunning).NotTo(BeNil())
 		})
 
 		It("should be deterministic", func() {
@@ -234,7 +234,7 @@ var _ = Describe("PullWorker", func() {
 			Expect(pullOk1).To(BeTrue())
 			pull2, pullOk2 := desired2.(*fsmv2.WrappedDesiredState[snapshot.PullDesiredState])
 			Expect(pullOk2).To(BeTrue())
-			Expect(pull1.GetState()).To(Equal(pull2.GetState()))
+			Expect(pull1).To(Equal(pull2))
 		})
 
 		It("should return error for invalid spec type", func() {

--- a/umh-core/pkg/fsmv2/workers/transport/push/snapshot/snapshot.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/snapshot/snapshot.go
@@ -56,8 +56,6 @@ type PushDependencies interface {
 
 // PushDesiredState represents the target configuration for the push worker.
 type PushDesiredState struct {
-	ParentMappedState string `json:"parent_mapped_state"`
-
 	State string `json:"state" yaml:"state"`
 	config.BaseDesiredState
 }
@@ -70,15 +68,6 @@ func (s *PushDesiredState) GetState() string {
 	}
 
 	return s.State
-}
-
-// ShouldBeRunning returns true if the push worker should be in a running state.
-func (s *PushDesiredState) ShouldBeRunning() bool {
-	if s.ShutdownRequested {
-		return false
-	}
-
-	return s.ParentMappedState == config.DesiredStateRunning
 }
 
 // PushStatus holds the runtime observation data for the push worker.

--- a/umh-core/pkg/fsmv2/workers/transport/push/snapshot/snapshot_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/snapshot/snapshot_test.go
@@ -22,30 +22,17 @@ import (
 )
 
 var _ = Describe("PushDesiredState", func() {
-	Describe("ShouldBeRunning", func() {
-		It("should return true when ParentMappedState is running and shutdown is not requested", func() {
-			desired := &snapshot.PushDesiredState{
-				ParentMappedState: "running",
-			}
+	Describe("GetState", func() {
+		It("should default to running when State is empty", func() {
+			desired := &snapshot.PushDesiredState{}
 
-			Expect(desired.ShouldBeRunning()).To(BeTrue())
+			Expect(desired.GetState()).To(Equal("running"))
 		})
 
-		It("should return false when ShutdownRequested is true", func() {
-			desired := &snapshot.PushDesiredState{
-				ParentMappedState: "running",
-			}
-			desired.SetShutdownRequested(true)
+		It("should return the explicit State when set", func() {
+			desired := &snapshot.PushDesiredState{State: "stopped"}
 
-			Expect(desired.ShouldBeRunning()).To(BeFalse())
-		})
-
-		It("should return false when ParentMappedState is stopped", func() {
-			desired := &snapshot.PushDesiredState{
-				ParentMappedState: "stopped",
-			}
-
-			Expect(desired.ShouldBeRunning()).To(BeFalse())
+			Expect(desired.GetState()).To(Equal("stopped"))
 		})
 	})
 })

--- a/umh-core/pkg/fsmv2/workers/transport/push/state/state_degraded.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/state/state_degraded.go
@@ -35,7 +35,7 @@ func (s *DegradedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&StoppingState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: shutdown=%t", snap.IsShutdownRequested), nil)
+			fmt.Sprintf("stop required: %s", snap.StopReason()), nil)
 	}
 
 	if snap.Status.ConsecutiveErrors == 0 {

--- a/umh-core/pkg/fsmv2/workers/transport/push/state/state_degraded.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/state/state_degraded.go
@@ -35,7 +35,7 @@ func (s *DegradedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&StoppingState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: %s", snap.StopReason()), nil)
+			"stop required: "+snap.StopReason(), nil)
 	}
 
 	if snap.Status.ConsecutiveErrors == 0 {

--- a/umh-core/pkg/fsmv2/workers/transport/push/state/state_degraded.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/state/state_degraded.go
@@ -35,7 +35,7 @@ func (s *DegradedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&StoppingState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: shutdown=%t, parentState(observed)=%s", snap.IsShutdownRequested, snap.ParentMappedState), nil)
+			fmt.Sprintf("stop required: shutdown=%t", snap.IsShutdownRequested), nil)
 	}
 
 	if snap.Status.ConsecutiveErrors == 0 {

--- a/umh-core/pkg/fsmv2/workers/transport/push/state/state_running.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/state/state_running.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	errorDegradedThreshold  = 3
+	errorDegradedThreshold   = 3
 	pendingDegradedThreshold = 100
 )
 
@@ -38,7 +38,7 @@ func (s *RunningState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&StoppingState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: shutdown=%t, parentState(observed)=%s", snap.IsShutdownRequested, snap.ParentMappedState), nil)
+			fmt.Sprintf("stop required: shutdown=%t", snap.IsShutdownRequested), nil)
 	}
 
 	if snap.Status.ConsecutiveErrors >= errorDegradedThreshold {

--- a/umh-core/pkg/fsmv2/workers/transport/push/state/state_running.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/state/state_running.go
@@ -38,7 +38,7 @@ func (s *RunningState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&StoppingState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: %s", snap.StopReason()), nil)
+			"stop required: "+snap.StopReason(), nil)
 	}
 
 	if snap.Status.ConsecutiveErrors >= errorDegradedThreshold {

--- a/umh-core/pkg/fsmv2/workers/transport/push/state/state_running.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/state/state_running.go
@@ -38,7 +38,7 @@ func (s *RunningState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&StoppingState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("stop required: shutdown=%t", snap.IsShutdownRequested), nil)
+			fmt.Sprintf("stop required: %s", snap.StopReason()), nil)
 	}
 
 	if snap.Status.ConsecutiveErrors >= errorDegradedThreshold {

--- a/umh-core/pkg/fsmv2/workers/transport/push/state/state_stopped.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/state/state_stopped.go
@@ -36,12 +36,8 @@ func (s *StoppedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 		return fsmv2.Transition(s, fsmv2.SignalNone, nil, "disabled by supervisor, staying stopped", nil)
 	}
 
-	if !snap.ShouldStop() {
-		return fsmv2.Transition(&RunningState{}, fsmv2.SignalNone, nil,
-			"parent wants running, transitioning to Running", nil)
-	}
-
-	return fsmv2.Transition(s, fsmv2.SignalNone, nil, "stopped, waiting for parent", nil)
+	return fsmv2.Transition(&RunningState{}, fsmv2.SignalNone, nil,
+		"parent wants running, transitioning to Running", nil)
 }
 
 func (s *StoppedState) String() string {

--- a/umh-core/pkg/fsmv2/workers/transport/push/state/state_stopped.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/state/state_stopped.go
@@ -15,10 +15,7 @@
 package state
 
 import (
-	"fmt"
-
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/config"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/internal/helpers"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/push/snapshot"
 )
@@ -39,13 +36,12 @@ func (s *StoppedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 		return fsmv2.Transition(s, fsmv2.SignalNone, nil, "disabled by supervisor, staying stopped", nil)
 	}
 
-	if snap.ParentMappedState == config.DesiredStateRunning {
+	if !snap.ShouldStop() {
 		return fsmv2.Transition(&RunningState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("parent mapped state is %q, transitioning to Running", snap.ParentMappedState), nil)
+			"parent wants running, transitioning to Running", nil)
 	}
 
-	return fsmv2.Transition(s, fsmv2.SignalNone, nil,
-		fmt.Sprintf("stopped, parent mapped state is %q", snap.ParentMappedState), nil)
+	return fsmv2.Transition(s, fsmv2.SignalNone, nil, "stopped, waiting for parent", nil)
 }
 
 func (s *StoppedState) String() string {

--- a/umh-core/pkg/fsmv2/workers/transport/push/state/state_stopping.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/state/state_stopping.go
@@ -35,7 +35,7 @@ func (s *StoppingState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	// See CLAUDE.md "State Transition Traps" for the full pattern.
 
 	return fsmv2.Transition(&StoppedState{}, fsmv2.SignalNone, nil,
-		fmt.Sprintf("stop complete: shutdown=%t", snap.IsShutdownRequested), nil)
+		fmt.Sprintf("stop complete: %s", snap.StopReason()), nil)
 }
 
 func (s *StoppingState) String() string {

--- a/umh-core/pkg/fsmv2/workers/transport/push/state/state_stopping.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/state/state_stopping.go
@@ -15,8 +15,6 @@
 package state
 
 import (
-	"fmt"
-
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/internal/helpers"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/push/snapshot"
@@ -35,7 +33,7 @@ func (s *StoppingState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	// See CLAUDE.md "State Transition Traps" for the full pattern.
 
 	return fsmv2.Transition(&StoppedState{}, fsmv2.SignalNone, nil,
-		fmt.Sprintf("stop complete: %s", snap.StopReason()), nil)
+		"stop complete: "+snap.StopReason(), nil)
 }
 
 func (s *StoppingState) String() string {

--- a/umh-core/pkg/fsmv2/workers/transport/push/state/state_stopping.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/state/state_stopping.go
@@ -35,8 +35,7 @@ func (s *StoppingState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	// See CLAUDE.md "State Transition Traps" for the full pattern.
 
 	return fsmv2.Transition(&StoppedState{}, fsmv2.SignalNone, nil,
-		fmt.Sprintf("stop complete: shutdown=%t, parentState(observed)=%s",
-			snap.IsShutdownRequested, snap.ParentMappedState), nil)
+		fmt.Sprintf("stop complete: shutdown=%t", snap.IsShutdownRequested), nil)
 }
 
 func (s *StoppingState) String() string {

--- a/umh-core/pkg/fsmv2/workers/transport/push/state/state_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/state/state_test.go
@@ -61,15 +61,21 @@ func makeSnapshotWithBackoff(
 	degradedEnteredAt time.Time,
 	lastErrorAt time.Time,
 ) fsmv2.Snapshot {
+	// L5b: parent-driven stop is now expressed via the disable-mapping pass
+	// (IsDisabled). A test that asks for a "stopped" parent maps to
+	// Disabled=true so ShouldStop() returns true.
+	disabled := parentMappedState == config.DesiredStateStopped
+
 	desired := &fsmv2.WrappedDesiredState[snapshot.PushDesiredState]{
 		Config: snapshot.PushDesiredState{
-			ParentMappedState: parentMappedState,
 			BaseDesiredState: config.BaseDesiredState{
 				ShutdownRequested: shutdownRequested,
+				Disabled:          disabled,
 			},
 		},
 		BaseDesiredState: config.BaseDesiredState{
 			ShutdownRequested: shutdownRequested,
+			Disabled:          disabled,
 		},
 	}
 
@@ -85,7 +91,6 @@ func makeSnapshotWithBackoff(
 			LastErrorAt:         lastErrorAt,
 		},
 	}
-	obs.ParentMappedState = parentMappedState
 
 	return fsmv2.Snapshot{
 		Observed: obs,

--- a/umh-core/pkg/fsmv2/workers/transport/push/worker.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/worker.go
@@ -128,14 +128,14 @@ func (w *PushWorker) DeriveDesiredState(spec interface{}) (fsmv2.DesiredState, e
 		Variables: userSpec.Variables,
 	}
 
-	parsed, err := config.ParseUserSpec[PushUserSpec](renderedSpec)
-	if err != nil {
+	// Parse to validate the rendered config. The push worker carries no
+	// lifecycle State of its own: it is a leaf child gated by the parent via
+	// Enabled/IsDisabled and routes lifecycle through snap.ShouldStop().
+	if _, err := config.ParseUserSpec[PushUserSpec](renderedSpec); err != nil {
 		return nil, err
 	}
 
-	return &fsmv2.WrappedDesiredState[snapshot.PushDesiredState]{
-		State: parsed.GetState(),
-	}, nil
+	return &fsmv2.WrappedDesiredState[snapshot.PushDesiredState]{}, nil
 }
 
 // GetInitialState returns StoppedState as the push worker's initial FSM state.

--- a/umh-core/pkg/fsmv2/workers/transport/push/worker_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/worker_test.go
@@ -180,7 +180,7 @@ var _ = Describe("PushWorker", func() {
 			Expect(desired).NotTo(BeNil())
 			typed, ok := desired.(*fsmv2.WrappedDesiredState[snapshot.PushDesiredState])
 			Expect(ok).To(BeTrue())
-			Expect(typed.GetState()).To(Equal("running"))
+			Expect(typed).NotTo(BeNil())
 		})
 
 		It("should return correct state for valid spec", func() {
@@ -195,7 +195,7 @@ var _ = Describe("PushWorker", func() {
 			Expect(desired).NotTo(BeNil())
 			typedStopped, okStopped := desired.(*fsmv2.WrappedDesiredState[snapshot.PushDesiredState])
 			Expect(okStopped).To(BeTrue())
-			Expect(typedStopped.GetState()).To(Equal("stopped"))
+			Expect(typedStopped).NotTo(BeNil())
 		})
 
 		It("should return running state for empty config", func() {
@@ -209,7 +209,7 @@ var _ = Describe("PushWorker", func() {
 			Expect(err).ToNot(HaveOccurred())
 			typedRunning, okRunning := desired.(*fsmv2.WrappedDesiredState[snapshot.PushDesiredState])
 			Expect(okRunning).To(BeTrue())
-			Expect(typedRunning.GetState()).To(Equal("running"))
+			Expect(typedRunning).NotTo(BeNil())
 		})
 
 		It("should be deterministic", func() {
@@ -227,7 +227,7 @@ var _ = Describe("PushWorker", func() {
 			Expect(pdOk1).To(BeTrue())
 			pd2, pdOk2 := desired2.(*fsmv2.WrappedDesiredState[snapshot.PushDesiredState])
 			Expect(pdOk2).To(BeTrue())
-			Expect(pd1.GetState()).To(Equal(pd2.GetState()))
+			Expect(pd1).To(Equal(pd2))
 		})
 
 		It("should return error for invalid spec type", func() {

--- a/umh-core/pkg/fsmv2/workers/transport/push/worker_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/worker_test.go
@@ -183,7 +183,7 @@ var _ = Describe("PushWorker", func() {
 			Expect(typed).NotTo(BeNil())
 		})
 
-		It("should return correct state for valid spec", func() {
+		It("parses a valid spec into a PushDesiredState wrapper without error", func() {
 			spec := fsmv2config.UserSpec{
 				Config:    `state: stopped`,
 				Variables: fsmv2config.VariableBundle{},
@@ -192,13 +192,11 @@ var _ = Describe("PushWorker", func() {
 			desired, err := worker.DeriveDesiredState(spec)
 
 			Expect(err).ToNot(HaveOccurred())
-			Expect(desired).NotTo(BeNil())
-			typedStopped, okStopped := desired.(*fsmv2.WrappedDesiredState[snapshot.PushDesiredState])
-			Expect(okStopped).To(BeTrue())
-			Expect(typedStopped).NotTo(BeNil())
+			_, ok := desired.(*fsmv2.WrappedDesiredState[snapshot.PushDesiredState])
+			Expect(ok).To(BeTrue())
 		})
 
-		It("should return running state for empty config", func() {
+		It("parses empty config into a PushDesiredState wrapper without error", func() {
 			spec := fsmv2config.UserSpec{
 				Config:    "",
 				Variables: fsmv2config.VariableBundle{},
@@ -207,9 +205,8 @@ var _ = Describe("PushWorker", func() {
 			desired, err := worker.DeriveDesiredState(spec)
 
 			Expect(err).ToNot(HaveOccurred())
-			typedRunning, okRunning := desired.(*fsmv2.WrappedDesiredState[snapshot.PushDesiredState])
-			Expect(okRunning).To(BeTrue())
-			Expect(typedRunning).NotTo(BeNil())
+			_, ok := desired.(*fsmv2.WrappedDesiredState[snapshot.PushDesiredState])
+			Expect(ok).To(BeTrue())
 		})
 
 		It("should be deterministic", func() {

--- a/umh-core/pkg/fsmv2/workers/transport/snapshot/snapshot.go
+++ b/umh-core/pkg/fsmv2/workers/transport/snapshot/snapshot.go
@@ -88,11 +88,10 @@ type TransportDesiredState struct {
 
 	// State is the desired lifecycle state ("stopped" or "running").
 	//
-	// Deprecated: Never populated in production. Lifecycle is owned by
-	// WrappedDesiredState.State, set from TransportUserSpec.GetState() in
-	// DeriveDesiredState. Forward-deletion candidate alongside ChildrenSpecs /
-	// GetChildrenSpecs / GetState / ShouldBeRunning — slated for the L9
-	// transport-snapshot cleanup.
+	// Deprecated: Never populated in production. Lifecycle is owned by the
+	// framework via TransportUserSpec.GetState() in DeriveDesiredState.
+	// Forward-deletion candidate alongside ChildrenSpecs / GetChildrenSpecs /
+	// GetState / ShouldBeRunning — slated for the L9 transport-snapshot cleanup.
 	State string `json:"state" yaml:"state"`
 
 	// Deprecated: ChildrenSpecs on TransportDesiredState is never populated. Child specs are
@@ -173,8 +172,8 @@ type TransportStatus struct {
 // Token buffer architecture: the parent TransportWorker uses a 10-minute buffer (proactive
 // refresh trigger) while child workers (push/pull) use a 1-minute buffer via IsTokenValid().
 // The 9-minute gap is safe by design: when IsTokenExpired triggers here, the parent
-// transitions Running → Starting, which causes children to stop (they are not in ChildStartStates
-// while the parent is Starting). Children never push or pull during the refresh window.
+// transitions Running → Starting and re-authenticates, propagating a fresh token to its
+// children well before their own 1-minute buffer would consider the token invalid.
 // The children's 1-minute buffer is a last-resort safety net for edge cases only.
 func (s TransportStatus) IsTokenExpired() bool {
 	if s.JWTExpiry.IsZero() {

--- a/umh-core/pkg/fsmv2/workers/transport/snapshot/snapshot_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/snapshot/snapshot_test.go
@@ -134,9 +134,9 @@ var _ = Describe("TransportDesiredState", func() {
 			desired := &snapshot.TransportDesiredState{
 				ChildrenSpecs: []config.ChildSpec{
 					{
-						Name:             "push",
-						WorkerType:       "push",
-						ChildStartStates: []string{"Running", "Degraded"},
+						Name:       "push",
+						WorkerType: "push",
+						Enabled:    true,
 					},
 				},
 			}
@@ -144,7 +144,7 @@ var _ = Describe("TransportDesiredState", func() {
 			Expect(specs).To(HaveLen(1))
 			Expect(specs[0].Name).To(Equal("push"))
 			Expect(specs[0].WorkerType).To(Equal("push"))
-			Expect(specs[0].ChildStartStates).To(ConsistOf("Running", "Degraded"))
+			Expect(specs[0].Enabled).To(BeTrue())
 		})
 
 		It("should implement config.ChildSpecProvider interface", func() {

--- a/umh-core/pkg/fsmv2/workers/transport/state/children_gating_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/state/children_gating_test.go
@@ -55,7 +55,6 @@ func expectChildren(specs []config.ChildSpec, enabled bool) {
 // StoppedState's IsDisabled branch is reachable.
 func makeDisabledSnapshot() fsmv2.Snapshot {
 	desired := &fsmv2.WrappedDesiredState[snapshot.TransportDesiredState]{
-		State: config.DesiredStateStopped,
 		BaseDesiredState: config.BaseDesiredState{
 			Disabled: true,
 		},

--- a/umh-core/pkg/fsmv2/workers/transport/state/state_starting.go
+++ b/umh-core/pkg/fsmv2/workers/transport/state/state_starting.go
@@ -28,9 +28,9 @@ import (
 
 // StartingState represents the state where the transport worker is authenticating.
 // It emits AuthenticateAction to obtain a JWT token from the relay server.
-// Once authenticated, transitions to RunningState. Children start via ChildStartStates
-// when the parent enters Running, avoiding a deadlock where children can't become healthy
-// while the parent waits in Starting.
+// Once authenticated, transitions to RunningState. The parent keeps its children
+// enabled while Starting (childrenAlive), avoiding a deadlock where children can't
+// become healthy while the parent waits in Starting.
 type StartingState struct {
 	helpers.StartingBase
 }
@@ -78,8 +78,8 @@ func (s *StartingState) Next(snapAny any) fsmv2.NextResult[any, any] {
 		return fsmv2.Transition(s, fsmv2.SignalNone, authAction, "No valid token, authenticating with relay", childrenAlive(snap.Config))
 	}
 
-	// Authenticated; transition to Running. Children start via ChildStartStates
-	// once parent enters Running; RunningState handles unhealthy children.
+	// Authenticated; transition to Running. Children remain enabled (childrenAlive);
+	// RunningState handles unhealthy children.
 	if snap.Status.HasValidToken() {
 		return fsmv2.Transition(&RunningState{}, fsmv2.SignalNone, nil, "Authenticated, transitioning to Running", childrenAlive(snap.Config))
 	}

--- a/umh-core/pkg/fsmv2/workers/transport/state/state_starting.go
+++ b/umh-core/pkg/fsmv2/workers/transport/state/state_starting.go
@@ -79,16 +79,9 @@ func (s *StartingState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	}
 
 	// Authenticated; transition to Running. Children remain enabled (childrenAlive);
-	// RunningState handles unhealthy children.
-	if snap.Status.HasValidToken() {
-		return fsmv2.Transition(&RunningState{}, fsmv2.SignalNone, nil, "Authenticated, transitioning to Running", childrenAlive(snap.Config))
-	}
-
-	// Unreachable: the !HasValidToken() block above returns in all paths, so
-	// control only reaches here when HasValidToken() is true. The catch-all is
-	// required by the architecture validator's MISSING_CATCHALL_RETURN rule.
-	return fsmv2.Transition(s, fsmv2.SignalNone, nil,
-		fmt.Sprintf("starting: awaiting token (hasValidToken=%t)", snap.Status.HasValidToken()), childrenAlive(snap.Config))
+	// RunningState handles unhealthy children. The !HasValidToken() block above
+	// returns in all paths, so reaching here means the token is valid.
+	return fsmv2.Transition(&RunningState{}, fsmv2.SignalNone, nil, "Authenticated, transitioning to Running", childrenAlive(snap.Config))
 }
 
 // isPermanentAuthError returns true for error types that indicate a configuration

--- a/umh-core/pkg/fsmv2/workers/transport/state/state_stopped.go
+++ b/umh-core/pkg/fsmv2/workers/transport/state/state_stopped.go
@@ -26,8 +26,7 @@ import (
 // The worker is not authenticated and no children are spawned.
 //
 // Transport is a top-level worker, not a child. Reason strings show
-// snap.Config.ShouldBeRunning() and snap.IsShutdownRequested directly;
-// snap.Observed.ParentMappedState is not applicable here (and is deleted in L5b).
+// snap.Config.ShouldBeRunning() and snap.IsShutdownRequested directly.
 type StoppedState struct {
 	helpers.StoppedBase
 }

--- a/umh-core/pkg/fsmv2/workers/transport/state/state_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/state/state_test.go
@@ -38,7 +38,6 @@ func makeSnapshotFull(shutdownRequested bool, desiredState string, jwtToken stri
 
 func makeSnapshotWithBackoff(shutdownRequested bool, desiredState string, jwtToken string, jwtExpiry time.Time, childrenHealthy, childrenUnhealthy int, consecutiveErrors int, lastErrorType types.ErrorType, lastAuthAttemptAt time.Time, lastRetryAfter time.Duration) fsmv2.Snapshot {
 	desired := &fsmv2.WrappedDesiredState[snapshot.TransportDesiredState]{
-		State: desiredState,
 		BaseDesiredState: config.BaseDesiredState{
 			ShutdownRequested: shutdownRequested,
 		},
@@ -80,7 +79,6 @@ func makeSnapshotWithBackoff(shutdownRequested bool, desiredState string, jwtTok
 // The failed config matches the desired config (simulating "config unchanged since failure").
 func makeAuthFailedSnapshot(authToken, relayURL, instanceUUID string, shutdownRequested bool) fsmv2.Snapshot {
 	desired := &fsmv2.WrappedDesiredState[snapshot.TransportDesiredState]{
-		State: config.DesiredStateRunning,
 		BaseDesiredState: config.BaseDesiredState{
 			ShutdownRequested: shutdownRequested,
 		},
@@ -114,7 +112,6 @@ func makeAuthFailedStartingSnapshot(
 	consecutiveErrors int, lastErrorType types.ErrorType,
 ) fsmv2.Snapshot {
 	desired := &fsmv2.WrappedDesiredState[snapshot.TransportDesiredState]{
-		State: config.DesiredStateRunning,
 		Config: snapshot.TransportDesiredState{
 			InstanceUUID: desiredUUID,
 			AuthToken:    desiredToken,
@@ -340,7 +337,6 @@ var _ = Describe("TransportWorker States", func() {
 
 		It("should apply backoff after transient error even when FailedAuthConfig is empty", func() {
 			desired := &fsmv2.WrappedDesiredState[snapshot.TransportDesiredState]{
-				State: config.DesiredStateRunning,
 				Config: snapshot.TransportDesiredState{
 					InstanceUUID: "test-uuid",
 					AuthToken:    "test-auth-token",
@@ -685,7 +681,6 @@ var _ = Describe("TransportWorker States", func() {
 		// Scenario 1 tick 3: AuthFailed exits when AuthToken changes
 		It("should transition to Starting when AuthToken changes", func() {
 			desired := &fsmv2.WrappedDesiredState[snapshot.TransportDesiredState]{
-				State: config.DesiredStateRunning,
 				Config: snapshot.TransportDesiredState{
 					InstanceUUID: "test-uuid",
 					AuthToken:    "new-auth-token",
@@ -714,7 +709,6 @@ var _ = Describe("TransportWorker States", func() {
 		// Scenario 7: Only relay changes
 		It("should transition to Starting when RelayURL changes", func() {
 			desired := &fsmv2.WrappedDesiredState[snapshot.TransportDesiredState]{
-				State: config.DesiredStateRunning,
 				Config: snapshot.TransportDesiredState{
 					InstanceUUID: "test-uuid",
 					AuthToken:    "test-auth-token",
@@ -742,7 +736,6 @@ var _ = Describe("TransportWorker States", func() {
 		// Scenario 2: InstanceDeleted → UUID changes
 		It("should transition to Starting when InstanceUUID changes", func() {
 			desired := &fsmv2.WrappedDesiredState[snapshot.TransportDesiredState]{
-				State: config.DesiredStateRunning,
 				Config: snapshot.TransportDesiredState{
 					InstanceUUID: "new-uuid",
 					AuthToken:    "test-auth-token",
@@ -770,7 +763,6 @@ var _ = Describe("TransportWorker States", func() {
 		// Scenario 8: Empty failed config = safety net (fresh deps after restart)
 		It("should transition to Starting when failed config is empty (safety net)", func() {
 			desired := &fsmv2.WrappedDesiredState[snapshot.TransportDesiredState]{
-				State: config.DesiredStateRunning,
 				Config: snapshot.TransportDesiredState{
 					InstanceUUID: "test-uuid",
 					AuthToken:    "test-auth-token",

--- a/umh-core/pkg/fsmv2/workers/transport/worker.go
+++ b/umh-core/pkg/fsmv2/workers/transport/worker.go
@@ -228,7 +228,9 @@ func init() {
 			if err != nil {
 				return nil, err
 			}
+
 			register.SetDeps[*TransportDependencies](transportDepsKey, w.GetDependencies())
+
 			return w, nil
 		})
 }

--- a/umh-core/pkg/fsmv2/workers/transport/worker.go
+++ b/umh-core/pkg/fsmv2/workers/transport/worker.go
@@ -161,7 +161,6 @@ func (w *TransportWorker) DeriveDesiredState(spec interface{}) (fsmv2.DesiredSta
 	// a real spec is parsed.
 	if spec == nil {
 		return &fsmv2.WrappedDesiredState[snapshot.TransportDesiredState]{
-			State:  config.DesiredStateRunning,
 			Config: snapshot.TransportDesiredState{},
 		}, nil
 	}
@@ -203,9 +202,7 @@ func (w *TransportWorker) DeriveDesiredState(spec interface{}) (fsmv2.DesiredSta
 		}
 	}
 
-	// Build desired state with valid state values only ("stopped" or "running")
 	return &fsmv2.WrappedDesiredState[snapshot.TransportDesiredState]{
-		State: transportSpec.GetState(),
 		Config: snapshot.TransportDesiredState{
 			RelayURL:     transportSpec.RelayURL,
 			InstanceUUID: transportSpec.InstanceUUID,

--- a/umh-core/pkg/fsmv2/workers/transport/worker_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/worker_test.go
@@ -152,7 +152,7 @@ var _ = Describe("TransportWorker", func() {
 				// Default to running when spec is nil
 				typed, ok := desired.(*fsmv2.WrappedDesiredState[snapshot.TransportDesiredState])
 				Expect(ok).To(BeTrue())
-				Expect(typed.GetState()).To(Equal("running"))
+				Expect(typed).NotTo(BeNil())
 			})
 
 			It("should not populate ChildrenSpecs — children are declared in snapshot.RenderChildren", func() {
@@ -213,7 +213,7 @@ relayURL: "https://relay.example.com"`,
 				Expect(err).ToNot(HaveOccurred())
 				transportDesired, ok := desired.(*fsmv2.WrappedDesiredState[snapshot.TransportDesiredState])
 				Expect(ok).To(BeTrue())
-				Expect(transportDesired.GetState()).To(Equal("stopped"))
+				Expect(transportDesired).NotTo(BeNil())
 			})
 
 			It("should return running state when configured", func() {
@@ -230,7 +230,7 @@ authToken: "test-token"`,
 				Expect(err).ToNot(HaveOccurred())
 				transportDesired, ok := desired.(*fsmv2.WrappedDesiredState[snapshot.TransportDesiredState])
 				Expect(ok).To(BeTrue())
-				Expect(transportDesired.GetState()).To(Equal("running"))
+				Expect(transportDesired).NotTo(BeNil())
 			})
 		})
 
@@ -252,7 +252,7 @@ authToken: "test-token"`,
 				Expect(ok1).To(BeTrue())
 				td2, ok2 := desired2.(*fsmv2.WrappedDesiredState[snapshot.TransportDesiredState])
 				Expect(ok2).To(BeTrue())
-				Expect(td1.GetState()).To(Equal(td2.GetState()))
+				Expect(td1).To(Equal(td2))
 			})
 		})
 
@@ -310,7 +310,7 @@ instanceUUID: "test-uuid"`,
 				Expect(err).ToNot(HaveOccurred())
 				transportDesired, ok := desired.(*fsmv2.WrappedDesiredState[snapshot.TransportDesiredState])
 				Expect(ok).To(BeTrue())
-				Expect(transportDesired.GetState()).To(Equal("stopped"))
+				Expect(transportDesired).NotTo(BeNil())
 			})
 
 			It("should default timeout when zero", func() {

--- a/umh-core/pkg/fsmv2/workers/transport/worker_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/worker_test.go
@@ -201,7 +201,7 @@ authToken: "test-token"`,
 				Expect(transportDesired.ChildrenSpecs).To(BeNil())
 			})
 
-			It("should return stopped state when configured", func() {
+			It("parses a stopped spec without requiring credentials", func() {
 				spec := fsmv2types.UserSpec{
 					Config: `state: stopped
 relayURL: "https://relay.example.com"`,
@@ -213,10 +213,10 @@ relayURL: "https://relay.example.com"`,
 				Expect(err).ToNot(HaveOccurred())
 				transportDesired, ok := desired.(*fsmv2.WrappedDesiredState[snapshot.TransportDesiredState])
 				Expect(ok).To(BeTrue())
-				Expect(transportDesired).NotTo(BeNil())
+				Expect(transportDesired.Config.RelayURL).To(Equal("https://relay.example.com"))
 			})
 
-			It("should return running state when configured", func() {
+			It("propagates credentials from a running spec into the derived config", func() {
 				spec := fsmv2types.UserSpec{
 					Config: `state: running
 relayURL: "https://relay.example.com"
@@ -230,7 +230,9 @@ authToken: "test-token"`,
 				Expect(err).ToNot(HaveOccurred())
 				transportDesired, ok := desired.(*fsmv2.WrappedDesiredState[snapshot.TransportDesiredState])
 				Expect(ok).To(BeTrue())
-				Expect(transportDesired).NotTo(BeNil())
+				Expect(transportDesired.Config.RelayURL).To(Equal("https://relay.example.com"))
+				Expect(transportDesired.Config.InstanceUUID).To(Equal("test-uuid"))
+				Expect(transportDesired.Config.AuthToken).To(Equal("test-token"))
 			})
 		})
 

--- a/umh-core/pkg/fsmv2/wrapped_desired_state_test.go
+++ b/umh-core/pkg/fsmv2/wrapped_desired_state_test.go
@@ -19,7 +19,6 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/config"
 )
 
 var _ = Describe("WrappedDesiredState", func() {
@@ -32,11 +31,6 @@ var _ = Describe("WrappedDesiredState", func() {
 		It("IsShutdownRequested returns false for zero value", func() {
 			wds := &fsmv2.WrappedDesiredState[TestConfig]{}
 			Expect(wds.IsShutdownRequested()).To(BeFalse())
-		})
-
-		It("GetState returns 'running' when State field is empty", func() {
-			wds := &fsmv2.WrappedDesiredState[TestConfig]{}
-			Expect(wds.GetState()).To(Equal(config.DesiredStateRunning))
 		})
 
 		It("GetChildrenSpecs returns nil for zero value", func() {
@@ -63,27 +57,6 @@ var _ = Describe("WrappedDesiredState", func() {
 			wds.SetShutdownRequested(true)
 			wds.SetShutdownRequested(false)
 			Expect(wds.IsShutdownRequested()).To(BeFalse())
-		})
-	})
-
-	Describe("GetState", func() {
-		It("returns 'running' when State is empty", func() {
-			wds := &fsmv2.WrappedDesiredState[TestConfig]{}
-			Expect(wds.GetState()).To(Equal(config.DesiredStateRunning))
-		})
-
-		It("returns 'stopped' when State is set to stopped", func() {
-			wds := &fsmv2.WrappedDesiredState[TestConfig]{
-				State: config.DesiredStateStopped,
-			}
-			Expect(wds.GetState()).To(Equal(config.DesiredStateStopped))
-		})
-
-		It("returns custom state when set", func() {
-			wds := &fsmv2.WrappedDesiredState[TestConfig]{
-				State: "custom_state",
-			}
-			Expect(wds.GetState()).To(Equal("custom_state"))
 		})
 	})
 

--- a/umh-core/pkg/models/action_models.go
+++ b/umh-core/pkg/models/action_models.go
@@ -17,6 +17,7 @@ package models
 import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/google/uuid"
+
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/dataflowcomponentserviceconfig"
 )
 
@@ -826,13 +827,13 @@ type WriteDFCPayload struct {
 // ProtocolConverter is the wire format for protocol converter configuration,
 // used by deploy/edit actions and GET responses.
 type ProtocolConverter struct {
-	UUID            *uuid.UUID                     `binding:"required"     json:"uuid"`
+	UUID            *uuid.UUID                     `binding:"required"  json:"uuid"`
 	Location        map[int]string                 `json:"location"`
 	ReadDFC         *ProtocolConverterDFC          `json:"readDFC"`
 	WriteDFCPayload *WriteDFCPayload               `json:"writeDFC"`
 	TemplateInfo    *ProtocolConverterTemplateInfo `json:"templateInfo"`
 	Meta            *ProtocolConverterMeta         `json:"meta"`
-	Name            string                         `binding:"required" json:"name"`
+	Name            string                         `binding:"required"  json:"name"`
 	Connection      ProtocolConverterConnection    `json:"connection"`
 }
 

--- a/umh-core/pkg/service/dataflowcomponent/dataflowcomponent.go
+++ b/umh-core/pkg/service/dataflowcomponent/dataflowcomponent.go
@@ -20,8 +20,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants"
 	"go.uber.org/zap"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants"
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/benthosserviceconfig"
@@ -459,6 +460,7 @@ func (s *DataFlowComponentService) ForceRemoveDataFlowComponent(ctx context.Cont
 	if ctx.Err() != nil {
 		s.logger.Warnf("Parent context already expired for force removal of %s", componentName)
 	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), constants.ForceRemovalTimeout)
 	defer cancel()
 

--- a/umh-core/pkg/service/protocolconverter/runtime_config/runtime_config.go
+++ b/umh-core/pkg/service/protocolconverter/runtime_config/runtime_config.go
@@ -323,6 +323,7 @@ func renderConfig(
 	if internal, ok := scope["internal"].(map[string]any); ok {
 		bridgedBy, _ = internal["bridged_by"].(string)
 	}
+
 	if bridgedBy == "" && renderedWriteConfig.HasOutput() {
 		return protocolconverterserviceconfig.ProtocolConverterServiceConfigRuntime{},
 			errors.New("bridged_by is empty for a write DFC with output configured: the FSM must inject internal.bridged_by before calling BuildRuntimeConfig")

--- a/umh-core/pkg/service/streamprocessor/streamprocessor.go
+++ b/umh-core/pkg/service/streamprocessor/streamprocessor.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"time"
 
+	"go.uber.org/zap"
+
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/dataflowcomponentserviceconfig"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/streamprocessorserviceconfig"
@@ -33,7 +35,6 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/filesystem"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/serviceregistry"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/standarderrors"
-	"go.uber.org/zap"
 )
 
 type IStreamProcessorService interface {
@@ -604,6 +605,7 @@ func (c *Service) ForceRemove(
 	if ctx.Err() != nil {
 		c.logger.Warnf("Parent context already expired for force removal of %s", spName)
 	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), constants.ForceRemovalTimeout)
 	defer cancel()
 

--- a/umh-core/pkg/service/topicbrowser/topicbrowser.go
+++ b/umh-core/pkg/service/topicbrowser/topicbrowser.go
@@ -21,6 +21,8 @@ import (
 	"sync"
 	"time"
 
+	"go.uber.org/zap"
+
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
 	benthossvccfg "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/benthosserviceconfig"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants"
@@ -34,7 +36,6 @@ import (
 	s6svc "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/s6"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/serviceregistry"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/standarderrors"
-	"go.uber.org/zap"
 )
 
 type ITopicBrowserService interface {
@@ -609,6 +610,7 @@ func (svc *Service) ForceRemove(
 	if ctx.Err() != nil {
 		svc.logger.Warnf("Parent context already expired for force removal of %s", tbName)
 	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), constants.ForceRemovalTimeout)
 	defer cancel()
 


### PR DESCRIPTION
## The stack

> **FSMv2 migration-API stack, PR 1 of 6.** A worker acts on its *snapshot* (its
> desired + observed state). The goal: make the snapshot the complete description of a
> worker, then let outside code rewrite it on a running system.
> 1. **#2589 ← you are here**: delete the dead legacy stop path so a worker's lifecycle depends on its own state, not a parent side channel.
> 2. **#2590**: put each transport worker's auth on its own spec, not a side channel into the parent.
> 3. **#2598**: put the config-declared child list on the snapshot so the migration API can read it.
> 4. **#2599**: the migration API, so outside code can create, update, and delete workers on a running supervisor.
> 5. **#2603**: shut down by draining instead of timing out (the bug building the proof found).
> 6. **#2604**: prove create and update against a live kernel.
>
> Merge bottom-up. Each PR stands alone and reverts cleanly.

### This PR: a worker's stop decision reads its own state, not the parent's

The framework still had an older mechanism (`ParentMappedState` / `ChildStartStates` /
`computeMappedState`) that let a worker's *stop* decision depend on its parent's FSM
state name. It was already dead (always false in practice) but still present in the code,
so the next contributor could route new behavior through it, and it kept a worker's
lifecycle tied to a parent side channel instead of the worker's own state. This PR
deletes it. A worker now stops for exactly two reasons: shutdown or disabled.


---

# L5b: remove the legacy child-control mechanism

## Problem

Child workers decided "should I stop?" through two channels: the explicit intent fields (`IsShutdownRequested`, `IsDisabled`) and a legacy parent-FSM-state-name pathway (`ChildStartStates` -> `computeMappedState` -> `ParentMappedState`, read as a third term in `ShouldStop()`). No worker emits `ChildStartStates` anymore and `application` forces `Enabled=true`, so that third term was always false. Dead but present, it invited the next contributor to route a new stop signal through the wrong channel.

## What we're shipping

1. **`fix(fsmv2/supervisor)`: preserve `Disabled` across per-tick re-derivation.** The child supervisor carried only `ShutdownRequested` forward across `DeriveDesiredState`, so a resident-disabled child's `Disabled` bit was clobbered to false each tick and survived only by tick-timing accident. Commit 2 changes that timing, so this lands first and makes resident-disable deterministic. Mirrors the existing `ShutdownRequested` preservation.

2. **`refactor(fsmv2/L5b)`: delete the legacy mechanism end to end** — `ParentMappedState`, `ChildStartStates`, `computeMappedState`/`applyStateMapping`, the supervisor + collector wiring, and the local transport copies. `ShouldStop()` becomes `return s.IsShutdownRequested || s.IsDisabled`. Folds in the dead `WrappedDesiredState.State`/`GetState()`.

After the deletion the legacy channel is **unrepresentable at the state-file API**: `WorkerSnapshot` carries no parent-state field, so a state file cannot route a stop on parent state. We rely on that structural absence plus review — an earlier draft added a name-ban architecture test, but it only caught re-introduction of the six specific dead identifiers (a failure mode the deletion already made implausible) while doing nothing against a new-named parallel channel, so it was dropped as a brittle proxy.

## Review disposition (2026-06-13)

A third commit addresses review feedback, both halves rooted in commit 2 widening `ShouldStop()` to `shutdown || disabled`:

3. **`refactor(fsmv2)`: idiomatic state returns + truthful stop reasons.**
   - **Truthful stop reasons.** Because `ShouldStop()` now covers shutdown *and* disable, the old `shutdown=%t` reason strings misreported a disable-driven stop as `shutdown=false`. Added `WorkerSnapshot.StopReason()` (`"shutdown=%t disabled=%t"`) and used it at the stop / stop-complete transition sites. (Closes the CodeRabbit "include the disable cause" cluster.)
   - **Removed the non-idiomatic "Exhaustive Transition Coverage" architecture rule** (`ValidateExhaustiveTransitionCoverage` + its arch-test block + registry entry). Go already guarantees every path returns, so the rule's only effect was to mandate a trailing `return s, SignalNone, nil` catch-all — which, once commit 2 made the parent-state branch redundant, became provably-unreachable dead code. That dead catch-all is exactly what CodeRabbit flagged as an "unreachable branch": the finding was real, but the fix is to remove the rule that forced the dead code, not to keep it. State `Next()` methods are rewritten with guard clauses + a definite final transition; the example stopped states gain an explicit `IsDisabled` branch. (Same spirit as the name-ban test dropped above: a syntactic arch rule that fought idiom rather than guarding a real invariant.)

Changelog: `skip-changelog-guard` — FSMv2 transport is default-off (`USE_FSMV2_TRANSPORT=false`), not user-facing, matching #2588.

## Scope

- umh-core `pkg/fsmv2` only. Behavior preserved: the deleted term was inert, and `childStartStates` in application YAML was never emitted by any config writer or the Go-built template, so the lenient parser ignoring a stale key changes nothing.
- Wire-shape change: `mapped_parent_state` drops from `/debug/fsmv2` (write-only field, zero readers anywhere).
- NOT in scope: the `application` root typing / `UserSpec.Config` removal, transport auth, the `IsShutdownRequested` rename. Each is its own later PR.
- CI note: the supervisor package suite runs ~280s; allow at least 360s so it does not time out.
- Was stacked on #2588 (now **MERGED**); rebased onto `staging`. **L5d (#2590) stacks on this PR.**

