### PR TITLE
feat(fsmv2/L5d): carry transport auth on the typed snapshot, not parent deps

### DIFF
--- a/umh-core/cmd/main.go
+++ b/umh-core/cmd/main.go
@@ -691,11 +691,11 @@ func wireFSMv2Communicator(
 					continue
 				}
 
-				if observed.Status.AuthenticatedUUID != "" && observed.Status.AuthenticatedUUID != placeholderUUID {
+				if observed.Status.AuthSession.InstanceUUID != "" && observed.Status.AuthSession.InstanceUUID != placeholderUUID {
 					logger.Infow("Detected real UUID from TransportWorker ObservedState, updating LoginResponse",
-						"realUUID", observed.Status.AuthenticatedUUID,
+						"realUUID", observed.Status.AuthSession.InstanceUUID,
 						"placeholderUUID", placeholderUUID)
-					communicationState.SetLoginResponseForFSMv2(observed.Status.AuthenticatedUUID)
+					communicationState.SetLoginResponseForFSMv2(observed.Status.AuthSession.InstanceUUID)
 
 					return
 				}

--- a/umh-core/pkg/fsmv2/integration/transport_token_reapply_test.go
+++ b/umh-core/pkg/fsmv2/integration/transport_token_reapply_test.go
@@ -1,0 +1,253 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/cse/storage"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
+	fsmconfig "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/config"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/register"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/supervisor"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/snapshot"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/types"
+
+	// Blank imports register the push and pull child factories so the supervisor
+	// can spawn them when the transport parent renders its children.
+	_ "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/pull"
+	_ "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/push"
+)
+
+// tokenReapplyChannelProvider is a minimal transport.ChannelProvider for the
+// resident-child token re-apply test. The children are driven only far enough to
+// re-derive their desired config; no real push/pull HTTP traffic occurs.
+type tokenReapplyChannelProvider struct {
+	inbound  chan *types.UMHMessage
+	outbound chan *types.UMHMessage
+}
+
+func newTokenReapplyChannelProvider() *tokenReapplyChannelProvider {
+	return &tokenReapplyChannelProvider{
+		inbound:  make(chan *types.UMHMessage, 16),
+		outbound: make(chan *types.UMHMessage, 16),
+	}
+}
+
+func (p *tokenReapplyChannelProvider) GetChannels(_ string) (chan<- *types.UMHMessage, <-chan *types.UMHMessage) {
+	return p.inbound, p.outbound
+}
+
+func (p *tokenReapplyChannelProvider) GetInboundStats(_ string) (capacity int, length int) {
+	return cap(p.inbound), len(p.inbound)
+}
+
+// childDesiredToken reads the token a resident push/pull child currently holds in
+// its persisted desired state. The path mirrors how RenderChildren stamps the auth
+// session: WrappedDesiredState marshals the child Config under "config", and the
+// push/pull desired Config carries "auth_session".
+func childDesiredToken(store storage.TriangularStoreInterface, workerType, workerID string) (string, bool) {
+	for _, w := range getWorkersFromStore(store) {
+		if w.WorkerType != workerType || w.WorkerID != workerID {
+			continue
+		}
+
+		cfg, ok := w.Desired["config"].(map[string]any)
+		if !ok {
+			return "", false
+		}
+
+		session, ok := cfg["auth_session"].(map[string]any)
+		if !ok {
+			return "", false
+		}
+
+		token, ok := session["token"].(string)
+
+		return token, ok
+	}
+
+	return "", false
+}
+
+// childObservedHasValidToken reads the resident push/pull child's observed
+// has_valid_token bool. The child sets it from its desired AuthSession via
+// IsUsable, so it stays true exactly while the child holds a usable token. The
+// second return is false when the child or the field is not yet present.
+func childObservedHasValidToken(store storage.TriangularStoreInterface, workerType, workerID string) (bool, bool) {
+	for _, w := range getWorkersFromStore(store) {
+		if w.WorkerType != workerType || w.WorkerID != workerID {
+			continue
+		}
+
+		hasToken, ok := w.Observed["has_valid_token"].(bool)
+
+		return hasToken, ok
+	}
+
+	return false, false
+}
+
+var _ = Describe("Transport resident-child JWT re-apply", func() {
+	var (
+		ctx          context.Context
+		cancel       context.CancelFunc
+		store        storage.TriangularStoreInterface
+		parentSup    *supervisor.Supervisor[fsmv2.Observation[snapshot.TransportStatus], *fsmv2.WrappedDesiredState[snapshot.TransportDesiredState]]
+		transportDep *transport.TransportDependencies
+	)
+
+	const (
+		oldToken = "jwt-token-old"
+		newToken = "jwt-token-new"
+	)
+
+	BeforeEach(func() {
+		ctx, cancel = context.WithTimeout(context.Background(), 30*time.Second)
+
+		store = setupTestStoreForScenario(deps.NewNopFSMLogger())
+
+		transport.SetChannelProvider(newTokenReapplyChannelProvider())
+
+		parentSup = supervisor.NewSupervisor[fsmv2.Observation[snapshot.TransportStatus], *fsmv2.WrappedDesiredState[snapshot.TransportDesiredState]](supervisor.Config{
+			WorkerType:              "transport",
+			Store:                   store,
+			Logger:                  deps.NewNopFSMLogger(),
+			GracefulShutdownTimeout: 10 * time.Second,
+		})
+
+		identity := deps.Identity{
+			ID:         "transport-001",
+			Name:       "Transport",
+			WorkerType: "transport",
+		}
+
+		worker, err := transport.NewTransportWorker(identity, deps.NewNopFSMLogger(), nil)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Publish the parent transport deps the same way the production worker
+		// factory does, so the push/pull deps builders can find them.
+		register.SetDeps[*transport.TransportDependencies]("transport", worker.GetDependencies())
+		transportDep = worker.GetDependencies()
+
+		Expect(parentSup.AddWorker(identity, worker)).To(Succeed())
+
+		// Start the collector goroutines (no owned tick loop) so observed state is
+		// refreshed asynchronously; reconciliation is then driven manually via
+		// TestTick. Newly spawned children are started the same way and ticked
+		// synchronously by the parent each tick.
+		parentSup.StartAsChild(ctx)
+
+		// Drive the parent to a running trajectory by giving it a valid spec.
+		parentSup.TestUpdateUserSpec(fsmconfig.UserSpec{
+			Config: `
+relayURL: "http://relay.invalid"
+instanceUUID: "test-instance-uuid"
+authToken: "test-auth-token"
+timeout: "5s"
+`,
+		})
+	})
+
+	AfterEach(func() {
+		cancel()
+		transport.ClearChannelProvider()
+	})
+
+	It("re-applies a rotated JWT to resident push and pull children without despawn", func() {
+		// Prime the initial token directly via the production setter so the parent
+		// authenticates without a relay round-trip and spawns its children.
+		transportDep.SetJWT(oldToken, time.Now().Add(time.Hour))
+
+		// Tick until both children are resident and reflect the initial token.
+		Eventually(func() bool {
+			_ = parentSup.TestTick(ctx)
+
+			children := parentSup.GetChildren()
+			if _, ok := children["push"]; !ok {
+				return false
+			}
+
+			if _, ok := children["pull"]; !ok {
+				return false
+			}
+
+			pushTok, pushOK := childDesiredToken(store, "push", "push-001")
+			pullTok, pullOK := childDesiredToken(store, "pull", "pull-001")
+
+			return pushOK && pullOK && pushTok == oldToken && pullTok == oldToken
+		}, "10s", "100ms").Should(BeTrue(),
+			"push and pull children must become resident and carry the initial token")
+
+		// Capture child identities to prove they are NOT recreated by the rotation.
+		childrenBefore := parentSup.GetChildren()
+		pushBefore := childrenBefore["push"]
+		pullBefore := childrenBefore["pull"]
+		Expect(pushBefore).ToNot(BeNil())
+		Expect(pullBefore).ToNot(BeNil())
+
+		// Baseline: both children observe a usable token before the rotation.
+		Eventually(func() bool {
+			_ = parentSup.TestTick(ctx)
+
+			pushValid, pushOK := childObservedHasValidToken(store, "push", "push-001")
+			pullValid, pullOK := childObservedHasValidToken(store, "pull", "pull-001")
+
+			return pushOK && pullOK && pushValid && pullValid
+		}, "10s", "100ms").Should(BeTrue(),
+			"push and pull children must observe a valid token before the rotation")
+
+		// Rotate the parent JWT using the same setter production uses on re-auth.
+		transportDep.SetJWT(newToken, time.Now().Add(time.Hour))
+
+		// Reconcile on the normal path. No despawn/respawn: the parent stays alive,
+		// so the supervisor re-applies the new child config to the resident children.
+		// No auth gap: every tick during propagation the child must keep observing a
+		// valid token, so it is never left tokenless while the new token lands.
+		Eventually(func() bool {
+			_ = parentSup.TestTick(ctx)
+
+			pushValid, pushValidOK := childObservedHasValidToken(store, "push", "push-001")
+			pullValid, pullValidOK := childObservedHasValidToken(store, "pull", "pull-001")
+			Expect(pushValidOK && pushValid).To(BeTrue(),
+				"push child must never lose its valid token across the rotation (no auth gap)")
+			Expect(pullValidOK && pullValid).To(BeTrue(),
+				"pull child must never lose its valid token across the rotation (no auth gap)")
+
+			pushTok, pushOK := childDesiredToken(store, "push", "push-001")
+			pullTok, pullOK := childDesiredToken(store, "pull", "pull-001")
+
+			return pushOK && pullOK && pushTok == newToken && pullTok == newToken
+		}, "10s", "100ms").Should(BeTrue(),
+			"resident push and pull children must pick up the rotated token via config re-apply")
+
+		// The children must be the SAME supervisor instances: re-apply, not respawn.
+		childrenAfter := parentSup.GetChildren()
+		Expect(childrenAfter["push"]).To(BeIdenticalTo(pushBefore),
+			"push child must be re-applied in place, not recreated")
+		Expect(childrenAfter["pull"]).To(BeIdenticalTo(pullBefore),
+			"pull child must be re-applied in place, not recreated")
+		Expect(parentSup.TestIsPendingRemoval("push")).To(BeFalse(),
+			"push child must never be marked for removal during a token rotation")
+		Expect(parentSup.TestIsPendingRemoval("pull")).To(BeFalse(),
+			"pull child must never be marked for removal during a token rotation")
+	})
+})

--- a/umh-core/pkg/fsmv2/workers/transport/action/authenticate.go
+++ b/umh-core/pkg/fsmv2/workers/transport/action/authenticate.go
@@ -150,6 +150,10 @@ func (a *AuthenticateAction) Execute(ctx context.Context, depsAny any) error {
 		depspkg.Bool("has_token", authResp.Token != ""),
 	)
 
+	// Only overwrite InstanceUUID when the re-auth response includes one. An
+	// omitted UUID means "unchanged" (the instance identity is stable across
+	// re-auths), not "cleared", so keeping the previous value is correct; clearing
+	// it here would drop a valid identity on a routine token refresh.
 	if authResp.InstanceUUID != "" {
 		logger.Info("authenticated_uuid_stored",
 			depspkg.String("uuid", authResp.InstanceUUID),

--- a/umh-core/pkg/fsmv2/workers/transport/action/authenticate_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/action/authenticate_test.go
@@ -144,7 +144,7 @@ var _ = Describe("AuthenticateAction", func() {
 			err := act.Execute(ctx, dependencies)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(dependencies.GetJWTToken()).To(Equal(expectedToken))
+			Expect(dependencies.GetAuthSession().Token).To(Equal(expectedToken))
 		})
 
 		It("should store JWT expiry in dependencies after successful authentication", func() {
@@ -159,8 +159,7 @@ var _ = Describe("AuthenticateAction", func() {
 			err := act.Execute(ctx, dependencies)
 			Expect(err).NotTo(HaveOccurred())
 
-			storedExpiry := dependencies.GetJWTExpiry()
-			Expect(storedExpiry.Unix()).To(Equal(expectedExpiry))
+			Expect(dependencies.GetAuthSession().Expiry.Unix()).To(Equal(expectedExpiry))
 		})
 	})
 
@@ -177,7 +176,7 @@ var _ = Describe("AuthenticateAction", func() {
 			err := act.Execute(ctx, dependencies)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(dependencies.GetAuthenticatedUUID()).To(Equal(expectedUUID))
+			Expect(dependencies.GetAuthSession().InstanceUUID).To(Equal(expectedUUID))
 		})
 
 		It("should handle missing instance UUID gracefully", func() {

--- a/umh-core/pkg/fsmv2/workers/transport/dependencies.go
+++ b/umh-core/pkg/fsmv2/workers/transport/dependencies.go
@@ -129,26 +129,6 @@ func (d *TransportDependencies) SetJWT(token string, expiry time.Time) {
 	d.authSession.Expiry = expiry
 }
 
-// GetJWTToken returns the stored JWT token.
-// Kept for child-deps delegation (push/pull still call parentDeps.GetJWTToken).
-// Removed in a later task once child deps no longer delegate.
-func (d *TransportDependencies) GetJWTToken() string {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-
-	return d.authSession.Token
-}
-
-// GetJWTExpiry returns the stored JWT expiry time.
-// Kept for child-deps delegation (push/pull still call parentDeps.GetJWTExpiry).
-// Removed in a later task once child deps no longer delegate.
-func (d *TransportDependencies) GetJWTExpiry() time.Time {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-
-	return d.authSession.Expiry
-}
-
 // GetAuthSession returns the current auth bundle under the read lock. Parent COS
 // uses this single locked read; per-field reads would race the SetJWT /
 // SetAuthenticatedUUID writers.
@@ -326,16 +306,6 @@ func (d *TransportDependencies) SetAuthenticatedUUID(uuid string) {
 	defer d.mu.Unlock()
 
 	d.authSession.InstanceUUID = uuid
-}
-
-// GetAuthenticatedUUID returns the stored UUID from backend authentication.
-// Kept for child-deps delegation (push still calls parentDeps.GetAuthenticatedUUID).
-// Removed in a later task once child deps no longer delegate.
-func (d *TransportDependencies) GetAuthenticatedUUID() string {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-
-	return d.authSession.InstanceUUID
 }
 
 // GetResetGeneration returns the current reset generation counter.

--- a/umh-core/pkg/fsmv2/workers/transport/dependencies.go
+++ b/umh-core/pkg/fsmv2/workers/transport/dependencies.go
@@ -58,7 +58,7 @@ var AuthFailureRateConfig = failurerate.Config{
 
 // TransportDependencies provides transport and channel access for transport worker actions.
 type TransportDependencies struct {
-	jwtExpiry         time.Time
+	authSession       types.AuthSession
 	lastAuthAttemptAt time.Time
 
 	transport types.Transport
@@ -67,8 +67,6 @@ type TransportDependencies struct {
 	authFailureRate *failurerate.Tracker
 	inboundChan     chan<- *types.UMHMessage
 	outboundChan    <-chan *types.UMHMessage
-	jwtToken        string
-	instanceUUID    string
 
 	failedAuthToken    string
 	failedRelayURL     string
@@ -127,24 +125,38 @@ func (d *TransportDependencies) SetJWT(token string, expiry time.Time) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	d.jwtToken = token
-	d.jwtExpiry = expiry
+	d.authSession.Token = token
+	d.authSession.Expiry = expiry
 }
 
 // GetJWTToken returns the stored JWT token.
+// Kept for child-deps delegation (push/pull still call parentDeps.GetJWTToken).
+// Removed in a later task once child deps no longer delegate.
 func (d *TransportDependencies) GetJWTToken() string {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 
-	return d.jwtToken
+	return d.authSession.Token
 }
 
 // GetJWTExpiry returns the stored JWT expiry time.
+// Kept for child-deps delegation (push/pull still call parentDeps.GetJWTExpiry).
+// Removed in a later task once child deps no longer delegate.
 func (d *TransportDependencies) GetJWTExpiry() time.Time {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 
-	return d.jwtExpiry
+	return d.authSession.Expiry
+}
+
+// GetAuthSession returns the current auth bundle under the read lock. Parent COS
+// uses this single locked read; per-field reads would race the SetJWT /
+// SetAuthenticatedUUID writers.
+func (d *TransportDependencies) GetAuthSession() types.AuthSession {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	return d.authSession
 }
 
 // RecordError increments consecutive errors and records when degraded mode started.
@@ -313,15 +325,17 @@ func (d *TransportDependencies) SetAuthenticatedUUID(uuid string) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	d.instanceUUID = uuid
+	d.authSession.InstanceUUID = uuid
 }
 
 // GetAuthenticatedUUID returns the stored UUID from backend authentication.
+// Kept for child-deps delegation (push still calls parentDeps.GetAuthenticatedUUID).
+// Removed in a later task once child deps no longer delegate.
 func (d *TransportDependencies) GetAuthenticatedUUID() string {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 
-	return d.instanceUUID
+	return d.authSession.InstanceUUID
 }
 
 // GetResetGeneration returns the current reset generation counter.

--- a/umh-core/pkg/fsmv2/workers/transport/dependencies_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/dependencies_test.go
@@ -161,6 +161,26 @@ var _ = Describe("TransportDependencies", func() {
 			})
 		})
 
+		Describe("GetAuthSession", func() {
+			It("should return the full auth bundle after SetJWT and SetAuthenticatedUUID", func() {
+				expiry := time.Now().Add(1 * time.Hour)
+				deps.SetJWT("tok", expiry)
+				deps.SetAuthenticatedUUID("be-uuid")
+
+				as := deps.GetAuthSession()
+				Expect(as.Token).To(Equal("tok"))
+				Expect(as.Expiry).To(BeTemporally("~", expiry, time.Second))
+				Expect(as.InstanceUUID).To(Equal("be-uuid"))
+			})
+
+			It("should return zero-value AuthSession when nothing is set", func() {
+				as := deps.GetAuthSession()
+				Expect(as.Token).To(BeEmpty())
+				Expect(as.Expiry.IsZero()).To(BeTrue())
+				Expect(as.InstanceUUID).To(BeEmpty())
+			})
+		})
+
 	})
 
 	Describe("Transport management", func() {

--- a/umh-core/pkg/fsmv2/workers/transport/dependencies_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/dependencies_test.go
@@ -133,8 +133,9 @@ var _ = Describe("TransportDependencies", func() {
 				expiry := time.Now().Add(1 * time.Hour)
 				deps.SetJWT("test-jwt-token", expiry)
 
-				Expect(deps.GetJWTToken()).To(Equal("test-jwt-token"))
-				Expect(deps.GetJWTExpiry()).To(BeTemporally("~", expiry, time.Second))
+				as := deps.GetAuthSession()
+				Expect(as.Token).To(Equal("test-jwt-token"))
+				Expect(as.Expiry).To(BeTemporally("~", expiry, time.Second))
 			})
 
 			It("should update JWT when called multiple times (re-authentication)", func() {
@@ -144,20 +145,9 @@ var _ = Describe("TransportDependencies", func() {
 				secondExpiry := time.Now().Add(2 * time.Hour)
 				deps.SetJWT("second-token", secondExpiry)
 
-				Expect(deps.GetJWTToken()).To(Equal("second-token"))
-				Expect(deps.GetJWTExpiry()).To(BeTemporally("~", secondExpiry, time.Second))
-			})
-		})
-
-		Describe("GetJWTToken", func() {
-			It("should return empty string when no token has been set", func() {
-				Expect(deps.GetJWTToken()).To(BeEmpty())
-			})
-		})
-
-		Describe("GetJWTExpiry", func() {
-			It("should return zero time when no expiry has been set", func() {
-				Expect(deps.GetJWTExpiry().IsZero()).To(BeTrue())
+				as := deps.GetAuthSession()
+				Expect(as.Token).To(Equal("second-token"))
+				Expect(as.Expiry).To(BeTemporally("~", secondExpiry, time.Second))
 			})
 		})
 

--- a/umh-core/pkg/fsmv2/workers/transport/pull/action/pull.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/action/pull.go
@@ -31,6 +31,16 @@ const PullActionName = "pull"
 // PullAction pulls inbound messages from the backend via long-poll and delivers
 // them to the inbound channel. It manages a pending-message buffer for partial
 // deliveries and applies backpressure when the channel nears capacity.
+//
+// Precondition: JWTToken is non-empty. The dispatching state validates it:
+// RunningState and DegradedState only emit a PullAction when
+// snap.Status.HasTransport && snap.Status.HasValidToken is true
+// (state_running.go, state_degraded.go), so
+// Execute never runs with an empty token in production. Do not construct a
+// PullAction outside that gate. There is intentionally no in-action
+// revalidation: an action reaching Execute with an empty token would mean the
+// dispatch gate regressed, and that should surface rather than be silently
+// turned into a no-op.
 type PullAction struct {
 	JWTToken string
 }

--- a/umh-core/pkg/fsmv2/workers/transport/pull/action/pull.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/action/pull.go
@@ -31,7 +31,9 @@ const PullActionName = "pull"
 // PullAction pulls inbound messages from the backend via long-poll and delivers
 // them to the inbound channel. It manages a pending-message buffer for partial
 // deliveries and applies backpressure when the channel nears capacity.
-type PullAction struct{}
+type PullAction struct {
+	JWTToken string
+}
 
 // Execute runs one pull cycle: delivers pending messages, checks backpressure,
 // pulls new messages from the backend, and delivers them to the inbound channel.
@@ -45,10 +47,6 @@ func (a *PullAction) Execute(ctx context.Context, depsAny any) error {
 	pullDeps, ok := depsAny.(snapshot.PullDependencies)
 	if !ok {
 		return errors.New("invalid dependencies type: expected PullDependencies")
-	}
-
-	if !pullDeps.IsTokenValid() {
-		return errors.New("token not valid, skipping pull")
 	}
 
 	t := pullDeps.GetTransport()
@@ -142,7 +140,7 @@ func (a *PullAction) Execute(ctx context.Context, depsAny any) error {
 	}
 
 	// Phase 3: Pull from backend
-	jwtToken := pullDeps.GetJWTToken()
+	jwtToken := a.JWTToken
 
 	pullStart := time.Now()
 	messages, err := t.Pull(ctx, jwtToken)

--- a/umh-core/pkg/fsmv2/workers/transport/pull/action/pull_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/action/pull_test.go
@@ -433,6 +433,7 @@ var _ = Describe("PullAction", func() {
 			var capturedToken string
 			mockTrans.pullFunc = func(_ context.Context, jwtToken string) ([]*types.UMHMessage, error) {
 				capturedToken = jwtToken
+
 				return nil, nil
 			}
 

--- a/umh-core/pkg/fsmv2/workers/transport/pull/action/pull_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/action/pull_test.go
@@ -426,15 +426,19 @@ var _ = Describe("PullAction", func() {
 		})
 	})
 
-	Describe("Token pre-check", func() {
-		It("should skip pull when token is invalid (without pulling)", func() {
-			mockDeps.tokenValid = false
+	Describe("Token threading", func() {
+		It("should use JWTToken field from action struct for pulling (not deps.GetJWTToken)", func() {
+			tokenAct := &action.PullAction{JWTToken: "struct-token"}
 
-			err := act.Execute(context.Background(), mockDeps)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("token not valid"))
+			var capturedToken string
+			mockTrans.pullFunc = func(_ context.Context, jwtToken string) ([]*types.UMHMessage, error) {
+				capturedToken = jwtToken
+				return nil, nil
+			}
 
-			Expect(mockTrans.pullCallCount).To(Equal(0))
+			err := tokenAct.Execute(context.Background(), mockDeps)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(capturedToken).To(Equal("struct-token"))
 		})
 	})
 

--- a/umh-core/pkg/fsmv2/workers/transport/pull/action/pull_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/action/pull_test.go
@@ -60,7 +60,6 @@ func (m *mockTransport) Reset() {}
 
 type mockPullDeps struct {
 	transport       types.Transport
-	jwtToken        string
 	metricsRecorder *deps.MetricsRecorder
 	logger          deps.FSMLogger
 
@@ -75,7 +74,6 @@ type mockPullDeps struct {
 	lastErrorType         types.ErrorType
 
 	pendingMessages   []*types.UMHMessage
-	tokenValid        bool
 	resetGeneration   uint64
 	resetCleared      bool
 	lastRetryAfter    time.Duration
@@ -94,7 +92,6 @@ func newMockPullDeps() *mockPullDeps {
 	return &mockPullDeps{
 		metricsRecorder: deps.NewMetricsRecorder(),
 		logger:          deps.NewNopFSMLogger(),
-		tokenValid:      true,
 		chanCapacity:    1000,
 		chanLength:      0,
 	}
@@ -144,10 +141,6 @@ func (m *mockPullDeps) GetTransport() types.Transport {
 	return m.transport
 }
 
-func (m *mockPullDeps) GetJWTToken() string {
-	return m.jwtToken
-}
-
 func (m *mockPullDeps) RecordTypedError(errType types.ErrorType, retryAfter time.Duration) {
 	m.recordTypedErrorCalls = append(m.recordTypedErrorCalls, typedErrorCall{
 		errType:    errType,
@@ -188,10 +181,6 @@ func (m *mockPullDeps) DrainPendingMessages() []*types.UMHMessage {
 
 func (m *mockPullDeps) PendingMessageCount() int {
 	return len(m.pendingMessages)
-}
-
-func (m *mockPullDeps) IsTokenValid() bool {
-	return m.tokenValid
 }
 
 func (m *mockPullDeps) GetResetGeneration() uint64 {
@@ -236,7 +225,6 @@ var _ = Describe("PullAction", func() {
 		mockDeps = newMockPullDeps()
 		mockDeps.inboundBi = inboundBi
 		mockDeps.transport = mockTrans
-		mockDeps.jwtToken = "test-jwt"
 	})
 
 	Describe("Successful pull", func() {

--- a/umh-core/pkg/fsmv2/workers/transport/pull/dependencies.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/dependencies.go
@@ -89,11 +89,6 @@ func (d *PullDependencies) GetTransport() types.Transport {
 	return d.parentDeps.GetTransport()
 }
 
-// GetJWTToken returns the parent's current JWT token.
-func (d *PullDependencies) GetJWTToken() string {
-	return d.parentDeps.GetJWTToken()
-}
-
 // RecordTypedError records a typed error for this child, propagates it to the parent
 // transport tracker, and emits a Sentry warning when the failure rate escalates.
 func (d *PullDependencies) RecordTypedError(errType types.ErrorType, retryAfter time.Duration) {
@@ -207,24 +202,6 @@ func (d *PullDependencies) SetBackpressured(v bool) {
 	defer d.backpressureMu.Unlock()
 
 	d.backpressured = v
-}
-
-// IsTokenValid reports whether the JWT token exists and has not expired
-// (with a 1-minute safety buffer).
-func (d *PullDependencies) IsTokenValid() bool {
-	token := d.parentDeps.GetJWTToken()
-	if token == "" {
-		return false
-	}
-
-	expiry := d.parentDeps.GetJWTExpiry()
-	if expiry.IsZero() {
-		return false
-	}
-
-	const safetyBuffer = 1 * time.Minute
-
-	return !time.Now().Add(safetyBuffer).After(expiry)
 }
 
 // GetLastRetryAfter returns the retry-after duration from the most recent error.

--- a/umh-core/pkg/fsmv2/workers/transport/pull/dependencies_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/dependencies_test.go
@@ -247,40 +247,6 @@ var _ = Describe("PullDependencies", func() {
 		})
 	})
 
-	Describe("IsTokenValid", func() {
-		var d *pull.PullDependencies
-
-		BeforeEach(func() {
-			var err error
-			d, err = pull.NewPullDependencies(parentDeps, deps.NewBaseDependencies(logger, nil, identity))
-			Expect(err).NotTo(HaveOccurred())
-		})
-
-		It("should return false when token is empty", func() {
-			Expect(d.IsTokenValid()).To(BeFalse())
-		})
-
-		It("should return false when expiry is zero", func() {
-			parentDeps.SetJWT("some-token", time.Time{})
-			Expect(d.IsTokenValid()).To(BeFalse())
-		})
-
-		It("should return false when token is expired", func() {
-			parentDeps.SetJWT("some-token", time.Now().Add(-10*time.Minute))
-			Expect(d.IsTokenValid()).To(BeFalse())
-		})
-
-		It("should return false when token expires within the safety buffer", func() {
-			parentDeps.SetJWT("some-token", time.Now().Add(30*time.Second))
-			Expect(d.IsTokenValid()).To(BeFalse())
-		})
-
-		It("should return true when token is valid and not near expiry", func() {
-			parentDeps.SetJWT("some-token", time.Now().Add(10*time.Minute))
-			Expect(d.IsTokenValid()).To(BeTrue())
-		})
-	})
-
 	Describe("CheckAndClearOnReset", func() {
 		var d *pull.PullDependencies
 
@@ -345,17 +311,6 @@ var _ = Describe("PullDependencies", func() {
 				newMt := &mockTransport{}
 				parentDeps.SetTransport(newMt)
 				Expect(d.GetTransport()).To(Equal(newMt))
-			})
-		})
-
-		Describe("GetJWTToken", func() {
-			It("should return empty when parent has no token", func() {
-				Expect(d.GetJWTToken()).To(BeEmpty())
-			})
-
-			It("should reflect parent JWT changes", func() {
-				parentDeps.SetJWT("test-token", time.Now().Add(time.Hour))
-				Expect(d.GetJWTToken()).To(Equal("test-token"))
 			})
 		})
 

--- a/umh-core/pkg/fsmv2/workers/transport/pull/snapshot/snapshot.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/snapshot/snapshot.go
@@ -29,7 +29,6 @@ type PullDependencies interface {
 	GetInboundChan() chan<- *types.UMHMessage
 	GetInboundChanStats() (capacity int, length int)
 	GetTransport() types.Transport
-	GetJWTToken() string
 	RecordTypedError(errType types.ErrorType, retryAfter time.Duration)
 	RecordSuccess()
 	RecordError()
@@ -43,8 +42,6 @@ type PullDependencies interface {
 
 	IsBackpressured() bool
 	SetBackpressured(v bool)
-
-	IsTokenValid() bool
 
 	GetResetGeneration() uint64
 	CheckAndClearOnReset() bool

--- a/umh-core/pkg/fsmv2/workers/transport/pull/snapshot/snapshot.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/snapshot/snapshot.go
@@ -56,7 +56,8 @@ type PullDependencies interface {
 
 // PullDesiredState represents the target configuration for the pull worker.
 type PullDesiredState struct {
-	State string `json:"state" yaml:"state"`
+	AuthSession types.AuthSession `json:"auth_session,omitempty" yaml:"auth_session,omitempty"`
+	State       string            `json:"state" yaml:"state"`
 	config.BaseDesiredState
 }
 

--- a/umh-core/pkg/fsmv2/workers/transport/pull/snapshot/snapshot.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/snapshot/snapshot.go
@@ -59,7 +59,9 @@ type PullDesiredState struct {
 }
 
 // GetState returns the desired lifecycle state, defaulting to "running" if empty.
-// For pull workers this is propagated from the parent's user spec.
+// Pull is a leaf child whose lifecycle is gated by the parent transport worker via
+// the Disabled bit, not by its own State. The transport worker therefore leaves State
+// unset when constructing PullDesiredState, and GetState defaults to running.
 func (s *PullDesiredState) GetState() string {
 	if s.State == "" {
 		return config.DesiredStateRunning

--- a/umh-core/pkg/fsmv2/workers/transport/pull/snapshot/snapshot.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/snapshot/snapshot.go
@@ -57,7 +57,7 @@ type PullDependencies interface {
 // PullDesiredState represents the target configuration for the pull worker.
 type PullDesiredState struct {
 	AuthSession types.AuthSession `json:"auth_session,omitempty" yaml:"auth_session,omitempty"`
-	State       string            `json:"state" yaml:"state"`
+	State       string            `json:"state"                  yaml:"state"`
 	config.BaseDesiredState
 }
 

--- a/umh-core/pkg/fsmv2/workers/transport/pull/state/state_degraded.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/state/state_degraded.go
@@ -66,7 +66,9 @@ func (s *DegradedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 					backoffDelay.Round(time.Second)), nil)
 		}
 
-		return fsmv2.Transition(s, fsmv2.SignalNone, &action.PullAction{},
+		return fsmv2.Transition(s, fsmv2.SignalNone, &action.PullAction{
+			JWTToken: snap.Config.AuthSession.Token,
+		},
 			fmt.Sprintf("degraded (%d consecutive errors, %d pending), still pulling",
 				snap.Status.ConsecutiveErrors, snap.Status.PendingMessageCount), nil)
 	}

--- a/umh-core/pkg/fsmv2/workers/transport/pull/state/state_running.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/state/state_running.go
@@ -58,7 +58,9 @@ func (s *RunningState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	}
 
 	if snap.Status.HasTransport && snap.Status.HasValidToken {
-		return fsmv2.Transition(s, fsmv2.SignalNone, &action.PullAction{}, "pulling messages (transport and token available)", nil)
+		return fsmv2.Transition(s, fsmv2.SignalNone, &action.PullAction{
+			JWTToken: snap.Config.AuthSession.Token,
+		}, "pulling messages (transport and token available)", nil)
 	}
 
 	return fsmv2.Transition(s, fsmv2.SignalNone, nil,

--- a/umh-core/pkg/fsmv2/workers/transport/pull/state/state_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/state/state_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/config"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/pull/action"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/pull/snapshot"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/pull/state"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/types"
@@ -102,6 +103,83 @@ func makeSnapshotWithBackoff(
 		},
 	}
 }
+
+func makeSnapshotWithAuthSession(authSession types.AuthSession) fsmv2.Snapshot {
+	desired := &fsmv2.WrappedDesiredState[snapshot.PullDesiredState]{
+		Config: snapshot.PullDesiredState{
+			BaseDesiredState: config.BaseDesiredState{},
+			AuthSession:      authSession,
+		},
+		BaseDesiredState: config.BaseDesiredState{},
+	}
+
+	obs := fsmv2.Observation[snapshot.PullStatus]{
+		Status: snapshot.PullStatus{
+			HasTransport:  true,
+			HasValidToken: true,
+		},
+	}
+
+	return fsmv2.Snapshot{
+		Observed: obs,
+		Desired:  desired,
+		Identity: deps.Identity{
+			ID:         "test-pull-worker",
+			Name:       "pull",
+			WorkerType: "pull",
+		},
+	}
+}
+
+var _ = Describe("RunningState AuthSession threading", func() {
+	It("should carry Token from snap.Config.AuthSession into PullAction", func() {
+		snap := makeSnapshotWithAuthSession(types.AuthSession{
+			Token:        "jwt",
+			InstanceUUID: "u",
+		})
+
+		result := (&state.RunningState{}).Next(snap)
+
+		Expect(result.Action).NotTo(BeNil())
+		pullAction, ok := result.Action.(*action.PullAction)
+		Expect(ok).To(BeTrue(), "expected *action.PullAction but got %T", result.Action)
+		Expect(pullAction.JWTToken).To(Equal("jwt"))
+	})
+
+	It("should carry Token from snap.Config.AuthSession into PullAction from DegradedState", func() {
+		snap := makeSnapshotWithAuthSession(types.AuthSession{
+			Token:        "degraded-jwt",
+			InstanceUUID: "u",
+		})
+		// Inject consecutive errors so DegradedState skips the backoff wait
+		desired := snap.Desired.(*fsmv2.WrappedDesiredState[snapshot.PullDesiredState])
+		obs := fsmv2.Observation[snapshot.PullStatus]{
+			Status: snapshot.PullStatus{
+				HasTransport:      true,
+				HasValidToken:     true,
+				ConsecutiveErrors: 1,
+				// DegradedEnteredAt zero → shouldWait=false → action is dispatched
+				DegradedEnteredAt: time.Time{},
+			},
+		}
+		snap = fsmv2.Snapshot{
+			Observed: obs,
+			Desired:  desired,
+			Identity: deps.Identity{
+				ID:         "test-pull-worker",
+				Name:       "pull",
+				WorkerType: "pull",
+			},
+		}
+
+		result := (&state.DegradedState{}).Next(snap)
+
+		Expect(result.Action).NotTo(BeNil())
+		pullAction, ok := result.Action.(*action.PullAction)
+		Expect(ok).To(BeTrue(), "expected *action.PullAction but got %T", result.Action)
+		Expect(pullAction.JWTToken).To(Equal("degraded-jwt"))
+	})
+})
 
 var _ = Describe("StoppedState", func() {
 	var s *state.StoppedState

--- a/umh-core/pkg/fsmv2/workers/transport/pull/userspec.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/userspec.go
@@ -16,10 +16,12 @@ package pull
 
 import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/config"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/types"
 )
 
 // PullUserSpec defines the typed configuration for the pull worker.
-// PullWorker config comes from parent TransportWorker, so this is minimal.
+// ChildAuthUserSpec carries the AuthSession stamped by the parent transport worker.
 type PullUserSpec struct {
-	config.BaseUserSpec `yaml:",inline"`
+	config.BaseUserSpec     `yaml:",inline"`
+	types.ChildAuthUserSpec `yaml:",inline"`
 }

--- a/umh-core/pkg/fsmv2/workers/transport/pull/userspec.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/userspec.go
@@ -19,8 +19,8 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/types"
 )
 
-// PullUserSpec defines the typed configuration for the pull worker.
-// ChildAuthUserSpec carries the AuthSession stamped by the parent transport worker.
+// PullUserSpec defines the typed configuration for the pull worker. It embeds
+// ChildAuthUserSpec to carry the AuthSession set by the parent transport worker.
 type PullUserSpec struct {
 	config.BaseUserSpec     `yaml:",inline"`
 	types.ChildAuthUserSpec `yaml:",inline"`

--- a/umh-core/pkg/fsmv2/workers/transport/pull/worker.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/worker.go
@@ -128,14 +128,16 @@ func (w *PullWorker) DeriveDesiredState(spec interface{}) (fsmv2.DesiredState, e
 		Variables: userSpec.Variables,
 	}
 
-	// Parse to validate the rendered config. The pull worker carries no
-	// lifecycle State of its own: it is a leaf child gated by the parent via
-	// Enabled/IsDisabled and routes lifecycle through snap.ShouldStop().
-	if _, err := config.ParseUserSpec[PullUserSpec](renderedSpec); err != nil {
+	// Parse the rendered config to validate it and extract the AuthSession
+	// stamped by the parent transport worker.
+	parsed, err := config.ParseUserSpec[PullUserSpec](renderedSpec)
+	if err != nil {
 		return nil, err
 	}
 
-	return &fsmv2.WrappedDesiredState[snapshot.PullDesiredState]{}, nil
+	return &fsmv2.WrappedDesiredState[snapshot.PullDesiredState]{
+		Config: snapshot.PullDesiredState{AuthSession: parsed.AuthSession},
+	}, nil
 }
 
 // GetInitialState returns StoppedState as the pull worker's initial FSM state.

--- a/umh-core/pkg/fsmv2/workers/transport/pull/worker.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/worker.go
@@ -26,7 +26,6 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/register"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/pull/snapshot"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/pull/state"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/types"
 
 	transport_pkg "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport"
 )
@@ -100,7 +99,7 @@ func (w *PullWorker) CollectObservedState(ctx context.Context, desired fsmv2.Des
 
 	status := snapshot.PullStatus{
 		HasTransport:        d.GetTransport() != nil,
-		HasValidToken:       authSessionValid(cfg.AuthSession),
+		HasValidToken:       cfg.AuthSession.IsUsable(time.Minute),
 		IsBackpressured:     d.IsBackpressured(),
 		ConsecutiveErrors:   d.GetConsecutiveErrors(),
 		PendingMessageCount: d.PendingMessageCount(),
@@ -111,16 +110,6 @@ func (w *PullWorker) CollectObservedState(ctx context.Context, desired fsmv2.Des
 	}
 
 	return fsmv2.NewObservation(status), nil
-}
-
-// authSessionValid mirrors the former child IsTokenValid check: a token is usable
-// when present and not within the 1-minute child safety buffer of expiry.
-func authSessionValid(a types.AuthSession) bool {
-	if a.Token == "" || a.Expiry.IsZero() {
-		return false
-	}
-
-	return !time.Now().Add(time.Minute).After(a.Expiry)
 }
 
 // DeriveDesiredState determines the desired state from the provided spec.

--- a/umh-core/pkg/fsmv2/workers/transport/pull/worker.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/worker.go
@@ -134,8 +134,6 @@ func (w *PullWorker) DeriveDesiredState(spec interface{}) (fsmv2.DesiredState, e
 		Variables: userSpec.Variables,
 	}
 
-	// Parse the rendered config to validate it and extract the AuthSession
-	// stamped by the parent transport worker.
 	parsed, err := config.ParseUserSpec[PullUserSpec](renderedSpec)
 	if err != nil {
 		return nil, err

--- a/umh-core/pkg/fsmv2/workers/transport/pull/worker.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/worker.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/config"
@@ -25,6 +26,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/register"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/pull/snapshot"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/pull/state"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/types"
 
 	transport_pkg "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport"
 )
@@ -82,7 +84,7 @@ func (w *PullWorker) GetDependencies() *PullDependencies {
 // CollectObservedState snapshots the current pull worker state.
 // Returns NewObservation; the collector handles CollectedAt, framework metrics,
 // action history, and metric accumulation automatically.
-func (w *PullWorker) CollectObservedState(ctx context.Context, _ fsmv2.DesiredState) (fsmv2.ObservedState, error) {
+func (w *PullWorker) CollectObservedState(ctx context.Context, desired fsmv2.DesiredState) (fsmv2.ObservedState, error) {
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()
@@ -91,9 +93,14 @@ func (w *PullWorker) CollectObservedState(ctx context.Context, _ fsmv2.DesiredSt
 
 	d := w.GetDependencies()
 
+	var cfg snapshot.PullDesiredState
+	if desired != nil {
+		cfg = fsmv2.ExtractConfig[snapshot.PullDesiredState](desired)
+	}
+
 	status := snapshot.PullStatus{
 		HasTransport:        d.GetTransport() != nil,
-		HasValidToken:       d.IsTokenValid(),
+		HasValidToken:       authSessionValid(cfg.AuthSession),
 		IsBackpressured:     d.IsBackpressured(),
 		ConsecutiveErrors:   d.GetConsecutiveErrors(),
 		PendingMessageCount: d.PendingMessageCount(),
@@ -104,6 +111,16 @@ func (w *PullWorker) CollectObservedState(ctx context.Context, _ fsmv2.DesiredSt
 	}
 
 	return fsmv2.NewObservation(status), nil
+}
+
+// authSessionValid mirrors the former child IsTokenValid check: a token is usable
+// when present and not within the 1-minute child safety buffer of expiry.
+func authSessionValid(a types.AuthSession) bool {
+	if a.Token == "" || a.Expiry.IsZero() {
+		return false
+	}
+
+	return !time.Now().Add(time.Minute).After(a.Expiry)
 }
 
 // DeriveDesiredState determines the desired state from the provided spec.

--- a/umh-core/pkg/fsmv2/workers/transport/pull/worker_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/worker_test.go
@@ -130,16 +130,43 @@ var _ = Describe("PullWorker", func() {
 			Expect(typedObs.Status.HasTransport).To(BeTrue())
 		})
 
-		It("should report JWT token availability from parent deps", func() {
-			parentDeps.SetJWT("test-token", time.Now().Add(time.Hour))
-
+		It("HasValidToken is true when the desired AuthSession token is present and unexpired", func() {
+			desired := &fsmv2.WrappedDesiredState[snapshot.PullDesiredState]{
+				Config: snapshot.PullDesiredState{AuthSession: types.AuthSession{Token: "t", Expiry: time.Now().Add(time.Hour)}},
+			}
 			ctx := context.Background()
-			observed, err := worker.CollectObservedState(ctx, nil)
+			observed, err := worker.CollectObservedState(ctx, desired)
 
 			Expect(err).ToNot(HaveOccurred())
 			typedObs, ok := observed.(fsmv2.Observation[snapshot.PullStatus])
 			Expect(ok).To(BeTrue())
 			Expect(typedObs.Status.HasValidToken).To(BeTrue())
+		})
+
+		It("HasValidToken is false when the desired AuthSession token is expired", func() {
+			desired := &fsmv2.WrappedDesiredState[snapshot.PullDesiredState]{
+				Config: snapshot.PullDesiredState{AuthSession: types.AuthSession{Token: "expired-token", Expiry: time.Now().Add(-1 * time.Hour)}},
+			}
+			ctx := context.Background()
+			observed, err := worker.CollectObservedState(ctx, desired)
+
+			Expect(err).ToNot(HaveOccurred())
+			typedObs, ok := observed.(fsmv2.Observation[snapshot.PullStatus])
+			Expect(ok).To(BeTrue())
+			Expect(typedObs.Status.HasValidToken).To(BeFalse())
+		})
+
+		It("HasValidToken is false when the desired AuthSession token is empty", func() {
+			desired := &fsmv2.WrappedDesiredState[snapshot.PullDesiredState]{
+				Config: snapshot.PullDesiredState{AuthSession: types.AuthSession{Token: "", Expiry: time.Now().Add(time.Hour)}},
+			}
+			ctx := context.Background()
+			observed, err := worker.CollectObservedState(ctx, desired)
+
+			Expect(err).ToNot(HaveOccurred())
+			typedObs, ok := observed.(fsmv2.Observation[snapshot.PullStatus])
+			Expect(ok).To(BeTrue())
+			Expect(typedObs.Status.HasValidToken).To(BeFalse())
 		})
 
 		It("should report consecutive errors from child deps", func() {

--- a/umh-core/pkg/fsmv2/workers/transport/pull/worker_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/worker_test.go
@@ -20,6 +20,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"gopkg.in/yaml.v3"
+
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	fsmv2config "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/config"
 	depspkg "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
@@ -28,6 +30,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/pull"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/pull/snapshot"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/pull/state"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/types"
 )
 
 var _ fsmv2.Worker = (*pull.PullWorker)(nil)
@@ -249,6 +252,28 @@ var _ = Describe("PullWorker", func() {
 
 			_, err := worker.DeriveDesiredState(spec)
 			Expect(err).To(HaveOccurred())
+		})
+
+		It("should bind AuthSession from parsed ChildAuthUserSpec into PullDesiredState", func() {
+			carrier := types.ChildAuthUserSpec{
+				AuthSession: types.AuthSession{
+					Token: "test-token-pull",
+				},
+			}
+			raw, err := yaml.Marshal(carrier)
+			Expect(err).ToNot(HaveOccurred())
+
+			spec := fsmv2config.UserSpec{
+				Config:    string(raw),
+				Variables: fsmv2config.VariableBundle{},
+			}
+
+			desired, err := worker.DeriveDesiredState(spec)
+
+			Expect(err).ToNot(HaveOccurred())
+			typed, ok := desired.(*fsmv2.WrappedDesiredState[snapshot.PullDesiredState])
+			Expect(ok).To(BeTrue())
+			Expect(typed.Config.AuthSession.Token).To(Equal("test-token-pull"))
 		})
 	})
 

--- a/umh-core/pkg/fsmv2/workers/transport/push/action/push.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/action/push.go
@@ -27,7 +27,10 @@ import (
 
 const PushActionName = "push"
 
-type PushAction struct{}
+type PushAction struct {
+	JWTToken     string
+	InstanceUUID string
+}
 
 func (a *PushAction) Execute(ctx context.Context, depsAny any) error {
 	select {
@@ -39,10 +42,6 @@ func (a *PushAction) Execute(ctx context.Context, depsAny any) error {
 	pushDeps, ok := depsAny.(snapshot.PushDependencies)
 	if !ok {
 		return errors.New("invalid dependencies type: expected PushDependencies")
-	}
-
-	if !pushDeps.IsTokenValid() {
-		return errors.New("token not valid, skipping push")
 	}
 
 	t := pushDeps.GetTransport()
@@ -112,8 +111,8 @@ drainLoop:
 		return nil
 	}
 
-	jwtToken := pushDeps.GetJWTToken()
-	authenticatedUUID := pushDeps.GetAuthenticatedUUID()
+	jwtToken := a.JWTToken
+	authenticatedUUID := a.InstanceUUID
 
 	for _, msg := range messagesToPush {
 		if msg != nil && authenticatedUUID != "" {
@@ -191,8 +190,8 @@ drainLoop:
 // returns the unsent tail of pending so the caller can buffer them for
 // the next tick.
 func (a *PushAction) retryPending(ctx context.Context, t types.Transport, pushDeps snapshot.PushDependencies, pending []*types.UMHMessage, metrics *depspkg.MetricsRecorder) ([]*types.UMHMessage, error) {
-	jwtToken := pushDeps.GetJWTToken()
-	authenticatedUUID := pushDeps.GetAuthenticatedUUID()
+	jwtToken := a.JWTToken
+	authenticatedUUID := a.InstanceUUID
 
 	for i, msg := range pending {
 		if msg == nil {

--- a/umh-core/pkg/fsmv2/workers/transport/push/action/push.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/action/push.go
@@ -27,6 +27,17 @@ import (
 
 const PushActionName = "push"
 
+// PushAction carries the JWT and instance UUID for one push attempt.
+//
+// Precondition: JWTToken is non-empty. The dispatching state validates it:
+// RunningState and DegradedState only emit a PushAction when
+// snap.Status.HasTransport && snap.Status.HasValidToken is true
+// (state_running.go, state_degraded.go), so
+// Execute never runs with an empty token in production. Do not construct a
+// PushAction outside that gate. There is intentionally no in-action
+// revalidation: an action reaching Execute with an empty token would mean the
+// dispatch gate regressed, and that should surface rather than be silently
+// turned into a no-op.
 type PushAction struct {
 	JWTToken     string
 	InstanceUUID string

--- a/umh-core/pkg/fsmv2/workers/transport/push/action/push_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/action/push_test.go
@@ -355,17 +355,18 @@ var _ = Describe("PushAction", func() {
 		})
 	})
 
-	Describe("Token pre-check", func() {
-		It("should skip push when token is invalid (without draining)", func() {
+	Describe("Token threading (no in-action pre-check)", func() {
+		It("should use JWTToken from action struct field, not from deps", func() {
+			// The State gates on HasValidToken before dispatching; the action
+			// trusts its own field and never calls deps.IsTokenValid.
+			act.JWTToken = "struct-jwt"
 			outboundBi <- &types.UMHMessage{Content: "msg1"}
-			mockDeps.tokenValid = false
 
 			err := act.Execute(context.Background(), mockDeps)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("token not valid"))
+			Expect(err).NotTo(HaveOccurred())
 
-			Expect(mockTrans.pushCallCount).To(Equal(0))
-			Expect(outboundBi).To(HaveLen(1))
+			Expect(mockTrans.pushCallCount).To(Equal(1))
+			Expect(mockTrans.pushedMsgs).To(HaveLen(1))
 		})
 	})
 
@@ -748,10 +749,11 @@ var _ = Describe("PushAction", func() {
 	})
 
 	Describe("UUID consistency (403 prevention)", func() {
-		It("should overwrite message InstanceUUID with authenticated UUID from dependencies", func() {
+		It("should overwrite message InstanceUUID with authenticated UUID from action struct field", func() {
 			// Scenario: SubscriberHandler created messages with placeholder UUID before
 			// authentication completed. The backend validates JWT claims match message UUID.
 			// If they don't match → 403 Forbidden.
+			// The State sets act.InstanceUUID from snap.Config.AuthSession.InstanceUUID.
 			placeholderUUID := "placeholder-uuid-before-auth"
 			authenticatedUUID := "real-uuid-from-backend-jwt"
 
@@ -761,7 +763,7 @@ var _ = Describe("PushAction", func() {
 				Email:        "user@example.com",
 			}
 
-			mockDeps.authenticatedUUID = authenticatedUUID
+			act.InstanceUUID = authenticatedUUID
 
 			err := act.Execute(context.Background(), mockDeps)
 			Expect(err).NotTo(HaveOccurred())
@@ -780,7 +782,7 @@ var _ = Describe("PushAction", func() {
 				{InstanceUUID: placeholderUUID, Content: "pending1"},
 				{InstanceUUID: placeholderUUID, Content: "pending2"},
 			}
-			mockDeps.authenticatedUUID = authenticatedUUID
+			act.InstanceUUID = authenticatedUUID
 
 			err := act.Execute(context.Background(), mockDeps)
 			Expect(err).NotTo(HaveOccurred())

--- a/umh-core/pkg/fsmv2/workers/transport/push/action/push_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/action/push_test.go
@@ -29,11 +29,11 @@ import (
 )
 
 type mockTransport struct {
-	pushErr        error
-	pushCallCount  int
-	pushedMsgs     []*types.UMHMessage
-	capturedToken  string
-	pushFunc       func(ctx context.Context, jwtToken string, messages []*types.UMHMessage) error
+	pushErr       error
+	pushCallCount int
+	pushedMsgs    []*types.UMHMessage
+	capturedToken string
+	pushFunc      func(ctx context.Context, jwtToken string, messages []*types.UMHMessage) error
 }
 
 func (m *mockTransport) Authenticate(_ context.Context, _ types.AuthRequest) (types.AuthResponse, error) {
@@ -63,7 +63,6 @@ func (m *mockTransport) Reset() {}
 type mockPushDeps struct {
 	outboundChan    <-chan *types.UMHMessage
 	transport       types.Transport
-	jwtToken        string
 	metricsRecorder *deps.MetricsRecorder
 	logger          deps.FSMLogger
 
@@ -74,13 +73,11 @@ type mockPushDeps struct {
 	lastErrorType         types.ErrorType
 
 	pendingMessages   []*types.UMHMessage
-	tokenValid        bool
 	resetGeneration   uint64
 	resetCleared      bool
 	lastRetryAfter    time.Duration
 	degradedEnteredAt time.Time
 	lastErrorAt       time.Time
-	authenticatedUUID string
 }
 
 type typedErrorCall struct {
@@ -92,7 +89,6 @@ func newMockPushDeps() *mockPushDeps {
 	return &mockPushDeps{
 		metricsRecorder: deps.NewMetricsRecorder(),
 		logger:          deps.NewNopFSMLogger(),
-		tokenValid:      true,
 	}
 }
 
@@ -122,10 +118,6 @@ func (m *mockPushDeps) GetOutboundChan() <-chan *types.UMHMessage {
 
 func (m *mockPushDeps) GetTransport() types.Transport {
 	return m.transport
-}
-
-func (m *mockPushDeps) GetJWTToken() string {
-	return m.jwtToken
 }
 
 func (m *mockPushDeps) RecordTypedError(errType types.ErrorType, retryAfter time.Duration) {
@@ -170,10 +162,6 @@ func (m *mockPushDeps) PendingMessageCount() int {
 	return len(m.pendingMessages)
 }
 
-func (m *mockPushDeps) IsTokenValid() bool {
-	return m.tokenValid
-}
-
 func (m *mockPushDeps) GetResetGeneration() uint64 {
 	return m.resetGeneration
 }
@@ -201,10 +189,6 @@ func (m *mockPushDeps) GetLastErrorAt() time.Time {
 	return m.lastErrorAt
 }
 
-func (m *mockPushDeps) GetAuthenticatedUUID() string {
-	return m.authenticatedUUID
-}
-
 var _ = Describe("PushAction", func() {
 	var (
 		act        *action.PushAction
@@ -220,7 +204,6 @@ var _ = Describe("PushAction", func() {
 		mockDeps = newMockPushDeps()
 		mockDeps.outboundChan = outboundBi
 		mockDeps.transport = mockTrans
-		mockDeps.jwtToken = "test-jwt"
 	})
 
 	Describe("Successful push", func() {

--- a/umh-core/pkg/fsmv2/workers/transport/push/action/push_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/action/push_test.go
@@ -29,10 +29,11 @@ import (
 )
 
 type mockTransport struct {
-	pushErr       error
-	pushCallCount int
-	pushedMsgs    []*types.UMHMessage
-	pushFunc      func(ctx context.Context, jwtToken string, messages []*types.UMHMessage) error
+	pushErr        error
+	pushCallCount  int
+	pushedMsgs     []*types.UMHMessage
+	capturedToken  string
+	pushFunc       func(ctx context.Context, jwtToken string, messages []*types.UMHMessage) error
 }
 
 func (m *mockTransport) Authenticate(_ context.Context, _ types.AuthRequest) (types.AuthResponse, error) {
@@ -46,6 +47,7 @@ func (m *mockTransport) Pull(_ context.Context, _ string) ([]*types.UMHMessage, 
 func (m *mockTransport) Push(ctx context.Context, jwtToken string, messages []*types.UMHMessage) error {
 	m.pushCallCount++
 	m.pushedMsgs = messages
+	m.capturedToken = jwtToken
 
 	if m.pushFunc != nil {
 		return m.pushFunc(ctx, jwtToken, messages)
@@ -367,6 +369,8 @@ var _ = Describe("PushAction", func() {
 
 			Expect(mockTrans.pushCallCount).To(Equal(1))
 			Expect(mockTrans.pushedMsgs).To(HaveLen(1))
+			// The token set on the action struct must reach the transport.
+			Expect(mockTrans.capturedToken).To(Equal("struct-jwt"))
 		})
 	})
 
@@ -806,14 +810,15 @@ var _ = Describe("PushAction", func() {
 				Email:        "user@example.com",
 			}
 
-			mockDeps.authenticatedUUID = "" // Empty - authentication not complete
+			// act.InstanceUUID is "" by default — authentication not complete.
+			// The action skips UUID overwrite when InstanceUUID is empty.
 
 			err := act.Execute(context.Background(), mockDeps)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(mockTrans.pushCallCount).To(Equal(1))
 			Expect(mockTrans.pushedMsgs).To(HaveLen(1))
-			// Original UUID should be preserved when authenticatedUUID is empty
+			// Original UUID should be preserved when InstanceUUID is empty
 			Expect(mockTrans.pushedMsgs[0].InstanceUUID).To(Equal(originalUUID))
 		})
 	})

--- a/umh-core/pkg/fsmv2/workers/transport/push/dependencies.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/dependencies.go
@@ -80,16 +80,6 @@ func (d *PushDependencies) GetTransport() types.Transport {
 	return d.parentDeps.GetTransport()
 }
 
-// GetJWTToken returns the parent's current JWT token.
-func (d *PushDependencies) GetJWTToken() string {
-	return d.parentDeps.GetJWTToken()
-}
-
-// GetAuthenticatedUUID returns the parent's currently authenticated instance UUID.
-func (d *PushDependencies) GetAuthenticatedUUID() string {
-	return d.parentDeps.GetAuthenticatedUUID()
-}
-
 // RecordTypedError records a typed error for this child, propagates it to the parent
 // transport tracker, and emits a Sentry warning when the failure rate escalates.
 func (d *PushDependencies) RecordTypedError(errType types.ErrorType, retryAfter time.Duration) {
@@ -185,24 +175,6 @@ func (d *PushDependencies) PendingMessageCount() int {
 	defer d.pendingMu.RUnlock()
 
 	return len(d.pendingMessages)
-}
-
-// IsTokenValid reports whether the JWT token exists and has not expired
-// (with a 1-minute safety buffer).
-func (d *PushDependencies) IsTokenValid() bool {
-	token := d.parentDeps.GetJWTToken()
-	if token == "" {
-		return false
-	}
-
-	expiry := d.parentDeps.GetJWTExpiry()
-	if expiry.IsZero() {
-		return false
-	}
-
-	const safetyBuffer = 1 * time.Minute
-
-	return !time.Now().Add(safetyBuffer).After(expiry)
 }
 
 // GetLastRetryAfter returns the retry-after duration from the most recent error.

--- a/umh-core/pkg/fsmv2/workers/transport/push/dependencies_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/dependencies_test.go
@@ -140,17 +140,6 @@ var _ = Describe("PushDependencies", func() {
 			})
 		})
 
-		Describe("GetJWTToken", func() {
-			It("should return empty when parent has no token", func() {
-				Expect(d.GetJWTToken()).To(BeEmpty())
-			})
-
-			It("should reflect parent JWT changes", func() {
-				parentDeps.SetJWT("test-token", time.Now().Add(time.Hour))
-				Expect(d.GetJWTToken()).To(Equal("test-token"))
-			})
-		})
-
 		Describe("RecordTypedError", func() {
 			It("should record on both child and parent", func() {
 				d.RecordTypedError(types.ErrorTypeBackendRateLimit, 30*time.Second)
@@ -294,30 +283,6 @@ var _ = Describe("PushDependencies", func() {
 
 			drained := d.MetricsRecorder().Drain()
 			Expect(drained.Counters[string(deps.CounterMessagesDropped)]).To(Equal(int64(5)))
-		})
-	})
-
-	Describe("IsTokenValid", func() {
-		var d *push.PushDependencies
-
-		BeforeEach(func() {
-			var err error
-			d, err = push.NewPushDependencies(parentDeps, deps.NewBaseDependencies(logger, nil, identity))
-			Expect(err).NotTo(HaveOccurred())
-		})
-
-		It("should return false when token is empty", func() {
-			Expect(d.IsTokenValid()).To(BeFalse())
-		})
-
-		It("should return false when token is expired", func() {
-			parentDeps.SetJWT("expired-token", time.Now().Add(-1*time.Hour))
-			Expect(d.IsTokenValid()).To(BeFalse())
-		})
-
-		It("should return true when token is valid and not near expiry", func() {
-			parentDeps.SetJWT("good-token", time.Now().Add(1*time.Hour))
-			Expect(d.IsTokenValid()).To(BeTrue())
 		})
 	})
 

--- a/umh-core/pkg/fsmv2/workers/transport/push/snapshot/snapshot.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/snapshot/snapshot.go
@@ -56,7 +56,8 @@ type PushDependencies interface {
 
 // PushDesiredState represents the target configuration for the push worker.
 type PushDesiredState struct {
-	State string `json:"state" yaml:"state"`
+	AuthSession types.AuthSession `json:"auth_session,omitempty" yaml:"auth_session,omitempty"`
+	State       string            `json:"state" yaml:"state"`
 	config.BaseDesiredState
 }
 

--- a/umh-core/pkg/fsmv2/workers/transport/push/snapshot/snapshot.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/snapshot/snapshot.go
@@ -57,7 +57,9 @@ type PushDesiredState struct {
 }
 
 // GetState returns the desired lifecycle state, defaulting to "running" if empty.
-// For push workers this is propagated from the parent's user spec.
+// Push is a leaf child whose lifecycle is gated by the parent transport worker via
+// the Disabled bit, not by its own State. The transport worker therefore leaves State
+// unset when constructing PushDesiredState, and GetState defaults to running.
 func (s *PushDesiredState) GetState() string {
 	if s.State == "" {
 		return config.DesiredStateRunning

--- a/umh-core/pkg/fsmv2/workers/transport/push/snapshot/snapshot.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/snapshot/snapshot.go
@@ -57,7 +57,7 @@ type PushDependencies interface {
 // PushDesiredState represents the target configuration for the push worker.
 type PushDesiredState struct {
 	AuthSession types.AuthSession `json:"auth_session,omitempty" yaml:"auth_session,omitempty"`
-	State       string            `json:"state" yaml:"state"`
+	State       string            `json:"state"                  yaml:"state"`
 	config.BaseDesiredState
 }
 

--- a/umh-core/pkg/fsmv2/workers/transport/push/snapshot/snapshot.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/snapshot/snapshot.go
@@ -27,8 +27,6 @@ type PushDependencies interface {
 	deps.Dependencies
 	GetOutboundChan() <-chan *types.UMHMessage
 	GetTransport() types.Transport
-	GetJWTToken() string
-	GetAuthenticatedUUID() string
 	RecordTypedError(errType types.ErrorType, retryAfter time.Duration)
 	RecordSuccess()
 	RecordError()
@@ -40,9 +38,6 @@ type PushDependencies interface {
 	StorePendingMessages(msgs []*types.UMHMessage)
 	DrainPendingMessages() []*types.UMHMessage
 	PendingMessageCount() int
-
-	// Token pre-check (1-minute safety buffer)
-	IsTokenValid() bool
 
 	// Parent transport reset detection
 	GetResetGeneration() uint64

--- a/umh-core/pkg/fsmv2/workers/transport/push/state/state_degraded.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/state/state_degraded.go
@@ -63,7 +63,10 @@ func (s *DegradedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 					backoffDelay.Round(time.Second)), nil)
 		}
 
-		return fsmv2.Transition(s, fsmv2.SignalNone, &action.PushAction{},
+		return fsmv2.Transition(s, fsmv2.SignalNone, &action.PushAction{
+			JWTToken:     snap.Config.AuthSession.Token,
+			InstanceUUID: snap.Config.AuthSession.InstanceUUID,
+		},
 			fmt.Sprintf("degraded (%d consecutive errors, %d pending), still pushing",
 				snap.Status.ConsecutiveErrors, snap.Status.PendingMessageCount), nil)
 	}

--- a/umh-core/pkg/fsmv2/workers/transport/push/state/state_running.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/state/state_running.go
@@ -53,7 +53,10 @@ func (s *RunningState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	}
 
 	if snap.Status.HasTransport && snap.Status.HasValidToken {
-		return fsmv2.Transition(s, fsmv2.SignalNone, &action.PushAction{}, "pushing messages (transport and token available)", nil)
+		return fsmv2.Transition(s, fsmv2.SignalNone, &action.PushAction{
+			JWTToken:     snap.Config.AuthSession.Token,
+			InstanceUUID: snap.Config.AuthSession.InstanceUUID,
+		}, "pushing messages (transport and token available)", nil)
 	}
 
 	return fsmv2.Transition(s, fsmv2.SignalNone, nil,

--- a/umh-core/pkg/fsmv2/workers/transport/push/state/state_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/state/state_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/config"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/push/action"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/push/snapshot"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/push/state"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/types"
@@ -102,6 +103,50 @@ func makeSnapshotWithBackoff(
 		},
 	}
 }
+
+func makeSnapshotWithAuthSession(authSession types.AuthSession) fsmv2.Snapshot {
+	desired := &fsmv2.WrappedDesiredState[snapshot.PushDesiredState]{
+		Config: snapshot.PushDesiredState{
+			BaseDesiredState: config.BaseDesiredState{},
+			AuthSession:      authSession,
+		},
+		BaseDesiredState: config.BaseDesiredState{},
+	}
+
+	obs := fsmv2.Observation[snapshot.PushStatus]{
+		Status: snapshot.PushStatus{
+			HasTransport:  true,
+			HasValidToken: true,
+		},
+	}
+
+	return fsmv2.Snapshot{
+		Observed: obs,
+		Desired:  desired,
+		Identity: deps.Identity{
+			ID:         "test-push-worker",
+			Name:       "push",
+			WorkerType: "push",
+		},
+	}
+}
+
+var _ = Describe("RunningState AuthSession threading", func() {
+	It("should carry Token and InstanceUUID from snap.Config.AuthSession into PushAction", func() {
+		snap := makeSnapshotWithAuthSession(types.AuthSession{
+			Token:        "jwt",
+			InstanceUUID: "u",
+		})
+
+		result := (&state.RunningState{}).Next(snap)
+
+		Expect(result.Action).NotTo(BeNil())
+		pushAction, ok := result.Action.(*action.PushAction)
+		Expect(ok).To(BeTrue(), "expected *action.PushAction but got %T", result.Action)
+		Expect(pushAction.JWTToken).To(Equal("jwt"))
+		Expect(pushAction.InstanceUUID).To(Equal("u"))
+	})
+})
 
 var _ = Describe("StoppedState", func() {
 	var s *state.StoppedState

--- a/umh-core/pkg/fsmv2/workers/transport/push/userspec.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/userspec.go
@@ -19,8 +19,8 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/types"
 )
 
-// PushUserSpec defines the typed configuration for the push worker.
-// ChildAuthUserSpec carries the AuthSession stamped by the parent transport worker.
+// PushUserSpec defines the typed configuration for the push worker. It embeds
+// ChildAuthUserSpec to carry the AuthSession set by the parent transport worker.
 type PushUserSpec struct {
 	config.BaseUserSpec     `yaml:",inline"`
 	types.ChildAuthUserSpec `yaml:",inline"`

--- a/umh-core/pkg/fsmv2/workers/transport/push/userspec.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/userspec.go
@@ -16,10 +16,12 @@ package push
 
 import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/config"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/types"
 )
 
 // PushUserSpec defines the typed configuration for the push worker.
-// PushWorker config comes from parent TransportWorker, so this is minimal.
+// ChildAuthUserSpec carries the AuthSession stamped by the parent transport worker.
 type PushUserSpec struct {
-	config.BaseUserSpec `yaml:",inline"`
+	config.BaseUserSpec     `yaml:",inline"`
+	types.ChildAuthUserSpec `yaml:",inline"`
 }

--- a/umh-core/pkg/fsmv2/workers/transport/push/worker.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/worker.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/config"
@@ -25,6 +26,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/register"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/push/snapshot"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/push/state"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/types"
 
 	transport_pkg "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport"
 )
@@ -82,7 +84,7 @@ func (w *PushWorker) GetDependencies() *PushDependencies {
 // CollectObservedState snapshots the current push worker state.
 // Returns NewObservation; the collector handles CollectedAt, framework metrics,
 // action history, and metric accumulation automatically.
-func (w *PushWorker) CollectObservedState(ctx context.Context, _ fsmv2.DesiredState) (fsmv2.ObservedState, error) {
+func (w *PushWorker) CollectObservedState(ctx context.Context, desired fsmv2.DesiredState) (fsmv2.ObservedState, error) {
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()
@@ -91,9 +93,14 @@ func (w *PushWorker) CollectObservedState(ctx context.Context, _ fsmv2.DesiredSt
 
 	d := w.GetDependencies()
 
+	var cfg snapshot.PushDesiredState
+	if desired != nil {
+		cfg = fsmv2.ExtractConfig[snapshot.PushDesiredState](desired)
+	}
+
 	status := snapshot.PushStatus{
 		HasTransport:        d.GetTransport() != nil,
-		HasValidToken:       d.IsTokenValid(),
+		HasValidToken:       authSessionValid(cfg.AuthSession),
 		ConsecutiveErrors:   d.GetConsecutiveErrors(),
 		PendingMessageCount: d.PendingMessageCount(),
 		LastErrorType:       d.GetLastErrorType(),
@@ -103,6 +110,16 @@ func (w *PushWorker) CollectObservedState(ctx context.Context, _ fsmv2.DesiredSt
 	}
 
 	return fsmv2.NewObservation(status), nil
+}
+
+// authSessionValid mirrors the former child IsTokenValid check: a token is usable
+// when present and not within the 1-minute child safety buffer of expiry.
+func authSessionValid(a types.AuthSession) bool {
+	if a.Token == "" || a.Expiry.IsZero() {
+		return false
+	}
+
+	return !time.Now().Add(time.Minute).After(a.Expiry)
 }
 
 // DeriveDesiredState determines the desired state from the provided spec.

--- a/umh-core/pkg/fsmv2/workers/transport/push/worker.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/worker.go
@@ -26,7 +26,6 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/register"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/push/snapshot"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/push/state"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/types"
 
 	transport_pkg "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport"
 )
@@ -100,7 +99,7 @@ func (w *PushWorker) CollectObservedState(ctx context.Context, desired fsmv2.Des
 
 	status := snapshot.PushStatus{
 		HasTransport:        d.GetTransport() != nil,
-		HasValidToken:       authSessionValid(cfg.AuthSession),
+		HasValidToken:       cfg.AuthSession.IsUsable(time.Minute),
 		ConsecutiveErrors:   d.GetConsecutiveErrors(),
 		PendingMessageCount: d.PendingMessageCount(),
 		LastErrorType:       d.GetLastErrorType(),
@@ -110,16 +109,6 @@ func (w *PushWorker) CollectObservedState(ctx context.Context, desired fsmv2.Des
 	}
 
 	return fsmv2.NewObservation(status), nil
-}
-
-// authSessionValid mirrors the former child IsTokenValid check: a token is usable
-// when present and not within the 1-minute child safety buffer of expiry.
-func authSessionValid(a types.AuthSession) bool {
-	if a.Token == "" || a.Expiry.IsZero() {
-		return false
-	}
-
-	return !time.Now().Add(time.Minute).After(a.Expiry)
 }
 
 // DeriveDesiredState determines the desired state from the provided spec.

--- a/umh-core/pkg/fsmv2/workers/transport/push/worker.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/worker.go
@@ -128,14 +128,16 @@ func (w *PushWorker) DeriveDesiredState(spec interface{}) (fsmv2.DesiredState, e
 		Variables: userSpec.Variables,
 	}
 
-	// Parse to validate the rendered config. The push worker carries no
-	// lifecycle State of its own: it is a leaf child gated by the parent via
-	// Enabled/IsDisabled and routes lifecycle through snap.ShouldStop().
-	if _, err := config.ParseUserSpec[PushUserSpec](renderedSpec); err != nil {
+	// Parse the rendered config to validate it and extract the AuthSession
+	// stamped by the parent transport worker.
+	parsed, err := config.ParseUserSpec[PushUserSpec](renderedSpec)
+	if err != nil {
 		return nil, err
 	}
 
-	return &fsmv2.WrappedDesiredState[snapshot.PushDesiredState]{}, nil
+	return &fsmv2.WrappedDesiredState[snapshot.PushDesiredState]{
+		Config: snapshot.PushDesiredState{AuthSession: parsed.AuthSession},
+	}, nil
 }
 
 // GetInitialState returns StoppedState as the push worker's initial FSM state.

--- a/umh-core/pkg/fsmv2/workers/transport/push/worker.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/worker.go
@@ -134,8 +134,6 @@ func (w *PushWorker) DeriveDesiredState(spec interface{}) (fsmv2.DesiredState, e
 		Variables: userSpec.Variables,
 	}
 
-	// Parse the rendered config to validate it and extract the AuthSession
-	// stamped by the parent transport worker.
 	parsed, err := config.ParseUserSpec[PushUserSpec](renderedSpec)
 	if err != nil {
 		return nil, err

--- a/umh-core/pkg/fsmv2/workers/transport/push/worker_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/worker_test.go
@@ -130,11 +130,12 @@ var _ = Describe("PushWorker", func() {
 			Expect(typedObs.Status.HasTransport).To(BeTrue())
 		})
 
-		It("should report JWT token availability from parent deps", func() {
-			parentDeps.SetJWT("test-token", time.Now().Add(time.Hour))
-
+		It("HasValidToken is true when the desired AuthSession token is present and unexpired", func() {
+			desired := &fsmv2.WrappedDesiredState[snapshot.PushDesiredState]{
+				Config: snapshot.PushDesiredState{AuthSession: types.AuthSession{Token: "t", Expiry: time.Now().Add(time.Hour)}},
+			}
 			ctx := context.Background()
-			observed, err := worker.CollectObservedState(ctx, nil)
+			observed, err := worker.CollectObservedState(ctx, desired)
 
 			Expect(err).ToNot(HaveOccurred())
 			typedObs, ok := observed.(fsmv2.Observation[snapshot.PushStatus])
@@ -142,11 +143,25 @@ var _ = Describe("PushWorker", func() {
 			Expect(typedObs.Status.HasValidToken).To(BeTrue())
 		})
 
-		It("should report HasValidToken false for expired token", func() {
-			parentDeps.SetJWT("expired-token", time.Now().Add(-1*time.Hour))
-
+		It("HasValidToken is false when the desired AuthSession token is expired", func() {
+			desired := &fsmv2.WrappedDesiredState[snapshot.PushDesiredState]{
+				Config: snapshot.PushDesiredState{AuthSession: types.AuthSession{Token: "expired-token", Expiry: time.Now().Add(-1 * time.Hour)}},
+			}
 			ctx := context.Background()
-			observed, err := worker.CollectObservedState(ctx, nil)
+			observed, err := worker.CollectObservedState(ctx, desired)
+
+			Expect(err).ToNot(HaveOccurred())
+			typedObs, ok := observed.(fsmv2.Observation[snapshot.PushStatus])
+			Expect(ok).To(BeTrue())
+			Expect(typedObs.Status.HasValidToken).To(BeFalse())
+		})
+
+		It("HasValidToken is false when the desired AuthSession token is empty", func() {
+			desired := &fsmv2.WrappedDesiredState[snapshot.PushDesiredState]{
+				Config: snapshot.PushDesiredState{AuthSession: types.AuthSession{Token: "", Expiry: time.Now().Add(time.Hour)}},
+			}
+			ctx := context.Background()
+			observed, err := worker.CollectObservedState(ctx, desired)
 
 			Expect(err).ToNot(HaveOccurred())
 			typedObs, ok := observed.(fsmv2.Observation[snapshot.PushStatus])

--- a/umh-core/pkg/fsmv2/workers/transport/push/worker_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/worker_test.go
@@ -20,6 +20,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"gopkg.in/yaml.v3"
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	fsmv2config "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/config"
@@ -29,6 +30,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/push"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/push/snapshot"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/push/state"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/types"
 )
 
 var _ fsmv2.Worker = (*push.PushWorker)(nil)
@@ -232,6 +234,30 @@ var _ = Describe("PushWorker", func() {
 
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("invalid spec type"))
+		})
+
+		It("should bind AuthSession from parsed ChildAuthUserSpec into PushDesiredState", func() {
+			carrier := types.ChildAuthUserSpec{
+				AuthSession: types.AuthSession{
+					Token:        "test-token-push",
+					InstanceUUID: "inst-uuid-push",
+				},
+			}
+			raw, err := yaml.Marshal(carrier)
+			Expect(err).ToNot(HaveOccurred())
+
+			spec := fsmv2config.UserSpec{
+				Config:    string(raw),
+				Variables: fsmv2config.VariableBundle{},
+			}
+
+			desired, err := worker.DeriveDesiredState(spec)
+
+			Expect(err).ToNot(HaveOccurred())
+			typed, ok := desired.(*fsmv2.WrappedDesiredState[snapshot.PushDesiredState])
+			Expect(ok).To(BeTrue())
+			Expect(typed.Config.AuthSession.Token).To(Equal("test-token-push"))
+			Expect(typed.Config.AuthSession.InstanceUUID).To(Equal("inst-uuid-push"))
 		})
 	})
 

--- a/umh-core/pkg/fsmv2/workers/transport/snapshot/children.go
+++ b/umh-core/pkg/fsmv2/workers/transport/snapshot/children.go
@@ -21,9 +21,9 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/types"
 )
 
-// RenderChildren returns the push and pull ChildSpecs with the auth session stamped onto both.
-// status.AuthSession is embedded in a types.ChildAuthUserSpec carrier so push/pull can parse it
-// from their snapshot without reaching into parent dependencies.
+// RenderChildren returns the push and pull ChildSpecs with the auth session set on both.
+// status.AuthSession is embedded in a types.ChildAuthUserSpec carrier so push/pull can read it
+// from their own snapshot without accessing parent dependencies.
 //
 // enabled=false keeps both children resident in Stopped (not despawned).
 // They hold connection buffers and retry state.

--- a/umh-core/pkg/fsmv2/workers/transport/snapshot/children.go
+++ b/umh-core/pkg/fsmv2/workers/transport/snapshot/children.go
@@ -18,28 +18,25 @@ import (
 	"fmt"
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/config"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/types"
 )
 
-// RenderChildren returns the push and pull ChildSpecs.
-// Both carry an empty config.BaseUserSpec{} because their config arrives via
-// injected dependencies (JWT token, transport interface), not via UserSpec.
-//
-// We use BaseUserSpec{} directly instead of PushUserSpec{} / PullUserSpec{}
-// because importing those packages here would create an import cycle (both
-// import the top-level transport package, which imports this one). Both embed
-// only BaseUserSpec with no extra fields, so the YAML output is identical.
+// RenderChildren returns the push and pull ChildSpecs with the auth session stamped onto both.
+// status.AuthSession is embedded in a types.ChildAuthUserSpec carrier so push/pull can parse it
+// from their snapshot without reaching into parent dependencies.
 //
 // enabled=false keeps both children resident in Stopped (not despawned).
 // They hold connection buffers and retry state.
-func RenderChildren(cfg TransportDesiredState, enabled bool) ([]config.ChildSpec, error) {
+func RenderChildren(cfg TransportDesiredState, status TransportStatus, enabled bool) ([]config.ChildSpec, error) {
 	_ = cfg // cfg currently unused; retained for API consistency and future field mapping
+	carrier := types.ChildAuthUserSpec{AuthSession: status.AuthSession}
 
-	pushSpec, err := config.NewChildSpec("push", "push", config.BaseUserSpec{}, enabled)
+	pushSpec, err := config.NewChildSpec("push", "push", carrier, enabled)
 	if err != nil {
 		return nil, fmt.Errorf("transport RenderChildren: push: %w", err)
 	}
 
-	pullSpec, err := config.NewChildSpec("pull", "pull", config.BaseUserSpec{}, enabled)
+	pullSpec, err := config.NewChildSpec("pull", "pull", carrier, enabled)
 	if err != nil {
 		return nil, fmt.Errorf("transport RenderChildren: pull: %w", err)
 	}

--- a/umh-core/pkg/fsmv2/workers/transport/snapshot/snapshot.go
+++ b/umh-core/pkg/fsmv2/workers/transport/snapshot/snapshot.go
@@ -148,23 +148,21 @@ func (f FailedAuthConfig) IsEmpty() bool {
 }
 
 // TransportStatus holds the runtime observation data for the transport worker.
-// NOTE: JWTToken must NOT use json:"-" — the supervisor reconciliation loop
+// NOTE: AuthSession must NOT use json:"-" — the supervisor reconciliation loop
 // serializes observed state to CSE storage between ticks and deserializes it
-// via LoadObservedTyped(). Excluding JWTToken from JSON would force
+// via LoadObservedTyped(). Excluding AuthSession from JSON would force
 // re-authentication on every tick (~10ms), hammering the relay server.
-// TODO(security): JWTToken included in CSE sync payloads. ENG-4405 tracks
+// TODO(security): AuthSession included in CSE sync payloads. ENG-4405 tracks
 // adding a CSE secret tier to persist locally but exclude from delta sync.
 type TransportStatus struct {
-	JWTExpiry           time.Time        `json:"jwt_expiry,omitempty"`
-	LastAuthAttemptAt   time.Time        `json:"last_auth_attempt_at,omitempty"`
-	FailedAuthConfig    FailedAuthConfig `json:"failed_auth_config,omitempty"`
-	JWTToken            string           `json:"jwt_token,omitempty"`
-	AuthenticatedUUID   string           `json:"authenticated_uuid,omitempty"`
-	LastErrorType       types.ErrorType  `json:"last_error_type"`
-	LastRetryAfter      time.Duration    `json:"last_retry_after,omitempty"`
-	TotalMessagesPushed int64            `json:"total_messages_pushed"`
-	TotalMessagesPulled int64            `json:"total_messages_pulled"`
-	ConsecutiveErrors   int              `json:"consecutive_errors"`
+	AuthSession         types.AuthSession `json:"auth_session,omitempty"`
+	LastAuthAttemptAt   time.Time         `json:"last_auth_attempt_at,omitempty"`
+	FailedAuthConfig    FailedAuthConfig  `json:"failed_auth_config,omitempty"`
+	LastErrorType       types.ErrorType   `json:"last_error_type"`
+	LastRetryAfter      time.Duration     `json:"last_retry_after,omitempty"`
+	TotalMessagesPushed int64             `json:"total_messages_pushed"`
+	TotalMessagesPulled int64             `json:"total_messages_pulled"`
+	ConsecutiveErrors   int               `json:"consecutive_errors"`
 }
 
 // IsTokenExpired returns true if the JWT token is expired or will expire within 10 minutes.
@@ -176,16 +174,16 @@ type TransportStatus struct {
 // children well before their own 1-minute buffer would consider the token invalid.
 // The children's 1-minute buffer is a last-resort safety net for edge cases only.
 func (s TransportStatus) IsTokenExpired() bool {
-	if s.JWTExpiry.IsZero() {
+	if s.AuthSession.Expiry.IsZero() {
 		return false
 	}
 
 	const refreshBuffer = 10 * time.Minute
 
-	return time.Now().Add(refreshBuffer).After(s.JWTExpiry)
+	return time.Now().Add(refreshBuffer).After(s.AuthSession.Expiry)
 }
 
 // HasValidToken returns true if there is a valid JWT token that hasn't expired.
 func (s TransportStatus) HasValidToken() bool {
-	return s.JWTToken != "" && !s.IsTokenExpired()
+	return s.AuthSession.Token != "" && !s.IsTokenExpired()
 }

--- a/umh-core/pkg/fsmv2/workers/transport/snapshot/snapshot.go
+++ b/umh-core/pkg/fsmv2/workers/transport/snapshot/snapshot.go
@@ -154,6 +154,13 @@ func (f FailedAuthConfig) IsEmpty() bool {
 // The token also rides into the push/pull child UserSpec.Config via
 // RenderChildren stamping ChildAuthUserSpec, so a future CSE secret-tier scrub
 // must cover the parent status AND both child-config copies.
+//
+// Upgrade note: auth_session replaces the previously-flat CSE keys
+// (jwt_token / jwt_expiry / authenticated_uuid). State written by a prior
+// version carries the old flat keys, which will not load into this nested
+// field, so on the first post-upgrade tick the parent reads an empty
+// AuthSession and re-authenticates once. This one-time re-auth is intended and
+// self-healing; no consumer reads the old flat keys.
 type TransportStatus struct {
 	AuthSession         types.AuthSession `json:"auth_session"`
 	LastAuthAttemptAt   time.Time         `json:"last_auth_attempt_at,omitempty"`

--- a/umh-core/pkg/fsmv2/workers/transport/snapshot/snapshot.go
+++ b/umh-core/pkg/fsmv2/workers/transport/snapshot/snapshot.go
@@ -35,8 +35,6 @@ type TransportDependencies interface {
 
 	// JWT token management
 	SetJWT(token string, expiry time.Time)
-	GetJWTToken() string
-	GetJWTExpiry() time.Time
 
 	// Error tracking for intelligent backoff
 	RecordError()
@@ -54,7 +52,6 @@ type TransportDependencies interface {
 
 	// Instance identity from backend
 	SetAuthenticatedUUID(uuid string)
-	GetAuthenticatedUUID() string
 
 	// Reset generation for parent-level transport reset signaling to children
 	GetResetGeneration() uint64
@@ -171,11 +168,12 @@ type TransportStatus struct {
 // IsTokenExpired returns true if the JWT token is expired or will expire within 10 minutes.
 //
 // Token buffer architecture: the parent TransportWorker uses a 10-minute buffer (proactive
-// refresh trigger) while child workers (push/pull) use a 1-minute buffer via IsTokenValid().
-// The 9-minute gap is safe by design: when IsTokenExpired triggers here, the parent
-// transitions Running → Starting and re-authenticates, propagating a fresh token to its
-// children well before their own 1-minute buffer would consider the token invalid.
-// The children's 1-minute buffer is a last-resort safety net for edge cases only.
+// refresh trigger) while child workers (push/pull) use a 1-minute buffer via
+// AuthSession.IsUsable(time.Minute) in their COS. The 9-minute gap is safe by design:
+// when IsTokenExpired triggers here, the parent transitions Running → Starting and
+// re-authenticates, propagating a fresh token to its children well before their own
+// 1-minute buffer would consider the token invalid. The children's 1-minute buffer is
+// a last-resort safety net for edge cases only.
 func (s TransportStatus) IsTokenExpired() bool {
 	if s.AuthSession.Expiry.IsZero() {
 		return false

--- a/umh-core/pkg/fsmv2/workers/transport/snapshot/snapshot.go
+++ b/umh-core/pkg/fsmv2/workers/transport/snapshot/snapshot.go
@@ -154,8 +154,11 @@ func (f FailedAuthConfig) IsEmpty() bool {
 // re-authentication on every tick (~10ms), hammering the relay server.
 // TODO(security): AuthSession included in CSE sync payloads. ENG-4405 tracks
 // adding a CSE secret tier to persist locally but exclude from delta sync.
+// The token also rides into the push/pull child UserSpec.Config via
+// RenderChildren stamping ChildAuthUserSpec, so a future CSE secret-tier scrub
+// must cover the parent status AND both child-config copies.
 type TransportStatus struct {
-	AuthSession         types.AuthSession `json:"auth_session,omitempty"`
+	AuthSession         types.AuthSession `json:"auth_session"`
 	LastAuthAttemptAt   time.Time         `json:"last_auth_attempt_at,omitempty"`
 	FailedAuthConfig    FailedAuthConfig  `json:"failed_auth_config,omitempty"`
 	LastErrorType       types.ErrorType   `json:"last_error_type"`

--- a/umh-core/pkg/fsmv2/workers/transport/snapshot/snapshot.go
+++ b/umh-core/pkg/fsmv2/workers/transport/snapshot/snapshot.go
@@ -166,6 +166,12 @@ type TransportStatus struct {
 }
 
 // IsTokenExpired returns true if the JWT token is expired or will expire within 10 minutes.
+// A zero Expiry is treated as NOT expired — the parent has not yet authenticated and there
+// is nothing to refresh. This is intentionally different from AuthSession.IsUsable, which
+// treats zero Expiry as unusable: IsUsable is a child-side gate ("can I use this token
+// right now?"), while IsTokenExpired is a parent-side trigger ("should I re-authenticate?").
+// Triggering re-auth on zero Expiry would cause the parent to loop before it has ever
+// obtained a token.
 //
 // Token buffer architecture: the parent TransportWorker uses a 10-minute buffer (proactive
 // refresh trigger) while child workers (push/pull) use a 1-minute buffer via
@@ -184,7 +190,12 @@ func (s TransportStatus) IsTokenExpired() bool {
 	return time.Now().Add(refreshBuffer).After(s.AuthSession.Expiry)
 }
 
-// HasValidToken returns true if there is a valid JWT token that hasn't expired.
+// HasValidToken returns true if there is a non-empty JWT token and IsTokenExpired is false.
+// Note: a token with zero Expiry and non-empty Token returns true here (IsTokenExpired
+// treats zero Expiry as not-expired). Children use AuthSession.IsUsable(time.Minute) in
+// their COS, which treats zero Expiry as unusable. This deliberate asymmetry lets the
+// parent hold a "just authenticated, expiry not yet set" window without triggering child
+// action dispatches.
 func (s TransportStatus) HasValidToken() bool {
 	return s.AuthSession.Token != "" && !s.IsTokenExpired()
 }

--- a/umh-core/pkg/fsmv2/workers/transport/snapshot/snapshot_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/snapshot/snapshot_test.go
@@ -23,63 +23,81 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/config"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/snapshot"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/types"
 )
 
 var _ = Describe("TransportStatus", func() {
 	Describe("HasValidToken", func() {
 		It("should return false when JWT token is empty", func() {
 			status := snapshot.TransportStatus{
-				JWTToken:  "",
-				JWTExpiry: time.Now().Add(1 * time.Hour),
+				AuthSession: types.AuthSession{
+					Token:  "",
+					Expiry: time.Now().Add(1 * time.Hour),
+				},
 			}
 			Expect(status.HasValidToken()).To(BeFalse())
 		})
 
 		It("should return false when token is present but expired", func() {
 			status := snapshot.TransportStatus{
-				JWTToken:  "valid-token",
-				JWTExpiry: time.Now().Add(-1 * time.Hour),
+				AuthSession: types.AuthSession{
+					Token:  "valid-token",
+					Expiry: time.Now().Add(-1 * time.Hour),
+				},
 			}
 			Expect(status.HasValidToken()).To(BeFalse())
 		})
 
 		It("should return true when token is present and not expired", func() {
 			status := snapshot.TransportStatus{
-				JWTToken:  "valid-token",
-				JWTExpiry: time.Now().Add(1 * time.Hour),
+				AuthSession: types.AuthSession{
+					Token:  "valid-token",
+					Expiry: time.Now().Add(1 * time.Hour),
+				},
 			}
 			Expect(status.HasValidToken()).To(BeTrue())
+		})
+
+		It("should return false when AuthSession is zero-value", func() {
+			status := snapshot.TransportStatus{}
+			Expect(status.HasValidToken()).To(BeFalse())
 		})
 	})
 
 	Describe("IsTokenExpired", func() {
 		It("should return false when expiry is zero", func() {
 			status := snapshot.TransportStatus{
-				JWTToken: "some-token",
+				AuthSession: types.AuthSession{Token: "some-token"},
 			}
 			Expect(status.IsTokenExpired()).To(BeFalse())
 		})
 
 		It("should return true when token expires within refresh buffer (10 min)", func() {
 			status := snapshot.TransportStatus{
-				JWTToken:  "valid-token",
-				JWTExpiry: time.Now().Add(5 * time.Minute),
+				AuthSession: types.AuthSession{
+					Token:  "valid-token",
+					Expiry: time.Now().Add(5 * time.Minute),
+				},
 			}
 			Expect(status.IsTokenExpired()).To(BeTrue())
 		})
 
 		It("should return false when token expires beyond refresh buffer", func() {
 			status := snapshot.TransportStatus{
-				JWTToken:  "valid-token",
-				JWTExpiry: time.Now().Add(15 * time.Minute),
+				AuthSession: types.AuthSession{
+					Token:  "valid-token",
+					Expiry: time.Now().Add(15 * time.Minute),
+				},
 			}
 			Expect(status.IsTokenExpired()).To(BeFalse())
 		})
 
 		It("should return true when token already expired", func() {
 			status := snapshot.TransportStatus{
-				JWTToken:  "expired-token",
-				JWTExpiry: time.Now().Add(-1 * time.Hour),
+				AuthSession: types.AuthSession{
+					Token:  "expired-token",
+					Expiry: time.Now().Add(-1 * time.Hour),
+				},
 			}
 			Expect(status.IsTokenExpired()).To(BeTrue())
 		})

--- a/umh-core/pkg/fsmv2/workers/transport/snapshot/snapshot_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/snapshot/snapshot_test.go
@@ -63,10 +63,25 @@ var _ = Describe("TransportStatus", func() {
 			status := snapshot.TransportStatus{}
 			Expect(status.HasValidToken()).To(BeFalse())
 		})
+
+		It("should return true for token+zero-expiry (IsTokenExpired=false for pre-auth window)", func() {
+			// Zero Expiry with a non-empty token: IsTokenExpired returns false,
+			// so HasValidToken returns true. Children's IsUsable(1m) returns false
+			// for the same session, so they stay idle until the parent populates Expiry.
+			status := snapshot.TransportStatus{
+				AuthSession: types.AuthSession{Token: "tok"},
+			}
+			Expect(status.HasValidToken()).To(BeTrue())
+			// Contrast: the child-side IsUsable gate correctly rejects it.
+			Expect(status.AuthSession.IsUsable(time.Minute)).To(BeFalse())
+		})
 	})
 
 	Describe("IsTokenExpired", func() {
-		It("should return false when expiry is zero", func() {
+		It("should return false when expiry is zero (deliberate: parent must not re-auth before first token)", func() {
+			// Zero Expiry with a non-empty token → NOT expired.
+			// Contrast: AuthSession.IsUsable(1m) treats the same value as unusable.
+			// See the IsTokenExpired doc comment for the rationale.
 			status := snapshot.TransportStatus{
 				AuthSession: types.AuthSession{Token: "some-token"},
 			}
@@ -137,6 +152,50 @@ var _ = Describe("RenderChildren", func() {
 			var carrier types.ChildAuthUserSpec
 			Expect(yaml.Unmarshal([]byte(sp.UserSpec.Config), &carrier)).To(Succeed())
 			Expect(carrier.AuthSession.Token).To(Equal("jwt"))
+		}
+	})
+
+	It("propagates a refreshed token when parent AuthSession changes (BS1 refresh propagation)", func() {
+		// Verifies that RenderChildren stamps the NEW token when the parent's
+		// TransportStatus.AuthSession changes. The supervisor re-applies the
+		// changed UserSpec to resident children every reconcile tick, so a
+		// token refresh reaches long-lived push/pull children without respawn.
+
+		status1 := snapshot.TransportStatus{
+			AuthSession: types.AuthSession{
+				Token:        "old-jwt",
+				InstanceUUID: "be-uuid",
+				Expiry:       time.Now().Add(time.Hour),
+			},
+		}
+		status2 := snapshot.TransportStatus{
+			AuthSession: types.AuthSession{
+				Token:        "new-jwt",
+				InstanceUUID: "be-uuid",
+				Expiry:       time.Now().Add(2 * time.Hour),
+			},
+		}
+
+		specs1, err := snapshot.RenderChildren(snapshot.TransportDesiredState{}, status1, true)
+		Expect(err).ToNot(HaveOccurred())
+
+		specs2, err := snapshot.RenderChildren(snapshot.TransportDesiredState{}, status2, true)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(specs1).To(HaveLen(2))
+		Expect(specs2).To(HaveLen(2))
+
+		for i := range 2 {
+			var c1, c2 types.ChildAuthUserSpec
+			Expect(yaml.Unmarshal([]byte(specs1[i].UserSpec.Config), &c1)).To(Succeed())
+			Expect(yaml.Unmarshal([]byte(specs2[i].UserSpec.Config), &c2)).To(Succeed())
+
+			Expect(c1.AuthSession.Token).To(Equal("old-jwt"),
+				"first render must carry the old token")
+			Expect(c2.AuthSession.Token).To(Equal("new-jwt"),
+				"second render must carry the refreshed token")
+			Expect(c2.AuthSession.Token).NotTo(Equal(c1.AuthSession.Token),
+				"tokens must differ: refresh must propagate")
 		}
 	})
 })

--- a/umh-core/pkg/fsmv2/workers/transport/snapshot/snapshot_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/snapshot/snapshot_test.go
@@ -138,11 +138,12 @@ var _ = Describe("TransportStatus", func() {
 
 var _ = Describe("RenderChildren", func() {
 	It("stamps AuthSession onto both push and pull children", func() {
+		expiry := time.Now().Add(time.Hour)
 		status := snapshot.TransportStatus{
 			AuthSession: types.AuthSession{
 				Token:        "jwt",
 				InstanceUUID: "be-uuid",
-				Expiry:       time.Now().Add(time.Hour),
+				Expiry:       expiry,
 			},
 		}
 		specs, err := snapshot.RenderChildren(snapshot.TransportDesiredState{}, status, true)
@@ -152,6 +153,8 @@ var _ = Describe("RenderChildren", func() {
 			var carrier types.ChildAuthUserSpec
 			Expect(yaml.Unmarshal([]byte(sp.UserSpec.Config), &carrier)).To(Succeed())
 			Expect(carrier.AuthSession.Token).To(Equal("jwt"))
+			Expect(carrier.AuthSession.InstanceUUID).To(Equal("be-uuid"))
+			Expect(carrier.AuthSession.Expiry).To(BeTemporally("==", expiry))
 		}
 	})
 

--- a/umh-core/pkg/fsmv2/workers/transport/snapshot/snapshot_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/snapshot/snapshot_test.go
@@ -19,6 +19,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"gopkg.in/yaml.v3"
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/config"
@@ -117,6 +118,26 @@ var _ = Describe("TransportStatus", func() {
 			}
 			Expect(fac.IsEmpty()).To(BeFalse())
 		})
+	})
+})
+
+var _ = Describe("RenderChildren", func() {
+	It("stamps AuthSession onto both push and pull children", func() {
+		status := snapshot.TransportStatus{
+			AuthSession: types.AuthSession{
+				Token:        "jwt",
+				InstanceUUID: "be-uuid",
+				Expiry:       time.Now().Add(time.Hour),
+			},
+		}
+		specs, err := snapshot.RenderChildren(snapshot.TransportDesiredState{}, status, true)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(specs).To(HaveLen(2))
+		for _, sp := range specs {
+			var carrier types.ChildAuthUserSpec
+			Expect(yaml.Unmarshal([]byte(sp.UserSpec.Config), &carrier)).To(Succeed())
+			Expect(carrier.AuthSession.Token).To(Equal("jwt"))
+		}
 	})
 })
 

--- a/umh-core/pkg/fsmv2/workers/transport/state/children_helpers.go
+++ b/umh-core/pkg/fsmv2/workers/transport/state/children_helpers.go
@@ -23,11 +23,11 @@ import (
 // Returning nil on a RenderChildren error is NOT safe: the supervisor falls
 // back to GetChildrenSpecs(), which is also nil for migrated workers, so
 // reconcileChildren(nil) marks every resident child pendingRemoval (despawn).
-// The only error source is yaml.Marshal of the static BaseUserSpec, which
+// The only error source is yaml.Marshal of the ChildAuthUserSpec carrier, which
 // fails deterministically and is covered by tests. The semantic fix
 // (nil = keep last rendered children) is tracked in ENG-5115.
-func childrenAlive(cfg snapshot.TransportDesiredState) []config.ChildSpec {
-	specs, err := snapshot.RenderChildren(cfg, true)
+func childrenAlive(cfg snapshot.TransportDesiredState, status snapshot.TransportStatus) []config.ChildSpec {
+	specs, err := snapshot.RenderChildren(cfg, status, true)
 	if err != nil {
 		logger.For("transport").Errorf("RenderChildren(enabled=true) failed, all resident children will be despawned (ENG-5115): %v", err)
 
@@ -37,8 +37,8 @@ func childrenAlive(cfg snapshot.TransportDesiredState) []config.ChildSpec {
 	return specs
 }
 
-func childrenStopped(cfg snapshot.TransportDesiredState) []config.ChildSpec {
-	specs, err := snapshot.RenderChildren(cfg, false)
+func childrenStopped(cfg snapshot.TransportDesiredState, status snapshot.TransportStatus) []config.ChildSpec {
+	specs, err := snapshot.RenderChildren(cfg, status, false)
 	if err != nil {
 		logger.For("transport").Errorf("RenderChildren(enabled=false) failed, all resident children will be despawned (ENG-5115): %v", err)
 

--- a/umh-core/pkg/fsmv2/workers/transport/state/state_auth_failed.go
+++ b/umh-core/pkg/fsmv2/workers/transport/state/state_auth_failed.go
@@ -40,7 +40,7 @@ func (s *AuthFailedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[snapshot.TransportDesiredState, snapshot.TransportStatus](snapAny)
 
 	if snap.IsShutdownRequested {
-		return fsmv2.Transition(&StoppingState{}, fsmv2.SignalNone, nil, "Shutdown requested, transitioning to Stopping", childrenStopped(snap.Config))
+		return fsmv2.Transition(&StoppingState{}, fsmv2.SignalNone, nil, "Shutdown requested, transitioning to Stopping", childrenStopped(snap.Config, snap.Status))
 	}
 
 	// FailedAuthConfig is guaranteed populated here because only permanent errors
@@ -53,12 +53,12 @@ func (s *AuthFailedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	if tokenChanged || relayChanged || uuidChanged {
 		return fsmv2.Transition(&StartingState{}, fsmv2.SignalNone, nil,
 			fmt.Sprintf("config changed (token=%t, relay=%t, uuid=%t), retrying auth",
-				tokenChanged, relayChanged, uuidChanged), childrenAlive(snap.Config))
+				tokenChanged, relayChanged, uuidChanged), childrenAlive(snap.Config, snap.Status))
 	}
 
 	return fsmv2.Transition(s, fsmv2.SignalNone, nil,
 		fmt.Sprintf("auth failed (%s), waiting for config change",
-			snap.Status.LastErrorType), childrenAlive(snap.Config))
+			snap.Status.LastErrorType), childrenAlive(snap.Config, snap.Status))
 }
 
 // String returns the state name derived from the type.

--- a/umh-core/pkg/fsmv2/workers/transport/state/state_degraded.go
+++ b/umh-core/pkg/fsmv2/workers/transport/state/state_degraded.go
@@ -35,29 +35,29 @@ func (s *DegradedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[snapshot.TransportDesiredState, snapshot.TransportStatus](snapAny)
 
 	if snap.IsShutdownRequested {
-		return fsmv2.Transition(&StoppingState{}, fsmv2.SignalNone, nil, "Shutdown requested, transitioning to Stopping", childrenStopped(snap.Config))
+		return fsmv2.Transition(&StoppingState{}, fsmv2.SignalNone, nil, "Shutdown requested, transitioning to Stopping", childrenStopped(snap.Config, snap.Status))
 	}
 
 	// If token is expired, need to re-authenticate (mirrors RunningState)
 	if snap.Status.IsTokenExpired() {
-		return fsmv2.Transition(&StartingState{}, fsmv2.SignalNone, nil, "Token expired, transitioning to Starting for re-authentication", childrenAlive(snap.Config))
+		return fsmv2.Transition(&StartingState{}, fsmv2.SignalNone, nil, "Token expired, transitioning to Starting for re-authentication", childrenAlive(snap.Config, snap.Status))
 	}
 
 	// Nuclear fallback: reset transport on prolonged child failures
 	if backoff.ShouldResetTransport(snap.Status.LastErrorType, snap.Status.ConsecutiveErrors) {
 		return fsmv2.Transition(s, fsmv2.SignalNone, action.NewResetTransportAction(),
 			fmt.Sprintf("resetting transport: %d consecutive errors (type=%d)",
-				snap.Status.ConsecutiveErrors, snap.Status.LastErrorType), childrenAlive(snap.Config))
+				snap.Status.ConsecutiveErrors, snap.Status.LastErrorType), childrenAlive(snap.Config, snap.Status))
 	}
 
 	// If all children are now healthy, transition back to Running
 	if snap.ChildrenUnhealthy == 0 {
-		return fsmv2.Transition(&RunningState{}, fsmv2.SignalNone, nil, "All children now healthy, transitioning to Running", childrenAlive(snap.Config))
+		return fsmv2.Transition(&RunningState{}, fsmv2.SignalNone, nil, "All children now healthy, transitioning to Running", childrenAlive(snap.Config, snap.Status))
 	}
 
 	return fsmv2.Transition(s, fsmv2.SignalNone, nil,
 		fmt.Sprintf("degraded: %d unhealthy children, %d consecutive errors",
-			snap.ChildrenUnhealthy, snap.Status.ConsecutiveErrors), childrenAlive(snap.Config))
+			snap.ChildrenUnhealthy, snap.Status.ConsecutiveErrors), childrenAlive(snap.Config, snap.Status))
 }
 
 // String returns the state name derived from the type.

--- a/umh-core/pkg/fsmv2/workers/transport/state/state_running.go
+++ b/umh-core/pkg/fsmv2/workers/transport/state/state_running.go
@@ -49,10 +49,10 @@ func (s *RunningState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	}
 
 	// Proactive night re-auth: if token would expire during business hours, re-auth at 3 AM
-	if ShouldProactivelyReauth(snap.Status.JWTExpiry, time.Now()) {
+	if ShouldProactivelyReauth(snap.Status.AuthSession.Expiry, time.Now()) {
 		return fsmv2.Transition(&StartingState{}, fsmv2.SignalNone, nil,
 			fmt.Sprintf("proactive night re-auth: token expires at %s (business hours), re-authing now",
-				snap.Status.JWTExpiry.Local().Format("15:04")), childrenAlive(snap.Config))
+				snap.Status.AuthSession.Expiry.Local().Format("15:04")), childrenAlive(snap.Config))
 	}
 
 	// If any children are unhealthy, transition to degraded

--- a/umh-core/pkg/fsmv2/workers/transport/state/state_running.go
+++ b/umh-core/pkg/fsmv2/workers/transport/state/state_running.go
@@ -40,28 +40,28 @@ func (s *RunningState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[snapshot.TransportDesiredState, snapshot.TransportStatus](snapAny)
 
 	if snap.IsShutdownRequested {
-		return fsmv2.Transition(&StoppingState{}, fsmv2.SignalNone, nil, "Shutdown requested, transitioning to Stopping", childrenStopped(snap.Config))
+		return fsmv2.Transition(&StoppingState{}, fsmv2.SignalNone, nil, "Shutdown requested, transitioning to Stopping", childrenStopped(snap.Config, snap.Status))
 	}
 
 	// If token is expired, need to re-authenticate
 	if snap.Status.IsTokenExpired() {
-		return fsmv2.Transition(&StartingState{}, fsmv2.SignalNone, nil, "Token expired, transitioning to Starting for re-authentication", childrenAlive(snap.Config))
+		return fsmv2.Transition(&StartingState{}, fsmv2.SignalNone, nil, "Token expired, transitioning to Starting for re-authentication", childrenAlive(snap.Config, snap.Status))
 	}
 
 	// Proactive night re-auth: if token would expire during business hours, re-auth at 3 AM
 	if ShouldProactivelyReauth(snap.Status.AuthSession.Expiry, time.Now()) {
 		return fsmv2.Transition(&StartingState{}, fsmv2.SignalNone, nil,
 			fmt.Sprintf("proactive night re-auth: token expires at %s (business hours), re-authing now",
-				snap.Status.AuthSession.Expiry.Local().Format("15:04")), childrenAlive(snap.Config))
+				snap.Status.AuthSession.Expiry.Local().Format("15:04")), childrenAlive(snap.Config, snap.Status))
 	}
 
 	// If any children are unhealthy, transition to degraded
 	if snap.ChildrenUnhealthy > 0 {
 		return fsmv2.Transition(&DegradedState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("children unhealthy (%d), transitioning to Degraded", snap.ChildrenUnhealthy), childrenAlive(snap.Config))
+			fmt.Sprintf("children unhealthy (%d), transitioning to Degraded", snap.ChildrenUnhealthy), childrenAlive(snap.Config, snap.Status))
 	}
 
-	return fsmv2.Transition(s, fsmv2.SignalNone, nil, "All children healthy, transport running", childrenAlive(snap.Config))
+	return fsmv2.Transition(s, fsmv2.SignalNone, nil, "All children healthy, transport running", childrenAlive(snap.Config, snap.Status))
 }
 
 // ShouldProactivelyReauth returns true if the token would expire during business

--- a/umh-core/pkg/fsmv2/workers/transport/state/state_starting.go
+++ b/umh-core/pkg/fsmv2/workers/transport/state/state_starting.go
@@ -40,7 +40,7 @@ func (s *StartingState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[snapshot.TransportDesiredState, snapshot.TransportStatus](snapAny)
 
 	if snap.IsShutdownRequested {
-		return fsmv2.Transition(&StoppingState{}, fsmv2.SignalNone, nil, "Shutdown requested, transitioning to Stopping", childrenStopped(snap.Config))
+		return fsmv2.Transition(&StoppingState{}, fsmv2.SignalNone, nil, "Shutdown requested, transitioning to Stopping", childrenStopped(snap.Config, snap.Status))
 	}
 
 	// If we don't have a valid token, authenticate (with backoff on repeated failures)
@@ -53,7 +53,7 @@ func (s *StartingState) Next(snapAny any) fsmv2.NextResult[any, any] {
 			if isPermanentAuthError(snap.Status.LastErrorType) {
 				return fsmv2.Transition(&AuthFailedState{}, fsmv2.SignalNone, nil,
 					fmt.Sprintf("permanent auth failure (%s after %d errors), entering AuthFailed",
-						snap.Status.LastErrorType, snap.Status.ConsecutiveErrors), childrenAlive(snap.Config))
+						snap.Status.LastErrorType, snap.Status.ConsecutiveErrors), childrenAlive(snap.Config, snap.Status))
 			}
 
 			delay := backoff.CalculateDelayForErrorType(
@@ -64,7 +64,7 @@ func (s *StartingState) Next(snapAny any) fsmv2.NextResult[any, any] {
 			if time.Since(snap.Status.LastAuthAttemptAt) < delay {
 				return fsmv2.Transition(s, fsmv2.SignalNone, nil,
 					fmt.Sprintf("auth backoff: %d errors (%s), delay %s",
-						snap.Status.ConsecutiveErrors, snap.Status.LastErrorType, delay.Round(time.Second)), childrenAlive(snap.Config))
+						snap.Status.ConsecutiveErrors, snap.Status.LastErrorType, delay.Round(time.Second)), childrenAlive(snap.Config, snap.Status))
 			}
 		}
 
@@ -75,13 +75,13 @@ func (s *StartingState) Next(snapAny any) fsmv2.NextResult[any, any] {
 			snap.Config.Timeout,
 		)
 
-		return fsmv2.Transition(s, fsmv2.SignalNone, authAction, "No valid token, authenticating with relay", childrenAlive(snap.Config))
+		return fsmv2.Transition(s, fsmv2.SignalNone, authAction, "No valid token, authenticating with relay", childrenAlive(snap.Config, snap.Status))
 	}
 
 	// Authenticated; transition to Running. Children remain enabled (childrenAlive);
 	// RunningState handles unhealthy children. The !HasValidToken() block above
 	// returns in all paths, so reaching here means the token is valid.
-	return fsmv2.Transition(&RunningState{}, fsmv2.SignalNone, nil, "Authenticated, transitioning to Running", childrenAlive(snap.Config))
+	return fsmv2.Transition(&RunningState{}, fsmv2.SignalNone, nil, "Authenticated, transitioning to Running", childrenAlive(snap.Config, snap.Status))
 }
 
 // isPermanentAuthError returns true for error types that indicate a configuration

--- a/umh-core/pkg/fsmv2/workers/transport/state/state_stopped.go
+++ b/umh-core/pkg/fsmv2/workers/transport/state/state_stopped.go
@@ -37,7 +37,7 @@ func (s *StoppedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	// Stopped emits children with enabled=false (resident, not despawned).
 	// On IsShutdownRequested, SignalNeedsRemoval drives removal so the children arg is ignored.
-	stopChildren, err := snapshot.RenderChildren(snap.Config, false)
+	stopChildren, err := snapshot.RenderChildren(snap.Config, snap.Status, false)
 	if err != nil {
 		stopChildren = nil
 	}
@@ -57,7 +57,7 @@ func (s *StoppedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	if snap.Config.ShouldBeRunning() {
 		// Transitioning to Starting: emit aliveChildren NOW (one tick early)
 		// so the supervisor flips enabled=true before Starting reads its first snapshot.
-		aliveChildren, aerr := snapshot.RenderChildren(snap.Config, true)
+		aliveChildren, aerr := snapshot.RenderChildren(snap.Config, snap.Status, true)
 		if aerr != nil {
 			aliveChildren = nil
 		}

--- a/umh-core/pkg/fsmv2/workers/transport/state/state_stopping.go
+++ b/umh-core/pkg/fsmv2/workers/transport/state/state_stopping.go
@@ -34,7 +34,7 @@ func (s *StoppingState) Next(snapAny any) fsmv2.NextResult[any, any] {
 
 	_ = snap.IsShutdownRequested // architecture invariant: shutdown check must be first conditional
 
-	stopChildren, err := snapshot.RenderChildren(snap.Config, false)
+	stopChildren, err := snapshot.RenderChildren(snap.Config, snap.Status, false)
 	if err != nil {
 		stopChildren = nil
 	}

--- a/umh-core/pkg/fsmv2/workers/transport/state/state_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/state/state_test.go
@@ -55,8 +55,10 @@ func makeSnapshotWithBackoff(shutdownRequested bool, desiredState string, jwtTok
 		ChildrenHealthy:   childrenHealthy,
 		ChildrenUnhealthy: childrenUnhealthy,
 		Status: snapshot.TransportStatus{
-			JWTToken:          jwtToken,
-			JWTExpiry:         jwtExpiry,
+			AuthSession: types.AuthSession{
+				Token:  jwtToken,
+				Expiry: jwtExpiry,
+			},
 			ConsecutiveErrors: consecutiveErrors,
 			LastErrorType:     lastErrorType,
 			LastAuthAttemptAt: lastAuthAttemptAt,

--- a/umh-core/pkg/fsmv2/workers/transport/types/types.go
+++ b/umh-core/pkg/fsmv2/workers/transport/types/types.go
@@ -25,11 +25,11 @@ import (
 	depspkg "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
 )
 
-// AuthSession bundles the auth state the parent transport worker shares with its
-// push/pull children: the JWT bearer token, its expiry, and the backend-confirmed
-// instance UUID. Bundled so a caller cannot set the token without its expiry. It
-// rides the typed snapshot from parent status to child config; children read it
-// from their own snapshot instead of reaching into parent dependencies.
+// AuthSession groups the auth fields that travel together from parent transport status
+// to push/pull child config: the JWT bearer token, its expiry, and the backend-confirmed
+// instance UUID. Atomic token+expiry update is provided by the SetJWT setter on
+// TransportDependencies, not enforced by the struct. Children read the session from
+// their own snapshot instead of reaching into parent dependencies.
 //
 // Defined here (a leaf package imported by snapshot, push, and pull) to avoid an
 // import cycle: RenderChildren (in the snapshot package) stamps it and push/pull

--- a/umh-core/pkg/fsmv2/workers/transport/types/types.go
+++ b/umh-core/pkg/fsmv2/workers/transport/types/types.go
@@ -41,8 +41,8 @@ type AuthSession struct {
 }
 
 // IsUsable reports whether the session has a token that will still be valid after
-// the given safety buffer. Mirrors the former child IsTokenValid check; the buffer
-// lets callers pick the child (1-minute) vs other windows.
+// the given safety buffer. Pass 1*time.Minute for child-worker COS checks or
+// 10*time.Minute for the parent's proactive refresh trigger.
 func (a AuthSession) IsUsable(buffer time.Duration) bool {
 	if a.Token == "" || a.Expiry.IsZero() {
 		return false

--- a/umh-core/pkg/fsmv2/workers/transport/types/types.go
+++ b/umh-core/pkg/fsmv2/workers/transport/types/types.go
@@ -40,6 +40,17 @@ type AuthSession struct {
 	InstanceUUID string    `json:"instanceUUID,omitempty" yaml:"instanceUUID,omitempty"`
 }
 
+// IsUsable reports whether the session has a token that will still be valid after
+// the given safety buffer. Mirrors the former child IsTokenValid check; the buffer
+// lets callers pick the child (1-minute) vs other windows.
+func (a AuthSession) IsUsable(buffer time.Duration) bool {
+	if a.Token == "" || a.Expiry.IsZero() {
+		return false
+	}
+
+	return !time.Now().Add(buffer).After(a.Expiry)
+}
+
 // ChildAuthUserSpec is the YAML carrier for the auth session that transport's
 // RenderChildren stamps onto its push/pull children. push/pull embed it in their
 // UserSpec so the marshal-then-parse round trip is structurally identical on both sides.

--- a/umh-core/pkg/fsmv2/workers/transport/types/types.go
+++ b/umh-core/pkg/fsmv2/workers/transport/types/types.go
@@ -25,6 +25,28 @@ import (
 	depspkg "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
 )
 
+// AuthSession bundles the auth state the parent transport worker shares with its
+// push/pull children: the JWT bearer token, its expiry, and the backend-confirmed
+// instance UUID. Bundled so a caller cannot set the token without its expiry. It
+// rides the typed snapshot from parent status to child config; children read it
+// from their own snapshot instead of reaching into parent dependencies.
+//
+// Defined here (a leaf package imported by snapshot, push, and pull) to avoid an
+// import cycle: RenderChildren (in the snapshot package) stamps it and push/pull
+// parse it, but snapshot cannot import push/pull.
+type AuthSession struct {
+	Expiry       time.Time `json:"expiry,omitempty"       yaml:"expiry,omitempty"`
+	Token        string    `json:"token,omitempty"        yaml:"token,omitempty"`
+	InstanceUUID string    `json:"instanceUUID,omitempty" yaml:"instanceUUID,omitempty"`
+}
+
+// ChildAuthUserSpec is the YAML carrier for the auth session that transport's
+// RenderChildren stamps onto its push/pull children. push/pull embed it in their
+// UserSpec so the marshal-then-parse round trip is structurally identical on both sides.
+type ChildAuthUserSpec struct {
+	AuthSession AuthSession `json:"authSession,omitempty" yaml:"authSession,omitempty"`
+}
+
 // UMHMessage represents a message in the umh-core push/pull protocol.
 // Note: InstanceUUID uses json tag "umhInstance" to match backend API (models.UMHMessage).
 type UMHMessage struct {

--- a/umh-core/pkg/fsmv2/workers/transport/types/types_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/types/types_test.go
@@ -15,7 +15,6 @@
 package types_test
 
 import (
-	"testing"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -64,21 +63,19 @@ var _ = Describe("AuthSession.IsUsable", func() {
 	)
 })
 
-func TestChildAuthUserSpecRoundTrip(t *testing.T) {
-	exp := time.Date(2026, 6, 2, 12, 0, 0, 0, time.UTC)
-	in := types.ChildAuthUserSpec{AuthSession: types.AuthSession{Token: "jwt-abc", Expiry: exp, InstanceUUID: "be-uuid"}}
+var _ = Describe("ChildAuthUserSpec", func() {
+	It("round-trips Token, InstanceUUID, and Expiry through YAML", func() {
+		exp := time.Date(2026, 6, 2, 12, 0, 0, 0, time.UTC)
+		in := types.ChildAuthUserSpec{AuthSession: types.AuthSession{Token: "jwt-abc", Expiry: exp, InstanceUUID: "be-uuid"}}
 
-	data, err := yaml.Marshal(in)
-	if err != nil {
-		t.Fatalf("marshal: %v", err)
-	}
+		data, err := yaml.Marshal(in)
+		Expect(err).ToNot(HaveOccurred())
 
-	var out types.ChildAuthUserSpec
-	if err := yaml.Unmarshal(data, &out); err != nil {
-		t.Fatalf("unmarshal: %v", err)
-	}
+		var out types.ChildAuthUserSpec
+		Expect(yaml.Unmarshal(data, &out)).To(Succeed())
 
-	if out.AuthSession.Token != "jwt-abc" || out.AuthSession.InstanceUUID != "be-uuid" || !out.AuthSession.Expiry.Equal(exp) {
-		t.Fatalf("round-trip mismatch: got %+v", out.AuthSession)
-	}
-}
+		Expect(out.AuthSession.Token).To(Equal("jwt-abc"))
+		Expect(out.AuthSession.InstanceUUID).To(Equal("be-uuid"))
+		Expect(out.AuthSession.Expiry).To(BeTemporally("==", exp))
+	})
+})

--- a/umh-core/pkg/fsmv2/workers/transport/types/types_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/types/types_test.go
@@ -18,10 +18,51 @@ import (
 	"testing"
 	"time"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"gopkg.in/yaml.v3"
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/types"
 )
+
+var _ = Describe("AuthSession.IsUsable", func() {
+	// IsUsable(buffer) returns false when: token empty, expiry zero, already expired, or
+	// expiry is within the buffer window. Returns true only when the token is non-empty and
+	// expires strictly beyond now+buffer.
+	//
+	// Use generous offsets (minutes/hours, not seconds) to avoid CI flakes; we never assert
+	// an exact boundary instant — only that clearly-inside and clearly-outside cases behave correctly.
+
+	DescribeTable("child buffer (1m)",
+		func(sess types.AuthSession, want bool) {
+			Expect(sess.IsUsable(time.Minute)).To(Equal(want))
+		},
+		Entry("empty token → false", types.AuthSession{}, false),
+		Entry("zero expiry with token → false",
+			types.AuthSession{Token: "tok"}, false),
+		Entry("token expired (1h ago) → false",
+			types.AuthSession{Token: "tok", Expiry: time.Now().Add(-time.Hour)}, false),
+		Entry("expiry within buffer (30s from now, buffer=1m) → false",
+			types.AuthSession{Token: "tok", Expiry: time.Now().Add(30 * time.Second)}, false),
+		Entry("expiry well beyond buffer (2h from now, buffer=1m) → true",
+			types.AuthSession{Token: "tok", Expiry: time.Now().Add(2 * time.Hour)}, true),
+	)
+
+	DescribeTable("parent buffer (10m)",
+		func(sess types.AuthSession, want bool) {
+			Expect(sess.IsUsable(10 * time.Minute)).To(Equal(want))
+		},
+		Entry("empty token → false", types.AuthSession{}, false),
+		Entry("zero expiry with token → false",
+			types.AuthSession{Token: "tok"}, false),
+		Entry("token expired (1h ago) → false",
+			types.AuthSession{Token: "tok", Expiry: time.Now().Add(-time.Hour)}, false),
+		Entry("expiry within buffer (5m from now, buffer=10m) → false",
+			types.AuthSession{Token: "tok", Expiry: time.Now().Add(5 * time.Minute)}, false),
+		Entry("expiry well beyond buffer (2h from now, buffer=10m) → true",
+			types.AuthSession{Token: "tok", Expiry: time.Now().Add(2 * time.Hour)}, true),
+	)
+})
 
 func TestChildAuthUserSpecRoundTrip(t *testing.T) {
 	exp := time.Date(2026, 6, 2, 12, 0, 0, 0, time.UTC)

--- a/umh-core/pkg/fsmv2/workers/transport/types/types_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/types/types_test.go
@@ -1,0 +1,43 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types_test
+
+import (
+	"testing"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/types"
+)
+
+func TestChildAuthUserSpecRoundTrip(t *testing.T) {
+	exp := time.Date(2026, 6, 2, 12, 0, 0, 0, time.UTC)
+	in := types.ChildAuthUserSpec{AuthSession: types.AuthSession{Token: "jwt-abc", Expiry: exp, InstanceUUID: "be-uuid"}}
+
+	data, err := yaml.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var out types.ChildAuthUserSpec
+	if err := yaml.Unmarshal(data, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if out.AuthSession.Token != "jwt-abc" || out.AuthSession.InstanceUUID != "be-uuid" || !out.AuthSession.Expiry.Equal(exp) {
+		t.Fatalf("round-trip mismatch: got %+v", out.AuthSession)
+	}
+}

--- a/umh-core/pkg/fsmv2/workers/transport/worker.go
+++ b/umh-core/pkg/fsmv2/workers/transport/worker.go
@@ -131,11 +131,10 @@ func (w *TransportWorker) CollectObservedState(ctx context.Context, _ fsmv2.Desi
 	d := w.GetDependencies()
 
 	failedToken, failedRelay, failedUUID := d.GetFailedAuthConfig()
+	as := d.GetAuthSession()
 
 	status := snapshot.TransportStatus{
-		JWTToken:          d.GetJWTToken(),
-		JWTExpiry:         d.GetJWTExpiry(),
-		AuthenticatedUUID: d.GetAuthenticatedUUID(),
+		AuthSession:       as,
 		ConsecutiveErrors: d.GetConsecutiveErrors(),
 		LastErrorType:     d.GetLastErrorType(),
 		LastAuthAttemptAt: d.GetLastAuthAttemptAt(),


### PR DESCRIPTION
## The stack

> **FSMv2 migration-API stack, PR 2 of 6.** A worker acts on its *snapshot* (its
> desired + observed state). The goal: make the snapshot the complete description of a
> worker, then let outside code rewrite it on a running system.
> 1. **#2589**: delete the dead legacy stop path so a worker's lifecycle depends on its own state, not a parent side channel.
> 2. **#2590 ← you are here**: put each transport worker's auth on its own spec, not a side channel into the parent.
> 3. **#2598**: put the config-declared child list on the snapshot so the migration API can read it.
> 4. **#2599**: the migration API, so outside code can create, update, and delete workers on a running supervisor.
> 5. **#2603**: shut down by draining instead of timing out (the bug building the proof found).
> 6. **#2604**: prove create and update against a live kernel.
>
> Merge bottom-up. Each PR stands alone and reverts cleanly.

### This PR: give each transport worker its own auth

A push or pull worker reads its JWT from the parent supervisor's in-memory state
directly, not from its own spec. So the spec does not fully describe the worker: two
workers with identical specs can behave differently depending on what the parent happens
to be holding, a worker cannot be run or tested on its own, and the token it acts on can
disagree with the rest of the config it was handed. This PR has the parent stamp the
token into each worker's own config, so its spec is its complete input.

**Prerequisite because:** the migration API only controls a worker if setting its spec
sets *everything* the worker needs; auth was the last input still arriving through a side
channel.


---

## Problem

Push and pull get the JWT by calling `GetJWTToken()` on the parent's deps. This isn't a live bug, but:

- **It breaks the framework's model.** Every other worker takes its inputs from its own snapshot; this is the only worker that reaches into another worker's deps. As a result the token isn't in the child's persisted state, so you can't tell from CSE or logs why a child pushed or stalled.
- **The child can't be tested on its own.** Exercising the token gate means building and mutating the parent's deps (`parentDeps.SetJWT(...)`).
- **The child can't work without the parent's internals.** It holds a pointer into the parent's mutable deps instead of receiving the token as its own config.

## What we're shipping

A typed `AuthSession` (token, expiry, backend UUID) the parent writes onto each child's spec in `RenderChildren`; the child reads it from its own snapshot and calls `AuthSession.IsUsable(1m)` to decide whether to send. `GetJWTToken`, `GetAuthenticatedUUID`, and `IsTokenValid` are deleted from parent and children. The token is still written to the parent's deps by the auth action; only how the children receive it changes. (`AuthSession` is in `types` because `snapshot` can't import `push`/`pull`.)

## Behavior change

Children read a snapshot copy of the token instead of a live parent read, so a refreshed token reaches a child one or two reconciles late. The supervisor re-applies each child's spec every reconcile (`updateUserSpec`), so already-running children get the new token. On expiry that's covered: the child's 1-minute buffer is shorter than the parent's 10-minute refresh. On revocation the child uses the stale token for a tick or two (a few auth failures, no messages dropped).

## Scope

- **In:** transport package + one `cmd/main.go` reader.
- **Deferred (ENG-4799):** dropping `TransportUserSpec.InstanceUUID`; a separate change, never sent on the wire.
- **ENG-4405:** the token is now also in both child configs (CSE-synced), not just parent status, so the secret-tier scrub must cover all three (TODO updated).
- Stacks on `feature/wapi-L5b` (#2589); lands after #2588. Draft until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

