### PR TITLE
Eng 5092 umh core rename schema

### DIFF
--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -2,13 +2,14 @@
 
 ## Unreleased
 
+### Fixes
+
+- Previously, a standalone data flow that writes to more than one destination (`switch`, `broker`, or `fallback`) showed zero or incomplete throughput in the Management Console even though it was processing data normally. The throughput, error, and connection counts now include every destination
+
 ### Preview: Write Flows
 
 - The write flow schema has been updated to use structured fields. The previous flat fields `input_topics` and `output` are replaced by `source.topics`, `destination.protocol`, `destination.code`, `processing`, and `extra`. Write flows configured before this release must be re-created from the UI; read flows and connection settings are not affected.
 
-### Fixes
-
-- Previously, a standalone data flow that writes to more than one destination (`switch`, `broker`, or `fallback`) showed zero or incomplete throughput in the Management Console even though it was processing data normally. The throughput, error, and connection counts now include every destination
 
 ## [0.44.22]
 

--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Preview: Write Flows
+
+- The write flow schema has been updated to use structured fields. The previous flat fields `input_topics` and `output` are replaced by `source.topics`, `destination.protocol`, `destination.code`, `processing`, and `extra`. Write flows configured before this release must be re-created from the UI; read flows and connection settings are not affected.
+
 ### Fixes
 
 - Previously, a standalone data flow that writes to more than one destination (`switch`, `broker`, or `fallback`) showed zero or incomplete throughput in the Management Console even though it was processing data normally. The throughput, error, and connection counts now include every destination

--- a/umh-core/examples/example-config-protocolconverter-templated.yaml
+++ b/umh-core/examples/example-config-protocolconverter-templated.yaml
@@ -30,10 +30,12 @@ templates:
             opcua:
               address: "opc.tcp://{{ .IP }}:{{ .PORT }}"
       dataflowcomponent_write:
-        input_topics: "umh.v1.{{ .location_path }}.temperature-sensor-pc.*"
-        output:
-          http_client:
-            url: "http://collector.local/ingest"   # static
+        source:
+          topics: "umh.v1.{{ .location_path }}.temperature-sensor-pc.*"
+        destination:
+          protocol: http_client
+          code: |
+            url: "http://collector.local/ingest"
 
 # ---------- Agent-wide settings ---------- #
 agent:

--- a/umh-core/internal/fsmtest/protocolconverter.go
+++ b/umh-core/internal/fsmtest/protocolconverter.go
@@ -53,9 +53,11 @@ var (
 	}
 
 	goodDataflowComponentWriteConfig = dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
-		InputTopics: "umh.v1.test.*",
-		Output: map[string]interface{}{
-			"stdout": map[string]interface{}{},
+		Source: dataflowcomponentserviceconfig.WriteConfigSource{
+			Topics: "umh.v1.test.*",
+		},
+		Destination: dataflowcomponentserviceconfig.WriteConfigDestination{
+			Protocol: "stdout",
 		},
 	}
 

--- a/umh-core/pkg/communicator/actions/deploy-protocolconverter_test.go
+++ b/umh-core/pkg/communicator/actions/deploy-protocolconverter_test.go
@@ -229,10 +229,12 @@ var _ = Describe("DeployProtocolConverter", func() {
 				},
 				"location": pcLocation,
 				"writeDFC": map[string]interface{}{
-					"output": map[string]interface{}{
-						"stdout": map[string]interface{}{},
+					"destination": map[string]interface{}{
+						"protocol": "stdout",
 					},
-					"input_topics": "umh.v1.{{ .location_path }}.{{ .IP }}.*",
+					"source": map[string]interface{}{
+						"topics": "umh.v1.{{ .location_path }}.{{ .IP }}.*",
+					},
 				},
 			}
 
@@ -376,7 +378,7 @@ var _ = Describe("DeployProtocolConverter", func() {
 			stateMocker.Stop()
 		})
 
-		It("should store InputTopics in write DFC config when deploying with write DFC", func() {
+		It("should store Source.Topics in write DFC config when deploying with write DFC", func() {
 			payload := map[string]any{
 				"name": pcName,
 				"connection": map[string]any{
@@ -385,10 +387,12 @@ var _ = Describe("DeployProtocolConverter", func() {
 				},
 				"location": pcLocation,
 				"writeDFC": map[string]any{
-					"output": map[string]any{
-						"stdout": map[string]any{},
+					"destination": map[string]any{
+						"protocol": "stdout",
 					},
-					"input_topics": "umh.v1.factory.*\numh.v1.plant.*",
+					"source": map[string]any{
+						"topics": "umh.v1.factory.*\numh.v1.plant.*",
+					},
 				},
 			}
 
@@ -409,7 +413,7 @@ var _ = Describe("DeployProtocolConverter", func() {
 			Expect(mockConfig.Config.ProtocolConverter).To(HaveLen(1))
 
 			addedPC := mockConfig.Config.ProtocolConverter[0]
-			Expect(addedPC.ProtocolConverterServiceConfig.Config.DataflowComponentWriteServiceConfig.InputTopics).To(Equal(
+			Expect(addedPC.ProtocolConverterServiceConfig.Config.DataflowComponentWriteServiceConfig.Source.Topics).To(Equal(
 				"umh.v1.factory.*\numh.v1.plant.*",
 			))
 		})
@@ -423,11 +427,13 @@ var _ = Describe("DeployProtocolConverter", func() {
 				},
 				"location": pcLocation,
 				"writeDFC": map[string]any{
-					"output": map[string]any{
-						"stdout": map[string]any{},
+					"destination": map[string]any{
+						"protocol": "stdout",
 					},
-					"input_topics": "umh.v1.factory.*",
-					"state":        "stopped",
+					"source": map[string]any{
+						"topics": "umh.v1.factory.*",
+					},
+					"state": "stopped",
 				},
 			}
 

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter.go
@@ -167,7 +167,7 @@ func (a *EditProtocolConverterAction) Parse(payload interface{}) error {
 	a.protocolConverterUUID = *pcPayload.UUID
 	a.name = pcPayload.Name
 
-	// Resolve user variables first — they are needed to render the InputTopics template.
+	// Resolve user variables first — they are needed to render the Source.Topics template.
 	if pcPayload.TemplateInfo != nil {
 		a.templateVars = pcPayload.TemplateInfo.Variables
 	} else {
@@ -396,10 +396,10 @@ func (a *EditProtocolConverterAction) applyMutation() (config.ProtocolConverterC
 		instanceToModify.ProtocolConverterServiceConfig.Config.DataflowComponentReadServiceConfig = *a.readDFCSvcCfg
 	}
 
-	// Apply write DFC config when the Output field was explicitly included in the payload
-	// (non-nil, even if empty). A nil Output means a state-only change; the existing
-	// config is preserved. An explicitly empty Output ({}) clears the write DFC output.
-	if a.writeDFCInput != nil && a.writeDFCInput.Output != nil {
+	// Apply write DFC config when the Destination field was explicitly included in the payload
+	// (non-nil, even if empty). A nil Destination means a state-only change; the existing
+	// config is preserved. An explicitly empty Destination ({}) clears the write DFC output.
+	if a.writeDFCInput != nil {
 		instanceToModify.ProtocolConverterServiceConfig.Config.DataflowComponentWriteServiceConfig = *a.writeDFCInput
 	}
 
@@ -1078,26 +1078,21 @@ func (a *EditProtocolConverterAction) writeDFCConfigDiffers(
 	if incomingState != "" && deployedState != "" && incomingState != deployedState {
 		return true
 	}
-	// Normalize nil maps to empty maps before comparison: YAML round-trip converts
-	// nil maps (Output/Buffer) to empty maps, and reflect.DeepEqual treats them as
-	// different, causing spurious drift detection on every reconcile.
+	// Normalize fields before comparison to avoid spurious drift detection on every reconcile.
 	return !reflect.DeepEqual(normalizeWriteConfigInput(incoming), normalizeWriteConfigInput(deployedConfig))
 }
 
-// normalizeWriteConfigInput replaces nil map fields with empty maps so that
-// reflect.DeepEqual comparisons are not tripped up by YAML round-trip nil→{} coercions.
+// normalizeWriteConfigInput normalizes fields so that reflect.DeepEqual comparisons
+// are not tripped up by YAML round-trip coercions.
 func normalizeWriteConfigInput(c dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput) dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput {
-	if c.Output == nil {
-		c.Output = map[string]any{}
+	// Mirror the defaults applied by ToDataflowComponentServiceConfig so that a config
+	// stored without explicit processing fields compares equal to a payload carrying
+	// the explicit defaults.
+	if c.Processing.Code == "" {
+		c.Processing.Code = "return msg;"
 	}
-	if c.Buffer == nil {
-		c.Buffer = map[string]any{}
-	}
-	// Mirror the default applied by ToDataflowComponentServiceConfig so that a config
-	// stored without an explicit JS snippet compares equal to one that was just parsed
-	// from a payload carrying the default "return msg;".
-	if c.ProcessingNoderedJS == "" {
-		c.ProcessingNoderedJS = "return msg;"
+	if c.Processing.Type == "" {
+		c.Processing.Type = "nodered_js"
 	}
 	return c
 }

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter_test.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter_test.go
@@ -183,12 +183,13 @@ var _ = Describe("EditProtocolConverter", func() {
 				"name": pcName,
 				"uuid": pcUUID.String(),
 				"writeDFC": map[string]interface{}{
-					"output": map[string]interface{}{
-						"kafka": map[string]interface{}{
-							"addresses": []interface{}{"localhost:9092"},
-						},
+					"destination": map[string]interface{}{
+						"protocol": "kafka",
+						"code":     "addresses:\n- localhost:9092\n",
 					},
-					"input_topics": "umh.v1.factory.*",
+					"source": map[string]interface{}{
+						"topics": "umh.v1.factory.*",
+					},
 				},
 			}
 
@@ -201,8 +202,8 @@ var _ = Describe("EditProtocolConverter", func() {
 
 			writeCfg := action.GetDesiredWriteDFCConfig()
 			Expect(writeCfg).NotTo(BeNil())
-			Expect(writeCfg.Output).To(HaveKey("kafka"))
-			Expect(writeCfg.InputTopics).To(Equal("umh.v1.factory.*"))
+			Expect(writeCfg.Destination.Protocol).To(Equal("kafka"))
+			Expect(writeCfg.Source.Topics).To(Equal("umh.v1.factory.*"))
 		})
 
 		It("should return error for missing UUID", func() {
@@ -268,10 +269,12 @@ var _ = Describe("EditProtocolConverter", func() {
 					},
 				},
 				"writeDFC": map[string]interface{}{
-					"output": map[string]interface{}{
-						"stdout": map[string]interface{}{},
+					"destination": map[string]interface{}{
+						"protocol": "stdout",
 					},
-					"input_topics": "umh.v1.factory.*",
+					"source": map[string]interface{}{
+						"topics": "umh.v1.factory.*",
+					},
 				},
 			}
 
@@ -285,10 +288,12 @@ var _ = Describe("EditProtocolConverter", func() {
 				"name": pcName,
 				"uuid": pcUUID.String(),
 				"writeDFC": map[string]interface{}{
-					"output": map[string]interface{}{
-						"stdout": map[string]interface{}{},
+					"destination": map[string]interface{}{
+						"protocol": "stdout",
 					},
-					"input_topics": "umh.v1.factory.*\numh.v1.plant.*",
+					"source": map[string]interface{}{
+						"topics": "umh.v1.factory.*\numh.v1.plant.*",
+					},
 				},
 			}
 
@@ -298,7 +303,7 @@ var _ = Describe("EditProtocolConverter", func() {
 
 			writeCfg := action.GetDesiredWriteDFCConfig()
 			Expect(writeCfg).NotTo(BeNil())
-			Expect(writeCfg.InputTopics).To(Equal("umh.v1.factory.*\numh.v1.plant.*"))
+			Expect(writeCfg.Source.Topics).To(Equal("umh.v1.factory.*\numh.v1.plant.*"))
 		})
 
 		It("should parse write DFC with golang template vars in input_topics", func() {
@@ -312,10 +317,12 @@ var _ = Describe("EditProtocolConverter", func() {
 					"port": 502,
 				},
 				"writeDFC": map[string]interface{}{
-					"output": map[string]interface{}{
-						"stdout": map[string]interface{}{},
+					"destination": map[string]interface{}{
+						"protocol": "stdout",
 					},
-					"input_topics": "umh.v1.{{ .location_path }}.{{ .IP }}.*",
+					"source": map[string]interface{}{
+						"topics": "umh.v1.{{ .location_path }}.{{ .IP }}.*",
+					},
 				},
 			}
 
@@ -324,7 +331,7 @@ var _ = Describe("EditProtocolConverter", func() {
 
 			writeCfg := action.GetDesiredWriteDFCConfig()
 			Expect(writeCfg).NotTo(BeNil())
-			Expect(writeCfg.InputTopics).To(Equal("umh.v1.{{ .location_path }}.{{ .IP }}.*"))
+			Expect(writeCfg.Source.Topics).To(Equal("umh.v1.{{ .location_path }}.{{ .IP }}.*"))
 		})
 
 		It("should preserve explicit 'stopped' state on read DFC", func() {
@@ -401,10 +408,12 @@ var _ = Describe("EditProtocolConverter", func() {
 				"name": pcName,
 				"uuid": pcUUID.String(),
 				"writeDFC": map[string]interface{}{
-					"output": map[string]interface{}{
-						"stdout": map[string]interface{}{},
+					"destination": map[string]interface{}{
+						"protocol": "stdout",
 					},
-					"input_topics": "umh.v1.factory.*",
+					"source": map[string]interface{}{
+						"topics": "umh.v1.factory.*",
+					},
 				},
 			}
 
@@ -437,10 +446,10 @@ var _ = Describe("EditProtocolConverter", func() {
 				"name": pcName,
 				"uuid": pcUUID.String(),
 				"writeDFC": map[string]interface{}{
-					"output": map[string]interface{}{
-						"stdout": map[string]interface{}{},
+					"destination": map[string]interface{}{
+						"protocol": "stdout",
 					},
-					// no umh_topics
+					// no source/topics
 				},
 			}
 
@@ -449,7 +458,7 @@ var _ = Describe("EditProtocolConverter", func() {
 
 			err = action.Validate()
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("input_topics"))
+			Expect(err.Error()).To(ContainSubstring("input topic"))
 		})
 
 		It("should return error for invalid DFC configuration", func() {
@@ -558,15 +567,17 @@ var _ = Describe("EditProtocolConverter", func() {
 			Expect(updatedPC.ProtocolConverterServiceConfig.TemplateRef).To(Equal(pcName))
 		})
 
-		It("should store InputTopics in typed write config when adding write DFC", func() {
+		It("should store Source.Topics in typed write config when adding write DFC", func() {
 			payload := map[string]interface{}{
 				"name": pcName,
 				"uuid": pcUUID.String(),
 				"writeDFC": map[string]interface{}{
-					"output": map[string]interface{}{
-						"stdout": map[string]interface{}{},
+					"destination": map[string]interface{}{
+						"protocol": "stdout",
 					},
-					"input_topics": "umh.v1.factory.line-1.*\numh.v1.factory.line-2.*",
+					"source": map[string]interface{}{
+						"topics": "umh.v1.factory.line-1.*\numh.v1.factory.line-2.*",
+					},
 				},
 			}
 
@@ -599,7 +610,7 @@ var _ = Describe("EditProtocolConverter", func() {
 				}
 			}
 			Expect(updatedPC).NotTo(BeNil())
-			Expect(updatedPC.ProtocolConverterServiceConfig.Config.DataflowComponentWriteServiceConfig.InputTopics).To(Equal("umh.v1.factory.line-1.*\numh.v1.factory.line-2.*"))
+			Expect(updatedPC.ProtocolConverterServiceConfig.Config.DataflowComponentWriteServiceConfig.Source.Topics).To(Equal("umh.v1.factory.line-1.*\numh.v1.factory.line-2.*"))
 		})
 
 		Context("when protocol converter already has both DFCs configured", func() {
@@ -610,9 +621,6 @@ var _ = Describe("EditProtocolConverter", func() {
 						"url": "http://original.example.com",
 					},
 				}
-				existingWriteOutput := map[string]interface{}{
-					"stdout": map[string]interface{}{},
-				}
 
 				mockConfig.Config.ProtocolConverter[0].ProtocolConverterServiceConfig.Config.DataflowComponentReadServiceConfig = dataflowcomponentserviceconfig.DataflowComponentServiceConfig{
 					BenthosConfig: dataflowcomponentserviceconfig.BenthosConfig{
@@ -620,8 +628,8 @@ var _ = Describe("EditProtocolConverter", func() {
 					},
 				}
 				mockConfig.Config.ProtocolConverter[0].ProtocolConverterServiceConfig.Config.DataflowComponentWriteServiceConfig = dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
-					Output:      existingWriteOutput,
-					InputTopics: "umh.v1.factory.*",
+					Destination: dataflowcomponentserviceconfig.WriteConfigDestination{Protocol: "stdout"},
+					Source:      dataflowcomponentserviceconfig.WriteConfigSource{Topics: "umh.v1.factory.*"},
 				}
 
 				stateMocker = actions.NewStateMocker(mockConfig)
@@ -634,12 +642,13 @@ var _ = Describe("EditProtocolConverter", func() {
 					"name": pcName,
 					"uuid": pcUUID.String(),
 					"writeDFC": map[string]interface{}{
-						"output": map[string]interface{}{
-							"kafka": map[string]interface{}{
-								"addresses": []interface{}{"localhost:9092"},
-							},
+						"destination": map[string]interface{}{
+							"protocol": "kafka",
+							"code":     "addresses:\n- localhost:9092\n",
 						},
-						"input_topics": "umh.v1.plant.*",
+						"source": map[string]interface{}{
+							"topics": "umh.v1.plant.*",
+						},
 					},
 				}
 
@@ -669,8 +678,8 @@ var _ = Describe("EditProtocolConverter", func() {
 				Expect(updatedPC).NotTo(BeNil())
 
 				// Write DFC output must have changed — new format stores directly without wrapper
-				writeOutput := updatedPC.ProtocolConverterServiceConfig.Config.DataflowComponentWriteServiceConfig.Output
-				Expect(writeOutput).To(HaveKey("kafka"))
+				writeDestType := updatedPC.ProtocolConverterServiceConfig.Config.DataflowComponentWriteServiceConfig.Destination.Protocol
+				Expect(writeDestType).To(Equal("kafka"))
 
 				// Read DFC input must be untouched — initial config set directly without wrapper
 				readInput := updatedPC.ProtocolConverterServiceConfig.Config.DataflowComponentReadServiceConfig.BenthosConfig.Input
@@ -730,11 +739,11 @@ var _ = Describe("EditProtocolConverter", func() {
 				Expect(readInput["input"].(map[string]interface{})["http_client"]).To(HaveKeyWithValue("url", "http://updated.example.com"))
 
 				// Write DFC output must be untouched — initial config set directly without wrapper
-				writeOutput := updatedPC.ProtocolConverterServiceConfig.Config.DataflowComponentWriteServiceConfig.Output
-				Expect(writeOutput).To(HaveKey("stdout"))
+				writeDestType := updatedPC.ProtocolConverterServiceConfig.Config.DataflowComponentWriteServiceConfig.Destination.Protocol
+				Expect(writeDestType).To(Equal("stdout"))
 
-				// InputTopics must be untouched
-				Expect(updatedPC.ProtocolConverterServiceConfig.Config.DataflowComponentWriteServiceConfig.InputTopics).To(Equal("umh.v1.factory.*"))
+				// Source.Topics must be untouched
+				Expect(updatedPC.ProtocolConverterServiceConfig.Config.DataflowComponentWriteServiceConfig.Source.Topics).To(Equal("umh.v1.factory.*"))
 			})
 		})
 
@@ -804,8 +813,8 @@ var _ = Describe("EditProtocolConverter", func() {
 					},
 				}
 				mockConfig.Config.ProtocolConverter[0].ProtocolConverterServiceConfig.Config.DataflowComponentWriteServiceConfig = dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
-					Output:      map[string]interface{}{"stdout": map[string]interface{}{}},
-					InputTopics: "umh.v1.factory.*",
+					Destination: dataflowcomponentserviceconfig.WriteConfigDestination{Protocol: "stdout"},
+					Source:      dataflowcomponentserviceconfig.WriteConfigSource{Topics: "umh.v1.factory.*"},
 				}
 				mockConfig.Config.ProtocolConverter[0].ProtocolConverterServiceConfig.ReadDFCDesiredState = "active"
 				mockConfig.Config.ProtocolConverter[0].ProtocolConverterServiceConfig.WriteDFCDesiredState = "active"
@@ -1048,10 +1057,12 @@ var _ = Describe("EditProtocolConverter", func() {
 						"port": 80,
 					},
 					"writeDFC": map[string]interface{}{
-						"output": map[string]interface{}{
-							"stdout": map[string]interface{}{},
+						"destination": map[string]interface{}{
+							"protocol": "stdout",
 						},
-						"input_topics": "umh.v1.factory.*",
+						"source": map[string]interface{}{
+							"topics": "umh.v1.factory.*",
+						},
 					},
 				}
 				firstAction := actions.NewEditProtocolConverterAction(userEmail, uuid.New(), instanceUUID, outboundChannel, mockConfig, nil)
@@ -1072,10 +1083,12 @@ var _ = Describe("EditProtocolConverter", func() {
 						"port": 80,
 					},
 					"writeDFC": map[string]interface{}{
-						"output": map[string]interface{}{
-							"stdout": map[string]interface{}{},
+						"destination": map[string]interface{}{
+							"protocol": "stdout",
 						},
-						"input_topics": "umh.v1.plant.*", // different topic
+						"source": map[string]interface{}{
+							"topics": "umh.v1.plant.*", // different topic
+						},
 					},
 				}
 				err = action2.Parse(payload)
@@ -1113,8 +1126,8 @@ var _ = Describe("EditProtocolConverter", func() {
 						"state": "active",
 					},
 					"writeDFC": map[string]interface{}{
-						"output":       map[string]interface{}{"stdout": map[string]interface{}{}},
-						"input_topics": "umh.v1.factory.*",
+						"destination": map[string]interface{}{"protocol": "stdout"},
+						"source":      map[string]interface{}{"topics": "umh.v1.factory.*"},
 					},
 				}
 				firstAction := actions.NewEditProtocolConverterAction(userEmail, uuid.New(), instanceUUID, outboundChannel, mockConfig, nil)
@@ -1155,8 +1168,8 @@ var _ = Describe("EditProtocolConverter", func() {
 						"state": "active",
 					},
 					"writeDFC": map[string]interface{}{
-						"output":       map[string]interface{}{"stdout": map[string]interface{}{}},
-						"input_topics": "umh.v1.factory.*",
+						"destination": map[string]interface{}{"protocol": "stdout"},
+						"source":      map[string]interface{}{"topics": "umh.v1.factory.*"},
 					},
 				}
 				err = action2.Parse(payload)
@@ -1226,8 +1239,8 @@ var _ = Describe("EditProtocolConverter", func() {
 					},
 				}
 				mockConfig.Config.ProtocolConverter[0].ProtocolConverterServiceConfig.Config.DataflowComponentWriteServiceConfig = dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
-					Output:      map[string]interface{}{"stdout": map[string]interface{}{}},
-					InputTopics: "umh.v1.factory.*",
+					Destination: dataflowcomponentserviceconfig.WriteConfigDestination{Protocol: "stdout"},
+					Source:      dataflowcomponentserviceconfig.WriteConfigSource{Topics: "umh.v1.factory.*"},
 				}
 				mockConfig.Config.ProtocolConverter[0].ProtocolConverterServiceConfig.ReadDFCDesiredState = "active"
 				mockConfig.Config.ProtocolConverter[0].ProtocolConverterServiceConfig.WriteDFCDesiredState = "active"
@@ -1256,12 +1269,13 @@ var _ = Describe("EditProtocolConverter", func() {
 						},
 					},
 					"writeDFC": map[string]interface{}{
-						"output": map[string]interface{}{
-							"kafka": map[string]interface{}{
-								"addresses": []interface{}{"localhost:9092"},
-							},
+						"destination": map[string]interface{}{
+							"protocol": "kafka",
+							"code":     "addresses:\n- localhost:9092\n",
 						},
-						"input_topics": "umh.v1.plant.*",
+						"source": map[string]interface{}{
+							"topics": "umh.v1.plant.*",
+						},
 					},
 				}
 
@@ -1299,11 +1313,11 @@ var _ = Describe("EditProtocolConverter", func() {
 				Expect(readInput["input"].(map[string]interface{})["http_client"]).To(HaveKeyWithValue("url", "http://new.example.com"))
 
 				// Write DFC: new format stores directly without wrapper
-				writeOutput := updatedPC.ProtocolConverterServiceConfig.Config.DataflowComponentWriteServiceConfig.Output
-				Expect(writeOutput).To(HaveKey("kafka"))
+				writeDestType := updatedPC.ProtocolConverterServiceConfig.Config.DataflowComponentWriteServiceConfig.Destination.Protocol
+				Expect(writeDestType).To(Equal("kafka"))
 
-				// InputTopics updated
-				Expect(updatedPC.ProtocolConverterServiceConfig.Config.DataflowComponentWriteServiceConfig.InputTopics).To(Equal("umh.v1.plant.*"))
+				// Source.Topics updated
+				Expect(updatedPC.ProtocolConverterServiceConfig.Config.DataflowComponentWriteServiceConfig.Source.Topics).To(Equal("umh.v1.plant.*"))
 			})
 		})
 
@@ -1386,8 +1400,8 @@ var _ = Describe("EditProtocolConverter", func() {
 			It("should complete when write DFC has reached the stopped state", Label("disable-bridges"), func() {
 				mockConfig.Config.ProtocolConverter[0].ProtocolConverterServiceConfig.WriteDFCDesiredState = "active"
 				mockConfig.Config.ProtocolConverter[0].ProtocolConverterServiceConfig.Config.DataflowComponentWriteServiceConfig = dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
-					Output:      map[string]interface{}{"stdout": map[string]interface{}{}},
-					InputTopics: "umh.v1.factory.*",
+					Destination: dataflowcomponentserviceconfig.WriteConfigDestination{Protocol: "stdout"},
+					Source:      dataflowcomponentserviceconfig.WriteConfigSource{Topics: "umh.v1.factory.*"},
 				}
 
 				snapshotMgr := fsm.NewSnapshotManager()

--- a/umh-core/pkg/communicator/actions/get-protocolconverter_test.go
+++ b/umh-core/pkg/communicator/actions/get-protocolconverter_test.go
@@ -177,10 +177,8 @@ var _ = Describe("GetProtocolConverter", func() {
 								},
 							},
 							DataflowComponentWriteServiceConfig: dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
-								Output: map[string]interface{}{
-									"stdout": map[string]interface{}{},
-								},
-								InputTopics: "umh.v1.factory.line-1.*",
+								Destination: dataflowcomponentserviceconfig.WriteConfigDestination{Protocol: "stdout"},
+								Source:      dataflowcomponentserviceconfig.WriteConfigSource{Topics: "umh.v1.factory.line-1.*"},
 							},
 						},
 						Variables: variables.VariableBundle{
@@ -289,7 +287,7 @@ var _ = Describe("GetProtocolConverter", func() {
 
 				// Verify write DFC is populated with InputTopics
 				Expect(response.WriteDFCPayload).NotTo(BeNil())
-				Expect(response.WriteDFCPayload.InputTopics).To(Equal("umh.v1.factory.line-1.*"))
+				Expect(response.WriteDFCPayload.Source.Topics).To(Equal("umh.v1.factory.line-1.*"))
 
 				// Verify meta information
 				Expect(response.Meta).NotTo(BeNil())

--- a/umh-core/pkg/communicator/actions/protocolconverter_helpers.go
+++ b/umh-core/pkg/communicator/actions/protocolconverter_helpers.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
-	"strings"
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/benthosserviceconfig"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/connectionserviceconfig"
@@ -41,7 +40,7 @@ func buildUserScope(templateInfo *models.ProtocolConverterTemplateInfo) map[stri
 
 // validateWriteDFCConfig validates a raw write DFC config input and its desired state.
 func validateWriteDFCConfig(cfg *dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput, state string) error {
-	if cfg != nil && cfg.HasOutput() && strings.TrimSpace(cfg.Source.Topics) == "" {
+	if cfg != nil && cfg.HasOutput() && len(cfg.ToWriteConfig().Topics) == 0 {
 		return errors.New("write DFC requires at least one input topic (source.topics)")
 	}
 	if state != "" {

--- a/umh-core/pkg/communicator/actions/protocolconverter_helpers.go
+++ b/umh-core/pkg/communicator/actions/protocolconverter_helpers.go
@@ -41,10 +41,8 @@ func buildUserScope(templateInfo *models.ProtocolConverterTemplateInfo) map[stri
 
 // validateWriteDFCConfig validates a raw write DFC config input and its desired state.
 func validateWriteDFCConfig(cfg *dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput, state string) error {
-	if cfg != nil && cfg.HasOutput() {
-		if strings.TrimSpace(cfg.InputTopics) == "" {
-			return errors.New("write DFC requires at least one input topic (input_topics)")
-		}
+	if cfg != nil && cfg.HasOutput() && strings.TrimSpace(cfg.Source.Topics) == "" {
+		return errors.New("write DFC requires at least one input topic (source.topics)")
 	}
 	if state != "" {
 		if err := ValidateDataFlowComponentState(state); err != nil {
@@ -53,7 +51,6 @@ func validateWriteDFCConfig(cfg *dataflowcomponentserviceconfig.DataflowComponen
 	}
 	return nil
 }
-
 
 // validateReadProtocolConverterDFC validates a read ProtocolConverterDFC's state and configuration.
 // Returns nil if dfc is nil (nothing to validate).

--- a/umh-core/pkg/config/dataflowcomponentserviceconfig/write_config.go
+++ b/umh-core/pkg/config/dataflowcomponentserviceconfig/write_config.go
@@ -154,11 +154,9 @@ func (c DataflowComponentWriteConfigInput) ToDataflowComponentServiceConfig(brid
 	return c.ToWriteConfig().ToDataflowComponentServiceConfig(bridgedBy)
 }
 
-// splitTopics splits a newline- or comma-separated topic string into a trimmed,
+// splitTopics splits a newline-separated topic string into a trimmed,
 // non-empty []string. YAML list entries prefixed with "- " are also handled.
 func splitTopics(s string) []string {
-	// normalize commas to newlines, then split
-	s = strings.ReplaceAll(s, ",", "\n")
 	parts := strings.Split(s, "\n")
 	out := make([]string, 0, len(parts))
 	for _, p := range parts {

--- a/umh-core/pkg/config/dataflowcomponentserviceconfig/write_config.go
+++ b/umh-core/pkg/config/dataflowcomponentserviceconfig/write_config.go
@@ -16,99 +16,127 @@ package dataflowcomponentserviceconfig
 
 import (
 	"strings"
+
+	"gopkg.in/yaml.v3"
 )
 
 // PlaceholderUMHTopicUnset is used when no input topics were configured for a write DFC.
 // It makes the misconfiguration visible in Benthos logs rather than silently subscribing to nothing.
 const PlaceholderUMHTopicUnset = "TOPIC_NOT_SET_BY_USER"
 
+// WriteConfigSource holds the source (input) configuration for a write DFC.
+type WriteConfigSource struct {
+	// Topics is either a plain topic list (newline- or comma-separated, each line
+	// optionally prefixed with "- ") or a Go template string that renders to such a list.
+	Topics string `yaml:"topics,omitempty" json:"topics,omitempty" mapstructure:"topics,omitempty"`
+}
+
+// WriteConfigProcessing holds the processing configuration for a write DFC.
+type WriteConfigProcessing struct {
+	// Type is the processor type. Currently hardcoded to "nodered_js".
+	Type string `yaml:"type,omitempty" json:"type,omitempty" mapstructure:"type,omitempty"`
+	// Code is the processor code snippet (e.g. Node-RED JS).
+	Code string `yaml:"code,omitempty" json:"code,omitempty" mapstructure:"code,omitempty"`
+}
+
+// WriteConfigDestination holds the destination (output) configuration for a write DFC.
+type WriteConfigDestination struct {
+	// Protocol is the Benthos output plugin name (e.g. "http_client", "kafka").
+	// Currently hardcoded to "http_client".
+	Protocol string `yaml:"protocol,omitempty" json:"protocol,omitempty" mapstructure:"protocol,omitempty"`
+	// Code is the YAML body of the Benthos output plugin config.
+	Code string `yaml:"code,omitempty" json:"code,omitempty" mapstructure:"code,omitempty"`
+}
+
+// WriteConfigExtra holds extra Benthos YAML that is inlined verbatim into the generated
+// Benthos service config. Supported top-level keys: cache_resources, rate_limit_resources, buffer.
+type WriteConfigExtra struct {
+	Code string `yaml:"code,omitempty" json:"code,omitempty" mapstructure:"code,omitempty"`
+}
+
 // DataflowComponentWriteConfig is the typed, validated configuration for write-side DFCs.
-// It replaces the generic DataflowComponentServiceConfig for write flows, making the
-// nodered_js processor and UNS topics first-class typed fields instead of free-form maps.
-//
-// This struct is the internal typed form used for FSM deployment. The wire format
-// (models.WriteDFC) embeds DataflowComponentWriteConfigInput so that InputTopics remains
-// a raw string (preserving template actions for round-trip fidelity).
+// It is the internal form used by the FSM after rendering and parsing.
 //
 // YAML / JSON shape:
 //
-//	input_topics:
-//	  - umh.v1.enterprise.site.line.device.*
-//	  - umh.v1.enterprise.site.line.otherDevice.*
-//	processing_nodered_js: |-
-//	  msg.payload["field"] = "value";
-//	  return msg;
-//	output:
-//	  http_client:
+//	source:
+//	  topics: |-
+//	    - umh.v1.enterprise.site.line.device.*
+//	    - umh.v1.enterprise.site.line.otherDevice.*
+//	processing:
+//	  type: "nodered_js"
+//	  code: |-
+//	    msg.payload["field"] = "value";
+//	    return msg;
+//	destination:
+//	  type: "http_client"
+//	  code: |-
 //	    url: http://{{ .IP }}:{{ .PORT }}/post
 //	    verb: POST
-//	buffer:
-//	  none: {}
+//	extra:
+//	  code: |-
+//	    buffer:
+//	      memory: {}
 type DataflowComponentWriteConfig struct {
-
-	// Output is the Benthos output configuration (e.g. http_client, mqtt).
-	// When non-empty, a UNS input is automatically generated during rendering.
-	Output map[string]any `yaml:"output,omitempty" json:"output,omitempty" mapstructure:"output,omitempty"`
-
-	// Buffer is the optional Benthos buffer configuration.
-	Buffer map[string]any `yaml:"buffer,omitempty" json:"buffer,omitempty" mapstructure:"buffer,omitempty"`
-
-	// ProcessingNoderedJS is the Node-RED JS snippet that transforms each message.
-	// Must end with "return msg;" (or "return null;" to drop the message).
-	// Defaults to "return msg;" when empty.
-	ProcessingNoderedJS string `yaml:"processing_nodered_js,omitempty" json:"processing_nodered_js,omitempty" mapstructure:"processing_nodered_js,omitempty"`
-
-	// InputTopics lists the UNS topics this write DFC subscribes to.
-	InputTopics []string `yaml:"input_topics,omitempty" json:"input_topics,omitempty" mapstructure:"input_topics,omitempty"`
+	// Topics lists the UNS topics this write DFC subscribes to (parsed from Source.Topics).
+	Topics      []string
+	Processing  WriteConfigProcessing
+	Destination WriteConfigDestination
+	Extra       *WriteConfigExtra
 }
 
 // DataflowComponentWriteConfigInput is the wire/input form of write DFC config.
-// InputTopics is a single string that may contain Go text/template actions
-// (e.g. "{{- range .topics }}{{ . }}\n{{ end }}") or a plain newline-/comma-separated
-// topic list. It is rendered with user-supplied variables at action time and
-// converted to the typed DataflowComponentWriteConfig before being stored.
+// Source.Topics may contain Go text/template actions and is rendered with
+// user-supplied variables before being stored as the typed DataflowComponentWriteConfig.
+//
+// UnrecognizedFields captures any YAML keys not recognized by the current schema
+// (e.g. fields from an older config format). They are round-tripped transparently
+// so that a config written in an older format is never silently erased on read/write.
 type DataflowComponentWriteConfigInput struct {
-	Output map[string]any `yaml:"output,omitempty"                json:"output,omitempty"`
-	Buffer map[string]any `yaml:"buffer,omitempty"                json:"buffer,omitempty"`
-	// InputTopics is either a plain topic list (newline- or comma-separated)
-	// or a Go template string that renders to such a list.
-	InputTopics         string `yaml:"input_topics,omitempty"          json:"input_topics,omitempty"`
-	ProcessingNoderedJS string `yaml:"processing_nodered_js,omitempty" json:"processing_nodered_js,omitempty"`
+	Source      WriteConfigSource      `yaml:"source,omitempty"      json:"source,omitempty"      mapstructure:"source,omitempty"`
+	Processing  WriteConfigProcessing  `yaml:"processing,omitempty"  json:"processing,omitempty"  mapstructure:"processing,omitempty"`
+	Destination WriteConfigDestination `yaml:"destination,omitempty" json:"destination,omitempty" mapstructure:"destination,omitempty"`
+	Extra       *WriteConfigExtra      `yaml:"extra,omitempty"       json:"extra,omitempty"       mapstructure:"extra,omitempty"`
+	// UnrecognizedFields preserves unknown YAML keys for round-trip fidelity.
+	UnrecognizedFields map[string]any `yaml:",inline" json:"-" mapstructure:"-"`
 }
 
 // HasOutput reports whether a write output is configured.
 func (c DataflowComponentWriteConfigInput) HasOutput() bool {
-	return len(c.Output) > 0
+	return c.Destination.Protocol != "" || c.Destination.Code != ""
 }
 
 // ToWriteConfig converts the input to a typed DataflowComponentWriteConfig by splitting
-// InputTopics on newlines/commas without any template rendering. Use this when the
-// InputTopics string is already fully resolved (e.g. structural conversions, GET responses).
+// Source.Topics without any template rendering. Use this when Source.Topics is already
+// fully resolved (e.g. structural conversions, GET responses).
 func (c DataflowComponentWriteConfigInput) ToWriteConfig() DataflowComponentWriteConfig {
 	return DataflowComponentWriteConfig{
-		InputTopics:         splitTopics(c.InputTopics),
-		ProcessingNoderedJS: c.ProcessingNoderedJS,
-		Output:              c.Output,
-		Buffer:              c.Buffer,
+		Topics:      splitTopics(c.Source.Topics),
+		Processing:  c.Processing,
+		Destination: c.Destination,
+		Extra:       c.Extra,
 	}
 }
 
 // ToDataflowComponentServiceConfig expands the input config into a full Benthos service
-// config. InputTopics is split without template rendering — call Render first if the
+// config. Source.Topics is split without template rendering — call Render first if the
 // string still contains {{ }} actions.
 func (c DataflowComponentWriteConfigInput) ToDataflowComponentServiceConfig(bridgedBy string) DataflowComponentServiceConfig {
 	return c.ToWriteConfig().ToDataflowComponentServiceConfig(bridgedBy)
 }
 
 // splitTopics splits a newline- or comma-separated topic string into a trimmed,
-// non-empty []string.
+// non-empty []string. YAML list entries prefixed with "- " are also handled.
 func splitTopics(s string) []string {
 	// normalize commas to newlines, then split
 	s = strings.ReplaceAll(s, ",", "\n")
 	parts := strings.Split(s, "\n")
 	out := make([]string, 0, len(parts))
 	for _, p := range parts {
-		if t := strings.TrimSpace(p); t != "" {
+		t := strings.TrimSpace(p)
+		t = strings.TrimPrefix(t, "- ")
+		t = strings.TrimSpace(t)
+		if t != "" {
 			out = append(out, t)
 		}
 	}
@@ -117,77 +145,143 @@ func splitTopics(s string) []string {
 
 // HasOutput reports whether a write output is configured.
 func (c DataflowComponentWriteConfig) HasOutput() bool {
-	return len(c.Output) > 0
+	return c.Destination.Protocol != "" || c.Destination.Code != ""
 }
 
 // ToDataflowComponentServiceConfig expands the typed write config into a full Benthos
 // service config ready for the FSM to deploy.
 //
-// bridgedBy is the resolved consumer-group identifier (from .internal.bridged_by in the
-// render scope). When empty the consumer_group field is left blank, which is acceptable
-// for structural-only conversions that never hit the wire (e.g. SpecToRuntime).
+// bridgedBy is the resolved consumer-group identifier. When empty the consumer_group
+// field is left blank (acceptable for structural-only conversions).
 func (c DataflowComponentWriteConfig) ToDataflowComponentServiceConfig(bridgedBy string) DataflowComponentServiceConfig {
-	code := c.ProcessingNoderedJS
-	pipeline := c.codeToPipeline(code)
+	processorType := c.Processing.Type
+	if processorType == "" {
+		processorType = "nodered_js"
+	}
+	pipeline := c.codeToPipeline(c.Processing.Code, processorType)
 
 	var input map[string]any
-	if len(c.Output) > 0 {
-		umhTopics := c.InputTopics
-		if len(umhTopics) == 0 {
-			// Sentinel: action validation normally rejects an empty InputTopics when
-			// Output is present, but set-config-file bypasses actions and can produce
-			// this state. The sentinel makes the misconfiguration visible in Benthos
-			// logs rather than silently subscribing to nothing.
-			umhTopics = []string{PlaceholderUMHTopicUnset}
+	var output map[string]any
+
+	if c.HasOutput() {
+		topics := c.Topics
+		if len(topics) == 0 {
+			topics = []string{PlaceholderUMHTopicUnset}
 		}
 		input = map[string]any{
 			"uns": map[string]any{
 				"consumer_group": bridgedBy,
-				"umh_topics":     umhTopics,
+				"umh_topics":     topics,
 			},
+		}
+
+		if c.Destination.Protocol != "" {
+			if c.Destination.Code != "" {
+				var listConfig []any
+				if err := yaml.Unmarshal([]byte(c.Destination.Code), &listConfig); err == nil {
+					output = map[string]any{c.Destination.Protocol: listConfig}
+				} else {
+					destConfig := map[string]any{}
+					if err := yaml.Unmarshal([]byte(c.Destination.Code), &destConfig); err != nil {
+						destConfig = map[string]any{"_raw": c.Destination.Code}
+					}
+					output = map[string]any{c.Destination.Protocol: destConfig}
+				}
+			} else {
+				output = map[string]any{c.Destination.Protocol: map[string]any{}}
+			}
 		}
 	}
 
+	cacheResources, rateLimitResources, buffer := c.parseExtra()
 	return DataflowComponentServiceConfig{
 		BenthosConfig: BenthosConfig{
-			Input:    input,
-			Pipeline: pipeline,
-			Output:   c.Output,
-			Buffer:   c.Buffer,
+			Input:              input,
+			Pipeline:           pipeline,
+			Output:             output,
+			CacheResources:     cacheResources,
+			RateLimitResources: rateLimitResources,
+			Buffer:             buffer,
 		},
 	}
 }
 
 // ToDisplayDataflowComponentServiceConfig converts the typed write config into a
 // DataflowComponentServiceConfig for display purposes (e.g. get-protocolconverter).
-// The UNS input is intentionally omitted — it is auto-generated at render time and
-// must not be exposed to the frontend as if it were user-configured.
+// The UNS input is intentionally omitted — it is auto-generated at render time.
 func (c DataflowComponentWriteConfig) ToDisplayDataflowComponentServiceConfig() DataflowComponentServiceConfig {
-	code := c.ProcessingNoderedJS
-	pipeline := c.codeToPipeline(code)
+	processorType := c.Processing.Type
+	if processorType == "" {
+		processorType = "nodered_js"
+	}
+	pipeline := c.codeToPipeline(c.Processing.Code, processorType)
 
+	var output map[string]any
+	if c.Destination.Protocol != "" {
+		destConfig := map[string]any{}
+		if c.Destination.Code != "" {
+			if err := yaml.Unmarshal([]byte(c.Destination.Code), &destConfig); err != nil {
+				destConfig = map[string]any{"_raw": c.Destination.Code}
+			}
+		}
+		output = map[string]any{c.Destination.Protocol: destConfig}
+	}
+
+	cacheResources, rateLimitResources, buffer := c.parseExtra()
 	return DataflowComponentServiceConfig{
 		BenthosConfig: BenthosConfig{
-			Pipeline: pipeline,
-			Output:   c.Output,
-			Buffer:   c.Buffer,
+			Pipeline:           pipeline,
+			Output:             output,
+			CacheResources:     cacheResources,
+			RateLimitResources: rateLimitResources,
+			Buffer:             buffer,
 		},
 	}
 }
 
-// codeToPipeline converts a code string to a Benthos pipeline configuration.
-func (c DataflowComponentWriteConfig) codeToPipeline(code string) map[string]any {
+// parseExtra parses Extra.Code into the three benthos top-level inject fields.
+// Known top-level keys: cache_resources, rate_limit_resources, buffer.
+// Unknown keys in the YAML are silently ignored.
+func (c DataflowComponentWriteConfig) parseExtra() (cacheResources []map[string]any, rateLimitResources []map[string]any, buffer map[string]any) {
+	if c.Extra == nil || c.Extra.Code == "" {
+		return nil, nil, nil
+	}
+	var parsed map[string]any
+	if err := yaml.Unmarshal([]byte(c.Extra.Code), &parsed); err != nil {
+		return nil, nil, nil
+	}
+	if raw, ok := parsed["cache_resources"].([]any); ok {
+		for _, item := range raw {
+			if m, ok := item.(map[string]any); ok {
+				cacheResources = append(cacheResources, m)
+			}
+		}
+	}
+	if raw, ok := parsed["rate_limit_resources"].([]any); ok {
+		for _, item := range raw {
+			if m, ok := item.(map[string]any); ok {
+				rateLimitResources = append(rateLimitResources, m)
+			}
+		}
+	}
+	if m, ok := parsed["buffer"].(map[string]any); ok {
+		buffer = m
+	}
+	return cacheResources, rateLimitResources, buffer
+}
+
+// codeToPipeline converts a code string and processor type to a Benthos pipeline config.
+func (c DataflowComponentWriteConfig) codeToPipeline(code, processorType string) map[string]any {
 	if code == "" {
 		code = "return msg;"
 	}
-	pipeline := map[string]any{
+	return map[string]any{
 		"processors": []any{
 			map[string]any{
-				"nodered_js": map[string]any{
+				processorType: map[string]any{
 					"code": code,
 				},
 			},
 		},
 	}
-	return pipeline
 }

--- a/umh-core/pkg/config/dataflowcomponentserviceconfig/write_config.go
+++ b/umh-core/pkg/config/dataflowcomponentserviceconfig/write_config.go
@@ -50,6 +50,30 @@ type WriteConfigDestination struct {
 	Code string `yaml:"code,omitempty" json:"code,omitempty" mapstructure:"code,omitempty"`
 }
 
+// toOutputMap builds the Benthos output map for this destination.
+// Protocol must be non-empty; Code may be empty (returns empty map config).
+// List-form YAML configs are preserved as []any; map-form as map[string]any;
+// unparseable code falls back to {"_raw": code}.
+func (d WriteConfigDestination) toOutputMap() map[string]any {
+	var destConfig any
+	if d.Code != "" {
+		var sliceVal []any
+		if err := yaml.Unmarshal([]byte(d.Code), &sliceVal); err == nil && sliceVal != nil {
+			destConfig = sliceVal
+		} else {
+			mapVal := map[string]any{}
+			if err := yaml.Unmarshal([]byte(d.Code), &mapVal); err != nil {
+				destConfig = map[string]any{"_raw": d.Code}
+			} else {
+				destConfig = mapVal
+			}
+		}
+	} else {
+		destConfig = map[string]any{}
+	}
+	return map[string]any{d.Protocol: destConfig}
+}
+
 // WriteConfigExtra holds extra Benthos YAML that is inlined verbatim into the generated
 // Benthos service config. Supported top-level keys: cache_resources, rate_limit_resources, buffer.
 type WriteConfigExtra struct {
@@ -181,20 +205,7 @@ func (c DataflowComponentWriteConfig) ToDataflowComponentServiceConfig(bridgedBy
 		}
 
 		if c.Destination.Protocol != "" {
-			if c.Destination.Code != "" {
-				var listConfig []any
-				if err := yaml.Unmarshal([]byte(c.Destination.Code), &listConfig); err == nil {
-					output = map[string]any{c.Destination.Protocol: listConfig}
-				} else {
-					destConfig := map[string]any{}
-					if err := yaml.Unmarshal([]byte(c.Destination.Code), &destConfig); err != nil {
-						destConfig = map[string]any{"_raw": c.Destination.Code}
-					}
-					output = map[string]any{c.Destination.Protocol: destConfig}
-				}
-			} else {
-				output = map[string]any{c.Destination.Protocol: map[string]any{}}
-			}
+			output = c.Destination.toOutputMap()
 		}
 	}
 
@@ -223,13 +234,7 @@ func (c DataflowComponentWriteConfig) ToDisplayDataflowComponentServiceConfig() 
 
 	var output map[string]any
 	if c.Destination.Protocol != "" {
-		destConfig := map[string]any{}
-		if c.Destination.Code != "" {
-			if err := yaml.Unmarshal([]byte(c.Destination.Code), &destConfig); err != nil {
-				destConfig = map[string]any{"_raw": c.Destination.Code}
-			}
-		}
-		output = map[string]any{c.Destination.Protocol: destConfig}
+		output = c.Destination.toOutputMap()
 	}
 
 	cacheResources, rateLimitResources, buffer := c.parseExtra()

--- a/umh-core/pkg/config/dataflowcomponentserviceconfig/write_config.go
+++ b/umh-core/pkg/config/dataflowcomponentserviceconfig/write_config.go
@@ -107,11 +107,11 @@ type WriteConfigExtra struct {
 //	    buffer:
 //	      memory: {}
 type DataflowComponentWriteConfig struct {
-	// Topics lists the UNS topics this write DFC subscribes to (parsed from Source.Topics).
-	Topics      []string
+	Extra       *WriteConfigExtra
 	Processing  WriteConfigProcessing
 	Destination WriteConfigDestination
-	Extra       *WriteConfigExtra
+	// Topics lists the UNS topics this write DFC subscribes to (parsed from Source.Topics).
+	Topics []string
 }
 
 // DataflowComponentWriteConfigInput is the wire/input form of write DFC config.
@@ -122,12 +122,12 @@ type DataflowComponentWriteConfig struct {
 // (e.g. fields from an older config format). They are round-tripped transparently
 // so that a config written in an older format is never silently erased on read/write.
 type DataflowComponentWriteConfigInput struct {
-	Source      WriteConfigSource      `yaml:"source,omitempty"      json:"source,omitempty"      mapstructure:"source,omitempty"`
-	Processing  WriteConfigProcessing  `yaml:"processing,omitempty"  json:"processing,omitempty"  mapstructure:"processing,omitempty"`
-	Destination WriteConfigDestination `yaml:"destination,omitempty" json:"destination,omitempty" mapstructure:"destination,omitempty"`
-	Extra       *WriteConfigExtra      `yaml:"extra,omitempty"       json:"extra,omitempty"       mapstructure:"extra,omitempty"`
+	Extra *WriteConfigExtra `yaml:"extra,omitempty"       json:"extra,omitempty"       mapstructure:"extra,omitempty"`
 	// UnrecognizedFields preserves unknown YAML keys for round-trip fidelity.
-	UnrecognizedFields map[string]any `yaml:",inline" json:"-" mapstructure:"-"`
+	UnrecognizedFields map[string]any         `yaml:",inline" json:"-" mapstructure:"-"`
+	Processing         WriteConfigProcessing  `yaml:"processing,omitempty"  json:"processing,omitempty"  mapstructure:"processing,omitempty"`
+	Destination        WriteConfigDestination `yaml:"destination,omitempty" json:"destination,omitempty" mapstructure:"destination,omitempty"`
+	Source             WriteConfigSource      `yaml:"source,omitempty"      json:"source,omitempty"      mapstructure:"source,omitempty"`
 }
 
 // HasOutput reports whether a write output is configured.

--- a/umh-core/pkg/config/dataflowcomponentserviceconfig/write_config.go
+++ b/umh-core/pkg/config/dataflowcomponentserviceconfig/write_config.go
@@ -36,6 +36,7 @@ type WriteConfigProcessing struct {
 	// Type is the processor type. Currently hardcoded to "nodered_js".
 	Type string `yaml:"type,omitempty" json:"type,omitempty" mapstructure:"type,omitempty"`
 	// Code is the processor code snippet (e.g. Node-RED JS).
+	// Might contain a Go template string that renders to a processor code snippet.
 	Code string `yaml:"code,omitempty" json:"code,omitempty" mapstructure:"code,omitempty"`
 }
 
@@ -45,12 +46,16 @@ type WriteConfigDestination struct {
 	// Currently hardcoded to "http_client".
 	Protocol string `yaml:"protocol,omitempty" json:"protocol,omitempty" mapstructure:"protocol,omitempty"`
 	// Code is the YAML body of the Benthos output plugin config.
+	// Might contain a Go template string that renders to a YAML body.
 	Code string `yaml:"code,omitempty" json:"code,omitempty" mapstructure:"code,omitempty"`
 }
 
 // WriteConfigExtra holds extra Benthos YAML that is inlined verbatim into the generated
 // Benthos service config. Supported top-level keys: cache_resources, rate_limit_resources, buffer.
 type WriteConfigExtra struct {
+	// Code is any extra Benthos YAML that is inlined verbatim into the generated
+	// Benthos service config.
+	// Might contain a Go template string that renders to a YAML body.
 	Code string `yaml:"code,omitempty" json:"code,omitempty" mapstructure:"code,omitempty"`
 }
 

--- a/umh-core/pkg/config/dataflowcomponentserviceconfig/write_config_test.go
+++ b/umh-core/pkg/config/dataflowcomponentserviceconfig/write_config_test.go
@@ -32,11 +32,9 @@ var _ = Describe("write_config", func() {
 				Expect(result).To(Equal(expected))
 			},
 			Entry("newline-separated", "a\nb\nc", []string{"a", "b", "c"}),
-			Entry("comma-separated", "a,b,c", []string{"a", "b", "c"}),
-			Entry("mixed newline and comma", "a,b\nc", []string{"a", "b", "c"}),
+			Entry("mixed newline and comma", "a,b\nc", []string{"a,b", "c"}),
 			Entry("trims whitespace", "  a  \n  b  ", []string{"a", "b"}),
 			Entry("skips empty lines", "a\n\nb", []string{"a", "b"}),
-			Entry("all commas (only-commas → empty)", ",,,,", []string{}),
 			Entry("single topic", "umh.v1.factory.*", []string{"umh.v1.factory.*"}),
 			Entry("empty string", "", []string{}),
 		)

--- a/umh-core/pkg/config/dataflowcomponentserviceconfig/write_config_test.go
+++ b/umh-core/pkg/config/dataflowcomponentserviceconfig/write_config_test.go
@@ -26,9 +26,9 @@ var _ = Describe("write_config", func() {
 		DescribeTable("splits topic strings correctly",
 			func(input string, expected []string) {
 				cfg := dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
-					InputTopics: input,
+					Source: dataflowcomponentserviceconfig.WriteConfigSource{Topics: input},
 				}
-				result := cfg.ToWriteConfig().InputTopics
+				result := cfg.ToWriteConfig().Topics
 				Expect(result).To(Equal(expected))
 			},
 			Entry("newline-separated", "a\nb\nc", []string{"a", "b", "c"}),
@@ -43,21 +43,24 @@ var _ = Describe("write_config", func() {
 	})
 
 	Describe("HasOutput", func() {
-		It("returns false when Output is nil", func() {
+		It("returns false when Destination is empty", func() {
 			cfg := dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{}
 			Expect(cfg.HasOutput()).To(BeFalse())
 		})
 
-		It("returns false when Output is empty map", func() {
+		It("returns false when Destination has no Protocol or Code", func() {
 			cfg := dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
-				Output: map[string]any{},
+				Destination: dataflowcomponentserviceconfig.WriteConfigDestination{},
 			}
 			Expect(cfg.HasOutput()).To(BeFalse())
 		})
 
-		It("returns true when Output has entries", func() {
+		It("returns true when Destination has Protocol", func() {
 			cfg := dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
-				Output: map[string]any{"http_client": map[string]any{"url": "http://example.com"}},
+				Destination: dataflowcomponentserviceconfig.WriteConfigDestination{
+					Protocol: "http_client",
+					Code:     "url: http://example.com\nverb: POST",
+				},
 			}
 			Expect(cfg.HasOutput()).To(BeTrue())
 		})
@@ -66,8 +69,10 @@ var _ = Describe("write_config", func() {
 	Describe("ToDataflowComponentServiceConfig", func() {
 		It("builds UNS input with provided topics", func() {
 			cfg := dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
-				InputTopics: "umh.v1.factory.*",
-				Output:      map[string]any{"stdout": map[string]any{}},
+				Source: dataflowcomponentserviceconfig.WriteConfigSource{Topics: "umh.v1.factory.*"},
+				Destination: dataflowcomponentserviceconfig.WriteConfigDestination{
+					Protocol: "stdout",
+				},
 			}
 			svc := cfg.ToDataflowComponentServiceConfig("my-bridge")
 			Expect(svc.BenthosConfig.Input).To(HaveKey("uns"))
@@ -76,10 +81,12 @@ var _ = Describe("write_config", func() {
 			Expect(uns["umh_topics"]).To(ContainElement("umh.v1.factory.*"))
 		})
 
-		It("uses sentinel when InputTopics is empty and Output is set", func() {
+		It("uses sentinel when Source.Topics is empty and Destination is set", func() {
 			cfg := dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
-				InputTopics: "",
-				Output:      map[string]any{"stdout": map[string]any{}},
+				Source: dataflowcomponentserviceconfig.WriteConfigSource{Topics: ""},
+				Destination: dataflowcomponentserviceconfig.WriteConfigDestination{
+					Protocol: "stdout",
+				},
 			}
 			svc := cfg.ToDataflowComponentServiceConfig("my-bridge")
 			uns := svc.BenthosConfig.Input["uns"].(map[string]any)
@@ -88,16 +95,18 @@ var _ = Describe("write_config", func() {
 
 		It("produces no input when no output is configured", func() {
 			cfg := dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
-				InputTopics: "umh.v1.factory.*",
+				Source: dataflowcomponentserviceconfig.WriteConfigSource{Topics: "umh.v1.factory.*"},
 			}
 			svc := cfg.ToDataflowComponentServiceConfig("my-bridge")
 			Expect(svc.BenthosConfig.Input).To(BeNil())
 		})
 
-		It("defaults ProcessingNoderedJS to 'return msg;' when empty", func() {
+		It("defaults Processing.Code to 'return msg;' when empty", func() {
 			cfg := dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
-				InputTopics: "umh.v1.*",
-				Output:      map[string]any{"stdout": map[string]any{}},
+				Source: dataflowcomponentserviceconfig.WriteConfigSource{Topics: "umh.v1.*"},
+				Destination: dataflowcomponentserviceconfig.WriteConfigDestination{
+					Protocol: "stdout",
+				},
 			}
 			svc := cfg.ToDataflowComponentServiceConfig("b")
 			processors := svc.BenthosConfig.Pipeline["processors"].([]any)
@@ -110,16 +119,39 @@ var _ = Describe("write_config", func() {
 	Describe("ToWriteConfig round-trip", func() {
 		It("preserves all fields through ToWriteConfig", func() {
 			input := dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
-				InputTopics:         "umh.v1.*\numh.v1.other.*",
-				ProcessingNoderedJS: "return msg;",
-				Output:              map[string]any{"kafka": map[string]any{}},
-				Buffer:              map[string]any{"none": map[string]any{}},
+				Source: dataflowcomponentserviceconfig.WriteConfigSource{
+					Topics: "umh.v1.*\numh.v1.other.*",
+				},
+				Processing: dataflowcomponentserviceconfig.WriteConfigProcessing{
+					Type: "nodered_js",
+					Code: "return msg;",
+				},
+				Destination: dataflowcomponentserviceconfig.WriteConfigDestination{
+					Protocol: "kafka",
+					Code:     "addresses:\n  - localhost:9092",
+				},
+				Extra: &dataflowcomponentserviceconfig.WriteConfigExtra{
+					Code: "buffer:\n  memory: {}\n",
+				},
 			}
 			got := input.ToWriteConfig()
-			Expect(got.InputTopics).To(ConsistOf("umh.v1.*", "umh.v1.other.*"))
-			Expect(got.ProcessingNoderedJS).To(Equal("return msg;"))
-			Expect(got.Output).To(HaveKey("kafka"))
-			Expect(got.Buffer).To(HaveKey("none"))
+			Expect(got.Topics).To(ConsistOf("umh.v1.*", "umh.v1.other.*"))
+			Expect(got.Processing.Code).To(Equal("return msg;"))
+			Expect(got.Destination.Protocol).To(Equal("kafka"))
+			Expect(got.Extra).NotTo(BeNil())
+			Expect(got.Extra.Code).To(ContainSubstring("buffer"))
+		})
+
+		It("injects buffer from Extra into BenthosConfig", func() {
+			input := dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
+				Source:      dataflowcomponentserviceconfig.WriteConfigSource{Topics: "umh.v1.*"},
+				Destination: dataflowcomponentserviceconfig.WriteConfigDestination{Protocol: "stdout"},
+				Extra: &dataflowcomponentserviceconfig.WriteConfigExtra{
+					Code: "buffer:\n  memory: {}\n",
+				},
+			}
+			svc := input.ToDataflowComponentServiceConfig("b")
+			Expect(svc.BenthosConfig.Buffer).To(HaveKey("memory"))
 		})
 	})
 })

--- a/umh-core/pkg/config/protocolconverterserviceconfig/config_customized.go
+++ b/umh-core/pkg/config/protocolconverterserviceconfig/config_customized.go
@@ -45,7 +45,7 @@ func (c ProtocolConverterServiceConfigSpec) GetDFCReadServiceConfig() dataflowco
 }
 
 // GetDFCWriteServiceConfig returns the write DFC input config from the spec.
-// InputTopics may contain Go template actions resolved at deploy time.
+// Source.Topics may contain Go template actions resolved at deploy time.
 func (c ProtocolConverterServiceConfigSpec) GetDFCWriteServiceConfig() dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput {
 	return c.Config.DataflowComponentWriteServiceConfig
 }

--- a/umh-core/pkg/config/protocolconverterserviceconfig/generator_test.go
+++ b/umh-core/pkg/config/protocolconverterserviceconfig/generator_test.go
@@ -62,12 +62,10 @@ var _ = Describe("ProtocolConverter YAML Generator", func() {
 							},
 						},
 						DataflowComponentWriteServiceConfig: dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
-							InputTopics: "umh.v1.enterprise.site.*",
-							Output: map[string]any{
-								"kafka": map[string]any{
-									"addresses": []string{"kafka:9092"},
-									"topic":     "output-topic",
-								},
+							Source: dataflowcomponentserviceconfig.WriteConfigSource{Topics: "umh.v1.enterprise.site.*"},
+							Destination: dataflowcomponentserviceconfig.WriteConfigDestination{
+								Protocol: "kafka",
+								Code:     "addresses:\n- kafka:9092\ntopic: output-topic\n",
 							},
 						},
 					},
@@ -81,12 +79,10 @@ var _ = Describe("ProtocolConverter YAML Generator", func() {
 					"    output:",
 					"      stdout: {}",
 					"dataflowcomponent_write:",
-					"  input_topics: umh.v1.enterprise.site.*",
-					"  output:",
-					"    kafka:",
-					"      addresses:",
-					"      - kafka:9092",
-					"      topic: output-topic",
+					"  source:",
+					"    topics: umh.v1.enterprise.site.*",
+					"  destination:",
+					"    protocol: kafka",
 				},
 				notExpected: []string{},
 			}),
@@ -108,21 +104,23 @@ var _ = Describe("ProtocolConverter YAML Generator", func() {
 							},
 						},
 						DataflowComponentWriteServiceConfig: dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
-							ProcessingNoderedJS: "msg.payload.foo = 'bar';\nreturn msg;",
-							Output: map[string]any{
-								"http_client": map[string]any{
-									"url": "http://api.example.com/ingest",
-								},
+							Processing: dataflowcomponentserviceconfig.WriteConfigProcessing{
+								Type: "nodered_js",
+								Code: "msg.payload.foo = 'bar';\nreturn msg;",
+							},
+							Destination: dataflowcomponentserviceconfig.WriteConfigDestination{
+								Protocol: "http_client",
+								Code:     "url: http://api.example.com/ingest\n",
 							},
 						},
 					},
 				},
 				expected: []string{
 					"dataflowcomponent_write:",
-					"  processing_nodered_js:",
-					"  output:",
-					"    http_client:",
-					"      url: http://api.example.com/ingest",
+					"  processing:",
+					"    type: nodered_js",
+					"  destination:",
+					"    protocol: http_client",
 				},
 				notExpected: []string{},
 			}),
@@ -179,22 +177,20 @@ var _ = Describe("ProtocolConverter YAML Generator", func() {
 							},
 						},
 						DataflowComponentWriteServiceConfig: dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
-							Output: map[string]any{
-								"redis_pubsub": map[string]any{
-									"url":     "redis://redis:6379",
-									"channel": "processed_data",
-								},
+							Destination: dataflowcomponentserviceconfig.WriteConfigDestination{
+								Protocol: "redis_pubsub",
+								Code:     "url: redis://redis:6379\nchannel: processed_data\n",
 							},
-							Buffer: map[string]any{"none": map[string]any{}},
+							Extra: &dataflowcomponentserviceconfig.WriteConfigExtra{
+								Code: "buffer:\n  none: {}",
+							},
 						},
 					},
 				},
 				expected: []string{
 					"dataflowcomponent_write:",
-					"  output:",
-					"    redis_pubsub:",
-					"      url: redis://redis:6379",
-					"      channel: processed_data",
+					"  destination:",
+					"    protocol: redis_pubsub",
 					"  buffer:",
 					"    none: {}",
 				},

--- a/umh-core/pkg/config/protocolconverterserviceconfig/normalizer_test.go
+++ b/umh-core/pkg/config/protocolconverterserviceconfig/normalizer_test.go
@@ -115,7 +115,7 @@ var _ = Describe("ProtocolConverter YAML Normalizer", func() {
 
 			// Write DFC uses a typed struct; with no write config set, it should be zero value.
 			Expect(config.Config.DataflowComponentWriteServiceConfig.HasOutput()).To(BeFalse())
-			Expect(config.Config.DataflowComponentWriteServiceConfig.InputTopics).To(BeEmpty())
+			Expect(config.Config.DataflowComponentWriteServiceConfig.Source.Topics).To(BeEmpty())
 
 			// Buffer should have the none buffer set
 			Expect(config.Config.DataflowComponentReadServiceConfig.BenthosConfig.Buffer).To(HaveKey("none"))

--- a/umh-core/pkg/config/protocolconverterserviceconfig/package.go
+++ b/umh-core/pkg/config/protocolconverterserviceconfig/package.go
@@ -38,8 +38,8 @@ var (
 type ProtocolConverterServiceConfigTemplate struct {
 
 	// DataflowComponentWriteServiceConfig is the blueprint for the *write* side
-	// of the converter. InputTopics is a string that may contain Go template actions
-	// rendered at deploy time; use DataflowComponentWriteConfigInput.Render to resolve it.
+	// of the converter. Source.Topics is a string that may contain Go template actions
+	// rendered at deploy time.
 	DataflowComponentWriteServiceConfig dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput `yaml:"dataflowcomponent_write,omitempty"`
 
 	// ConnectionServiceConfig describes how the converter connects to the
@@ -181,7 +181,7 @@ func SpecToRuntime(spec ProtocolConverterServiceConfigSpec) (ProtocolConverterSe
 		ConnectionServiceConfig:            connRuntime,
 		DataflowComponentReadServiceConfig: spec.Config.DataflowComponentReadServiceConfig,
 		// bridgedBy is intentionally empty: SpecToRuntime does structural conversion only,
-		// not full template rendering (InputTopics is split as-is). Use BuildRuntimeConfig for deploys.
+		// not full template rendering (Source.Topics is split as-is). Use BuildRuntimeConfig for deploys.
 		DataflowComponentWriteServiceConfig: spec.Config.DataflowComponentWriteServiceConfig.ToDataflowComponentServiceConfig(""),
 	}, nil
 }

--- a/umh-core/pkg/service/protocolconverter/runtime_config/runtime_config.go
+++ b/umh-core/pkg/service/protocolconverter/runtime_config/runtime_config.go
@@ -309,7 +309,7 @@ func renderConfig(
 		read = appendDownsampler(read)
 	}
 
-	// Render the write DFC template (resolves {{ .IP }}, {{ .PORT }}, etc. in write_output).
+	// Render the write DFC template (resolves {{ .IP }}, {{ .PORT }}, etc. in Source.Topics and Destination.Code).
 	renderedWriteConfig, err := config.RenderTemplate(spec.Config.DataflowComponentWriteServiceConfig, scope)
 	if err != nil {
 		return protocolconverterserviceconfig.ProtocolConverterServiceConfigRuntime{}, err

--- a/umh-core/pkg/service/protocolconverter/runtime_config/runtime_config_test.go
+++ b/umh-core/pkg/service/protocolconverter/runtime_config/runtime_config_test.go
@@ -181,7 +181,7 @@ var _ = Describe("BuildRuntimeConfig", func() {
 				Config: protocolconverterserviceconfig.ProtocolConverterServiceConfigTemplate{
 					ConnectionServiceConfig: createConnectionConfig(),
 					DataflowComponentWriteServiceConfig: dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
-						Output: map[string]any{"stdout": map[string]any{}},
+						Destination: dataflowcomponentserviceconfig.WriteConfigDestination{Protocol: "stdout"},
 					},
 				},
 			}
@@ -202,8 +202,8 @@ var _ = Describe("BuildRuntimeConfig", func() {
 				Config: protocolconverterserviceconfig.ProtocolConverterServiceConfigTemplate{
 					ConnectionServiceConfig: createConnectionConfig(),
 					DataflowComponentWriteServiceConfig: dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
-						InputTopics: "umh.v1.factory.line-1.*\numh.v1.factory.line-2.*",
-						Output:      map[string]any{"stdout": map[string]any{}},
+						Source:      dataflowcomponentserviceconfig.WriteConfigSource{Topics: "umh.v1.factory.line-1.*\numh.v1.factory.line-2.*"},
+						Destination: dataflowcomponentserviceconfig.WriteConfigDestination{Protocol: "stdout"},
 					},
 				},
 			}
@@ -474,7 +474,7 @@ var _ = Describe("BuildRuntimeConfig", func() {
 				Config: protocolconverterserviceconfig.ProtocolConverterServiceConfigTemplate{
 					ConnectionServiceConfig: createConnectionConfig(),
 					DataflowComponentWriteServiceConfig: dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
-						Output: map[string]any{"stdout": map[string]any{}},
+						Destination: dataflowcomponentserviceconfig.WriteConfigDestination{Protocol: "stdout"},
 					},
 				},
 			}
@@ -488,8 +488,8 @@ var _ = Describe("BuildRuntimeConfig", func() {
 				Config: protocolconverterserviceconfig.ProtocolConverterServiceConfigTemplate{
 					ConnectionServiceConfig: createConnectionConfig(),
 					DataflowComponentWriteServiceConfig: dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
-						Output:              map[string]any{"stdout": map[string]any{}},
-						ProcessingNoderedJS: "msg.payload.foo = 'bar';\nreturn msg;",
+						Destination: dataflowcomponentserviceconfig.WriteConfigDestination{Protocol: "stdout"},
+						Processing:  dataflowcomponentserviceconfig.WriteConfigProcessing{Type: "nodered_js", Code: "msg.payload.foo = 'bar';\nreturn msg;"},
 					},
 				},
 			}
@@ -503,8 +503,8 @@ var _ = Describe("BuildRuntimeConfig", func() {
 				Config: protocolconverterserviceconfig.ProtocolConverterServiceConfigTemplate{
 					ConnectionServiceConfig: createConnectionConfig(),
 					DataflowComponentWriteServiceConfig: dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
-						Output:              map[string]any{"stdout": map[string]any{}},
-						ProcessingNoderedJS: "return msg;",
+						Destination: dataflowcomponentserviceconfig.WriteConfigDestination{Protocol: "stdout"},
+						Processing:  dataflowcomponentserviceconfig.WriteConfigProcessing{Type: "nodered_js", Code: "return msg;"},
 					},
 				},
 			}


### PR DESCRIPTION
> [!NOTE]
> Use the following MC branch to review this, due to breaking changes in frontend: `eng-5091-frontend-rename-schema`


1. Write flow now uses schema like this. Check `write_config.go` for matching `struct`.

```yaml
source:
    topics: umh.v1.UMHDEVTEST._historian.my_data
processing:
    type: nodered_js
    code: |
        return msg;
destination:
    protocol: http_client
    code: |
        url: http://{{ .IP }}:{{ .PORT }}/post
        verb: POST
        headers: {}
        timeout: 5s
        retry_period: 1s
extra:
    code: |-
        rate_limit_resources:
          - label: http_limiter
            local:
              count: 1
              interval: 1s
```

2. Now also allows `yaml` lists in the `extra.code` block. Before just was `map[string]any` i.e. just yaml keys.
3. Unexpected parts for the write flow is now gathered in `UnrecognizedFields` instead of just dropped silently
4. From `extra` yaml field, only these three things are extracted, rest is silently dropped: `cache_resources, rate_limit_resources, buffer`