### PR TITLE
feat(fsmv2): add a worker's desired ChildrenSpecs to WorkerSnapshot

### DIFF
--- a/umh-core/pkg/fsmv2/api.go
+++ b/umh-core/pkg/fsmv2/api.go
@@ -482,10 +482,18 @@ func (d *WrappedDesiredState[TConfig]) GetChildrenSpecs() []config.ChildSpec {
 // WorkerSnapshot is the typed snapshot passed to State.Next(). It eliminates
 // unsafe type assertions previously required in every state file.
 type WorkerSnapshot[TConfig any, TStatus any] struct {
-	CollectedAt         time.Time
-	Config              TConfig
-	Status              TStatus
-	ChildrenView        config.ChildrenView
+	CollectedAt  time.Time
+	Config       TConfig
+	Status       TStatus
+	ChildrenView config.ChildrenView
+	// ChildrenSpecs is the worker's own DESIRED child set, copied verbatim from
+	// WrappedDesiredState.ChildrenSpecs (the legacy DeriveDesiredState path). It is
+	// NOT the effective reconciled set: for parents that declare children via the
+	// Next() Children override it does not reflect the override and may be stale or
+	// empty. It is also distinct from the observed ChildrenView above, which reports
+	// the children that actually exist. nil means "no opinion" (parent does not
+	// populate ChildrenSpecs); an empty non-nil slice means "zero children".
+	ChildrenSpecs       []config.ChildSpec
 	Identity            deps.Identity
 	LastActionResults   []deps.ActionResult
 	Metrics             deps.MetricsEmbedder
@@ -543,6 +551,7 @@ func ConvertWorkerSnapshot[TConfig any, TStatus any](snapAny any) WorkerSnapshot
 		ChildrenHealthy:     obs.ChildrenHealthy,
 		ChildrenUnhealthy:   obs.ChildrenUnhealthy,
 		ChildrenView:        obs.ChildrenView,
+		ChildrenSpecs:       des.ChildrenSpecs,
 	}
 }
 

--- a/umh-core/pkg/fsmv2/worker_snapshot_test.go
+++ b/umh-core/pkg/fsmv2/worker_snapshot_test.go
@@ -137,6 +137,37 @@ var _ = Describe("ConvertWorkerSnapshot (happy paths)", func() {
 
 		Expect(snap.ChildrenSpecs).To(Equal(children))
 	})
+
+	// The nil vs empty-non-nil discriminator on ChildrenSpecs is load-bearing for
+	// the underlying WrappedDesiredState.ChildrenSpecs: nil means "no opinion"
+	// (the parent declares children via RenderChildren, so DeriveDesiredState no
+	// longer writes ChildrenSpecs) while an empty non-nil slice means "zero
+	// children". ConvertWorkerSnapshot must copy the field verbatim so a future
+	// nil<->empty normalization can never flip one into the other unnoticed.
+	It("preserves a nil ChildrenSpecs as nil through the convert path", func() {
+		obs := fsmv2.Observation[workerTestStatus]{CollectedAt: now}
+		wds := &fsmv2.WrappedDesiredState[workerTestConfig]{
+			ChildrenSpecs: nil,
+		}
+
+		raw := fsmv2.Snapshot{Observed: obs, Desired: wds, Identity: identity}
+		snap := fsmv2.ConvertWorkerSnapshot[workerTestConfig, workerTestStatus](raw)
+
+		Expect(snap.ChildrenSpecs).To(BeNil())
+	})
+
+	It("preserves an empty non-nil ChildrenSpecs as empty non-nil through the convert path", func() {
+		obs := fsmv2.Observation[workerTestStatus]{CollectedAt: now}
+		wds := &fsmv2.WrappedDesiredState[workerTestConfig]{
+			ChildrenSpecs: []config.ChildSpec{},
+		}
+
+		raw := fsmv2.Snapshot{Observed: obs, Desired: wds, Identity: identity}
+		snap := fsmv2.ConvertWorkerSnapshot[workerTestConfig, workerTestStatus](raw)
+
+		Expect(snap.ChildrenSpecs).NotTo(BeNil())
+		Expect(snap.ChildrenSpecs).To(BeEmpty())
+	})
 })
 
 var _ = Describe("ShouldStop", func() {

--- a/umh-core/pkg/fsmv2/worker_snapshot_test.go
+++ b/umh-core/pkg/fsmv2/worker_snapshot_test.go
@@ -26,6 +26,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/config"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
 )
 
@@ -119,6 +120,22 @@ var _ = Describe("ConvertWorkerSnapshot (happy paths)", func() {
 		Expect(snap.LastActionResults[0].ActionType).To(Equal("connect"))
 		Expect(snap.ChildrenHealthy).To(Equal(3))
 		Expect(snap.ChildrenUnhealthy).To(Equal(1))
+	})
+
+	It("surfaces the desired ChildrenSpecs from WrappedDesiredState", func() {
+		children := []config.ChildSpec{
+			{Name: "child-a", WorkerType: "test", Enabled: true},
+			{Name: "child-b", WorkerType: "test", Enabled: true},
+		}
+		obs := fsmv2.Observation[workerTestStatus]{CollectedAt: now}
+		wds := &fsmv2.WrappedDesiredState[workerTestConfig]{
+			ChildrenSpecs: children,
+		}
+
+		raw := fsmv2.Snapshot{Observed: obs, Desired: wds, Identity: identity}
+		snap := fsmv2.ConvertWorkerSnapshot[workerTestConfig, workerTestStatus](raw)
+
+		Expect(snap.ChildrenSpecs).To(Equal(children))
 	})
 })
 


### PR DESCRIPTION
## The stack

> **FSMv2 migration-API stack, PR 3 of 6.** A worker acts on its *snapshot* (its
> desired + observed state). The goal: make the snapshot the complete description of a
> worker, then let outside code rewrite it on a running system.
> 1. **#2589**: delete the dead legacy stop path so a worker's lifecycle depends on its own state, not a parent side channel.
> 2. **#2590**: put each transport worker's auth on its own spec, not a side channel into the parent.
> 3. **#2598 ← you are here**: put the config-declared child list on the snapshot so the migration API can read it.
> 4. **#2599**: the migration API, so outside code can create, update, and delete workers on a running supervisor.
> 5. **#2603**: shut down by draining instead of timing out (the bug building the proof found).
> 6. **#2604**: prove create and update against a live kernel.
>
> Merge bottom-up. Each PR stands alone and reverts cleanly.

### This PR: put the config-declared child list where the API can read it

A worker runs off its snapshot, but the snapshot did not include the list of children
declared for it in config. The migration API (#2599) has each application worker compute
its children as the union of that config-declared list with the registry's dynamic ones,
and it computes that union from inside the worker, off the snapshot. So the declared list
has to be on the snapshot for #2599 to read it. This PR puts it there, write-only:
nothing reads it until #2599.


---

> **Stack:** based on `feature/wapi-L5d` (#2590); `eng-5088-migration-api` stacks on this.

## Problem

This PR opens the FSMv1→FSMv2 migration-API stack. Context: the FSMv2 internal refactor (the cascade behind #2588/#2589/#2590, in review below this stack) is deliberately paused so FSMv2 can earn production usage first. This stack is that usage push.

The target consumer is the Probe worker (ENG-4839): one FSMv2 worker per network connection, created and removed as users edit config.yaml, replacing the Nmap connection check. That requires FSMv1 — which owns config.yaml — to start, reconfigure, and stop FSMv2 workers at runtime. Today an FSMv2 worker runs only if it is hardcoded in the application root's YAML children template.

Two known debts sit underneath. First, the application's children are declared as raw YAML, making it the only type-agnostic worker; typing them is ENG-5097. Second, the supervisor resolves children from two sources: what a state's `Next()` returns, with a fallback to the `DeriveDesiredState`-computed list when a state returns nil. The fallback was left transitional by the children-rendering cutover; its deletion is ENG-5115, unblocked once the migration-API PR (stacked directly on this one) has every worker rendering from `Next()`.

The specific gap this PR fixes: the application's states must take over child-rendering (emit "the declared children plus dynamically registered ones"), but the snapshot passed to `Next()` does not carry the declared children, so a state cannot re-emit them.

## What this ships

`WorkerSnapshot` gains a `ChildrenSpecs` field carrying the worker's declared children, filled in `ConvertWorkerSnapshot`. Nothing reads it yet; no behavior change; the stacked migration-API PR is the first reader. This is deliberate scaffolding: it lives exactly as long as YAML-declared children do — ENG-5097 deletes it together with the raw-YAML carrier, once states read declared children from typed config directly.

## What this does NOT ship

- **NOT any reader of the field**: the stacked migration-API PR is the first one.
- **NOT the typed replacement** (ENG-5097): typed child structure and the raw-YAML carrier deletion.

Contributes the minimal slice of ENG-5097. **Do not close ENG-5097.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

