### PR TITLE
Demote bridge config dumps to DEBUG, report config divergence in bridge status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ finalization/
 *.result.txt
 .worktrees/
 .self-review/
+vsdd/

--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -5,6 +5,10 @@
 ### New Features
 - Preview: an instance can now store a connection to an external TimescaleDB or PostgreSQL historian database (host, port, database, login, and TLS mode), which can be created, viewed, updated, and removed. Storing the connection does not yet route any data to it
 
+### Improvements
+
+- The full bridge and stream-processor configuration is no longer written to the umh-core log at INFO on every internal re-apply (moved to DEBUG), removing a source of log flooding and CPU pressure when a config keeps being re-applied. While a bridge's observed config differs from its desired config, its status in the Management Console now shows a bounded summary of what differs, and the umh-core log carries one warning per bridge per minute, so the cause is visible without enabling debug logging
+
 ## [0.44.28]
 
 ### New Features
@@ -43,8 +47,6 @@
 - Editing a bridge whose new configuration keeps failing to render now fails after three identical render failures (a few seconds) and rolls back to the previous configuration automatically, naming the render failure as the root cause; while the edit is still retrying, each progress update also names the render failure. Previously such an edit retried for the full 30-second timeout before rolling back, and progress updates gave no reason
 
 ![Bridge update failed dialog showing the failing region of the rendered config and the automatic rollback message](./changelog-images/2026-06-19-bridge-render-error.png)
-
-- The full bridge and stream-processor configuration is no longer written to the umh-core log at INFO on every internal re-apply (moved to DEBUG), removing a source of log flooding and CPU pressure when a config keeps being re-applied. While a bridge's observed config differs from its desired config, its status in the Management Console now shows a bounded summary of what differs, and the umh-core log carries one warning per bridge per minute, so the cause is visible without enabling debug logging
 
 ### Fixes
 

--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -44,6 +44,8 @@
 
 ![Bridge update failed dialog showing the failing region of the rendered config and the automatic rollback message](./changelog-images/2026-06-19-bridge-render-error.png)
 
+- The full bridge and stream-processor configuration is no longer written to the umh-core log at INFO on every internal re-apply (moved to DEBUG), removing a source of log flooding and CPU pressure when a config keeps being re-applied. While a bridge's observed config differs from its desired config, its status in the Management Console now shows a bounded summary of what differs, and the umh-core log carries one warning per bridge per minute, so the cause is visible without enabling debug logging
+
 ### Fixes
 
 - OPC UA: reading or subscribing to large tag sets (roughly a thousand or more) over an encrypted connection no longer drops the connection with an `EOF` error

--- a/umh-core/pkg/config/protocolconverterserviceconfig/bounddiff.go
+++ b/umh-core/pkg/config/protocolconverterserviceconfig/bounddiff.go
@@ -1,0 +1,54 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build test
+
+// BoundDiff has no production caller yet; the test build tag above keeps it
+// out of production binaries until the first non-test caller is added.
+
+package protocolconverterserviceconfig
+
+import (
+	"strconv"
+	"strings"
+	"unicode/utf8"
+)
+
+// BoundDiff caps a config-diff string at capRunes runes, rune-safe, appending a
+// truncation marker when the diff exceeds the cap. capRunes values <= 0 are
+// treated as 0.
+func BoundDiff(diff string, capRunes int) string {
+	if capRunes < 0 {
+		capRunes = 0
+	}
+
+	total := utf8.RuneCountInString(diff)
+	if total <= capRunes {
+		return diff
+	}
+
+	var b strings.Builder
+	i := 0
+	for _, r := range diff {
+		if i >= capRunes {
+			break
+		}
+		b.WriteRune(r)
+		i++
+	}
+	b.WriteString(" …[truncated, ")
+	b.WriteString(strconv.Itoa(total))
+	b.WriteString(" chars total]")
+	return b.String()
+}

--- a/umh-core/pkg/config/protocolconverterserviceconfig/bounddiff.go
+++ b/umh-core/pkg/config/protocolconverterserviceconfig/bounddiff.go
@@ -12,11 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build test
-
-// BoundDiff has no production caller yet; the test build tag above keeps it
-// out of production binaries until the first non-test caller is added.
-
 package protocolconverterserviceconfig
 
 import (

--- a/umh-core/pkg/config/protocolconverterserviceconfig/bounddiff.go
+++ b/umh-core/pkg/config/protocolconverterserviceconfig/bounddiff.go
@@ -38,6 +38,7 @@ func BoundDiff(diff string, capRunes int) string {
 	if diff == "" {
 		return EmptyDiffSentinel
 	}
+
 	if capRunes < 0 {
 		capRunes = 0
 	}
@@ -48,16 +49,21 @@ func BoundDiff(diff string, capRunes int) string {
 	}
 
 	var b strings.Builder
+
 	i := 0
 	for _, r := range diff {
 		if i >= capRunes {
 			break
 		}
+
 		b.WriteRune(r)
+
 		i++
 	}
+
 	b.WriteString(" …[truncated, ")
 	b.WriteString(strconv.Itoa(total))
 	b.WriteString(" chars total]")
+
 	return b.String()
 }

--- a/umh-core/pkg/config/protocolconverterserviceconfig/bounddiff.go
+++ b/umh-core/pkg/config/protocolconverterserviceconfig/bounddiff.go
@@ -25,10 +25,24 @@ import (
 	"unicode/utf8"
 )
 
-// BoundDiff caps a config-diff string at capRunes runes, rune-safe, appending a
-// truncation marker when the diff exceeds the cap. capRunes values <= 0 are
-// treated as 0.
+// EmptyDiffSentinel is the exact string BoundDiff returns when the diff is empty
+// but the configs are known to differ — the silent-mismatch class that hid the
+// ENG-5090 re-apply cause. Surfaced verbatim in StatusReason and the WARN line.
+const EmptyDiffSentinel = "configs differ but field diff is empty (divergence outside compared fields)"
+
+// BoundDiff caps the prefix of a config-diff string at capRunes runes,
+// rune-safe. capRunes values <= 0 are treated as 0.
+//
+// When the diff exceeds the cap, BoundDiff returns the first capRunes runes
+// followed by a truncation marker carrying the total rune count; the marker is
+// additional and exempt from the cap. When the diff is empty, BoundDiff returns
+// EmptyDiffSentinel regardless of capRunes; the sentinel is also exempt from
+// the cap. An empty diff is surfaced explicitly rather than collapsing to an
+// empty string that is indistinguishable from "nothing to report".
 func BoundDiff(diff string, capRunes int) string {
+	if diff == "" {
+		return EmptyDiffSentinel
+	}
 	if capRunes < 0 {
 		capRunes = 0
 	}

--- a/umh-core/pkg/config/protocolconverterserviceconfig/bounddiff_test.go
+++ b/umh-core/pkg/config/protocolconverterserviceconfig/bounddiff_test.go
@@ -1,0 +1,81 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build test
+
+package protocolconverterserviceconfig
+
+import (
+	"strings"
+	"unicode/utf8"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("BoundDiff", func() {
+	It("passes a short diff through unchanged", func() {
+		short := "hello world"
+		Expect(BoundDiff(short, 400)).To(Equal(short),
+			"short diff should pass through unchanged")
+	})
+
+	It("passes a diff of exactly capRunes through unchanged with no marker", func() {
+		exactCap := strings.Repeat("a", 400)
+		Expect(BoundDiff(exactCap, 400)).To(Equal(exactCap),
+			"diff of exactly capRunes runes should pass through unchanged with no marker")
+	})
+
+	It("truncates a long diff to the first capRunes runes plus a marker with the total rune count", func() {
+		longRunes := []rune(strings.Repeat("b", 1000))
+		longDiff := string(longRunes)
+		got := BoundDiff(longDiff, 400)
+		expectedPrefix := string(longRunes[:400])
+		expectedMarker := " …[truncated, 1000 chars total]"
+		Expect(got).To(Equal(expectedPrefix+expectedMarker),
+			"long diff should be truncated to first capRunes runes plus marker with total rune count")
+	})
+
+	It("truncates multibyte input on a rune boundary keeping the output valid UTF-8", func() {
+		multibyte := strings.Repeat("ü", 500) // ü is 2 bytes, 1 rune
+		gotMB := BoundDiff(multibyte, 400)
+		Expect(utf8.ValidString(gotMB)).To(BeTrue(),
+			"truncated multibyte output must stay valid UTF-8")
+		Expect(gotMB).To(HavePrefix(strings.Repeat("ü", 400)),
+			"truncated multibyte output must prefix with the first capRunes runes")
+		Expect(gotMB).To(Equal(strings.Repeat("ü", 400)+" …[truncated, 500 chars total]"),
+			"multibyte truncation must use rune-indexed cut and correct total count")
+	})
+
+	It("treats capRunes of 0 as marker-only output", func() {
+		// Use a non-empty diff so the truncation path is taken; the empty-diff
+		// case is handled separately.
+		nonEmpty := "x"
+		Expect(BoundDiff(nonEmpty, 0)).To(Equal(" …[truncated, 1 chars total]"),
+			"capRunes 0 should yield marker-only output")
+	})
+
+	It("treats negative capRunes as 0", func() {
+		nonEmpty := "x"
+		Expect(BoundDiff(nonEmpty, -5)).To(Equal(" …[truncated, 1 chars total]"),
+			"negative capRunes should be treated as 0 and yield marker-only output")
+	})
+
+	It("passes an empty diff through unchanged", func() {
+		// Empty diff is not special-cased: len([]rune("")) == 0 <= capRunes, so
+		// it is returned unchanged.
+		Expect(BoundDiff("", 400)).To(Equal(""),
+			"empty diff should pass through unchanged")
+	})
+})

--- a/umh-core/pkg/config/protocolconverterserviceconfig/bounddiff_test.go
+++ b/umh-core/pkg/config/protocolconverterserviceconfig/bounddiff_test.go
@@ -59,8 +59,6 @@ var _ = Describe("BoundDiff", func() {
 	})
 
 	It("treats capRunes of 0 as marker-only output", func() {
-		// Use a non-empty diff so the truncation path is taken; the empty-diff
-		// case is handled separately.
 		nonEmpty := "x"
 		Expect(BoundDiff(nonEmpty, 0)).To(Equal(" …[truncated, 1 chars total]"),
 			"capRunes 0 should yield marker-only output")
@@ -72,10 +70,10 @@ var _ = Describe("BoundDiff", func() {
 			"negative capRunes should be treated as 0 and yield marker-only output")
 	})
 
-	It("passes an empty diff through unchanged", func() {
-		// Empty diff is not special-cased: len([]rune("")) == 0 <= capRunes, so
-		// it is returned unchanged.
-		Expect(BoundDiff("", 400)).To(Equal(""),
-			"empty diff should pass through unchanged")
+	It("returns the empty-diff sentinel when diff is empty, regardless of capRunes", func() {
+		Expect(BoundDiff("", 400)).To(Equal(EmptyDiffSentinel),
+			"empty diff with capRunes=400 should return the sentinel")
+		Expect(BoundDiff("", 0)).To(Equal(EmptyDiffSentinel),
+			"empty diff with capRunes=0 should still return the sentinel, not the marker-only output")
 	})
 })

--- a/umh-core/pkg/constants/protocolconverter.go
+++ b/umh-core/pkg/constants/protocolconverter.go
@@ -29,5 +29,5 @@ const (
 	// divergent protocol converter emits a heartbeat WARN to surface that its config
 	// is still being re-applied. The interval is tick-count-based; the nominal
 	// 1-minute cadence assumes the reconcile loop keeps up with DefaultTickerTime.
-	ProtocolConverterDivergenceWarnIntervalTicks = uint64(time.Minute / DefaultTickerTime) // 1 minute
+	ProtocolConverterDivergenceWarnIntervalTicks = uint64(time.Minute / DefaultTickerTime)
 )

--- a/umh-core/pkg/constants/protocolconverter.go
+++ b/umh-core/pkg/constants/protocolconverter.go
@@ -24,4 +24,10 @@ const (
 	// ProtocolConverterConfigDivergenceCapRunes caps the config-diff preview staged in
 	// ObservedState.ConfigDivergence and surfaced via StatusReason and the divergence WARN.
 	ProtocolConverterConfigDivergenceCapRunes = 400
+
+	// ProtocolConverterDivergenceWarnIntervalTicks is the tick interval at which a
+	// divergent protocol converter emits a heartbeat WARN to surface that its config
+	// is still being re-applied. The interval is tick-count-based; the nominal
+	// 1-minute cadence assumes the reconcile loop keeps up with DefaultTickerTime.
+	ProtocolConverterDivergenceWarnIntervalTicks = uint64(time.Minute / DefaultTickerTime) // 1 minute
 )

--- a/umh-core/pkg/constants/protocolconverter.go
+++ b/umh-core/pkg/constants/protocolconverter.go
@@ -20,4 +20,8 @@ const (
 	// ProtocolConverter Operation Timeouts - Level 3 Service (depends on DataflowComponent)
 	// ProtocolConverterUpdateObservedStateTimeout is used to set the context timeout for updating the observed state of a ProtocolConverter instance.
 	ProtocolConverterUpdateObservedStateTimeout = 10 * time.Millisecond
+
+	// ProtocolConverterConfigDivergenceCapRunes caps the config-diff preview staged in
+	// ObservedState.ConfigDivergence and surfaced via StatusReason and the divergence WARN.
+	ProtocolConverterConfigDivergenceCapRunes = 400
 )

--- a/umh-core/pkg/fsm/protocolconverter/actions.go
+++ b/umh-core/pkg/fsm/protocolconverter/actions.go
@@ -24,6 +24,7 @@ import (
 
 	internalfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/internal/fsm"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/protocolconverterserviceconfig"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
 	connectionfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/connection"
 	dataflowfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/dataflowcomponent"
@@ -238,6 +239,11 @@ func (p *ProtocolConverterInstance) getServiceStatus(ctx context.Context, servic
 
 // UpdateObservedStateOfInstance updates the observed state of the service.
 func (p *ProtocolConverterInstance) UpdateObservedStateOfInstance(ctx context.Context, services serviceregistry.Provider, snapshot fsm.SystemSnapshot) error {
+	// Reset ConfigDivergence as the first statement, before the ctx.Err()
+	// guard, so a stale value from a previous tick is cleared even when the
+	// context is already expired.
+	p.ObservedState.ConfigDivergence = ""
+
 	if ctx.Err() != nil {
 		if p.baseFSMInstance.IsDeadlineExceededAndHandle(ctx.Err(), snapshot.Tick, "UpdateObservedStateOfInstance") {
 			return nil
@@ -352,6 +358,7 @@ func (p *ProtocolConverterInstance) UpdateObservedStateOfInstance(ctx context.Co
 		p.baseFSMInstance.GetLogger().Debugf("Observed bridge config is different from desired config, updating bridge configuration")
 
 		diffStr := protocolconverterserviceconfig.ConfigDiffRuntime(p.runtimeConfig, p.ObservedState.ObservedProtocolConverterRuntimeConfig)
+		p.ObservedState.ConfigDivergence = protocolconverterserviceconfig.BoundDiff(diffStr, constants.ProtocolConverterConfigDivergenceCapRunes)
 		p.baseFSMInstance.GetLogger().Debugf("Configuration differences: %s", diffStr)
 
 		// Update the config through the manager directly, without a prior

--- a/umh-core/pkg/fsm/protocolconverter/actions.go
+++ b/umh-core/pkg/fsm/protocolconverter/actions.go
@@ -239,9 +239,6 @@ func (p *ProtocolConverterInstance) getServiceStatus(ctx context.Context, servic
 
 // UpdateObservedStateOfInstance updates the observed state of the service.
 func (p *ProtocolConverterInstance) UpdateObservedStateOfInstance(ctx context.Context, services serviceregistry.Provider, snapshot fsm.SystemSnapshot) error {
-	// Reset ConfigDivergence as the first statement, before the ctx.Err()
-	// guard, so a stale value from a previous tick is cleared even when the
-	// context is already expired.
 	p.ObservedState.ConfigDivergence = ""
 
 	if ctx.Err() != nil {

--- a/umh-core/pkg/fsm/protocolconverter/actions.go
+++ b/umh-core/pkg/fsm/protocolconverter/actions.go
@@ -361,6 +361,10 @@ func (p *ProtocolConverterInstance) UpdateObservedStateOfInstance(ctx context.Co
 		p.ObservedState.ConfigDivergence = protocolconverterserviceconfig.BoundDiff(diffStr, constants.ProtocolConverterConfigDivergenceCapRunes)
 		p.baseFSMInstance.GetLogger().Debugf("Configuration differences: %s", diffStr)
 
+		if snapshot.Tick%constants.ProtocolConverterDivergenceWarnIntervalTicks == 0 {
+			p.baseFSMInstance.GetLogger().Warnf("re-applying config: bridge %s config diverged: %s", p.baseFSMInstance.GetID(), p.ObservedState.ConfigDivergence)
+		}
+
 		// Update the config through the manager directly, without a prior
 		// ServiceExists check. A check-then-act pattern here is a TOCTOU race: the
 		// service can be created or removed between the check and the update.

--- a/umh-core/pkg/fsm/protocolconverter/models.go
+++ b/umh-core/pkg/fsm/protocolconverter/models.go
@@ -153,8 +153,9 @@ type ProtocolConverterObservedState struct {
 
 	// ConfigDivergence describes the difference between the desired and the
 	// observed runtime configuration. It is reset to "" at the start of every
-	// UpdateObservedStateOfInstance call and set to the ConfigDiffRuntime text
-	// when a divergence is detected and the service exists.
+	// UpdateObservedStateOfInstance call and, when a divergence is detected and
+	// the service exists, set to a rune-capped, truncation-marked summary of the
+	// ConfigDiffRuntime text produced by BoundDiff.
 	ConfigDivergence string
 
 	// ObservedProtocolConverterSpecConfig contains the observed ProtocolConverter service config spec with variables

--- a/umh-core/pkg/fsm/protocolconverter/models.go
+++ b/umh-core/pkg/fsm/protocolconverter/models.go
@@ -160,6 +160,12 @@ type ProtocolConverterObservedState struct {
 
 	// ServiceInfo contains information about the ProtocolConverter service
 	ServiceInfo protocolconvertersvc.ServiceInfo
+
+	// ConfigDivergence describes the difference between the desired and the
+	// observed runtime configuration. It is reset to "" at the start of every
+	// UpdateObservedStateOfInstance call and set to the ConfigDiffRuntime text
+	// when a divergence is detected and the service exists.
+	ConfigDivergence string
 }
 
 // IsObservedState implements the ObservedState interface.

--- a/umh-core/pkg/fsm/protocolconverter/models.go
+++ b/umh-core/pkg/fsm/protocolconverter/models.go
@@ -151,6 +151,12 @@ func IsRunningState(state string) bool {
 // ProtocolConverterObservedState contains the observed runtime state of a ProtocolConverter instance.
 type ProtocolConverterObservedState struct {
 
+	// ConfigDivergence describes the difference between the desired and the
+	// observed runtime configuration. It is reset to "" at the start of every
+	// UpdateObservedStateOfInstance call and set to the ConfigDiffRuntime text
+	// when a divergence is detected and the service exists.
+	ConfigDivergence string
+
 	// ObservedProtocolConverterSpecConfig contains the observed ProtocolConverter service config spec with variables
 	// it is here for the purpose of the UI to display the variables and the location
 	ObservedProtocolConverterSpecConfig protocolconverterconfig.ProtocolConverterServiceConfigSpec
@@ -160,12 +166,6 @@ type ProtocolConverterObservedState struct {
 
 	// ServiceInfo contains information about the ProtocolConverter service
 	ServiceInfo protocolconvertersvc.ServiceInfo
-
-	// ConfigDivergence describes the difference between the desired and the
-	// observed runtime configuration. It is reset to "" at the start of every
-	// UpdateObservedStateOfInstance call and set to the ConfigDiffRuntime text
-	// when a divergence is detected and the service exists.
-	ConfigDivergence string
 }
 
 // IsObservedState implements the ObservedState interface.

--- a/umh-core/pkg/fsm/protocolconverter/reconcile.go
+++ b/umh-core/pkg/fsm/protocolconverter/reconcile.go
@@ -101,8 +101,6 @@ func (p *ProtocolConverterInstance) Reconcile(ctx context.Context, snapshot fsm.
 	if p.baseFSMInstance.IsRemoving() {
 		// Skip external changes detection during removal - config files may be deleted
 		p.baseFSMInstance.GetLogger().Debugf("Skipping external changes detection during removal")
-		// Clear stale ConfigDivergence so the composition block below does not
-		// stamp "re-applying config" on an instance being deleted.
 		p.ObservedState.ConfigDivergence = ""
 	} else {
 		if err = p.reconcileExternalChanges(ctx, services, snapshot); err != nil {

--- a/umh-core/pkg/fsm/protocolconverter/reconcile.go
+++ b/umh-core/pkg/fsm/protocolconverter/reconcile.go
@@ -101,6 +101,9 @@ func (p *ProtocolConverterInstance) Reconcile(ctx context.Context, snapshot fsm.
 	if p.baseFSMInstance.IsRemoving() {
 		// Skip external changes detection during removal - config files may be deleted
 		p.baseFSMInstance.GetLogger().Debugf("Skipping external changes detection during removal")
+		// Clear stale ConfigDivergence so the composition block below does not
+		// stamp "re-applying config" on an instance being deleted.
+		p.ObservedState.ConfigDivergence = ""
 	} else {
 		if err = p.reconcileExternalChanges(ctx, services, snapshot); err != nil {
 			if p.baseFSMInstance.IsDeadlineExceededAndHandle(err, snapshot.Tick, "reconcileExternalChanges") {
@@ -120,6 +123,27 @@ func (p *ProtocolConverterInstance) Reconcile(ctx context.Context, snapshot fsm.
 	currentTime := snapshot.SnapshotTime // this is used to check if the instance is degraded and for the log check
 
 	err, reconciled = p.reconcileStateTransition(ctx, services, snapshot, currentTime)
+
+	// Compose ConfigDivergence into StatusReason so a divergent config is
+	// visible on the instance status while it is being re-applied. This APPENDS
+	// to any operational reason that reconcileStateTransition just wrote
+	// (degraded/starting/stopping), joined with "; " so Step 3's reason is
+	// preserved in front. Placement here — BEFORE the err-block returns — is
+	// load-bearing: on Step-3 error ticks (deadline-exceeded, SendEvent
+	// failure, ErrInstanceRemoved), Reconcile returns inside the err block, so
+	// composition MUST run before it or the divergence diagnostic is lost on
+	// exactly the overload ticks ENG-5108 exists to fix. Guard on a non-empty
+	// divergence so converged ticks (and removal ticks, where the IsRemoving
+	// branch clears ConfigDivergence) retain the operational reason.
+	if p.ObservedState.ConfigDivergence != "" {
+		divergenceText := "re-applying config: " + p.ObservedState.ConfigDivergence
+		if p.ObservedState.ServiceInfo.StatusReason != "" {
+			p.ObservedState.ServiceInfo.StatusReason += "; " + divergenceText
+		} else {
+			p.ObservedState.ServiceInfo.StatusReason = divergenceText
+		}
+	}
+
 	if err != nil {
 		// If the instance is removed, we don't want to return an error here, because we want to continue reconciling
 		if errors.Is(err, standarderrors.ErrInstanceRemoved) {

--- a/umh-core/pkg/service/protocolconverter/logging_test.go
+++ b/umh-core/pkg/service/protocolconverter/logging_test.go
@@ -1,0 +1,116 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build test
+
+package protocolconverter
+
+import (
+	"context"
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/protocolconverterserviceconfig"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+var _ = Describe("demotes per-tick config dumps to DEBUG", func() {
+	It("emits only the two lifecycle INFO lines per real create and nothing on retries/dumps", func() {
+		ctx := context.Background()
+		const protConvName = "test-pc"
+
+		// White-box: capture every log the service emits via a zap observer core
+		// and drive the real (unmodified) service through its manager methods.
+		core, logs := observer.New(zapcore.DebugLevel)
+		svc := NewDefaultProtocolConverterService(protConvName)
+		svc.logger = zap.New(core).Sugar()
+
+		// filesystemService is not dereferenced by Add/Update/Remove; nil is safe.
+		// A zero-value runtime config is sufficient — the methods only append/reassign it.
+		var cfg protocolconverterserviceconfig.ProtocolConverterServiceConfigRuntime
+
+		Expect(svc.AddToManager(ctx, nil, &cfg, protConvName, false)).To(Succeed())
+		infoAfterFirst := logs.FilterLevelExact(zapcore.InfoLevel)
+		Expect(infoAfterFirst.Len()).To(Equal(2),
+			"first AddToManager should log exactly 2 INFO lines (Adding + added to manager); "+
+				"the per-tick config dumps must be DEBUG")
+		Expect(messages(infoAfterFirst.All())).To(ConsistOf(
+			"Adding ProtocolConverter "+protConvName,
+			"ProtocolConverter "+protConvName+" added to manager",
+		))
+
+		// Idempotent AddToManager retry logs zero INFO lines.
+		err := svc.AddToManager(ctx, nil, &cfg, protConvName, false)
+		Expect(err).To(HaveOccurred())
+		Expect(errors.Is(err, ErrServiceAlreadyExists)).To(BeTrue())
+		Expect(logs.FilterLevelExact(zapcore.InfoLevel).Len()).To(Equal(2),
+			"second AddToManager must log ZERO additional INFO lines "+
+				"(Adding moved below the exists-check so idempotent retries are silent)")
+
+		// UpdateInManager emits none of the demoted lines at INFO, and emits them
+		// at DEBUG.
+		infoBeforeUpdate := logs.FilterLevelExact(zapcore.InfoLevel).Len()
+		debugBeforeUpdate := logs.FilterLevelExact(zapcore.DebugLevel).Len()
+		Expect(svc.UpdateInManager(ctx, nil, &cfg, protConvName, false)).To(Succeed())
+		Expect(logs.FilterLevelExact(zapcore.InfoLevel).Len()).To(Equal(infoBeforeUpdate),
+			"UpdateInManager must emit ZERO INFO lines (all lifecycle lines demoted to DEBUG)")
+		for _, e := range logs.FilterLevelExact(zapcore.InfoLevel).All() {
+			Expect(e.Message).NotTo(ContainSubstring("Updating protocolconverter"),
+				"'Updating protocolconverter' must be demoted to DEBUG, not INFO")
+			Expect(e.Message).NotTo(ContainSubstring("Updated protocolconverter config in manager"),
+				"'Updated protocolconverter config in manager' must be demoted to DEBUG, not INFO")
+			Expect(e.Message).NotTo(ContainSubstring("Connection config:"),
+				"the 'Connection config: %+v' dump must be demoted to DEBUG, not INFO")
+			Expect(e.Message).NotTo(ContainSubstring("Dataflow component config:"),
+				"the 'Dataflow component config: %+v' dump must be demoted to DEBUG, not INFO")
+		}
+		newDebugMessages := messages(logs.FilterLevelExact(zapcore.DebugLevel).All()[debugBeforeUpdate:])
+		Expect(newDebugMessages).To(ContainElement(ContainSubstring("Updating protocolconverter")),
+			"'Updating protocolconverter' must reappear at DEBUG")
+		Expect(newDebugMessages).To(ContainElement(ContainSubstring("Updated protocolconverter config in manager")),
+			"'Updated protocolconverter config in manager' must reappear at DEBUG")
+		Expect(newDebugMessages).To(ContainElement(ContainSubstring("Connection config:")),
+			"the 'Connection config: %+v' dump must reappear at DEBUG")
+		Expect(newDebugMessages).To(ContainElement(ContainSubstring("Dataflow component config:")),
+			"the 'Dataflow component config: %+v' dump must reappear at DEBUG")
+
+		// RemoveFromManager retries emit zero INFO lines and emit the demoted
+		// 'Removing dataflowcomponent' line at DEBUG. The fresh child managers hold
+		// no FSM instances, so each retry slices the already-removed config
+		// (idempotent) and returns nil.
+		infoBeforeRemove := logs.FilterLevelExact(zapcore.InfoLevel).Len()
+		debugBeforeRemove := logs.FilterLevelExact(zapcore.DebugLevel).Len()
+		for i := 0; i < 5; i++ {
+			Expect(svc.RemoveFromManager(ctx, nil, protConvName)).To(Succeed(),
+				"RemoveFromManager must be idempotent and return nil on each retry")
+		}
+		Expect(logs.FilterLevelExact(zapcore.InfoLevel).Len()).To(Equal(infoBeforeRemove),
+			"RemoveFromManager retries must emit ZERO INFO lines "+
+				"('Removing dataflowcomponent' demoted to DEBUG)")
+		removeDebugMessages := messages(logs.FilterLevelExact(zapcore.DebugLevel).All()[debugBeforeRemove:])
+		Expect(removeDebugMessages).To(ContainElement(ContainSubstring("Removing dataflowcomponent")),
+			"'Removing dataflowcomponent' must reappear at DEBUG across retries")
+	})
+})
+
+func messages(entries []observer.LoggedEntry) []string {
+	out := make([]string, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, e.Message)
+	}
+	return out
+}

--- a/umh-core/pkg/service/protocolconverter/mock.go
+++ b/umh-core/pkg/service/protocolconverter/mock.go
@@ -492,6 +492,12 @@ func (m *MockProtocolConverterService) RemoveFromManager(
 
 	m.RemoveFromManagerCalled = true
 
+	// Consult RemoveFromManagerError before mutating config so a pending
+	// removal holds the FSM in the removing state across many ticks.
+	if m.RemoveFromManagerError != nil {
+		return m.RemoveFromManagerError
+	}
+
 	underlyingName := "protocolconverter-" + protConvName
 
 	dfcFound := false

--- a/umh-core/pkg/service/protocolconverter/protocolconverter.go
+++ b/umh-core/pkg/service/protocolconverter/protocolconverter.go
@@ -466,8 +466,6 @@ func (p *ProtocolConverterService) AddToManager(
 		return errors.New("dataflowcomponent manager not initialized")
 	}
 
-	p.logger.Infof("Adding ProtocolConverter %s", protConvName)
-
 	if ctx.Err() != nil {
 		return ctx.Err()
 	}
@@ -482,6 +480,8 @@ func (p *ProtocolConverterService) AddToManager(
 			return ErrServiceAlreadyExists
 		}
 	}
+
+	p.logger.Infof("Adding ProtocolConverter %s", protConvName)
 
 	connServiceConfig := cfg.ConnectionServiceConfig
 	dfcReadServiceConfig := cfg.DataflowComponentReadServiceConfig
@@ -519,8 +519,8 @@ func (p *ProtocolConverterService) AddToManager(
 	p.dataflowComponentConfig = append(p.dataflowComponentConfig, dfcReadConfig, dfcWriteConfig)
 
 	p.logger.Infof("ProtocolConverter %s added to manager", protConvName)
-	p.logger.Infof("Connection config: %+v", p.connectionConfig)
-	p.logger.Infof("Dataflow component config: %+v", p.dataflowComponentConfig)
+	p.logger.Debugf("Connection config: %+v", p.connectionConfig)
+	p.logger.Debugf("Dataflow component config: %+v", p.dataflowComponentConfig)
 
 	return nil
 }
@@ -545,7 +545,7 @@ func (p *ProtocolConverterService) UpdateInManager(
 		return errors.New("config is nil")
 	}
 
-	p.logger.Infof("Updating protocolconverter %s", protConvName)
+	p.logger.Debugf("Updating protocolconverter %s", protConvName)
 
 	if ctx.Err() != nil {
 		return ctx.Err()
@@ -637,9 +637,9 @@ func (p *ProtocolConverterService) UpdateInManager(
 		}
 	}
 
-	p.logger.Info("Updated protocolconverter config in manager")
-	p.logger.Infof("Connection config: %+v", p.connectionConfig)
-	p.logger.Infof("Dataflow component config: %+v", p.dataflowComponentConfig)
+	p.logger.Debug("Updated protocolconverter config in manager")
+	p.logger.Debugf("Connection config: %+v", p.connectionConfig)
+	p.logger.Debugf("Dataflow component config: %+v", p.dataflowComponentConfig)
 
 	return nil
 }
@@ -658,7 +658,7 @@ func (p *ProtocolConverterService) RemoveFromManager(
 		return errors.New("dataflowcomponent manager not initialized")
 	}
 
-	p.logger.Infof("Removing dataflowcomponent %s", protConvName)
+	p.logger.Debugf("Removing dataflowcomponent %s", protConvName)
 
 	if ctx.Err() != nil {
 		return ctx.Err()

--- a/umh-core/pkg/service/protocolconverter/protocolconverter.go
+++ b/umh-core/pkg/service/protocolconverter/protocolconverter.go
@@ -545,11 +545,11 @@ func (p *ProtocolConverterService) UpdateInManager(
 		return errors.New("config is nil")
 	}
 
-	p.logger.Debugf("Updating protocolconverter %s", protConvName)
-
 	if ctx.Err() != nil {
 		return ctx.Err()
 	}
+
+	p.logger.Debugf("Updating protocolconverter %s", protConvName)
 
 	// Check if the connectionconfig exists
 	foundConn := false
@@ -658,11 +658,11 @@ func (p *ProtocolConverterService) RemoveFromManager(
 		return errors.New("dataflowcomponent manager not initialized")
 	}
 
-	p.logger.Debugf("Removing dataflowcomponent %s", protConvName)
-
 	if ctx.Err() != nil {
 		return ctx.Err()
 	}
+
+	p.logger.Debugf("Removing dataflowcomponent %s", protConvName)
 
 	connectionName := p.getUnderlyingConnectionName(protConvName)
 	dfcReadName := p.getUnderlyingDFCReadName(protConvName)

--- a/umh-core/pkg/service/streamprocessor/logging_test.go
+++ b/umh-core/pkg/service/streamprocessor/logging_test.go
@@ -1,0 +1,117 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build test
+
+package streamprocessor
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/dataflowcomponentserviceconfig"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+var _ = Describe("demotes per-tick config dumps to DEBUG", func() {
+	It("emits only the two lifecycle INFO lines per real create and nothing on retries/dumps", func() {
+		ctx := context.Background()
+		const spName = "test-sp"
+
+		// White-box: capture every log the service emits via a zap observer core
+		// and drive the real (unmodified) service through its manager methods.
+		core, logs := observer.New(zapcore.DebugLevel)
+		svc := NewDefaultService(spName)
+		svc.logger = zap.New(core).Sugar()
+
+		// FileSystemService is not dereferenced by Add/Update/Remove; nil is safe.
+		// A zero-value config is sufficient — the methods only append/reassign it.
+		var cfg dataflowcomponentserviceconfig.DataflowComponentServiceConfig
+
+		Expect(svc.AddToManager(ctx, nil, &cfg, spName)).To(Succeed())
+		infoAfterFirst := logs.FilterLevelExact(zapcore.InfoLevel)
+		Expect(infoAfterFirst.Len()).To(Equal(2),
+			"first AddToManager should log exactly 2 INFO lines (Adding + added to manager); "+
+				"the per-tick config dumps must be DEBUG")
+		Expect(messages(infoAfterFirst.All())).To(ConsistOf(
+			"Adding StreamProcessor "+spName,
+			"Stream Processor "+spName+" added to manager",
+		))
+
+		// Idempotent AddToManager retry logs zero INFO lines.
+		err := svc.AddToManager(ctx, nil, &cfg, spName)
+		Expect(err).To(HaveOccurred())
+		Expect(errors.Is(err, ErrServiceAlreadyExists)).To(BeTrue())
+		Expect(logs.FilterLevelExact(zapcore.InfoLevel).Len()).To(Equal(2),
+			"second AddToManager must log ZERO additional INFO lines "+
+				"(Adding moved below the exists-check so idempotent retries are silent)")
+
+		// UpdateInManager emits none of the demoted lines at INFO, and emits them
+		// at DEBUG.
+		infoBeforeUpdate := logs.FilterLevelExact(zapcore.InfoLevel).Len()
+		debugBeforeUpdate := logs.FilterLevelExact(zapcore.DebugLevel).Len()
+		Expect(svc.UpdateInManager(ctx, nil, &cfg, spName)).To(Succeed())
+		Expect(logs.FilterLevelExact(zapcore.InfoLevel).Len()).To(Equal(infoBeforeUpdate),
+			"UpdateInManager must emit ZERO INFO lines (all lifecycle lines demoted to DEBUG)")
+		newDebugMessages := messages(logs.FilterLevelExact(zapcore.DebugLevel).All()[debugBeforeUpdate:])
+		Expect(newDebugMessages).To(ContainElement(ContainSubstring("Updating streamprocessor")),
+			"'Updating streamprocessor' must reappear at DEBUG")
+		Expect(newDebugMessages).To(ContainElement(ContainSubstring("Updated streamprocessor config in manager")),
+			"'Updated streamprocessor config in manager' must reappear at DEBUG")
+		Expect(newDebugMessages).To(ContainElement(ContainSubstring("Dataflow component config:")),
+			"the 'Dataflow component config: %+v' dump must reappear at DEBUG")
+
+		// RemoveFromManager retries emit zero INFO lines and emit the demoted
+		// 'Removing dataflowcomponent' line at DEBUG. AddToManager above only
+		// appends to the config slice and never creates a live FSM instance in
+		// the manager, so GetInstance returns ok=false and RemoveFromManager
+		// returns nil on each retry (config-slice path only). In production the
+		// reconcile loop seeds a live FSM, so the first RemoveFromManager returns
+		// standarderrors.ErrRemovalPending until the FSM is reaped; that
+		// real-lifecycle path is not exercised here.
+		infoBeforeRemove := logs.FilterLevelExact(zapcore.InfoLevel).Len()
+		debugBeforeRemove := logs.FilterLevelExact(zapcore.DebugLevel).Len()
+		for i := 0; i < 5; i++ {
+			Expect(svc.RemoveFromManager(ctx, nil, spName)).To(Succeed(),
+				"RemoveFromManager returns nil when no live FSM instance exists "+
+					"(config-slice path only); production removal returns "+
+					"ErrRemovalPending until the FSM is reaped")
+		}
+		Expect(logs.FilterLevelExact(zapcore.InfoLevel).Len()).To(Equal(infoBeforeRemove),
+			"RemoveFromManager retries must emit ZERO INFO lines "+
+				"('Removing dataflowcomponent' demoted to DEBUG)")
+		removeDebugMessages := messages(logs.FilterLevelExact(zapcore.DebugLevel).All()[debugBeforeRemove:])
+		var removeDebugCount int
+		for _, m := range removeDebugMessages {
+			if strings.Contains(m, "Removing dataflowcomponent") {
+				removeDebugCount++
+			}
+		}
+		Expect(removeDebugCount).To(Equal(5),
+			"'Removing dataflowcomponent' must fire exactly once per retry (5 calls) at DEBUG")
+	})
+})
+
+func messages(entries []observer.LoggedEntry) []string {
+	out := make([]string, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, e.Message)
+	}
+	return out
+}

--- a/umh-core/pkg/service/streamprocessor/streamprocessor.go
+++ b/umh-core/pkg/service/streamprocessor/streamprocessor.go
@@ -290,8 +290,6 @@ func (p *Service) AddToManager(
 		return errors.New("dataflowcomponent manager not initialized")
 	}
 
-	p.logger.Infof("Adding StreamProcessor %s", spName)
-
 	if ctx.Err() != nil {
 		return ctx.Err()
 	}
@@ -305,6 +303,8 @@ func (p *Service) AddToManager(
 		}
 	}
 
+	p.logger.Infof("Adding StreamProcessor %s", spName)
+
 	dfcConfig := config.DataFlowComponentConfig{
 		FSMInstanceConfig: config.FSMInstanceConfig{
 			Name:            underlyingDFCName,
@@ -317,7 +317,7 @@ func (p *Service) AddToManager(
 	p.dataflowComponentConfig = append(p.dataflowComponentConfig, dfcConfig)
 
 	p.logger.Infof("Stream Processor %s added to manager", spName)
-	p.logger.Infof("Dataflow component config: %+v", p.dataflowComponentConfig)
+	p.logger.Debugf("Dataflow component config: %+v", p.dataflowComponentConfig)
 
 	return nil
 }
@@ -337,11 +337,11 @@ func (p *Service) UpdateInManager(
 		return errors.New("config is nil")
 	}
 
-	p.logger.Infof("Updating streamprocessor %s", spName)
-
 	if ctx.Err() != nil {
 		return ctx.Err()
 	}
+
+	p.logger.Debugf("Updating streamprocessor %s", spName)
 
 	// Check if the dfcconfig exists
 	foundDFC := false
@@ -362,19 +362,17 @@ func (p *Service) UpdateInManager(
 	}
 
 	// Create a config.DataflowComponentConfig that wraps the DataflowComponentServiceConfig
-	if foundDFC {
-		dfcCurrentDesiredState := p.dataflowComponentConfig[indexDFC].DesiredFSMState
-		p.dataflowComponentConfig[indexDFC] = config.DataFlowComponentConfig{
-			FSMInstanceConfig: config.FSMInstanceConfig{
-				Name:            p.getUnderlyingDFCReadName(spName),
-				DesiredFSMState: dfcCurrentDesiredState,
-			},
-			DataFlowComponentServiceConfig: *cfg,
-		}
+	dfcCurrentDesiredState := p.dataflowComponentConfig[indexDFC].DesiredFSMState
+	p.dataflowComponentConfig[indexDFC] = config.DataFlowComponentConfig{
+		FSMInstanceConfig: config.FSMInstanceConfig{
+			Name:            p.getUnderlyingDFCReadName(spName),
+			DesiredFSMState: dfcCurrentDesiredState,
+		},
+		DataFlowComponentServiceConfig: *cfg,
 	}
 
-	p.logger.Info("Updated streamprocessor config in manager")
-	p.logger.Infof("Dataflow component config: %+v", p.dataflowComponentConfig)
+	p.logger.Debug("Updated streamprocessor config in manager")
+	p.logger.Debugf("Dataflow component config: %+v", p.dataflowComponentConfig)
 
 	return nil
 }
@@ -389,11 +387,11 @@ func (p *Service) RemoveFromManager(
 		return errors.New("dataflowcomponent manager not initialized")
 	}
 
-	p.logger.Infof("Removing dataflowcomponent %s", spName)
-
 	if ctx.Err() != nil {
 		return ctx.Err()
 	}
+
+	p.logger.Debugf("Removing dataflowcomponent %s", spName)
 
 	dfcName := p.getUnderlyingDFCReadName(spName)
 

--- a/umh-core/test/fsm/protocolconverter/logging_inversion_test.go
+++ b/umh-core/test/fsm/protocolconverter/logging_inversion_test.go
@@ -18,6 +18,7 @@ package protocolconverter_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -27,11 +28,14 @@ import (
 
 	internalfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/internal/fsm"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/internal/fsmtest"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
 	protocolconverterfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/protocolconverter"
 	protocolconvertersvc "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/protocolconverter"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/protocolconverter/runtime_config"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/serviceregistry"
+	standarderrors "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/standarderrors"
 )
 
 var _ = Describe("ConfigDivergence reset and staging", func() {
@@ -164,5 +168,267 @@ var _ = Describe("ConfigDivergence reset and staging", func() {
 		Expect(instance.UpdateObservedStateOfInstance(
 			ctx, mockRegistry, fsm.SystemSnapshot{Tick: tick})).To(Succeed())
 		Expect(instance.ObservedState.ConfigDivergence).To(Equal(""))
+	})
+})
+
+var _ = Describe("ConfigDivergence composition into StatusReason", func() {
+	var (
+		instance      *protocolconverterfsm.ProtocolConverterInstance
+		mockService   *protocolconvertersvc.MockProtocolConverterService
+		componentName string
+		ctx           context.Context
+		tick          uint64
+		mockRegistry  *serviceregistry.Registry
+		startTime     time.Time
+	)
+
+	BeforeEach(func() {
+		componentName = "test-pc-composition"
+		ctx = context.Background()
+		tick = 0
+		startTime = time.Now()
+
+		instance, mockService, _ = fsmtest.SetupProtocolConverterInstance(componentName, protocolconverterfsm.OperationalStateStopped)
+		mockRegistry = serviceregistry.NewMockRegistry()
+	})
+
+	// snapshotFor builds a SystemSnapshot matching the shape the reconcile loop
+	// uses in production (tick-pinned time, agent location carried for the
+	// observed-state render).
+	snapshotFor := func(t uint64) fsm.SystemSnapshot {
+		return fsm.SystemSnapshot{
+			Tick:         t,
+			SnapshotTime: startTime.Add(time.Duration(t) * constants.DefaultTickerTime),
+			CurrentConfig: config.FullConfig{
+				Agent: config.AgentConfig{
+					Location: map[int]string{},
+				},
+			},
+		}
+	}
+
+	It("composes the divergence into StatusReason on a diverged tick and bounds it across removal ticks (edges 5 and 14)", func() {
+		var err error
+		// Walk the lifecycle to operational stopped so the
+		// to_be_created/creating early-return no longer short-circuits
+		// UpdateObservedStateOfInstance before the divergence branch.
+		tick, err = fsmtest.TestProtocolConverterStateTransition(
+			ctx, instance, mockService, mockRegistry, componentName,
+			internalfsm.LifecycleStateToBeCreated,
+			internalfsm.LifecycleStateCreating, 5, tick, startTime)
+		Expect(err).NotTo(HaveOccurred())
+
+		mockService.ExistingComponents[componentName] = true
+		fsmtest.TransitionToProtocolConverterState(mockService, componentName, protocolconverterfsm.OperationalStateStopped)
+
+		tick, err = fsmtest.TestProtocolConverterStateTransition(
+			ctx, instance, mockService, mockRegistry, componentName,
+			internalfsm.LifecycleStateCreating,
+			protocolconverterfsm.OperationalStateStopped, 5, tick, startTime)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Desired Active so the "both stopped" early-return does not skip the
+		// divergence evaluation.
+		Expect(instance.SetDesiredFSMState(protocolconverterfsm.OperationalStateActive)).To(Succeed())
+
+		mockService.ServiceExistsResult = true
+
+		// Converged baseline: render the config exactly as
+		// UpdateObservedStateOfInstance will render it from the spec, and assign
+		// it to GetConfigResult as the LAST setup statement (after any
+		// TransitionToProtocolConverterState call that clobbers it via
+		// ConfigureProtocolConverterServiceConfig).
+		cfg := instance.GetConfig()
+		rendered, err := runtime_config.BuildRuntimeConfig(
+			cfg,
+			map[string]string{},
+			nil,
+			runtime_config.BridgedByPlaceholder,
+			componentName,
+		)
+		Expect(err).NotTo(HaveOccurred())
+		mockService.GetConfigResult = rendered
+
+		// --- Divergent config: large Input map (>400 runes) so BoundDiff
+		// emits its truncation marker; the diff comparator reports this as
+		// "Input config differences".
+		divergent := rendered
+		largeInput := make(map[string]any, 50)
+		longValue := strings.Repeat("x", 30)
+		for i := 0; i < 50; i++ {
+			largeInput[fmt.Sprintf("input_key_%02d", i)] = map[string]any{
+				"value":   longValue,
+				"mapping": `root = {"message":"diverged"}`,
+			}
+		}
+		divergent.DataflowComponentReadServiceConfig.BenthosConfig.Input = largeInput
+		mockService.GetConfigResult = divergent
+
+		// --- EDGE 5: one full Reconcile() tick on an active-diverging instance.
+		// Composition must append "re-applying config: " to StatusReason.
+		tick++
+		err, _ = instance.Reconcile(ctx, snapshotFor(tick), mockRegistry)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(instance.ObservedState.ServiceInfo.StatusReason).To(ContainSubstring("re-applying config: "))
+		Expect(instance.ObservedState.ConfigDivergence).To(ContainSubstring("Input config differences"))
+		Expect(instance.ObservedState.ServiceInfo.StatusReason).To(ContainSubstring(instance.ObservedState.ConfigDivergence))
+
+		// --- EDGE 5 APPEND-SEMANTICS PIN ---
+		// ContainSubstring passes under overwrite too, so it cannot
+		// discriminate append from overwrite. When Step 3 wrote a non-empty
+		// operational reason on this tick, the divergence text must come AFTER
+		// it with "; " as the join. Assert the divergence text is a SUFFIX
+		// preceded by "; " — this goes RED if composition overwrites
+		// StatusReason instead of appending.
+		statusReason := instance.ObservedState.ServiceInfo.StatusReason
+		if idx := strings.Index(statusReason, "re-applying config:"); idx > 0 {
+			Expect(statusReason[:idx]).To(HaveSuffix("; "),
+				"operational reason must be preserved in front of the divergence text, joined with \"; \"")
+		}
+
+		// --- EDGE 14: request removal, then loop 30 ticks with a pending removal.
+		Expect(instance.Remove(ctx)).To(Succeed())
+
+		// Put the mock into stopped flags so IsProtocolConverterStopped()
+		// returns true during the stopping state, letting the FSM converge
+		// stopped -> removing. TransitionToProtocolConverterState also resets
+		// GetConfigResult, so re-inject the divergent config afterwards so
+		// ConfigDivergence stays non-empty on every operational tick and is
+		// non-empty when the FSM enters the removing branch.
+		fsmtest.TransitionToProtocolConverterState(mockService, componentName, protocolconverterfsm.OperationalStateStopped)
+		mockService.GetConfigResult = divergent
+		// Pending removal: RemoveFromManager must hold the FSM in removing
+		// across many ticks. This requires the mock to consult
+		// RemoveFromManagerError BEFORE mutating config; the current code
+		// mutates then returns the error, completing removal after one tick.
+		mockService.RemoveFromManagerError = standarderrors.ErrRemovalPending
+
+		sawRemoving := false
+		removingTickCount := 0
+		divergenceDuringRemoving := false
+
+		for i := 0; i < 30; i++ {
+			wasRemoving := instance.IsRemoving()
+			if wasRemoving {
+				sawRemoving = true
+				removingTickCount++
+			}
+
+			tick++
+			rErr, _ := instance.Reconcile(ctx, snapshotFor(tick), mockRegistry)
+			// Once removal completes Reconcile returns ErrInstanceRemoved;
+			// the loop keeps ticking to observe the removal-window invariant.
+			_ = rErr
+
+			if wasRemoving && instance.ObservedState.ConfigDivergence != "" {
+				divergenceDuringRemoving = true
+			}
+		}
+
+		// Mock fix: removal stays pending across many ticks.
+		Expect(sawRemoving).To(BeTrue(), "expected the FSM to enter the removing state")
+		Expect(removingTickCount).To(BeNumerically(">=", 10), "expected at least 10 removing ticks while removal is pending")
+		// The IsRemoving branch clears ConfigDivergence per tick so the
+		// composition block does not stamp "re-applying config" on an
+		// instance being deleted.
+		Expect(divergenceDuringRemoving).To(BeFalse(), "ConfigDivergence must be cleared during removal ticks")
+	})
+
+	It("composes the divergence into StatusReason even when reconcileStateTransition errors on a diverged tick (edge 15)", func() {
+		var err error
+		// Walk the lifecycle to operational stopped, same setup as edge 5/14.
+		tick, err = fsmtest.TestProtocolConverterStateTransition(
+			ctx, instance, mockService, mockRegistry, componentName,
+			internalfsm.LifecycleStateToBeCreated,
+			internalfsm.LifecycleStateCreating, 5, tick, startTime)
+		Expect(err).NotTo(HaveOccurred())
+
+		mockService.ExistingComponents[componentName] = true
+		fsmtest.TransitionToProtocolConverterState(mockService, componentName, protocolconverterfsm.OperationalStateStopped)
+
+		tick, err = fsmtest.TestProtocolConverterStateTransition(
+			ctx, instance, mockService, mockRegistry, componentName,
+			internalfsm.LifecycleStateCreating,
+			protocolconverterfsm.OperationalStateStopped, 5, tick, startTime)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Desired Active so the FSM will try to start the instance.
+		Expect(instance.SetDesiredFSMState(protocolconverterfsm.OperationalStateActive)).To(Succeed())
+
+		mockService.ServiceExistsResult = true
+
+		// Converged baseline, then make it divergent with a large Input map.
+		cfg := instance.GetConfig()
+		rendered, err := runtime_config.BuildRuntimeConfig(
+			cfg,
+			map[string]string{},
+			nil,
+			runtime_config.BridgedByPlaceholder,
+			componentName,
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		divergent := rendered
+		largeInput := make(map[string]any, 50)
+		longValue := strings.Repeat("x", 30)
+		for i := 0; i < 50; i++ {
+			largeInput[fmt.Sprintf("input_key_%02d", i)] = map[string]any{
+				"value":   longValue,
+				"mapping": `root = {"message":"diverged"}`,
+			}
+		}
+		divergent.DataflowComponentReadServiceConfig.BenthosConfig.Input = largeInput
+		mockService.GetConfigResult = divergent
+
+		// snapshotFor is scoped to the edge-15 It because the Describe-level
+		// helper lives inside the first It's closure; rebuild it here.
+		snapshotFor := func(t uint64) fsm.SystemSnapshot {
+			return fsm.SystemSnapshot{
+				Tick:         t,
+				SnapshotTime: startTime.Add(time.Duration(t) * constants.DefaultTickerTime),
+				CurrentConfig: config.FullConfig{
+					Agent: config.AgentConfig{
+						Location: map[int]string{},
+					},
+				},
+			}
+		}
+
+		// Tick 1: stopped with desired Active. This tick fires EventStart only
+		// (no service call yet), so no error is injected — it just advances the
+		// FSM into starting_connection.
+		tick++
+		rErr, _ := instance.Reconcile(ctx, snapshotFor(tick), mockRegistry)
+		Expect(rErr).NotTo(HaveOccurred())
+
+		// Tick 2: FSM is now in starting_connection. reconcileStateTransition
+		// calls StartConnectionInstance, which hits StartConnectionError and
+		// returns an error → Reconcile enters the `if err != nil` block and
+		// returns. The composition block MUST have run BEFORE that return, or
+		// the divergence diagnostic is lost on this overload tick.
+		mockService.StartConnectionError = errors.New("injected start failure")
+		tick++
+		err2, _ := instance.Reconcile(ctx, snapshotFor(tick), mockRegistry)
+		_ = err2
+
+		// Prove the error path was actually hit — without this the test is
+		// vacuous (a tick that never called StartConnection cannot discriminate
+		// before-err vs after-err placement).
+		Expect(mockService.StartConnectionCalled).To(BeTrue(),
+			"StartConnection must be called so the error path is actually exercised")
+
+		// The divergence must have been staged by
+		// UpdateObservedStateOfInstance on this tick.
+		Expect(instance.ObservedState.ConfigDivergence).NotTo(BeEmpty(),
+			"ConfigDivergence must be staged on the diverged tick")
+
+		// The load-bearing assertion: composition ran BEFORE the err-block
+		// return, so StatusReason carries the divergence text. This goes RED
+		// if the composition block is placed AFTER the err block.
+		Expect(instance.ObservedState.ServiceInfo.StatusReason).To(ContainSubstring("re-applying config: "),
+			"composition must run before the err-block return so the divergence surfaces on error ticks")
+
+		// Reset the injected error so downstream specs are not affected.
+		mockService.StartConnectionError = nil
 	})
 })

--- a/umh-core/test/fsm/protocolconverter/logging_inversion_test.go
+++ b/umh-core/test/fsm/protocolconverter/logging_inversion_test.go
@@ -25,6 +25,9 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 
 	internalfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/internal/fsm"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/internal/fsmtest"
@@ -32,6 +35,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
 	protocolconverterfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/protocolconverter"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/logger"
 	protocolconvertersvc "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/protocolconverter"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/protocolconverter/runtime_config"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/serviceregistry"
@@ -430,5 +434,151 @@ var _ = Describe("ConfigDivergence composition into StatusReason", func() {
 
 		// Reset the injected error so downstream specs are not affected.
 		mockService.StartConnectionError = nil
+	})
+})
+
+var _ = Describe("Heartbeat WARN on the PC divergence branch", func() {
+	var (
+		instance       *protocolconverterfsm.ProtocolConverterInstance
+		mockService    *protocolconvertersvc.MockProtocolConverterService
+		componentName  string
+		ctx            context.Context
+		mockRegistry   *serviceregistry.Registry
+		startTime      time.Time
+		logs           *observer.ObservedLogs
+		restoreGlobals func()
+	)
+
+	BeforeEach(func() {
+		componentName = "test-pc-warn"
+		ctx = context.Background()
+		startTime = time.Now()
+
+		// logger.For binds the instance logger to the zap global at construction
+		// (machine.go calls zap.S().Named(...)). Its lazy Initialize runs once
+		// via sync.Once and would otherwise call zap.ReplaceGlobals AFTER we
+		// install the observer, wiping it. Consume the sync.Once first so the
+		// instance built below picks up our observer-backed global.
+		_ = logger.For("warmup")
+
+		core, obs := observer.New(zapcore.WarnLevel)
+		restoreGlobals = zap.ReplaceGlobals(zap.New(core))
+		logs = obs
+
+		instance, mockService, _ = fsmtest.SetupProtocolConverterInstance(componentName, protocolconverterfsm.OperationalStateStopped)
+		mockRegistry = serviceregistry.NewMockRegistry()
+	})
+
+	AfterEach(func() {
+		restoreGlobals()
+	})
+
+	// divergenceWarns returns every captured WARN whose message carries the
+	// divergence heartbeat text, across all ticks driven so far.
+	divergenceWarns := func() []observer.LoggedEntry {
+		return logs.FilterLevelExact(zapcore.WarnLevel).
+			FilterMessageSnippet("re-applying config").All()
+	}
+
+	c := uint64(constants.ProtocolConverterDivergenceWarnIntervalTicks)
+	It("fires one heartbeat WARN per bridge on ticks that are multiples of the interval and none in a window spanning no multiple (edges 6 and 7)", func() {
+		var err error
+		// Walk the lifecycle to operational stopped so the
+		// to_be_created/creating early-return no longer short-circuits
+		// UpdateObservedStateOfInstance before the divergence branch.
+		var tick uint64
+		tick, err = fsmtest.TestProtocolConverterStateTransition(
+			ctx, instance, mockService, mockRegistry, componentName,
+			internalfsm.LifecycleStateToBeCreated,
+			internalfsm.LifecycleStateCreating, 5, tick, startTime)
+		Expect(err).NotTo(HaveOccurred())
+
+		mockService.ExistingComponents[componentName] = true
+		fsmtest.TransitionToProtocolConverterState(mockService, componentName, protocolconverterfsm.OperationalStateStopped)
+
+		tick, err = fsmtest.TestProtocolConverterStateTransition(
+			ctx, instance, mockService, mockRegistry, componentName,
+			internalfsm.LifecycleStateCreating,
+			protocolconverterfsm.OperationalStateStopped, 5, tick, startTime)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Desired Active so the "both stopped" early-return does not skip the
+		// divergence evaluation.
+		Expect(instance.SetDesiredFSMState(protocolconverterfsm.OperationalStateActive)).To(Succeed())
+
+		mockService.ServiceExistsResult = true
+
+		// Converged baseline rendered exactly as UpdateObservedStateOfInstance
+		// renders it, assigned LAST (TransitionToProtocolConverterState
+		// clobbers GetConfigResult).
+		cfg := instance.GetConfig()
+		rendered, err := runtime_config.BuildRuntimeConfig(
+			cfg,
+			map[string]string{},
+			nil,
+			runtime_config.BridgedByPlaceholder,
+			componentName,
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		divergent := rendered
+		largeInput := make(map[string]any, 50)
+		longValue := strings.Repeat("x", 30)
+		for i := 0; i < 50; i++ {
+			largeInput[fmt.Sprintf("input_key_%02d", i)] = map[string]any{
+				"value":   longValue,
+				"mapping": `root = {"message":"diverged"}`,
+			}
+		}
+		divergent.DataflowComponentReadServiceConfig.BenthosConfig.Input = largeInput
+
+		mockService.GetConfigResult = divergent
+		Expect(instance.UpdateObservedStateOfInstance(
+			ctx, mockRegistry, fsm.SystemSnapshot{Tick: 1})).To(Succeed(),
+			"tick 1 is the first real production tick (loop.go increments before the first Reconcile, so tick 0 never reaches here)")
+		Expect(divergenceWarns()).To(HaveLen(0),
+			"tick 1 is not a multiple of the WARN interval, so no WARN fires")
+		Expect(instance.ObservedState.ConfigDivergence).NotTo(BeEmpty(),
+			"the divergence branch still ran and staged ConfigDivergence, just no WARN")
+
+		mockService.GetConfigResult = divergent
+		Expect(instance.UpdateObservedStateOfInstance(
+			ctx, mockRegistry, fsm.SystemSnapshot{Tick: c})).To(Succeed(),
+			"tick c (c %% c == 0) must reach the divergence branch")
+		warnsThroughC := divergenceWarns()
+		Expect(warnsThroughC).To(HaveLen(1),
+			"tick c must increment the WARN count by exactly one (1 total: tick c is the first multiple that fires)")
+		Expect(warnsThroughC[0].Message).To(ContainSubstring(componentName),
+			"the heartbeat WARN must carry the bridge ID")
+		Expect(warnsThroughC[0].Message).To(ContainSubstring("Input config differences"),
+			"the heartbeat WARN must carry the bounded ConfigDivergence text")
+
+		// Edge 7: a divergent window spanning no multiple of the interval must
+		// emit zero WARN while ConfigDivergence stays non-empty. GetConfigResult
+		// is already divergent from the tick-c setup above and MockProtocolConverterService.GetConfig
+		// does not mutate it, so the per-tick reassignment is unnecessary.
+		warnsBeforeWindow := len(divergenceWarns())
+		for t := uint64(c + 1); t <= 2*c-1; t++ {
+			Expect(instance.UpdateObservedStateOfInstance(
+				ctx, mockRegistry, fsm.SystemSnapshot{Tick: t})).To(Succeed())
+			Expect(instance.ObservedState.ConfigDivergence).NotTo(BeEmpty(),
+				"ConfigDivergence must be staged non-empty on every divergent tick in the window (tick %d)", t)
+		}
+		Expect(len(divergenceWarns())).To(Equal(warnsBeforeWindow),
+			"a divergent window spanning no multiple of the interval must emit ZERO WARN")
+
+		// Third multiple proves the heartbeat REPEATS at subsequent multiples
+		// rather than firing only at 0 and the first interval.
+		mockService.GetConfigResult = divergent
+		Expect(instance.UpdateObservedStateOfInstance(
+			ctx, mockRegistry, fsm.SystemSnapshot{Tick: 2 * c})).To(Succeed(),
+			"tick 2c (2c %% c == 0) must reach the divergence branch")
+		warnsThrough2C := divergenceWarns()
+		Expect(warnsThrough2C).To(HaveLen(2),
+			"tick 2c must increment the WARN count by exactly one (2 total: tick c + tick 2c)")
+		Expect(warnsThrough2C[1].Message).To(ContainSubstring(componentName),
+			"the heartbeat WARN must carry the bridge ID")
+		Expect(warnsThrough2C[1].Message).To(ContainSubstring("Input config differences"),
+			"the heartbeat WARN must carry the bounded ConfigDivergence text")
 	})
 })

--- a/umh-core/test/fsm/protocolconverter/logging_inversion_test.go
+++ b/umh-core/test/fsm/protocolconverter/logging_inversion_test.go
@@ -582,3 +582,188 @@ var _ = Describe("Heartbeat WARN on the PC divergence branch", func() {
 			"the heartbeat WARN must carry the bounded ConfigDivergence text")
 	})
 })
+
+var _ = Describe("Capstone: full Reconcile lifecycle under sustained divergence", func() {
+	var (
+		instance       *protocolconverterfsm.ProtocolConverterInstance
+		mockService    *protocolconvertersvc.MockProtocolConverterService
+		componentName  string
+		ctx            context.Context
+		mockRegistry   *serviceregistry.Registry
+		startTime      time.Time
+		logs           *observer.ObservedLogs
+		restoreGlobals func()
+	)
+
+	BeforeEach(func() {
+		componentName = "test-pc-capstone"
+		ctx = context.Background()
+		startTime = time.Now()
+
+		_ = logger.For("capstone-warmup")
+
+		core, obs := observer.New(zapcore.DebugLevel)
+		restoreGlobals = zap.ReplaceGlobals(zap.New(core))
+		logs = obs
+
+		instance, mockService, _ = fsmtest.SetupProtocolConverterInstance(componentName, protocolconverterfsm.OperationalStateStopped)
+		mockRegistry = serviceregistry.NewMockRegistry()
+	})
+
+	AfterEach(func() {
+		restoreGlobals()
+	})
+
+	snapshotFor := func(t uint64) fsm.SystemSnapshot {
+		return fsm.SystemSnapshot{
+			Tick:         t,
+			SnapshotTime: startTime.Add(time.Duration(t) * constants.DefaultTickerTime),
+			CurrentConfig: config.FullConfig{
+				Agent: config.AgentConfig{
+					Location: map[int]string{},
+				},
+			},
+		}
+	}
+
+	It("drives a bridge through sustained divergence, two deadline-injection points, convergence, and diverge-into-removal, asserting end-of-tick StatusReason, WARN count, and removal boundedness", func() {
+		var err error
+		var tick uint64
+
+		tick, err = fsmtest.TestProtocolConverterStateTransition(
+			ctx, instance, mockService, mockRegistry, componentName,
+			internalfsm.LifecycleStateToBeCreated,
+			internalfsm.LifecycleStateCreating, 5, tick, startTime)
+		Expect(err).NotTo(HaveOccurred())
+
+		mockService.ExistingComponents[componentName] = true
+		fsmtest.TransitionToProtocolConverterState(mockService, componentName, protocolconverterfsm.OperationalStateStopped)
+
+		tick, err = fsmtest.TestProtocolConverterStateTransition(
+			ctx, instance, mockService, mockRegistry, componentName,
+			internalfsm.LifecycleStateCreating,
+			protocolconverterfsm.OperationalStateStopped, 5, tick, startTime)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(instance.SetDesiredFSMState(protocolconverterfsm.OperationalStateActive)).To(Succeed())
+		mockService.ServiceExistsResult = true
+
+		cfg := instance.GetConfig()
+		rendered, err := runtime_config.BuildRuntimeConfig(
+			cfg,
+			map[string]string{},
+			nil,
+			runtime_config.BridgedByPlaceholder,
+			componentName,
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		divergent := rendered
+		largeInput := make(map[string]any, 50)
+		longValue := strings.Repeat("x", 30)
+		for i := 0; i < 50; i++ {
+			largeInput[fmt.Sprintf("input_key_%02d", i)] = map[string]any{
+				"value":   longValue,
+				"mapping": `root = {"message":"diverged"}`,
+			}
+		}
+		divergent.DataflowComponentReadServiceConfig.BenthosConfig.Input = largeInput
+
+		mockService.GetConfigResult = divergent
+
+		// --- Sustained divergence loop (ticks 1..1300) with two deadline
+		// injections at distinct points in UpdateObservedStateOfInstance. ---
+		for t := uint64(1); t <= 1300; t++ {
+			switch t {
+			case 250:
+				mockService.StatusError = context.DeadlineExceeded
+			case 850:
+				mockService.GetConfigError = context.DeadlineExceeded
+			case 251:
+				mockService.StatusError = nil
+			case 851:
+				mockService.GetConfigError = nil
+			}
+
+			reasonBefore := instance.ObservedState.ServiceInfo.StatusReason
+			rErr, _ := instance.Reconcile(ctx, snapshotFor(t), mockRegistry)
+			_ = rErr
+
+			switch t {
+			case 250:
+				// EDGE 11b-iii: deadline BEFORE the ServiceInfo store —
+				// composition did not run, StatusReason retains the previous
+				// tick's composed value (pre-existing staleness, no compounding).
+				Expect(instance.ObservedState.ServiceInfo.StatusReason).To(Equal(reasonBefore),
+					"tick 250 (11b-iii): pre-store deadline must preserve the previous tick's StatusReason")
+				Expect(strings.Count(instance.ObservedState.ServiceInfo.StatusReason, "re-applying config")).To(BeNumerically("<=", 1),
+					"tick 250 (11b-iii): no compounding — composition did not run")
+			case 850:
+				// EDGE 11b-ii: deadline AFTER the ServiceInfo store —
+				// ServiceInfo was refreshed to a fresh suffix-free Status()
+				// reason, composition did not run.
+				Expect(instance.ObservedState.ServiceInfo.StatusReason).NotTo(ContainSubstring("re-applying config"),
+					"tick 850 (11b-ii): post-store deadline must leave a suffix-free StatusReason")
+			default:
+				// Placement invariant: composition is the last StatusReason
+				// write of a non-deadline-exit divergent tick.
+				Expect(instance.ObservedState.ServiceInfo.StatusReason).To(ContainSubstring("re-applying config: "),
+					"tick %d: divergent tick must compose the divergence into StatusReason", t)
+			}
+		}
+
+		// --- Exact WARN count: only ticks 600 and 1200 are multiples of the
+		// 600-tick interval in 1..1300. Deadline ticks 250/850 are not
+		// multiples and exit before the divergence branch anyway. ---
+		warnCount := len(logs.FilterLevelExact(zapcore.WarnLevel).
+			FilterMessageSnippet("re-applying config").All())
+		Expect(warnCount).To(Equal(2),
+			"exactly two heartbeat WARNs expected (ticks 600 and 1200)")
+
+		// --- DEBUG diff present: the full untruncated diff logs at DEBUG on
+		// every divergent tick. ---
+		debugDiffCount := len(logs.FilterLevelExact(zapcore.DebugLevel).
+			FilterMessageSnippet("Configuration differences").All())
+		Expect(debugDiffCount).To(BeNumerically(">", 0),
+			"the full Configuration differences diff must log at DEBUG on divergent ticks")
+
+		// --- Convergence: after switching to the converged baseline, the
+		// next tick must be clean (no "re-applying config" suffix). ---
+		mockService.GetConfigResult = rendered
+		tick = 1301
+		rErr, _ := instance.Reconcile(ctx, snapshotFor(tick), mockRegistry)
+		_ = rErr
+		Expect(instance.ObservedState.ServiceInfo.StatusReason).NotTo(ContainSubstring("re-applying config"),
+			"tick 1301: converged tick must not carry the divergence suffix")
+
+		// --- Diverge-into-removal (edge 14 end-to-end): re-diverge, compose
+		// once, then enter removal with a pending RemoveFromManager that holds
+		// the FSM in removing across many ticks. The IsRemoving branch clears
+		// ConfigDivergence so composition does not stamp "re-applying config"
+		// on an instance being deleted. ---
+		mockService.GetConfigResult = divergent
+		tick = 1302
+		cErr, _ := instance.Reconcile(ctx, snapshotFor(tick), mockRegistry)
+		_ = cErr
+
+		Expect(instance.Remove(ctx)).To(Succeed())
+		fsmtest.TransitionToProtocolConverterState(mockService, componentName, protocolconverterfsm.OperationalStateStopped)
+		mockService.RemoveFromManagerError = standarderrors.ErrRemovalPending
+
+		removingTickCount := 0
+		for t := uint64(1303); t <= 1352; t++ {
+			if instance.IsRemoving() {
+				removingTickCount++
+			}
+			rErr, _ := instance.Reconcile(ctx, snapshotFor(t), mockRegistry)
+			_ = rErr
+		}
+
+		Expect(removingTickCount).To(BeNumerically(">=", 10),
+			"the pending removal must hold the FSM in removing for at least 10 ticks")
+		Expect(strings.Count(instance.ObservedState.ServiceInfo.StatusReason, "re-applying config")).To(BeNumerically("<=", 1),
+			"last removal tick: ConfigDivergence is cleared during removal, no suffix repetition")
+
+		mockService.RemoveFromManagerError = nil
+	})
+})

--- a/umh-core/test/fsm/protocolconverter/logging_inversion_test.go
+++ b/umh-core/test/fsm/protocolconverter/logging_inversion_test.go
@@ -1,0 +1,168 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build test
+
+package protocolconverter_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	internalfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/internal/fsm"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/internal/fsmtest"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
+	protocolconverterfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/protocolconverter"
+	protocolconvertersvc "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/protocolconverter"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/protocolconverter/runtime_config"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/serviceregistry"
+)
+
+var _ = Describe("ConfigDivergence reset and staging", func() {
+	var (
+		instance      *protocolconverterfsm.ProtocolConverterInstance
+		mockService   *protocolconvertersvc.MockProtocolConverterService
+		componentName string
+		ctx           context.Context
+		tick          uint64
+		mockRegistry  *serviceregistry.Registry
+		startTime     time.Time
+	)
+
+	BeforeEach(func() {
+		componentName = "test-pc-config-divergence"
+		ctx = context.Background()
+		tick = 0
+		startTime = time.Now()
+
+		// Desired Active, lifecycle walked to stopped below.
+		instance, mockService, _ = fsmtest.SetupProtocolConverterInstance(componentName, protocolconverterfsm.OperationalStateStopped)
+		mockRegistry = serviceregistry.NewMockRegistry()
+	})
+
+	It("resets ConfigDivergence as the first statement of UpdateObservedStateOfInstance, before the ctx.Err() guard", func() {
+		// Phase 1: walk the lifecycle to operational stopped so the
+		// to_be_created/creating early-return no longer short-circuits
+		// UpdateObservedStateOfInstance before the divergence branch.
+		var err error
+		tick, err = fsmtest.TestProtocolConverterStateTransition(
+			ctx, instance, mockService, mockRegistry, componentName,
+			internalfsm.LifecycleStateToBeCreated,
+			internalfsm.LifecycleStateCreating, 5, tick, startTime)
+		Expect(err).NotTo(HaveOccurred())
+
+		mockService.ExistingComponents[componentName] = true
+		fsmtest.TransitionToProtocolConverterState(mockService, componentName, protocolconverterfsm.OperationalStateStopped)
+
+		tick, err = fsmtest.TestProtocolConverterStateTransition(
+			ctx, instance, mockService, mockRegistry, componentName,
+			internalfsm.LifecycleStateCreating,
+			protocolconverterfsm.OperationalStateStopped, 5, tick, startTime)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Desired Active so the "both stopped" early-return does not skip the
+		// divergence evaluation.
+		Expect(instance.SetDesiredFSMState(protocolconverterfsm.OperationalStateActive)).To(Succeed())
+
+		// ServiceExists must report true so the divergence branch (which sets
+		// ConfigDivergence inside the ServiceExists check) is entered.
+		mockService.ServiceExistsResult = true
+
+		// Build a CONVERGED observed-config baseline that exactly matches what
+		// UpdateObservedStateOfInstance will render from the spec, using the
+		// same agent location (empty), global vars (nil), node name and pc ID
+		// the function uses internally. This is assigned as the LAST step after
+		// any TransitionToProtocolConverterState call, which clobbers
+		// GetConfigResult via ConfigureProtocolConverterServiceConfig.
+		cfg := instance.GetConfig()
+		rendered, err := runtime_config.BuildRuntimeConfig(
+			cfg,
+			map[string]string{},
+			nil,
+			runtime_config.BridgedByPlaceholder,
+			componentName,
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		// --- Divergent tick: observed config differs in the read DFC Input ---
+		// Derive divergence by replacing the Input map with a fresh, different
+		// one. The diff comparator reports this as "Input config differences"
+		// (NOT a connection Target mutation, which prints as a pointer
+		// address). The injected Input map is deliberately LARGE (50 keys each
+		// with a long value) so the raw ConfigDiffRuntime output exceeds 400
+		// runes and forces BoundDiff to emit its truncation marker — the raw
+		// diff never contains that marker, so asserting it pins the BoundDiff
+		// call rather than the raw-diffStr assignment.
+		divergent := rendered
+		largeInput := make(map[string]any, 50)
+		longValue := strings.Repeat("x", 30)
+		for i := 0; i < 50; i++ {
+			largeInput[fmt.Sprintf("input_key_%02d", i)] = map[string]any{
+				"value":   longValue,
+				"mapping": `root = {"message":"diverged"}`,
+			}
+		}
+		divergent.DataflowComponentReadServiceConfig.BenthosConfig.Input = largeInput
+		mockService.GetConfigResult = divergent
+
+		// Drive one observation tick with a live context. After the GREEN
+		// implementation, ConfigDivergence must be non-empty and carry the
+		// "Input config differences" text produced by ConfigDiffRuntime, AND
+		// the BoundDiff truncation marker (the raw diffStr has no such marker,
+		// so this assertion fails if the cell still assigns raw diffStr).
+		tick++
+		Expect(instance.UpdateObservedStateOfInstance(
+			ctx, mockRegistry, fsm.SystemSnapshot{Tick: tick})).To(Succeed())
+		Expect(instance.ObservedState.ConfigDivergence).To(ContainSubstring("Input config differences"))
+		Expect(instance.ObservedState.ConfigDivergence).To(ContainSubstring("…[truncated,"))
+
+		// --- EDGE 11b-i ORDERING PIN ---
+		// The divergent tick above left ConfigDivergence non-empty. Now call
+		// UpdateObservedStateOfInstance with an ALREADY-EXPIRED context. The
+		// entry reset must have run BEFORE the ctx.Err() guard, so the stale
+		// value is cleared and the function returns nil with ConfigDivergence
+		// == "". This is the ONLY assertion that goes RED when the reset is
+		// placed after the ctx guard; every other ordering passes regardless.
+		expiredCtx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
+		defer cancel()
+		tick++
+		Expect(instance.UpdateObservedStateOfInstance(
+			expiredCtx, mockRegistry, fsm.SystemSnapshot{Tick: tick})).To(Succeed())
+		Expect(instance.ObservedState.ConfigDivergence).To(Equal(""))
+
+		// --- CONVERGED-CLEARS PATH ---
+		// Re-establish a divergent observed config so ConfigDivergence is
+		// non-empty again, then drive a converged tick with a LIVE context.
+		// The reset at the top of UpdateObservedStateOfInstance must clear
+		// the stale divergent value on the normal control flow (where the
+		// divergence branch is simply not entered), distinct from the
+		// expired-ctx early return above.
+		mockService.GetConfigResult = divergent
+		tick++
+		Expect(instance.UpdateObservedStateOfInstance(
+			ctx, mockRegistry, fsm.SystemSnapshot{Tick: tick})).To(Succeed())
+		Expect(instance.ObservedState.ConfigDivergence).To(ContainSubstring("Input config differences"))
+
+		mockService.GetConfigResult = rendered
+		tick++
+		Expect(instance.UpdateObservedStateOfInstance(
+			ctx, mockRegistry, fsm.SystemSnapshot{Tick: tick})).To(Succeed())
+		Expect(instance.ObservedState.ConfigDivergence).To(Equal(""))
+	})
+})


### PR DESCRIPTION
## Problem

The bridge reconcile loop compares each bridge's observed config to its desired config every 100 ms. When they differ it re-applies and writes the full rendered config (connection settings, data-flow component configs) to the agent log at INFO.

On one customer instance with 27 bridges, the bridges re-applied every tick and these INFO dumps reached ~8,000 lines per second, a 10 MB log file every 7 seconds, on a box already burning 4 to 6 of 8 cores. Once an instance climbed into high CPU it stayed there instead of recovering. The working theory, not yet proven, is that the logging is part of what keeps it there: under load the reconcile can't finish in its time budget, an unfinished reconcile keeps re-applying and dumping full configs, and writing that much log costs the CPU the reconcile needed to catch up.

The line that would explain why the re-apply kept firing, the config diff, was at DEBUG. The only way to read it is to raise the log level, which turns the dumps back on.

## What we're shipping

- **A bounded config-diff helper.** `BoundDiff(diff, capRunes)` in the protocol-converter config package caps a diff string at 400 runes, rune-safe (the cut never splits a multibyte character), and appends a truncation marker with the total rune count. An empty diff returns a named sentinel (`configs differ but field diff is empty (divergence outside compared fields)`) instead of a blank line, so the silent-mismatch class that hid the original cause is reported explicitly. Pure, no state, no logging.

- **Full config dumps moved from INFO to DEBUG.** In both the protocol-converter and stream-processor services, the `Connection config: %+v` / `Dataflow component config: %+v` dumps on the create and update paths, plus the per-retry `Updating`, `Updated`, and `Removing` lines, now log at DEBUG. The once-per-create lifecycle lines (`Adding …`, `… added to manager`) stay at INFO, and `Adding` now logs only on a real create instead of on every idempotent retry (it moved below the already-exists check). `Removing` is demoted rather than made fire-once because the removal path retries on genuine pending state, not idempotent no-ops; a single removal stays visible at DEBUG.

- **Divergence surfaced in the bridge status, not just logs.** When a bridge's observed config differs from desired, a bounded summary of the diff shows up in that bridge's status reason in the Management Console, so an operator can see *what* is being re-applied without enabling debug logging. It's appended after (not replacing) the operational reason Step 3 already set (e.g. "active", "starting"), so both are visible. The text is cleared every tick and only set when there is a real divergence, so it never grows unbounded or leaks across ticks.

- **One heartbeat WARN per bridge per minute.** While config diverges, on ticks where `snapshot.Tick % 600 == 0` (600 ticks at 100 ms = one minute), one WARN is logged with the bridge ID and the bounded diff. It recurs rather than firing once, so a tail-kept log export taken hours into an incident still contains a recent WARN. Divergent windows that span no multiple of 600 emit no WARN.

- **Stream processors get the demotions too**, since they have the same dump sites. The status surfacing and WARN are protocol-converter only (the proven-hot path).

- **FF: none.** Additive. The only behavior change is the status text on a bridge that is actively re-applying, which now names the diverging config. No schema change, no field any automation parses, and a converged bridge's status is unchanged.

## What we're NOT shipping

- **NOT fixing the re-apply loop.** Why a bridge's observed config never converges to desired is still open under ENG-5090. This removes one of the things feeding the loop (the log flood) and makes the cause visible; it does not stop the loop. Whether a stuck instance recovers on its own is unverified until this ships.

- **NOT changing FSM states or transitions.** Only the status-reason string is composed; the state machine is untouched. The one new field is a tick-scoped string on `ObservedState`, reset every observation, nothing that persists or accumulates across ticks.

- **NOT generalized log de-noising.** No fingerprinting, no suppression counters, no throttle infrastructure, no touching the existing external-changes warning line. That is a separate effort.

- **NOT touching benthos child logs.** Only umh-core's own reconcile logging changes; the benthos process logs are untouched.

- **NOT credential redaction.** ENG-3483 stays open; moving dumps to DEBUG shrinks the exposure, it does not close it.

## Tests

A reconcile-lifecycle test drives a bridge through ~1,300 sustained-divergence ticks, two distinct deadline-injection points (before and after the status-info store), convergence, and diverge-into-removal, asserting the status reason names the diverging config while diverged, is clean once converged, and stays bounded across removal retries. Reverting the composition placement, the per-tick reset, or the removal clear makes it fail. Per-edge tests pin the `BoundDiff` contract (truncation, rune-safety, empty-diff sentinel), the reset-before-deadline-guard ordering, and the WARN cadence.

## Empirical verification

Verified the demotion in a container on real images, before/after, with an identical trigger (a data-flow component whose benthos stays unhealthy, so the reconcile re-applies every tick — the same path that produced the customer flood).

**RED** = `ghcr.io/united-manufacturing-hub/umh-core:v0.44.24` (pre-PR, the four dump lines are INFO).
**GREEN** = `ghcr.io/united-manufacturing-hub/umh-core:sha-cef1501` (this PR).

Same config, same bundled benthos, same unhealthy-DFC trigger in both runs.

On a single re-applying bridge over ~50s at `LOGGING_LEVEL=INFO`:

| Line (was INFO) | RED, at INFO | GREEN, at INFO |
|---|---|---|
| `Updating protocolconverter %s` | 515 | 0 |
| `Updated protocolconverter config in manager` | 515 | 0 |
| `Connection config: %+v` | 515 | 0 |
| `Dataflow component config: %+v` | 515 | 0 |

Same line, same trigger, now zero at INFO. The flood (the customer case had 27 bridges re-applying, each emitting several such lines per tick) is gone from the INFO log.

To confirm the lines were **demoted, not removed**, the GREEN image was re-run at `LOGGING_LEVEL=DEBUG`. The same four lines fire at DEBUG (571/571/572/572 over the window), from `protocolconverter.go:552` — the same sites, shifted by the `ctx.Err()`-guard reordering in this PR:

- RED:    `[INFO]  protocolconverter/protocolconverter.go:548  Updating protocolconverter vibration-sensor-pc`
- GREEN:  `[DEBUG] protocolconverter/protocolconverter.go:552  Updating protocolconverter vibration-sensor-pc`

Under the production INFO level, DEBUG output is suppressed, so the dumps disappear from the log without losing the re-apply behavior. The trigger (the unhealthy DFC re-applying) is unchanged between the two runs — the only difference is the log level.

The two features that make the cause visible without DEBUG were also observed in the GREEN run (absent in RED):

- the **WARN heartbeat** (`re-applying config: bridge … config diverged: …`) fires while a bridge is diverging, bounded (one per snapshot interval, recurring, so a late log export still has a recent entry);
- the bounded **config-diff** is logged at DEBUG (`Configuration differences: …`, 589 occurrences in the DEBUG run vs 0 in RED), confirming the divergence-detection path runs.

Status-reason surfacing in the Management Console UI was not exercised here (no MC in the test container) and remains covered by the reconcile-lifecycle test above.


Refs ENG-5108, ENG-5090.

