### PR TITLE
docs: prepare v0.44.25 release changelog

### DIFF
--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## [0.44.25]
+
 ### Improvements
 
 - OPC UA: encrypted connections (`Basic256Sha256`, both `Sign` and `Sign & Encrypt`) now complete reliably, including signing-only mode which previously failed to connect


### PR DESCRIPTION
## Problem

Releasing umh-core requires the `## Unreleased` changelog section to be renamed to the version being shipped before cutting the tag (see `umh-core/RELEASING.md`). The `update-github-release.yml` and `sync-changelog.yml` automation extract the `## [0.44.25]` section to populate the GitHub Release body and changelog.umh.app.

## What this ships

Renames `## Unreleased` → `## [0.44.25]` and opens a fresh empty `## Unreleased` above it. No content changes.

v0.44.25 covers everything merged to staging since v0.44.24:
- OPC UA improvements + fixes from the benthos-umh v0.13.0 bump (gopcua v0.9.0) — #2609
- Bridge edit render-failure surfacing + fast rollback (ENG-5103) — #2600

## Scope

Changelog-only. Released sections are byte-identical (validated by the released-section guard).