### PR TITLE
[ENG-5258] Standalone Deployment return UUID

### DIFF
--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Deploying a stand-alone flow now returns its component ID in the action reply, so the Management Console's "Continue Editing" button opens the flow's editing view instead of only closing the dialog.
+
 ## [0.44.26]
 
 ### Improvements

--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## Unreleased
 
-### Fixes
-
-- Deploying a stand-alone flow now returns its component ID in the action reply, so the Management Console's "Continue Editing" button opens the flow's editing view instead of only closing the dialog.
-
 ## [0.44.26]
 
 ### Improvements

--- a/umh-core/pkg/communicator/actions/deploy-dataflowcomponent.go
+++ b/umh-core/pkg/communicator/actions/deploy-dataflowcomponent.go
@@ -256,7 +256,11 @@ func (a *DeployDataflowComponentAction) Execute() (interface{}, map[string]inter
 	// return success message, but do not send it as this is done by the caller
 	successMsg := Label("deploy", a.name) + "component successfully deployed"
 
-	return successMsg, nil, nil
+	componentUUID := dataflowcomponentserviceconfig.GenerateUUIDFromName(a.name)
+
+	return successMsg, map[string]interface{}{
+		"dataflowcomponentUUID": componentUUID.String(),
+	}, nil
 }
 
 // getUserEmail implements the Action interface by returning the user email associated with this action.

--- a/umh-core/pkg/communicator/actions/deploy-dataflowcomponent_test.go
+++ b/umh-core/pkg/communicator/actions/deploy-dataflowcomponent_test.go
@@ -481,7 +481,8 @@ var _ = Describe("DeployDataflowComponent", func() {
 			result, metadata, err := action.Execute()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(ContainSubstring("success"))
-			Expect(metadata).To(BeNil())
+			Expect(metadata).To(HaveKey("dataflowcomponentUUID"))
+			Expect(metadata["dataflowcomponentUUID"]).NotTo(BeEmpty())
 
 			// Stop the state mocker
 			stateMocker.Stop()
@@ -703,7 +704,8 @@ buffer:
 			result, metadata, err := action.Execute()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(ContainSubstring("success"))
-			Expect(metadata).To(BeNil())
+			Expect(metadata).To(HaveKey("dataflowcomponentUUID"))
+			Expect(metadata["dataflowcomponentUUID"]).NotTo(BeEmpty())
 
 			// Stop the state mocker
 			stateMocker.Stop()
@@ -770,7 +772,8 @@ buffer:
 			result, metadata, err := action.Execute()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(ContainSubstring("success"))
-			Expect(metadata).To(BeNil())
+			Expect(metadata).To(HaveKey("dataflowcomponentUUID"))
+			Expect(metadata["dataflowcomponentUUID"]).NotTo(BeEmpty())
 
 			// Stop the state mocker
 			stateMocker.Stop()


### PR DESCRIPTION
## What
After deploying a standalone flow the MC can't redirect correctly to it's edit page, because the UUID of the deployed bridge did not correctly return from umh-core.

There is also the ManagementConsole [PR 3281](https://github.com/united-manufacturing-hub/ManagementConsole/pull/3281) which will hold the Changelog entries and screenshots.
