### PR TITLE
feat(generator): emit per-side benthos protocol ids on the protocol-converter status row (ENG-5230)

### DIFF
--- a/umh-core/pkg/communicator/pkg/generator/protocolconverter.go
+++ b/umh-core/pkg/communicator/pkg/generator/protocolconverter.go
@@ -167,6 +167,17 @@ func buildProtocolConverterAsDfc(
 		writeDesiredState,
 	)
 
+	inputType := dataflowcomponentserviceconfig.BenthosPluginID(input)
+	outputType := observed.ObservedProtocolConverterSpecConfig.Config.DataflowComponentWriteServiceConfig.Destination.Protocol
+
+	var bridge *models.DfcBridgeInfo
+	if inputType != "" || outputType != "" {
+		bridge = &models.DfcBridgeInfo{
+			InputType:  inputType,
+			OutputType: outputType,
+		}
+	}
+
 	dfc := models.Dfc{
 		Type:        models.DfcTypeProtocolConverter,
 		UUID:        uuid.String(),
@@ -181,9 +192,8 @@ func buildProtocolConverterAsDfc(
 		ReadFlowHealth:  readFlowHealth,
 		WriteFlowHealth: writeFlowHealth,
 		// Metrics are added below
-		Metrics: nil,
-		// Bridge info is not applicable for protocol converters
-		Bridge:        nil,
+		Metrics:       nil,
+		Bridge:        bridge,
 		IsInitialized: isInitialized,
 	}
 

--- a/umh-core/pkg/communicator/pkg/generator/protocolconverter.go
+++ b/umh-core/pkg/communicator/pkg/generator/protocolconverter.go
@@ -170,11 +170,9 @@ func buildProtocolConverterAsDfc(
 	inputType := dataflowcomponentserviceconfig.BenthosPluginID(input)
 	outputType := observed.ObservedProtocolConverterSpecConfig.Config.DataflowComponentWriteServiceConfig.Destination.Protocol
 
-	// Bridge carries the per-side benthos plugin names so the frontend (ENG-5249)
-	// can render per-side "configured" state. DfcBridgeInfo fields deliberately
-	// lack omitempty: an unconfigured side must serialize as "" (present) so the
-	// frontend's `bridge.outputType != ""` proxy sees "not configured" rather than
-	// "absent". Do not add omitempty to DfcBridgeInfo fields.
+	// No omitempty on DfcBridgeInfo fields: an unconfigured side must serialize as
+	// "" (present). The frontend reads bridge.outputType == "" as "not configured";
+	// omitting it would read as "absent" and fall back to the wrong render.
 	var bridge *models.DfcBridgeInfo
 	if inputType != "" || outputType != "" {
 		bridge = &models.DfcBridgeInfo{
@@ -183,14 +181,20 @@ func buildProtocolConverterAsDfc(
 		}
 	}
 
-	// Spec Behavioral Contract + cases 7 and 11: debug-log when a protocol id is
-	// derivable-looking (input present / write configured) but resolves empty —
-	// the only diagnostic for an operator chasing a bridge that renders as
-	// not-configured despite a configured side.
+	// These two debug logs are the only signal for an operator whose bridge shows
+	// "not configured" despite a configured side: a compound/malformed read input,
+	// or a write side with no Destination.Protocol (Code-without-Protocol).
 	if inputType == "" && len(input) > 0 {
 		log.Debugf("protocol-converter %q: read input present but BenthosPluginID returned empty (compound or malformed input): %v", instance.ID, input)
 	}
 
+	// A Code-only write (Destination.Code set, Protocol empty) leaves outputType
+	// empty, so a write-only Code bridge keeps Bridge nil above. That is deliberate:
+	// there is no protocol id to report, and the frontend falls back to per-side
+	// flow health, which renders the running write correctly. The MC editor can't
+	// produce this (Protocol is a required field); it only arises from a
+	// hand-edited config. Do not gate on HasOutput() to force a non-nil Bridge —
+	// that emits outputType "" for a configured side, which renders as "add write flow".
 	writeCfg := observed.ObservedProtocolConverterSpecConfig.Config.DataflowComponentWriteServiceConfig
 	if outputType == "" && writeCfg.HasOutput() {
 		log.Debugf("protocol-converter %q: write side configured (HasOutput) but Destination.Protocol empty — Code-without-Protocol, OutputType emitted as empty", instance.ID)

--- a/umh-core/pkg/communicator/pkg/generator/protocolconverter.go
+++ b/umh-core/pkg/communicator/pkg/generator/protocolconverter.go
@@ -170,12 +170,30 @@ func buildProtocolConverterAsDfc(
 	inputType := dataflowcomponentserviceconfig.BenthosPluginID(input)
 	outputType := observed.ObservedProtocolConverterSpecConfig.Config.DataflowComponentWriteServiceConfig.Destination.Protocol
 
+	// Bridge carries the per-side benthos plugin names so the frontend (ENG-5249)
+	// can render per-side "configured" state. DfcBridgeInfo fields deliberately
+	// lack omitempty: an unconfigured side must serialize as "" (present) so the
+	// frontend's `bridge.outputType != ""` proxy sees "not configured" rather than
+	// "absent". Do not add omitempty to DfcBridgeInfo fields.
 	var bridge *models.DfcBridgeInfo
 	if inputType != "" || outputType != "" {
 		bridge = &models.DfcBridgeInfo{
 			InputType:  inputType,
 			OutputType: outputType,
 		}
+	}
+
+	// Spec Behavioral Contract + cases 7 and 11: debug-log when a protocol id is
+	// derivable-looking (input present / write configured) but resolves empty —
+	// the only diagnostic for an operator chasing a bridge that renders as
+	// not-configured despite a configured side.
+	if inputType == "" && len(input) > 0 {
+		log.Debugf("protocol-converter %q: read input present but BenthosPluginID returned empty (compound or malformed input): %v", instance.ID, input)
+	}
+
+	writeCfg := observed.ObservedProtocolConverterSpecConfig.Config.DataflowComponentWriteServiceConfig
+	if outputType == "" && writeCfg.HasOutput() {
+		log.Debugf("protocol-converter %q: write side configured (HasOutput) but Destination.Protocol empty — Code-without-Protocol, OutputType emitted as empty", instance.ID)
 	}
 
 	dfc := models.Dfc{

--- a/umh-core/pkg/communicator/pkg/generator/protocolconverter.go
+++ b/umh-core/pkg/communicator/pkg/generator/protocolconverter.go
@@ -185,7 +185,11 @@ func buildProtocolConverterAsDfc(
 	// "not configured" despite a configured side: a compound/malformed read input,
 	// or a write side with no Destination.Protocol (Code-without-Protocol).
 	if inputType == "" && len(input) > 0 {
-		log.Debugf("protocol-converter %q: read input present but BenthosPluginID returned empty (compound or malformed input): %v", instance.ID, input)
+		keys := make([]string, 0, len(input))
+		for k := range input {
+			keys = append(keys, k)
+		}
+		log.Debugf("protocol-converter %q: read input present but BenthosPluginID returned empty (compound or malformed input), keys=%v", instance.ID, keys)
 	}
 
 	// A Code-only write (Destination.Code set, Protocol empty) leaves outputType

--- a/umh-core/pkg/communicator/pkg/generator/protocolconverter_test.go
+++ b/umh-core/pkg/communicator/pkg/generator/protocolconverter_test.go
@@ -1,0 +1,65 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/dataflowcomponentserviceconfig"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/protocolconverterserviceconfig"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/protocolconverter"
+	"go.uber.org/zap"
+)
+
+var _ = Describe("buildProtocolConverterAsDfc", func() {
+	log := zap.NewNop().Sugar()
+
+	It("emits Dfc.Bridge with InputType (wrapped) and OutputType set for a bidirectional PC", func() {
+		snap := &protocolconverter.ProtocolConverterObservedStateSnapshot{
+			ObservedProtocolConverterSpecConfig: protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec{
+				Config: protocolconverterserviceconfig.ProtocolConverterServiceConfigTemplate{
+					DataflowComponentReadServiceConfig: dataflowcomponentserviceconfig.DataflowComponentServiceConfig{
+						BenthosConfig: dataflowcomponentserviceconfig.BenthosConfig{
+							Input: map[string]any{"input": map[string]any{"http_client": map[string]any{"url": "http://x"}}},
+						},
+					},
+					DataflowComponentWriteServiceConfig: dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
+						Destination: dataflowcomponentserviceconfig.WriteConfigDestination{Protocol: "kafka"},
+					},
+				},
+			},
+		}
+		instance := fsm.FSMInstanceSnapshot{ID: "pc-bidi", CurrentState: protocolconverter.OperationalStateActive, DesiredState: protocolconverter.OperationalStateActive, LastObservedState: snap}
+
+		dfc, err := buildProtocolConverterAsDfc(instance, log)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(dfc.Bridge).NotTo(BeNil(), "configured PC must populate Bridge")
+		Expect(dfc.Bridge.InputType).To(Equal("http_client"), "InputType = wrapped read plugin (descent)")
+		Expect(dfc.Bridge.OutputType).To(Equal("kafka"), "OutputType = write Destination.Protocol")
+		Expect(dfc.Bridge.DataContract).To(BeEmpty(), "PCs have no data contract")
+		Expect(dfc.IsInitialized).To(BeTrue(), "populated read input means IsInitialized")
+	})
+
+	It("leaves Dfc.Bridge nil for an uninitialized PC (no protocol id to emit)", func() {
+		snap := &protocolconverter.ProtocolConverterObservedStateSnapshot{}
+		instance := fsm.FSMInstanceSnapshot{ID: "pc-uninit", CurrentState: protocolconverter.OperationalStateActive, DesiredState: protocolconverter.OperationalStateActive, LastObservedState: snap}
+
+		dfc, err := buildProtocolConverterAsDfc(instance, log)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(dfc.Bridge).To(BeNil(), "uninitialized PC emits no Bridge (preserves prior wire behavior — empty bridge{} would serialize on the wire since DfcBridgeInfo fields lack omitempty)")
+		Expect(dfc.IsInitialized).To(BeFalse())
+	})
+})

--- a/umh-core/pkg/communicator/pkg/generator/protocolconverter_test.go
+++ b/umh-core/pkg/communicator/pkg/generator/protocolconverter_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/protocolconverter"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 var _ = Describe("buildProtocolConverterAsDfc", func() {
@@ -199,5 +201,62 @@ var _ = Describe("regression: no FSM behavior change from Bridge population", fu
 		Expect(dfc.ReadFlowHealth).To(BeNil())
 		Expect(dfc.Bridge).NotTo(BeNil(), "Bridge populated regardless of the transient")
 		Expect(dfc.Bridge.InputType).To(Equal("http_client"))
+	})
+})
+
+var _ = Describe("auditability: debug-logs when a protocol id is derivable-looking but empty", func() {
+	// The spec's Behavioral Contract + cases 7 and 11 require the generator to
+	// debug-log when BenthosPluginID returns "" for a non-empty read input
+	// (compound/malformed) and when a configured write side has no Protocol
+	// (Code-without-Protocol divergence). These are the only diagnostic channel
+	// for an operator chasing "why does my configured bridge render as
+	// not-configured?" once ENG-5249 gates on bridge.inputType/outputType.
+
+	It("logs when read input is non-empty but BenthosPluginID returns empty (compound, case 7)", func() {
+		core, logs := observer.New(zapcore.DebugLevel)
+		log := zap.New(core).Sugar()
+
+		compound := &protocolconverter.ProtocolConverterObservedStateSnapshot{
+			ObservedProtocolConverterSpecConfig: protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec{
+				Config: protocolconverterserviceconfig.ProtocolConverterServiceConfigTemplate{
+					DataflowComponentReadServiceConfig: dataflowcomponentserviceconfig.DataflowComponentServiceConfig{
+						BenthosConfig: dataflowcomponentserviceconfig.BenthosConfig{
+							Input: map[string]any{
+								"mqtt":  map[string]any{"url": "tcp://x"},
+								"opcua": map[string]any{"endpoint": "opc.tcp://y"},
+							},
+						},
+					},
+				},
+			},
+		}
+		_, err := buildProtocolConverterAsDfc(toInstance("pc-compound", compound), log)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(logs.FilterMessageSnippet("BenthosPluginID").All()).
+			To(HaveLen(1), "must debug-log the empty-result-for-non-empty-read-input case (spec case 7)")
+	})
+
+	It("logs when write side is configured (HasOutput) but Destination.Protocol is empty (Code-without-Protocol, case 11)", func() {
+		core, logs := observer.New(zapcore.DebugLevel)
+		log := zap.New(core).Sugar()
+
+		codeOnly := &protocolconverter.ProtocolConverterObservedStateSnapshot{
+			ObservedProtocolConverterSpecConfig: protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec{
+				Config: protocolconverterserviceconfig.ProtocolConverterServiceConfigTemplate{
+					DataflowComponentReadServiceConfig: dataflowcomponentserviceconfig.DataflowComponentServiceConfig{
+						BenthosConfig: dataflowcomponentserviceconfig.BenthosConfig{
+							Input: map[string]any{"input": map[string]any{"http_client": map[string]any{"url": "http://x"}}},
+						},
+					},
+					DataflowComponentWriteServiceConfig: dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
+						Destination: dataflowcomponentserviceconfig.WriteConfigDestination{Code: "self|json"},
+					},
+				},
+			},
+		}
+		_, err := buildProtocolConverterAsDfc(toInstance("pc-code", codeOnly), log)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(logs.FilterMessageSnippet("Code-without-Protocol").All()).
+			To(HaveLen(1), "must debug-log the HasOutput-true/Protocol-empty divergence (spec case 11)")
 	})
 })

--- a/umh-core/pkg/communicator/pkg/generator/protocolconverter_test.go
+++ b/umh-core/pkg/communicator/pkg/generator/protocolconverter_test.go
@@ -204,15 +204,15 @@ var _ = Describe("regression: no FSM behavior change from Bridge population", fu
 	})
 })
 
-var _ = Describe("auditability: debug-logs when a protocol id is derivable-looking but empty", func() {
-	// The spec's Behavioral Contract + cases 7 and 11 require the generator to
-	// debug-log when BenthosPluginID returns "" for a non-empty read input
-	// (compound/malformed) and when a configured write side has no Protocol
-	// (Code-without-Protocol divergence). These are the only diagnostic channel
-	// for an operator chasing "why does my configured bridge render as
-	// not-configured?" once ENG-5249 gates on bridge.inputType/outputType.
+var _ = Describe("auditability: debug-logs when a configured side resolves to an empty protocol id", func() {
+	// The generator debug-logs two divergences that otherwise leave an operator
+	// asking "why does my configured bridge render as not-configured?" once
+	// ENG-5249 gates on bridge.inputType/outputType: a non-empty read input whose
+	// BenthosPluginID resolves to "" (compound/malformed), and a configured write
+	// side with no Destination.Protocol (Code-without-Protocol). These logs are
+	// the only signal for either case.
 
-	It("logs when read input is non-empty but BenthosPluginID returns empty (compound, case 7)", func() {
+	It("logs when read input is non-empty but BenthosPluginID returns empty (compound input)", func() {
 		core, logs := observer.New(zapcore.DebugLevel)
 		log := zap.New(core).Sugar()
 
@@ -233,10 +233,10 @@ var _ = Describe("auditability: debug-logs when a protocol id is derivable-looki
 		_, err := buildProtocolConverterAsDfc(toInstance("pc-compound", compound), log)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(logs.FilterMessageSnippet("BenthosPluginID").All()).
-			To(HaveLen(1), "must debug-log the empty-result-for-non-empty-read-input case (spec case 7)")
+			To(HaveLen(1), "must debug-log the empty-result-for-non-empty-read-input case")
 	})
 
-	It("logs when write side is configured (HasOutput) but Destination.Protocol is empty (Code-without-Protocol, case 11)", func() {
+	It("logs when write side is configured (HasOutput) but Destination.Protocol is empty (Code-without-Protocol)", func() {
 		core, logs := observer.New(zapcore.DebugLevel)
 		log := zap.New(core).Sugar()
 
@@ -257,6 +257,6 @@ var _ = Describe("auditability: debug-logs when a protocol id is derivable-looki
 		_, err := buildProtocolConverterAsDfc(toInstance("pc-code", codeOnly), log)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(logs.FilterMessageSnippet("Code-without-Protocol").All()).
-			To(HaveLen(1), "must debug-log the HasOutput-true/Protocol-empty divergence (spec case 11)")
+			To(HaveLen(1), "must debug-log the HasOutput-true/Protocol-empty divergence")
 	})
 })

--- a/umh-core/pkg/communicator/pkg/generator/protocolconverter_test.go
+++ b/umh-core/pkg/communicator/pkg/generator/protocolconverter_test.go
@@ -62,4 +62,71 @@ var _ = Describe("buildProtocolConverterAsDfc", func() {
 		Expect(dfc.Bridge).To(BeNil(), "uninitialized PC emits no Bridge (preserves prior wire behavior — empty bridge{} would serialize on the wire since DfcBridgeInfo fields lack omitempty)")
 		Expect(dfc.IsInitialized).To(BeFalse())
 	})
+
+	It("read-only PC emits Bridge with InputType set, OutputType empty", func() {
+		snap := &protocolconverter.ProtocolConverterObservedStateSnapshot{
+			ObservedProtocolConverterSpecConfig: protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec{
+				Config: protocolconverterserviceconfig.ProtocolConverterServiceConfigTemplate{
+					DataflowComponentReadServiceConfig: dataflowcomponentserviceconfig.DataflowComponentServiceConfig{
+						BenthosConfig: dataflowcomponentserviceconfig.BenthosConfig{
+							Input: map[string]any{"input": map[string]any{"modbus": map[string]any{"address": "1"}}},
+						},
+					},
+					DataflowComponentWriteServiceConfig: dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{},
+				},
+			},
+		}
+		instance := fsm.FSMInstanceSnapshot{ID: "pc-ro", CurrentState: protocolconverter.OperationalStateActive, DesiredState: protocolconverter.OperationalStateActive, LastObservedState: snap}
+
+		dfc, err := buildProtocolConverterAsDfc(instance, log)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(dfc.Bridge).NotTo(BeNil())
+		Expect(dfc.Bridge.InputType).To(Equal("modbus"))
+		Expect(dfc.Bridge.OutputType).To(BeEmpty(), "no write configured")
+	})
+
+	It("write-only PC emits Bridge with OutputType set, InputType empty (gate is not read-biased)", func() {
+		snap := &protocolconverter.ProtocolConverterObservedStateSnapshot{
+			ObservedProtocolConverterSpecConfig: protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec{
+				Config: protocolconverterserviceconfig.ProtocolConverterServiceConfigTemplate{
+					DataflowComponentReadServiceConfig: dataflowcomponentserviceconfig.DataflowComponentServiceConfig{},
+					DataflowComponentWriteServiceConfig: dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
+						Destination: dataflowcomponentserviceconfig.WriteConfigDestination{Protocol: "questdb"},
+					},
+				},
+			},
+		}
+		instance := fsm.FSMInstanceSnapshot{ID: "pc-wo", CurrentState: protocolconverter.OperationalStateActive, DesiredState: protocolconverter.OperationalStateActive, LastObservedState: snap}
+
+		dfc, err := buildProtocolConverterAsDfc(instance, log)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(dfc.Bridge).NotTo(BeNil(), "write-only PC has a protocol id to emit (OutputType)")
+		Expect(dfc.Bridge.InputType).To(BeEmpty(), "no read configured")
+		Expect(dfc.Bridge.OutputType).To(Equal("questdb"))
+		Expect(dfc.IsInitialized).To(BeFalse(), "isInitialized is read-biased; write-only stays false until ENG-5251")
+	})
+
+	It("Code-without-Protocol emits OutputType empty (diverges from HasOutput)", func() {
+		snap := &protocolconverter.ProtocolConverterObservedStateSnapshot{
+			ObservedProtocolConverterSpecConfig: protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec{
+				Config: protocolconverterserviceconfig.ProtocolConverterServiceConfigTemplate{
+					DataflowComponentReadServiceConfig: dataflowcomponentserviceconfig.DataflowComponentServiceConfig{
+						BenthosConfig: dataflowcomponentserviceconfig.BenthosConfig{
+							Input: map[string]any{"input": map[string]any{"mqtt": map[string]any{}}},
+						},
+					},
+					DataflowComponentWriteServiceConfig: dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
+						Destination: dataflowcomponentserviceconfig.WriteConfigDestination{Code: "kafka:\n  topic: t"},
+					},
+				},
+			},
+		}
+		instance := fsm.FSMInstanceSnapshot{ID: "pc-code", CurrentState: protocolconverter.OperationalStateActive, DesiredState: protocolconverter.OperationalStateActive, LastObservedState: snap}
+
+		dfc, err := buildProtocolConverterAsDfc(instance, log)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(dfc.Bridge).NotTo(BeNil(), "read configured → InputType non-empty → Bridge populated")
+		Expect(dfc.Bridge.InputType).To(Equal("mqtt"))
+		Expect(dfc.Bridge.OutputType).To(BeEmpty(), "OutputType is Destination.Protocol, which is empty; HasOutput()=true but the gate uses Protocol, not HasOutput")
+	})
 })

--- a/umh-core/pkg/communicator/pkg/generator/protocolconverter_test.go
+++ b/umh-core/pkg/communicator/pkg/generator/protocolconverter_test.go
@@ -130,3 +130,74 @@ var _ = Describe("buildProtocolConverterAsDfc", func() {
 		Expect(dfc.Bridge.OutputType).To(BeEmpty(), "OutputType is Destination.Protocol, which is empty; HasOutput()=true but the gate uses Protocol, not HasOutput")
 	})
 })
+
+func bidirectionalSnap() *protocolconverter.ProtocolConverterObservedStateSnapshot {
+	return &protocolconverter.ProtocolConverterObservedStateSnapshot{
+		ObservedProtocolConverterSpecConfig: protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec{
+			Config: protocolconverterserviceconfig.ProtocolConverterServiceConfigTemplate{
+				DataflowComponentReadServiceConfig: dataflowcomponentserviceconfig.DataflowComponentServiceConfig{
+					BenthosConfig: dataflowcomponentserviceconfig.BenthosConfig{
+						Input: map[string]any{"input": map[string]any{"http_client": map[string]any{"url": "http://x"}}},
+					},
+				},
+				DataflowComponentWriteServiceConfig: dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
+					Destination: dataflowcomponentserviceconfig.WriteConfigDestination{Protocol: "kafka"},
+				},
+			},
+		},
+	}
+}
+
+func toInstance(id string, snap *protocolconverter.ProtocolConverterObservedStateSnapshot) fsm.FSMInstanceSnapshot {
+	return fsm.FSMInstanceSnapshot{
+		ID:                id,
+		CurrentState:      protocolconverter.OperationalStateActive,
+		DesiredState:      protocolconverter.OperationalStateActive,
+		LastObservedState: snap,
+	}
+}
+
+var _ = Describe("regression: no FSM behavior change from Bridge population", func() {
+	log := zap.NewNop().Sugar()
+
+	It("isInitialized keys off read input presence, not Bridge", func() {
+		dfc, err := buildProtocolConverterAsDfc(toInstance("pc-init", bidirectionalSnap()), log)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(dfc.IsInitialized).To(BeTrue(), "read input present")
+
+		writeOnly := &protocolconverter.ProtocolConverterObservedStateSnapshot{
+			ObservedProtocolConverterSpecConfig: protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec{
+				Config: protocolconverterserviceconfig.ProtocolConverterServiceConfigTemplate{
+					DataflowComponentWriteServiceConfig: dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
+						Destination: dataflowcomponentserviceconfig.WriteConfigDestination{Protocol: "questdb"},
+					},
+				},
+			},
+		}
+		dfc2, err := buildProtocolConverterAsDfc(toInstance("pc-wo", writeOnly), log)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(dfc2.IsInitialized).To(BeFalse(), "read-biased; write-only stays false until ENG-5251")
+	})
+
+	It("Health reflects instance.CurrentState, not Bridge", func() {
+		dfc, err := buildProtocolConverterAsDfc(toInstance("pc-health", bidirectionalSnap()), log)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(dfc.Health).NotTo(BeNil())
+		Expect(dfc.Health.ObservedState).To(Equal(protocolconverter.OperationalStateActive))
+	})
+
+	It("Metrics stays nil when no benthos metrics observed", func() {
+		dfc, err := buildProtocolConverterAsDfc(toInstance("pc-metrics", bidirectionalSnap()), log)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(dfc.Metrics).To(BeNil())
+	})
+
+	It("reconcile transient: empty write FSM state leaves writeFlowHealth nil, Bridge still populated (case 15)", func() {
+		dfc, err := buildProtocolConverterAsDfc(toInstance("pc-transient", bidirectionalSnap()), log)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(dfc.WriteFlowHealth).To(BeNil(), "buildDFCFlowHealth returns nil on empty FSM state")
+		Expect(dfc.ReadFlowHealth).To(BeNil())
+		Expect(dfc.Bridge).NotTo(BeNil(), "Bridge populated regardless of the transient")
+		Expect(dfc.Bridge.InputType).To(Equal("http_client"))
+	})
+})

--- a/umh-core/pkg/config/dataflowcomponentserviceconfig/plugin_id.go
+++ b/umh-core/pkg/config/dataflowcomponentserviceconfig/plugin_id.go
@@ -1,0 +1,61 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dataflowcomponentserviceconfig
+
+// BenthosPluginID returns the benthos plugin name from a single-section input
+// map, descending one level through the "input" wrapper. Non-plugin metadata
+// keys (label, processors) are skipped so that labeled inputs such as
+// {"label":"x","mqtt":{...}} resolve to "mqtt".
+func BenthosPluginID(m map[string]any) string {
+	pluginKey, ok := benthosPluginKey(m)
+	if !ok {
+		return ""
+	}
+
+	if pluginKey != "input" {
+		return pluginKey
+	}
+
+	inner, _ := m["input"].(map[string]any)
+
+	innerKey, ok := benthosPluginKey(inner)
+	if !ok {
+		return ""
+	}
+
+	return innerKey
+}
+
+// benthosPluginKey returns the sole plugin key in a benthos input map after
+// skipping non-plugin metadata keys. It reports false when the map holds zero
+// or more than one plugin key.
+func benthosPluginKey(m map[string]any) (string, bool) {
+	var pluginKeys []string
+
+	for k := range m {
+		switch k {
+		case "label", "processors":
+			continue
+		}
+
+		pluginKeys = append(pluginKeys, k)
+	}
+
+	if len(pluginKeys) != 1 {
+		return "", false
+	}
+
+	return pluginKeys[0], true
+}

--- a/umh-core/pkg/config/dataflowcomponentserviceconfig/plugin_id_test.go
+++ b/umh-core/pkg/config/dataflowcomponentserviceconfig/plugin_id_test.go
@@ -1,0 +1,42 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dataflowcomponentserviceconfig_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/dataflowcomponentserviceconfig"
+)
+
+var _ = Describe("BenthosPluginID", func() {
+	DescribeTable("extracts the benthos plugin name",
+		func(input map[string]any, expected string) {
+			Expect(dataflowcomponentserviceconfig.BenthosPluginID(input)).To(Equal(expected))
+		},
+		Entry("nil map", nil, ""),
+		Entry("empty map", map[string]any{}, ""),
+		Entry("direct single key", map[string]any{"mqtt": map[string]any{"topic": "t"}}, "mqtt"),
+		Entry("wrapped single key (normal observed form)", map[string]any{"input": map[string]any{"http_client": map[string]any{"url": "u"}}}, "http_client"),
+		Entry("wrapped empty inner", map[string]any{"input": map[string]any{}}, ""),
+		Entry("wrapped scalar inner", map[string]any{"input": "scalar"}, ""),
+		Entry("labeled direct form", map[string]any{"label": "x", "http_client": map[string]any{}}, "http_client"),
+		Entry("labeled wrapped form", map[string]any{"input": map[string]any{"label": "x", "http_client": map[string]any{}}}, "http_client"),
+		Entry("two top-level plugin keys", map[string]any{"mqtt": map[string]any{}, "http_client": map[string]any{}}, ""),
+		Entry("two plugin keys inside input wrapper", map[string]any{"input": map[string]any{"mqtt": map[string]any{}, "http_client": map[string]any{}}}, ""),
+		Entry("processors metadata + direct plugin", map[string]any{"processors": []any{}, "mqtt": map[string]any{}}, "mqtt"),
+		Entry("processors metadata inside input wrapper", map[string]any{"input": map[string]any{"processors": []any{}, "mqtt": map[string]any{}}}, "mqtt"),
+		Entry("scalar value direct", map[string]any{"mqtt": "scalar"}, "mqtt"),
+	)
+})

--- a/umh-core/pkg/models/status_message.go
+++ b/umh-core/pkg/models/status_message.go
@@ -162,7 +162,7 @@ type Dfc struct {
 	WriteFlowHealth    *Health        `json:"writeFlowHealth,omitempty"` // Health of the write (sink) data flow, only for protocol-converter type
 	Type               DfcType        `json:"dfcType"`                   // Type of the DFC
 	Metrics            *DfcMetrics    `json:"metrics"`
-	Bridge             *DfcBridgeInfo `json:"bridge,omitempty"` // Additional info for data-bridge type
+	Bridge             *DfcBridgeInfo `json:"bridge,omitempty"` // Additional info for data-bridge and protocol-converter types
 	// For 'protocol-converter' type, this array contains exactly one connection.
 	//
 	// For 'data-bridge' type, this array always contains exactly two connections.


### PR DESCRIPTION

## Problem

The bridges-table throughput cell (shipped in ENG-4976 / MC#3272) cannot tell a "not available" side (a protocol that cannot have a read or write flow — e.g. Modbus has no write) from a "not configured" side. The cell already reads `bridge?.inputType` / `bridge?.outputType` and computes a disabled-reason, but the lock stays dormant because umh-core hardcodes `Dfc.Bridge = nil` for protocol-converters, so `bridge?.inputType` is `undefined` and the disabled-reason is never reached.

ENG-5230 puts the protocol id on the wire. The cell-side gate fix (swap `{#if flowHealth}` → `{#if configured}`) is the consuming frontend PR, [ManagementConsole#3285](https://github.com/united-manufacturing-hub/ManagementConsole/pull/3285) (ENG-5249). The two are order-independent: ENG-5249's cell falls back to per-side flow health when this signal is absent, so neither PR blocks the other.

## What we're shipping

umh-core populates `Dfc.Bridge` for protocol-converters (previously `nil`) with the per-side benthos plugin names:

- `InputType` = the read-side plugin name, via a new pure helper `BenthosPluginID` (`pkg/config/dataflowcomponentserviceconfig/plugin_id.go`) that recovers the top-level benthos plugin key of `BenthosConfig.Input`, descending one level through the `"input"` wrapper and skipping `label`/`processors` metadata keys.
- `OutputType` = `DataflowComponentWriteConfigInput.Destination.Protocol` (direct string field).
- `DataContract` = `""` (protocol-converters have no data contract).
- Gated: `Bridge` is `nil` when both sides are empty, so uninitialized PCs keep the prior wire behavior (`DfcBridgeInfo` fields lack `omitempty`; a non-nil empty `Bridge` would serialize as `bridge:{""}`).
- Spec-mandated debug-log: when `BenthosPluginID` returns `""` for a non-empty read input (compound/malformed), and when a configured write side has no `Destination.Protocol` (Code-without-Protocol) — the only diagnostic for an operator chasing a bridge that renders as not-configured despite a configured side.

No new wire fields: the existing `DfcBridgeInfo` struct is reused. No FSM behavior change: `isInitialized`, `AddToManager`, health, and metrics are unchanged; `buildStreamProcessorAsDfc` and the data-bridge row path are untouched.

## Why this reverses the "do not un-nil `Dfc.Bridge`" instruction

The earlier instruction not to populate `Dfc.Bridge` for protocol-converters assumed `DfcBridgeInfo.InputType`/`OutputType` are data-contract types. The frontend schema says otherwise: `status-message-dataflowcomponent.schema.d.ts:71-79` calls them "Benthos name of the input/output type", and `read-write-mapping.json` keys on benthos plugin names (`opcua`, `mqtt`, `modbus`, …). `BenthosPluginID` returns a benthos map key, which is what those fields already mean — so this populates existing fields, it does not repurpose them. No new wire fields, no contract break, no frontend poller change: `coreDfc.bridge` already flows onto `DfcRowData.bridge` via the existing `...dfc` spread. The parent `Bridge` field godoc now notes it also serves protocol-converters.

## Verification

- **Unit:** `BenthosPluginID` resolves `{"label":"x","mqtt":{...}}` → `mqtt`, descends the `input` wrapper, and returns `""` for zero or >1 plugin keys. The generator emits `Bridge: nil` when both sides are empty and a populated `Bridge` otherwise; the two debug logs fire on an empty-resolved read input and a Code-only write. See `plugin_id_test.go` and `protocolconverter_test.go`.
- **Live wire:** on a real container→prod→frontend rig, the frontend `coreStatusMessages` store showed `bridge: {dataContract:"", inputType:"generate", outputType:""}` for a labeled read input (label correctly skipped), and `bridge` absent for protocol-converters on an old-umh-core instance (backward-compat). The cell↔overview "configured" divergence is reproduced and fixed — see ManagementConsole#3285 for the before/after.

## Scope / not shipping

- No DFC lifecycle change. `AddToManager` still creates both DFCs; the unconfigured side stays present-but-stopped. This PR only *reports* configured-ness; it does not make a side genuinely uninitialized (ENG-5251).
- No steady-state cell render change. In steady state `flowHealth` is truthy and the value-branch renders, unchanged. The 4-state configured render is ENG-5249; the lock-icon visual is ENG-5250.
- No compound-input handling. `BenthosPluginID` returns `""` for >1 top-level keys (invalid benthos config; `broker`/`switch` are single-key plugins wrapping an `inputs:` array, not >1 top-level keys).
- `isInitialized` untouched (stays read-biased; write-only symmetry is ENG-5251).

## CHANGELOG

`skip-changelog-guard` — this PR is umh-core-only and has no user-visible effect alone (the visible effect is ENG-5249's frontend, which consumes the signal). The changelog entry rides with ENG-5249.

## Pre-existing bugs noticed (not this PR, separate tickets TBD)

1. `determineProtocol` (`pkg/communicator/actions/dataflow-component-parser.go:411` + `get-protocolconverter.go:182`) takes the first map key without skipping `label` and without deterministic ordering → overview "Protocol: label" for configs with sibling metadata keys. Second instance of the cell↔overview protocol-derivation inconsistency ENG-5249 unifies.
2. (hypothesis, untested) MC-UI write path emits `{outputs}` where umh-core decodes `{destination}` → `Destination.Protocol` may be empty for UI-created write flows → `bridge.outputType:""`. Scenarios A3/A4 on the live rig would confirm.

## Coordination

Do not merge blind: the plan is to validate the consuming frontend PR [ManagementConsole#3285](https://github.com/united-manufacturing-hub/ManagementConsole/pull/3285) against the live two-version rig (old umh-core + new umh-core + new frontend) before merging either. That validation passed — the before/after + cell↔overview proof lives in #3285's description. This PR can sit as a draft until reviewed.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


