### PR TITLE
feat(benthos): wire FF-on benthos_monitor read path behind USE_FSMV2_BENTHOS_MONITOR

### DIFF
--- a/umh-core/cmd/main.go
+++ b/umh-core/cmd/main.go
@@ -52,6 +52,15 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/register"
 	fsmv2sentry "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/sentry"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/application"
+	// Blank-import the benthos_monitor state subpackage so its init() registers
+	// the worker's initial state (fsmv2.RegisterInitialState). Unlike the
+	// application worker, benthos_monitor/worker.go cannot blank-import its own
+	// state subpackage (state imports the parent for WorkerTypeName + the
+	// Config/Status types, which would be an import cycle), so the registration
+	// must happen here at the binary root. Without this, the supervisor cannot
+	// instantiate a benthos_monitor child and GetFresh returns Unregistered for
+	// every bridge under USE_FSMV2_BENTHOS_MONITOR.
+	_ "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/benthos_monitor/state"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/configworker"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/configworker/dynamicchildren"
@@ -626,6 +635,7 @@ children:
 	fsmv2Logger = fsmv2Logger.Desugar().WithOptions(zap.WrapCore(fsmv2Hook.Wrap)).Sugar()
 
 	fsmv2Deps := map[string]any{}
+
 	if configData.Agent.UseFSMv2MemoryCleanup {
 		register.SetDeps[*persistenceWorker.PersistenceDependencies](persistenceWorker.WorkerTypeName, persistenceWorker.NewStoreOnlyDependencies(store))
 	}

--- a/umh-core/cmd/worker_registration_test.go
+++ b/umh-core/cmd/worker_registration_test.go
@@ -1,0 +1,40 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
+	benthos_monitor "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/benthos_monitor"
+)
+
+// TestBenthosMonitorWorkerInitialStateRegistered guards the blank import of
+// pkg/fsmv2/workers/benthos_monitor/state in main.go. The benthos_monitor
+// worker's initial state is registered from that subpackage's init(); unlike
+// the application worker, benthos_monitor/worker.go cannot blank-import its own
+// state subpackage (an import cycle: state imports the parent for
+// WorkerTypeName and the Config/Status types), so the registration must happen
+// at the binary root. Without it the supervisor cannot instantiate a
+// benthos_monitor child and GetFresh returns Unregistered for every bridge
+// under USE_FSMV2_BENTHOS_MONITOR — the FF-on path would be a silent no-op.
+// This test fails loudly if the main.go blank import is dropped.
+func TestBenthosMonitorWorkerInitialStateRegistered(t *testing.T) {
+	if fsmv2.LookupInitialState(benthos_monitor.WorkerTypeName) == nil {
+		t.Fatalf("LookupInitialState(%q) = nil; the benthos_monitor initial state is not registered. "+
+			"main.go must blank-import pkg/fsmv2/workers/benthos_monitor/state so its init() runs.",
+			benthos_monitor.WorkerTypeName)
+	}
+}

--- a/umh-core/pkg/fsmv2/integration/benthos_monitor_ff_on_scenario_test.go
+++ b/umh-core/pkg/fsmv2/integration/benthos_monitor_ff_on_scenario_test.go
@@ -1,0 +1,360 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/s6"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/fsmv2client"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/register"
+	bmworker "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/benthos_monitor"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/configworker/dynamicchildren"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/benthos"
+)
+
+// restartBenthosMetrics mirrors a freshly-restarted benthos whose counters have
+// reset to zero. Its input_received counter is 0, distinct from the primary
+// stub's 18, so R12b can prove a restart (count 0 < window's last 18) trips the
+// counter-reset branch and wipes the throughput window — the parity-correct
+// behavior the FF-off path also exhibits.
+const restartBenthosMetrics = `# HELP input_received Benthos Counter metric
+# TYPE input_received counter
+input_received{label="",path="root.input"} 0
+# HELP input_latency_ns Benthos Timing metric
+# TYPE input_latency_ns summary
+input_latency_ns_sum{label="",path="root.input"} 0
+input_latency_ns_count{label="",path="root.input"} 0
+# HELP output_sent Benthos Counter metric
+# TYPE output_sent counter
+output_sent{label="",path="root.output"} 0
+`
+
+// cliWatcher adapts the direct fsmv2client.FSMv2Client to the (unexported)
+// benthos.benthosMonitorWatcher seam. It is the test stand-in for the production
+// defaultBenthosMonitorWatcher, which delegates to the process-scoped singleton.
+// Defining it here (rather than reusing the singleton) keeps the test hermetic:
+// the cli writes through a per-test Writer and reads through a per-test store,
+// both owned by the in-process application supervisor.
+type cliWatcher struct {
+	cli *fsmv2client.FSMv2Client
+}
+
+func (w cliWatcher) GetFresh(ctx context.Context, ref dynamicchildren.Ref, maxAge time.Duration) (bmworker.BenthosMonitorStatus, fsmv2client.Freshness, error) {
+	return fsmv2client.GetFresh[bmworker.BenthosMonitorStatus](ctx, w.cli, ref, maxAge)
+}
+
+func (w cliWatcher) Upsert(ref dynamicchildren.Ref, cfg map[string]any) error {
+	return w.cli.Upsert(ref, cfg)
+}
+
+func (w cliWatcher) Delete(ref dynamicchildren.Ref) {
+	w.cli.Delete(ref)
+}
+
+// tickSupervisor is the subset of *supervisor.Supervisor the capstone drives:
+// TestMarkAsStarted arms the supervisor, TestTick advances the collector one
+// tick so the benthos_monitor child scrapes and publishes its observation.
+type tickSupervisor interface {
+	TestMarkAsStarted()
+	TestTick(context.Context) error
+}
+
+var _ = Describe("FF-on benthos_monitor read path through the real supervisor", func() {
+	const (
+		configWorkerKey = "configworker"
+		benthosName     = "cap1"
+		// s6ServiceName is the ref Name GetHealthCheckAndMetrics builds
+		// (benthos.go:658) and the S6 guard keys on (benthos.go:645). The
+		// cli-watcher's ref MUST match.
+		s6ServiceName = "benthos-cap1"
+	)
+
+	var (
+		ctx      context.Context
+		cancel   context.CancelFunc
+		cli      *fsmv2client.FSMv2Client
+		sup      tickSupervisor
+		ref      dynamicchildren.Ref
+		bSvc     *benthos.BenthosService
+		stubSrvs []*httptest.Server
+		readTick uint64
+	)
+
+	BeforeEach(func() {
+		ctx, cancel = context.WithTimeout(context.Background(), 60*time.Second)
+
+		// Arm the FF-on read/lifecycle paths via the cross-package seam.
+		*benthos.EnableFSMv2BenthosMonitorForTest = true
+
+		logger := deps.NewNopFSMLogger()
+		reg := dynamicchildren.NewWriter()
+		register.SetDeps[*dynamicchildren.Registry](configWorkerKey, reg.Registry())
+
+		s, store, _ := newAppSupervisorWithStore(logger)
+		s.TestMarkAsStarted()
+		sup = s
+		cli = fsmv2client.NewFSMv2Client(reg, store)
+
+		// A mocked S6 manager whose GetInstance returns exists=true for
+		// s6ServiceName, satisfying the :610 guard that gates the FF-on branch.
+		s6Mgr := s6.NewS6ManagerWithMockedServices("cap")
+		s6Mgr.AddInstanceForTest(s6ServiceName, nil)
+
+		bSvc = benthos.NewDefaultBenthosService(benthosName,
+			benthos.WithFSMv2BenthosWatcher(cliWatcher{cli: cli}),
+			benthos.WithS6Manager(s6Mgr),
+		)
+
+		ref = dynamicchildren.Ref{WorkerType: bmworker.WorkerTypeName, Name: s6ServiceName}
+		readTick = 0
+	})
+
+	AfterEach(func() {
+		if cancel != nil {
+			cancel()
+		}
+		register.ClearDeps(configWorkerKey)
+		// Reset the FF so it cannot leak into a sibling spec in this suite.
+		*benthos.EnableFSMv2BenthosMonitorForTest = false
+		for _, srv := range stubSrvs {
+			srv.Close()
+		}
+		stubSrvs = nil
+	})
+
+	// tickRead advances the supervisor one tick and calls the FF-on read path.
+	// The tick is monotonic across the scenario so the throughput window sees
+	// advancing ticks (the counter-reset branch keys off tick diffs).
+	tickRead := func() (benthos.BenthosStatus, error) {
+		Expect(sup.TestTick(ctx)).To(Succeed())
+		readTick++
+
+		return bSvc.GetHealthCheckAndMetrics(ctx, nil, readTick, time.Now(), benthosName, nil)
+	}
+
+	// upsert upserts a child-spec WITHOUT ticking (the caller ticks via
+	// tickRead/Eventually). Splitting upsert from tick lets a scenario change
+	// the stub state between the upsert and the ticks that observe it.
+	upsert := func(state string, port uint16) {
+		Expect(cli.Upsert(ref, map[string]any{"state": state, "metricsPort": port})).To(Succeed())
+	}
+
+	// waitUntil ticks+reads until pred holds on the returned status, returning
+	// the last status. Mirrors the PR2 harness's tickLoad/Eventually pattern:
+	// the benthos_monitor worker needs several ticks to spawn, scrape, and
+	// publish, so single-tick assertions race the collector.
+	waitUntil := func(desc string, pred func(got benthos.BenthosStatus) bool) benthos.BenthosStatus {
+		var last benthos.BenthosStatus
+		Eventually(func(g Gomega) bool {
+			got, err := tickRead()
+			if err != nil {
+				return false
+			}
+			last = got
+
+			return pred(got)
+		}, "10s", "50ms").Should(BeTrue(), desc)
+
+		return last
+	}
+
+	// R12a: a transient benthos down→up (NOT a restart — the SAME counters come
+	// back) must NOT spike or wipe the throughput window. The C2 freeze (feed
+	// only when MetricsAvailable) prevents the zero-feed that would trip the
+	// counter-reset branch, so LastCount survives the outage and the resumed
+	// feed sees count==LastCount (no reset, no spike).
+	It("R12a: a transient down-up does not spike or wipe the throughput window", func() {
+		stubSrv, stub := newBenthosStub(sampleBenthosMetrics)
+		stubSrvs = append(stubSrvs, stubSrv)
+		port := stubPort(stubSrv)
+
+		// Step 1: up, counters=18. Window fed (LastCount=18, active).
+		upsert("running", port)
+		got1 := waitUntil("step 1: worker must reach Running with a fresh, healthy scan (IsLive, 18)",
+			func(g benthos.BenthosStatus) bool {
+				return g.HealthCheck.IsLive && g.BenthosMetrics.Metrics.InputReceivedTotal() == 18
+			})
+		Expect(got1.BenthosMetrics.MetricsState).ToNot(BeNil())
+		Expect(got1.BenthosMetrics.MetricsState.Input.LastCount).To(Equal(int64(18)),
+			"step 1: the window must be fed the stub's input_received counter (18)")
+		Expect(got1.BenthosMetrics.MetricsState.IsActive).To(BeTrue(), "step 1: the window must be active")
+		windowLenBeforeOutage := len(got1.BenthosMetrics.MetricsState.Input.Window)
+
+		// Step 2: stub DOWN (transient outage, NOT a restart). IsLive=false,
+		// MetricsAvailable=false → C2 freeze: the down read must NOT feed the
+		// window. (During the lag before the worker's down scrape lands, the
+		// read serves the pre-outage Fresh observation with MetricsAvailable=true
+		// and correctly feeds — that is not the freeze; the freeze is that the
+		// down observation itself, once served, does not advance LastTick.)
+		stub.down.Store(true)
+		got2 := waitUntil("step 2: a down stub must yield IsLive=false",
+			func(g benthos.BenthosStatus) bool { return !g.HealthCheck.IsLive })
+		Expect(got2.HealthCheck.IsLive).To(BeFalse(), "step 2: IsLive must be false when the stub is down")
+		Expect(got2.BenthosMetrics.MetricsState.LastTick).To(BeNumerically("<", readTick),
+			"step 2 (C2 freeze): the down read (MetricsAvailable=false) must NOT feed the window — LastTick stays below the current readTick")
+		Expect(got2.BenthosMetrics.MetricsState.Input.LastCount).To(Equal(int64(18)),
+			"step 2 (C2 freeze): LastCount must survive the outage (no zero-feed → no counter-reset)")
+
+		// Step 3: stub UP again with the SAME counters (18 — transient, not a
+		// restart). The C2 freeze kept LastCount=18, so the resumed feed sees
+		// count=18 == LastCount=18 → NO counter-reset → no wipe, no spike.
+		stub.down.Store(false)
+		got3 := waitUntil("step 3: the stub is up again, IsLive must recover",
+			func(g benthos.BenthosStatus) bool { return g.HealthCheck.IsLive })
+		Expect(got3.HealthCheck.IsLive).To(BeTrue(), "step 3: IsLive must recover when the stub is up again")
+		Expect(got3.BenthosMetrics.MetricsState.Input.LastCount).To(Equal(int64(18)),
+			"step 3: LastCount must still be 18 (the counter-reset branch must NOT fire on a transient outage)")
+		Expect(len(got3.BenthosMetrics.MetricsState.Input.Window)).To(BeNumerically(">=", windowLenBeforeOutage),
+			"step 3: the window must NOT be wiped across a transient outage (pre-outage entries survive)")
+		// The spike would be ~18 msg/tick (the full counter as a per-tick rate)
+		// if the zero-feed had wiped the window. With the C2 freeze, the resumed
+		// feed sees count==LastCount so countDiff=0 → rate 0 (continuous, no spike).
+		Expect(got3.BenthosMetrics.MetricsState.Input.MessagesPerTick).To(BeNumerically("<", 18.0),
+			"step 3: the rate must NOT spike to ~18 (the C2 freeze prevented the counter-reset a zero-feed would trip)")
+	})
+
+	// R12b: a crash+restart (the benthos comes back with counters reset to 0) is
+	// a LEGITIMATE wipe: count 0 < window's last 18 trips the counter-reset
+	// branch, wiping the window. This is parity-correct — the FF-off path wipes
+	// the same way via its errgroup-freeze-then-feed — so it is NOT a regression.
+	It("R12b: a crash-restart legitimately wipes the throughput window (parity-correct)", func() {
+		stubSrv1, _ := newBenthosStub(sampleBenthosMetrics)
+		stubSrvs = append(stubSrvs, stubSrv1)
+		port1 := stubPort(stubSrv1)
+
+		// Step 1: up, counters=18. Window fed (LastCount=18).
+		upsert("running", port1)
+		got1 := waitUntil("step 1: worker must reach Running with counters=18",
+			func(g benthos.BenthosStatus) bool {
+				return g.HealthCheck.IsLive && g.BenthosMetrics.Metrics.InputReceivedTotal() == 18
+			})
+		Expect(got1.BenthosMetrics.MetricsState.Input.LastCount).To(Equal(int64(18)),
+			"step 1: the window must be seeded with the stub's counter (18)")
+
+		// Step 2: the benthos crashed and restarted on a fresh port with counters
+		// reset to 0 (a restarted benthos resets its Prometheus counters). The
+		// scrape is Fresh + MetricsAvailable=true (stub2 is up), so the C2 guard
+		// does NOT freeze — the feed happens with count=0.
+		stubSrv2, _ := newBenthosStub(restartBenthosMetrics)
+		stubSrvs = append(stubSrvs, stubSrv2)
+		port2 := stubPort(stubSrv2)
+		upsert("running", port2)
+		got2 := waitUntil("step 2: the restarted stub (counters=0) must be scraped and served",
+			func(g benthos.BenthosStatus) bool {
+				return g.HealthCheck.IsLive && g.BenthosMetrics.Metrics.InputReceivedTotal() == 0
+			})
+
+		// count 0 < LastCount 18 → counter-reset branch fired → window wiped.
+		Expect(got2.BenthosMetrics.MetricsState.Input.LastCount).To(Equal(int64(0)),
+			"step 2: the counter-reset branch must fire (count 0 < last 18) and reset LastCount to 0")
+		Expect(got2.BenthosMetrics.MetricsState.Input.Window).To(HaveLen(1),
+			"step 2: the window must be wiped to a single reset entry (the counter-reset branch clears the window)")
+		Expect(got2.BenthosMetrics.MetricsState.Input.MessagesPerTick).To(Equal(float64(0)),
+			"step 2: the wiped window's rate is 0 (no fake throughput from a restarted counter)")
+	})
+
+	// R13: a stopped bridge (admin-paused) skips the scrape entirely. The
+	// worker's COS guard leaves /metrics un-hit, and the read path's Stopped
+	// guard returns empty+nil (Fresh + Stopped → NOT unhealthy, per v6.1c).
+	It("R13: a stopped bridge skips the scrape and reads Fresh-stopped (not unhealthy)", func() {
+		stubSrv, stub := newBenthosStub(sampleBenthosMetrics)
+		stubSrvs = append(stubSrvs, stubSrv)
+		port := stubPort(stubSrv)
+
+		// Drive to running first so the worker has a live observation and the
+		// /metrics hit counter is non-zero; the stop must NOT advance it.
+		upsert("running", port)
+		waitUntil("precondition: the running worker must scrape /metrics and read IsLive",
+			func(g benthos.BenthosStatus) bool { return g.HealthCheck.IsLive })
+		hitsBeforeStop := stub.metricsHits.Load()
+		Expect(hitsBeforeStop).To(BeNumerically(">", 0),
+			"precondition: the running worker must have scraped /metrics at least once")
+
+		// Stop: the worker's COS scrape-skip must leave /metrics un-hit, and the
+		// read path's Stopped guard returns empty+nil (Fresh+Stopped → not
+		// unhealthy). The ref stays registered (no Delete), so the empty read is
+		// Fresh+Stopped, NOT Unregistered. waitUntil ticks until the read returns
+		// the empty status (nil MetricsState — the zero BenthosStatus carries no
+		// window pointer, distinguishing it from a Fresh+MetricsAvailable read).
+		upsert("stopped", port)
+		waitUntil("R13: a stopped bridge must read Fresh+Stopped (empty BenthosStatus, nil MetricsState)",
+			func(g benthos.BenthosStatus) bool {
+				return g.BenthosMetrics.MetricsState == nil
+			})
+		got, err := tickRead()
+		Expect(err).ToNot(HaveOccurred(),
+			"R13: a stopped bridge must return empty+nil (Fresh+Stopped → not unhealthy, v6.1c)")
+		Expect(got.BenthosMetrics.MetricsState).To(BeNil(),
+			"R13: a stopped bridge must serve an empty BenthosStatus (nil window — not Degraded)")
+		Expect(got.BenthosMetrics.Metrics.InputReceivedTotal()).To(Equal(int64(0)),
+			"R13: a stopped bridge must serve zero metrics (the scrape was skipped)")
+		Expect(stub.metricsHits.Load()).To(Equal(hitsBeforeStop),
+			"R13: the /metrics endpoint must not be hit while the worker is Stopped (COS scrape-skip)")
+	})
+
+	// R14: a port change on the SAME ref (no Delete+re-add) keeps the ref
+	// registered, so the read never returns Unregistered. After the Upsert of
+	// the new port, ~one tick may still serve the stale old-port observation as
+	// Fresh (the documented deviation — the CSE store does not clear a despawned
+	// child's observation until ENG-5107); once the worker scrapes the new stub,
+	// the new counters appear.
+	It("R14: a port change on the same ref never reads Unregistered", func() {
+		stubSrv1, stub1 := newBenthosStub(sampleBenthosMetrics)
+		stubSrvs = append(stubSrvs, stubSrv1)
+		port1 := stubPort(stubSrv1)
+
+		// Step 1: stub1 scraped, counters=18 served as Fresh.
+		upsert("running", port1)
+		waitUntil("step 1: stub1 must be scraped and serve counters=18",
+			func(g benthos.BenthosStatus) bool {
+				return g.HealthCheck.IsLive && g.BenthosMetrics.Metrics.InputReceivedTotal() == 18
+			})
+		Expect(stub1.metricsHits.Load()).To(BeNumerically(">", 0),
+			"step 1: stub1 must have been scraped")
+
+		// Step 2: Upsert stub2 on the SAME ref (no Delete) + ONE tick. The ref
+		// stays registered (Contains==true), so the read must NOT return an
+		// error/Unregistered — it serves Fresh metrics (stale-old-port or new).
+		stubSrv2, stub2 := newBenthosStub(altBenthosMetrics)
+		stubSrvs = append(stubSrvs, stubSrv2)
+		port2 := stubPort(stubSrv2)
+		upsert("running", port2)
+		// One tick after the port-change upsert.
+		got2, err := tickRead()
+		Expect(err).ToNot(HaveOccurred(),
+			"R14: a port change on the same ref must NOT read Unregistered (no Delete → ref stays registered)")
+		// Whatever the one-tick lag serves, it must be live metrics (not the
+		// empty BenthosStatus an Unregistered read returns).
+		Expect(got2.HealthCheck.IsLive).To(BeTrue(),
+			"R14: the read after a port change must serve live metrics (stale-old-port or fresh-new-port)")
+
+		// Step 3: eventually the worker scrapes stub2 and its counters (42)
+		// appear. The KEY assertion is that the new stub IS scraped and served
+		// without an Unregistered gap in between.
+		waitUntil("R14: after the port change stub2's counters (42) must eventually be served",
+			func(g benthos.BenthosStatus) bool {
+				return g.BenthosMetrics.Metrics.InputReceivedTotal() == 42
+			})
+		Expect(stub2.metricsHits.Load()).To(BeNumerically(">", 0),
+			"R14: stub2 must actually have been scraped")
+	})
+})

--- a/umh-core/pkg/service/benthos/benthos.go
+++ b/umh-core/pkg/service/benthos/benthos.go
@@ -33,6 +33,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/logger"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/metrics"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/benthos_monitor"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/benthosmetrics"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/filesystem"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/serviceregistry"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/standarderrors"
@@ -203,6 +204,13 @@ type BenthosService struct {
 
 	benthosMonitorManager *benthos_monitor_fsm.BenthosMonitorManager
 
+	// window is the per-bridge BenthosMetricsState owned by BenthosService.
+	// On the FF-off path it is fed from the metrics returned by the S6 monitor
+	// during GetHealthCheckAndMetrics; on the FF-on path it will be fed from
+	// GetFresh (wired in a later commit). One BenthosService exists per bridge,
+	// so one window per bridge.
+	window *benthosmetrics.BenthosMetricsState
+
 	// -----------------------------------------------------------------------------
 	// 🌶️  Hot-path YAML-parsing cache
 	// -----------------------------------------------------------------------------
@@ -282,6 +290,7 @@ func NewDefaultBenthosService(benthosName string, opts ...BenthosServiceOption) 
 		s6Manager:             s6fsm.NewS6Manager(managerName),
 		s6Service:             s6service.NewDefaultService(),
 		benthosMonitorManager: benthos_monitor_fsm.NewBenthosMonitorManager(benthosName),
+		window:                benthosmetrics.NewBenthosMetricsState(),
 	}
 
 	// Apply options
@@ -650,6 +659,15 @@ func (s *BenthosService) GetHealthCheckAndMetrics(ctx context.Context, filesyste
 		return BenthosStatus{}, ErrBenthosMonitorNotRunning
 	}
 
+	// Feed BenthosService's own window from the metrics the S6 monitor returned
+	// and point the status at it. This replaces the monitor's window pointer
+	// (which is now nil) with this service's owned window. The feed cadence
+	// (every GetHealthCheckAndMetrics call that returns metrics) and the data
+	// (the monitor's returned Metrics) match the previous ProcessMetricsData
+	// feed, so behavior is preserved on the FF-off path.
+	s.window.UpdateFromMetrics(benthosStatus.BenthosMetrics.Metrics, tick)
+	benthosStatus.BenthosMetrics.MetricsState = s.window
+
 	return benthosStatus, nil
 }
 
@@ -848,6 +866,11 @@ func (s *BenthosService) RemoveBenthosFromS6Manager(
 		return fmt.Errorf("%w: monitor instance state=%s",
 			standarderrors.ErrRemovalPending, inst.GetCurrentFSMState())
 	}
+
+	// Reset the per-bridge window now that the bridge is really gone. This
+	// mirrors the previous monitor-side reset (benthos_monitor.go) and keeps
+	// the window idempotent across a remove → re-add cycle for the same name.
+	s.window = benthosmetrics.NewBenthosMetricsState()
 
 	// Everything really removed ➜ success, idempotent
 	return nil

--- a/umh-core/pkg/service/benthos/benthos.go
+++ b/umh-core/pkg/service/benthos/benthos.go
@@ -691,12 +691,28 @@ func (s *BenthosService) GetHealthCheckAndMetrics(ctx context.Context, filesyste
 				},
 			}, nil
 
+		case fsmv2client.Stale:
+			// Wedged watcher (CollectedAt > maxAge). The store IS the cache — Stale
+			// is the one branch that surfaces stored last-good: serve the stale obs's
+			// Metrics + override IsLive=false. No error (reconcile.go:104-115 catches
+			// non-fatal; serving last-good+unhealthy is the round4 #7 fix). v6.3d:
+			// Degraded-for-all on wedge (incl stopped) — a wedged watcher is a global
+			// alarm; do NOT exempt stopped bridges. Do NOT feed s.window (C2: feed
+			// only on Fresh+MetricsAvailable; Stale is not Fresh).
+			staleHC := status.Scan.HealthCheck
+			staleHC.IsLive = false
+
+			return BenthosStatus{
+				HealthCheck: staleHC,
+				BenthosMetrics: benthosmetrics.BenthosMetrics{
+					Metrics:      status.Scan.Metrics,
+					MetricsState: s.window,
+				},
+			}, nil
+
 		default:
-			// Stale / Unregistered / NeverObserved — R2-R7 fill these in.
-			// TODO(R2-R7): Stale→serve the stale obs GetFresh returned + override
-			// IsLive=false (NO cache — C3: the store is the cache via this branch);
-			// Unregistered/NeverObserved→serve empty/not-ready (warming); Unknown
-			// is already handled above (err != nil).
+			// Unregistered / NeverObserved → serve empty/not-ready (warming);
+			// Unknown handled above (err != nil).
 			return BenthosStatus{}, nil
 		}
 	}

--- a/umh-core/pkg/service/benthos/benthos.go
+++ b/umh-core/pkg/service/benthos/benthos.go
@@ -229,7 +229,7 @@ type BenthosService struct {
 
 	// lastFedScanAt is the LastUpdatedAt of the last scan fed into the window
 	// on the FF-off path. The FF-off feed (GetHealthCheckAndMetrics) is gated
-	// on it so the window is fed only when the monitor produced a new scan —
+	// on it so the window is fed only when the monitor produced a new scan,
 	// matching the earlier behavior where the feed lived inside
 	// ProcessMetricsData and fired only on a successful parse. On a benthos-down
 	// outage the monitor retains last-good (its action returns err without
@@ -680,16 +680,16 @@ func (s *BenthosService) GetHealthCheckAndMetrics(ctx context.Context, filesyste
 	if fsmv2BenthosMonitorEnabled {
 		// FF-on: read the benthos_monitor worker's published
 		// BenthosMonitorStatus through the fsmv2 watcher instead of the v1
-		// monitor manager. The ref Name MUST be s6ServiceName ("benthos-"+name)
-		// — the monitor FSM keys on it; using raw benthosName makes Contains
+		// monitor manager. The ref Name MUST be s6ServiceName ("benthos-"+name):
+		// the monitor FSM keys on it; using raw benthosName makes Contains
 		// false and every read returns Unregistered.
 		ref := dynamicchildren.Ref{WorkerType: "benthos_monitor", Name: s6ServiceName}
 
 		status, res, err := s.fsmv2Watcher.GetFresh(ctx, ref, benthosMonitorMaxAge)
 		if err != nil {
 			// Unknown: GetFresh could not classify the observation (a nil
-			// fsmv2 client — USE_FSMV2_BENTHOS_MONITOR=ON requires
-			// USE_FSMV2_TRANSPORT=ON, so a nil client is misconfig — or a
+			// fsmv2 client, since USE_FSMV2_BENTHOS_MONITOR=ON requires
+			// USE_FSMV2_TRANSPORT=ON so a nil client is misconfig, or a
 			// store read error). Return the raw err; it hard-propagates
 			// through Status() as a "failed to get health check" error
 			// (benthos.go Status -> actions.go getServiceStatus), which is
@@ -701,10 +701,10 @@ func (s *BenthosService) GetHealthCheckAndMetrics(ctx context.Context, filesyste
 		switch res {
 		case fsmv2client.Fresh:
 			if status.Stopped {
-				// A stopped bridge reads Fresh with Stopped=true: the worker
-				// skipped the scrape, so Scan is the zero value. Return a
-				// not-unhealthy empty status — do not treat the zero IsLive as
-				// Degraded (a stopped bridge is not a down bridge).
+				// A stopped bridge reads Fresh with Stopped=true, so Scan is
+				// the zero value (no scrape ran). Return a not-unhealthy empty
+				// status; do not treat the zero IsLive as Degraded (a stopped
+				// bridge is not a down bridge).
 				return BenthosStatus{}, nil
 			}
 
@@ -717,7 +717,7 @@ func (s *BenthosService) GetHealthCheckAndMetrics(ctx context.Context, filesyste
 			}
 
 			// No client-side last-good cache: the store is the cache (the Stale
-			// branch below surfaces stored last-good). Return the raw IsLive.
+			// branch below returns stored last-good). Return the raw IsLive.
 			return BenthosStatus{
 				HealthCheck: status.Scan.HealthCheck,
 				BenthosMetrics: benthosmetrics.BenthosMetrics{
@@ -727,13 +727,13 @@ func (s *BenthosService) GetHealthCheckAndMetrics(ctx context.Context, filesyste
 			}, nil
 
 		case fsmv2client.Stale:
-			// A wedged watcher (CollectedAt older than maxAge). The store is the
-			// cache, so Stale is the one branch that surfaces stored last-good:
-			// serve the stale scan's metrics but override IsLive=false. A wedged
-			// collector is a global alarm, not per-bridge, so stopped bridges are
-			// not exempted (they read unhealthy too). Do not feed the window —
-			// only a Fresh scan with metrics feeds. Returning last-good +
-			// unhealthy (rather than an error) lets the reconcile path degrade
+			// CollectedAt is older than maxAge. The store is the cache, so
+			// Stale is the one branch that returns stored last-good: serve the
+			// stale scan's metrics but override IsLive=false. A slow collector
+			// affects every bridge, not just one, so stopped bridges are not
+			// exempted (they read unhealthy too). Do not feed the window; only a
+			// Fresh scan with metrics feeds. Returning last-good + unhealthy
+			// (rather than an error) lets the reconcile path degrade
 			// non-fatally.
 			staleHC := status.Scan.HealthCheck
 			staleHC.IsLive = false
@@ -795,7 +795,7 @@ func (s *BenthosService) GetHealthCheckAndMetrics(ctx context.Context, filesyste
 	// scan-freshness: feed only when the monitor produced a new scan
 	// (LastUpdatedAt changed since the last feed). This matches the earlier
 	// behavior where the feed lived inside ProcessMetricsData and fired only on
-	// a successful parse — on a benthos-down outage the monitor retains
+	// a successful parse. On a benthos-down outage the monitor retains
 	// last-good (its action returns err without updating
 	// ObservedState.ServiceInfo), so LastUpdatedAt stops changing and the
 	// window freezes instead of re-feeding last-good every tick (which would
@@ -1155,8 +1155,8 @@ func (s *BenthosService) ReconcileManager(ctx context.Context, services servicer
 
 	if fsmv2BenthosMonitorEnabled {
 		// Under FF-on, push each monitor config to the FSMv2 watcher via Upsert
-		// and SKIP the S6 monitor manager.Reconcile entirely. The S6 fork tree
-		// never spawns — this is the CPU win. Upsert errors are logged and
+		// and SKIP the S6 monitor manager.Reconcile entirely, so the S6 fork
+		// tree never spawns (the CPU saving). Upsert errors are logged and
 		// swallowed (non-fatal): the next tick re-Upserts, so a single bad
 		// config must not fail the whole reconcile.
 		for _, cfg := range s.benthosMonitorConfigs {

--- a/umh-core/pkg/service/benthos/benthos.go
+++ b/umh-core/pkg/service/benthos/benthos.go
@@ -671,9 +671,14 @@ func (s *BenthosService) GetHealthCheckAndMetrics(ctx context.Context, filesyste
 
 		status, res, err := s.fsmv2Watcher.GetFresh(ctx, ref, benthosMonitorMaxAge)
 		if err != nil {
-			// Unknown: GetFresh could not classify the observation (store read
-			// error). Return it raw; reconcile.go catches this non-fatally so
-			// the read path degrades rather than fatals.
+			// Unknown: GetFresh could not classify the observation (a nil
+			// fsmv2 client — USE_FSMV2_BENTHOS_MONITOR=ON requires
+			// USE_FSMV2_TRANSPORT=ON, so a nil client is misconfig — or a
+			// store read error). Return the raw err; it hard-propagates
+			// through Status() as a "failed to get health check" error
+			// (benthos.go Status -> actions.go getServiceStatus), which is
+			// consistent with the FF-off path's treatment of unrecognized
+			// monitor errors. It does NOT degrade silently.
 			return BenthosStatus{}, err
 		}
 

--- a/umh-core/pkg/service/benthos/benthos.go
+++ b/umh-core/pkg/service/benthos/benthos.go
@@ -32,6 +32,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/logger"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/metrics"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/sentry"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/benthos_monitor"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/benthosmetrics"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/filesystem"
@@ -203,6 +204,13 @@ func (bs *BenthosStatus) CopyBenthosLogs(src []s6service.LogEntry) error {
 	return nil
 }
 
+// upsertStuckThreshold is the number of consecutive FF-on watcher Upsert
+// failures for one bridge after which a single Sentry warning is emitted, so
+// a bridge whose monitor child-spec never lands (stuck Unregistered) is
+// distinguishable from a transient per-tick Upsert blip in logs and Sentry.
+// The counter resets on the next successful Upsert and on Remove.
+const upsertStuckThreshold = 3
+
 // BenthosService is the default implementation of the IBenthosService interface.
 type BenthosService struct {
 	s6Service s6service.Service // S6 service for direct S6 operations
@@ -237,6 +245,13 @@ type BenthosService struct {
 	// production default delegates to the process-scoped fsmv2client; tests
 	// inject a fake via WithFSMv2BenthosWatcher.
 	fsmv2Watcher benthosMonitorWatcher
+
+	// upsertFailures counts consecutive FF-on watcher Upsert failures per
+	// bridge (keyed by cfg.Name, the S6 service name). It only surfaces a
+	// Sentry warning at upsertStuckThreshold; Upsert stays non-fatal and the
+	// next tick re-Upserts. Reset on a successful Upsert and on Remove.
+	// ReconcileManager is the only writer, so no mutex is needed.
+	upsertFailures map[string]int
 
 	// -----------------------------------------------------------------------------
 	// 🌶️  Hot-path YAML-parsing cache
@@ -329,6 +344,7 @@ func NewDefaultBenthosService(benthosName string, opts ...BenthosServiceOption) 
 		benthosMonitorManager: benthos_monitor_fsm.NewBenthosMonitorManager(benthosName),
 		window:                benthosmetrics.NewBenthosMetricsState(),
 		fsmv2Watcher:          defaultBenthosMonitorWatcher{},
+		upsertFailures:        make(map[string]int),
 	}
 
 	// Apply options
@@ -989,6 +1005,7 @@ func (s *BenthosService) RemoveBenthosFromS6Manager(
 	// benthosName). Idempotent: Delete on an already-removed ref is a no-op.
 	if fsmv2BenthosMonitorEnabled {
 		s.fsmv2Watcher.Delete(dynamicchildren.Ref{WorkerType: "benthos_monitor", Name: s6Name})
+		delete(s.upsertFailures, s6Name)
 	}
 
 	// ------------------------------------------------------------------
@@ -1149,6 +1166,20 @@ func (s *BenthosService) ReconcileManager(ctx context.Context, services servicer
 				"metricsPort": cfg.MetricsPort,
 			}); upsertErr != nil {
 				s.logger.Errorf("fsmv2 watcher Upsert failed for %s: %v", cfg.Name, upsertErr)
+
+				s.upsertFailures[cfg.Name]++
+				if s.upsertFailures[cfg.Name] == upsertStuckThreshold {
+					// A persistently-failing Upsert leaves the bridge's monitor
+					// child-spec Unregistered, so the read path serves an empty
+					// (not-unhealthy) BenthosStatus and the bridge reads as
+					// healthy to MC. Surface one warning at the threshold so a
+					// stuck bridge is distinguishable from a transient blip.
+					sentry.ReportIssuef(sentry.IssueTypeWarning, s.logger,
+						"benthos_monitor child-spec Upsert stuck for %s: %d consecutive reconcile failures (last: %v)",
+						cfg.Name, s.upsertFailures[cfg.Name], upsertErr)
+				}
+			} else {
+				delete(s.upsertFailures, cfg.Name)
 			}
 		}
 

--- a/umh-core/pkg/service/benthos/benthos.go
+++ b/umh-core/pkg/service/benthos/benthos.go
@@ -219,16 +219,16 @@ type BenthosService struct {
 	// exists per bridge, so one window per bridge.
 	window *benthosmetrics.BenthosMetricsState
 
-	// lastFedScanAt is the LastUpdatedAt of the last scan fed into window on
-	// the FF-off path. The FF-off feed (GetHealthCheckAndMetrics) is gated on
-	// it so the window is fed only when the monitor produced a NEW scan —
-	// restoring the pre-A1 parity where the feed lived inside ProcessMetricsData
-	// and fired only on a successful parse. On a benthos-down outage the monitor
-	// retains last-good (its action returns err without updating
-	// ObservedState.ServiceInfo), so LastUpdatedAt stops advancing and the
-	// window freezes instead of re-feeding last-good every tick (which would
-	// drive MessagesPerTick to 0). Reset to the zero time alongside the window
-	// on Remove so a re-added bridge feeds fresh.
+	// lastFedScanAt is the LastUpdatedAt of the last scan fed into the window
+	// on the FF-off path. The FF-off feed (GetHealthCheckAndMetrics) is gated
+	// on it so the window is fed only when the monitor produced a new scan —
+	// matching the earlier behavior where the feed lived inside
+	// ProcessMetricsData and fired only on a successful parse. On a benthos-down
+	// outage the monitor retains last-good (its action returns err without
+	// updating ObservedState.ServiceInfo), so LastUpdatedAt stops changing and
+	// the window freezes instead of re-feeding last-good every tick (which
+	// would drive MessagesPerTick to 0). Reset to the zero time alongside the
+	// window on Remove so a re-added bridge feeds fresh.
 	lastFedScanAt time.Time
 
 	// fsmv2Watcher is the FF-on read seam: behind USE_FSMV2_BENTHOS_MONITOR
@@ -685,21 +685,23 @@ func (s *BenthosService) GetHealthCheckAndMetrics(ctx context.Context, filesyste
 		switch res {
 		case fsmv2client.Fresh:
 			if status.Stopped {
-				// v6.1c: a stopped bridge is Fresh + Stopped=true — the worker
-				// skipped the scrape so Scan is the zero value. Do NOT treat
-				// IsLive=false as Degraded; return a not-unhealthy empty status.
+				// A stopped bridge reads Fresh with Stopped=true: the worker
+				// skipped the scrape, so Scan is the zero value. Return a
+				// not-unhealthy empty status — do not treat the zero IsLive as
+				// Degraded (a stopped bridge is not a down bridge).
 				return BenthosStatus{}, nil
 			}
 
-			// C2: feed the window ONLY when the scrape produced metrics, so a
-			// benthos-down observation (MetricsAvailable=false) does not freeze
-			// the throughput window on a counter-reset spike.
+			// Feed the window only when the scrape produced metrics. A
+			// benthos-down observation has MetricsAvailable=false; feeding those
+			// zeros would trip the counter-reset branch and wipe the window,
+			// spiking the rate on recovery.
 			if status.Scan.MetricsAvailable {
 				s.window.UpdateFromMetrics(status.Scan.Metrics, tick)
 			}
 
-			// C3: no last-good cache — the store IS the cache via the Stale
-			// branch (R3). Return the raw IsLive with no debounce.
+			// No client-side last-good cache: the store is the cache (the Stale
+			// branch below surfaces stored last-good). Return the raw IsLive.
 			return BenthosStatus{
 				HealthCheck: status.Scan.HealthCheck,
 				BenthosMetrics: benthosmetrics.BenthosMetrics{
@@ -709,13 +711,14 @@ func (s *BenthosService) GetHealthCheckAndMetrics(ctx context.Context, filesyste
 			}, nil
 
 		case fsmv2client.Stale:
-			// Wedged watcher (CollectedAt > maxAge). The store IS the cache — Stale
-			// is the one branch that surfaces stored last-good: serve the stale obs's
-			// Metrics + override IsLive=false. No error (reconcile.go:104-115 catches
-			// non-fatal; serving last-good+unhealthy is the round4 #7 fix). v6.3d:
-			// Degraded-for-all on wedge (incl stopped) — a wedged watcher is a global
-			// alarm; do NOT exempt stopped bridges. Do NOT feed s.window (C2: feed
-			// only on Fresh+MetricsAvailable; Stale is not Fresh).
+			// A wedged watcher (CollectedAt older than maxAge). The store is the
+			// cache, so Stale is the one branch that surfaces stored last-good:
+			// serve the stale scan's metrics but override IsLive=false. A wedged
+			// collector is a global alarm, not per-bridge, so stopped bridges are
+			// not exempted (they read unhealthy too). Do not feed the window —
+			// only a Fresh scan with metrics feeds. Returning last-good +
+			// unhealthy (rather than an error) lets the reconcile path degrade
+			// non-fatally.
 			staleHC := status.Scan.HealthCheck
 			staleHC.IsLive = false
 
@@ -773,12 +776,12 @@ func (s *BenthosService) GetHealthCheckAndMetrics(ctx context.Context, filesyste
 	// Feed BenthosService's own window from the metrics the S6 monitor returned
 	// and point the status at it. This replaces the monitor's window pointer
 	// (which is now nil) with this service's owned window. The feed is gated on
-	// scan-freshness: feed ONLY when the monitor produced a NEW scan
-	// (LastUpdatedAt advanced since the last feed). This restores the pre-A1
-	// parity where the feed lived inside ProcessMetricsData and fired only on a
-	// successful parse — on a benthos-down outage the monitor retains
+	// scan-freshness: feed only when the monitor produced a new scan
+	// (LastUpdatedAt changed since the last feed). This matches the earlier
+	// behavior where the feed lived inside ProcessMetricsData and fired only on
+	// a successful parse — on a benthos-down outage the monitor retains
 	// last-good (its action returns err without updating
-	// ObservedState.ServiceInfo), so LastUpdatedAt stops advancing and the
+	// ObservedState.ServiceInfo), so LastUpdatedAt stops changing and the
 	// window freezes instead of re-feeding last-good every tick (which would
 	// drive MessagesPerTick to 0).
 	lastScan := lastBenthosMonitorObservedState.ServiceInfo.BenthosStatus.LastScan
@@ -981,7 +984,7 @@ func (s *BenthosService) RemoveBenthosFromS6Manager(
 	s.s6ServiceConfigs = sliceRemoveByName(s.s6ServiceConfigs, s6Name)
 	s.benthosMonitorConfigs = sliceRemoveMonitorByName(s.benthosMonitorConfigs, s6Name)
 
-	// R9: under FF-on, tell the FSMv2 watcher to drop this child-spec. The ref
+	// Under FF-on, tell the FSMv2 watcher to drop this child-spec. The ref
 	// Name is s6Name (the s6ServiceName the config was keyed on, NOT raw
 	// benthosName). Idempotent: Delete on an already-removed ref is a no-op.
 	if fsmv2BenthosMonitorEnabled {
@@ -1134,10 +1137,10 @@ func (s *BenthosService) ReconcileManager(ctx context.Context, services servicer
 	}
 
 	if fsmv2BenthosMonitorEnabled {
-		// R8 + R11: under FF-on, push each monitor config to the FSMv2 watcher
-		// via Upsert and SKIP the S6 monitor manager.Reconcile entirely. The S6
-		// fork tree never spawns — this is the CPU win. Upsert errors are logged
-		// and swallowed (non-fatal): the next tick re-Upserts, so a single bad
+		// Under FF-on, push each monitor config to the FSMv2 watcher via Upsert
+		// and SKIP the S6 monitor manager.Reconcile entirely. The S6 fork tree
+		// never spawns — this is the CPU win. Upsert errors are logged and
+		// swallowed (non-fatal): the next tick re-Upserts, so a single bad
 		// config must not fail the whole reconcile.
 		for _, cfg := range s.benthosMonitorConfigs {
 			ref := dynamicchildren.Ref{WorkerType: "benthos_monitor", Name: cfg.Name}

--- a/umh-core/pkg/service/benthos/benthos.go
+++ b/umh-core/pkg/service/benthos/benthos.go
@@ -219,6 +219,18 @@ type BenthosService struct {
 	// exists per bridge, so one window per bridge.
 	window *benthosmetrics.BenthosMetricsState
 
+	// lastFedScanAt is the LastUpdatedAt of the last scan fed into window on
+	// the FF-off path. The FF-off feed (GetHealthCheckAndMetrics) is gated on
+	// it so the window is fed only when the monitor produced a NEW scan —
+	// restoring the pre-A1 parity where the feed lived inside ProcessMetricsData
+	// and fired only on a successful parse. On a benthos-down outage the monitor
+	// retains last-good (its action returns err without updating
+	// ObservedState.ServiceInfo), so LastUpdatedAt stops advancing and the
+	// window freezes instead of re-feeding last-good every tick (which would
+	// drive MessagesPerTick to 0). Reset to the zero time alongside the window
+	// on Remove so a re-added bridge feeds fresh.
+	lastFedScanAt time.Time
+
 	// fsmv2Watcher is the FF-on read seam: behind USE_FSMV2_BENTHOS_MONITOR
 	// GetHealthCheckAndMetrics reads the benthos_monitor worker's published
 	// BenthosMonitorStatus through it instead of the v1 monitor manager. The
@@ -755,11 +767,21 @@ func (s *BenthosService) GetHealthCheckAndMetrics(ctx context.Context, filesyste
 
 	// Feed BenthosService's own window from the metrics the S6 monitor returned
 	// and point the status at it. This replaces the monitor's window pointer
-	// (which is now nil) with this service's owned window. The feed cadence
-	// (every GetHealthCheckAndMetrics call that returns metrics) and the data
-	// (the monitor's returned Metrics) match the previous ProcessMetricsData
-	// feed, so behavior is preserved on the FF-off path.
-	s.window.UpdateFromMetrics(benthosStatus.BenthosMetrics.Metrics, tick)
+	// (which is now nil) with this service's owned window. The feed is gated on
+	// scan-freshness: feed ONLY when the monitor produced a NEW scan
+	// (LastUpdatedAt advanced since the last feed). This restores the pre-A1
+	// parity where the feed lived inside ProcessMetricsData and fired only on a
+	// successful parse — on a benthos-down outage the monitor retains
+	// last-good (its action returns err without updating
+	// ObservedState.ServiceInfo), so LastUpdatedAt stops advancing and the
+	// window freezes instead of re-feeding last-good every tick (which would
+	// drive MessagesPerTick to 0).
+	lastScan := lastBenthosMonitorObservedState.ServiceInfo.BenthosStatus.LastScan
+	if lastScan.LastUpdatedAt.After(s.lastFedScanAt) {
+		s.window.UpdateFromMetrics(benthosStatus.BenthosMetrics.Metrics, tick)
+		s.lastFedScanAt = lastScan.LastUpdatedAt
+	}
+
 	benthosStatus.BenthosMetrics.MetricsState = s.window
 
 	return benthosStatus, nil
@@ -971,7 +993,10 @@ func (s *BenthosService) RemoveBenthosFromS6Manager(
 	// Reset the per-bridge window now that the bridge is really gone. This
 	// mirrors the previous monitor-side reset (benthos_monitor.go) and keeps
 	// the window idempotent across a remove → re-add cycle for the same name.
+	// lastFedScanAt is reset alongside so a re-added bridge (whose first scan
+	// lands with a LastUpdatedAt > zero time) feeds the window fresh.
 	s.window = benthosmetrics.NewBenthosMetricsState()
+	s.lastFedScanAt = time.Time{}
 
 	// Everything really removed ➜ success, idempotent
 	return nil

--- a/umh-core/pkg/service/benthos/benthos.go
+++ b/umh-core/pkg/service/benthos/benthos.go
@@ -41,6 +41,8 @@ import (
 
 	benthos_monitor_fsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/benthos_monitor"
 	s6fsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/s6"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/fsmv2client"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/configworker/dynamicchildren"
 	"gopkg.in/yaml.v3"
 
 	s6service "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/s6"
@@ -65,6 +67,12 @@ const (
 	//
 	// Reference: https://github.com/gopcua/opcua/blob/main/debug/debug.go
 	OPCDebugEnvVar = "OPC_DEBUG"
+
+	// benthosMonitorMaxAge is the Freshness window the FF-on read path passes
+	// to GetFresh: an observation older than this is Stale (the watcher is
+	// wedged or slow). 10s mirrors the v1 monitor's scrape cadence so a single
+	// missed scrape does not flip a healthy bridge to Stale.
+	benthosMonitorMaxAge = 10 * time.Second
 )
 
 // IBenthosService is the interface for managing Benthos services.
@@ -206,10 +214,17 @@ type BenthosService struct {
 
 	// window is the per-bridge BenthosMetricsState owned by BenthosService.
 	// On the FF-off path it is fed from the metrics returned by the S6 monitor
-	// during GetHealthCheckAndMetrics; on the FF-on path it will be fed from
-	// GetFresh (wired in a later commit). One BenthosService exists per bridge,
-	// so one window per bridge.
+	// during GetHealthCheckAndMetrics; on the FF-on path it is fed from
+	// GetFresh (wired behind USE_FSMV2_BENTHOS_MONITOR). One BenthosService
+	// exists per bridge, so one window per bridge.
 	window *benthosmetrics.BenthosMetricsState
+
+	// fsmv2Watcher is the FF-on read seam: behind USE_FSMV2_BENTHOS_MONITOR
+	// GetHealthCheckAndMetrics reads the benthos_monitor worker's published
+	// BenthosMonitorStatus through it instead of the v1 monitor manager. The
+	// production default delegates to the process-scoped fsmv2client; tests
+	// inject a fake via WithFSMv2BenthosWatcher.
+	fsmv2Watcher benthosMonitorWatcher
 
 	// -----------------------------------------------------------------------------
 	// 🌶️  Hot-path YAML-parsing cache
@@ -274,6 +289,16 @@ func WithMonitorManager(monitorManager *benthos_monitor_fsm.BenthosMonitorManage
 	}
 }
 
+// WithFSMv2BenthosWatcher injects a fake benthosMonitorWatcher for tests of the
+// FF-on (USE_FSMV2_BENTHOS_MONITOR) read path. Production code leaves the
+// default (defaultBenthosMonitorWatcher, which delegates to fsmv2client) in
+// place.
+func WithFSMv2BenthosWatcher(w benthosMonitorWatcher) BenthosServiceOption {
+	return func(s *BenthosService) {
+		s.fsmv2Watcher = w
+	}
+}
+
 // WithS6Manager sets a custom S6 manager for the BenthosService.
 func WithS6Manager(s6Manager *s6fsm.S6Manager) BenthosServiceOption {
 	return func(s *BenthosService) {
@@ -291,6 +316,7 @@ func NewDefaultBenthosService(benthosName string, opts ...BenthosServiceOption) 
 		s6Service:             s6service.NewDefaultService(),
 		benthosMonitorManager: benthos_monitor_fsm.NewBenthosMonitorManager(benthosName),
 		window:                benthosmetrics.NewBenthosMetricsState(),
+		fsmv2Watcher:          defaultBenthosMonitorWatcher{},
 	}
 
 	// Apply options
@@ -622,6 +648,58 @@ func (s *BenthosService) GetHealthCheckAndMetrics(ctx context.Context, filesyste
 
 	// Get the last observed state of the benthos monitor
 	s6ServiceName := s.GetS6ServiceName(benthosName)
+
+	if fsmv2BenthosMonitorEnabled {
+		// FF-on: read the benthos_monitor worker's published
+		// BenthosMonitorStatus through the fsmv2 watcher instead of the v1
+		// monitor manager. The ref Name MUST be s6ServiceName ("benthos-"+name)
+		// — the monitor FSM keys on it; using raw benthosName makes Contains
+		// false and every read returns Unregistered.
+		ref := dynamicchildren.Ref{WorkerType: "benthos_monitor", Name: s6ServiceName}
+
+		status, res, err := s.fsmv2Watcher.GetFresh(ctx, ref, benthosMonitorMaxAge)
+		if err != nil {
+			// Unknown: GetFresh could not classify the observation (store read
+			// error). Return it raw; reconcile.go catches this non-fatally so
+			// the read path degrades rather than fatals.
+			return BenthosStatus{}, err
+		}
+
+		switch res {
+		case fsmv2client.Fresh:
+			if status.Stopped {
+				// v6.1c: a stopped bridge is Fresh + Stopped=true — the worker
+				// skipped the scrape so Scan is the zero value. Do NOT treat
+				// IsLive=false as Degraded; return a not-unhealthy empty status.
+				return BenthosStatus{}, nil
+			}
+
+			// C2: feed the window ONLY when the scrape produced metrics, so a
+			// benthos-down observation (MetricsAvailable=false) does not freeze
+			// the throughput window on a counter-reset spike.
+			if status.Scan.MetricsAvailable {
+				s.window.UpdateFromMetrics(status.Scan.Metrics, tick)
+			}
+
+			// C3: no last-good cache — the store IS the cache via the Stale
+			// branch (R3). Return the raw IsLive with no debounce.
+			return BenthosStatus{
+				HealthCheck: status.Scan.HealthCheck,
+				BenthosMetrics: benthosmetrics.BenthosMetrics{
+					Metrics:      status.Scan.Metrics,
+					MetricsState: s.window,
+				},
+			}, nil
+
+		default:
+			// Stale / Unregistered / NeverObserved — R2-R7 fill these in.
+			// TODO(R2-R7): Stale→serve the stale obs GetFresh returned + override
+			// IsLive=false (NO cache — C3: the store is the cache via this branch);
+			// Unregistered/NeverObserved→serve empty/not-ready (warming); Unknown
+			// is already handled above (err != nil).
+			return BenthosStatus{}, nil
+		}
+	}
 
 	lastObservedState, err := s.benthosMonitorManager.GetLastObservedState(s6ServiceName)
 	if err != nil {

--- a/umh-core/pkg/service/benthos/benthos.go
+++ b/umh-core/pkg/service/benthos/benthos.go
@@ -210,7 +210,7 @@ type BenthosService struct {
 
 	s6Manager *s6fsm.S6Manager
 
-	benthosMonitorManager *benthos_monitor_fsm.BenthosMonitorManager
+	benthosMonitorManager BenthosMonitorReconciler
 
 	// window is the per-bridge BenthosMetricsState owned by BenthosService.
 	// On the FF-off path it is fed from the metrics returned by the S6 monitor
@@ -283,7 +283,7 @@ func WithS6Service(s6Service s6service.Service) BenthosServiceOption {
 }
 
 // WithMonitorManager sets a custom monitor manager for the BenthosService.
-func WithMonitorManager(monitorManager *benthos_monitor_fsm.BenthosMonitorManager) BenthosServiceOption {
+func WithMonitorManager(monitorManager BenthosMonitorReconciler) BenthosServiceOption {
 	return func(s *BenthosService) {
 		s.benthosMonitorManager = monitorManager
 	}
@@ -948,6 +948,13 @@ func (s *BenthosService) RemoveBenthosFromS6Manager(
 	s.s6ServiceConfigs = sliceRemoveByName(s.s6ServiceConfigs, s6Name)
 	s.benthosMonitorConfigs = sliceRemoveMonitorByName(s.benthosMonitorConfigs, s6Name)
 
+	// R9: under FF-on, tell the FSMv2 watcher to drop this child-spec. The ref
+	// Name is s6Name (the s6ServiceName the config was keyed on, NOT raw
+	// benthosName). Idempotent: Delete on an already-removed ref is a no-op.
+	if fsmv2BenthosMonitorEnabled {
+		s.fsmv2Watcher.Delete(dynamicchildren.Ref{WorkerType: "benthos_monitor", Name: s6Name})
+	}
+
 	// ------------------------------------------------------------------
 	// 2) Are the instances already gone?
 	// ------------------------------------------------------------------
@@ -1088,6 +1095,25 @@ func (s *BenthosService) ReconcileManager(ctx context.Context, services servicer
 	s6Err, s6Reconciled := s.s6Manager.Reconcile(ctx, s6Snapshot, services)
 	if s6Err != nil {
 		return fmt.Errorf("failed to reconcile S6 manager: %w", s6Err), false
+	}
+
+	if fsmv2BenthosMonitorEnabled {
+		// R8 + R11: under FF-on, push each monitor config to the FSMv2 watcher
+		// via Upsert and SKIP the S6 monitor manager.Reconcile entirely. The S6
+		// fork tree never spawns — this is the CPU win. Upsert errors are logged
+		// and swallowed (non-fatal): the next tick re-Upserts, so a single bad
+		// config must not fail the whole reconcile.
+		for _, cfg := range s.benthosMonitorConfigs {
+			ref := dynamicchildren.Ref{WorkerType: "benthos_monitor", Name: cfg.Name}
+			if upsertErr := s.fsmv2Watcher.Upsert(ref, map[string]any{
+				"state":       mapFromBenthosMonitorState(cfg.DesiredFSMState),
+				"metricsPort": cfg.MetricsPort,
+			}); upsertErr != nil {
+				s.logger.Errorf("fsmv2 watcher Upsert failed for %s: %v", cfg.Name, upsertErr)
+			}
+		}
+
+		return nil, true
 	}
 
 	// Also reconcile the benthos monitor

--- a/umh-core/pkg/service/benthos/benthos.go
+++ b/umh-core/pkg/service/benthos/benthos.go
@@ -782,7 +782,13 @@ func (s *BenthosService) GetHealthCheckAndMetrics(ctx context.Context, filesyste
 	// window freezes instead of re-feeding last-good every tick (which would
 	// drive MessagesPerTick to 0).
 	lastScan := lastBenthosMonitorObservedState.ServiceInfo.BenthosStatus.LastScan
-	if lastScan.LastUpdatedAt.After(s.lastFedScanAt) {
+	// Feed only when the scan's LastUpdatedAt CHANGED since the last feed
+	// (not strictly advancing): a backwards NTP step produces a fresh scan
+	// whose timestamp is older than the prior peak, and that must still feed
+	// (the throughput math uses count + monotonic read tick, not LastUpdatedAt).
+	// Same timestamp → Equal → skip (freezes the window on a retained
+	// last-good outage).
+	if !lastScan.LastUpdatedAt.Equal(s.lastFedScanAt) {
 		s.window.UpdateFromMetrics(benthosStatus.BenthosMetrics.Metrics, tick)
 		s.lastFedScanAt = lastScan.LastUpdatedAt
 	}

--- a/umh-core/pkg/service/benthos/fsmv2_watcher.go
+++ b/umh-core/pkg/service/benthos/fsmv2_watcher.go
@@ -1,0 +1,96 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package benthos
+
+// This file defines the FSMv2 benthos_monitor watcher seam: the interface the
+// BenthosService read/lifecycle paths call behind USE_FSMV2_BENTHOS_MONITOR,
+// the production default that delegates to the process-scoped fsmv2client, and
+// the feature-flag cache. The monitor→worker state vocabulary translation
+// (mapFrom) lands in R8 alongside its first call site. The seam is wired into
+// GetHealthCheckAndMetrics by the PR3b rungs; FF-off stays byte-identical
+// because every branch is guarded by fsmv2BenthosMonitorEnabled.
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/env"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/fsmv2client"
+	bmworker "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/benthos_monitor"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/configworker/dynamicchildren"
+)
+
+// fsmv2BenthosMonitorEnabled gates the FF-on read + lifecycle paths. It is read
+// once at package init from USE_FSMV2_BENTHOS_MONITOR (default OFF). env.GetAsBool
+// reads os.Getenv directly (no config-file parsing), so init-time is correct and
+// the value is fixed for the process lifetime. It is NOT threaded through
+// NewBenthosManager (honors C-Inject: the CPU-target benthos runs through the
+// DataFlowComponent manager, which the ctor wouldn't reach).
+var fsmv2BenthosMonitorEnabled bool
+
+func init() {
+	// required=false ⇒ never errors; silently falls back to the default (OFF).
+	fsmv2BenthosMonitorEnabled, _ = env.GetAsBool("USE_FSMV2_BENTHOS_MONITOR", false, false)
+}
+
+// benthosMonitorWatcher is the seam the BenthosService FF-on paths call. The
+// production default (defaultBenthosMonitorWatcher) delegates to the
+// process-scoped fsmv2client; tests inject a fake via WithFSMv2BenthosWatcher.
+//
+// GetFresh returns the worker's published BenthosMonitorStatus{Scan, Stopped}
+// (NOT a bare Scan — Scan has no Stopped field, and decoding the flat
+// {scan,stopped} JSON into a bare Scan yields a zero Scan for every bridge,
+// breaking v6.1c). Upsert/Delete drive the watcher's child-spec lifecycle.
+type benthosMonitorWatcher interface {
+	GetFresh(ctx context.Context, ref dynamicchildren.Ref, maxAge time.Duration) (bmworker.BenthosMonitorStatus, fsmv2client.Freshness, error)
+	Upsert(ref dynamicchildren.Ref, cfg map[string]any) error
+	Delete(ref dynamicchildren.Ref)
+}
+
+// defaultBenthosMonitorWatcher is the production implementation: it reaches the
+// process-scoped fsmv2client singleton published at startup (inside the
+// USE_FSMV2_TRANSPORT block, cmd/main.go:278/644). USE_FSMV2_BENTHOS_MONITOR=ON
+// therefore REQUIRES USE_FSMV2_TRANSPORT=ON — if the client is nil (transport FF
+// off / supervisor not built), every method fails soft (GetFresh → Unknown+err,
+// Upsert → err, Delete → no-op) rather than dereferencing nil.
+type defaultBenthosMonitorWatcher struct{}
+
+func (defaultBenthosMonitorWatcher) GetFresh(ctx context.Context, ref dynamicchildren.Ref, maxAge time.Duration) (bmworker.BenthosMonitorStatus, fsmv2client.Freshness, error) {
+	c := fsmv2client.GetClient()
+	if c == nil {
+		return bmworker.BenthosMonitorStatus{}, fsmv2client.Unknown, errors.New("fsmv2 client not initialized (USE_FSMV2_TRANSPORT off?)")
+	}
+
+	return fsmv2client.GetFresh[bmworker.BenthosMonitorStatus](ctx, c, ref, maxAge)
+}
+
+func (defaultBenthosMonitorWatcher) Upsert(ref dynamicchildren.Ref, cfg map[string]any) error {
+	c := fsmv2client.GetClient()
+	if c == nil {
+		return errors.New("fsmv2 client not initialized (USE_FSMV2_TRANSPORT off?)")
+	}
+
+	return c.Upsert(ref, cfg)
+}
+
+func (defaultBenthosMonitorWatcher) Delete(ref dynamicchildren.Ref) {
+	c := fsmv2client.GetClient()
+	if c == nil {
+		return
+	}
+
+	c.Delete(ref)
+}

--- a/umh-core/pkg/service/benthos/fsmv2_watcher.go
+++ b/umh-core/pkg/service/benthos/fsmv2_watcher.go
@@ -18,9 +18,8 @@ package benthos
 // BenthosService read/lifecycle paths call behind USE_FSMV2_BENTHOS_MONITOR,
 // the production default that delegates to the process-scoped fsmv2client, and
 // the feature-flag cache. The monitor→worker state vocabulary translation
-// (mapFrom) lands in R8 alongside its first call site. The seam is wired into
-// GetHealthCheckAndMetrics by the PR3b rungs; FF-off stays byte-identical
-// because every branch is guarded by fsmv2BenthosMonitorEnabled.
+// (mapFrom) sits alongside its first call site below. Every branch is guarded
+// by fsmv2BenthosMonitorEnabled, so FF-off is byte-identical to the v1 path.
 
 import (
 	"context"
@@ -40,8 +39,9 @@ import (
 // once at package init from USE_FSMV2_BENTHOS_MONITOR (default OFF). env.GetAsBool
 // reads os.Getenv directly (no config-file parsing), so init-time is correct and
 // the value is fixed for the process lifetime. It is NOT threaded through
-// NewBenthosManager (honors C-Inject: the CPU-target benthos runs through the
-// DataFlowComponent manager, which the ctor wouldn't reach).
+// NewBenthosManager: the CPU-target benthos runs through the DataFlowComponent
+// manager, which the constructor would not reach, so a process-scoped flag is
+// the only thing every BenthosService instance sees.
 var fsmv2BenthosMonitorEnabled bool
 
 func init() {
@@ -53,10 +53,11 @@ func init() {
 // production default (defaultBenthosMonitorWatcher) delegates to the
 // process-scoped fsmv2client; tests inject a fake via WithFSMv2BenthosWatcher.
 //
-// GetFresh returns the worker's published BenthosMonitorStatus{Scan, Stopped}
-// (NOT a bare Scan — Scan has no Stopped field, and decoding the flat
-// {scan,stopped} JSON into a bare Scan yields a zero Scan for every bridge,
-// breaking v6.1c). Upsert/Delete drive the watcher's child-spec lifecycle.
+// GetFresh returns the worker's published BenthosMonitorStatus{Scan, Stopped}.
+// It must NOT decode into a bare Scan: Scan has no Stopped field, and decoding
+// the flat {scan,stopped} JSON into a bare Scan yields a zero Scan for every
+// bridge (a stopped bridge would lose its Stopped flag). Upsert/Delete drive
+// the watcher's child-spec lifecycle.
 type benthosMonitorWatcher interface {
 	GetFresh(ctx context.Context, ref dynamicchildren.Ref, maxAge time.Duration) (bmworker.BenthosMonitorStatus, fsmv2client.Freshness, error)
 	Upsert(ref dynamicchildren.Ref, cfg map[string]any) error
@@ -66,9 +67,9 @@ type benthosMonitorWatcher interface {
 // BenthosMonitorReconciler is the subset of *BenthosMonitorManager that
 // BenthosService calls. Defining it as an interface (rather than the concrete
 // *benthos_monitor_fsm.BenthosMonitorManager pointer) lets tests inject a fake
-// that records Reconcile calls — which is how R11 asserts the FF-on path SKIPS
-// the S6 monitor reconcile. The concrete manager satisfies this interface via
-// its embedded *fsm.BaseFSMManager. The FF-off call sites are byte-identical
+// that records Reconcile calls — which is how the FF-on path is asserted to
+// SKIP the S6 monitor reconcile. The concrete manager satisfies this interface
+// via its embedded *fsm.BaseFSMManager. The FF-off call sites are byte-identical
 // whether the field holds a concrete pointer or this interface.
 type BenthosMonitorReconciler interface {
 	Reconcile(ctx context.Context, snapshot public_fsm.SystemSnapshot, services serviceregistry.Provider) (error, bool)

--- a/umh-core/pkg/service/benthos/fsmv2_watcher.go
+++ b/umh-core/pkg/service/benthos/fsmv2_watcher.go
@@ -29,6 +29,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/env"
 	public_fsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
 	benthos_monitor_fsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/benthos_monitor"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/config"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/fsmv2client"
 	bmworker "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/benthos_monitor"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/configworker/dynamicchildren"
@@ -113,23 +114,25 @@ func (defaultBenthosMonitorWatcher) Delete(ref dynamicchildren.Ref) {
 }
 
 // mapFromBenthosMonitorState translates a benthos_monitor desired FSM state
-// (the vocabulary the v1 monitor manager used) into the worker's child-spec
-// state vocabulary that the dynamicchildren Upsert expects.
+// (the vocabulary the v1 monitor manager used) into the child-spec desired
+// state vocabulary (config.DesiredStateRunning / config.DesiredStateStopped)
+// that the dynamicchildren Upsert stores on BaseUserSpec.State.
 //
-// "active" maps to "running" (the monitor is running and metrics are OK).
-// "benthos_monitoring_stopped", "benthos_monitoring_stopping", and
-// "benthos_monitoring_starting" all map to "stopped" (the monitor is not in a
-// steady running state). Any other value (including lifecycle states and
-// "degraded") defaults to "stopped".
+// "active" maps to DesiredStateRunning. "benthos_monitoring_stopped",
+// "benthos_monitoring_stopping", and "benthos_monitoring_starting" all map to
+// DesiredStateStopped (the monitor is not in a steady running state). Any
+// other value (including lifecycle states and "degraded") defaults to
+// DesiredStateStopped. Returning the typed constants means a typo in the
+// return value is a compile error, not a silently misrouted child lifecycle.
 func mapFromBenthosMonitorState(state string) string {
 	switch state {
 	case benthos_monitor_fsm.OperationalStateActive:
-		return "running"
+		return config.DesiredStateRunning
 	case benthos_monitor_fsm.OperationalStateStopped,
 		benthos_monitor_fsm.OperationalStateStopping,
 		benthos_monitor_fsm.OperationalStateStarting:
-		return "stopped"
+		return config.DesiredStateStopped
 	default:
-		return "stopped"
+		return config.DesiredStateStopped
 	}
 }

--- a/umh-core/pkg/service/benthos/fsmv2_watcher.go
+++ b/umh-core/pkg/service/benthos/fsmv2_watcher.go
@@ -68,7 +68,7 @@ type benthosMonitorWatcher interface {
 // BenthosMonitorReconciler is the subset of *BenthosMonitorManager that
 // BenthosService calls. Defining it as an interface (rather than the concrete
 // *benthos_monitor_fsm.BenthosMonitorManager pointer) lets tests inject a fake
-// that records Reconcile calls — which is how the FF-on path is asserted to
+// that records Reconcile calls, which is how the FF-on path is asserted to
 // SKIP the S6 monitor reconcile. The concrete manager satisfies this interface
 // via its embedded *fsm.BaseFSMManager. The FF-off call sites are byte-identical
 // whether the field holds a concrete pointer or this interface.
@@ -81,7 +81,7 @@ type BenthosMonitorReconciler interface {
 // defaultBenthosMonitorWatcher is the production implementation: it reaches the
 // process-scoped fsmv2client singleton published at startup (inside the
 // USE_FSMV2_TRANSPORT block, cmd/main.go:278/644). USE_FSMV2_BENTHOS_MONITOR=ON
-// therefore REQUIRES USE_FSMV2_TRANSPORT=ON — if the client is nil (transport FF
+// therefore REQUIRES USE_FSMV2_TRANSPORT=ON; if the client is nil (transport FF
 // off / supervisor not built), every method fails soft (GetFresh → Unknown+err,
 // Upsert → err, Delete → no-op) rather than dereferencing nil.
 type defaultBenthosMonitorWatcher struct{}

--- a/umh-core/pkg/service/benthos/fsmv2_watcher.go
+++ b/umh-core/pkg/service/benthos/fsmv2_watcher.go
@@ -28,9 +28,12 @@ import (
 	"time"
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/env"
+	public_fsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
+	benthos_monitor_fsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/benthos_monitor"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/fsmv2client"
 	bmworker "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/benthos_monitor"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/configworker/dynamicchildren"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/serviceregistry"
 )
 
 // fsmv2BenthosMonitorEnabled gates the FF-on read + lifecycle paths. It is read
@@ -58,6 +61,19 @@ type benthosMonitorWatcher interface {
 	GetFresh(ctx context.Context, ref dynamicchildren.Ref, maxAge time.Duration) (bmworker.BenthosMonitorStatus, fsmv2client.Freshness, error)
 	Upsert(ref dynamicchildren.Ref, cfg map[string]any) error
 	Delete(ref dynamicchildren.Ref)
+}
+
+// BenthosMonitorReconciler is the subset of *BenthosMonitorManager that
+// BenthosService calls. Defining it as an interface (rather than the concrete
+// *benthos_monitor_fsm.BenthosMonitorManager pointer) lets tests inject a fake
+// that records Reconcile calls — which is how R11 asserts the FF-on path SKIPS
+// the S6 monitor reconcile. The concrete manager satisfies this interface via
+// its embedded *fsm.BaseFSMManager. The FF-off call sites are byte-identical
+// whether the field holds a concrete pointer or this interface.
+type BenthosMonitorReconciler interface {
+	Reconcile(ctx context.Context, snapshot public_fsm.SystemSnapshot, services serviceregistry.Provider) (error, bool)
+	GetInstance(name string) (public_fsm.FSMInstance, bool)
+	GetLastObservedState(serviceName string) (public_fsm.ObservedState, error)
 }
 
 // defaultBenthosMonitorWatcher is the production implementation: it reaches the
@@ -93,4 +109,26 @@ func (defaultBenthosMonitorWatcher) Delete(ref dynamicchildren.Ref) {
 	}
 
 	c.Delete(ref)
+}
+
+// mapFromBenthosMonitorState translates a benthos_monitor desired FSM state
+// (the vocabulary the v1 monitor manager used) into the worker's child-spec
+// state vocabulary that the dynamicchildren Upsert expects.
+//
+// "active" maps to "running" (the monitor is running and metrics are OK).
+// "benthos_monitoring_stopped", "benthos_monitoring_stopping", and
+// "benthos_monitoring_starting" all map to "stopped" (the monitor is not in a
+// steady running state). Any other value (including lifecycle states and
+// "degraded") defaults to "stopped".
+func mapFromBenthosMonitorState(state string) string {
+	switch state {
+	case benthos_monitor_fsm.OperationalStateActive:
+		return "running"
+	case benthos_monitor_fsm.OperationalStateStopped,
+		benthos_monitor_fsm.OperationalStateStopping,
+		benthos_monitor_fsm.OperationalStateStarting:
+		return "stopped"
+	default:
+		return "stopped"
+	}
 }

--- a/umh-core/pkg/service/benthos/fsmv2_watcher_gate.go
+++ b/umh-core/pkg/service/benthos/fsmv2_watcher_gate.go
@@ -1,0 +1,29 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package benthos
+
+// EnableFSMv2BenthosMonitorForTest exposes the package-private
+// fsmv2BenthosMonitorEnabled flag as a settable pointer so external test
+// packages (integration_test) can arm the FF-on read/lifecycle paths without
+// touching USE_FSMV2_BENTHOS_MONITOR at the process level.
+//
+// This is a test-gate seam, not a behavior change: production code never reads
+// this variable, only the flag it points at. It is a non-test file (rather than
+// an export_test.go) solely because Go compiles a package's _test.go files only
+// into that package's own test binary — an export_test.go in package benthos is
+// invisible to pkg/fsmv2/integration's test binary, so it cannot flip the flag
+// cross-package. A non-test file is the minimal seam that satisfies the
+// cross-package access requirement while changing no FF-off behavior.
+var EnableFSMv2BenthosMonitorForTest = &fsmv2BenthosMonitorEnabled

--- a/umh-core/pkg/service/benthos/fsmv2_watcher_test.go
+++ b/umh-core/pkg/service/benthos/fsmv2_watcher_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -27,9 +28,13 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/fsmv2client"
 	bmworker "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/benthos_monitor"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/configworker/dynamicchildren"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/sentry"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/benthos_monitor"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/benthosmetrics"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/serviceregistry"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 // fakeBenthosMonitorWatcher is a test double for benthosMonitorWatcher. It
@@ -1075,4 +1080,122 @@ func TestFSMv2Watcher_DefaultWatcher_NilClientSoftFails(t *testing.T) {
 	}()
 
 	w.Delete(ref)
+}
+
+// upsertSeqWatcher is a benthosMonitorWatcher whose Upsert returns the next
+// error in upsertErrs, then nil once the sequence is exhausted. GetFresh/Delete
+// are unused by ReconcileManager. Used to drive the FF-on Upsert loop through a
+// run of consecutive failures and then a success.
+type upsertSeqWatcher struct {
+	upsertErrs []error
+	calls      int
+}
+
+func (w *upsertSeqWatcher) GetFresh(context.Context, dynamicchildren.Ref, time.Duration) (bmworker.BenthosMonitorStatus, fsmv2client.Freshness, error) {
+	return bmworker.BenthosMonitorStatus{}, fsmv2client.Unknown, nil
+}
+
+func (w *upsertSeqWatcher) Upsert(dynamicchildren.Ref, map[string]any) error {
+	i := w.calls
+	w.calls++
+
+	if i < len(w.upsertErrs) {
+		return w.upsertErrs[i]
+	}
+
+	return nil
+}
+
+func (w *upsertSeqWatcher) Delete(dynamicchildren.Ref) {}
+
+// TestFSMv2Watcher_ReconcileManager_FFOn_UpsertStuckWarnsAtThreshold verifies
+// the stuck-Upsert signal: a bridge whose watcher.Upsert fails on every
+// reconcile for upsertStuckThreshold consecutive ticks emits ONE distinct
+// warning (not a per-tick flood), and the counter resets on the next
+// successful Upsert. Reconcile stays non-fatal throughout (returns nil, true).
+//
+// The service logger is replaced with a zap observer so the Warn-level report
+// emitted by sentry.ReportIssuef(IssueTypeWarning) is observable. Sentry's
+// warning debounce is disabled (InitSentry("", false), which short-circuits
+// before initializing the Sentry client, so no network) so the threshold
+// crossing is emitted; restored in t.Cleanup.
+func TestFSMv2Watcher_ReconcileManager_FFOn_UpsertStuckWarnsAtThreshold(t *testing.T) {
+	prev := fsmv2BenthosMonitorEnabled
+	fsmv2BenthosMonitorEnabled = true
+
+	t.Cleanup(func() { fsmv2BenthosMonitorEnabled = prev })
+
+	// Disable Sentry's 2h warning debounce so the threshold crossing is emitted;
+	// InitSentry("") short-circuits before initializing the Sentry client.
+	sentry.InitSentry("", false)
+	t.Cleanup(func() { sentry.InitSentry("", true) })
+
+	core, logs := observer.New(zapcore.WarnLevel)
+	watcher := &upsertSeqWatcher{
+		upsertErrs: []error{
+			errors.New("upsert failed 1"),
+			errors.New("upsert failed 2"),
+			errors.New("upsert failed 3"),
+			// 4th call succeeds: counter resets.
+		},
+	}
+	s := NewDefaultBenthosService("test",
+		WithFSMv2BenthosWatcher(watcher),
+		WithMonitorManager(&fakeBenthosMonitorManager{}),
+	)
+	s.logger = zap.New(core).Sugar()
+	s.benthosMonitorConfigs = []config.BenthosMonitorConfig{
+		{
+			FSMInstanceConfig: config.FSMInstanceConfig{
+				Name:            "benthos-stuck",
+				DesiredFSMState: benthos_monitor_fsm.OperationalStateActive,
+			},
+			MetricsPort: 4195,
+		},
+	}
+
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(100*time.Second))
+	defer cancel()
+
+	snap := public_fsm.SystemSnapshot{Tick: 1, SnapshotTime: time.Now()}
+	registry := serviceregistry.NewMockRegistry()
+
+	// Ticks 1-3: Upsert fails. The 3rd failure crosses the threshold and emits
+	// one warning; reconcile stays non-fatal.
+	for tick := uint64(1); tick <= 3; tick++ {
+		snap.Tick = tick
+
+		err, _ := s.ReconcileManager(ctx, registry, snap)
+		if err != nil {
+			t.Fatalf("tick %d: ReconcileManager err = %v, want nil (Upsert failure is non-fatal)", tick, err)
+		}
+	}
+
+	if got := s.upsertFailures["benthos-stuck"]; got != upsertStuckThreshold {
+		t.Errorf("upsertFailures after 3 failures = %d, want %d", got, upsertStuckThreshold)
+	}
+
+	warns := logs.FilterLevelExact(zapcore.WarnLevel).All()
+	if len(warns) != 1 {
+		t.Fatalf("warn logs after 3 failures = %d, want 1 (one distinct stuck signal, not a per-tick flood); got %#v",
+			len(warns), warns)
+	}
+
+	if msg := warns[0].Message; !strings.Contains(msg, "benthos-stuck") || !strings.Contains(msg, "Upsert stuck") {
+		t.Errorf("warn message = %q, want substrings \"benthos-stuck\" and \"Upsert stuck\"", msg)
+	}
+
+	// Tick 4: Upsert succeeds. The counter resets and no NEW warning fires.
+	snap.Tick = 4
+	if err, _ := s.ReconcileManager(ctx, registry, snap); err != nil {
+		t.Fatalf("tick 4: ReconcileManager err = %v, want nil", err)
+	}
+
+	if _, ok := s.upsertFailures["benthos-stuck"]; ok {
+		t.Errorf("upsertFailures still has benthos-stuck after a successful Upsert (counter must reset)")
+	}
+
+	if got := logs.FilterLevelExact(zapcore.WarnLevel).Len(); got != 1 {
+		t.Errorf("warn logs after recovery = %d, want 1 (the successful Upsert must not emit a new warning)", got)
+	}
 }

--- a/umh-core/pkg/service/benthos/fsmv2_watcher_test.go
+++ b/umh-core/pkg/service/benthos/fsmv2_watcher_test.go
@@ -851,3 +851,80 @@ func TestFSMv2Watcher_GetHealthCheckAndMetrics_FFOff_OutageFreezesWindow(t *test
 		t.Errorf("step 3: len(window.Input.Window) = %d, want >= 2 (count 20 > last 18 must NOT trip the counter-reset wipe)", len(s.window.Input.Window))
 	}
 }
+
+// TestFSMv2Watcher_GetHealthCheckAndMetrics_FFOff_FreshScanSameCountFeeds is the
+// triangulation companion to OutageFreezesWindow. It discriminates the
+// LastUpdatedAt-advancement gate (the shipped M1 fix) from a wrong
+// count-change gate ("feed only when count != LastCount"): a fresh, healthy
+// scan whose count is UNCHANGED (benthos up, producing fresh scans, but no new
+// messages arrived) must STILL feed the window — advancing LastTick and
+// recording MessagesPerTick=0 for the idle interval (the truthful rate).
+//
+// The OutageFreezesWindow test cannot tell the two gates apart because its
+// outage holds BOTH LastUpdatedAt and count fixed, and its recovery advances
+// BOTH. A count-change gate would green OutageFreezesWindow (count unchanged →
+// no feed → freeze) while REGRESSING this healthy-idle case (count unchanged →
+// no feed → LastTick stalls → throughput window freezes at a stale rate even
+// though benthos is healthy and publishing fresh scans).
+//
+// Forcing assertion: after a fresh scan with LastUpdatedAt advanced (t2) but
+// count still 18, s.window.LastTick MUST advance past the prior feed tick AND
+// MessagesPerTick MUST be 0 (the truthful idle rate), NOT the retained
+// pre-idle rate. A count-change gate would leave LastTick frozen + the rate
+// retained → fails RED.
+func TestFSMv2Watcher_GetHealthCheckAndMetrics_FFOff_FreshScanSameCountFeeds(t *testing.T) {
+	prev := fsmv2BenthosMonitorEnabled
+	fsmv2BenthosMonitorEnabled = false
+
+	t.Cleanup(func() { fsmv2BenthosMonitorEnabled = prev })
+
+	const benthosName = "testbridge"
+
+	t1 := time.Now()
+	t2 := t1.Add(time.Second) // fresh scan: LastUpdatedAt advanced, count UNCHANGED
+
+	monMgr := &fakeBenthosMonitorManager{
+		observedStates: []public_fsm.ObservedState{
+			ffOffObservedState(t1, 18, true), // tick 1: healthy, count=18
+			ffOffObservedState(t2, 18, true), // tick 2: fresh scan (t2 advanced), count STILL 18 (idle)
+		},
+	}
+	s := NewDefaultBenthosService(benthosName, WithMonitorManager(monMgr))
+	s.s6Manager.AddInstanceForTest(s.GetS6ServiceName(benthosName), nil)
+
+	// Tick 1: healthy scan seeds the window (count=18, non-zero rate).
+	const tick1 uint64 = 1
+	if _, err := s.GetHealthCheckAndMetrics(context.Background(), nil, tick1, time.Now(), benthosName, nil); err != nil {
+		t.Fatalf("tick 1: err = %v, want nil", err)
+	}
+
+	if s.window.Input.LastCount != 18 {
+		t.Fatalf("tick 1: LastCount = %d, want 18 (healthy scan must seed the window)", s.window.Input.LastCount)
+	}
+
+	// Tick 2: fresh scan (LastUpdatedAt advanced to t2) with count UNCHANGED.
+	// The LastUpdatedAt-advancement gate MUST feed — the scan is fresh even
+	// though idle. LastTick advances; MessagesPerTick is 0 (countDiff=0 over
+	// the interval — the truthful idle rate). A count-change gate would NOT
+	// feed (count unchanged) → LastTick stays at tick1 + the rate stays
+	// non-zero → this assertion fails.
+	const tick2 uint64 = 2
+	if _, err := s.GetHealthCheckAndMetrics(context.Background(), nil, tick2, time.Now(), benthosName, nil); err != nil {
+		t.Fatalf("tick 2: err = %v, want nil (fresh idle scan is served, not an error)", err)
+	}
+
+	if s.window.LastTick != tick2 {
+		t.Errorf("tick 2: window.LastTick = %d, want %d (a fresh scan MUST feed even when count is unchanged — the LastUpdatedAt-advancement gate fires; a count-change gate would leave it frozen at tick1)",
+			s.window.LastTick, tick2)
+	}
+
+	if s.window.Input.MessagesPerTick != 0 {
+		t.Errorf("tick 2: MessagesPerTick = %v, want 0 (fresh idle scan: count unchanged over the interval → the truthful rate is 0; a count-change gate would retain the stale non-zero rate)",
+			s.window.Input.MessagesPerTick)
+	}
+
+	// LastCount must still be 18 (no counter-reset: 18 is not < 18).
+	if s.window.Input.LastCount != 18 {
+		t.Errorf("tick 2: LastCount = %d, want 18 (unchanged count must not trip counter-reset)", s.window.Input.LastCount)
+	}
+}

--- a/umh-core/pkg/service/benthos/fsmv2_watcher_test.go
+++ b/umh-core/pkg/service/benthos/fsmv2_watcher_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/fsmv2client"
 	bmworker "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/benthos_monitor"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/configworker/dynamicchildren"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/benthos_monitor"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/benthosmetrics"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/serviceregistry"
 )
@@ -400,10 +401,17 @@ func TestFSMv2Watcher_GetHealthCheckAndMetrics_Fresh_Stopped_NotUnhealthy(t *tes
 
 // fakeBenthosMonitorManager is a test double for BenthosMonitorReconciler. It
 // records Reconcile calls so the R11 test can assert the FF-on path SKIPS the
-// S6 monitor reconcile. GetInstance and GetLastObservedState return
-// not-found/nil so the Remove path proceeds to the window reset.
+// S6 monitor reconcile. GetInstance returns not-found so the Remove path
+// proceeds to the window reset.
+//
+// GetLastObservedState drains a queue of scripted observed states
+// (observedStates) so the FF-off down→recovery parity test can drive the read
+// path through a healthy scan, a retained-last-good outage, and a fresh
+// recovery scan. When the queue is empty it returns (nil, nil) — preserving
+// the behavior the R10/R11 tests rely on.
 type fakeBenthosMonitorManager struct {
 	reconcileCalls int
+	observedStates []public_fsm.ObservedState
 }
 
 func (f *fakeBenthosMonitorManager) Reconcile(_ context.Context, _ public_fsm.SystemSnapshot, _ serviceregistry.Provider) (error, bool) {
@@ -417,7 +425,14 @@ func (f *fakeBenthosMonitorManager) GetInstance(_ string) (public_fsm.FSMInstanc
 }
 
 func (f *fakeBenthosMonitorManager) GetLastObservedState(_ string) (public_fsm.ObservedState, error) {
-	return nil, nil
+	if len(f.observedStates) == 0 {
+		return nil, nil
+	}
+
+	state := f.observedStates[0]
+	f.observedStates = f.observedStates[1:]
+
+	return state, nil
 }
 
 // TestFSMv2Watcher_ReconcileManager_FFOn_UpsertsEachConfig_SkipsS6MonitorReconcile
@@ -669,5 +684,170 @@ func TestFSMv2Watcher_Remove_FFOn_ResetsWindow(t *testing.T) {
 
 	if s.window.IsActive {
 		t.Errorf("window.IsActive = true, want false (fresh window must be inactive)")
+	}
+}
+
+// ffOffObservedState builds a BenthosMonitorObservedState carrying a single
+// input scan with the given LastUpdatedAt, received-count, and liveness. The
+// monitor FSM is marked Running (the FF-off read path's IsRunning guard at
+// benthos.go:752 must pass for the feed site at :762 to be reached). Used by
+// the FF-off down→recovery parity test to script the monitor's
+// GetLastObservedState return values across the healthy → outage → recovery
+// sequence.
+func ffOffObservedState(lastUpdatedAt time.Time, count int64, isLive bool) benthos_monitor_fsm.BenthosMonitorObservedState {
+	return benthos_monitor_fsm.BenthosMonitorObservedState{
+		ServiceInfo: &benthos_monitor.ServiceInfo{
+			BenthosStatus: benthos_monitor.BenthosMonitorStatus{
+				IsRunning: true,
+				LastScan: &benthos_monitor.BenthosMetricsScan{
+					LastUpdatedAt: lastUpdatedAt,
+					HealthCheck: benthosmetrics.HealthCheck{
+						IsLive:  isLive,
+						IsReady: true,
+					},
+					BenthosMetrics: &benthos_monitor.BenthosMetrics{
+						Metrics: benthosmetrics.Metrics{
+							Inputs: map[string]benthosmetrics.InputInstance{
+								"in1": {Received: count},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// TestFSMv2Watcher_GetHealthCheckAndMetrics_FFOff_OutageFreezesWindow is the
+// FF-off mirror of the R12a capstone. It pins the M1 parity fix: the A1
+// window-move relocated the throughput feed from monitor-side
+// ProcessMetricsData (fired only on a successful parse) to
+// GetHealthCheckAndMetrics (benthos.go:762, every read tick). On a benthos-down
+// outage the monitor retains last-good (UpdateObservedStateOfInstance returns
+// err without updating ObservedState.ServiceInfo), so LastScan.LastUpdatedAt
+// stops advancing. The feed must therefore be gated on scan-freshness — feeding
+// only when LastUpdatedAt advances since the last feed — so the window FREEZES
+// on outage (MessagesPerTick retains its pre-outage value) instead of re-feeding
+// last-good every tick (which would drive MessagesPerTick to 0).
+//
+// Sequence:
+//  1. Healthy tick (count=18, t1): window fed, MetricsState non-nil, IsLive.
+//  2. Outage ticks 2-5: monitor RETAINS the same last-good scan (same t1, same
+//     count=18, IsRunning=true). The window must FREEZE — MessagesPerTick
+//     retains the pre-outage value and LastTick does not advance past tick 1.
+//     THIS IS THE RED ASSERTION: on the ungated code the re-feed drives
+//     MessagesPerTick to 0 and advances LastTick, so these fail.
+//  3. Recovery tick (count=20, t2 advanced): window fed the new scan, no
+//     counter-reset wipe (20 > 18 → LastCount advances to 20), IsLive.
+//
+// Forcing assertion: MessagesPerTick after the outage == the pre-outage value
+// (NOT 0) AND s.window.LastTick == the healthy tick. Without the
+// LastUpdatedAt gate at benthos.go:762, the outage re-feeds last-good every
+// tick → count==LastCount → MessagesPerTick drops to 0 → fails RED.
+func TestFSMv2Watcher_GetHealthCheckAndMetrics_FFOff_OutageFreezesWindow(t *testing.T) {
+	prev := fsmv2BenthosMonitorEnabled
+	fsmv2BenthosMonitorEnabled = false
+
+	t.Cleanup(func() { fsmv2BenthosMonitorEnabled = prev })
+
+	const benthosName = "testbridge"
+
+	t1 := time.Now()
+	t2 := t1.Add(time.Second)
+
+	monMgr := &fakeBenthosMonitorManager{
+		observedStates: []public_fsm.ObservedState{
+			ffOffObservedState(t1, 18, true), // tick 1: healthy
+			ffOffObservedState(t1, 18, true), // ticks 2-5: retained last-good
+			ffOffObservedState(t1, 18, true),
+			ffOffObservedState(t1, 18, true),
+			ffOffObservedState(t1, 18, true),
+			ffOffObservedState(t2, 20, true), // tick 6: recovery (fresh scan)
+		},
+	}
+	s := NewDefaultBenthosService(benthosName, WithMonitorManager(monMgr))
+
+	// The GetInstance guard runs before the FF-off branch, so the s6 service
+	// must be registered for the read path to reach the monitor manager.
+	s.s6Manager.AddInstanceForTest(s.GetS6ServiceName(benthosName), nil)
+
+	// --- Step 1: healthy tick (count=18, t1) — window fed ---
+	const healthyTick uint64 = 1
+
+	got1, err := s.GetHealthCheckAndMetrics(context.Background(), nil, healthyTick, time.Now(), benthosName, nil)
+	if err != nil {
+		t.Fatalf("step 1: err = %v, want nil", err)
+	}
+
+	if !got1.HealthCheck.IsLive {
+		t.Fatalf("step 1: IsLive = false, want true (healthy scan)")
+	}
+
+	if got1.BenthosMetrics.MetricsState == nil {
+		t.Fatalf("step 1: MetricsState = nil, want the live window (fed on a healthy scan)")
+	}
+
+	if s.window.Input.LastCount != 18 {
+		t.Fatalf("step 1: window.Input.LastCount = %d, want 18 (window must be fed the healthy scan)", s.window.Input.LastCount)
+	}
+
+	preOutageRate := s.window.Input.MessagesPerTick
+	if preOutageRate == 0 {
+		t.Fatalf("step 1: pre-outage MessagesPerTick = 0, want non-zero (healthy scan with count=18 must seed a non-zero rate)")
+	}
+
+	// --- Step 2: outage ticks 2-5 — monitor retains last-good (same t1) ---
+	// The feed must NOT re-feed last-good: the window FREEZES (MessagesPerTick
+	// retains the pre-outage value, LastTick stays at the healthy tick). On the
+	// ungated code the re-feed drives MessagesPerTick to 0 and advances LastTick.
+	for outageTick := uint64(2); outageTick <= 5; outageTick++ {
+		got, err := s.GetHealthCheckAndMetrics(context.Background(), nil, outageTick, time.Now(), benthosName, nil)
+		if err != nil {
+			t.Fatalf("step 2 (tick %d): err = %v, want nil (retained last-good is served, not an error)", outageTick, err)
+		}
+
+		if !got.HealthCheck.IsLive {
+			t.Errorf("step 2 (tick %d): IsLive = false, want true (retained last-good is healthy)", outageTick)
+		}
+	}
+
+	if s.window.LastTick != healthyTick {
+		t.Errorf("step 2: window.LastTick = %d, want %d (the outage must NOT re-feed the window — LastUpdatedAt did not advance)",
+			s.window.LastTick, healthyTick)
+	}
+
+	if s.window.Input.MessagesPerTick != preOutageRate {
+		t.Errorf("step 2: window.Input.MessagesPerTick = %v, want %v (the pre-outage rate must be RETAINED — re-feeding last-good drives it to 0)",
+			s.window.Input.MessagesPerTick, preOutageRate)
+	}
+
+	if s.window.Input.LastCount != 18 {
+		t.Errorf("step 2: window.Input.LastCount = %d, want 18 (LastCount must survive the outage — no counter-reset wipe)", s.window.Input.LastCount)
+	}
+
+	// --- Step 3: recovery tick (count=20, t2 advanced) — window fed, no wipe ---
+	const recoveryTick uint64 = 6
+
+	got3, err := s.GetHealthCheckAndMetrics(context.Background(), nil, recoveryTick, time.Now(), benthosName, nil)
+	if err != nil {
+		t.Fatalf("step 3: err = %v, want nil", err)
+	}
+
+	if !got3.HealthCheck.IsLive {
+		t.Errorf("step 3: IsLive = false, want true (recovery scan is healthy)")
+	}
+
+	if s.window.Input.LastCount != 20 {
+		t.Errorf("step 3: window.Input.LastCount = %d, want 20 (the fresh recovery scan must feed the window)", s.window.Input.LastCount)
+	}
+
+	if s.window.LastTick != recoveryTick {
+		t.Errorf("step 3: window.LastTick = %d, want %d (the fresh recovery scan must advance LastTick)", s.window.LastTick, recoveryTick)
+	}
+
+	// 20 > 18 → counter-reset branch must NOT fire; the pre-outage window
+	// entry survives (the window is not wiped to a single reset entry).
+	if len(s.window.Input.Window) < 2 {
+		t.Errorf("step 3: len(window.Input.Window) = %d, want >= 2 (count 20 > last 18 must NOT trip the counter-reset wipe)", len(s.window.Input.Window))
 	}
 }

--- a/umh-core/pkg/service/benthos/fsmv2_watcher_test.go
+++ b/umh-core/pkg/service/benthos/fsmv2_watcher_test.go
@@ -16,6 +16,7 @@ package benthos
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"testing"
 	"time"
@@ -147,5 +148,231 @@ func TestFSMv2Watcher_GetHealthCheckAndMetrics_FreshReadPath(t *testing.T) {
 
 	if fake.gotMaxAge != benthosMonitorMaxAge {
 		t.Errorf("watcher maxAge = %v, want %v", fake.gotMaxAge, benthosMonitorMaxAge)
+	}
+}
+
+// newFFOnService builds a BenthosService wired to the FF-on read path with the
+// given fake watcher. It registers the s6 instance (the GetInstance guard at
+// the top of GetHealthCheckAndMetrics runs before the FF-on branch) and arms
+// the feature flag with a cleanup that restores the prior value.
+func newFFOnService(t *testing.T, benthosName string, fake *fakeBenthosMonitorWatcher) *BenthosService {
+	t.Helper()
+
+	prev := fsmv2BenthosMonitorEnabled
+	fsmv2BenthosMonitorEnabled = true
+
+	t.Cleanup(func() { fsmv2BenthosMonitorEnabled = prev })
+
+	s := NewDefaultBenthosService(benthosName, WithFSMv2BenthosWatcher(fake))
+	s.s6Manager.AddInstanceForTest(s.GetS6ServiceName(benthosName), nil)
+
+	return s
+}
+
+// nonZeroMetrics returns a Metrics value with a non-zero input so deep-equality
+// can distinguish "served" from "zero/empty" in the assertions.
+func nonZeroMetrics() benthosmetrics.Metrics {
+	return benthosmetrics.Metrics{
+		Inputs: map[string]benthosmetrics.InputInstance{
+			"in1": {Received: 5},
+		},
+	}
+}
+
+// TestFSMv2Watcher_GetHealthCheckAndMetrics_Fresh_NoMetricsAvailable_FreezesWindow
+// pins R1's C2 freeze guard: when the scrape is Fresh but MetricsAvailable is
+// false (benthos down/unreachable), the status is still served but s.window is
+// NOT fed (a counter-reset spike must not freeze the throughput window).
+//
+// Forcing assertion: s.window.LastTick is unchanged across the call. Without
+// the MetricsAvailable gate at benthos.go:680, the feed would advance LastTick
+// to tick and this test would fail.
+func TestFSMv2Watcher_GetHealthCheckAndMetrics_Fresh_NoMetricsAvailable_FreezesWindow(t *testing.T) {
+	const (
+		benthosName        = "testbridge"
+		tick        uint64 = 42
+	)
+
+	metrics := nonZeroMetrics()
+	scan := benthosmetrics.Scan{
+		Metrics:          metrics,
+		HealthCheck:      benthosmetrics.HealthCheck{IsLive: true, IsReady: true, Version: "v1.2.3"},
+		MetricsAvailable: false,
+	}
+	fake := &fakeBenthosMonitorWatcher{
+		status: bmworker.BenthosMonitorStatus{Scan: scan, Stopped: false},
+		res:    fsmv2client.Fresh,
+	}
+	s := newFFOnService(t, benthosName, fake)
+
+	// Pre-seed a known LastTick so "unchanged" is a meaningful assertion (not
+	// just the zero default).
+	const seedTick uint64 = 99
+
+	s.window.LastTick = seedTick
+
+	got, err := s.GetHealthCheckAndMetrics(context.Background(), nil, tick, time.Now(), benthosName, nil)
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+
+	// The Fresh branch serves the status regardless of MetricsAvailable.
+	if !reflect.DeepEqual(got.BenthosMetrics.Metrics, metrics) {
+		t.Errorf("Metrics = %+v, want %+v (Fresh status must be served even when MetricsAvailable=false)", got.BenthosMetrics.Metrics, metrics)
+	}
+
+	// C2 freeze: the window must NOT be fed when MetricsAvailable is false.
+	if s.window.LastTick != seedTick {
+		t.Errorf("window.LastTick = %d, want %d (window must not be fed when MetricsAvailable=false — the C2 freeze)",
+			s.window.LastTick, seedTick)
+	}
+}
+
+// TestFSMv2Watcher_GetHealthCheckAndMetrics_Stale_ServesLastGoodOverridesIsLive
+// verifies the Stale branch (R3): a wedged watcher (CollectedAt > maxAge) still
+// surfaces the stored last-good Metrics, but overrides IsLive=false so the
+// bridge reads as unhealthy. The window is NOT fed (C2: feed only on Fresh).
+//
+// Forcing assertion: got.BenthosMetrics.Metrics == stale M. Before R3 is
+// implemented, the default stub returns BenthosStatus{} (zero Metrics), so this
+// assertion fails RED — the stale Metrics are not served.
+func TestFSMv2Watcher_GetHealthCheckAndMetrics_Stale_ServesLastGoodOverridesIsLive(t *testing.T) {
+	const (
+		benthosName        = "testbridge"
+		tick        uint64 = 42
+	)
+
+	metrics := nonZeroMetrics()
+	scan := benthosmetrics.Scan{
+		Metrics:     metrics,
+		HealthCheck: benthosmetrics.HealthCheck{IsLive: true, IsReady: true, Version: "v1.2.3"},
+	}
+	fake := &fakeBenthosMonitorWatcher{
+		status: bmworker.BenthosMonitorStatus{Scan: scan, Stopped: false},
+		res:    fsmv2client.Stale,
+	}
+	s := newFFOnService(t, benthosName, fake)
+
+	const seedTick uint64 = 99
+
+	s.window.LastTick = seedTick
+
+	got, err := s.GetHealthCheckAndMetrics(context.Background(), nil, tick, time.Now(), benthosName, nil)
+	if err != nil {
+		t.Fatalf("err = %v, want nil (Stale serves last-good, no error)", err)
+	}
+
+	// Stale serves the stored last-good Metrics.
+	if !reflect.DeepEqual(got.BenthosMetrics.Metrics, metrics) {
+		t.Errorf("Metrics = %+v, want %+v (Stale must serve the stored last-good Metrics)", got.BenthosMetrics.Metrics, metrics)
+	}
+
+	// IsLive is OVERRIDDEN to false — a wedged watcher is unhealthy even if the
+	// stale scan said IsLive=true.
+	if got.HealthCheck.IsLive {
+		t.Errorf("HealthCheck.IsLive = true, want false (Stale must override IsLive to false)")
+	}
+
+	// C2: the window is NOT fed on Stale (feed only on Fresh+MetricsAvailable).
+	if s.window.LastTick != seedTick {
+		t.Errorf("window.LastTick = %d, want %d (window must not be fed on Stale)", s.window.LastTick, seedTick)
+	}
+}
+
+// TestFSMv2Watcher_GetHealthCheckAndMetrics_Unregistered_ServesEmptyNil pins
+// the default stub's behavior for Unregistered: serve empty/not-ready (warming),
+// no error, and NOT the ErrServiceNotExist sentinel.
+func TestFSMv2Watcher_GetHealthCheckAndMetrics_Unregistered_ServesEmptyNil(t *testing.T) {
+	const benthosName = "testbridge"
+
+	fake := &fakeBenthosMonitorWatcher{
+		status: bmworker.BenthosMonitorStatus{},
+		res:    fsmv2client.Unregistered,
+	}
+	s := newFFOnService(t, benthosName, fake)
+
+	got, err := s.GetHealthCheckAndMetrics(context.Background(), nil, 1, time.Now(), benthosName, nil)
+	if err != nil {
+		t.Fatalf("err = %v, want nil (Unregistered serves empty, no error)", err)
+	}
+
+	want := BenthosStatus{}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got = %+v, want %+v (Unregistered must serve empty BenthosStatus)", got, want)
+	}
+}
+
+// TestFSMv2Watcher_GetHealthCheckAndMetrics_NeverObserved_ServesEmptyNil pins
+// the default stub's behavior for NeverObserved: serve empty/not-ready
+// (warming), no error.
+func TestFSMv2Watcher_GetHealthCheckAndMetrics_NeverObserved_ServesEmptyNil(t *testing.T) {
+	const benthosName = "testbridge"
+
+	fake := &fakeBenthosMonitorWatcher{
+		status: bmworker.BenthosMonitorStatus{},
+		res:    fsmv2client.NeverObserved,
+	}
+	s := newFFOnService(t, benthosName, fake)
+
+	got, err := s.GetHealthCheckAndMetrics(context.Background(), nil, 1, time.Now(), benthosName, nil)
+	if err != nil {
+		t.Fatalf("err = %v, want nil (NeverObserved serves empty, no error)", err)
+	}
+
+	want := BenthosStatus{}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got = %+v, want %+v (NeverObserved must serve empty BenthosStatus)", got, want)
+	}
+}
+
+// TestFSMv2Watcher_GetHealthCheckAndMetrics_Unknown_ReturnsErrRaw pins R1's
+// err-first guard: when GetFresh returns a non-nil err (store read failure),
+// the err is returned raw (reconcile.go catches it non-fatally) and the status
+// is empty. The Freshness is Unknown (the zero value — only meaningful when err
+// is nil).
+func TestFSMv2Watcher_GetHealthCheckAndMetrics_Unknown_ReturnsErrRaw(t *testing.T) {
+	const benthosName = "testbridge"
+
+	sentinel := errors.New("store read failed")
+	fake := &fakeBenthosMonitorWatcher{
+		status: bmworker.BenthosMonitorStatus{},
+		res:    fsmv2client.Unknown,
+		err:    sentinel,
+	}
+	s := newFFOnService(t, benthosName, fake)
+
+	got, err := s.GetHealthCheckAndMetrics(context.Background(), nil, 1, time.Now(), benthosName, nil)
+
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("err = %v, want the sentinel %v (Unknown must return the raw err)", err, sentinel)
+	}
+
+	want := BenthosStatus{}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got = %+v, want %+v (Unknown must return empty BenthosStatus)", got, want)
+	}
+}
+
+// TestFSMv2Watcher_GetHealthCheckAndMetrics_Fresh_Stopped_NotUnhealthy pins
+// R1's stopped guard: a Fresh + Stopped=true bridge (admin-paused, scrape
+// skipped) returns empty+nil — NOT Degraded. IsLive=false on a stopped bridge
+// must not surface as unhealthy.
+func TestFSMv2Watcher_GetHealthCheckAndMetrics_Fresh_Stopped_NotUnhealthy(t *testing.T) {
+	const benthosName = "testbridge"
+
+	fake := &fakeBenthosMonitorWatcher{
+		status: bmworker.BenthosMonitorStatus{Stopped: true, Scan: benthosmetrics.Scan{}},
+		res:    fsmv2client.Fresh,
+	}
+	s := newFFOnService(t, benthosName, fake)
+
+	got, err := s.GetHealthCheckAndMetrics(context.Background(), nil, 1, time.Now(), benthosName, nil)
+	if err != nil {
+		t.Fatalf("err = %v, want nil (Fresh+Stopped returns empty, no error)", err)
+	}
+
+	want := BenthosStatus{}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got = %+v, want %+v (Fresh+Stopped must return empty BenthosStatus, not Degraded)", got, want)
 	}
 }

--- a/umh-core/pkg/service/benthos/fsmv2_watcher_test.go
+++ b/umh-core/pkg/service/benthos/fsmv2_watcher_test.go
@@ -1,0 +1,151 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package benthos
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/fsmv2client"
+	bmworker "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/benthos_monitor"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/configworker/dynamicchildren"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/benthosmetrics"
+)
+
+// fakeBenthosMonitorWatcher is a test double for benthosMonitorWatcher. It
+// returns a canned (status, res, err) and records the ref/maxAge it was called
+// with so the test can assert the FF-on read path used s6ServiceName (not raw
+// benthosName) for the ref Name.
+type fakeBenthosMonitorWatcher struct {
+	status    bmworker.BenthosMonitorStatus
+	res       fsmv2client.Freshness
+	err       error
+	gotRef    dynamicchildren.Ref
+	gotMaxAge time.Duration
+}
+
+func (f *fakeBenthosMonitorWatcher) GetFresh(_ context.Context, ref dynamicchildren.Ref, maxAge time.Duration) (bmworker.BenthosMonitorStatus, fsmv2client.Freshness, error) {
+	f.gotRef = ref
+	f.gotMaxAge = maxAge
+
+	return f.status, f.res, f.err
+}
+
+func (f *fakeBenthosMonitorWatcher) Upsert(_ dynamicchildren.Ref, _ map[string]any) error { return nil }
+func (f *fakeBenthosMonitorWatcher) Delete(_ dynamicchildren.Ref)                         {}
+
+// TestFSMv2Watcher_GetHealthCheckAndMetrics_FreshReadPath verifies the FF-on
+// (USE_FSMV2_BENTHOS_MONITOR) Fresh branch of GetHealthCheckAndMetrics:
+//
+//   - The returned HealthCheck is the worker's raw scan.HealthCheck (not
+//     synthesized).
+//   - The returned Metrics are the worker's raw scan.Metrics.
+//   - The returned MetricsState is the BenthosService's own s.window pointer
+//     (the live instance, not a copy).
+//   - s.window was fed (LastTick advanced, IsActive reflects the non-zero
+//     input metrics) — only when MetricsAvailable is true (C2 freeze guard).
+//   - err is nil.
+//   - The watcher ref uses s6ServiceName ("benthos-"+name), not raw benthosName.
+//
+// Each assertion is front-loaded so the test FAILS before the FF-on branch
+// exists: the FF-off path never calls the fake watcher, so gotRef stays zero
+// and the returned status comes from the (nil) v1 monitor manager instead of
+// the fake.
+func TestFSMv2Watcher_GetHealthCheckAndMetrics_FreshReadPath(t *testing.T) {
+	// --- FF-on ---
+	prev := fsmv2BenthosMonitorEnabled
+	fsmv2BenthosMonitorEnabled = true
+
+	t.Cleanup(func() { fsmv2BenthosMonitorEnabled = prev })
+
+	const (
+		benthosName        = "testbridge"
+		tick        uint64 = 42
+	)
+
+	scan := benthosmetrics.Scan{
+		Metrics: benthosmetrics.Metrics{
+			Inputs: map[string]benthosmetrics.InputInstance{
+				"in1": {Received: 5},
+			},
+		},
+		HealthCheck: benthosmetrics.HealthCheck{
+			IsLive:  true,
+			IsReady: true,
+			Version: "v1.2.3",
+		},
+		MetricsAvailable: true,
+	}
+	fake := &fakeBenthosMonitorWatcher{
+		status: bmworker.BenthosMonitorStatus{Scan: scan, Stopped: false},
+		res:    fsmv2client.Fresh,
+	}
+
+	s := NewDefaultBenthosService(benthosName, WithFSMv2BenthosWatcher(fake))
+
+	// The GetInstance guard runs BEFORE the FF-on branch, so the s6 service
+	// must be registered for the read path to reach the watcher. The instance
+	// value is unused on the FF-on path (only existence is checked).
+	s.s6Manager.AddInstanceForTest(s.GetS6ServiceName(benthosName), nil)
+
+	got, err := s.GetHealthCheckAndMetrics(context.Background(), nil, tick, time.Now(), benthosName, nil)
+
+	// (e) err == nil
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+
+	// (a) HealthCheck == fake's scan.HealthCheck (raw, not synthesized).
+	if !reflect.DeepEqual(got.HealthCheck, scan.HealthCheck) {
+		t.Errorf("HealthCheck = %+v, want %+v", got.HealthCheck, scan.HealthCheck)
+	}
+
+	// (b) Metrics == fake's scan.Metrics.
+	if !reflect.DeepEqual(got.BenthosMetrics.Metrics, scan.Metrics) {
+		t.Errorf("Metrics = %+v, want %+v", got.BenthosMetrics.Metrics, scan.Metrics)
+	}
+
+	// (c) MetricsState == s.window (same pointer — the live instance).
+	if got.BenthosMetrics.MetricsState != s.window {
+		t.Errorf("MetricsState = %p, want s.window %p (must be the live pointer)",
+			got.BenthosMetrics.MetricsState, s.window)
+	}
+
+	// (d) s.window was fed — LastTick advanced to tick and IsActive reflects
+	// the non-zero input metrics (Received=5 > 0).
+	if s.window.LastTick != tick {
+		t.Errorf("window.LastTick = %d, want %d (window must be fed on Fresh+MetricsAvailable)",
+			s.window.LastTick, tick)
+	}
+
+	if !s.window.IsActive {
+		t.Errorf("window.IsActive = false, want true (non-zero input metrics were fed)")
+	}
+
+	// The watcher ref must use s6ServiceName ("benthos-"+name), not raw
+	// benthosName — the monitor FSM keys on s6ServiceName; a mismatch makes
+	// Contains==false and every read returns Unregistered.
+	wantRef := dynamicchildren.Ref{WorkerType: "benthos_monitor", Name: s.GetS6ServiceName(benthosName)}
+
+	if fake.gotRef != wantRef {
+		t.Errorf("watcher ref = %+v, want %+v (must use s6ServiceName)", fake.gotRef, wantRef)
+	}
+
+	if fake.gotMaxAge != benthosMonitorMaxAge {
+		t.Errorf("watcher maxAge = %v, want %v", fake.gotMaxAge, benthosMonitorMaxAge)
+	}
+}

--- a/umh-core/pkg/service/benthos/fsmv2_watcher_test.go
+++ b/umh-core/pkg/service/benthos/fsmv2_watcher_test.go
@@ -21,22 +21,36 @@ import (
 	"testing"
 	"time"
 
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
+	public_fsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
+	benthos_monitor_fsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/benthos_monitor"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/fsmv2client"
 	bmworker "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/benthos_monitor"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/configworker/dynamicchildren"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/benthosmetrics"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/serviceregistry"
 )
 
 // fakeBenthosMonitorWatcher is a test double for benthosMonitorWatcher. It
 // returns a canned (status, res, err) and records the ref/maxAge it was called
 // with so the test can assert the FF-on read path used s6ServiceName (not raw
-// benthosName) for the ref Name.
+// benthosName) for the ref Name. Upsert/Delete calls are recorded so the R8/R9
+// lifecycle tests can assert the refs and maps they were called with.
 type fakeBenthosMonitorWatcher struct {
 	status    bmworker.BenthosMonitorStatus
 	res       fsmv2client.Freshness
 	err       error
 	gotRef    dynamicchildren.Ref
 	gotMaxAge time.Duration
+
+	upsertCalls []upsertCall
+	deleteCalls []dynamicchildren.Ref
+}
+
+// upsertCall records one Upsert invocation's ref and config map.
+type upsertCall struct {
+	ref dynamicchildren.Ref
+	cfg map[string]any
 }
 
 func (f *fakeBenthosMonitorWatcher) GetFresh(_ context.Context, ref dynamicchildren.Ref, maxAge time.Duration) (bmworker.BenthosMonitorStatus, fsmv2client.Freshness, error) {
@@ -46,8 +60,15 @@ func (f *fakeBenthosMonitorWatcher) GetFresh(_ context.Context, ref dynamicchild
 	return f.status, f.res, f.err
 }
 
-func (f *fakeBenthosMonitorWatcher) Upsert(_ dynamicchildren.Ref, _ map[string]any) error { return nil }
-func (f *fakeBenthosMonitorWatcher) Delete(_ dynamicchildren.Ref)                         {}
+func (f *fakeBenthosMonitorWatcher) Upsert(ref dynamicchildren.Ref, cfg map[string]any) error {
+	f.upsertCalls = append(f.upsertCalls, upsertCall{ref: ref, cfg: cfg})
+
+	return nil
+}
+
+func (f *fakeBenthosMonitorWatcher) Delete(ref dynamicchildren.Ref) {
+	f.deleteCalls = append(f.deleteCalls, ref)
+}
 
 // TestFSMv2Watcher_GetHealthCheckAndMetrics_FreshReadPath verifies the FF-on
 // (USE_FSMV2_BENTHOS_MONITOR) Fresh branch of GetHealthCheckAndMetrics:
@@ -374,5 +395,279 @@ func TestFSMv2Watcher_GetHealthCheckAndMetrics_Fresh_Stopped_NotUnhealthy(t *tes
 	want := BenthosStatus{}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got = %+v, want %+v (Fresh+Stopped must return empty BenthosStatus, not Degraded)", got, want)
+	}
+}
+
+// fakeBenthosMonitorManager is a test double for BenthosMonitorReconciler. It
+// records Reconcile calls so the R11 test can assert the FF-on path SKIPS the
+// S6 monitor reconcile. GetInstance and GetLastObservedState return
+// not-found/nil so the Remove path proceeds to the window reset.
+type fakeBenthosMonitorManager struct {
+	reconcileCalls int
+}
+
+func (f *fakeBenthosMonitorManager) Reconcile(_ context.Context, _ public_fsm.SystemSnapshot, _ serviceregistry.Provider) (error, bool) {
+	f.reconcileCalls++
+
+	return nil, false
+}
+
+func (f *fakeBenthosMonitorManager) GetInstance(_ string) (public_fsm.FSMInstance, bool) {
+	return nil, false
+}
+
+func (f *fakeBenthosMonitorManager) GetLastObservedState(_ string) (public_fsm.ObservedState, error) {
+	return nil, nil
+}
+
+// TestFSMv2Watcher_ReconcileManager_FFOn_UpsertsEachConfig_SkipsS6MonitorReconcile
+// verifies R8 (Upsert each config + mapFrom) and R11 (skip the S6 monitor
+// reconcile) under FF-on:
+//
+//   - R8: for each cfg in s.benthosMonitorConfigs, the watcher's Upsert is
+//     called with ref{WorkerType:"benthos_monitor", Name:cfg.Name} and a map
+//     {state: mapFrom(cfg.DesiredFSMState), metricsPort: cfg.MetricsPort}.
+//     Active→"running", Stopped→"stopped".
+//   - R11: benthosMonitorManager.Reconcile is NOT called (the S6 fork tree
+//     never spawns — the CPU win).
+//
+// Forcing assertion: fake.upsertCalls has exactly 2 entries with the right
+// refs/maps AND fakeBenthosMonitorManager.reconcileCalls == 0. Before the FF-on
+// branch exists, no Upsert is called (upsertCalls is empty) and Reconcile IS
+// called (reconcileCalls == 1), so both halves fail RED.
+func TestFSMv2Watcher_ReconcileManager_FFOn_UpsertsEachConfig_SkipsS6MonitorReconcile(t *testing.T) {
+	prev := fsmv2BenthosMonitorEnabled
+	fsmv2BenthosMonitorEnabled = true
+
+	t.Cleanup(func() { fsmv2BenthosMonitorEnabled = prev })
+
+	fake := &fakeBenthosMonitorWatcher{}
+	monMgr := &fakeBenthosMonitorManager{}
+	s := NewDefaultBenthosService("test",
+		WithFSMv2BenthosWatcher(fake),
+		WithMonitorManager(monMgr),
+	)
+
+	// cfg.Name IS s6ServiceName (set at AddBenthosToS6Manager:706/:765 — NOT raw
+	// benthosName). Directly set two monitor configs with Active + Stopped.
+	s.benthosMonitorConfigs = []config.BenthosMonitorConfig{
+		{
+			FSMInstanceConfig: config.FSMInstanceConfig{
+				Name:            "benthos-a",
+				DesiredFSMState: benthos_monitor_fsm.OperationalStateActive,
+			},
+			MetricsPort: 4195,
+		},
+		{
+			FSMInstanceConfig: config.FSMInstanceConfig{
+				Name:            "benthos-b",
+				DesiredFSMState: benthos_monitor_fsm.OperationalStateStopped,
+			},
+			MetricsPort: 4196,
+		},
+	}
+
+	// The s6 manager's Reconcile requires a context with a deadline (it enforces
+	// a per-tick time budget). Use a generous deadline so the empty-config
+	// reconcile completes instantly.
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(100*time.Second))
+	defer cancel()
+
+	_, _ = s.ReconcileManager(
+		ctx,
+		serviceregistry.NewMockRegistry(),
+		public_fsm.SystemSnapshot{Tick: 1, SnapshotTime: time.Now()},
+	)
+
+	// --- R8: Upsert called twice with correct refs + maps ---
+
+	if len(fake.upsertCalls) != 2 {
+		t.Fatalf("upsertCalls = %d, want 2 (one per config)", len(fake.upsertCalls))
+	}
+
+	wantRefA := dynamicchildren.Ref{WorkerType: "benthos_monitor", Name: "benthos-a"}
+	if fake.upsertCalls[0].ref != wantRefA {
+		t.Errorf("upsertCalls[0].ref = %+v, want %+v", fake.upsertCalls[0].ref, wantRefA)
+	}
+
+	if state, ok := fake.upsertCalls[0].cfg["state"].(string); !ok || state != "running" {
+		t.Errorf("upsertCalls[0].cfg[\"state\"] = %v, want \"running\" (Active→running)", fake.upsertCalls[0].cfg["state"])
+	}
+
+	if port, ok := fake.upsertCalls[0].cfg["metricsPort"].(uint16); !ok || port != 4195 {
+		t.Errorf("upsertCalls[0].cfg[\"metricsPort\"] = %v, want uint16(4195)", fake.upsertCalls[0].cfg["metricsPort"])
+	}
+
+	wantRefB := dynamicchildren.Ref{WorkerType: "benthos_monitor", Name: "benthos-b"}
+	if fake.upsertCalls[1].ref != wantRefB {
+		t.Errorf("upsertCalls[1].ref = %+v, want %+v", fake.upsertCalls[1].ref, wantRefB)
+	}
+
+	if state, ok := fake.upsertCalls[1].cfg["state"].(string); !ok || state != "stopped" {
+		t.Errorf("upsertCalls[1].cfg[\"state\"] = %v, want \"stopped\" (Stopped→stopped)", fake.upsertCalls[1].cfg["state"])
+	}
+
+	if port, ok := fake.upsertCalls[1].cfg["metricsPort"].(uint16); !ok || port != 4196 {
+		t.Errorf("upsertCalls[1].cfg[\"metricsPort\"] = %v, want uint16(4196)", fake.upsertCalls[1].cfg["metricsPort"])
+	}
+
+	// --- R11: benthosMonitorManager.Reconcile NOT called (the skip) ---
+
+	if monMgr.reconcileCalls != 0 {
+		t.Errorf("monitor manager.Reconcile called %d time(s), want 0 (FF-on must SKIP the S6 monitor reconcile)", monMgr.reconcileCalls)
+	}
+}
+
+// TestFSMv2Watcher_ReconcileManager_FFOff_CallsS6MonitorReconcile is the FF-off
+// characterization complement to the R11 skip test: with the feature flag OFF,
+// ReconcileManager calls benthosMonitorManager.Reconcile (the existing path).
+// This pins that the FF-on early-return did not accidentally swallow the FF-off
+// branch — the two paths are mutually exclusive on the flag.
+func TestFSMv2Watcher_ReconcileManager_FFOff_CallsS6MonitorReconcile(t *testing.T) {
+	prev := fsmv2BenthosMonitorEnabled
+	fsmv2BenthosMonitorEnabled = false
+
+	t.Cleanup(func() { fsmv2BenthosMonitorEnabled = prev })
+
+	fake := &fakeBenthosMonitorWatcher{}
+	monMgr := &fakeBenthosMonitorManager{}
+	s := NewDefaultBenthosService("test",
+		WithFSMv2BenthosWatcher(fake),
+		WithMonitorManager(monMgr),
+	)
+
+	s.benthosMonitorConfigs = []config.BenthosMonitorConfig{
+		{
+			FSMInstanceConfig: config.FSMInstanceConfig{
+				Name:            "benthos-a",
+				DesiredFSMState: benthos_monitor_fsm.OperationalStateActive,
+			},
+			MetricsPort: 4195,
+		},
+	}
+
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(100*time.Second))
+	defer cancel()
+
+	_, _ = s.ReconcileManager(
+		ctx,
+		serviceregistry.NewMockRegistry(),
+		public_fsm.SystemSnapshot{Tick: 1, SnapshotTime: time.Now()},
+	)
+
+	// FF-off: benthosMonitorManager.Reconcile IS called.
+	if monMgr.reconcileCalls != 1 {
+		t.Errorf("monitor manager.Reconcile called %d time(s), want 1 (FF-off must call the S6 monitor reconcile)", monMgr.reconcileCalls)
+	}
+
+	// FF-off: the watcher's Upsert is NOT called (the FF-on lifecycle is off).
+	if len(fake.upsertCalls) != 0 {
+		t.Errorf("upsertCalls = %d, want 0 (FF-off must not use the fsmv2 watcher lifecycle)", len(fake.upsertCalls))
+	}
+}
+
+// TestFSMv2Watcher_Remove_FFOn_DeletesRef verifies R9: when a config leaves the
+// slice during RemoveBenthosFromS6Manager and FF-on is active, the watcher's
+// Delete is called with ref{WorkerType:"benthos_monitor", Name:s6ServiceName}.
+//
+// Forcing assertion: fake.deleteCalls has exactly one entry with the right ref.
+// Before the FF-on Delete branch exists, deleteCalls is empty → fails RED.
+func TestFSMv2Watcher_Remove_FFOn_DeletesRef(t *testing.T) {
+	prev := fsmv2BenthosMonitorEnabled
+	fsmv2BenthosMonitorEnabled = true
+
+	t.Cleanup(func() { fsmv2BenthosMonitorEnabled = prev })
+
+	fake := &fakeBenthosMonitorWatcher{}
+	monMgr := &fakeBenthosMonitorManager{}
+	s := NewDefaultBenthosService("test",
+		WithFSMv2BenthosWatcher(fake),
+		WithMonitorManager(monMgr),
+	)
+
+	// cfg.Name = s6ServiceName = "benthos-" + benthosName. For benthosName "a",
+	// the s6ServiceName is "benthos-a".
+	s.benthosMonitorConfigs = []config.BenthosMonitorConfig{
+		{
+			FSMInstanceConfig: config.FSMInstanceConfig{
+				Name:            "benthos-a",
+				DesiredFSMState: benthos_monitor_fsm.OperationalStateActive,
+			},
+			MetricsPort: 4195,
+		},
+	}
+
+	err := s.RemoveBenthosFromS6Manager(context.Background(), nil, "a")
+	if err != nil {
+		t.Fatalf("err = %v, want nil (Remove is idempotent, no instances to block)", err)
+	}
+
+	wantRef := dynamicchildren.Ref{WorkerType: "benthos_monitor", Name: "benthos-a"}
+
+	if len(fake.deleteCalls) != 1 {
+		t.Fatalf("deleteCalls = %d, want 1 (the removed config's ref)", len(fake.deleteCalls))
+	}
+
+	if fake.deleteCalls[0] != wantRef {
+		t.Errorf("deleteCalls[0] = %+v, want %+v", fake.deleteCalls[0], wantRef)
+	}
+}
+
+// TestFSMv2Watcher_Remove_FFOn_ResetsWindow verifies R10: A1's window reset on
+// Remove — after RemoveBenthosFromS6Manager, s.window is a FRESH instance
+// (LastTick==0, IsActive==false). A1 already implements this reset; this test
+// PINS it so a future refactor cannot silently drop the reset.
+//
+// Forcing assertion: s.window.LastTick == 0 after the call. A1's reset at
+// benthos.go:967 assigns NewBenthosMetricsState(), so this passes GREEN from
+// the start — it's a pin, not a RED→GREEN rung.
+func TestFSMv2Watcher_Remove_FFOn_ResetsWindow(t *testing.T) {
+	prev := fsmv2BenthosMonitorEnabled
+	fsmv2BenthosMonitorEnabled = true
+
+	t.Cleanup(func() { fsmv2BenthosMonitorEnabled = prev })
+
+	fake := &fakeBenthosMonitorWatcher{}
+	monMgr := &fakeBenthosMonitorManager{}
+	s := NewDefaultBenthosService("test",
+		WithFSMv2BenthosWatcher(fake),
+		WithMonitorManager(monMgr),
+	)
+
+	// Pre-seed the window so "fresh" is a meaningful assertion (not just the
+	// zero default). Feed it non-zero metrics + a known LastTick.
+	s.window.UpdateFromMetrics(benthosmetrics.Metrics{
+		Inputs: map[string]benthosmetrics.InputInstance{
+			"in1": {Received: 5},
+		},
+	}, 99)
+
+	if s.window.LastTick != 99 || !s.window.IsActive {
+		t.Fatalf("pre-condition: window not seeded (LastTick=%d, IsActive=%v)", s.window.LastTick, s.window.IsActive)
+	}
+
+	// Add a config so Remove has something to remove.
+	s.benthosMonitorConfigs = []config.BenthosMonitorConfig{
+		{
+			FSMInstanceConfig: config.FSMInstanceConfig{
+				Name:            "benthos-a",
+				DesiredFSMState: benthos_monitor_fsm.OperationalStateActive,
+			},
+			MetricsPort: 4195,
+		},
+	}
+
+	err := s.RemoveBenthosFromS6Manager(context.Background(), nil, "a")
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+
+	// R10: window is a FRESH instance.
+	if s.window.LastTick != 0 {
+		t.Errorf("window.LastTick = %d, want 0 (window must be reset on Remove)", s.window.LastTick)
+	}
+
+	if s.window.IsActive {
+		t.Errorf("window.IsActive = true, want false (fresh window must be inactive)")
 	}
 }

--- a/umh-core/pkg/service/benthos/fsmv2_watcher_test.go
+++ b/umh-core/pkg/service/benthos/fsmv2_watcher_test.go
@@ -928,3 +928,96 @@ func TestFSMv2Watcher_GetHealthCheckAndMetrics_FFOff_FreshScanSameCountFeeds(t *
 		t.Errorf("tick 2: LastCount = %d, want 18 (unchanged count must not trip counter-reset)", s.window.Input.LastCount)
 	}
 }
+
+// TestFSMv2Watcher_GetHealthCheckAndMetrics_FFOff_BackwardsScanFeeds pins the
+// ff-off-feed-backwards-parity rung: a FRESH FF-off benthos_monitor scan whose
+// LastUpdatedAt went BACKWARDS (e.g. an NTP step correction while benthos is
+// running) must STILL feed the BenthosService throughput window — advancing
+// s.window.LastTick and updating s.window.Input.LastCount to the scan's count —
+// matching pre-A1 behavior, where the feed lived inside ProcessMetricsData and
+// fired on every successful scrape regardless of timestamp direction.
+//
+// The shipped gate at benthos.go:785 (`if lastScan.LastUpdatedAt.After(
+// s.lastFedScanAt)`) wrongly skips a backwards timestamp (t0 is not After t1),
+// causing a persistent freeze until the clock re-climbs above the prior peak.
+// The throughput math (metrics_state.go updateComponentThroughput) takes only
+// count + the monotonic read tick, NOT LastUpdatedAt, so feeding a backwards
+// timestamp is safe (no corruption). The fix gates on LastUpdatedAt CHANGING
+// (!Equal) instead of strictly advancing (After).
+//
+// Forcing assertions (RED on the shipped After() gate): tick2's backwards-t0
+// scan must (a) advance s.window.LastTick to 2 (on After it stays 1 — RED),
+// (b) update s.window.Input.LastCount to 20 (on After it stays 18 — RED), and
+// (c) leave >= 2 window entries (20 > 18 → no counter-reset wipe). The existing
+// OutageFreezesWindow (same LastUpdatedAt → Equal → no feed → freeze) and
+// FreshScanSameCountFeeds (forward change → !Equal → feed) regression guards
+// MUST stay green: !Equal preserves both (same → Equal → no feed; forward →
+// !Equal → feed).
+func TestFSMv2Watcher_GetHealthCheckAndMetrics_FFOff_BackwardsScanFeeds(t *testing.T) {
+	prev := fsmv2BenthosMonitorEnabled
+	fsmv2BenthosMonitorEnabled = false
+
+	t.Cleanup(func() { fsmv2BenthosMonitorEnabled = prev })
+
+	const benthosName = "testbridge"
+
+	t1 := time.Now()
+	t0 := t1.Add(-1 * time.Second) // BEFORE t1 — an NTP backward step
+
+	monMgr := &fakeBenthosMonitorManager{
+		observedStates: []public_fsm.ObservedState{
+			ffOffObservedState(t1, 18, true), // tick 1: healthy scan (feeds + seeds)
+			ffOffObservedState(t0, 20, true), // tick 2: FRESH scan, LastUpdatedAt went BACKWARDS, count advanced to 20
+		},
+	}
+	s := NewDefaultBenthosService(benthosName, WithMonitorManager(monMgr))
+	s.s6Manager.AddInstanceForTest(s.GetS6ServiceName(benthosName), nil)
+
+	// --- Tick 1: healthy scan (t1, count=18) — feeds + seeds ---
+	const tick1 uint64 = 1
+	got1, err := s.GetHealthCheckAndMetrics(context.Background(), nil, tick1, time.Now(), benthosName, nil)
+	if err != nil {
+		t.Fatalf("tick 1: err = %v, want nil", err)
+	}
+
+	if !got1.HealthCheck.IsLive {
+		t.Fatalf("tick 1: IsLive = false, want true (healthy scan)")
+	}
+
+	if s.window.Input.LastCount != 18 {
+		t.Fatalf("tick 1: LastCount = %d, want 18 (healthy scan must seed the window)", s.window.Input.LastCount)
+	}
+
+	if !s.lastFedScanAt.Equal(t1) {
+		t.Fatalf("tick 1: lastFedScanAt = %v, want %v (must be seeded to the scan's LastUpdatedAt)", s.lastFedScanAt, t1)
+	}
+
+	// --- Tick 2: FRESH scan with LastUpdatedAt BACKWARDS (t0 < t1), count=20 ---
+	// The shipped After() gate skips t0 (t0 is not After t1) → LastTick stays 1
+	// and LastCount stays 18 — RED. The !Equal fix feeds (t0 != t1) → advances.
+	const tick2 uint64 = 2
+	got2, err := s.GetHealthCheckAndMetrics(context.Background(), nil, tick2, time.Now(), benthosName, nil)
+	if err != nil {
+		t.Fatalf("tick 2: err = %v, want nil (fresh backwards scan is served, not an error)", err)
+	}
+
+	if !got2.HealthCheck.IsLive {
+		t.Errorf("tick 2: IsLive = false, want true (the backwards scan is healthy)")
+	}
+
+	if s.window.LastTick != tick2 {
+		t.Errorf("tick 2: window.LastTick = %d, want %d (a fresh backwards-timestamp scan MUST feed — LastUpdatedAt CHANGED; the shipped After() gate wrongly skips it because t0 is not After t1, leaving LastTick frozen at 1)",
+			s.window.LastTick, tick2)
+	}
+
+	if s.window.Input.LastCount != 20 {
+		t.Errorf("tick 2: window.Input.LastCount = %d, want 20 (the backwards scan's count must be fed; the shipped After() gate skips the feed so LastCount stays 18 — RED)",
+			s.window.Input.LastCount)
+	}
+
+	// 20 > 18 → counter-reset branch must NOT fire; the prior window entry
+	// survives (the window is not wiped to a single reset entry).
+	if len(s.window.Input.Window) < 2 {
+		t.Errorf("tick 2: len(window.Input.Window) = %d, want >= 2 (count 20 > last 18 must NOT trip the counter-reset wipe)", len(s.window.Input.Window))
+	}
+}

--- a/umh-core/pkg/service/benthos/fsmv2_watcher_test.go
+++ b/umh-core/pkg/service/benthos/fsmv2_watcher_test.go
@@ -1023,3 +1023,56 @@ func TestFSMv2Watcher_GetHealthCheckAndMetrics_FFOff_BackwardsScanFeeds(t *testi
 		t.Errorf("tick 2: len(window.Input.Window) = %d, want >= 2 (count 20 > last 18 must NOT trip the counter-reset wipe)", len(s.window.Input.Window))
 	}
 }
+
+// TestFSMv2Watcher_DefaultWatcher_NilClientSoftFails characterizes the nil-client
+// soft-fail in defaultBenthosMonitorWatcher. USE_FSMV2_BENTHOS_MONITOR=ON without
+// USE_FSMV2_TRANSPORT=ON (or before the supervisor publishes the client) leaves
+// the process-scoped fsmv2client nil. Each method must fail soft rather than
+// nil-dereference: GetFresh returns a zero status + Unknown + a non-nil err;
+// Upsert returns a non-nil err; Delete is a no-op. This branch is the misconfig
+// guard for FF-on without transport and had no coverage.
+//
+// Mutation-verify: removing any `if c == nil` guard makes the method dereference
+// c.w on a nil *FSMv2Client (GetFresh at fsmv2client.go:143, Upsert at :63,
+// Delete at :68) and panic. This test fails on that panic.
+func TestFSMv2Watcher_DefaultWatcher_NilClientSoftFails(t *testing.T) {
+	// The client is a process singleton; no test in this package publishes one,
+	// so it is nil by default. Force nil explicitly and restore the prior value
+	// so the test stays self-contained.
+	prev := fsmv2client.GetClient()
+	fsmv2client.SetClient(nil)
+	t.Cleanup(func() { fsmv2client.SetClient(prev) })
+
+	w := defaultBenthosMonitorWatcher{}
+	ctx := context.Background()
+	ref := dynamicchildren.Ref{WorkerType: "benthos_monitor", Name: "nilclientbridge"}
+
+	// GetFresh: zero status, Unknown freshness, non-nil err.
+	status, freshness, err := w.GetFresh(ctx, ref, time.Second)
+	if err == nil {
+		t.Fatal("GetFresh: err = nil, want non-nil (nil client must soft-fail, not dereference)")
+	}
+
+	if freshness != fsmv2client.Unknown {
+		t.Errorf("GetFresh: freshness = %v, want Unknown (a nil client cannot classify the observation)", freshness)
+	}
+
+	if !reflect.DeepEqual(status, bmworker.BenthosMonitorStatus{}) {
+		t.Errorf("GetFresh: status = %+v, want zero BenthosMonitorStatus (no observation to return)", status)
+	}
+
+	// Upsert: non-nil err (a nil client cannot record the spec).
+	if upsertErr := w.Upsert(ref, map[string]any{"state": "running"}); upsertErr == nil {
+		t.Fatal("Upsert: err = nil, want non-nil (nil client must soft-fail, not dereference)")
+	}
+
+	// Delete: no panic, no-op. The deferred recover turns a removed nil guard
+	// (which would dereference c.w) into a test failure.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Delete: panicked on nil client (%v); the nil guard must short-circuit to a no-op", r)
+		}
+	}()
+
+	w.Delete(ref)
+}

--- a/umh-core/pkg/service/benthos/fsmv2_watcher_test.go
+++ b/umh-core/pkg/service/benthos/fsmv2_watcher_test.go
@@ -975,6 +975,7 @@ func TestFSMv2Watcher_GetHealthCheckAndMetrics_FFOff_BackwardsScanFeeds(t *testi
 
 	// --- Tick 1: healthy scan (t1, count=18) — feeds + seeds ---
 	const tick1 uint64 = 1
+
 	got1, err := s.GetHealthCheckAndMetrics(context.Background(), nil, tick1, time.Now(), benthosName, nil)
 	if err != nil {
 		t.Fatalf("tick 1: err = %v, want nil", err)
@@ -996,6 +997,7 @@ func TestFSMv2Watcher_GetHealthCheckAndMetrics_FFOff_BackwardsScanFeeds(t *testi
 	// The shipped After() gate skips t0 (t0 is not After t1) → LastTick stays 1
 	// and LastCount stays 18 — RED. The !Equal fix feeds (t0 != t1) → advances.
 	const tick2 uint64 = 2
+
 	got2, err := s.GetHealthCheckAndMetrics(context.Background(), nil, tick2, time.Now(), benthosName, nil)
 	if err != nil {
 		t.Fatalf("tick 2: err = %v, want nil (fresh backwards scan is served, not an error)", err)

--- a/umh-core/pkg/service/benthos_monitor/benthos_monitor.go
+++ b/umh-core/pkg/service/benthos_monitor/benthos_monitor.go
@@ -139,7 +139,6 @@ var _ IBenthosMonitorService = (*BenthosMonitorService)(nil)
 
 type BenthosMonitorService struct {
 	logger          *zap.SugaredLogger
-	metricsState    *BenthosMetricsState
 	s6Manager       *s6fsm.S6Manager
 	s6Service       s6service.Service
 	s6ServiceConfig *config.S6FSMConfig // There can only be one monitor per benthos instance
@@ -171,11 +170,10 @@ func NewBenthosMonitorService(benthosName string, opts ...BenthosMonitorServiceO
 	managerName := fmt.Sprintf("%s%s", logger.ComponentBenthosService, "benthos-monitor-"+benthosName)
 
 	service := &BenthosMonitorService{
-		logger:       logger.For(managerName),
-		metricsState: benthosmetrics.NewBenthosMetricsState(),
-		s6Manager:    s6fsm.NewS6Manager(logger.ComponentBenthosMonitorService),
-		s6Service:    s6service.NewDefaultService(),
-		benthosName:  benthosName,
+		logger:      logger.For(managerName),
+		s6Manager:   s6fsm.NewS6Manager(logger.ComponentBenthosMonitorService),
+		s6Service:   s6service.NewDefaultService(),
+		benthosName: benthosName,
 	}
 	for _, opt := range opts {
 		opt(service)
@@ -797,12 +795,11 @@ func (s *BenthosMonitorService) ProcessMetricsData(metricsDataBytes []byte, tick
 		return nil, fmt.Errorf("failed to parse metrics data: %w", err)
 	}
 
-	// Update the metrics state
-	s.metricsState.UpdateFromMetrics(metrics, tick)
-
+	// The window is no longer the monitor's concern: BenthosService owns and
+	// feeds its own per-bridge window from the Metrics returned here.
 	return &BenthosMetrics{
 		Metrics:      metrics,
-		MetricsState: s.metricsState,
+		MetricsState: nil,
 	}, nil
 }
 
@@ -1001,9 +998,6 @@ func (s *BenthosMonitorService) RemoveBenthosMonitorFromS6Manager(ctx context.Co
 		return fmt.Errorf("%w: S6 instance state=%s",
 			standarderrors.ErrRemovalPending, inst.GetCurrentFSMState())
 	}
-
-	// Clean up the metrics state
-	s.metricsState = benthosmetrics.NewBenthosMetricsState()
 
 	return nil
 }

--- a/umh-core/pkg/service/benthos_monitor/mock.go
+++ b/umh-core/pkg/service/benthos_monitor/mock.go
@@ -24,7 +24,6 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
 	s6fsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/s6"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/benthosmetrics"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/filesystem"
 	s6service "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/s6"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/serviceregistry"
@@ -50,8 +49,6 @@ type MockBenthosMonitorService struct {
 	// State control for FSM testing
 	stateFlags *ServiceStateFlags
 
-	// Mock metrics state
-	metricsState *BenthosMetricsState
 	// Return values for each method
 	GenerateS6ConfigForBenthosMonitorResult s6serviceconfig.S6ServiceConfig
 	GetConfigResult                         config.BenthosMonitorConfig
@@ -91,7 +88,6 @@ func NewMockBenthosMonitorService() *MockBenthosMonitorService {
 		ServiceExistsFlag: false,
 		S6ServiceConfig:   nil,
 		stateFlags:        &ServiceStateFlags{},
-		metricsState:      benthosmetrics.NewBenthosMetricsState(),
 	}
 }
 
@@ -102,9 +98,7 @@ func (m *MockBenthosMonitorService) SetServiceState(flags ServiceStateFlags) {
 		m.ServiceState = &ServiceInfo{
 			BenthosStatus: BenthosMonitorStatus{
 				LastScan: &BenthosMetricsScan{
-					BenthosMetrics: &BenthosMetrics{
-						MetricsState: m.metricsState,
-					},
+					BenthosMetrics: &BenthosMetrics{},
 				},
 			},
 		}
@@ -117,14 +111,9 @@ func (m *MockBenthosMonitorService) SetServiceState(flags ServiceStateFlags) {
 		m.ServiceState.S6FSMState = s6fsm.OperationalStateStopped
 	}
 
-	// Update the metrics state based on IsMetricsActive
-	if flags.IsMetricsActive {
-		m.metricsState.IsActive = true
-	} else {
-		m.metricsState.IsActive = false
-	}
-
-	// Store the flags
+	// Store the flags. IsMetricsActive is retained on the flags (read via
+	// GetServiceState); the mock no longer carries a MetricsState —
+	// BenthosService owns and feeds the window from the returned Metrics.
 	m.stateFlags = &flags
 }
 
@@ -303,7 +292,9 @@ func (m *MockBenthosMonitorService) Status(ctx context.Context, services service
 			LastUpdatedAt:  m.LastScanTime,
 		}
 		if m.ServiceState.BenthosStatus.LastScan.BenthosMetrics != nil {
-			m.ServiceState.BenthosStatus.LastScan.BenthosMetrics.MetricsState = m.metricsState
+			// BenthosService owns and feeds the window now; the mock returns
+			// a nil MetricsState so the service's own window is used.
+			m.ServiceState.BenthosStatus.LastScan.BenthosMetrics.MetricsState = nil
 		}
 
 		return *m.ServiceState, m.StatusError
@@ -470,26 +461,32 @@ func (m *MockBenthosMonitorService) ServiceExists(ctx context.Context, services 
 }
 
 // SetMetricsState allows tests to directly set the metrics state.
+//
+// After the window ownership moved from BenthosMonitorService to
+// BenthosService, the mock no longer carries a MetricsState. Instead it
+// returns Metrics whose counters yield the requested IsActive when
+// BenthosService feeds its own window via UpdateFromMetrics: a non-zero
+// Received makes the first feed active (MessagesPerTick > 0), zero makes it
+// inactive.
 func (m *MockBenthosMonitorService) SetMetricsState(isActive bool) {
-	if m.metricsState == nil {
-		m.metricsState = benthosmetrics.NewBenthosMetricsState()
-	}
-
-	m.metricsState.IsActive = isActive
-
-	// Update the service state if it existsSetMetricsState
 	if m.ServiceState != nil && m.ServiceState.BenthosStatus.LastScan != nil {
+		var received int64
+		if isActive {
+			received = 1
+		}
+
 		m.ServiceState.BenthosStatus.LastScan.BenthosMetrics = &BenthosMetrics{
 			Metrics: Metrics{
 				Inputs: map[string]InputInstance{
-					"root.input": {Path: "root.input", ConnectionUp: 1},
+					"root.input": {Path: "root.input", Received: received, ConnectionUp: 1},
 				},
 				Outputs: map[string]OutputInstance{
-					"root.output": {Path: "root.output", ConnectionUp: 1},
+					"root.output": {Path: "root.output", Sent: received, ConnectionUp: 1},
 				},
 			},
+			// nil: BenthosService owns and feeds the window now.
+			MetricsState: nil,
 		}
-		m.ServiceState.BenthosStatus.LastScan.BenthosMetrics.MetricsState = m.metricsState
 	}
 }
 
@@ -499,9 +496,7 @@ func (m *MockBenthosMonitorService) SetMockLogs(logs []s6service.LogEntry) {
 		m.ServiceState = &ServiceInfo{
 			BenthosStatus: BenthosMonitorStatus{
 				LastScan: &BenthosMetricsScan{
-					BenthosMetrics: &BenthosMetrics{
-						MetricsState: m.metricsState,
-					},
+					BenthosMetrics: &BenthosMetrics{},
 				},
 			},
 		}


### PR DESCRIPTION
> **Draft — Jeremy-only review.** Phase 3 (real self-review + da-sweep) done; 16 findings addressed (12 fixed, 4 dismissed, 2 deferred — see below). The branch was rebased onto the new PR2 tip (3 PR2 fix commits landed); the remote will be force-pushed to match once Jeremy OKs it.

**Stack:** PR1 (#2621) ← PR2 (#2620) ← **this PR** (base `benthos-monitor-fsmv2-pr2`).

## Problem
Each benthos instance runs a second S6 service (`benthos-monitor-<name>`) that forks ~14 processes/sec (4×curl + 4×gzip + 4×xxd + date) to scrape benthos's localhost endpoints, gzip-hex the bodies through a 64KB log, and re-parse at 10Hz while the data refreshes ~1Hz (~90% redundant parse). At 50 bridges this is ~0.5 core of overhead, ~58% kernel time (fork/exec/pipe). benthos itself is only ~1.6 mC/bridge.

## Shipping (this PR)
PR3 of a 3-PR stack. Wires the FF-on read + lifecycle path into `BenthosService` behind `USE_FSMV2_BENTHOS_MONITOR` (default OFF). When ON, `BenthosService` reads the `benthos_monitor` worker's published status via the process-scoped `fsmv2client` (`GetFresh`) + drives the worker's child-spec lifecycle (`Upsert`/`Delete`), **skipping the v1 S6 monitor reconcile** (the fork tree never spawns = the CPU win). When OFF, byte-identical to PR2 (the seam is fully guarded).

- The `benthosMonitorWatcher` seam (interface + nil-guarded default delegating to `fsmv2client.GetClient()`) + `WithFSMv2BenthosWatcher` option.
- The FF-on read path (Fresh / Stale / Unregistered / NeverObserved / Unknown) mirroring the v1 monitor's sentinel-error contract.
- The FF-on lifecycle (per-config `Upsert` + removal `Delete`) + the A1 full-replace (skip `benthosMonitorManager.Reconcile`).
- `mapFromBenthosMonitorState` (active→running; stopped-family→stopped), typed `config.DesiredState*` constants.
- A B1 single-window refactor (the throughput window moves from `BenthosMonitorService` to `BenthosService`, shared by both paths so a flag flip preserves throughput history) + the FF-off feed gate (`!LastUpdatedAt.Equal(lastFedScanAt)`) that rate-matches the 10Hz read path to the 1Hz scrape rate.
- Unit tests (fake watcher) + a real-supervisor capstone (down→recovery no-spike, crash+restart legitimate-wipe, stopped-no-scrape, port-change same-ref).

## Scope
`pkg/service/benthos/{benthos.go, fsmv2_watcher.go, fsmv2_watcher_gate.go, fsmv2_watcher_test.go}`, `pkg/fsmv2/integration/benthos_monitor_ff_on_scenario_test.go`, `pkg/service/benthos_monitor/{benthos_monitor.go, mock.go}`, `cmd/main.go` (+ `cmd/worker_registration_test.go`).

## Parity
FF-on == FF-off user-visible EXCEPT two documented deviations:
1. A genuine benthos outage degrades to `IsLive=false` immediately (~1s) rather than serving stale-healthy for up to 10s (the v1 monitor's age-grace). Truthful, not a regression.
2. A benthos port-change serves ~1 tick of stale-old-port as Fresh before the new port is scraped (same shape as the v1 path's brief Degraded).

## Phase 3 findings (real self-review + da-sweep)
- **Fixed (12):** the `cmd/main.go` missing state-import critical (FF-on shipped no monitoring in production — the worker's state subpackage was never imported; the capstone passed only because the test binary imported it directly); the FF-off feed-gate `After()`→`!Equal()` critical (NTP-backward freeze); slop rewrite (rung/phase labels → plain words); `mapFrom` typed constants; nil-client tests; stuck-Upsert Sentry warning. + 3 PR2 fixes (Observe /metrics-regression logging; worker.go typed state; parser godoc).
- **Dismissed (4):** the Delete+re-Upsert leftover-observation gap (ENG-5107 store-tombstone, tracked separately); the FF-on/FF-off IsLive outage divergence (the documented J2 deviation); Fresh+Stopped nil vs ErrBenthosMonitorNotRunning (admin-paused case, FF-on correct); Stale Metrics/MetricsState disagreement (IsLive=false masks it).
- **Deferred (2, follow-up):** the FF-on feed has no freshness gate (the FF-on equivalent of M1, bounded at 10s by maxAge, self-corrects via Stale; the fix needs exposing `CollectedAt` from `fsmv2client.GetFresh` — a cross-PR API change); the stalled-shell-clock case (the `!Equal` gate freezes on a system-clock failure; the UNION gate would handle it but is non-trivial for an exotic case).

## Notes for reviewers
- `fsmv2_watcher_gate.go` is a 1-line cross-package test-seam (`var EnableFSMv2BenthosMonitorForTest = &fsmv2BenthosMonitorEnabled`) — Go's `_test.go` scoping prevents `export_test.go` from being visible to the integration test binary. The pointer is the minimal seam; "ForTest" suffix is honest.
- `cmd/main.go` blank-imports `pkg/fsmv2/workers/benthos_monitor/state` to trigger the worker's `RegisterInitialState` init (the worker package can't self-import its state subpackage — an import cycle; a cleaner refactor that breaks the cycle is deferred).
- `skip-changelog-guard` — inert until the FF flips; no user-visible change yet.

## Measured (validation)
Benchmarked FF-off vs FF-on on one image (this branch's build), N ∈ {0,5,10} `generate→stdout` bridges, 3×60s windows/median, slope = per-bridge marginal CPU (fixed cost subtracted via N=0). Both arms `USE_FSMV2_TRANSPORT=ON`, differing only in `USE_FSMV2_BENTHOS_MONITOR`; FF-on verified to actually monitor (all bridges reach Active via the in-process scrape, S6 monitor count 0).

| Metric (per bridge, marginal) | FF-off | FF-on | Change |
|---|---|---|---|
| CPU | 19.2 mC | 5.3 mC | **−72%** |
| marginal system-time fraction | 38% | 10.5% | fork/exec kernel cost removed |
| process spawns/sec | ~14 | ~0.16 | (side effect — see below) |

Extrapolated to 50 bridges: **~0.70 core** saved. The system-time collapse is the mechanism: FF-off's per-bridge cost is dominated by fork/exec/pipe syscalls; FF-on's residual is mostly the in-process `http.Get`+parse (user time).

On the side: because the FF-on path scrapes in-process, it also removes the per-bridge process-spawn churn (~14/s → ~0 forks/s per bridge).

_Numbers measured on an arm64 Docker VM (M-series) — magnitudes are VM-relative; re-measure on an amd64 host before quoting an absolute externally. The % reduction and the mechanism (fork tree → in-process) are the durable results._


