### PR TITLE
feat(gk): certfetcher FSMv2 worker + wiring of gatekeeper

### DIFF
--- a/.github/workflows/build-umh-core.yml
+++ b/.github/workflows/build-umh-core.yml
@@ -74,7 +74,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: united-manufacturing-hub/ManagementConsole
-          path: ../ManagementConsole
+          path: ManagementConsole
           token: ${{ steps.mc-token.outputs.token }}
           persist-credentials: false
 
@@ -129,7 +129,8 @@ jobs:
 
           make build-depot \
             VERSION=${{ steps.version.outputs.VERSION }} \
-            TAGS="$TAGS"
+            TAGS="$TAGS" \
+            MC_PATH=${{ github.workspace }}/ManagementConsole
 
       - name: Get image digest
         id: digest

--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+- Gatekeeper (preview): instances can now validate that a user is authorized for a requested action before running it, rejecting unauthorized requests with a clear message instead of running them. Only affects instances started with `USE_GATEKEEPER=true`
+
 ## [0.44.27]
 
 ### New Features

--- a/umh-core/cmd/main.go
+++ b/umh-core/cmd/main.go
@@ -53,10 +53,15 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/register"
 	fsmv2sentry "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/sentry"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/application"
+	certfetcher "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/certfetcher"
+	_ "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/certfetcher/state"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator"
 	persistenceWorker "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/persistence"
 	transportWorker "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport"
 	transportSnapshot "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/snapshot"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/gatekeeper"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/gatekeeper/certificatehandler"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/gatekeeper/validator"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/logger"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/metrics"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/models"
@@ -173,6 +178,9 @@ func main() {
 		FSMv2ProtocolConverterEnabled: configData.Agent.UseFSMv2ProtocolConverter,
 		ResourceLimitBlockingEnabled:  configData.Agent.EnableResourceLimitBlocking,
 	}
+
+	gatekeeperEnabled, _ := env.GetAsBool("USE_GATEKEEPER", false, false)
+	configData.Agent.UseGatekeeper = gatekeeperEnabled
 
 	// Ensure the S6 repository directory exists
 	// This is particularly important when using /tmp/umh-core/services (the default)
@@ -509,7 +517,7 @@ func enableBackendConnection(ctx context.Context, config *config.FullConfig, com
 
 		communicationState.InitialiseAndStartPuller()
 		communicationState.InitialiseAndStartPusher()
-		communicationState.InitialiseAndStartSubscriberHandler(time.Minute*5, time.Minute, config, snapshotManager, configManager, nil) // nil = legacy mode uses Pusher
+		communicationState.InitialiseAndStartSubscriberHandler(time.Minute*5, time.Minute, config, snapshotManager, configManager, nil, nil) // nil = legacy mode uses Pusher
 		communicationState.InitialiseAndStartRouter()
 		communicationState.InitialiseReAuthHandler(config.Agent.AuthToken, config.Agent.AllowInsecureTLS)
 
@@ -554,8 +562,10 @@ func buildFSMv2Supervisor(
 		0,
 	)
 
-	// Start conversion goroutines.
-	channelAdapter.Start(ctx)
+	// Bridge conversion goroutines only needed without gatekeeper.
+	if !configData.Agent.UseGatekeeper {
+		channelAdapter.Start(ctx)
+	}
 
 	// Set the global ChannelProvider singleton BEFORE creating the supervisor.
 	// Phase 1 architecture: singleton is THE ONLY way to provide channels to the communicator.
@@ -563,9 +573,36 @@ func buildFSMv2Supervisor(
 	communicator.SetChannelProvider(channelAdapter)
 	transportWorker.SetChannelProvider(channelAdapter)
 
+	var certHandler *certificatehandler.CertHandler
+
+	// Gatekeeper setup (behind feature flag)
+	if configData.Agent.UseGatekeeper {
+		logger.Info("Gatekeeper enabled (feature flag)")
+		inboundRaw, outboundRaw := channelAdapter.RawChannels()
+		certHandler = certificatehandler.NewHandler(
+			validator.NewValidator(logger),
+			"", // JWT set after auth via polling
+			configData.Agent.APIURL,
+			configData.Agent.AuthToken,
+			"", // instanceUUID set after auth via polling
+			configData.Agent.AllowInsecureTLS,
+			logger,
+		)
+		gk := gatekeeper.New(
+			inboundRaw,
+			outboundRaw,
+			certHandler,
+			validator.NewValidator(logger),
+			logger,
+			gatekeeper.WithLocation(configData.Agent.Location),
+		)
+		gk.Start(ctx)
+		communicationState.Gatekeeper = gk
+	}
+
 	// Build YAML config for FSMv2 ApplicationSupervisor.
 	// instanceUUID is a placeholder — the real UUID is returned by the backend
-	// and picked up by polling TransportWorker.ObservedState.AuthenticatedUUID below (Bug #6 fix).
+	// and picked up by polling TransportWorker.ObservedState below (Bug #6 fix).
 	placeholderUUID = uuid.New().String()
 	yamlConfig := fmt.Sprintf(`
 children:
@@ -579,6 +616,14 @@ children:
         timeout: "10s"
         state: "running"
 `, configData.Agent.APIURL, placeholderUUID, configData.Agent.AuthToken)
+
+	if configData.Agent.UseGatekeeper {
+		yamlConfig += `  - name: "certfetcher"
+    workerType: "certfetcher"
+`
+		register.SetDeps[*certfetcher.CertFetcherDependencies](certfetcher.WorkerTypeName,
+			certfetcher.NewCertHandlerSeedDependencies(communicationState.Gatekeeper.CertificateHandler()))
+	}
 
 	if configData.Agent.UseFSMv2MemoryCleanup {
 		yamlConfig += `  - name: "persistence"
@@ -658,27 +703,43 @@ func wireFSMv2Communicator(
 	// 4. Start Router (processes inbound messages, generates status via Subscriber)
 	communicationState.InitializeWriteOnlyPusher(placeholderUUID)
 	communicationState.SetLoginResponseForFSMv2(placeholderUUID)
-	communicationState.InitialiseAndStartSubscriberHandler(
-		5*time.Minute, // TTL: time until subscriber considered dead
-		1*time.Minute, // Cull: cycle time to remove dead subscribers
-		configData,
-		communicationState.SystemSnapshotManager,
-		communicationState.ConfigManager,
-		channelAdapter.GetOutboundWriteChannel(), // FSMv2 mode: bypass Pusher, write directly to FSMv2 transport
-	)
+	if configData.Agent.UseGatekeeper {
+		communicationState.InitialiseAndStartSubscriberHandler(
+			5*time.Minute, // TTL: time until subscriber considered dead
+			1*time.Minute, // Cull: cycle time to remove dead subscribers
+			configData,
+			communicationState.SystemSnapshotManager,
+			communicationState.ConfigManager,
+			nil, // no legacy FSMv2 channel when gatekeeper is active
+			communicationState.Gatekeeper.VerifiedOutboundChan(), // Gatekeeper mode: write MessageWithSender
+		)
+		communicationState.Gatekeeper.CertificateHandler().SetSubHandler(communicationState.SubscriberHandler)
+	} else {
+		communicationState.InitialiseAndStartSubscriberHandler(
+			5*time.Minute, // TTL: time until subscriber considered dead
+			1*time.Minute, // Cull: cycle time to remove dead subscribers
+			configData,
+			communicationState.SystemSnapshotManager,
+			communicationState.ConfigManager,
+			channelAdapter.GetOutboundWriteChannel(), // FSMv2 without gatekeeper
+			nil,                                      // no gatekeeper channel
+		)
+	}
 	communicationState.InitializeRouterForFSMv2()
 
-	// Poll the TransportWorker's ObservedState for AuthenticatedUUID.
-	// TransportWorker handles authentication (ENG-4264) and exposes the UUID
-	// from the backend response. The transport child ID follows the supervisor
-	// naming convention: spec.Name + "-001" = "transport-001".
+	// Poll the TransportWorker's ObservedState for the authenticated UUID and JWT.
+	// TransportWorker handles authentication (ENG-4264) and exposes both via
+	// AuthSession. The transport child ID follows the supervisor naming
+	// convention: spec.Name + "-001" = "transport-001". When the gatekeeper is
+	// active, the UUID and JWT are forwarded to it here.
 	//
-	// This goroutine exits as soon as the real UUID is detected or the context
-	// is cancelled; it does not block the caller.
+	// This goroutine exits as soon as the context is cancelled; it does not
+	// block the caller.
 	go func() {
 		ticker := time.NewTicker(100 * time.Millisecond)
 		defer ticker.Stop()
 
+		uuidSet := false
 		for {
 			select {
 			case <-ctx.Done():
@@ -691,13 +752,19 @@ func wireFSMv2Communicator(
 					continue
 				}
 
-				if observed.Status.AuthSession.InstanceUUID != "" && observed.Status.AuthSession.InstanceUUID != placeholderUUID {
+				if !uuidSet && observed.Status.AuthSession.InstanceUUID != "" && observed.Status.AuthSession.InstanceUUID != placeholderUUID {
 					logger.Infow("Detected real UUID from TransportWorker ObservedState, updating LoginResponse",
 						"realUUID", observed.Status.AuthSession.InstanceUUID,
 						"placeholderUUID", placeholderUUID)
 					communicationState.SetLoginResponseForFSMv2(observed.Status.AuthSession.InstanceUUID)
+					if communicationState.Gatekeeper != nil {
+						communicationState.Gatekeeper.SetInstanceUUID(observed.Status.AuthSession.InstanceUUID)
+					}
+					uuidSet = true
+				}
 
-					return
+				if communicationState.Gatekeeper != nil && observed.Status.AuthSession.Token != "" {
+					communicationState.Gatekeeper.SetJWT(observed.Status.AuthSession.Token)
 				}
 			}
 		}

--- a/umh-core/cmd/main.go
+++ b/umh-core/cmd/main.go
@@ -57,12 +57,17 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/register"
 	fsmv2sentry "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/sentry"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/application"
+	certfetcher "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/certfetcher"
+	_ "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/certfetcher/state"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/configworker"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/configworker/dynamicchildren"
 	persistenceWorker "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/persistence"
 	transportWorker "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport"
 	transportSnapshot "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/snapshot"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/gatekeeper"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/gatekeeper/certificatehandler"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/gatekeeper/validator"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/logger"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/metrics"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/models"
@@ -181,6 +186,9 @@ func main() {
 		HistorianConfigured:           configData.Historian != nil,
 		HistorianBridgeCount:          countHistorianBridges(configData),
 	}
+
+	gatekeeperEnabled, _ := env.GetAsBool("USE_GATEKEEPER", false, false)
+	configData.Agent.UseGatekeeper = gatekeeperEnabled
 
 	// Ensure the S6 repository directory exists
 	// This is particularly important when using /tmp/umh-core/services (the default)
@@ -594,7 +602,7 @@ func enableBackendConnection(ctx context.Context, config *config.FullConfig, com
 
 		communicationState.InitialiseAndStartPuller()
 		communicationState.InitialiseAndStartPusher()
-		communicationState.InitialiseAndStartSubscriberHandler(time.Minute*5, time.Minute, config, snapshotManager, configManager, nil) // nil = legacy mode uses Pusher
+		communicationState.InitialiseAndStartSubscriberHandler(time.Minute*5, time.Minute, config, snapshotManager, configManager, nil, nil) // nil = legacy mode uses Pusher
 		communicationState.InitialiseAndStartRouter()
 		communicationState.InitialiseReAuthHandler(config.Agent.AuthToken, config.Agent.AllowInsecureTLS)
 
@@ -658,7 +666,11 @@ func buildFSMv2Supervisor(
 	// This loss is bounded by the per-level drain budget (base × subtree height)
 	// and accepted here: the process is terminating, so an action arriving after
 	// SIGTERM could not complete or have its reply delivered anyway.
-	channelAdapter.Start(ctx)
+	//
+	// Bridge conversion goroutines only needed without gatekeeper.
+	if !configData.Agent.UseGatekeeper {
+		channelAdapter.Start(ctx)
+	}
 
 	// Set the global ChannelProvider singleton BEFORE creating the supervisor.
 	// Phase 1 architecture: singleton is THE ONLY way to provide channels to the communicator.
@@ -666,9 +678,36 @@ func buildFSMv2Supervisor(
 	communicator.SetChannelProvider(channelAdapter)
 	transportWorker.SetChannelProvider(channelAdapter)
 
+	var certHandler *certificatehandler.CertHandler
+
+	// Gatekeeper setup (behind feature flag)
+	if configData.Agent.UseGatekeeper {
+		logger.Info("Gatekeeper enabled (feature flag)")
+		inboundRaw, outboundRaw := channelAdapter.RawChannels()
+		certHandler = certificatehandler.NewHandler(
+			validator.NewValidator(logger),
+			"", // JWT set after auth via polling
+			configData.Agent.APIURL,
+			configData.Agent.AuthToken,
+			"", // instanceUUID set after auth via polling
+			configData.Agent.AllowInsecureTLS,
+			logger,
+		)
+		gk := gatekeeper.New(
+			inboundRaw,
+			outboundRaw,
+			certHandler,
+			validator.NewValidator(logger),
+			logger,
+			gatekeeper.WithLocation(configData.Agent.Location),
+		)
+		gk.Start(ctx)
+		communicationState.Gatekeeper = gk
+	}
+
 	// Build YAML config for FSMv2 ApplicationSupervisor.
 	// instanceUUID is a placeholder — the real UUID is returned by the backend
-	// and picked up by polling TransportWorker.ObservedState.AuthenticatedUUID below (Bug #6 fix).
+	// and picked up by polling TransportWorker.ObservedState below (Bug #6 fix).
 	placeholderUUID = uuid.New().String()
 	yamlConfig := fmt.Sprintf(`
 children:
@@ -682,6 +721,14 @@ children:
         timeout: "10s"
         state: "running"
 `, configData.Agent.APIURL, placeholderUUID, configData.Agent.AuthToken)
+
+	if configData.Agent.UseGatekeeper {
+		yamlConfig += `  - name: "certfetcher"
+    workerType: "certfetcher"
+`
+		register.SetDeps[*certfetcher.CertFetcherDependencies](certfetcher.WorkerTypeName,
+			certfetcher.NewCertHandlerSeedDependencies(communicationState.Gatekeeper.CertificateHandler()))
+	}
 
 	if configData.Agent.UseFSMv2MemoryCleanup {
 		yamlConfig += `  - name: "persistence"
@@ -807,27 +854,43 @@ func wireFSMv2Communicator(
 	// 4. Start Router (processes inbound messages, generates status via Subscriber)
 	communicationState.InitializeWriteOnlyPusher(placeholderUUID)
 	communicationState.SetLoginResponseForFSMv2(placeholderUUID)
-	communicationState.InitialiseAndStartSubscriberHandler(
-		5*time.Minute, // TTL: time until subscriber considered dead
-		1*time.Minute, // Cull: cycle time to remove dead subscribers
-		configData,
-		communicationState.SystemSnapshotManager,
-		communicationState.ConfigManager,
-		channelAdapter.GetOutboundWriteChannel(), // FSMv2 mode: bypass Pusher, write directly to FSMv2 transport
-	)
+	if configData.Agent.UseGatekeeper {
+		communicationState.InitialiseAndStartSubscriberHandler(
+			5*time.Minute, // TTL: time until subscriber considered dead
+			1*time.Minute, // Cull: cycle time to remove dead subscribers
+			configData,
+			communicationState.SystemSnapshotManager,
+			communicationState.ConfigManager,
+			nil, // no legacy FSMv2 channel when gatekeeper is active
+			communicationState.Gatekeeper.VerifiedOutboundChan(), // Gatekeeper mode: write MessageWithSender
+		)
+		communicationState.Gatekeeper.CertificateHandler().SetSubHandler(communicationState.SubscriberHandler)
+	} else {
+		communicationState.InitialiseAndStartSubscriberHandler(
+			5*time.Minute, // TTL: time until subscriber considered dead
+			1*time.Minute, // Cull: cycle time to remove dead subscribers
+			configData,
+			communicationState.SystemSnapshotManager,
+			communicationState.ConfigManager,
+			channelAdapter.GetOutboundWriteChannel(), // FSMv2 without gatekeeper
+			nil,                                      // no gatekeeper channel
+		)
+	}
 	communicationState.InitializeRouterForFSMv2()
 
-	// Poll the TransportWorker's ObservedState for AuthenticatedUUID.
-	// TransportWorker handles authentication (ENG-4264) and exposes the UUID
-	// from the backend response. The transport child ID follows the supervisor
-	// naming convention: spec.Name + "-001" = "transport-001".
+	// Poll the TransportWorker's ObservedState for the authenticated UUID and JWT.
+	// TransportWorker handles authentication (ENG-4264) and exposes both via
+	// AuthSession. The transport child ID follows the supervisor naming
+	// convention: spec.Name + "-001" = "transport-001". When the gatekeeper is
+	// active, the UUID and JWT are forwarded to it here.
 	//
-	// This goroutine exits as soon as the real UUID is detected or the context
-	// is cancelled; it does not block the caller.
+	// This goroutine exits as soon as the context is cancelled; it does not
+	// block the caller.
 	go func() {
 		ticker := time.NewTicker(100 * time.Millisecond)
 		defer ticker.Stop()
 
+		uuidSet := false
 		for {
 			select {
 			case <-ctx.Done():
@@ -840,13 +903,19 @@ func wireFSMv2Communicator(
 					continue
 				}
 
-				if observed.Status.AuthSession.InstanceUUID != "" && observed.Status.AuthSession.InstanceUUID != placeholderUUID {
+				if !uuidSet && observed.Status.AuthSession.InstanceUUID != "" && observed.Status.AuthSession.InstanceUUID != placeholderUUID {
 					logger.Infow("Detected real UUID from TransportWorker ObservedState, updating LoginResponse",
 						"realUUID", observed.Status.AuthSession.InstanceUUID,
 						"placeholderUUID", placeholderUUID)
 					communicationState.SetLoginResponseForFSMv2(observed.Status.AuthSession.InstanceUUID)
+					if communicationState.Gatekeeper != nil {
+						communicationState.Gatekeeper.SetInstanceUUID(observed.Status.AuthSession.InstanceUUID)
+					}
+					uuidSet = true
+				}
 
-					return
+				if communicationState.Gatekeeper != nil && observed.Status.AuthSession.Token != "" {
+					communicationState.Gatekeeper.SetJWT(observed.Status.AuthSession.Token)
 				}
 			}
 		}

--- a/umh-core/pkg/communicator/communication_state/communication_state.go
+++ b/umh-core/pkg/communicator/communication_state/communication_state.go
@@ -33,6 +33,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
 	topicbrowserfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/topicbrowser"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/types"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/gatekeeper"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/models"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/sentry"
 	"go.uber.org/zap"
@@ -50,6 +51,7 @@ type CommunicationState struct {
 	SubscriberHandler     *subscriber.Handler
 	OutboundChannel       chan *models.UMHMessage
 	Router                *router.Router
+	Gatekeeper            *gatekeeper.Gatekeeper
 	SystemSnapshotManager *fsm.SnapshotManager
 	Logger                *zap.SugaredLogger
 	TopicBrowserCache     *topicbrowser.Cache
@@ -246,7 +248,7 @@ func (c *CommunicationState) UpdateTopicBrowserCache() error {
 // InitialiseAndStartSubscriberHandler creates a new subscriber handler and starts it
 // ttl is the time until a subscriber is considered dead (if no new subscriber message is received)
 // cull is the cycle time to remove dead subscribers.
-func (c *CommunicationState) InitialiseAndStartSubscriberHandler(ttl time.Duration, cull time.Duration, config *config.FullConfig, systemSnapshotManager *fsm.SnapshotManager, configManager config.ConfigManager, fsmOutboundChannel chan<- *types.UMHMessage) {
+func (c *CommunicationState) InitialiseAndStartSubscriberHandler(ttl time.Duration, cull time.Duration, config *config.FullConfig, systemSnapshotManager *fsm.SnapshotManager, configManager config.ConfigManager, fsmOutboundChannel chan<- *types.UMHMessage, gatekeeperOutboundChannel chan<- *types.MessageWithSender) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -297,7 +299,8 @@ func (c *CommunicationState) InitialiseAndStartSubscriberHandler(ttl time.Durati
 		configManager,
 		c.Logger,
 		topicBrowserCommunicator,
-		fsmOutboundChannel, // FSMv2 direct channel (nil for legacy mode)
+		fsmOutboundChannel,        // FSMv2 direct channel (nil for legacy mode)
+		gatekeeperOutboundChannel, // Gatekeeper channel (nil when gatekeeper disabled)
 		c.FeatureUsage,
 	)
 	if c.SubscriberHandler == nil {
@@ -449,7 +452,11 @@ func (c *CommunicationState) InitializeRouterForFSMv2() {
 	c.mu.Lock()
 	c.LoginResponseMu.RLock()
 	// Note: Puller is nil for FSMv2 mode - FSMv2 handles pulling via PullWorker
-	c.Router = router.NewRouter(c.Watchdog, c.InboundChannel, c.LoginResponse.UUID, c.OutboundChannel, c.ReleaseChannel, c.SubscriberHandler, c.SystemSnapshotManager, c.ConfigManager, c.Logger)
+	if c.Gatekeeper != nil {
+		c.Router = router.NewRouterForFSMv2(c.Watchdog, c.Gatekeeper.VerifiedInboundChan(), c.LoginResponse.UUID, c.Gatekeeper.LegacyOutboundChan(), c.ReleaseChannel, c.SubscriberHandler, c.SystemSnapshotManager, c.ConfigManager, c.Logger)
+	} else {
+		c.Router = router.NewRouter(c.Watchdog, c.InboundChannel, c.LoginResponse.UUID, c.OutboundChannel, c.ReleaseChannel, c.SubscriberHandler, c.SystemSnapshotManager, c.ConfigManager, c.Logger)
+	}
 	c.LoginResponseMu.RUnlock()
 	c.mu.Unlock()
 
@@ -460,6 +467,13 @@ func (c *CommunicationState) InitializeRouterForFSMv2() {
 	}
 
 	c.Router.Start()
+}
+
+// GetSubscriberHandler returns the current subscriber handler (thread-safe).
+func (c *CommunicationState) GetSubscriberHandler() *subscriber.Handler {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.SubscriberHandler
 }
 
 // parseUUIDForFSMv2 attempts to parse a UUID string, returning uuid.Nil on failure.

--- a/umh-core/pkg/communicator/fsmv2_adapter/legacy_bridge.go
+++ b/umh-core/pkg/communicator/fsmv2_adapter/legacy_bridge.go
@@ -36,7 +36,7 @@
 //
 //	┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
 //	│  FSMv2 Worker   │────▶│  Legacy Bridge  │────▶│     Router      │
-//	│  (transport.*)  │◀────│   (converts)    │◀────│  (models.*)     │
+//	│  (types.*)  │◀────│   (converts)    │◀────│  (models.*)     │
 //	└─────────────────┘     └─────────────────┘     └─────────────────┘
 //
 // Flow:
@@ -268,4 +268,9 @@ func (b *LegacyChannelBridge) GetInboundStats(_ string) (capacity int, length in
 // Used for Priority 0: Remove Pusher from FSMv2 flow.
 func (b *LegacyChannelBridge) GetOutboundWriteChannel() chan<- *types.UMHMessage {
 	return b.fsmOutbound
+}
+
+// RawChannels returns the raw bidirectional FSMv2 channels for the gatekeeper.
+func (b *LegacyChannelBridge) RawChannels() (inbound chan *types.UMHMessage, outbound chan *types.UMHMessage) {
+	return b.fsmInbound, b.fsmOutbound
 }

--- a/umh-core/pkg/communicator/pkg/subscriber/subscribers.go
+++ b/umh-core/pkg/communicator/pkg/subscriber/subscribers.go
@@ -41,7 +41,8 @@ type Handler struct {
 	configManager              config.ConfigManager
 	subscriberRegistry         *subscribers.Registry
 	pusher                     *push.Pusher
-	fsmOutboundChannel         chan<- *types.UMHMessage // FSMv2 direct channel (nil for legacy mode)
+	fsmOutboundChannel         chan<- *types.UMHMessage        // FSMv2 without gatekeeper (nil for legacy mode)
+	gatekeeperOutboundChannel  chan<- *types.MessageWithSender // FSMv2 with gatekeeper (nil when gatekeeper disabled)
 	StatusCollector            *generator.StatusCollectorType
 	systemSnapshotManager      *fsm.SnapshotManager
 	topicBrowserCommunicator   *topicbrowser.TopicBrowserCommunicator
@@ -65,7 +66,8 @@ func NewHandler(
 	configManager config.ConfigManager,
 	logger *zap.SugaredLogger,
 	topicBrowserCommunicator *topicbrowser.TopicBrowserCommunicator,
-	fsmOutboundChannel chan<- *types.UMHMessage, // FSMv2 direct channel (nil for legacy mode)
+	fsmOutboundChannel chan<- *types.UMHMessage, // FSMv2 without gatekeeper (nil for legacy mode)
+	gatekeeperOutboundChannel chan<- *types.MessageWithSender, // FSMv2 with gatekeeper (nil when gatekeeper disabled)
 	featureUsage *models.FeatureUsage,
 ) *Handler {
 	s := &Handler{}
@@ -73,6 +75,7 @@ func NewHandler(
 	s.dog = dog
 	s.pusher = pusher
 	s.fsmOutboundChannel = fsmOutboundChannel
+	s.gatekeeperOutboundChannel = gatekeeperOutboundChannel
 	s.instanceUUID = instanceUUID
 	s.systemSnapshotManager = systemSnapshotManager
 	s.configManager = configManager
@@ -104,6 +107,12 @@ func (s *Handler) GetSubscribers() []string {
 	s.dog.SetHasSubscribers(len(subscribers) > 0)
 
 	return subscribers
+}
+
+// Subscribers returns the list of active subscriber emails.
+// Implements certificatehandler.SubHandler interface.
+func (s *Handler) Subscribers() []string {
+	return s.GetSubscribers()
 }
 
 // SetInstanceUUID updates the instance UUID used for status messages.
@@ -182,38 +191,57 @@ func (s *Handler) notify() {
 			return
 		}
 
-		message, err := encoding.EncodeMessageFromUMHInstanceToUser(models.UMHMessageContent{
-			MessageType: models.Status,
-			Payload:     statusMessage,
-		})
-		if err != nil {
-			s.logger.Warnf("Failed to encrypt message for subscriber %s", email)
-
-			return
-		}
-
-		// FSMv2 mode: write directly to FSMv2 outbound channel (bypasses legacy Pusher)
-		// Legacy mode: use Pusher as before
-		if s.fsmOutboundChannel != nil {
-			msg := &types.UMHMessage{
-				InstanceUUID: s.GetInstanceUUID().String(),
-				Content:      message,
-				Email:        email,
+		// Gatekeeper mode: write raw MessageWithSender
+		if s.gatekeeperOutboundChannel != nil {
+			msg := &types.MessageWithSender{
+				Content: models.UMHMessageContent{
+					MessageType: models.Status,
+					Payload:     statusMessage,
+				},
+				SenderEmail: email,
 			}
 			select {
-			case s.fsmOutboundChannel <- msg:
-				// Successfully sent to FSMv2 transport
+			case s.gatekeeperOutboundChannel <- msg:
+				// Successfully sent to gatekeeper
 			default:
-				s.logger.Warnf("FSMv2 outbound channel full, dropping message for subscriber %s", email)
+				s.logger.Warnf("Gatekeeper outbound channel full, dropping message for subscriber %s", email)
 
 				return
 			}
 		} else {
-			s.pusher.Push(models.UMHMessage{
-				Content:      message,
-				Email:        email,
-				InstanceUUID: s.GetInstanceUUID(),
+			message, err := encoding.EncodeMessageFromUMHInstanceToUser(models.UMHMessageContent{
+				MessageType: models.Status,
+				Payload:     statusMessage,
 			})
+			if err != nil {
+				s.logger.Warnf("Failed to encrypt message for subscriber %s", email)
+
+				return
+			}
+
+			// FSMv2 mode without gatekeeper: write encoded types.UMHMessage
+			if s.fsmOutboundChannel != nil {
+				msg := &types.UMHMessage{
+					InstanceUUID: s.GetInstanceUUID().String(),
+					Content:      message,
+					Email:        email,
+				}
+				select {
+				case s.fsmOutboundChannel <- msg:
+					// Successfully sent to FSMv2 transport
+				default:
+					s.logger.Warnf("FSMv2 outbound channel full, dropping message for subscriber %s", email)
+
+					return
+				}
+			} else {
+				// Legacy mode: use Pusher
+				s.pusher.Push(models.UMHMessage{
+					Content:      message,
+					Email:        email,
+					InstanceUUID: s.GetInstanceUUID(),
+				})
+			}
 		}
 
 		// Mark subscriber as bootstrapped after first message

--- a/umh-core/pkg/communicator/pkg/subscriber/subscribers_fsmv2_test.go
+++ b/umh-core/pkg/communicator/pkg/subscriber/subscribers_fsmv2_test.go
@@ -63,6 +63,7 @@ var _ = Describe("FSMv2 Direct Channel Mode", func() {
 				logger,
 				nil, // topicBrowserCommunicator
 				fsmOutboundChannel,
+				nil, // gatekeeperOutboundChannel
 				nil, // featureUsage
 			)
 		})
@@ -100,6 +101,7 @@ var _ = Describe("FSMv2 Direct Channel Mode", func() {
 				logger,
 				nil, // topicBrowserCommunicator
 				nil, // fsmOutboundChannel - nil for legacy mode
+				nil, // gatekeeperOutboundChannel
 				nil, // featureUsage
 			)
 		})
@@ -132,6 +134,7 @@ var _ = Describe("FSMv2 Direct Channel Mode", func() {
 				logger,
 				nil,
 				nil, // legacy mode
+				nil, // gatekeeperOutboundChannel
 				nil, // featureUsage
 			)
 
@@ -152,7 +155,8 @@ var _ = Describe("FSMv2 Direct Channel Mode", func() {
 				logger,
 				nil,
 				fsmv2Channel, // FSMv2 mode
-				nil,          // featureUsage
+				nil, // gatekeeperOutboundChannel
+				nil, // featureUsage
 			)
 
 			// Both handlers should work independently

--- a/umh-core/pkg/communicator/pkg/subscriber/subscribers_race_test.go
+++ b/umh-core/pkg/communicator/pkg/subscriber/subscribers_race_test.go
@@ -61,6 +61,7 @@ var _ = Describe("SubscriberHandler Race Condition", func() {
 			logger,
 			nil, // topicBrowserCommunicator
 			nil, // fsmOutboundChannel - nil for legacy mode test
+			nil, // gatekeeperOutboundChannel
 			nil, // featureUsage
 		)
 	})

--- a/umh-core/pkg/communicator/router/router.go
+++ b/umh-core/pkg/communicator/router/router.go
@@ -210,10 +210,13 @@ func (r *Router) handleSub(message *types.MessageWithSender, watcherUUID uuid.UU
 	}
 
 	var subscribePayload models.SubscribeMessagePayload
-	if message.Content.Payload != nil {
-		// Try direct type assertion first
-		if payload, ok := message.Content.Payload.(models.SubscribeMessagePayload); ok {
-			subscribePayload = payload
+
+	switch payload := message.Content.Payload.(type) {
+	case models.SubscribeMessagePayload:
+		subscribePayload = payload
+	case map[string]any:
+		if err := maptostruct.MapToStruct(payload, &subscribePayload); err != nil {
+			r.routerLogger.Warnf("Failed to convert payload into SubscribeMessagePayload: %v", err)
 		}
 	}
 

--- a/umh-core/pkg/communicator/router/router.go
+++ b/umh-core/pkg/communicator/router/router.go
@@ -27,6 +27,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/communicator/pkg/subscriber"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/communicator/pkg/tools/maptostruct"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/communicator/pkg/tools/watchdog"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/types"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/models"
 	"go.uber.org/zap"
 )
@@ -34,7 +35,7 @@ import (
 type Router struct {
 	dog                   watchdog.Iface
 	configManager         config.ConfigManager
-	inboundChannel        chan *models.UMHMessage
+	inboundChannel        <-chan *types.MessageWithSender
 	outboundChannel       chan *models.UMHMessage
 	clientConnections     map[string]*ClientConnection
 	subHandler            *subscriber.Handler
@@ -52,8 +53,63 @@ type ClientConnection struct {
 	CompanionToFrontendChannel chan []byte
 }
 
+// NewRouter creates a Router for the legacy (non-FSMv2) path.
+// Deprecated: Use NewRouterForFSMv2 for FSMv2 mode with gatekeeper.
 func NewRouter(dog watchdog.Iface,
 	inboundChannel chan *models.UMHMessage,
+	instanceUUID uuid.UUID,
+	outboundChannel chan *models.UMHMessage,
+	releaseChannel config.ReleaseChannel,
+	subHandler *subscriber.Handler,
+	systemSnapshotManager *fsm.SnapshotManager,
+	configManager config.ConfigManager,
+	logger *zap.SugaredLogger,
+) *Router {
+	// Legacy path: spawn adapter goroutine that decodes and forwards
+	verifiedChan := make(chan *types.MessageWithSender, cap(inboundChannel))
+	go func() {
+		for msg := range inboundChannel {
+			messageContent, err := encoding.DecodeMessageFromUserToUMHInstance(msg.Content)
+			if err != nil {
+				logger.Warnf("Failed to decrypt message: %s", err.Error())
+
+				continue
+			}
+
+			traceID := ""
+			if msg.Metadata != nil {
+				traceID = msg.Metadata.TraceID.String()
+			}
+
+			verifiedChan <- &types.MessageWithSender{
+				Content:     messageContent,
+				SenderEmail: msg.Email,
+				TraceID:     traceID,
+			}
+		}
+		close(verifiedChan)
+	}()
+
+	return &Router{
+		dog:                   dog,
+		inboundChannel:        verifiedChan,
+		instanceUUID:          instanceUUID,
+		outboundChannel:       outboundChannel,
+		releaseChannel:        releaseChannel,
+		clientConnections:     make(map[string]*ClientConnection),
+		clientConnectionsLock: sync.RWMutex{},
+		subHandler:            subHandler,
+		systemSnapshotManager: systemSnapshotManager,
+		configManager:         configManager,
+		actionLogger:          logger,
+		routerLogger:          logger,
+	}
+}
+
+// NewRouterForFSMv2 creates a Router for FSMv2 mode where the gatekeeper
+// provides pre-decoded MessageWithSender on the inbound channel.
+func NewRouterForFSMv2(dog watchdog.Iface,
+	inboundChannel <-chan *types.MessageWithSender,
 	instanceUUID uuid.UUID,
 	outboundChannel chan *models.UMHMessage,
 	releaseChannel config.ReleaseChannel,
@@ -121,21 +177,15 @@ func (r *Router) router() {
 			}
 
 			r.dog.ReportHeartbeatStatus(watcherUUID, watchdog.HEARTBEAT_STATUS_OK)
-			// Decode message
-			messageContent, err := encoding.DecodeMessageFromUserToUMHInstance(message.Content)
-			if err != nil {
-				r.routerLogger.Warnf("Failed to decrypt message: %s", err.Error())
 
-				continue
-			}
-
-			switch messageContent.MessageType {
+			// Message already decoded by gatekeeper
+			switch message.Content.MessageType {
 			case models.Subscribe:
-				r.handleSub(message, messageContent, watcherUUID)
+				r.handleSub(message, watcherUUID)
 			case models.Action:
-				r.handleAction(messageContent, message, watcherUUID)
+				r.handleAction(message, watcherUUID)
 			default:
-				r.routerLogger.Warnf("Unexpected message type: %s", messageContent.MessageType)
+				r.routerLogger.Warnf("Unexpected message type: %s", message.Content.MessageType)
 
 				continue
 			}
@@ -151,7 +201,7 @@ func (r *Router) router() {
 // this is an optimization to avoid sending a "new subscriber" message, containing the cached uns data with at least
 // one event for every topic, to the frontend when the user is already subscribed
 // we should avoid unnecessary new subscriber message generation because of its high memory and cpu usage.
-func (r *Router) handleSub(message *models.UMHMessage, messageContent models.UMHMessageContent, watcherUUID uuid.UUID) {
+func (r *Router) handleSub(message *types.MessageWithSender, watcherUUID uuid.UUID) {
 	if r.subHandler == nil {
 		r.dog.ReportHeartbeatStatus(watcherUUID, watchdog.HEARTBEAT_STATUS_WARNING)
 		r.routerLogger.Warnf("Subscribe handler not yet initialized")
@@ -160,22 +210,22 @@ func (r *Router) handleSub(message *models.UMHMessage, messageContent models.UMH
 	}
 
 	var subscribePayload models.SubscribeMessagePayload
-	if messageContent.Payload != nil {
+	if message.Content.Payload != nil {
 		// Try direct type assertion first
-		if payload, ok := messageContent.Payload.(models.SubscribeMessagePayload); ok {
+		if payload, ok := message.Content.Payload.(models.SubscribeMessagePayload); ok {
 			subscribePayload = payload
 		}
 	}
 
-	r.subHandler.AddOrRefreshSubscriber(message.Email, subscribePayload.Resubscribed)
+	r.subHandler.AddOrRefreshSubscriber(message.SenderEmail, subscribePayload.Resubscribed)
 }
 
-func (r *Router) handleAction(messageContent models.UMHMessageContent, message *models.UMHMessage, watcherUUID uuid.UUID) {
+func (r *Router) handleAction(message *types.MessageWithSender, watcherUUID uuid.UUID) {
 	var actionPayload models.ActionMessagePayload
 
-	payloadMap, ok := messageContent.Payload.(map[string]interface{})
+	payloadMap, ok := message.Content.Payload.(map[string]interface{})
 	if !ok {
-		r.routerLogger.Warnf("Warning: Could not assert payload to map[string]interface{}. Actual type: %T, Value: %v", messageContent.Payload, messageContent.Payload)
+		r.routerLogger.Warnf("Warning: Could not assert payload to map[string]interface{}. Actual type: %T, Value: %v", message.Content.Payload, message.Content.Payload)
 
 		return
 	}
@@ -186,19 +236,22 @@ func (r *Router) handleAction(messageContent models.UMHMessageContent, message *
 		return
 	}
 
-	traceId := uuid.Nil
-	if message.Metadata != nil {
-		traceId = message.Metadata.TraceID
+	traceID := uuid.Nil
+	if message.TraceID != "" {
+		parsed, err := uuid.Parse(message.TraceID)
+		if err == nil {
+			traceID = parsed
+		}
 	}
 
 	go actions.HandleActionMessage(
 		r.GetInstanceUUID(),
 		actionPayload,
-		message.Email,
+		message.SenderEmail,
 		r.outboundChannel,
 		r.releaseChannel,
 		r.dog,
-		traceId,
+		traceID,
 		r.systemSnapshotManager,
 		r.configManager,
 	)

--- a/umh-core/pkg/config/config.go
+++ b/umh-core/pkg/config/config.go
@@ -104,6 +104,7 @@ type AgentConfig struct {
 	EnableFSMv2               bool `yaml:"enableFSMv2,omitempty"`               // Master switch: starts ApplicationSupervisor
 	UseFSMv2ProtocolConverter bool `yaml:"useFSMv2ProtocolConverter,omitempty"` // Migrate Protocol Converter to FSMv2
 	UseFSMv2MemoryCleanup     bool `yaml:"useFSMv2MemoryCleanup,omitempty"`     // Enable PersistenceWorker for delta compaction
+	UseGatekeeper             bool `yaml:"useGatekeeper,omitempty"`             // Enable gatekeeper middleware for message validation and encryption
 }
 
 type CommunicatorConfig struct {

--- a/umh-core/pkg/config/config.go
+++ b/umh-core/pkg/config/config.go
@@ -105,6 +105,7 @@ type AgentConfig struct {
 	EnableFSMv2               bool `yaml:"enableFSMv2,omitempty"`               // Master switch: starts ApplicationSupervisor
 	UseFSMv2ProtocolConverter bool `yaml:"useFSMv2ProtocolConverter,omitempty"` // Migrate Protocol Converter to FSMv2
 	UseFSMv2MemoryCleanup     bool `yaml:"useFSMv2MemoryCleanup,omitempty"`     // Enable PersistenceWorker for delta compaction
+	UseGatekeeper             bool `yaml:"useGatekeeper,omitempty"`             // Enable gatekeeper middleware for message validation and encryption
 }
 
 type CommunicatorConfig struct {

--- a/umh-core/pkg/fsmv2/deps/metrics.go
+++ b/umh-core/pkg/fsmv2/deps/metrics.go
@@ -134,6 +134,9 @@ const (
 	// Resets to 0 on successful operation.
 	GaugeConsecutiveErrors GaugeName = "consecutive_errors"
 
+	// GaugeCachedCerts tracks the number of subscriber certificates currently cached.
+	GaugeCachedCerts GaugeName = "cached_certs"
+
 	// GaugeBackpressureActive indicates whether the communicator is in backpressure state.
 	// 1 = backpressure active (pulling paused), 0 = normal operation.
 	GaugeBackpressureActive GaugeName = "backpressure_active"

--- a/umh-core/pkg/fsmv2/examples/certfetcher_scenario.go
+++ b/umh-core/pkg/fsmv2/examples/certfetcher_scenario.go
@@ -1,0 +1,245 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package examples
+
+import (
+	"context"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"fmt"
+	"math/big"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/register"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/application"
+	certfetcher "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/certfetcher"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/gatekeeper/certificatehandler"
+)
+
+var _ certificatehandler.Handler = (*MockCertHandler)(nil)
+
+// MockSubHandler implements certificatehandler.SubHandler for tests.
+type MockSubHandler struct {
+	emails []string
+}
+
+// Subscribers returns the configured subscriber emails.
+func (m *MockSubHandler) Subscribers() []string {
+	return m.emails
+}
+
+// MockCertHandler implements certificatehandler.Handler with configurable behavior.
+type MockCertHandler struct {
+	subHandler *MockSubHandler
+	fetchError error
+	fetchCount atomic.Int64
+	certs      map[string]*x509.Certificate
+
+	mu sync.RWMutex
+}
+
+// NewMockCertHandler creates a mock cert handler.
+func NewMockCertHandler(emails []string, fetchError error) *MockCertHandler {
+	m := &MockCertHandler{
+		fetchError: fetchError,
+		certs:      make(map[string]*x509.Certificate),
+	}
+
+	if emails != nil {
+		m.subHandler = &MockSubHandler{emails: emails}
+		for _, email := range emails {
+			m.certs[email] = &x509.Certificate{
+				SerialNumber: big.NewInt(1),
+				Subject:      pkix.Name{CommonName: email},
+			}
+		}
+	}
+
+	return m
+}
+
+// Certificate returns a dummy certificate for known emails.
+func (m *MockCertHandler) Certificate(email string) *x509.Certificate {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.certs[email]
+}
+
+// IntermediateCerts returns nil (not needed for tests).
+func (m *MockCertHandler) IntermediateCerts(_ string) []*x509.Certificate {
+	return nil
+}
+
+// RootCA returns nil (not needed for tests).
+func (m *MockCertHandler) RootCA() *x509.Certificate {
+	return nil
+}
+
+// FetchCertForEmail fetches a single user's certificate on demand.
+func (m *MockCertHandler) FetchCertForEmail(_ context.Context, _ string) error {
+	return m.fetchError
+}
+
+// FetchAllCerts tracks call count and returns the configured error.
+func (m *MockCertHandler) FetchAllCerts(_ context.Context) error {
+	m.fetchCount.Add(1)
+	return m.fetchError
+}
+
+// Subscribers returns mock subscriber emails via the sub handler.
+func (m *MockCertHandler) Subscribers() []string {
+	m.mu.RLock()
+	sh := m.subHandler
+	m.mu.RUnlock()
+	if sh == nil {
+		return nil
+	}
+	return sh.Subscribers()
+}
+
+// HasSubHandler returns true when the mock sub handler is set.
+func (m *MockCertHandler) HasSubHandler() bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.subHandler != nil
+}
+
+// SetSubHandler satisfies certificatehandler.Handler; the mock seeds its sub
+// handler at construction, so this is a no-op.
+func (m *MockCertHandler) SetSubHandler(_ certificatehandler.SubHandler) {}
+
+// FetchCallCount returns how many times FetchAllCerts was called.
+func (m *MockCertHandler) FetchCallCount() int {
+	return int(m.fetchCount.Load())
+}
+
+// CertFetcherRunConfig configures a cert fetcher scenario run.
+type CertFetcherRunConfig struct {
+	SubscriberEmails []string      // Emails the mock sub handler returns; nil means no sub handler
+	FetchError       error         // If set, FetchAllCerts returns this error
+	Duration         time.Duration // How long to run the scenario
+	TickInterval     time.Duration // Defaults to 100ms
+	Logger           deps.FSMLogger
+}
+
+// CertFetcherRunResult contains observable results after scenario completion.
+type CertFetcherRunResult struct {
+	Error          error
+	Done           <-chan struct{}
+	Shutdown       func()
+	FetchCallCount int
+}
+
+// RunCertFetcherScenario runs the FSMv2 certfetcher worker via ApplicationSupervisor with a mock cert handler.
+func RunCertFetcherScenario(ctx context.Context, cfg CertFetcherRunConfig) *CertFetcherRunResult {
+	done := make(chan struct{})
+
+	if cfg.Duration < 0 {
+		close(done)
+
+		return &CertFetcherRunResult{
+			Done:     done,
+			Shutdown: func() {},
+			Error:    fmt.Errorf("invalid duration %v: must be non-negative", cfg.Duration),
+		}
+	}
+
+	if ctx.Err() != nil {
+		close(done)
+
+		return &CertFetcherRunResult{
+			Done:     done,
+			Shutdown: func() {},
+			Error:    fmt.Errorf("context already cancelled: %w", ctx.Err()),
+		}
+	}
+
+	logger := cfg.Logger
+	if logger == nil {
+		logger = deps.NewNopFSMLogger()
+	}
+
+	tickInterval := cfg.TickInterval
+	if tickInterval == 0 {
+		tickInterval = 100 * time.Millisecond
+	}
+
+	mockHandler := NewMockCertHandler(cfg.SubscriberEmails, cfg.FetchError)
+
+	register.SetDeps[*certfetcher.CertFetcherDependencies](certfetcher.WorkerTypeName,
+		certfetcher.NewCertHandlerSeedDependencies(mockHandler))
+
+	store := SetupStore(logger)
+
+	yamlConfig := `
+children:
+  - name: "certfetcher"
+    workerType: "certfetcher"
+`
+
+	appSup, err := application.NewApplicationSupervisor(application.SupervisorConfig{
+		ID:           "scenario-certfetcher",
+		Name:         "certfetcher",
+		Store:        store,
+		Logger:       logger,
+		TickInterval: tickInterval,
+		YAMLConfig:   yamlConfig,
+	})
+	if err != nil {
+		close(done)
+
+		return &CertFetcherRunResult{
+			Done:     done,
+			Shutdown: func() {},
+			Error:    fmt.Errorf("failed to create supervisor: %w", err),
+		}
+	}
+
+	supDone := appSup.Start(ctx)
+
+	result := &CertFetcherRunResult{
+		Done:     done,
+		Shutdown: appSup.Shutdown,
+	}
+
+	go func() {
+		if cfg.Duration > 0 {
+			select {
+			case <-time.After(cfg.Duration):
+				appSup.Shutdown()
+			case <-ctx.Done():
+				appSup.Shutdown()
+			case <-supDone:
+			}
+		} else {
+			select {
+			case <-ctx.Done():
+				appSup.Shutdown()
+			case <-supDone:
+			}
+		}
+
+		<-supDone
+
+		result.FetchCallCount = mockHandler.FetchCallCount()
+
+		close(done)
+	}()
+
+	return result
+}

--- a/umh-core/pkg/fsmv2/examples/certfetcher_scenario_test.go
+++ b/umh-core/pkg/fsmv2/examples/certfetcher_scenario_test.go
@@ -1,0 +1,73 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package examples_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/examples"
+)
+
+var _ = Describe("CertFetcher Scenario", func() {
+	var ctx context.Context
+	var cancel context.CancelFunc
+
+	BeforeEach(func() {
+		ctx, cancel = context.WithTimeout(context.Background(), 30*time.Second)
+	})
+
+	AfterEach(func() {
+		cancel()
+	})
+
+	It("starts and fetches certs for subscribers", func() {
+		result := examples.RunCertFetcherScenario(ctx, examples.CertFetcherRunConfig{
+			Duration:         15 * time.Second,
+			SubscriberEmails: []string{"alice@example.com", "bob@example.com"},
+		})
+		Expect(result.Error).NotTo(HaveOccurred())
+		<-result.Done
+		Expect(result.FetchCallCount).To(BeNumerically(">=", 1),
+			"FetchAllCerts should have been called at least once for 2 subscribers")
+	})
+
+	It("enters degraded state after consecutive failures", func() {
+		result := examples.RunCertFetcherScenario(ctx, examples.CertFetcherRunConfig{
+			Duration:         20 * time.Second,
+			SubscriberEmails: []string{"alice@example.com"},
+			FetchError:       fmt.Errorf("simulated API failure"),
+		})
+		Expect(result.Error).NotTo(HaveOccurred())
+		<-result.Done
+		Expect(result.FetchCallCount).To(BeNumerically(">=", 3),
+			"FetchAllCerts should be called at least DegradedThreshold times before degraded backoff kicks in")
+	})
+
+	It("stays in stopped state without sub handler", func() {
+		result := examples.RunCertFetcherScenario(ctx, examples.CertFetcherRunConfig{
+			Duration:         5 * time.Second,
+			SubscriberEmails: nil, // No sub handler
+		})
+		Expect(result.Error).NotTo(HaveOccurred())
+		<-result.Done
+		Expect(result.FetchCallCount).To(Equal(0),
+			"FetchAllCerts should never be called when there is no sub handler")
+	})
+})

--- a/umh-core/pkg/fsmv2/examples/runner.go
+++ b/umh-core/pkg/fsmv2/examples/runner.go
@@ -23,6 +23,8 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/application"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/persistence/memory"
 
+	_ "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/certfetcher"
+	_ "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/certfetcher/state"
 	_ "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator"
 	_ "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator/state"
 	_ "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/examplechild"

--- a/umh-core/pkg/fsmv2/examples/runner.go
+++ b/umh-core/pkg/fsmv2/examples/runner.go
@@ -29,6 +29,8 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/configworker/dynamicchildren"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/persistence/memory"
 
+	_ "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/certfetcher"
+	_ "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/certfetcher/state"
 	_ "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator"
 	_ "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator/state"
 	_ "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/examplechild"

--- a/umh-core/pkg/fsmv2/workers/certfetcher/action/fetchcerts.go
+++ b/umh-core/pkg/fsmv2/workers/certfetcher/action/fetchcerts.go
@@ -1,0 +1,42 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package action provides idempotent actions for the certfetcher worker.
+package action
+
+import (
+	"context"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/certfetcher"
+)
+
+// FetchCertsAction fetches certificates for all active subscribers.
+type FetchCertsAction struct{}
+
+// Execute fetches certificates for all active subscribers.
+func (a *FetchCertsAction) Execute(ctx context.Context, d *certfetcher.CertFetcherDependencies) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
+	return d.FetchAllCerts(ctx)
+}
+
+// Name returns the action name for logging.
+func (a *FetchCertsAction) Name() string { return "fetch_certs" }
+
+// String returns the action name.
+func (a *FetchCertsAction) String() string { return a.Name() }

--- a/umh-core/pkg/fsmv2/workers/certfetcher/config.go
+++ b/umh-core/pkg/fsmv2/workers/certfetcher/config.go
@@ -1,0 +1,31 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package certfetcher
+
+import "time"
+
+// CertFetcherConfig holds user-provided configuration for the cert fetcher worker.
+// Empty because certfetcher has no user-configurable fields.
+type CertFetcherConfig struct{}
+
+// CertFetcherStatus holds runtime observation data for the cert fetcher worker.
+type CertFetcherStatus struct {
+	LastFetchAt time.Time `json:"last_fetch_at,omitempty"`
+
+	ConsecutiveErrors int  `json:"consecutive_errors"`
+	SubscriberCount   int  `json:"subscriber_count"`
+	CachedCertCount   int  `json:"cached_cert_count"`
+	HasSubHandler     bool `json:"has_sub_handler"`
+}

--- a/umh-core/pkg/fsmv2/workers/certfetcher/dependencies.go
+++ b/umh-core/pkg/fsmv2/workers/certfetcher/dependencies.go
@@ -1,0 +1,116 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package certfetcher
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/gatekeeper/certificatehandler"
+)
+
+// CertFetcherDependencies holds the cert fetcher's runtime dependencies.
+type CertFetcherDependencies struct {
+	*deps.BaseDependencies
+
+	certHandler certificatehandler.Handler
+
+	lastFetchAt       time.Time
+	consecutiveErrors int
+
+	mu sync.RWMutex
+}
+
+// NewCertFetcherDependencies creates dependencies for the cert fetcher worker.
+func NewCertFetcherDependencies(
+	certHandler certificatehandler.Handler,
+	baseDeps *deps.BaseDependencies,
+) (*CertFetcherDependencies, error) {
+	if certHandler == nil {
+		return nil, errors.New("certHandler must not be nil")
+	}
+
+	return &CertFetcherDependencies{
+		BaseDependencies: baseDeps,
+		certHandler:      certHandler,
+	}, nil
+}
+
+// NewCertHandlerSeedDependencies builds a seed dependency holding only the cert
+// handler. The certfetcher worker constructor rebuilds full dependencies with the
+// worker's BaseDependencies. Used by main.go to inject the cert handler via
+// register.SetDeps before the worker is constructed.
+func NewCertHandlerSeedDependencies(certHandler certificatehandler.Handler) *CertFetcherDependencies {
+	if certHandler == nil {
+		panic("NewCertHandlerSeedDependencies: certHandler cannot be nil")
+	}
+
+	return &CertFetcherDependencies{certHandler: certHandler}
+}
+
+// CertHandler returns the certificate handler.
+func (d *CertFetcherDependencies) CertHandler() certificatehandler.Handler {
+	return d.certHandler
+}
+
+// FetchAllCerts delegates to cert handler, then tracks success/failure.
+func (d *CertFetcherDependencies) FetchAllCerts(ctx context.Context) error {
+	err := d.certHandler.FetchAllCerts(ctx)
+	if err != nil {
+		d.RecordFetchError()
+
+		return err
+	}
+
+	d.RecordFetchSuccess()
+
+	return nil
+}
+
+// RecordFetchSuccess records a successful fetch cycle.
+func (d *CertFetcherDependencies) RecordFetchSuccess() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.lastFetchAt = time.Now()
+	d.consecutiveErrors = 0
+}
+
+// RecordFetchError increments the consecutive error count.
+func (d *CertFetcherDependencies) RecordFetchError() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.consecutiveErrors++
+}
+
+// LastFetchAt returns the time of the last successful fetch.
+func (d *CertFetcherDependencies) LastFetchAt() time.Time {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	return d.lastFetchAt
+}
+
+// ConsecutiveErrors returns the current consecutive error count.
+func (d *CertFetcherDependencies) ConsecutiveErrors() int {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	return d.consecutiveErrors
+}

--- a/umh-core/pkg/fsmv2/workers/certfetcher/state/state_degraded.go
+++ b/umh-core/pkg/fsmv2/workers/certfetcher/state/state_degraded.go
@@ -1,0 +1,61 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package state
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/internal/helpers"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/certfetcher"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/certfetcher/action"
+)
+
+// DegradedBackoff is the wait time between retries in degraded state.
+const DegradedBackoff = 5 * time.Minute
+
+// DegradedState retries certificate fetching with backoff after consecutive failures.
+type DegradedState struct {
+	helpers.RunningDegradedBase
+}
+
+// Next recovers to Running when errors clear, otherwise retries with backoff.
+func (s *DegradedState) Next(snapAny any) fsmv2.NextResult[any, any] {
+	snap := fsmv2.ConvertWorkerSnapshot[certfetcher.CertFetcherConfig, certfetcher.CertFetcherStatus](snapAny)
+
+	if snap.IsShutdownRequested {
+		return fsmv2.Transition(&StoppedState{}, fsmv2.SignalNone, nil, "shutdown requested", nil)
+	}
+
+	if snap.Status.ConsecutiveErrors == 0 {
+		return fsmv2.Transition(&RunningState{}, fsmv2.SignalNone, nil, "errors cleared, recovering", nil)
+	}
+
+	timeSinceLastFetch := snap.CollectedAt.Sub(snap.Status.LastFetchAt)
+	if timeSinceLastFetch >= DegradedBackoff {
+		return fsmv2.Transition(s, fsmv2.SignalNone, &action.FetchCertsAction{},
+			fmt.Sprintf("degraded retry: %d errors, last fetch %s ago",
+				snap.Status.ConsecutiveErrors, timeSinceLastFetch.Round(time.Second)), nil)
+	}
+
+	return fsmv2.Transition(s, fsmv2.SignalNone, nil,
+		fmt.Sprintf("degraded backoff: %d errors, retry in %s",
+			snap.Status.ConsecutiveErrors, (DegradedBackoff-timeSinceLastFetch).Round(time.Second)), nil)
+}
+
+func (s *DegradedState) String() string {
+	return helpers.DeriveStateName(s)
+}

--- a/umh-core/pkg/fsmv2/workers/certfetcher/state/state_degraded.go
+++ b/umh-core/pkg/fsmv2/workers/certfetcher/state/state_degraded.go
@@ -36,8 +36,12 @@ type DegradedState struct {
 func (s *DegradedState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[certfetcher.CertFetcherConfig, certfetcher.CertFetcherStatus](snapAny)
 
-	if snap.IsShutdownRequested {
-		return fsmv2.Transition(&StoppedState{}, fsmv2.SignalNone, nil, "shutdown requested", nil)
+	if snap.ShouldStop() {
+		return fsmv2.Transition(&StoppedState{}, fsmv2.SignalNone, nil, fmt.Sprintf("stop required: %s", snap.StopReason()), nil)
+	}
+
+	if !snap.Status.HasSubHandler {
+		return fsmv2.Transition(&StoppedState{}, fsmv2.SignalNone, nil, "sub handler lost", nil)
 	}
 
 	if snap.Status.ConsecutiveErrors == 0 {

--- a/umh-core/pkg/fsmv2/workers/certfetcher/state/state_running.go
+++ b/umh-core/pkg/fsmv2/workers/certfetcher/state/state_running.go
@@ -40,8 +40,8 @@ type RunningState struct {
 func (s *RunningState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[certfetcher.CertFetcherConfig, certfetcher.CertFetcherStatus](snapAny)
 
-	if snap.IsShutdownRequested {
-		return fsmv2.Transition(&StoppedState{}, fsmv2.SignalNone, nil, "shutdown requested", nil)
+	if snap.ShouldStop() {
+		return fsmv2.Transition(&StoppedState{}, fsmv2.SignalNone, nil, fmt.Sprintf("stop required: %s", snap.StopReason()), nil)
 	}
 
 	if !snap.Status.HasSubHandler {

--- a/umh-core/pkg/fsmv2/workers/certfetcher/state/state_running.go
+++ b/umh-core/pkg/fsmv2/workers/certfetcher/state/state_running.go
@@ -1,0 +1,70 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package state
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/internal/helpers"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/certfetcher"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/certfetcher/action"
+)
+
+const (
+	// FetchInterval is the minimum time between certificate fetch cycles.
+	FetchInterval = 1 * time.Minute
+	// DegradedThreshold is the number of consecutive errors before entering degraded state.
+	DegradedThreshold = 3
+)
+
+// RunningState periodically fetches certificates for active subscribers.
+type RunningState struct {
+	helpers.RunningHealthyBase
+}
+
+// Next checks if a fetch is due and emits FetchCertsAction if so.
+func (s *RunningState) Next(snapAny any) fsmv2.NextResult[any, any] {
+	snap := fsmv2.ConvertWorkerSnapshot[certfetcher.CertFetcherConfig, certfetcher.CertFetcherStatus](snapAny)
+
+	if snap.IsShutdownRequested {
+		return fsmv2.Transition(&StoppedState{}, fsmv2.SignalNone, nil, "shutdown requested", nil)
+	}
+
+	if !snap.Status.HasSubHandler {
+		return fsmv2.Transition(&StoppedState{}, fsmv2.SignalNone, nil, "sub handler lost", nil)
+	}
+
+	if snap.Status.ConsecutiveErrors >= DegradedThreshold {
+		return fsmv2.Transition(&DegradedState{}, fsmv2.SignalNone, nil,
+			fmt.Sprintf("degrading: %d consecutive errors", snap.Status.ConsecutiveErrors), nil)
+	}
+
+	timeSinceLastFetch := snap.CollectedAt.Sub(snap.Status.LastFetchAt)
+	if timeSinceLastFetch >= FetchInterval || (snap.Status.LastFetchAt.IsZero() && timeSinceLastFetch >= 10*time.Second) {
+		return fsmv2.Transition(s, fsmv2.SignalNone, &action.FetchCertsAction{},
+			fmt.Sprintf("fetching: %d subscribers, last fetch %s ago",
+				snap.Status.SubscriberCount, timeSinceLastFetch.Round(time.Second)), nil)
+	}
+
+	return fsmv2.Transition(s, fsmv2.SignalNone, nil,
+		fmt.Sprintf("idle: next fetch in %s, %d subscribers",
+			(FetchInterval-timeSinceLastFetch).Round(time.Second), snap.Status.SubscriberCount), nil)
+}
+
+func (s *RunningState) String() string {
+	return helpers.DeriveStateName(s)
+}

--- a/umh-core/pkg/fsmv2/workers/certfetcher/state/state_stopped.go
+++ b/umh-core/pkg/fsmv2/workers/certfetcher/state/state_stopped.go
@@ -1,0 +1,51 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package state
+
+import (
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/internal/helpers"
+	certfetcher "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/certfetcher"
+)
+
+const workerType = "certfetcher"
+
+func init() {
+	fsmv2.RegisterInitialState(workerType, &StoppedState{})
+}
+
+// StoppedState is the initial state of the cert fetcher worker.
+type StoppedState struct {
+	helpers.StoppedBase
+}
+
+// Next transitions to Running when SubHandler is available.
+func (s *StoppedState) Next(snapAny any) fsmv2.NextResult[any, any] {
+	snap := fsmv2.ConvertWorkerSnapshot[certfetcher.CertFetcherConfig, certfetcher.CertFetcherStatus](snapAny)
+
+	if snap.IsShutdownRequested {
+		return fsmv2.Transition(s, fsmv2.SignalNeedsRemoval, nil, "shutdown requested", nil)
+	}
+
+	if snap.Status.HasSubHandler {
+		return fsmv2.Transition(&RunningState{}, fsmv2.SignalNone, nil, "sub handler available, starting", nil)
+	}
+
+	return fsmv2.Transition(s, fsmv2.SignalNone, nil, "waiting for sub handler", nil)
+}
+
+func (s *StoppedState) String() string {
+	return helpers.DeriveStateName(s)
+}

--- a/umh-core/pkg/fsmv2/workers/certfetcher/worker.go
+++ b/umh-core/pkg/fsmv2/workers/certfetcher/worker.go
@@ -1,0 +1,136 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package certfetcher implements an FSMv2 worker that periodically fetches
+// certificates for active subscribers from the Management Console API.
+package certfetcher
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/register"
+)
+
+// WorkerTypeName is the canonical worker-type identifier for the certfetcher worker.
+const WorkerTypeName = "certfetcher"
+
+const workerType = WorkerTypeName
+
+var _ fsmv2.Worker = (*CertFetcherWorker)(nil)
+
+// CertFetcherWorker fetches certificates for active subscribers.
+type CertFetcherWorker struct {
+	fsmv2.WorkerBase[CertFetcherConfig, CertFetcherStatus, *CertFetcherDependencies]
+}
+
+// NewCertFetcherWorker creates a new cert fetcher worker.
+//
+// dependencies may be a seed (built via NewCertHandlerSeedDependencies, with a nil
+// BaseDependencies) — the constructor rebuilds full deps with this worker's
+// identity/logger/stateReader — or a fully built value (via NewCertFetcherDependencies).
+func NewCertFetcherWorker(
+	identity deps.Identity,
+	logger deps.FSMLogger,
+	stateReader deps.StateReader,
+	dependencies *CertFetcherDependencies,
+) (fsmv2.Worker, error) {
+	if logger == nil {
+		return nil, errors.New("logger must not be nil")
+	}
+
+	if identity.WorkerType == "" {
+		identity.WorkerType = workerType
+	}
+
+	if dependencies == nil {
+		return nil, errors.New("certfetcher worker requires a certHandler; pass via NewCertFetcherDependencies or NewCertHandlerSeedDependencies")
+	}
+
+	w := &CertFetcherWorker{}
+	bd := w.InitBase(identity, logger, stateReader)
+
+	if dependencies.BaseDependencies == nil {
+		d, err := NewCertFetcherDependencies(dependencies.certHandler, bd)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create dependencies: %w", err)
+		}
+
+		dependencies = d
+	}
+
+	w.BindDeps(dependencies)
+
+	return w, nil
+}
+
+// GetDependencies returns the typed certfetcher dependencies.
+// Panics with a clear message if BindDeps was not called before this worker is used.
+func (w *CertFetcherWorker) GetDependencies() *CertFetcherDependencies {
+	raw := w.GetDependenciesAny()
+
+	d, ok := raw.(*CertFetcherDependencies)
+	if !ok || d == nil {
+		panic("CertFetcherWorker: GetDependencies called before BindDeps")
+	}
+
+	return d
+}
+
+// CollectObservedState snapshots the cert fetcher state.
+func (w *CertFetcherWorker) CollectObservedState(ctx context.Context, _ fsmv2.DesiredState) (fsmv2.ObservedState, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
+	d := w.GetDependencies()
+	ch := d.CertHandler()
+	emails := ch.Subscribers()
+
+	cachedCount := 0
+
+	for _, email := range emails {
+		if ch.Certificate(email) != nil {
+			cachedCount++
+		}
+	}
+
+	// Current-state gauges for potential later exposure on the UI. These are
+	// point-in-time values (not cumulative events), so they use SetGauge —
+	// IncrementCounter would accumulate additively on every COS tick.
+	d.MetricsRecorder().SetGauge("cached_certs", float64(cachedCount))
+	d.MetricsRecorder().SetGauge("consecutive_errors", float64(d.ConsecutiveErrors()))
+
+	return fsmv2.NewObservation(CertFetcherStatus{
+		ConsecutiveErrors: d.ConsecutiveErrors(),
+		SubscriberCount:   len(emails),
+		CachedCertCount:   cachedCount,
+		LastFetchAt:       d.LastFetchAt(),
+		HasSubHandler:     ch.HasSubHandler(),
+	}), nil
+}
+
+func init() {
+	register.Worker[CertFetcherConfig, CertFetcherStatus, *CertFetcherDependencies](WorkerTypeName,
+		func(id deps.Identity, logger deps.FSMLogger, sr deps.StateReader) (fsmv2.Worker, error) {
+			d := register.GetDeps[*CertFetcherDependencies](WorkerTypeName)
+
+			return NewCertFetcherWorker(id, logger, sr, d)
+		})
+}

--- a/umh-core/pkg/fsmv2/workers/certfetcher/worker.go
+++ b/umh-core/pkg/fsmv2/workers/certfetcher/worker.go
@@ -114,8 +114,8 @@ func (w *CertFetcherWorker) CollectObservedState(ctx context.Context, _ fsmv2.De
 	// Current-state gauges for potential later exposure on the UI. These are
 	// point-in-time values (not cumulative events), so they use SetGauge —
 	// IncrementCounter would accumulate additively on every COS tick.
-	d.MetricsRecorder().SetGauge("cached_certs", float64(cachedCount))
-	d.MetricsRecorder().SetGauge("consecutive_errors", float64(d.ConsecutiveErrors()))
+	d.MetricsRecorder().SetGauge(deps.GaugeCachedCerts, float64(cachedCount))
+	d.MetricsRecorder().SetGauge(deps.GaugeConsecutiveErrors, float64(d.ConsecutiveErrors()))
 
 	return fsmv2.NewObservation(CertFetcherStatus{
 		ConsecutiveErrors: d.ConsecutiveErrors(),

--- a/umh-core/test/communicator/subscribe_and_receive_test.go
+++ b/umh-core/test/communicator/subscribe_and_receive_test.go
@@ -195,6 +195,7 @@ var _ = Describe("Subscribe and Receive Test", func() {
 			logger.For(logger.ComponentCommunicator),
 			topicBrowserCommunicator,
 			nil, // fsmOutboundChannel - nil for legacy mode test
+			nil, // gatekeeperOutboundChannel
 			nil, // featureUsage
 		)
 		subHandler.StartNotifier()
@@ -255,7 +256,7 @@ var _ = Describe("Subscribe and Receive Test", func() {
 
 		By("Verifying the subscriber was added")
 		// Verify the subscriber was added
-		subscribers := subHandler.GetSubscribers()
+		subscribers := subHandler.Subscribers()
 		Expect(subscribers).To(ContainElement(testEmail))
 		GinkgoWriter.Printf("Confirmed subscriber was added\n")
 


### PR DESCRIPTION
# Description

This PR introduces the `certfetcher`-fsm, which is used in order to fetch certificates for users, which then at a later stage will try to use some actions. Those actions are guarded by specific roles, which are defined in the `action-type-role-map.json` within ManagementConsole.

It also wires the gatekeeper package behind a FeatureFlag `USE_GATEKEEPER`.
Also Sentry reporting is wired here under `feature=certfetcher` and created a rule in Sentry for automatic reporting to linear and assigning myself.

---
Linked issues:
- ENG-4661
- ENG-4611