### PR TITLE
Fsmv2 simplification new rebase

### DIFF
--- a/umh-core/pkg/constants/fsm.go
+++ b/umh-core/pkg/constants/fsm.go
@@ -30,3 +30,8 @@ const FSMTransitionTimeout = 200 * time.Millisecond
 // Set to 5 seconds to allow thorough cleanup including file operations and service stops.
 // See Linear ticket ENG-3420 for full context.
 const ForceRemovalTimeout = 5 * time.Second
+
+// NmapBackendFSMv2 is the NMAP_BACKEND env-var value that selects the fsmv2
+// TCP-connect scanner (no S6, no nmap binary). Three files branch on this
+// value; a single constant prevents typo-induced split-backend states.
+const NmapBackendFSMv2 = "fsmv2"

--- a/umh-core/pkg/control/loop.go
+++ b/umh-core/pkg/control/loop.go
@@ -135,7 +135,7 @@ func NewControlLoop(configManager config.ConfigManager) *ControlLoop {
 	// legacy "fsm" backend additionally registers a top-level NmapManager here
 	// for global state tracking; the fsmv2 backend is self-contained inside
 	// ConnectionService.
-	if os.Getenv("NMAP_BACKEND") != "fsmv2" {
+	if os.Getenv("NMAP_BACKEND") != constants.NmapBackendFSMv2 {
 		managers = append(managers, nmap.NewNmapManager(constants.DefaultManagerName))
 	}
 

--- a/umh-core/pkg/control/loop.go
+++ b/umh-core/pkg/control/loop.go
@@ -38,6 +38,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"sync"
 	"time"
 
@@ -123,13 +124,28 @@ func NewControlLoop(configManager config.ConfigManager) *ControlLoop {
 		container.NewContainerManager(constants.DefaultManagerName),
 		redpanda.NewRedpandaManager(constants.DefaultManagerName),
 		agent_monitor.NewAgentManager(constants.DefaultManagerName),
-		nmap.NewNmapManager(constants.DefaultManagerName),
+	}
+
+	// NMAP_BACKEND selects the connection scanning implementation:
+	//   "fsm"   (default) — legacy FSM + S6 + nmap binary
+	//   "fsmv2" — fsmv2 worker with net.DialTimeout (no S6)
+	//
+	// The nmap manager is created inside each ConnectionService instance
+	// (pkg/service/connection/connection.go) based on NMAP_BACKEND. Only the
+	// legacy "fsm" backend additionally registers a top-level NmapManager here
+	// for global state tracking; the fsmv2 backend is self-contained inside
+	// ConnectionService.
+	if os.Getenv("NMAP_BACKEND") != "fsmv2" {
+		managers = append(managers, nmap.NewNmapManager(constants.DefaultManagerName))
+	}
+
+	managers = append(managers,
 		dataflowcomponent.NewDataflowComponentManager(constants.DefaultManagerName),
 		connection.NewConnectionManager(constants.DefaultManagerName),
 		protocolconverter.NewProtocolConverterManager(constants.DefaultManagerName),
 		topicbrowser.NewTopicBrowserManager(constants.DefaultManagerName),
 		streamprocessor.NewManager(constants.DefaultManagerName),
-	}
+	)
 
 	// Create a starvation checker
 	starvationChecker := starvationchecker.NewStarvationChecker(constants.StarvationThreshold)

--- a/umh-core/pkg/fsm/protocolconverter/actions.go
+++ b/umh-core/pkg/fsm/protocolconverter/actions.go
@@ -350,22 +350,24 @@ func (p *ProtocolConverterInstance) UpdateObservedStateOfInstance(ctx context.Co
 	metrics.ObserveReconcileTime(logger.ComponentProtocolConverterInstance, p.baseFSMInstance.GetID()+".buildRuntimeConfig", time.Since(start))
 
 	if !protocolconverterserviceconfig.ConfigsEqualRuntime(p.runtimeConfig, p.ObservedState.ObservedProtocolConverterRuntimeConfig) {
-		// Check if the service exists before attempting to update
-		if p.service.ServiceExists(ctx, services.GetFileSystem(), p.baseFSMInstance.GetID()) {
-			p.baseFSMInstance.GetLogger().Debugf("Observed bridge config is different from desired config, updating bridge configuration")
+		p.baseFSMInstance.GetLogger().Debugf("Observed bridge config is different from desired config, updating bridge configuration")
 
-			diffStr := protocolconverterserviceconfig.ConfigDiffRuntime(p.runtimeConfig, p.ObservedState.ObservedProtocolConverterRuntimeConfig)
-			p.baseFSMInstance.GetLogger().Debugf("Configuration differences: %s", diffStr)
+		diffStr := protocolconverterserviceconfig.ConfigDiffRuntime(p.runtimeConfig, p.ObservedState.ObservedProtocolConverterRuntimeConfig)
+		p.baseFSMInstance.GetLogger().Debugf("Configuration differences: %s", diffStr)
 
-			// Update the config in the Benthos manager
-			err := p.service.UpdateInManager(ctx, services.GetFileSystem(), &p.runtimeConfig, p.baseFSMInstance.GetID(), p.debugLevel)
-			if err != nil {
+		// UpdateInManager updates in-memory config slices and is safe to call even
+		// when S6 services are not yet created.  If the service is not yet registered
+		// in memory (ErrServiceNotExist), we skip silently — the condition above will
+		// be true again on the next tick and we retry automatically.
+		err := p.service.UpdateInManager(ctx, services.GetFileSystem(), &p.runtimeConfig, p.baseFSMInstance.GetID(), p.debugLevel)
+		if err != nil {
+			if errors.Is(err, protocolconvertersvc.ErrServiceNotExist) {
+				p.baseFSMInstance.GetLogger().Debugf("Service not yet registered, skipping config update (will retry)")
+			} else {
 				return fmt.Errorf("failed to update bridge configuration: %w", err)
 			}
-
-			p.baseFSMInstance.GetLogger().Debugf("config updated")
 		} else {
-			p.baseFSMInstance.GetLogger().Debugf("Config differences detected but service does not exist yet, skipping update")
+			p.baseFSMInstance.GetLogger().Debugf("config updated")
 		}
 	}
 

--- a/umh-core/pkg/fsmv2/adapter/instance.go
+++ b/umh-core/pkg/fsmv2/adapter/instance.go
@@ -24,72 +24,87 @@ import (
 
 	publicfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/fsmv2client"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/configworker/dynamicchildren"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/filesystem"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/serviceregistry"
 )
 
-// AdaptedInstance wraps a fsmv2 child worker observed via a shared StateReader
+// AdaptedInstance wraps a fsmv2 child worker observed via the global FSMv2Client
 // and satisfies publicfsm.FSMInstance.
 //
 // All lifecycle methods (CreateInstance, RemoveInstance, etc.) are no-ops
-// because fsmv2 manages its own lifecycle through the ApplicationSupervisor.
-// Callers supply MapState and MapObservedState to translate fsmv2 observations
-// into the legacy state vocabulary the rest of the system expects.
+// because fsmv2 manages its own lifecycle through the shared global runtime.
+// The instance reads state via GetFreshObs, distinguishing Unregistered,
+// NeverObserved, Stale, and Fresh so mappers can produce clean FSMv1 states.
 //
 // TStatus is the worker's status type (e.g. simple.Status[NmapStatus]).
-// TDomainConfig is the domain config type that flows through the fsmv1 control
+// TDomainConfig is the domain config type flowing through the fsmv1 control
 // loop (e.g. config.NmapConfig).
 type AdaptedInstance[TStatus any, TDomainConfig any] struct {
-	sr               deps.StateReader
-	mapState         func(fsmv2.Observation[TStatus], TDomainConfig) string
-	mapObservedState func(TDomainConfig, fsmv2.Observation[TStatus]) publicfsm.ObservedState
-	domainConfig     TDomainConfig
-	workerType       string
-	childID          string
-	desiredState     string
-	minRequiredTime  time.Duration
+	// mapState maps an observation + freshness reason to an FSMv1 state string.
+	// Unregistered/NeverObserved → return a "starting" equivalent.
+	// Stale → return a "degraded" equivalent.
+	// Fresh → inspect status fields for the actual port/process state.
+	mapState func(fsmv2.Observation[TStatus], fsmv2client.Freshness, TDomainConfig) string
+
+	// mapObservedState builds the full FSMv1 ObservedState from an observation.
+	mapObservedState func(TDomainConfig, fsmv2.Observation[TStatus], fsmv2client.Freshness) publicfsm.ObservedState
+
+	domainConfig    TDomainConfig
+	ref             dynamicchildren.Ref
+	desiredState    string
+	minRequiredTime time.Duration
+	maxAge          time.Duration
 }
 
-// NewAdaptedInstance creates an AdaptedInstance. workerType and childID must
-// match the values used when building the ApplicationSupervisor's children spec.
+// NewAdaptedInstance creates an AdaptedInstance. ref must match the Ref used in
+// Upsert/Delete calls so reads resolve to the correct child observation.
 func NewAdaptedInstance[TStatus any, TDomainConfig any](
-	sr deps.StateReader,
-	workerType, childID string,
+	ref dynamicchildren.Ref,
 	cfg TDomainConfig,
 	desiredState string,
 	minTime time.Duration,
-	mapState func(fsmv2.Observation[TStatus], TDomainConfig) string,
-	mapObs func(TDomainConfig, fsmv2.Observation[TStatus]) publicfsm.ObservedState,
+	mapState func(fsmv2.Observation[TStatus], fsmv2client.Freshness, TDomainConfig) string,
+	mapObs func(TDomainConfig, fsmv2.Observation[TStatus], fsmv2client.Freshness) publicfsm.ObservedState,
 ) *AdaptedInstance[TStatus, TDomainConfig] {
 	return &AdaptedInstance[TStatus, TDomainConfig]{
-		sr:               sr,
-		workerType:       workerType,
-		childID:          childID,
+		ref:              ref,
 		domainConfig:     cfg,
 		desiredState:     desiredState,
 		minRequiredTime:  minTime,
+		maxAge:           minTime,
 		mapState:         mapState,
 		mapObservedState: mapObs,
 	}
 }
 
-// UpdateDomainConfig replaces the stored domain config without touching the
-// childID or mappers. Call this when config values change but the identity
-// (name/workerType) stays the same.
+// UpdateDomainConfig replaces the stored domain config without touching the ref
+// or mappers. Call when config values change but identity stays the same.
 func (i *AdaptedInstance[TStatus, TDomainConfig]) UpdateDomainConfig(cfg TDomainConfig, desiredState string) {
 	i.domainConfig = cfg
 	i.desiredState = desiredState
 }
 
+func (i *AdaptedInstance[TStatus, TDomainConfig]) getFreshObs(ctx context.Context) (fsmv2.Observation[TStatus], fsmv2client.Freshness) {
+	c := fsmv2client.GetClient()
+	if c == nil {
+		return fsmv2.Observation[TStatus]{}, fsmv2client.Unregistered
+	}
+
+	obs, freshness, err := fsmv2client.GetFreshObs[TStatus](ctx, c, i.ref, i.maxAge)
+	if err != nil {
+		return fsmv2.Observation[TStatus]{}, fsmv2client.Unknown
+	}
+
+	return obs, freshness
+}
+
 // --- publicfsm.FSMInstance implementation ---
 
 func (i *AdaptedInstance[TStatus, TDomainConfig]) GetCurrentFSMState() string {
-	var obs fsmv2.Observation[TStatus]
-
-	_ = i.sr.LoadObservedTyped(context.Background(), i.workerType, i.childID, &obs)
-
-	return i.mapState(obs, i.domainConfig)
+	obs, freshness := i.getFreshObs(context.Background())
+	return i.mapState(obs, freshness, i.domainConfig)
 }
 
 func (i *AdaptedInstance[TStatus, TDomainConfig]) GetDesiredFSMState() string {
@@ -98,7 +113,6 @@ func (i *AdaptedInstance[TStatus, TDomainConfig]) GetDesiredFSMState() string {
 
 func (i *AdaptedInstance[TStatus, TDomainConfig]) SetDesiredFSMState(s string) error {
 	i.desiredState = s
-
 	return nil
 }
 
@@ -115,11 +129,8 @@ func (i *AdaptedInstance[TStatus, TDomainConfig]) Remove(_ context.Context) erro
 }
 
 func (i *AdaptedInstance[TStatus, TDomainConfig]) GetLastObservedState() publicfsm.ObservedState {
-	var obs fsmv2.Observation[TStatus]
-
-	_ = i.sr.LoadObservedTyped(context.Background(), i.workerType, i.childID, &obs)
-
-	return i.mapObservedState(i.domainConfig, obs)
+	obs, freshness := i.getFreshObs(context.Background())
+	return i.mapObservedState(i.domainConfig, obs, freshness)
 }
 
 func (i *AdaptedInstance[TStatus, TDomainConfig]) GetMinimumRequiredTime() time.Duration {

--- a/umh-core/pkg/fsmv2/adapter/instance.go
+++ b/umh-core/pkg/fsmv2/adapter/instance.go
@@ -38,7 +38,7 @@ import (
 // The instance reads state via GetFreshObs, distinguishing Unregistered,
 // NeverObserved, Stale, and Fresh so mappers can produce clean FSMv1 states.
 //
-// TStatus is the worker's status type (e.g. simple.Status[NmapStatus]).
+// TStatus is the worker's status type (e.g. nmap_worker.NmapStatus).
 // TDomainConfig is the domain config type flowing through the fsmv1 control
 // loop (e.g. config.NmapConfig).
 type AdaptedInstance[TStatus any, TDomainConfig any] struct {

--- a/umh-core/pkg/fsmv2/adapter/instance.go
+++ b/umh-core/pkg/fsmv2/adapter/instance.go
@@ -30,6 +30,10 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/serviceregistry"
 )
 
+// storeReadTimeout bounds how long getFreshObs blocks on a CSE store read.
+// The StateReader non-blocking contract requires a deadline-bounded context.
+const storeReadTimeout = 100 * time.Millisecond
+
 // AdaptedInstance wraps a fsmv2 child worker observed via the global FSMv2Client
 // and satisfies publicfsm.FSMInstance.
 //
@@ -55,16 +59,24 @@ type AdaptedInstance[TStatus any, TDomainConfig any] struct {
 	ref             dynamicchildren.Ref
 	desiredState    string
 	minRequiredTime time.Duration
-	maxAge          time.Duration
+	// maxAge is the observation age threshold for Stale classification.
+	// Kept separate from minRequiredTime: minRequiredTime is an fsmv1 concept
+	// (how long before a state change is considered stable); maxAge is an
+	// fsmv2 read concept (how old an observation can be before the child is
+	// considered unreachable).
+	maxAge time.Duration
 }
 
 // NewAdaptedInstance creates an AdaptedInstance. ref must match the Ref used in
 // Upsert/Delete calls so reads resolve to the correct child observation.
+// minRequiredTime and maxAge serve distinct purposes and should be set
+// independently (see field docs above).
 func NewAdaptedInstance[TStatus any, TDomainConfig any](
 	ref dynamicchildren.Ref,
 	cfg TDomainConfig,
 	desiredState string,
-	minTime time.Duration,
+	minRequiredTime time.Duration,
+	maxAge time.Duration,
 	mapState func(fsmv2.Observation[TStatus], fsmv2client.Freshness, TDomainConfig) string,
 	mapObs func(TDomainConfig, fsmv2.Observation[TStatus], fsmv2client.Freshness) publicfsm.ObservedState,
 ) *AdaptedInstance[TStatus, TDomainConfig] {
@@ -72,25 +84,21 @@ func NewAdaptedInstance[TStatus any, TDomainConfig any](
 		ref:              ref,
 		domainConfig:     cfg,
 		desiredState:     desiredState,
-		minRequiredTime:  minTime,
-		maxAge:           minTime,
+		minRequiredTime:  minRequiredTime,
+		maxAge:           maxAge,
 		mapState:         mapState,
 		mapObservedState: mapObs,
 	}
 }
 
-// UpdateDomainConfig replaces the stored domain config without touching the ref
-// or mappers. Call when config values change but identity stays the same.
-func (i *AdaptedInstance[TStatus, TDomainConfig]) UpdateDomainConfig(cfg TDomainConfig, desiredState string) {
-	i.domainConfig = cfg
-	i.desiredState = desiredState
-}
-
-func (i *AdaptedInstance[TStatus, TDomainConfig]) getFreshObs(ctx context.Context) (fsmv2.Observation[TStatus], fsmv2client.Freshness) {
+func (i *AdaptedInstance[TStatus, TDomainConfig]) getFreshObs() (fsmv2.Observation[TStatus], fsmv2client.Freshness) {
 	c := fsmv2client.GetClient()
 	if c == nil {
 		return fsmv2.Observation[TStatus]{}, fsmv2client.Unregistered
 	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), storeReadTimeout)
+	defer cancel()
 
 	obs, freshness, err := fsmv2client.GetFreshObs[TStatus](ctx, c, i.ref, i.maxAge)
 	if err != nil {
@@ -103,7 +111,7 @@ func (i *AdaptedInstance[TStatus, TDomainConfig]) getFreshObs(ctx context.Contex
 // --- publicfsm.FSMInstance implementation ---
 
 func (i *AdaptedInstance[TStatus, TDomainConfig]) GetCurrentFSMState() string {
-	obs, freshness := i.getFreshObs(context.Background())
+	obs, freshness := i.getFreshObs()
 	return i.mapState(obs, freshness, i.domainConfig)
 }
 
@@ -133,7 +141,7 @@ func (i *AdaptedInstance[TStatus, TDomainConfig]) Remove(_ context.Context) erro
 }
 
 func (i *AdaptedInstance[TStatus, TDomainConfig]) GetLastObservedState() publicfsm.ObservedState {
-	obs, freshness := i.getFreshObs(context.Background())
+	obs, freshness := i.getFreshObs()
 	return i.mapObservedState(i.domainConfig, obs, freshness)
 }
 

--- a/umh-core/pkg/fsmv2/adapter/instance.go
+++ b/umh-core/pkg/fsmv2/adapter/instance.go
@@ -1,0 +1,155 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package adapter bridges fsmv2 workers to the fsmv1 FSMInstance / FSMManager
+// interfaces so that fsmv2-backed components can be used as drop-in
+// replacements inside the existing control loop without writing boilerplate
+// per worker type.
+package adapter
+
+import (
+	"context"
+	"time"
+
+	publicfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/filesystem"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/serviceregistry"
+)
+
+// AdaptedInstance wraps a fsmv2 child worker observed via a shared StateReader
+// and satisfies publicfsm.FSMInstance.
+//
+// All lifecycle methods (CreateInstance, RemoveInstance, etc.) are no-ops
+// because fsmv2 manages its own lifecycle through the ApplicationSupervisor.
+// Callers supply MapState and MapObservedState to translate fsmv2 observations
+// into the legacy state vocabulary the rest of the system expects.
+//
+// TStatus is the worker's status type (e.g. simple.Status[NmapStatus]).
+// TDomainConfig is the domain config type that flows through the fsmv1 control
+// loop (e.g. config.NmapConfig).
+type AdaptedInstance[TStatus any, TDomainConfig any] struct {
+	sr               deps.StateReader
+	mapState         func(fsmv2.Observation[TStatus], TDomainConfig) string
+	mapObservedState func(TDomainConfig, fsmv2.Observation[TStatus]) publicfsm.ObservedState
+	domainConfig     TDomainConfig
+	workerType       string
+	childID          string
+	desiredState     string
+	minRequiredTime  time.Duration
+}
+
+// NewAdaptedInstance creates an AdaptedInstance. workerType and childID must
+// match the values used when building the ApplicationSupervisor's children spec.
+func NewAdaptedInstance[TStatus any, TDomainConfig any](
+	sr deps.StateReader,
+	workerType, childID string,
+	cfg TDomainConfig,
+	desiredState string,
+	minTime time.Duration,
+	mapState func(fsmv2.Observation[TStatus], TDomainConfig) string,
+	mapObs func(TDomainConfig, fsmv2.Observation[TStatus]) publicfsm.ObservedState,
+) *AdaptedInstance[TStatus, TDomainConfig] {
+	return &AdaptedInstance[TStatus, TDomainConfig]{
+		sr:               sr,
+		workerType:       workerType,
+		childID:          childID,
+		domainConfig:     cfg,
+		desiredState:     desiredState,
+		minRequiredTime:  minTime,
+		mapState:         mapState,
+		mapObservedState: mapObs,
+	}
+}
+
+// UpdateDomainConfig replaces the stored domain config without touching the
+// childID or mappers. Call this when config values change but the identity
+// (name/workerType) stays the same.
+func (i *AdaptedInstance[TStatus, TDomainConfig]) UpdateDomainConfig(cfg TDomainConfig, desiredState string) {
+	i.domainConfig = cfg
+	i.desiredState = desiredState
+}
+
+// --- publicfsm.FSMInstance implementation ---
+
+func (i *AdaptedInstance[TStatus, TDomainConfig]) GetCurrentFSMState() string {
+	var obs fsmv2.Observation[TStatus]
+
+	_ = i.sr.LoadObservedTyped(context.Background(), i.workerType, i.childID, &obs)
+
+	return i.mapState(obs, i.domainConfig)
+}
+
+func (i *AdaptedInstance[TStatus, TDomainConfig]) GetDesiredFSMState() string {
+	return i.desiredState
+}
+
+func (i *AdaptedInstance[TStatus, TDomainConfig]) SetDesiredFSMState(s string) error {
+	i.desiredState = s
+
+	return nil
+}
+
+func (i *AdaptedInstance[TStatus, TDomainConfig]) IsTransientStreakCounterMaxed() bool {
+	return false
+}
+
+func (i *AdaptedInstance[TStatus, TDomainConfig]) Reconcile(_ context.Context, _ publicfsm.SystemSnapshot, _ serviceregistry.Provider) (error, bool) {
+	return nil, false
+}
+
+func (i *AdaptedInstance[TStatus, TDomainConfig]) Remove(_ context.Context) error {
+	return nil
+}
+
+func (i *AdaptedInstance[TStatus, TDomainConfig]) GetLastObservedState() publicfsm.ObservedState {
+	var obs fsmv2.Observation[TStatus]
+
+	_ = i.sr.LoadObservedTyped(context.Background(), i.workerType, i.childID, &obs)
+
+	return i.mapObservedState(i.domainConfig, obs)
+}
+
+func (i *AdaptedInstance[TStatus, TDomainConfig]) GetMinimumRequiredTime() time.Duration {
+	return i.minRequiredTime
+}
+
+// --- publicfsm.FSMInstanceActions no-ops ---
+
+func (i *AdaptedInstance[TStatus, TDomainConfig]) CreateInstance(_ context.Context, _ filesystem.Service) error {
+	return nil
+}
+
+func (i *AdaptedInstance[TStatus, TDomainConfig]) RemoveInstance(_ context.Context, _ filesystem.Service) error {
+	return nil
+}
+
+func (i *AdaptedInstance[TStatus, TDomainConfig]) StartInstance(_ context.Context, _ filesystem.Service) error {
+	return nil
+}
+
+func (i *AdaptedInstance[TStatus, TDomainConfig]) StopInstance(_ context.Context, _ filesystem.Service) error {
+	return nil
+}
+
+func (i *AdaptedInstance[TStatus, TDomainConfig]) UpdateObservedStateOfInstance(_ context.Context, _ serviceregistry.Provider, _ publicfsm.SystemSnapshot) error {
+	return nil
+}
+
+func (i *AdaptedInstance[TStatus, TDomainConfig]) CheckForCreation(_ context.Context, _ filesystem.Service) bool {
+	return true
+}
+
+var _ publicfsm.FSMInstance = (*AdaptedInstance[struct{}, struct{}])(nil)

--- a/umh-core/pkg/fsmv2/adapter/instance.go
+++ b/umh-core/pkg/fsmv2/adapter/instance.go
@@ -65,6 +65,11 @@ type AdaptedInstance[TStatus any, TDomainConfig any] struct {
 	// fsmv2 read concept (how old an observation can be before the child is
 	// considered unreachable).
 	maxAge time.Duration
+
+	// isDisabled is set when the worker is deliberately disabled (not running).
+	// GetCurrentFSMState returns desiredState directly so the fsmv1 control loop
+	// sees current==desired and does not wait for a non-existent state transition.
+	isDisabled bool
 }
 
 // NewAdaptedInstance creates an AdaptedInstance. ref must match the Ref used in
@@ -79,6 +84,7 @@ func NewAdaptedInstance[TStatus any, TDomainConfig any](
 	maxAge time.Duration,
 	mapState func(fsmv2.Observation[TStatus], fsmv2client.Freshness, TDomainConfig) string,
 	mapObs func(TDomainConfig, fsmv2.Observation[TStatus], fsmv2client.Freshness) publicfsm.ObservedState,
+	isDisabled bool,
 ) *AdaptedInstance[TStatus, TDomainConfig] {
 	return &AdaptedInstance[TStatus, TDomainConfig]{
 		ref:              ref,
@@ -88,6 +94,7 @@ func NewAdaptedInstance[TStatus any, TDomainConfig any](
 		maxAge:           maxAge,
 		mapState:         mapState,
 		mapObservedState: mapObs,
+		isDisabled:       isDisabled,
 	}
 }
 
@@ -111,6 +118,9 @@ func (i *AdaptedInstance[TStatus, TDomainConfig]) getFreshObs() (fsmv2.Observati
 // --- publicfsm.FSMInstance implementation ---
 
 func (i *AdaptedInstance[TStatus, TDomainConfig]) GetCurrentFSMState() string {
+	if i.isDisabled {
+		return i.desiredState
+	}
 	obs, freshness := i.getFreshObs()
 	return i.mapState(obs, freshness, i.domainConfig)
 }

--- a/umh-core/pkg/fsmv2/adapter/instance.go
+++ b/umh-core/pkg/fsmv2/adapter/instance.go
@@ -125,6 +125,10 @@ func (i *AdaptedInstance[TStatus, TDomainConfig]) Reconcile(_ context.Context, _
 }
 
 func (i *AdaptedInstance[TStatus, TDomainConfig]) Remove(_ context.Context) error {
+	if c := fsmv2client.GetClient(); c != nil {
+		c.Delete(i.ref)
+	}
+
 	return nil
 }
 

--- a/umh-core/pkg/fsmv2/adapter/manager.go
+++ b/umh-core/pkg/fsmv2/adapter/manager.go
@@ -1,0 +1,219 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package adapter
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.uber.org/zap"
+
+	publicfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
+	fsmv2config "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/config"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/serviceregistry"
+)
+
+// WorkerManagerSpec describes the domain-specific behaviour that WorkerManager
+// needs to manage a fleet of fsmv2 child workers as fsmv1 FSMInstances.
+//
+// TDomainConfig is the domain config type that flows through the fsmv1 control
+// loop (e.g. config.NmapConfig).
+type WorkerManagerSpec[TDomainConfig any] struct {
+	// ManagerName is used for logging and snapshot labels.
+	ManagerName string
+
+	// Log is the sugared logger for the manager.
+	Log *zap.SugaredLogger
+
+	// UpdateSpec pushes a new children spec to the ApplicationSupervisor.
+	// Typically: func(spec) { sup.UpdateUserSpec(spec) }
+	UpdateSpec func(fsmv2config.UserSpec)
+
+	// ExtractConfigs pulls the relevant config slice from a SystemSnapshot.
+	ExtractConfigs func(snapshot publicfsm.SystemSnapshot) []TDomainConfig
+
+	// NameOf returns the unique name for a config entry.
+	NameOf func(cfg TDomainConfig) string
+
+	// DesiredStateOf returns the desired FSM state string from a config entry.
+	DesiredStateOf func(cfg TDomainConfig) string
+
+	// ConfigEqual returns true when two configs are semantically identical.
+	ConfigEqual func(a, b TDomainConfig) bool
+
+	// NewInstance creates an FSMInstance adapter for a config entry.
+	// The implementation typically calls adapter.NewAdaptedInstance with the
+	// domain-specific mapper functions.
+	NewInstance func(cfg TDomainConfig) publicfsm.FSMInstance
+
+	// BuildSpec marshals the current domain config map into the YAML envelope
+	// that ApplicationWorker.DeriveDesiredState expects.
+	BuildSpec func(configs map[string]TDomainConfig) fsmv2config.UserSpec
+}
+
+// WorkerManager is a generic fsmv1-compatible manager that owns a fleet of
+// fsmv2 child workers, each wrapped in an FSMInstance adapter.
+//
+// It satisfies the superset of publicfsm.FSMManager[any] required by provider
+// interfaces such as NmapManagerProvider.
+type WorkerManager[TDomainConfig any] struct {
+	spec          WorkerManagerSpec[TDomainConfig]
+	instances     map[string]publicfsm.FSMInstance
+	domainConfigs map[string]TDomainConfig
+	cancel        context.CancelFunc
+}
+
+// NewWorkerManager creates a WorkerManager from spec.
+// cancel is called by Stop() to cancel the supervisor's context.
+func NewWorkerManager[TDomainConfig any](
+	spec WorkerManagerSpec[TDomainConfig],
+	cancel context.CancelFunc,
+) *WorkerManager[TDomainConfig] {
+	return &WorkerManager[TDomainConfig]{
+		spec:          spec,
+		instances:     make(map[string]publicfsm.FSMInstance),
+		domainConfigs: make(map[string]TDomainConfig),
+		cancel:        cancel,
+	}
+}
+
+func (m *WorkerManager[TDomainConfig]) GetInstances() map[string]publicfsm.FSMInstance {
+	return m.instances
+}
+
+func (m *WorkerManager[TDomainConfig]) GetInstance(n string) (publicfsm.FSMInstance, bool) {
+	inst, ok := m.instances[n]
+
+	return inst, ok
+}
+
+func (m *WorkerManager[TDomainConfig]) GetManagerName() string {
+	return m.spec.ManagerName
+}
+
+// Reconcile syncs the instance map to the desired configs from the snapshot,
+// then pushes an updated children spec to the supervisor when anything changed.
+func (m *WorkerManager[TDomainConfig]) Reconcile(ctx context.Context, snapshot publicfsm.SystemSnapshot, _ serviceregistry.Provider) (error, bool) {
+	if ctx.Err() != nil {
+		return ctx.Err(), false
+	}
+
+	desired := m.spec.ExtractConfigs(snapshot)
+	changed := false
+
+	desiredNames := make(map[string]struct{}, len(desired))
+	for _, cfg := range desired {
+		desiredNames[m.spec.NameOf(cfg)] = struct{}{}
+	}
+
+	// Remove workers no longer in config.
+	for name := range m.instances {
+		if _, exists := desiredNames[name]; !exists {
+			m.spec.Log.Infof("Removing worker %s (no longer in config)", name)
+			delete(m.instances, name)
+			delete(m.domainConfigs, name)
+
+			changed = true
+		}
+	}
+
+	// Add new workers and update changed ones.
+	for _, cfg := range desired {
+		name := m.spec.NameOf(cfg)
+		existing, exists := m.domainConfigs[name]
+
+		if !exists {
+			m.instances[name] = m.spec.NewInstance(cfg)
+			m.domainConfigs[name] = cfg
+			m.spec.Log.Infof("Created worker %s", name)
+
+			changed = true
+
+			continue
+		}
+
+		if !m.spec.ConfigEqual(existing, cfg) {
+			m.instances[name] = m.spec.NewInstance(cfg)
+			m.domainConfigs[name] = cfg
+
+			changed = true
+		}
+	}
+
+	if changed {
+		m.spec.UpdateSpec(m.spec.BuildSpec(m.domainConfigs))
+	}
+
+	return nil, changed
+}
+
+func (m *WorkerManager[TDomainConfig]) GetLastObservedState(serviceName string) (publicfsm.ObservedState, error) {
+	if inst, exists := m.instances[serviceName]; exists {
+		return inst.GetLastObservedState(), nil
+	}
+
+	return nil, fmt.Errorf("instance %s not found", serviceName)
+}
+
+func (m *WorkerManager[TDomainConfig]) GetCurrentFSMState(serviceName string) (string, error) {
+	if inst, exists := m.instances[serviceName]; exists {
+		return inst.GetCurrentFSMState(), nil
+	}
+
+	return "", fmt.Errorf("instance %s not found", serviceName)
+}
+
+// CreateSnapshot builds a ManagerSnapshot from current instance states.
+func (m *WorkerManager[TDomainConfig]) CreateSnapshot() publicfsm.ManagerSnapshot {
+	snap := &workerManagerSnapshot{
+		name:      m.spec.ManagerName,
+		instances: make(map[string]*publicfsm.FSMInstanceSnapshot, len(m.instances)),
+		snapTime:  time.Now(),
+	}
+
+	for name, inst := range m.instances {
+		snap.instances[name] = &publicfsm.FSMInstanceSnapshot{
+			ID:           name,
+			CurrentState: inst.GetCurrentFSMState(),
+			DesiredState: inst.GetDesiredFSMState(),
+		}
+	}
+
+	return snap
+}
+
+// Stop cancels the supervisor's context.
+func (m *WorkerManager[TDomainConfig]) Stop() {
+	if m.cancel != nil {
+		m.cancel()
+	}
+}
+
+// workerManagerSnapshot implements publicfsm.ManagerSnapshot.
+type workerManagerSnapshot struct {
+	name      string
+	instances map[string]*publicfsm.FSMInstanceSnapshot
+	tick      uint64
+	snapTime  time.Time
+}
+
+func (s *workerManagerSnapshot) GetName() string { return s.name }
+func (s *workerManagerSnapshot) GetInstances() map[string]*publicfsm.FSMInstanceSnapshot {
+	return s.instances
+}
+func (s *workerManagerSnapshot) GetSnapshotTime() time.Time { return s.snapTime }
+func (s *workerManagerSnapshot) GetManagerTick() uint64     { return s.tick }
+func (s *workerManagerSnapshot) IsObservedStateSnapshot()   {}

--- a/umh-core/pkg/fsmv2/adapter/manager.go
+++ b/umh-core/pkg/fsmv2/adapter/manager.go
@@ -71,6 +71,7 @@ type WorkerManager[TDomainConfig any] struct {
 	spec          WorkerManagerSpec[TDomainConfig]
 	instances     map[string]publicfsm.FSMInstance
 	domainConfigs map[string]TDomainConfig
+	tick          uint64
 }
 
 // NewWorkerManager creates a WorkerManager from spec.
@@ -105,6 +106,7 @@ func (m *WorkerManager[TDomainConfig]) Reconcile(ctx context.Context, snapshot p
 		return ctx.Err(), false
 	}
 
+	m.tick++
 	client := fsmv2client.GetClient()
 
 	desired := m.spec.ExtractConfigs(snapshot)
@@ -132,30 +134,38 @@ func (m *WorkerManager[TDomainConfig]) Reconcile(ctx context.Context, snapshot p
 	for _, cfg := range desired {
 		name := m.spec.NameOf(cfg)
 		existing, exists := m.domainConfigs[name]
+		enabled := m.spec.DesiredStateOf(cfg) != "stopped"
 
 		if !exists {
 			if client != nil {
-				cfgMap, err := m.spec.CfgFor(cfg)
-				if err != nil {
-					m.spec.Log.Warnf("fsmv2: build spec for %s: %v", name, err)
-				} else if err := client.Upsert(m.spec.RefFor(cfg), cfgMap); err != nil {
-					m.spec.Log.Warnf("fsmv2: upsert %s: %v", name, err)
+				if enabled {
+					cfgMap, err := m.spec.CfgFor(cfg)
+					if err != nil {
+						m.spec.Log.Warnf("fsmv2: build spec for %s: %v", name, err)
+					} else if err := client.Upsert(m.spec.RefFor(cfg), cfgMap); err != nil {
+						m.spec.Log.Warnf("fsmv2: upsert %s: %v", name, err)
+					}
 				}
+				// stopped configs are never registered in the fsmv2 runtime
 			}
 			m.instances[name] = m.spec.NewInstance(cfg)
 			m.domainConfigs[name] = cfg
-			m.spec.Log.Infof("Created worker %s", name)
+			m.spec.Log.Infof("Created worker %s (enabled=%v)", name, enabled)
 			changed = true
 			continue
 		}
 
 		if !m.spec.ConfigEqual(existing, cfg) {
 			if client != nil {
-				cfgMap, err := m.spec.CfgFor(cfg)
-				if err != nil {
-					m.spec.Log.Warnf("fsmv2: build spec for %s: %v", name, err)
-				} else if err := client.Upsert(m.spec.RefFor(cfg), cfgMap); err != nil {
-					m.spec.Log.Warnf("fsmv2: upsert %s: %v", name, err)
+				if enabled {
+					cfgMap, err := m.spec.CfgFor(cfg)
+					if err != nil {
+						m.spec.Log.Warnf("fsmv2: build spec for %s: %v", name, err)
+					} else if err := client.Upsert(m.spec.RefFor(cfg), cfgMap); err != nil {
+						m.spec.Log.Warnf("fsmv2: upsert %s: %v", name, err)
+					}
+				} else {
+					client.Delete(m.spec.RefFor(cfg))
 				}
 			}
 			m.instances[name] = m.spec.NewInstance(cfg)
@@ -187,6 +197,7 @@ func (m *WorkerManager[TDomainConfig]) CreateSnapshot() publicfsm.ManagerSnapsho
 		name:      m.spec.ManagerName,
 		instances: make(map[string]*publicfsm.FSMInstanceSnapshot, len(m.instances)),
 		snapTime:  time.Now(),
+		tick:      m.tick,
 	}
 	for name, inst := range m.instances {
 		snap.instances[name] = &publicfsm.FSMInstanceSnapshot{

--- a/umh-core/pkg/fsmv2/adapter/manager.go
+++ b/umh-core/pkg/fsmv2/adapter/manager.go
@@ -22,7 +22,8 @@ import (
 	"go.uber.org/zap"
 
 	publicfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
-	fsmv2config "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/config"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/fsmv2client"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/configworker/dynamicchildren"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/serviceregistry"
 )
 
@@ -38,10 +39,6 @@ type WorkerManagerSpec[TDomainConfig any] struct {
 	// Log is the sugared logger for the manager.
 	Log *zap.SugaredLogger
 
-	// UpdateSpec pushes a new children spec to the ApplicationSupervisor.
-	// Typically: func(spec) { sup.UpdateUserSpec(spec) }
-	UpdateSpec func(fsmv2config.UserSpec)
-
 	// ExtractConfigs pulls the relevant config slice from a SystemSnapshot.
 	ExtractConfigs func(snapshot publicfsm.SystemSnapshot) []TDomainConfig
 
@@ -55,17 +52,18 @@ type WorkerManagerSpec[TDomainConfig any] struct {
 	ConfigEqual func(a, b TDomainConfig) bool
 
 	// NewInstance creates an FSMInstance adapter for a config entry.
-	// The implementation typically calls adapter.NewAdaptedInstance with the
-	// domain-specific mapper functions.
 	NewInstance func(cfg TDomainConfig) publicfsm.FSMInstance
 
-	// BuildSpec marshals the current domain config map into the YAML envelope
-	// that ApplicationWorker.DeriveDesiredState expects.
-	BuildSpec func(configs map[string]TDomainConfig) fsmv2config.UserSpec
+	// RefFor builds the dynamicchildren.Ref for a config entry.
+	RefFor func(cfg TDomainConfig) dynamicchildren.Ref
+
+	// CfgFor builds the map[string]any payload for Upsert from a config entry.
+	CfgFor func(cfg TDomainConfig) (map[string]any, error)
 }
 
-// WorkerManager is a generic fsmv1-compatible manager that owns a fleet of
-// fsmv2 child workers, each wrapped in an FSMInstance adapter.
+// WorkerManager is a generic fsmv1-compatible manager that drives a fleet of
+// fsmv2 child workers via the global FSMv2Client (Upsert/Delete) and exposes
+// each child as an FSMInstance adapter.
 //
 // It satisfies the superset of publicfsm.FSMManager[any] required by provider
 // interfaces such as NmapManagerProvider.
@@ -73,20 +71,14 @@ type WorkerManager[TDomainConfig any] struct {
 	spec          WorkerManagerSpec[TDomainConfig]
 	instances     map[string]publicfsm.FSMInstance
 	domainConfigs map[string]TDomainConfig
-	cancel        context.CancelFunc
 }
 
 // NewWorkerManager creates a WorkerManager from spec.
-// cancel is called by Stop() to cancel the supervisor's context.
-func NewWorkerManager[TDomainConfig any](
-	spec WorkerManagerSpec[TDomainConfig],
-	cancel context.CancelFunc,
-) *WorkerManager[TDomainConfig] {
+func NewWorkerManager[TDomainConfig any](spec WorkerManagerSpec[TDomainConfig]) *WorkerManager[TDomainConfig] {
 	return &WorkerManager[TDomainConfig]{
 		spec:          spec,
 		instances:     make(map[string]publicfsm.FSMInstance),
 		domainConfigs: make(map[string]TDomainConfig),
-		cancel:        cancel,
 	}
 }
 
@@ -96,7 +88,6 @@ func (m *WorkerManager[TDomainConfig]) GetInstances() map[string]publicfsm.FSMIn
 
 func (m *WorkerManager[TDomainConfig]) GetInstance(n string) (publicfsm.FSMInstance, bool) {
 	inst, ok := m.instances[n]
-
 	return inst, ok
 }
 
@@ -104,12 +95,17 @@ func (m *WorkerManager[TDomainConfig]) GetManagerName() string {
 	return m.spec.ManagerName
 }
 
-// Reconcile syncs the instance map to the desired configs from the snapshot,
-// then pushes an updated children spec to the supervisor when anything changed.
+// Reconcile diffs the desired configs from the snapshot against the current
+// instance map, calling client.Upsert for new/changed entries and client.Delete
+// for removed entries. When the global client is nil (fsmv2 runtime not yet
+// started) the instance map is still updated but no Upsert/Delete calls are
+// made.
 func (m *WorkerManager[TDomainConfig]) Reconcile(ctx context.Context, snapshot publicfsm.SystemSnapshot, _ serviceregistry.Provider) (error, bool) {
 	if ctx.Err() != nil {
 		return ctx.Err(), false
 	}
+
+	client := fsmv2client.GetClient()
 
 	desired := m.spec.ExtractConfigs(snapshot)
 	changed := false
@@ -120,12 +116,14 @@ func (m *WorkerManager[TDomainConfig]) Reconcile(ctx context.Context, snapshot p
 	}
 
 	// Remove workers no longer in config.
-	for name := range m.instances {
+	for name, existing := range m.domainConfigs {
 		if _, exists := desiredNames[name]; !exists {
 			m.spec.Log.Infof("Removing worker %s (no longer in config)", name)
+			if client != nil {
+				client.Delete(m.spec.RefFor(existing))
+			}
 			delete(m.instances, name)
 			delete(m.domainConfigs, name)
-
 			changed = true
 		}
 	}
@@ -136,25 +134,34 @@ func (m *WorkerManager[TDomainConfig]) Reconcile(ctx context.Context, snapshot p
 		existing, exists := m.domainConfigs[name]
 
 		if !exists {
+			if client != nil {
+				cfgMap, err := m.spec.CfgFor(cfg)
+				if err != nil {
+					m.spec.Log.Warnf("fsmv2: build spec for %s: %v", name, err)
+				} else if err := client.Upsert(m.spec.RefFor(cfg), cfgMap); err != nil {
+					m.spec.Log.Warnf("fsmv2: upsert %s: %v", name, err)
+				}
+			}
 			m.instances[name] = m.spec.NewInstance(cfg)
 			m.domainConfigs[name] = cfg
 			m.spec.Log.Infof("Created worker %s", name)
-
 			changed = true
-
 			continue
 		}
 
 		if !m.spec.ConfigEqual(existing, cfg) {
+			if client != nil {
+				cfgMap, err := m.spec.CfgFor(cfg)
+				if err != nil {
+					m.spec.Log.Warnf("fsmv2: build spec for %s: %v", name, err)
+				} else if err := client.Upsert(m.spec.RefFor(cfg), cfgMap); err != nil {
+					m.spec.Log.Warnf("fsmv2: upsert %s: %v", name, err)
+				}
+			}
 			m.instances[name] = m.spec.NewInstance(cfg)
 			m.domainConfigs[name] = cfg
-
 			changed = true
 		}
-	}
-
-	if changed {
-		m.spec.UpdateSpec(m.spec.BuildSpec(m.domainConfigs))
 	}
 
 	return nil, changed
@@ -164,7 +171,6 @@ func (m *WorkerManager[TDomainConfig]) GetLastObservedState(serviceName string) 
 	if inst, exists := m.instances[serviceName]; exists {
 		return inst.GetLastObservedState(), nil
 	}
-
 	return nil, fmt.Errorf("instance %s not found", serviceName)
 }
 
@@ -172,7 +178,6 @@ func (m *WorkerManager[TDomainConfig]) GetCurrentFSMState(serviceName string) (s
 	if inst, exists := m.instances[serviceName]; exists {
 		return inst.GetCurrentFSMState(), nil
 	}
-
 	return "", fmt.Errorf("instance %s not found", serviceName)
 }
 
@@ -183,7 +188,6 @@ func (m *WorkerManager[TDomainConfig]) CreateSnapshot() publicfsm.ManagerSnapsho
 		instances: make(map[string]*publicfsm.FSMInstanceSnapshot, len(m.instances)),
 		snapTime:  time.Now(),
 	}
-
 	for name, inst := range m.instances {
 		snap.instances[name] = &publicfsm.FSMInstanceSnapshot{
 			ID:           name,
@@ -191,16 +195,11 @@ func (m *WorkerManager[TDomainConfig]) CreateSnapshot() publicfsm.ManagerSnapsho
 			DesiredState: inst.GetDesiredFSMState(),
 		}
 	}
-
 	return snap
 }
 
-// Stop cancels the supervisor's context.
-func (m *WorkerManager[TDomainConfig]) Stop() {
-	if m.cancel != nil {
-		m.cancel()
-	}
-}
+// Stop is a no-op: the fsmv2 global runtime is managed externally.
+func (m *WorkerManager[TDomainConfig]) Stop() {}
 
 // workerManagerSnapshot implements publicfsm.ManagerSnapshot.
 type workerManagerSnapshot struct {

--- a/umh-core/pkg/fsmv2/adapter/manager.go
+++ b/umh-core/pkg/fsmv2/adapter/manager.go
@@ -59,6 +59,12 @@ type WorkerManagerSpec[TDomainConfig any] struct {
 
 	// CfgFor builds the map[string]any payload for Upsert from a config entry.
 	CfgFor func(cfg TDomainConfig) (map[string]any, error)
+
+	// IsEnabled reports whether a config entry should be running in the fsmv2
+	// runtime. Disabled entries are kept in the fsmv1 instance map (so their
+	// state is visible) but are not Upserted; existing registrations are
+	// deleted. If nil, all entries are treated as enabled.
+	IsEnabled func(cfg TDomainConfig) bool
 }
 
 // WorkerManager is a generic fsmv1-compatible manager that drives a fleet of
@@ -134,7 +140,7 @@ func (m *WorkerManager[TDomainConfig]) Reconcile(ctx context.Context, snapshot p
 	for _, cfg := range desired {
 		name := m.spec.NameOf(cfg)
 		existing, exists := m.domainConfigs[name]
-		enabled := m.spec.DesiredStateOf(cfg) != "stopped"
+		enabled := m.spec.IsEnabled == nil || m.spec.IsEnabled(cfg)
 
 		if !exists {
 			if client != nil {

--- a/umh-core/pkg/fsmv2/adapter/manager.go
+++ b/umh-core/pkg/fsmv2/adapter/manager.go
@@ -45,9 +45,6 @@ type WorkerManagerSpec[TDomainConfig any] struct {
 	// NameOf returns the unique name for a config entry.
 	NameOf func(cfg TDomainConfig) string
 
-	// DesiredStateOf returns the desired FSM state string from a config entry.
-	DesiredStateOf func(cfg TDomainConfig) string
-
 	// ConfigEqual returns true when two configs are semantically identical.
 	ConfigEqual func(a, b TDomainConfig) bool
 
@@ -143,16 +140,16 @@ func (m *WorkerManager[TDomainConfig]) Reconcile(ctx context.Context, snapshot p
 		enabled := m.spec.IsEnabled == nil || m.spec.IsEnabled(cfg)
 
 		if !exists {
-			if client != nil {
-				if enabled {
-					cfgMap, err := m.spec.CfgFor(cfg)
-					if err != nil {
-						m.spec.Log.Warnf("fsmv2: build spec for %s: %v", name, err)
-					} else if err := client.Upsert(m.spec.RefFor(cfg), cfgMap); err != nil {
-						m.spec.Log.Warnf("fsmv2: upsert %s: %v", name, err)
-					}
+			if client != nil && enabled {
+				cfgMap, err := m.spec.CfgFor(cfg)
+				if err != nil {
+					m.spec.Log.Warnf("fsmv2: build spec for %s: %v — will retry next tick", name, err)
+					continue
 				}
-				// stopped configs are never registered in the fsmv2 runtime
+				if err := client.Upsert(m.spec.RefFor(cfg), cfgMap); err != nil {
+					m.spec.Log.Warnf("fsmv2: upsert %s: %v — will retry next tick", name, err)
+					continue
+				}
 			}
 			m.instances[name] = m.spec.NewInstance(cfg)
 			m.domainConfigs[name] = cfg

--- a/umh-core/pkg/fsmv2/architecture_test.go
+++ b/umh-core/pkg/fsmv2/architecture_test.go
@@ -39,6 +39,7 @@ import (
 	_ "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/examplepanic"
 	_ "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/exampleparent"
 	_ "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/exampleslow"
+	_ "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/nmap"
 	_ "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/persistence"
 	_ "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport"
 	_ "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/pull"

--- a/umh-core/pkg/fsmv2/fsmv2client/fsmv2client.go
+++ b/umh-core/pkg/fsmv2/fsmv2client/fsmv2client.go
@@ -160,6 +160,33 @@ func GetFresh[TStatus any](ctx context.Context, c *FSMv2Client, ref dynamicchild
 	return obs.Status, Fresh, nil
 }
 
+// GetFreshObs is like GetFresh but returns the full Observation so callers can
+// access CollectedAt and other framework fields alongside the Freshness reason.
+// A non-ErrNotObserved read error is returned verbatim alongside Unknown
+// Freshness; the returned observation is the zero value in all error paths.
+func GetFreshObs[TStatus any](ctx context.Context, c *FSMv2Client, ref dynamicchildren.Ref, maxAge time.Duration) (fsmv2.Observation[TStatus], Freshness, error) {
+	var zero fsmv2.Observation[TStatus]
+
+	if !c.w.Registry().Contains(ref) {
+		return zero, Unregistered, nil
+	}
+
+	obs, err := Get[TStatus](ctx, c, ref)
+	if err != nil {
+		if errors.Is(err, ErrNotObserved) {
+			return zero, NeverObserved, nil
+		}
+
+		return zero, Unknown, err
+	}
+
+	if time.Since(obs.CollectedAt) > maxAge {
+		return obs, Stale, nil
+	}
+
+	return obs, Fresh, nil
+}
+
 // globalCli is the process-scoped FSMv2Client published once at startup so any
 // FSMv1 component (regardless of which benthos manager constructed it) can
 // reach the FSMv2 child-observation read path via GetClient. NewBenthosManager

--- a/umh-core/pkg/fsmv2/simple/simple.go
+++ b/umh-core/pkg/fsmv2/simple/simple.go
@@ -137,7 +137,14 @@ type stoppingState[TC any, TS any] struct {
 func (s *stoppingState[TC, TS]) Next(snapAny any) fsmv2.NextResult[any, any] {
 	snap := fsmv2.ConvertWorkerSnapshot[TC, TS](snapAny)
 
-	return fsmv2.Transition(&stoppedState[TC, TS]{}, fsmv2.SignalNeedsRemoval, nil,
+	if snap.IsShutdownRequested {
+		return fsmv2.Transition(&stoppedState[TC, TS]{}, fsmv2.SignalNeedsRemoval, nil,
+			"stopping complete: "+snap.StopReason(), nil)
+	}
+
+	// Disabled-only stop: stay resident in stoppedState so the worker can resume
+	// when re-enabled, rather than being removed entirely.
+	return fsmv2.Transition(&stoppedState[TC, TS]{}, fsmv2.SignalNone, nil,
 		"stopping complete: "+snap.StopReason(), nil)
 }
 

--- a/umh-core/pkg/fsmv2/simple/simple.go
+++ b/umh-core/pkg/fsmv2/simple/simple.go
@@ -102,6 +102,11 @@ func (s *stoppedState[TC, TS]) Next(snapAny any) fsmv2.NextResult[any, any] {
 			"shutdown requested while stopped", nil)
 	}
 
+	if snap.IsDisabled {
+		return fsmv2.Transition(s, fsmv2.SignalNone, nil,
+			"disabled, staying resident", nil)
+	}
+
 	return fsmv2.Transition(&runningState[TC, TS]{}, fsmv2.SignalNone, nil,
 		"starting worker", nil)
 }

--- a/umh-core/pkg/fsmv2/simple/simple.go
+++ b/umh-core/pkg/fsmv2/simple/simple.go
@@ -18,8 +18,8 @@
 //
 // Callers register a worker type with Register[TConfig, TStatus], supplying
 // a function called once per interval with the current config and a context.
-// The framework manages started/stopped lifecycle, interval tracking, and
-// result storage automatically.
+// The framework manages started/stopped lifecycle automatically; interval
+// tracking and result storage live directly on the worker.
 //
 // Example:
 //
@@ -31,7 +31,6 @@ package simple
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
@@ -40,123 +39,53 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/register"
 )
 
-// --- private dependencies ---
-
-// simpleDeps holds mutable state shared between CollectObservedState ticks.
-// All fields are protected by mu.
-type simpleDeps[TConfig any, TStatus any] struct {
-	*deps.BaseDependencies
-
-	fn        func(ctx context.Context, cfg TConfig) (TStatus, error)
-	mu        sync.RWMutex
-	cfg       TConfig
-	lastResult TStatus
-	lastRunAt time.Time
-	interval  time.Duration
-}
-
-func newSimpleDeps[TConfig any, TStatus any](
-	bd *deps.BaseDependencies,
-	fn func(ctx context.Context, cfg TConfig) (TStatus, error),
-	interval time.Duration,
-) *simpleDeps[TConfig, TStatus] {
-	return &simpleDeps[TConfig, TStatus]{
-		BaseDependencies: bd,
-		fn:               fn,
-		interval:         interval,
-	}
-}
-
-func (d *simpleDeps[TConfig, TStatus]) setConfig(cfg TConfig) {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-
-	d.cfg = cfg
-}
-
-func (d *simpleDeps[TConfig, TStatus]) getConfig() TConfig {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-
-	return d.cfg
-}
-
-func (d *simpleDeps[TConfig, TStatus]) shouldRun() bool {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-
-	return d.lastRunAt.IsZero() || time.Since(d.lastRunAt) >= d.interval
-}
-
-func (d *simpleDeps[TConfig, TStatus]) setResult(r TStatus) {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-
-	d.lastResult = r
-	d.lastRunAt = time.Now()
-}
-
-// markRunAttempt records the current time regardless of success, so a failed
-// fn call still advances the interval instead of hammering on every tick.
-func (d *simpleDeps[TConfig, TStatus]) markRunAttempt() {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-
-	d.lastRunAt = time.Now()
-}
-
-func (d *simpleDeps[TConfig, TStatus]) getResult() TStatus {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-
-	return d.lastResult
-}
-
 // --- worker ---
 
+// simpleWorker is a no-deps worker that calls fn once per interval in
+// CollectObservedState. All mutable state lives directly on the struct; no
+// separate deps layer is needed because COS runs single-threaded in the
+// worker's own goroutine.
 type simpleWorker[TConfig any, TStatus any] struct {
-	fsmv2.WorkerBase[TConfig, TStatus, *simpleDeps[TConfig, TStatus]]
+	fsmv2.WorkerBase[TConfig, TStatus, struct{}]
+
+	fn         func(ctx context.Context, cfg TConfig) (TStatus, error)
+	lastResult TStatus
+	lastRunAt  time.Time
+	interval   time.Duration
 }
 
-func (w *simpleWorker[TConfig, TStatus]) GetDependencies() *simpleDeps[TConfig, TStatus] {
-	raw := w.GetDependenciesAny()
-
-	d, ok := raw.(*simpleDeps[TConfig, TStatus])
-	if !ok || d == nil {
-		panic("simpleWorker: GetDependencies called before BindDeps")
-	}
-
-	return d
-}
-
-// CollectObservedState extracts the current config from the desired state and,
-// when the configured interval has elapsed, calls the user function in-place.
-// The result is returned as the observation; no action dispatch is needed.
-func (w *simpleWorker[TConfig, TStatus]) CollectObservedState(ctx context.Context, desired fsmv2.DesiredState) (fsmv2.ObservedState, error) {
-	d := w.GetDependencies()
-
-	cfg := fsmv2.ExtractConfig[TConfig](desired)
-	d.setConfig(cfg)
-
-	if d.shouldRun() {
-		d.markRunAttempt()
-
-		result, err := d.fn(ctx, d.getConfig())
-		if err != nil {
-			return nil, err
-		}
-
-		d.setResult(result)
-	}
-
-	return fsmv2.NewObservation(d.getResult()), nil
-}
+// GetDependenciesAny returns nil so the framework does not inject metrics into
+// a struct{} deps box (WorkerBase boxes struct{}{} into a non-nil any, which
+// silently skips injection without this override).
+func (w *simpleWorker[TConfig, TStatus]) GetDependenciesAny() any { return nil }
 
 // GetInitialState returns a fresh stoppedState without touching the global
 // initial-state registry, so simple workers do not pollute the registry with
 // per-instance generic instantiations.
 func (w *simpleWorker[TConfig, TStatus]) GetInitialState() fsmv2.State[any, any] {
 	return &stoppedState[TConfig, TStatus]{}
+}
+
+// CollectObservedState reads the current config from the desired state and,
+// when the configured interval has elapsed, calls fn in-place. The result is
+// returned as the observation; no action dispatch is needed.
+func (w *simpleWorker[TConfig, TStatus]) CollectObservedState(ctx context.Context, desired fsmv2.DesiredState) (fsmv2.ObservedState, error) {
+	cfg := fsmv2.ExtractConfig[TConfig](desired)
+
+	if w.lastRunAt.IsZero() || time.Since(w.lastRunAt) >= w.interval {
+		// Record the attempt before calling fn so a failure still advances the
+		// interval and avoids hammering a broken dependency on every tick.
+		w.lastRunAt = time.Now()
+
+		result, err := w.fn(ctx, cfg)
+		if err != nil {
+			return nil, err
+		}
+
+		w.lastResult = result
+	}
+
+	return fsmv2.NewObservation(w.lastResult), nil
 }
 
 // --- states ---
@@ -219,12 +148,13 @@ func Register[TConfig any, TStatus any](
 	interval time.Duration,
 	fn func(ctx context.Context, cfg TConfig) (TStatus, error),
 ) {
-	register.Worker[TConfig, TStatus, *simpleDeps[TConfig, TStatus]](workerType,
+	register.Worker[TConfig, TStatus, struct{}](workerType,
 		func(id deps.Identity, logger deps.FSMLogger, sr deps.StateReader) (fsmv2.Worker, error) {
-			w := &simpleWorker[TConfig, TStatus]{}
-			bd := w.InitBase(id, logger, sr)
-			d := newSimpleDeps(bd, fn, interval)
-			w.BindDeps(d)
+			w := &simpleWorker[TConfig, TStatus]{
+				fn:       fn,
+				interval: interval,
+			}
+			w.InitBase(id, logger, sr)
 
 			return w, nil
 		})

--- a/umh-core/pkg/fsmv2/simple/simple.go
+++ b/umh-core/pkg/fsmv2/simple/simple.go
@@ -1,0 +1,267 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package simple provides a periodic worker that eliminates the boilerplate
+// state, action, and deps files required for workers that only need to run a
+// function on a fixed interval.
+//
+// Callers register a worker type with Register[TConfig, TStatus], supplying
+// a function called once per interval with the current config and a context.
+// The framework manages started/stopped lifecycle, interval tracking, and
+// result storage automatically.
+//
+// Example:
+//
+//	simple.Register[MyConfig, MyResult]("myworker", 5*time.Second,
+//	    func(ctx context.Context, cfg MyConfig) (MyResult, error) {
+//	        return doWork(ctx, cfg)
+//	    })
+package simple
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/internal/helpers"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/register"
+)
+
+// Status wraps the user-defined status type with framework metadata produced
+// by the simple worker on each observation cycle.
+type Status[TStatus any] struct {
+	// Inner holds the result of the last successful user function call.
+	Inner TStatus `json:"inner"`
+	// ShouldRun indicates whether the interval has elapsed and the function
+	// will be dispatched on the next tick.
+	ShouldRun bool `json:"shouldRun"`
+}
+
+// --- private dependencies ---
+
+// simpleDeps holds mutable state shared between CollectObservedState and the
+// runAction. All fields are protected by mu.
+type simpleDeps[TConfig any, TStatus any] struct {
+	*deps.BaseDependencies
+
+	fn         func(ctx context.Context, cfg TConfig) (TStatus, error)
+	mu         sync.RWMutex
+	cfg        TConfig
+	lastResult TStatus
+	lastRunAt  time.Time
+	interval   time.Duration
+}
+
+func newSimpleDeps[TConfig any, TStatus any](
+	bd *deps.BaseDependencies,
+	fn func(ctx context.Context, cfg TConfig) (TStatus, error),
+	interval time.Duration,
+) *simpleDeps[TConfig, TStatus] {
+	return &simpleDeps[TConfig, TStatus]{
+		BaseDependencies: bd,
+		fn:               fn,
+		interval:         interval,
+	}
+}
+
+func (d *simpleDeps[TConfig, TStatus]) setConfig(cfg TConfig) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.cfg = cfg
+}
+
+func (d *simpleDeps[TConfig, TStatus]) getConfig() TConfig {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	return d.cfg
+}
+
+// ShouldRun returns true when the interval has elapsed since the last run.
+// On the very first call (lastRunAt is zero) it returns true immediately.
+func (d *simpleDeps[TConfig, TStatus]) ShouldRun() bool {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	if d.lastRunAt.IsZero() {
+		return true
+	}
+
+	return time.Since(d.lastRunAt) >= d.interval
+}
+
+func (d *simpleDeps[TConfig, TStatus]) setResult(r TStatus) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.lastResult = r
+	d.lastRunAt = time.Now()
+}
+
+func (d *simpleDeps[TConfig, TStatus]) getResult() TStatus {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	return d.lastResult
+}
+
+// --- worker ---
+
+type simpleWorker[TConfig any, TStatus any] struct {
+	fsmv2.WorkerBase[TConfig, Status[TStatus], *simpleDeps[TConfig, TStatus]]
+}
+
+func (w *simpleWorker[TConfig, TStatus]) GetDependencies() *simpleDeps[TConfig, TStatus] {
+	raw := w.GetDependenciesAny()
+
+	d, ok := raw.(*simpleDeps[TConfig, TStatus])
+	if !ok || d == nil {
+		panic("simpleWorker: GetDependencies called before BindDeps")
+	}
+
+	return d
+}
+
+// CollectObservedState extracts the current config from the desired state,
+// checks whether the interval has elapsed, and returns an observation that the
+// state machine uses to decide whether to dispatch a run action.
+func (w *simpleWorker[TConfig, TStatus]) CollectObservedState(ctx context.Context, desired fsmv2.DesiredState) (fsmv2.ObservedState, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
+	d := w.GetDependencies()
+
+	cfg := fsmv2.ExtractConfig[TConfig](desired)
+	d.setConfig(cfg)
+
+	status := Status[TStatus]{
+		Inner:     d.getResult(),
+		ShouldRun: d.ShouldRun(),
+	}
+
+	return fsmv2.NewObservation(status), nil
+}
+
+// GetInitialState returns a fresh stoppedState without touching the global
+// initial-state registry, so simple workers do not pollute the registry with
+// per-instance generic instantiations.
+func (w *simpleWorker[TConfig, TStatus]) GetInitialState() fsmv2.State[any, any] {
+	return &stoppedState[TConfig, TStatus]{}
+}
+
+// --- states ---
+
+type stoppedState[TC any, TS any] struct {
+	helpers.StoppedBase
+}
+
+func (s *stoppedState[TC, TS]) Next(snapAny any) fsmv2.NextResult[any, any] {
+	snap := fsmv2.ConvertWorkerSnapshot[TC, Status[TS]](snapAny)
+
+	if snap.IsShutdownRequested {
+		return fsmv2.Transition(s, fsmv2.SignalNeedsRemoval, nil,
+			"shutdown requested while stopped", nil)
+	}
+
+	return fsmv2.Transition(&runningState[TC, TS]{}, fsmv2.SignalNone, nil,
+		"starting worker", nil)
+}
+
+func (s *stoppedState[TC, TS]) String() string { return "stopped" }
+
+type runningState[TC any, TS any] struct {
+	helpers.RunningHealthyBase
+}
+
+func (s *runningState[TC, TS]) Next(snapAny any) fsmv2.NextResult[any, any] {
+	snap := fsmv2.ConvertWorkerSnapshot[TC, Status[TS]](snapAny)
+
+	if snap.ShouldStop() {
+		return fsmv2.Transition(&stoppingState[TC, TS]{}, fsmv2.SignalNone, nil,
+			"stop required: "+snap.StopReason(), nil)
+	}
+
+	if snap.Status.ShouldRun {
+		return fsmv2.Transition(s, fsmv2.SignalNone,
+			&runAction[TC, TS]{},
+			"interval elapsed, dispatching run", nil)
+	}
+
+	return fsmv2.Transition(s, fsmv2.SignalNone, nil, "running: waiting for interval", nil)
+}
+
+func (s *runningState[TC, TS]) String() string { return "running" }
+
+type stoppingState[TC any, TS any] struct {
+	helpers.StoppingBase
+}
+
+func (s *stoppingState[TC, TS]) Next(snapAny any) fsmv2.NextResult[any, any] {
+	snap := fsmv2.ConvertWorkerSnapshot[TC, Status[TS]](snapAny)
+
+	return fsmv2.Transition(&stoppedState[TC, TS]{}, fsmv2.SignalNeedsRemoval, nil,
+		"stopping complete: "+snap.StopReason(), nil)
+}
+
+func (s *stoppingState[TC, TS]) String() string { return "stopping" }
+
+// --- action ---
+
+type runAction[TC any, TS any] struct{}
+
+func (a *runAction[TC, TS]) Execute(ctx context.Context, d *simpleDeps[TC, TS]) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
+	result, err := d.fn(ctx, d.getConfig())
+	if err != nil {
+		return err
+	}
+
+	d.setResult(result)
+
+	return nil
+}
+
+func (a *runAction[TC, TS]) Name() string { return "run" }
+
+// --- public registration ---
+
+// Register registers a simple periodic worker under workerType.
+// fn is called with the current config once per interval.
+// The worker type string must be unique across the process.
+func Register[TConfig any, TStatus any](
+	workerType string,
+	interval time.Duration,
+	fn func(ctx context.Context, cfg TConfig) (TStatus, error),
+) {
+	register.Worker[TConfig, Status[TStatus], *simpleDeps[TConfig, TStatus]](workerType,
+		func(id deps.Identity, logger deps.FSMLogger, sr deps.StateReader) (fsmv2.Worker, error) {
+			w := &simpleWorker[TConfig, TStatus]{}
+			bd := w.InitBase(id, logger, sr)
+			d := newSimpleDeps(bd, fn, interval)
+			w.BindDeps(d)
+
+			return w, nil
+		})
+}

--- a/umh-core/pkg/fsmv2/simple/simple.go
+++ b/umh-core/pkg/fsmv2/simple/simple.go
@@ -104,12 +104,21 @@ func (d *simpleDeps[TConfig, TStatus]) ShouldRun() bool {
 	return time.Since(d.lastRunAt) >= d.interval
 }
 
+// markRunAttempt records the current time as the last run attempt regardless of
+// success or failure, so ShouldRun respects the configured cadence even when the
+// user function errors.
+func (d *simpleDeps[TConfig, TStatus]) markRunAttempt() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.lastRunAt = time.Now()
+}
+
 func (d *simpleDeps[TConfig, TStatus]) setResult(r TStatus) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
 	d.lastResult = r
-	d.lastRunAt = time.Now()
 }
 
 func (d *simpleDeps[TConfig, TStatus]) getResult() TStatus {
@@ -139,13 +148,7 @@ func (w *simpleWorker[TConfig, TStatus]) GetDependencies() *simpleDeps[TConfig, 
 // CollectObservedState extracts the current config from the desired state,
 // checks whether the interval has elapsed, and returns an observation that the
 // state machine uses to decide whether to dispatch a run action.
-func (w *simpleWorker[TConfig, TStatus]) CollectObservedState(ctx context.Context, desired fsmv2.DesiredState) (fsmv2.ObservedState, error) {
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	default:
-	}
-
+func (w *simpleWorker[TConfig, TStatus]) CollectObservedState(_ context.Context, desired fsmv2.DesiredState) (fsmv2.ObservedState, error) {
 	d := w.GetDependencies()
 
 	cfg := fsmv2.ExtractConfig[TConfig](desired)
@@ -227,11 +230,7 @@ func (s *stoppingState[TC, TS]) String() string { return "stopping" }
 type runAction[TC any, TS any] struct{}
 
 func (a *runAction[TC, TS]) Execute(ctx context.Context, d *simpleDeps[TC, TS]) error {
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	default:
-	}
+	d.markRunAttempt()
 
 	result, err := d.fn(ctx, d.getConfig())
 	if err != nil {

--- a/umh-core/pkg/fsmv2/simple/simple.go
+++ b/umh-core/pkg/fsmv2/simple/simple.go
@@ -40,29 +40,26 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/register"
 )
 
-// Status wraps the user-defined status type with framework metadata produced
-// by the simple worker on each observation cycle.
+// Status wraps the user-defined status type with the last result produced by
+// the user function.
 type Status[TStatus any] struct {
 	// Inner holds the result of the last successful user function call.
 	Inner TStatus `json:"inner"`
-	// ShouldRun indicates whether the interval has elapsed and the function
-	// will be dispatched on the next tick.
-	ShouldRun bool `json:"shouldRun"`
 }
 
 // --- private dependencies ---
 
-// simpleDeps holds mutable state shared between CollectObservedState and the
-// runAction. All fields are protected by mu.
+// simpleDeps holds mutable state shared between CollectObservedState ticks.
+// All fields are protected by mu.
 type simpleDeps[TConfig any, TStatus any] struct {
 	*deps.BaseDependencies
 
-	fn         func(ctx context.Context, cfg TConfig) (TStatus, error)
-	mu         sync.RWMutex
-	cfg        TConfig
+	fn        func(ctx context.Context, cfg TConfig) (TStatus, error)
+	mu        sync.RWMutex
+	cfg       TConfig
 	lastResult TStatus
-	lastRunAt  time.Time
-	interval   time.Duration
+	lastRunAt time.Time
+	interval  time.Duration
 }
 
 func newSimpleDeps[TConfig any, TStatus any](
@@ -91,27 +88,11 @@ func (d *simpleDeps[TConfig, TStatus]) getConfig() TConfig {
 	return d.cfg
 }
 
-// ShouldRun returns true when the interval has elapsed since the last run.
-// On the very first call (lastRunAt is zero) it returns true immediately.
-func (d *simpleDeps[TConfig, TStatus]) ShouldRun() bool {
+func (d *simpleDeps[TConfig, TStatus]) shouldRun() bool {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 
-	if d.lastRunAt.IsZero() {
-		return true
-	}
-
-	return time.Since(d.lastRunAt) >= d.interval
-}
-
-// markRunAttempt records the current time as the last run attempt regardless of
-// success or failure, so ShouldRun respects the configured cadence even when the
-// user function errors.
-func (d *simpleDeps[TConfig, TStatus]) markRunAttempt() {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-
-	d.lastRunAt = time.Now()
+	return d.lastRunAt.IsZero() || time.Since(d.lastRunAt) >= d.interval
 }
 
 func (d *simpleDeps[TConfig, TStatus]) setResult(r TStatus) {
@@ -119,6 +100,16 @@ func (d *simpleDeps[TConfig, TStatus]) setResult(r TStatus) {
 	defer d.mu.Unlock()
 
 	d.lastResult = r
+	d.lastRunAt = time.Now()
+}
+
+// markRunAttempt records the current time regardless of success, so a failed
+// fn call still advances the interval instead of hammering on every tick.
+func (d *simpleDeps[TConfig, TStatus]) markRunAttempt() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.lastRunAt = time.Now()
 }
 
 func (d *simpleDeps[TConfig, TStatus]) getResult() TStatus {
@@ -145,21 +136,27 @@ func (w *simpleWorker[TConfig, TStatus]) GetDependencies() *simpleDeps[TConfig, 
 	return d
 }
 
-// CollectObservedState extracts the current config from the desired state,
-// checks whether the interval has elapsed, and returns an observation that the
-// state machine uses to decide whether to dispatch a run action.
-func (w *simpleWorker[TConfig, TStatus]) CollectObservedState(_ context.Context, desired fsmv2.DesiredState) (fsmv2.ObservedState, error) {
+// CollectObservedState extracts the current config from the desired state and,
+// when the configured interval has elapsed, calls the user function in-place.
+// The result is returned as the observation; no action dispatch is needed.
+func (w *simpleWorker[TConfig, TStatus]) CollectObservedState(ctx context.Context, desired fsmv2.DesiredState) (fsmv2.ObservedState, error) {
 	d := w.GetDependencies()
 
 	cfg := fsmv2.ExtractConfig[TConfig](desired)
 	d.setConfig(cfg)
 
-	status := Status[TStatus]{
-		Inner:     d.getResult(),
-		ShouldRun: d.ShouldRun(),
+	if d.shouldRun() {
+		d.markRunAttempt()
+
+		result, err := d.fn(ctx, d.getConfig())
+		if err != nil {
+			return nil, err
+		}
+
+		d.setResult(result)
 	}
 
-	return fsmv2.NewObservation(status), nil
+	return fsmv2.NewObservation(Status[TStatus]{Inner: d.getResult()}), nil
 }
 
 // GetInitialState returns a fresh stoppedState without touching the global
@@ -201,13 +198,7 @@ func (s *runningState[TC, TS]) Next(snapAny any) fsmv2.NextResult[any, any] {
 			"stop required: "+snap.StopReason(), nil)
 	}
 
-	if snap.Status.ShouldRun {
-		return fsmv2.Transition(s, fsmv2.SignalNone,
-			&runAction[TC, TS]{},
-			"interval elapsed, dispatching run", nil)
-	}
-
-	return fsmv2.Transition(s, fsmv2.SignalNone, nil, "running: waiting for interval", nil)
+	return fsmv2.Transition(s, fsmv2.SignalNone, nil, "running", nil)
 }
 
 func (s *runningState[TC, TS]) String() string { return "running" }
@@ -224,25 +215,6 @@ func (s *stoppingState[TC, TS]) Next(snapAny any) fsmv2.NextResult[any, any] {
 }
 
 func (s *stoppingState[TC, TS]) String() string { return "stopping" }
-
-// --- action ---
-
-type runAction[TC any, TS any] struct{}
-
-func (a *runAction[TC, TS]) Execute(ctx context.Context, d *simpleDeps[TC, TS]) error {
-	d.markRunAttempt()
-
-	result, err := d.fn(ctx, d.getConfig())
-	if err != nil {
-		return err
-	}
-
-	d.setResult(result)
-
-	return nil
-}
-
-func (a *runAction[TC, TS]) Name() string { return "run" }
 
 // --- public registration ---
 

--- a/umh-core/pkg/fsmv2/simple/simple.go
+++ b/umh-core/pkg/fsmv2/simple/simple.go
@@ -70,6 +70,10 @@ func (w *simpleWorker[TConfig, TStatus]) GetInitialState() fsmv2.State[any, any]
 // when the configured interval has elapsed, calls fn in-place. The result is
 // returned as the observation; no action dispatch is needed.
 func (w *simpleWorker[TConfig, TStatus]) CollectObservedState(ctx context.Context, desired fsmv2.DesiredState) (fsmv2.ObservedState, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
 	cfg := fsmv2.ExtractConfig[TConfig](desired)
 
 	if w.lastRunAt.IsZero() || time.Since(w.lastRunAt) >= w.interval {

--- a/umh-core/pkg/fsmv2/simple/simple.go
+++ b/umh-core/pkg/fsmv2/simple/simple.go
@@ -40,13 +40,6 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/register"
 )
 
-// Status wraps the user-defined status type with the last result produced by
-// the user function.
-type Status[TStatus any] struct {
-	// Inner holds the result of the last successful user function call.
-	Inner TStatus `json:"inner"`
-}
-
 // --- private dependencies ---
 
 // simpleDeps holds mutable state shared between CollectObservedState ticks.
@@ -122,7 +115,7 @@ func (d *simpleDeps[TConfig, TStatus]) getResult() TStatus {
 // --- worker ---
 
 type simpleWorker[TConfig any, TStatus any] struct {
-	fsmv2.WorkerBase[TConfig, Status[TStatus], *simpleDeps[TConfig, TStatus]]
+	fsmv2.WorkerBase[TConfig, TStatus, *simpleDeps[TConfig, TStatus]]
 }
 
 func (w *simpleWorker[TConfig, TStatus]) GetDependencies() *simpleDeps[TConfig, TStatus] {
@@ -156,7 +149,7 @@ func (w *simpleWorker[TConfig, TStatus]) CollectObservedState(ctx context.Contex
 		d.setResult(result)
 	}
 
-	return fsmv2.NewObservation(Status[TStatus]{Inner: d.getResult()}), nil
+	return fsmv2.NewObservation(d.getResult()), nil
 }
 
 // GetInitialState returns a fresh stoppedState without touching the global
@@ -173,7 +166,7 @@ type stoppedState[TC any, TS any] struct {
 }
 
 func (s *stoppedState[TC, TS]) Next(snapAny any) fsmv2.NextResult[any, any] {
-	snap := fsmv2.ConvertWorkerSnapshot[TC, Status[TS]](snapAny)
+	snap := fsmv2.ConvertWorkerSnapshot[TC, TS](snapAny)
 
 	if snap.IsShutdownRequested {
 		return fsmv2.Transition(s, fsmv2.SignalNeedsRemoval, nil,
@@ -191,7 +184,7 @@ type runningState[TC any, TS any] struct {
 }
 
 func (s *runningState[TC, TS]) Next(snapAny any) fsmv2.NextResult[any, any] {
-	snap := fsmv2.ConvertWorkerSnapshot[TC, Status[TS]](snapAny)
+	snap := fsmv2.ConvertWorkerSnapshot[TC, TS](snapAny)
 
 	if snap.ShouldStop() {
 		return fsmv2.Transition(&stoppingState[TC, TS]{}, fsmv2.SignalNone, nil,
@@ -208,7 +201,7 @@ type stoppingState[TC any, TS any] struct {
 }
 
 func (s *stoppingState[TC, TS]) Next(snapAny any) fsmv2.NextResult[any, any] {
-	snap := fsmv2.ConvertWorkerSnapshot[TC, Status[TS]](snapAny)
+	snap := fsmv2.ConvertWorkerSnapshot[TC, TS](snapAny)
 
 	return fsmv2.Transition(&stoppedState[TC, TS]{}, fsmv2.SignalNeedsRemoval, nil,
 		"stopping complete: "+snap.StopReason(), nil)
@@ -226,7 +219,7 @@ func Register[TConfig any, TStatus any](
 	interval time.Duration,
 	fn func(ctx context.Context, cfg TConfig) (TStatus, error),
 ) {
-	register.Worker[TConfig, Status[TStatus], *simpleDeps[TConfig, TStatus]](workerType,
+	register.Worker[TConfig, TStatus, *simpleDeps[TConfig, TStatus]](workerType,
 		func(id deps.Identity, logger deps.FSMLogger, sr deps.StateReader) (fsmv2.Worker, error) {
 			w := &simpleWorker[TConfig, TStatus]{}
 			bd := w.InitBase(id, logger, sr)

--- a/umh-core/pkg/fsmv2/supervisor/api.go
+++ b/umh-core/pkg/fsmv2/supervisor/api.go
@@ -613,6 +613,13 @@ func (s *Supervisor[TObserved, TDesired]) IsObservationStale() bool {
 	return true
 }
 
+// UpdateUserSpec sets the user specification for this supervisor.
+// Config changes are reflected on the next tick when DeriveDesiredState is called.
+// Use this when the supervisor is owned by an external manager rather than a parent worker.
+func (s *Supervisor[TObserved, TDesired]) UpdateUserSpec(spec config.UserSpec) {
+	s.updateUserSpec(spec)
+}
+
 // updateUserSpec implements SupervisorInterface.
 func (s *Supervisor[TObserved, TDesired]) updateUserSpec(spec config.UserSpec) {
 	s.mu.Lock()

--- a/umh-core/pkg/fsmv2/supervisor/api_boundary_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/api_boundary_test.go
@@ -78,6 +78,7 @@ var _ = Describe("Supervisor API Boundary", func() {
 		It("should export configuration methods", func() {
 			publicMethods := []string{
 				"SetGlobalVariables",
+				"UpdateUserSpec",
 			}
 
 			for _, methodName := range publicMethods {

--- a/umh-core/pkg/fsmv2/workers/nmap/nmap.go
+++ b/umh-core/pkg/fsmv2/workers/nmap/nmap.go
@@ -34,7 +34,9 @@ import (
 
 const (
 	defaultScanInterval = 1 * time.Second
-	scanTimeout         = 3 * time.Second
+	// scanTimeout must be < DefaultObservationTimeout (interval + MaxCgroupThrottlePeriod + 1s ≈ 2.2s)
+	// so the parent context deadline never fires before the dial can return a "filtered" result.
+	scanTimeout = 1500 * time.Millisecond
 )
 
 // NmapConfig holds the user-provided configuration for the nmap worker.

--- a/umh-core/pkg/fsmv2/workers/nmap/nmap.go
+++ b/umh-core/pkg/fsmv2/workers/nmap/nmap.go
@@ -1,0 +1,115 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package nmap_worker provides an FSMv2 worker that periodically performs TCP
+// connect scans against a target:port and reports the result
+// (open/closed/filtered/degraded).
+//
+// NAMING CONVENTION: The package name uses underscore (nmap_worker) but the
+// folder name is "nmap". The type prefix must be "Nmap" (one capital) to
+// derive correctly as worker type "nmap".
+package nmap_worker
+
+import (
+	"context"
+	"errors"
+	"net"
+	"strconv"
+	"time"
+
+	fsmv2config "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/config"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/simple"
+)
+
+const (
+	defaultScanInterval = 1 * time.Second
+	scanTimeout         = 3 * time.Second
+)
+
+// NmapConfig holds the user-provided configuration for the nmap worker.
+type NmapConfig struct {
+	fsmv2config.BaseUserSpec `yaml:",inline"`
+
+	// Target is the hostname or IP address to scan.
+	Target string `json:"target" yaml:"target"`
+	// Port is the TCP port to scan.
+	Port uint16 `json:"port" yaml:"port"`
+}
+
+// NmapStatus holds the runtime observation data for the nmap worker.
+type NmapStatus struct {
+	// ScanError contains the last scan error message, if any.
+	ScanError string `json:"scanError,omitempty"`
+	// PortState is the last observed port state: "open", "closed", "filtered", or "degraded".
+	PortState string `json:"portState,omitempty"`
+	// Target is the scan target (copied from config for observability).
+	Target string `json:"target,omitempty"`
+	// LatencyMs is the last measured TCP connect latency in milliseconds.
+	LatencyMs float64 `json:"latencyMs"`
+	// Port is the scanned port (copied from config for observability).
+	Port uint16 `json:"port,omitempty"`
+	// IsRunning indicates whether the port is currently open.
+	IsRunning bool `json:"isRunning"`
+}
+
+// scan performs a TCP connect scan against cfg.Target:cfg.Port and returns the
+// port state. It returns an error only for context cancellation; network
+// failures are represented as "closed" or "filtered" states.
+func scan(ctx context.Context, cfg NmapConfig) (NmapStatus, error) {
+	select {
+	case <-ctx.Done():
+		return NmapStatus{}, ctx.Err()
+	default:
+	}
+
+	if cfg.Target == "" || cfg.Port == 0 {
+		return NmapStatus{Target: cfg.Target, Port: cfg.Port, PortState: "degraded"}, nil
+	}
+
+	start := time.Now()
+	addr := net.JoinHostPort(cfg.Target, strconv.Itoa(int(cfg.Port)))
+
+	conn, dialErr := net.DialTimeout("tcp", addr, scanTimeout)
+	latencyMs := float64(time.Since(start).Milliseconds())
+
+	if dialErr != nil {
+		portState := "closed"
+
+		var netErr net.Error
+		if errors.As(dialErr, &netErr) && netErr.Timeout() {
+			portState = "filtered"
+		}
+
+		return NmapStatus{
+			Target:    cfg.Target,
+			Port:      cfg.Port,
+			PortState: portState,
+			LatencyMs: latencyMs,
+		}, nil
+	}
+
+	_ = conn.Close()
+
+	return NmapStatus{
+		Target:    cfg.Target,
+		Port:      cfg.Port,
+		PortState: "open",
+		LatencyMs: latencyMs,
+		IsRunning: true,
+	}, nil
+}
+
+func init() {
+	simple.Register[NmapConfig, NmapStatus]("nmap", defaultScanInterval, scan)
+}

--- a/umh-core/pkg/fsmv2/workers/nmap/nmap.go
+++ b/umh-core/pkg/fsmv2/workers/nmap/nmap.go
@@ -64,15 +64,9 @@ type NmapStatus struct {
 }
 
 // scan performs a TCP connect scan against cfg.Target:cfg.Port and returns the
-// port state. It returns an error only for context cancellation; network
-// failures are represented as "closed" or "filtered" states.
+// port state. Network failures are represented as "closed" or "filtered" states,
+// never as errors, so the caller only sees an error on context cancellation.
 func scan(ctx context.Context, cfg NmapConfig) (NmapStatus, error) {
-	select {
-	case <-ctx.Done():
-		return NmapStatus{}, ctx.Err()
-	default:
-	}
-
 	if cfg.Target == "" || cfg.Port == 0 {
 		return NmapStatus{Target: cfg.Target, Port: cfg.Port, PortState: "degraded"}, nil
 	}
@@ -80,10 +74,17 @@ func scan(ctx context.Context, cfg NmapConfig) (NmapStatus, error) {
 	start := time.Now()
 	addr := net.JoinHostPort(cfg.Target, strconv.Itoa(int(cfg.Port)))
 
-	conn, dialErr := net.DialTimeout("tcp", addr, scanTimeout)
+	dialCtx, cancel := context.WithTimeout(ctx, scanTimeout)
+	defer cancel()
+
+	conn, dialErr := (&net.Dialer{}).DialContext(dialCtx, "tcp", addr)
 	latencyMs := float64(time.Since(start).Milliseconds())
 
 	if dialErr != nil {
+		if ctx.Err() != nil {
+			return NmapStatus{}, ctx.Err()
+		}
+
 		portState := "closed"
 
 		var netErr net.Error
@@ -96,6 +97,7 @@ func scan(ctx context.Context, cfg NmapConfig) (NmapStatus, error) {
 			Port:      cfg.Port,
 			PortState: portState,
 			LatencyMs: latencyMs,
+			ScanError: dialErr.Error(),
 		}, nil
 	}
 
@@ -111,5 +113,5 @@ func scan(ctx context.Context, cfg NmapConfig) (NmapStatus, error) {
 }
 
 func init() {
-	simple.Register[NmapConfig, NmapStatus]("nmap", defaultScanInterval, scan)
+	simple.Register("nmap", defaultScanInterval, scan)
 }

--- a/umh-core/pkg/fsmv2nmap/instance.go
+++ b/umh-core/pkg/fsmv2nmap/instance.go
@@ -24,13 +24,12 @@ import (
 	fsmv2adapter "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/adapter"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/fsmv2client"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/configworker/dynamicchildren"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/simple"
 	nmap_worker "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/nmap"
 	nmapservice "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/nmap"
 )
 
 // nmapStatusType is the observation type stored by the simple nmap worker.
-type nmapStatusType = simple.Status[nmap_worker.NmapStatus]
+type nmapStatusType = nmap_worker.NmapStatus
 
 // newNmapInstance creates an AdaptedInstance for one nmap scan target.
 // It reads via the global FSMv2Client; no local store is needed.
@@ -56,7 +55,7 @@ func nmapMapState(obs fsmv2.Observation[nmapStatusType], freshness fsmv2client.F
 	}
 
 	// Fresh — map port state.
-	portState := obs.Status.Inner.PortState
+	portState := obs.Status.PortState
 	switch portState {
 	case "open", "closed", "filtered", "unfiltered", "open|filtered", "closed|filtered", "degraded":
 		return portState
@@ -75,7 +74,7 @@ func nmapMapObservedState(cfg config.NmapConfig, obs fsmv2.Observation[nmapStatu
 		return result
 	}
 
-	inner := obs.Status.Inner
+	inner := obs.Status
 	if inner.PortState != "" || inner.ScanError != "" {
 		result.ServiceInfo = nmapservice.ServiceInfo{
 			NmapStatus: nmapservice.NmapServiceInfo{

--- a/umh-core/pkg/fsmv2nmap/instance.go
+++ b/umh-core/pkg/fsmv2nmap/instance.go
@@ -43,6 +43,7 @@ const (
 // It reads via the global FSMv2Client; no local store is needed.
 func newNmapInstance(cfg config.NmapConfig) publicfsm.FSMInstance {
 	ref := dynamicchildren.Ref{WorkerType: "nmap", Name: cfg.Name}
+	isDisabled := cfg.DesiredFSMState == "stopped"
 
 	return fsmv2adapter.NewAdaptedInstance(
 		ref,
@@ -52,6 +53,7 @@ func newNmapInstance(cfg config.NmapConfig) publicfsm.FSMInstance {
 		nmapMaxAge,
 		nmapMapState,
 		nmapMapObservedState,
+		isDisabled,
 	)
 }
 
@@ -66,7 +68,7 @@ func nmapMapState(obs fsmv2.Observation[nmap_worker.NmapStatus], freshness fsmv2
 	// Fresh — map port state.
 	portState := obs.Status.PortState
 	switch portState {
-	case "open", "closed", "filtered", "unfiltered", "open|filtered", "closed|filtered", "degraded":
+	case "open", "closed", "filtered", "degraded":
 		return portState
 	default:
 		return nmapfsm.OperationalStateStarting
@@ -76,7 +78,10 @@ func nmapMapState(obs fsmv2.Observation[nmap_worker.NmapStatus], freshness fsmv2
 func nmapMapObservedState(cfg config.NmapConfig, obs fsmv2.Observation[nmap_worker.NmapStatus], freshness fsmv2client.Freshness) publicfsm.ObservedState {
 	result := nmapfsm.NmapObservedState{
 		ObservedNmapServiceConfig: cfg.NmapServiceConfig,
-		LastStateChange:           time.Now().Unix(),
+	}
+
+	if freshness == fsmv2client.Fresh {
+		result.LastStateChange = obs.CollectedAt.Unix()
 	}
 
 	if freshness != fsmv2client.Fresh && freshness != fsmv2client.Stale {

--- a/umh-core/pkg/fsmv2nmap/instance.go
+++ b/umh-core/pkg/fsmv2nmap/instance.go
@@ -28,8 +28,15 @@ import (
 	nmapservice "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/nmap"
 )
 
-// nmapStatusType is the observation type stored by the simple nmap worker.
-type nmapStatusType = nmap_worker.NmapStatus
+const (
+	// nmapMinRequiredTime is how long the fsmv1 control loop waits before
+	// considering a state transition stable.
+	nmapMinRequiredTime = 5 * time.Second
+
+	// nmapMaxAge is how old a nmap observation may be before the child is
+	// considered stale (unreachable). Three missed 1-second scan intervals.
+	nmapMaxAge = 3 * time.Second
+)
 
 // newNmapInstance creates an AdaptedInstance for one nmap scan target.
 // It reads via the global FSMv2Client; no local store is needed.
@@ -40,13 +47,14 @@ func newNmapInstance(cfg config.NmapConfig) publicfsm.FSMInstance {
 		ref,
 		cfg,
 		cfg.DesiredFSMState,
-		5*time.Second,
+		nmapMinRequiredTime,
+		nmapMaxAge,
 		nmapMapState,
 		nmapMapObservedState,
 	)
 }
 
-func nmapMapState(obs fsmv2.Observation[nmapStatusType], freshness fsmv2client.Freshness, _ config.NmapConfig) string {
+func nmapMapState(obs fsmv2.Observation[nmap_worker.NmapStatus], freshness fsmv2client.Freshness, _ config.NmapConfig) string {
 	switch freshness {
 	case fsmv2client.Unregistered, fsmv2client.NeverObserved, fsmv2client.Unknown:
 		return nmapfsm.OperationalStateStarting
@@ -64,7 +72,7 @@ func nmapMapState(obs fsmv2.Observation[nmapStatusType], freshness fsmv2client.F
 	}
 }
 
-func nmapMapObservedState(cfg config.NmapConfig, obs fsmv2.Observation[nmapStatusType], freshness fsmv2client.Freshness) publicfsm.ObservedState {
+func nmapMapObservedState(cfg config.NmapConfig, obs fsmv2.Observation[nmap_worker.NmapStatus], freshness fsmv2client.Freshness) publicfsm.ObservedState {
 	result := nmapfsm.NmapObservedState{
 		ObservedNmapServiceConfig: cfg.NmapServiceConfig,
 		LastStateChange:           time.Now().Unix(),

--- a/umh-core/pkg/fsmv2nmap/instance.go
+++ b/umh-core/pkg/fsmv2nmap/instance.go
@@ -34,8 +34,9 @@ const (
 	nmapMinRequiredTime = 5 * time.Second
 
 	// nmapMaxAge is how old a nmap observation may be before the child is
-	// considered stale (unreachable). Three missed 1-second scan intervals.
-	nmapMaxAge = 3 * time.Second
+	// considered stale. Formula: scanTimeout + 2*defaultScanInterval = 1.5s + 2s = 3.5s,
+	// which covers a slow-but-successful scan without a spurious stale flip.
+	nmapMaxAge = 3500 * time.Millisecond
 )
 
 // newNmapInstance creates an AdaptedInstance for one nmap scan target.

--- a/umh-core/pkg/fsmv2nmap/instance.go
+++ b/umh-core/pkg/fsmv2nmap/instance.go
@@ -21,25 +21,24 @@ import (
 	publicfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
 	nmapfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/nmap"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
-	fsmv2config "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/adapter"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
+	fsmv2adapter "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/adapter"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/fsmv2client"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/configworker/dynamicchildren"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/simple"
 	nmap_worker "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/nmap"
 	nmapservice "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/nmap"
-	v2config "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/config"
 )
 
 // nmapStatusType is the observation type stored by the simple nmap worker.
 type nmapStatusType = simple.Status[nmap_worker.NmapStatus]
 
 // newNmapInstance creates an AdaptedInstance for one nmap scan target.
-func newNmapInstance(cfg config.NmapConfig, sr deps.StateReader) publicfsm.FSMInstance {
-	childID := v2config.ChildID(cfg.Name)
+// It reads via the global FSMv2Client; no local store is needed.
+func newNmapInstance(cfg config.NmapConfig) publicfsm.FSMInstance {
+	ref := dynamicchildren.Ref{WorkerType: "nmap", Name: cfg.Name}
 
-	return fsmv2config.NewAdaptedInstance[nmapStatusType, config.NmapConfig](
-		sr,
-		"nmap",
-		childID,
+	return fsmv2adapter.NewAdaptedInstance(
+		ref,
 		cfg,
 		cfg.DesiredFSMState,
 		5*time.Second,
@@ -48,9 +47,16 @@ func newNmapInstance(cfg config.NmapConfig, sr deps.StateReader) publicfsm.FSMIn
 	)
 }
 
-func nmapMapState(obs fsmv2.Observation[nmapStatusType], _ config.NmapConfig) string {
-	portState := obs.Status.Inner.PortState
+func nmapMapState(obs fsmv2.Observation[nmapStatusType], freshness fsmv2client.Freshness, _ config.NmapConfig) string {
+	switch freshness {
+	case fsmv2client.Unregistered, fsmv2client.NeverObserved, fsmv2client.Unknown:
+		return nmapfsm.OperationalStateStarting
+	case fsmv2client.Stale:
+		return "degraded"
+	}
 
+	// Fresh — map port state.
+	portState := obs.Status.Inner.PortState
 	switch portState {
 	case "open", "closed", "filtered", "unfiltered", "open|filtered", "closed|filtered", "degraded":
 		return portState
@@ -59,10 +65,14 @@ func nmapMapState(obs fsmv2.Observation[nmapStatusType], _ config.NmapConfig) st
 	}
 }
 
-func nmapMapObservedState(cfg config.NmapConfig, obs fsmv2.Observation[nmapStatusType]) publicfsm.ObservedState {
+func nmapMapObservedState(cfg config.NmapConfig, obs fsmv2.Observation[nmapStatusType], freshness fsmv2client.Freshness) publicfsm.ObservedState {
 	result := nmapfsm.NmapObservedState{
 		ObservedNmapServiceConfig: cfg.NmapServiceConfig,
 		LastStateChange:           time.Now().Unix(),
+	}
+
+	if freshness != fsmv2client.Fresh && freshness != fsmv2client.Stale {
+		return result
 	}
 
 	inner := obs.Status.Inner

--- a/umh-core/pkg/fsmv2nmap/instance.go
+++ b/umh-core/pkg/fsmv2nmap/instance.go
@@ -1,0 +1,87 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fsmv2nmap
+
+import (
+	"time"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
+	publicfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
+	nmapfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/nmap"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
+	fsmv2config "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/adapter"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/simple"
+	nmap_worker "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/nmap"
+	nmapservice "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/nmap"
+	v2config "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/config"
+)
+
+// nmapStatusType is the observation type stored by the simple nmap worker.
+type nmapStatusType = simple.Status[nmap_worker.NmapStatus]
+
+// newNmapInstance creates an AdaptedInstance for one nmap scan target.
+func newNmapInstance(cfg config.NmapConfig, sr deps.StateReader) publicfsm.FSMInstance {
+	childID := v2config.ChildID(cfg.Name)
+
+	return fsmv2config.NewAdaptedInstance[nmapStatusType, config.NmapConfig](
+		sr,
+		"nmap",
+		childID,
+		cfg,
+		cfg.DesiredFSMState,
+		5*time.Second,
+		nmapMapState,
+		nmapMapObservedState,
+	)
+}
+
+func nmapMapState(obs fsmv2.Observation[nmapStatusType], _ config.NmapConfig) string {
+	portState := obs.Status.Inner.PortState
+
+	switch portState {
+	case "open", "closed", "filtered", "unfiltered", "open|filtered", "closed|filtered", "degraded":
+		return portState
+	default:
+		return nmapfsm.OperationalStateStarting
+	}
+}
+
+func nmapMapObservedState(cfg config.NmapConfig, obs fsmv2.Observation[nmapStatusType]) publicfsm.ObservedState {
+	result := nmapfsm.NmapObservedState{
+		ObservedNmapServiceConfig: cfg.NmapServiceConfig,
+		LastStateChange:           time.Now().Unix(),
+	}
+
+	inner := obs.Status.Inner
+	if inner.PortState != "" || inner.ScanError != "" {
+		result.ServiceInfo = nmapservice.ServiceInfo{
+			NmapStatus: nmapservice.NmapServiceInfo{
+				LastScan: &nmapservice.NmapScanResult{
+					Timestamp: obs.CollectedAt,
+					Error:     inner.ScanError,
+					PortResult: nmapservice.PortResult{
+						State:     inner.PortState,
+						LatencyMs: inner.LatencyMs,
+						Port:      inner.Port,
+					},
+				},
+				IsRunning: inner.IsRunning,
+			},
+		}
+	}
+
+	return result
+}

--- a/umh-core/pkg/fsmv2nmap/manager.go
+++ b/umh-core/pkg/fsmv2nmap/manager.go
@@ -68,5 +68,8 @@ func NewFsmv2NmapManager(name string) *adapter.WorkerManager[config.NmapConfig] 
 				"port":   cfg.NmapServiceConfig.Port,
 			}, nil
 		},
+		IsEnabled: func(cfg config.NmapConfig) bool {
+			return cfg.DesiredFSMState != "stopped"
+		},
 	})
 }

--- a/umh-core/pkg/fsmv2nmap/manager.go
+++ b/umh-core/pkg/fsmv2nmap/manager.go
@@ -19,74 +19,34 @@
 // suturenmap.SutureNmapManager, toggled via the NMAP_BACKEND="fsmv2"
 // environment variable.
 //
-// One application supervisor manages all nmap child workers. Target additions
-// and removals update the supervisor's user spec; the supervisor reconciles
-// children on the next tick without per-target goroutine overhead.
+// The shared global fsmv2 runtime owns child execution. This manager is a thin
+// control-loop adapter: it diffs desired configs, calls Upsert/Delete on the
+// global FSMv2Client, and exposes each child as an FSMv1 FSMInstance.
 package fsmv2nmap
 
 import (
-	"context"
 	"fmt"
-	"sort"
-	"time"
-
-	"go.uber.org/zap"
-	"gopkg.in/yaml.v3"
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
 	publicfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
-	cseStorage "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/cse/storage"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/adapter"
-	fsmv2config "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/config"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/application"
-	nmap_worker "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/nmap"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/configworker/dynamicchildren"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/logger"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/metrics"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/persistence/memory"
 )
 
-// nmapChildrenConfig is the YAML envelope the ApplicationWorker parses in
-// DeriveDesiredState. Each entry becomes a child nmap worker.
-type nmapChildrenConfig struct {
-	Children []fsmv2config.ChildSpec `yaml:"children"`
-}
-
 // NewFsmv2NmapManager creates a new FSMv2-backed nmap manager.
-// A single application supervisor owns all nmap children; target set changes
-// are reflected via UpdateUserSpec rather than spawning per-target supervisors.
+// Child execution is owned by the shared global fsmv2 runtime (wired in
+// cmd/main.go via fsmv2client.SetClient). This manager only reconciles config
+// changes into Upsert/Delete calls on that runtime.
 func NewFsmv2NmapManager(name string) *adapter.WorkerManager[config.NmapConfig] {
 	managerName := fmt.Sprintf("%s_%s", logger.ComponentNmapManager, name)
-
-	ctx, cancel := context.WithCancel(context.Background())
-
 	metrics.InitErrorCounter(metrics.ComponentNmapManager, name)
-
-	fsmLog := deps.NewFSMLogger(zap.L().Sugar().Named(managerName))
-	store := cseStorage.NewTriangularStore(memory.NewInMemoryStore(), fsmLog)
-
-	sup, err := application.NewApplicationSupervisor(application.SupervisorConfig{
-		Store:        store,
-		Logger:       fsmLog,
-		ID:           managerName,
-		Name:         managerName,
-		TickInterval: 100 * time.Millisecond,
-	})
-	if err != nil {
-		// NewApplicationSupervisor only fails on identity collision, which
-		// cannot happen with a fresh store. Panic so mis-wiring surfaces
-		// immediately rather than silently dropping scans.
-		panic(fmt.Sprintf("fsmv2nmap: create application supervisor: %v", err))
-	}
-
-	_ = sup.Start(ctx)
-
 	log := logger.For(managerName)
 
 	return adapter.NewWorkerManager(adapter.WorkerManagerSpec[config.NmapConfig]{
 		ManagerName: managerName,
 		Log:         log,
-		UpdateSpec:  sup.UpdateUserSpec,
 		ExtractConfigs: func(snapshot publicfsm.SystemSnapshot) []config.NmapConfig {
 			return snapshot.CurrentConfig.Internal.Nmap
 		},
@@ -97,52 +57,16 @@ func NewFsmv2NmapManager(name string) *adapter.WorkerManager[config.NmapConfig] 
 				a.NmapServiceConfig.Equal(b.NmapServiceConfig)
 		},
 		NewInstance: func(cfg config.NmapConfig) publicfsm.FSMInstance {
-			return newNmapInstance(cfg, store)
+			return newNmapInstance(cfg)
 		},
-		BuildSpec: buildNmapChildrenSpec,
-	}, cancel)
-}
-
-// buildNmapChildrenSpec marshals the current domain config map into the YAML
-// envelope that ApplicationWorker.DeriveDesiredState expects. Names are sorted
-// so the YAML is deterministic and does not produce spurious UpdateUserSpec calls.
-func buildNmapChildrenSpec(configs map[string]config.NmapConfig) fsmv2config.UserSpec {
-	names := make([]string, 0, len(configs))
-	for name := range configs {
-		names = append(names, name)
-	}
-
-	sort.Strings(names)
-
-	children := make([]fsmv2config.ChildSpec, 0, len(names))
-
-	for _, name := range names {
-		cfg := configs[name]
-
-		spec, err := fsmv2config.NewChildSpec[nmap_worker.NmapConfig](
-			name,
-			"nmap",
-			nmap_worker.NmapConfig{
-				Target: cfg.NmapServiceConfig.Target,
-				Port:   cfg.NmapServiceConfig.Port,
-			},
-			true,
-		)
-		if err != nil {
-			zap.L().Sugar().Warnf("fsmv2nmap: failed to build child spec for %s: %v", name, err)
-
-			continue
-		}
-
-		children = append(children, spec)
-	}
-
-	data, err := yaml.Marshal(nmapChildrenConfig{Children: children})
-	if err != nil {
-		zap.L().Sugar().Warnf("fsmv2nmap: failed to marshal nmap children spec: %v", err)
-
-		return fsmv2config.UserSpec{}
-	}
-
-	return fsmv2config.UserSpec{Config: string(data)}
+		RefFor: func(cfg config.NmapConfig) dynamicchildren.Ref {
+			return dynamicchildren.Ref{WorkerType: "nmap", Name: cfg.Name}
+		},
+		CfgFor: func(cfg config.NmapConfig) (map[string]any, error) {
+			return map[string]any{
+				"target": cfg.NmapServiceConfig.Target,
+				"port":   cfg.NmapServiceConfig.Port,
+			}, nil
+		},
+	})
 }

--- a/umh-core/pkg/fsmv2nmap/manager.go
+++ b/umh-core/pkg/fsmv2nmap/manager.go
@@ -1,0 +1,148 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package fsmv2nmap provides an FSMManager implementation for nmap connection
+// scanning backed by the fsmv2 framework instead of S6 or suture.
+//
+// It is a drop-in replacement for both nmap.NmapManager and
+// suturenmap.SutureNmapManager, toggled via the NMAP_BACKEND="fsmv2"
+// environment variable.
+//
+// One application supervisor manages all nmap child workers. Target additions
+// and removals update the supervisor's user spec; the supervisor reconciles
+// children on the next tick without per-target goroutine overhead.
+package fsmv2nmap
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	"go.uber.org/zap"
+	"gopkg.in/yaml.v3"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
+	publicfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
+	cseStorage "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/cse/storage"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/adapter"
+	fsmv2config "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/config"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/application"
+	nmap_worker "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/nmap"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/logger"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/metrics"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/persistence/memory"
+)
+
+// nmapChildrenConfig is the YAML envelope the ApplicationWorker parses in
+// DeriveDesiredState. Each entry becomes a child nmap worker.
+type nmapChildrenConfig struct {
+	Children []fsmv2config.ChildSpec `yaml:"children"`
+}
+
+// NewFsmv2NmapManager creates a new FSMv2-backed nmap manager.
+// A single application supervisor owns all nmap children; target set changes
+// are reflected via UpdateUserSpec rather than spawning per-target supervisors.
+func NewFsmv2NmapManager(name string) *adapter.WorkerManager[config.NmapConfig] {
+	managerName := fmt.Sprintf("%s_%s", logger.ComponentNmapManager, name)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	metrics.InitErrorCounter(metrics.ComponentNmapManager, name)
+
+	fsmLog := deps.NewFSMLogger(zap.L().Sugar().Named(managerName))
+	store := cseStorage.NewTriangularStore(memory.NewInMemoryStore(), fsmLog)
+
+	sup, err := application.NewApplicationSupervisor(application.SupervisorConfig{
+		Store:        store,
+		Logger:       fsmLog,
+		ID:           managerName,
+		Name:         managerName,
+		TickInterval: 100 * time.Millisecond,
+	})
+	if err != nil {
+		// NewApplicationSupervisor only fails on identity collision, which
+		// cannot happen with a fresh store. Panic so mis-wiring surfaces
+		// immediately rather than silently dropping scans.
+		panic(fmt.Sprintf("fsmv2nmap: create application supervisor: %v", err))
+	}
+
+	_ = sup.Start(ctx)
+
+	log := logger.For(managerName)
+
+	return adapter.NewWorkerManager(adapter.WorkerManagerSpec[config.NmapConfig]{
+		ManagerName: managerName,
+		Log:         log,
+		UpdateSpec:  sup.UpdateUserSpec,
+		ExtractConfigs: func(snapshot publicfsm.SystemSnapshot) []config.NmapConfig {
+			return snapshot.CurrentConfig.Internal.Nmap
+		},
+		NameOf:         func(cfg config.NmapConfig) string { return cfg.Name },
+		DesiredStateOf: func(cfg config.NmapConfig) string { return cfg.DesiredFSMState },
+		ConfigEqual: func(a, b config.NmapConfig) bool {
+			return a.FSMInstanceConfig == b.FSMInstanceConfig &&
+				a.NmapServiceConfig.Equal(b.NmapServiceConfig)
+		},
+		NewInstance: func(cfg config.NmapConfig) publicfsm.FSMInstance {
+			return newNmapInstance(cfg, store)
+		},
+		BuildSpec: buildNmapChildrenSpec,
+	}, cancel)
+}
+
+// buildNmapChildrenSpec marshals the current domain config map into the YAML
+// envelope that ApplicationWorker.DeriveDesiredState expects. Names are sorted
+// so the YAML is deterministic and does not produce spurious UpdateUserSpec calls.
+func buildNmapChildrenSpec(configs map[string]config.NmapConfig) fsmv2config.UserSpec {
+	names := make([]string, 0, len(configs))
+	for name := range configs {
+		names = append(names, name)
+	}
+
+	sort.Strings(names)
+
+	children := make([]fsmv2config.ChildSpec, 0, len(names))
+
+	for _, name := range names {
+		cfg := configs[name]
+
+		spec, err := fsmv2config.NewChildSpec[nmap_worker.NmapConfig](
+			name,
+			"nmap",
+			nmap_worker.NmapConfig{
+				Target: cfg.NmapServiceConfig.Target,
+				Port:   cfg.NmapServiceConfig.Port,
+			},
+			true,
+		)
+		if err != nil {
+			zap.L().Sugar().Warnf("fsmv2nmap: failed to build child spec for %s: %v", name, err)
+
+			continue
+		}
+
+		children = append(children, spec)
+	}
+
+	data, err := yaml.Marshal(nmapChildrenConfig{Children: children})
+	if err != nil {
+		zap.L().Sugar().Warnf("fsmv2nmap: failed to marshal nmap children spec: %v", err)
+
+		return fsmv2config.UserSpec{}
+	}
+
+	return fsmv2config.UserSpec{Config: string(data)}
+}

--- a/umh-core/pkg/fsmv2nmap/manager.go
+++ b/umh-core/pkg/fsmv2nmap/manager.go
@@ -50,8 +50,7 @@ func NewFsmv2NmapManager(name string) *adapter.WorkerManager[config.NmapConfig] 
 		ExtractConfigs: func(snapshot publicfsm.SystemSnapshot) []config.NmapConfig {
 			return snapshot.CurrentConfig.Internal.Nmap
 		},
-		NameOf:         func(cfg config.NmapConfig) string { return cfg.Name },
-		DesiredStateOf: func(cfg config.NmapConfig) string { return cfg.DesiredFSMState },
+		NameOf:      func(cfg config.NmapConfig) string { return cfg.Name },
 		ConfigEqual: func(a, b config.NmapConfig) bool {
 			return a.FSMInstanceConfig == b.FSMInstanceConfig &&
 				a.NmapServiceConfig.Equal(b.NmapServiceConfig)

--- a/umh-core/pkg/service/connection/connection.go
+++ b/umh-core/pkg/service/connection/connection.go
@@ -179,6 +179,7 @@ type ConnectionService struct {
 	nmapManager      NmapManagerProvider
 	recentNmapStates map[string][]string
 	nmapConfigs      []config.NmapConfig
+	usesFsmv2Backend bool
 }
 
 // ConnectionServiceOption is a function that configures a ConnectionService.
@@ -215,8 +216,9 @@ func NewDefaultConnectionService(connectionName string, opts ...ConnectionServic
 
 	// NMAP_BACKEND selects the connection scanning implementation.
 	switch os.Getenv("NMAP_BACKEND") {
-	case "fsmv2":
+	case constants.NmapBackendFSMv2:
 		service.nmapManager = fsmv2nmap.NewFsmv2NmapManager(managerName)
+		service.usesFsmv2Backend = true
 	default:
 		service.nmapManager = nmapfsm.NewNmapManager(managerName)
 		service.nmapService = nmap.NewDefaultNmapService(connectionName)
@@ -264,7 +266,7 @@ func (c *ConnectionService) GetConfig(
 	// Returning the desired config here ensures the protocol converter's
 	// UpdateObservedStateOfInstance doesn't bail out early, allowing
 	// BuildRuntimeConfig to run and populate the real target/port.
-	if c.nmapService == nil {
+	if c.usesFsmv2Backend {
 		for _, cfg := range c.nmapConfigs {
 			if cfg.Name == nmapName {
 				return connectionserviceconfig.FromNmapServiceConfig(cfg.NmapServiceConfig), nil
@@ -640,7 +642,7 @@ func (c *ConnectionService) ServiceExists(
 	nmapName := c.getNmapName(connectionName)
 
 	// When using fsmv2-based nmap, check the manager for the instance
-	if c.nmapService == nil {
+	if c.usesFsmv2Backend {
 		_, exists := c.nmapManager.GetInstance(nmapName)
 		return exists
 	}
@@ -669,7 +671,7 @@ func (c *ConnectionService) ForceRemoveConnection(
 	nmapName := c.getNmapName(connectionName)
 
 	// When using fsmv2-based nmap, remove via the manager
-	if c.nmapService == nil {
+	if c.usesFsmv2Backend {
 		if inst, ok := c.nmapManager.GetInstance(nmapName); ok {
 			return inst.Remove(ctx)
 		}

--- a/umh-core/pkg/service/connection/connection.go
+++ b/umh-core/pkg/service/connection/connection.go
@@ -32,6 +32,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
@@ -40,6 +41,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
 	nmapfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/nmap"
+	fsmv2nmap "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2nmap"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/logger"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/metrics"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/filesystem"
@@ -158,13 +160,23 @@ type ServiceInfo struct {
 	IsFlaky bool
 }
 
+// NmapManagerProvider is the interface for the nmap manager used by ConnectionService.
+type NmapManagerProvider interface {
+	GetInstances() map[string]fsm.FSMInstance
+	GetInstance(name string) (fsm.FSMInstance, bool)
+	GetLastObservedState(serviceName string) (fsm.ObservedState, error)
+	GetCurrentFSMState(serviceName string) (string, error)
+	Reconcile(ctx context.Context, snapshot fsm.SystemSnapshot, services serviceregistry.Provider) (error, bool)
+	GetManagerName() string
+}
+
 // ConnectionService implements IConnectionService using Nmap as the underlying
 // connectivity probe mechanism. It maintains a history of recent states to detect
 // flaky connections and provides a higher-level abstraction over raw Nmap results.
 type ConnectionService struct {
 	nmapService      nmap.INmapService
 	logger           *zap.SugaredLogger
-	nmapManager      *nmapfsm.NmapManager
+	nmapManager      NmapManagerProvider
 	recentNmapStates map[string][]string
 	nmapConfigs      []config.NmapConfig
 }
@@ -177,7 +189,7 @@ func WithNmapService(nmapService nmap.INmapService) ConnectionServiceOption {
 	return func(c *ConnectionService) { c.nmapService = nmapService }
 }
 
-func WithNmapManager(mgr *nmapfsm.NmapManager) ConnectionServiceOption {
+func WithNmapManager(mgr NmapManagerProvider) ConnectionServiceOption {
 	return func(c *ConnectionService) { c.nmapManager = mgr }
 }
 
@@ -197,10 +209,17 @@ func NewDefaultConnectionService(connectionName string, opts ...ConnectionServic
 	managerName := fmt.Sprintf("%s%s", logger.ComponentConnectionService, connectionName)
 	service := &ConnectionService{
 		logger:           logger.For(managerName),
-		nmapManager:      nmapfsm.NewNmapManager(managerName),
-		nmapService:      nmap.NewDefaultNmapService(connectionName),
 		nmapConfigs:      []config.NmapConfig{},
 		recentNmapStates: make(map[string][]string),
+	}
+
+	// NMAP_BACKEND selects the connection scanning implementation.
+	switch os.Getenv("NMAP_BACKEND") {
+	case "fsmv2":
+		service.nmapManager = fsmv2nmap.NewFsmv2NmapManager(managerName)
+	default:
+		service.nmapManager = nmapfsm.NewNmapManager(managerName)
+		service.nmapService = nmap.NewDefaultNmapService(connectionName)
 	}
 
 	// Apply options
@@ -237,6 +256,24 @@ func (c *ConnectionService) GetConfig(
 	}
 
 	nmapName := c.getNmapName(connectionName)
+
+	// When using fsmv2-based nmap, return the desired config from our local
+	// nmapConfigs slice. We can't read from the actor's observed state because
+	// the actor may have been created with empty config (the real config arrives
+	// later via UpdateConnectionInNmapManager after template rendering).
+	// Returning the desired config here ensures the protocol converter's
+	// UpdateObservedStateOfInstance doesn't bail out early, allowing
+	// BuildRuntimeConfig to run and populate the real target/port.
+	if c.nmapService == nil {
+		for _, cfg := range c.nmapConfigs {
+			if cfg.Name == nmapName {
+				return connectionserviceconfig.FromNmapServiceConfig(cfg.NmapServiceConfig), nil
+			}
+		}
+		// Instance not in our configs yet — return empty config without error
+		// so the caller doesn't treat this as a fatal failure.
+		return connectionserviceconfig.ConnectionServiceConfig{}, nil
+	}
 
 	// Get the Nmap config
 	nmapCfg, err := c.nmapService.GetConfig(ctx, filesystemService, nmapName)
@@ -582,7 +619,7 @@ func (c *ConnectionService) ReconcileManager(
 			Internal: config.InternalConfig{
 				Nmap: c.nmapConfigs,
 			}},
-		Tick: snapshot.Tick,
+		Tick:         snapshot.Tick,
 		SnapshotTime: snapshot.SnapshotTime,
 	}, services)
 }
@@ -602,6 +639,12 @@ func (c *ConnectionService) ServiceExists(
 
 	nmapName := c.getNmapName(connectionName)
 
+	// When using fsmv2-based nmap, check the manager for the instance
+	if c.nmapService == nil {
+		_, exists := c.nmapManager.GetInstance(nmapName)
+		return exists
+	}
+
 	// Check if the actual service exists
 	return c.nmapService.ServiceExists(ctx, filesystemService, nmapName)
 }
@@ -619,12 +662,22 @@ func (c *ConnectionService) ForceRemoveConnection(
 	if ctx.Err() != nil {
 		c.logger.Warnf("Parent context already expired for force removal of %s", connectionName)
 	}
-	
+
 	ctx, cancel := context.WithTimeout(context.Background(), constants.ForceRemovalTimeout)
 	defer cancel()
 
+	nmapName := c.getNmapName(connectionName)
+
+	// When using fsmv2-based nmap, remove via the manager
+	if c.nmapService == nil {
+		if inst, ok := c.nmapManager.GetInstance(nmapName); ok {
+			return inst.Remove(ctx)
+		}
+		return nil // already gone
+	}
+
 	// force remove from Nmap manager
-	return c.nmapService.ForceRemoveNmap(ctx, filesystemService, c.getNmapName(connectionName))
+	return c.nmapService.ForceRemoveNmap(ctx, filesystemService, nmapName)
 }
 
 // updateRecentScans adds a new scan result to the history for flakiness detection.

--- a/umh-core/pkg/service/protocolconverter/protocolconverter.go
+++ b/umh-core/pkg/service/protocolconverter/protocolconverter.go
@@ -1082,8 +1082,7 @@ func (p *ProtocolConverterService) ServiceExists(
 	// When using fsmv2-based nmap, the connection always exists in memory (no S6).
 	// DFC S6 services may still be initializing. Allow partial existence so that
 	// Status() can return connection state while DFCs are being created.
-	nmapBackend := os.Getenv("NMAP_BACKEND")
-	if nmapBackend == "fsmv2" {
+	if os.Getenv("NMAP_BACKEND") == constants.NmapBackendFSMv2 {
 		return connExists || dfcReadExists || dfcWriteExists
 	}
 

--- a/umh-core/pkg/service/protocolconverter/protocolconverter.go
+++ b/umh-core/pkg/service/protocolconverter/protocolconverter.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"runtime"
 	"time"
 
@@ -1077,6 +1078,14 @@ func (p *ProtocolConverterService) ServiceExists(
 	connExists := p.connectionService.ServiceExists(ctx, filesystemService, connectionName)
 	dfcReadExists := p.dataflowComponentService.ServiceExists(ctx, filesystemService, dfcReadName)
 	dfcWriteExists := p.dataflowComponentService.ServiceExists(ctx, filesystemService, dfcWriteName)
+
+	// When using fsmv2-based nmap, the connection always exists in memory (no S6).
+	// DFC S6 services may still be initializing. Allow partial existence so that
+	// Status() can return connection state while DFCs are being created.
+	nmapBackend := os.Getenv("NMAP_BACKEND")
+	if nmapBackend == "fsmv2" {
+		return connExists || dfcReadExists || dfcWriteExists
+	}
 
 	// if one of the services doesn't exist we should return that
 	return connExists && (dfcReadExists || dfcWriteExists)


### PR DESCRIPTION
- As discussed, this is a rebase + rework of https://github.com/united-manufacturing-hub/united-manufacturing-hub/pull/2622 onto the `benthos-monitor-fsmv2-pr1` with this PR https://github.com/united-manufacturing-hub/united-manufacturing-hub/pull/2621 branch.
- Still has the simple worker, but cleaned up with dropping `Dependencies` etc.
- Still fsmv1 <-> fsmv2 adapter, but using the new `Upsert`
- Adapted the new nmap worker