### PR TITLE
Eng 5318 historian crud actions in umh core

### DIFF
--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -2,13 +2,16 @@
 
 ## Unreleased
 
+### New Features
+- TimescaleDB Historian output that saves a UNS data contract into TimescaleDB under a dedicated umh schema. By default every metadata key is stored; metadata_keys_exclude drops selected keys by exact name or prefix_* while keeping the rest.
+
 ## [0.44.28]
 
 ### New Features
 
 - Node-RED JS and tag processor expose a `protobuf` namespace (`protobuf.decode` / `protobuf.encode`) to decode and encode protobuf messages inline using an embedded base64 descriptor set, including proto2 extension fields
 - Sparkplug B input decodes proto2 extension fields from an inline schema, exposing them per metric as `spb_ext_*` and `spb_metric_decoded` metadata
-- TimescaleDB Historian output that saves a UNS data contract into TimescaleDB under a dedicated umh schema. By default every metadata key is stored; metadata_keys_exclude drops selected keys by exact name or prefix_* while keeping the rest.
+- Preview: an instance can now store a connection to an external TimescaleDB or PostgreSQL historian database (host, port, database, login, and TLS mode), which can be created, viewed, updated, and removed. Storing the connection does not yet route any data to it
 
 ### Improvements
 

--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New Features
 - TimescaleDB Historian output that saves a UNS data contract into TimescaleDB under a dedicated umh schema. By default every metadata key is stored; metadata_keys_exclude drops selected keys by exact name or prefix_* while keeping the rest.
+- Preview: an instance can now store a connection to an external TimescaleDB or PostgreSQL historian database (host, port, database, login, and TLS mode), which can be created, viewed, updated, and removed. Storing the connection does not yet route any data to it
 
 ## [0.44.28]
 
@@ -11,7 +12,6 @@
 
 - Node-RED JS and tag processor expose a `protobuf` namespace (`protobuf.decode` / `protobuf.encode`) to decode and encode protobuf messages inline using an embedded base64 descriptor set, including proto2 extension fields
 - Sparkplug B input decodes proto2 extension fields from an inline schema, exposing them per metric as `spb_ext_*` and `spb_metric_decoded` metadata
-- Preview: an instance can now store a connection to an external TimescaleDB or PostgreSQL historian database (host, port, database, login, and TLS mode), which can be created, viewed, updated, and removed. Storing the connection does not yet route any data to it
 
 ### Improvements
 

--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## Unreleased
 
 ### New Features
-- TimescaleDB Historian output that saves a UNS data contract into TimescaleDB under a dedicated umh schema. By default every metadata key is stored; metadata_keys_exclude drops selected keys by exact name or prefix_* while keeping the rest.
 - Preview: an instance can now store a connection to an external TimescaleDB or PostgreSQL historian database (host, port, database, login, and TLS mode), which can be created, viewed, updated, and removed. Storing the connection does not yet route any data to it
 
 ## [0.44.28]
@@ -12,6 +11,7 @@
 
 - Node-RED JS and tag processor expose a `protobuf` namespace (`protobuf.decode` / `protobuf.encode`) to decode and encode protobuf messages inline using an embedded base64 descriptor set, including proto2 extension fields
 - Sparkplug B input decodes proto2 extension fields from an inline schema, exposing them per metric as `spb_ext_*` and `spb_metric_decoded` metadata
+- TimescaleDB Historian output that saves a UNS data contract into TimescaleDB under a dedicated umh schema. By default every metadata key is stored; metadata_keys_exclude drops selected keys by exact name or prefix_* while keeping the rest
 
 ### Improvements
 

--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 - Node-RED JS and tag processor expose a `protobuf` namespace (`protobuf.decode` / `protobuf.encode`) to decode and encode protobuf messages inline using an embedded base64 descriptor set, including proto2 extension fields
 - Sparkplug B input decodes proto2 extension fields from an inline schema, exposing them per metric as `spb_ext_*` and `spb_metric_decoded` metadata
-- TimescaleDB Historian output that saves a UNS data contract into TimescaleDB under a dedicated umh schema. By default every metadata key is stored; metadata_keys_exclude drops selected keys by exact name or prefix_* while keeping the rest
+- TimescaleDB Historian output that saves a UNS data contract into TimescaleDB under a dedicated umh schema. By default every metadata key is stored; metadata_keys_exclude drops selected keys by exact name or prefix_* while keeping the rest.
 
 ### Improvements
 

--- a/umh-core/pkg/communicator/actions/actions.go
+++ b/umh-core/pkg/communicator/actions/actions.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"regexp"
 	"runtime/debug"
 	"sync"
 	"time"
@@ -128,7 +129,7 @@ func HandleActionMessage(instanceUUID uuid.UUID, payload models.ActionMessagePay
 	}()
 
 	// Start a new transaction for this action
-	log.Debugf("Handling action message: Type: %s, Payload: %v", payload.ActionType, payload.ActionPayload)
+	log.Debugf("Handling action message: Type: %s, Payload: %v", payload.ActionType, redactSensitive(payload.ActionPayload))
 
 	action := newActionFromPayloadFn(instanceUUID, payload, sender, outboundChannel, systemSnapshotManager, configManager, log, fsmLogger)
 	if action == nil {
@@ -623,6 +624,41 @@ func generateUMHMessage(instanceUUID uuid.UUID, userEmail string, messageType mo
 // Example usage:
 //
 //	myPayload, err := ParseActionPayload[MyCustomStruct](actionPayload)
+//
+// sensitiveKeyPattern matches map keys whose values must never be logged, so a
+// debug-level payload dump cannot leak a historian password, connection secret,
+// or auth token into support bundles or Sentry.
+var sensitiveKeyPattern = regexp.MustCompile(`(?i)(passwd|password|secret|token|credential|api[_-]?key|private[_-]?key)`)
+
+// redactSensitive returns a copy of v with the values of sensitive-looking keys
+// masked, recursing into nested maps and slices. It only shapes what gets
+// logged — the original payload is untouched, so parsing and execution still see
+// the real values.
+func redactSensitive(v interface{}) interface{} {
+	switch val := v.(type) {
+	case map[string]interface{}:
+		out := make(map[string]interface{}, len(val))
+		for k, vv := range val {
+			if sensitiveKeyPattern.MatchString(k) {
+				out[k] = "[REDACTED]"
+			} else {
+				out[k] = redactSensitive(vv)
+			}
+		}
+
+		return out
+	case []interface{}:
+		out := make([]interface{}, len(val))
+		for i, vv := range val {
+			out[i] = redactSensitive(vv)
+		}
+
+		return out
+	default:
+		return v
+	}
+}
+
 func ParseActionPayload[T any](actionPayload interface{}) (T, error) {
 	var payload T
 

--- a/umh-core/pkg/communicator/actions/actions.go
+++ b/umh-core/pkg/communicator/actions/actions.go
@@ -513,6 +513,14 @@ func newActionFromPayload(
 		return NewDeployStreamProcessorAction(sender, payload.ActionUUID, instanceUUID, outboundChannel, configManager, systemSnapshotManager)
 	case models.GetStreamProcessor:
 		return NewGetStreamProcessorAction(sender, payload.ActionUUID, instanceUUID, outboundChannel, configManager, systemSnapshotManager)
+	case models.DeployHistorian:
+		return NewDeployHistorianAction(sender, payload.ActionUUID, instanceUUID, outboundChannel, configManager)
+	case models.EditHistorian:
+		return NewEditHistorianAction(sender, payload.ActionUUID, instanceUUID, outboundChannel, configManager)
+	case models.GetHistorian:
+		return NewGetHistorianAction(sender, payload.ActionUUID, instanceUUID, outboundChannel, configManager)
+	case models.DeleteHistorian:
+		return NewDeleteHistorianAction(sender, payload.ActionUUID, instanceUUID, outboundChannel, configManager)
 	}
 
 	return nil

--- a/umh-core/pkg/communicator/actions/delete-historian.go
+++ b/umh-core/pkg/communicator/actions/delete-historian.go
@@ -109,8 +109,6 @@ func (a *DeleteHistorianAction) Execute() (interface{}, map[string]interface{}, 
 		return nil, nil, fmt.Errorf("%s", errorMsg)
 	}
 
-	SendActionReply(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedSuccessfull,
-		"Historian deleted successfully", a.outboundChannel, models.DeleteHistorian)
-
-	return nil, nil, nil
+	// The terminal ActionFinishedSuccessfull reply is sent by the caller (see actions.go).
+	return "Historian deleted successfully", nil, nil
 }

--- a/umh-core/pkg/communicator/actions/delete-historian.go
+++ b/umh-core/pkg/communicator/actions/delete-historian.go
@@ -1,0 +1,116 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package actions contains implementations of the Action interface that create
+// and manage historian configurations in the UMH system.
+//
+// -----------------------------------------------------------------------------
+// BUSINESS CONTEXT
+// -----------------------------------------------------------------------------
+// "Deleting" a historian removes the `historian:` section from config.yaml
+// entirely. The action is a no-op (succeeds silently) when no historian is
+// configured, to keep the frontend delete flow idempotent.
+// -----------------------------------------------------------------------------
+
+package actions
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/logger"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/models"
+)
+
+// DeleteHistorianAction implements the Action interface for removing the historian
+// section from config.yaml. All fields are immutable after construction.
+type DeleteHistorianAction struct {
+	configManager   config.ConfigManager
+	outboundChannel chan *models.UMHMessage
+	actionLogger    *zap.SugaredLogger
+
+	userEmail    string
+	actionUUID   uuid.UUID
+	instanceUUID uuid.UUID
+}
+
+// NewDeleteHistorianAction returns an un-parsed action instance.
+func NewDeleteHistorianAction(
+	userEmail string,
+	actionUUID uuid.UUID,
+	instanceUUID uuid.UUID,
+	outboundChannel chan *models.UMHMessage,
+	configManager config.ConfigManager,
+) *DeleteHistorianAction {
+	return &DeleteHistorianAction{
+		userEmail:       userEmail,
+		actionUUID:      actionUUID,
+		instanceUUID:    instanceUUID,
+		outboundChannel: outboundChannel,
+		configManager:   configManager,
+		actionLogger:    logger.For(logger.ComponentCommunicator),
+	}
+}
+
+// Parse implements the Action interface. DeleteHistorian carries no payload.
+func (a *DeleteHistorianAction) Parse(_ interface{}) error {
+	return nil
+}
+
+// Validate implements the Action interface. Nothing to validate for a delete.
+func (a *DeleteHistorianAction) Validate() error {
+	return nil
+}
+
+// getUserEmail implements the Action interface.
+func (a *DeleteHistorianAction) getUserEmail() string {
+	return a.userEmail
+}
+
+// getUuid implements the Action interface.
+func (a *DeleteHistorianAction) getUuid() uuid.UUID {
+	return a.actionUUID
+}
+
+// Execute implements the Action interface by removing the historian config.
+func (a *DeleteHistorianAction) Execute() (interface{}, map[string]interface{}, error) {
+	a.actionLogger.Info("Executing DeleteHistorian action")
+
+	SendActionReply(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionConfirmed,
+		"Starting deletion of Historian", a.outboundChannel, models.DeleteHistorian)
+
+	ctx, cancel := context.WithTimeout(context.Background(), constants.ActionTimeout)
+	defer cancel()
+
+	SendActionReply(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionExecuting,
+		"Removing Historian configuration...", a.outboundChannel, models.DeleteHistorian)
+
+	if err := a.configManager.AtomicDeleteHistorian(ctx); err != nil {
+		errorMsg := fmt.Sprintf("Failed to delete Historian configuration: %v", err)
+		SendActionReplyV2(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedWithFailure,
+			errorMsg, models.ErrRetryConfigWriteFailed, nil, a.outboundChannel, models.DeleteHistorian, nil)
+
+		return nil, nil, fmt.Errorf("%s", errorMsg)
+	}
+
+	SendActionReply(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedSuccessfull,
+		"Historian deleted successfully", a.outboundChannel, models.DeleteHistorian)
+
+	return nil, nil, nil
+}

--- a/umh-core/pkg/communicator/actions/delete-historian_test.go
+++ b/umh-core/pkg/communicator/actions/delete-historian_test.go
@@ -1,0 +1,106 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package actions_test
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/communicator/actions"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/models"
+)
+
+var _ = Describe("DeleteHistorian", func() {
+	var (
+		action          *actions.DeleteHistorianAction
+		userEmail       string
+		actionUUID      uuid.UUID
+		instanceUUID    uuid.UUID
+		outboundChannel chan *models.UMHMessage
+		mockConfig      *config.MockConfigManager
+		messages        []*models.UMHMessage
+		mu              sync.Mutex
+	)
+
+	BeforeEach(func() {
+		userEmail = "test@example.com"
+		actionUUID = uuid.New()
+		instanceUUID = uuid.New()
+		outboundChannel = make(chan *models.UMHMessage, 10)
+
+		mockConfig = config.NewMockConfigManager().WithConfig(config.FullConfig{
+			Historian: &config.HistorianConfig{
+				Host:     "timescale.example.com",
+				Password: "secret",
+			},
+		})
+
+		action = actions.NewDeleteHistorianAction(userEmail, actionUUID, instanceUUID, outboundChannel, mockConfig)
+
+		go actions.ConsumeOutboundMessages(outboundChannel, &messages, &mu, true)
+	})
+
+	AfterEach(func() {
+		for len(outboundChannel) > 0 {
+			<-outboundChannel
+		}
+		close(outboundChannel)
+	})
+
+	Describe("Parse and Validate", func() {
+		It("should accept an empty payload", func() {
+			Expect(action.Parse(nil)).To(Succeed())
+			Expect(action.Validate()).To(Succeed())
+		})
+	})
+
+	Describe("Execute", func() {
+		It("should remove an existing historian config", func() {
+			result, metadata, err := action.Execute()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeNil())
+			Expect(metadata).To(BeNil())
+
+			Expect(mockConfig.AtomicDeleteHistorianCalled).To(BeTrue())
+			Expect(mockConfig.Config.Historian).To(BeNil())
+		})
+
+		It("should succeed when no historian is configured (idempotent)", func() {
+			mockConfig.WithConfig(config.FullConfig{})
+
+			result, metadata, err := action.Execute()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeNil())
+			Expect(metadata).To(BeNil())
+
+			Expect(mockConfig.AtomicDeleteHistorianCalled).To(BeTrue())
+			Expect(mockConfig.Config.Historian).To(BeNil())
+		})
+
+		It("should handle AtomicDeleteHistorian failure", func() {
+			mockConfig.WithAtomicDeleteHistorianError(errors.New("mock delete failure"))
+
+			result, metadata, err := action.Execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Failed to delete Historian configuration"))
+			Expect(result).To(BeNil())
+			Expect(metadata).To(BeNil())
+		})
+	})
+})

--- a/umh-core/pkg/communicator/actions/delete-historian_test.go
+++ b/umh-core/pkg/communicator/actions/delete-historian_test.go
@@ -36,6 +36,7 @@ var _ = Describe("DeleteHistorian", func() {
 		mockConfig      *config.MockConfigManager
 		messages        []*models.UMHMessage
 		mu              sync.Mutex
+		consumerDone    chan struct{}
 	)
 
 	BeforeEach(func() {
@@ -56,14 +57,19 @@ var _ = Describe("DeleteHistorian", func() {
 		action = actions.NewDeleteHistorianAction(userEmail, actionUUID, instanceUUID, outboundChannel, mockConfig)
 
 		messages = nil
-		go actions.ConsumeOutboundMessages(outboundChannel, &messages, &mu, true)
+		consumerDone = make(chan struct{})
+		go func() {
+			defer GinkgoRecover()
+			actions.ConsumeOutboundMessages(outboundChannel, &messages, &mu, true)
+			close(consumerDone)
+		}()
 	})
 
 	AfterEach(func() {
-		for len(outboundChannel) > 0 {
-			<-outboundChannel
-		}
+		// Close the channel and wait for the consumer to drain and exit before the
+		// next spec resets `messages`, so the reset cannot race a running consumer.
 		close(outboundChannel)
+		<-consumerDone
 	})
 
 	Describe("Parse and Validate", func() {

--- a/umh-core/pkg/communicator/actions/delete-historian_test.go
+++ b/umh-core/pkg/communicator/actions/delete-historian_test.go
@@ -46,8 +46,10 @@ var _ = Describe("DeleteHistorian", func() {
 
 		mockConfig = config.NewMockConfigManager().WithConfig(config.FullConfig{
 			Historian: &config.HistorianConfig{
-				Host:     "timescale.example.com",
-				Password: "secret",
+				Timescale: &config.TimescaleConfig{
+					Host:     "timescale.example.com",
+					Password: "secret",
+				},
 			},
 		})
 

--- a/umh-core/pkg/communicator/actions/delete-historian_test.go
+++ b/umh-core/pkg/communicator/actions/delete-historian_test.go
@@ -53,6 +53,7 @@ var _ = Describe("DeleteHistorian", func() {
 
 		action = actions.NewDeleteHistorianAction(userEmail, actionUUID, instanceUUID, outboundChannel, mockConfig)
 
+		messages = nil
 		go actions.ConsumeOutboundMessages(outboundChannel, &messages, &mu, true)
 	})
 
@@ -74,11 +75,18 @@ var _ = Describe("DeleteHistorian", func() {
 		It("should remove an existing historian config", func() {
 			result, metadata, err := action.Execute()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(BeNil())
+			Expect(result).To(Equal("Historian deleted successfully"))
 			Expect(metadata).To(BeNil())
 
 			Expect(mockConfig.AtomicDeleteHistorianCalled).To(BeTrue())
 			Expect(mockConfig.Config.Historian).To(BeNil())
+
+			// Execute emits only the progress replies; the terminal success reply is
+			// the dispatcher's job. A self-sent ActionFinishedSuccessfull here would be
+			// the double-reply regression.
+			Eventually(func() []models.ActionReplyState {
+				return historianReplyStates(&messages, &mu)
+			}).Should(Equal([]models.ActionReplyState{models.ActionConfirmed, models.ActionExecuting}))
 		})
 
 		It("should succeed when no historian is configured (idempotent)", func() {
@@ -86,11 +94,15 @@ var _ = Describe("DeleteHistorian", func() {
 
 			result, metadata, err := action.Execute()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(BeNil())
+			Expect(result).To(Equal("Historian deleted successfully"))
 			Expect(metadata).To(BeNil())
 
 			Expect(mockConfig.AtomicDeleteHistorianCalled).To(BeTrue())
 			Expect(mockConfig.Config.Historian).To(BeNil())
+
+			Eventually(func() []models.ActionReplyState {
+				return historianReplyStates(&messages, &mu)
+			}).Should(Equal([]models.ActionReplyState{models.ActionConfirmed, models.ActionExecuting}))
 		})
 
 		It("should handle AtomicDeleteHistorian failure", func() {
@@ -101,6 +113,10 @@ var _ = Describe("DeleteHistorian", func() {
 			Expect(err.Error()).To(ContainSubstring("Failed to delete Historian configuration"))
 			Expect(result).To(BeNil())
 			Expect(metadata).To(BeNil())
+
+			Eventually(func() []models.ActionReplyState {
+				return historianReplyStates(&messages, &mu)
+			}).Should(Equal([]models.ActionReplyState{models.ActionConfirmed, models.ActionExecuting, models.ActionFinishedWithFailure}))
 		})
 	})
 })

--- a/umh-core/pkg/communicator/actions/delete-historian_test.go
+++ b/umh-core/pkg/communicator/actions/delete-historian_test.go
@@ -47,7 +47,7 @@ var _ = Describe("DeleteHistorian", func() {
 
 		mockConfig = config.NewMockConfigManager().WithConfig(config.FullConfig{
 			Historian: &config.HistorianConfig{
-				Timescale: &config.TimescaleConfig{
+				Timescale: config.TimescaleConfig{
 					Host:     "timescale.example.com",
 					Password: "secret",
 				},

--- a/umh-core/pkg/communicator/actions/deploy-historian.go
+++ b/umh-core/pkg/communicator/actions/deploy-historian.go
@@ -134,8 +134,5 @@ func (a *DeployHistorianAction) Execute() (interface{}, map[string]interface{}, 
 		return nil, nil, fmt.Errorf("%s", errorMsg)
 	}
 
-	// Blank the password in the reply: no historian reply sent to the Management
-	// Console carries the credential (write-only), matching get-historian. Redact a
-	// fresh copy so the stored config keeps the real password.
-	return redactHistorianReply(cfg), nil, nil
+	return withoutPasswords(cfg), nil, nil
 }

--- a/umh-core/pkg/communicator/actions/deploy-historian.go
+++ b/umh-core/pkg/communicator/actions/deploy-historian.go
@@ -82,10 +82,8 @@ func (a *DeployHistorianAction) Parse(payload interface{}) error {
 
 	a.payload = parsed
 
-	if a.payload.Timescale != nil {
-		a.actionLogger.Debugf("Parsed DeployHistorian action payload: timescale host=%s port=%d database=%s",
-			a.payload.Timescale.Host, a.payload.Timescale.Port, a.payload.Timescale.Database)
-	}
+	a.actionLogger.Debugf("Parsed DeployHistorian action payload: timescale host=%s port=%d database=%s",
+		a.payload.Timescale.Host, a.payload.Timescale.Port, a.payload.Timescale.Database)
 
 	return nil
 }

--- a/umh-core/pkg/communicator/actions/deploy-historian.go
+++ b/umh-core/pkg/communicator/actions/deploy-historian.go
@@ -124,9 +124,6 @@ func (a *DeployHistorianAction) Execute() (interface{}, map[string]interface{}, 
 		return nil, nil, fmt.Errorf("%s", errorMsg)
 	}
 
-	SendActionReply(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedSuccessfull,
-		"Historian deployed successfully", a.outboundChannel, models.DeployHistorian)
-
+	// The terminal ActionFinishedSuccessfull reply is sent by the caller (see actions.go).
 	return cfg, nil, nil
 }
-

--- a/umh-core/pkg/communicator/actions/deploy-historian.go
+++ b/umh-core/pkg/communicator/actions/deploy-historian.go
@@ -124,7 +124,7 @@ func (a *DeployHistorianAction) Execute() (interface{}, map[string]interface{}, 
 			SendActionReplyV2(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedWithFailure,
 				errorMsg, models.ErrValidationFailed, nil, a.outboundChannel, models.DeployHistorian, nil)
 
-			return nil, nil, errors.New(errorMsg)
+			return nil, nil, fmt.Errorf("%s", errorMsg)
 		}
 
 		errorMsg := fmt.Sprintf("Failed to write Historian configuration: %v", err)

--- a/umh-core/pkg/communicator/actions/deploy-historian.go
+++ b/umh-core/pkg/communicator/actions/deploy-historian.go
@@ -1,0 +1,132 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package actions contains implementations of the Action interface that create
+// and manage historian configurations in the UMH system.
+//
+// -----------------------------------------------------------------------------
+// BUSINESS CONTEXT
+// -----------------------------------------------------------------------------
+// "Deploying" a historian writes (or overwrites) the top-level `historian:`
+// section in config.yaml with the supplied TimescaleDB/Postgres connection
+// settings. The historian section is a singleton — there is at most one per
+// instance. If a historian is already configured, use the edit-historian action
+// instead to preserve the audit trail of intent.
+// -----------------------------------------------------------------------------
+
+package actions
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/logger"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/models"
+)
+
+// DeployHistorianAction implements the Action interface for writing the historian
+// configuration into config.yaml. All fields are immutable after construction.
+type DeployHistorianAction struct {
+	configManager   config.ConfigManager
+	outboundChannel chan *models.UMHMessage
+	actionLogger    *zap.SugaredLogger
+
+	userEmail    string
+	payload      config.HistorianConfig
+	actionUUID   uuid.UUID
+	instanceUUID uuid.UUID
+}
+
+// NewDeployHistorianAction returns an un-parsed action instance.
+func NewDeployHistorianAction(
+	userEmail string,
+	actionUUID uuid.UUID,
+	instanceUUID uuid.UUID,
+	outboundChannel chan *models.UMHMessage,
+	configManager config.ConfigManager,
+) *DeployHistorianAction {
+	return &DeployHistorianAction{
+		userEmail:       userEmail,
+		actionUUID:      actionUUID,
+		instanceUUID:    instanceUUID,
+		outboundChannel: outboundChannel,
+		configManager:   configManager,
+		actionLogger:    logger.For(logger.ComponentCommunicator),
+	}
+}
+
+// Parse implements the Action interface.
+func (a *DeployHistorianAction) Parse(payload interface{}) error {
+	parsed, err := ParseActionPayload[config.HistorianConfig](payload)
+	if err != nil {
+		return fmt.Errorf("failed to parse payload: %w", err)
+	}
+
+	a.payload = parsed
+
+	a.actionLogger.Debugf("Parsed DeployHistorian action payload: host=%s port=%d database=%s",
+		a.payload.Host, a.payload.Port, a.payload.Database)
+
+	return nil
+}
+
+// Validate implements the Action interface.
+func (a *DeployHistorianAction) Validate() error {
+	return a.payload.Validate()
+}
+
+// getUserEmail implements the Action interface.
+func (a *DeployHistorianAction) getUserEmail() string {
+	return a.userEmail
+}
+
+// getUuid implements the Action interface.
+func (a *DeployHistorianAction) getUuid() uuid.UUID {
+	return a.actionUUID
+}
+
+// Execute implements the Action interface by writing the historian config.
+func (a *DeployHistorianAction) Execute() (interface{}, map[string]interface{}, error) {
+	a.actionLogger.Info("Executing DeployHistorian action")
+
+	SendActionReply(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionConfirmed,
+		"Starting deployment of Historian", a.outboundChannel, models.DeployHistorian)
+
+	cfg := a.payload.WithDefaults()
+
+	ctx, cancel := context.WithTimeout(context.Background(), constants.ActionTimeout)
+	defer cancel()
+
+	SendActionReply(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionExecuting,
+		"Writing Historian configuration...", a.outboundChannel, models.DeployHistorian)
+
+	if err := a.configManager.AtomicSetHistorian(ctx, cfg); err != nil {
+		errorMsg := fmt.Sprintf("Failed to write Historian configuration: %v", err)
+		SendActionReplyV2(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedWithFailure,
+			errorMsg, models.ErrRetryConfigWriteFailed, nil, a.outboundChannel, models.DeployHistorian, nil)
+
+		return nil, nil, fmt.Errorf("%s", errorMsg)
+	}
+
+	SendActionReply(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedSuccessfull,
+		"Historian deployed successfully", a.outboundChannel, models.DeployHistorian)
+
+	return cfg, nil, nil
+}
+

--- a/umh-core/pkg/communicator/actions/deploy-historian.go
+++ b/umh-core/pkg/communicator/actions/deploy-historian.go
@@ -18,17 +18,19 @@
 // -----------------------------------------------------------------------------
 // BUSINESS CONTEXT
 // -----------------------------------------------------------------------------
-// "Deploying" a historian writes (or overwrites) the top-level `historian:`
-// section in config.yaml with the supplied TimescaleDB/Postgres connection
-// settings. The historian section is a singleton — there is at most one per
-// instance. If a historian is already configured, use the edit-historian action
-// instead to preserve the audit trail of intent.
+// "Deploying" a historian creates the top-level `historian:` section in
+// config.yaml with the supplied TimescaleDB/Postgres connection settings. The
+// section is a singleton: at most one per instance. Deploy is create-only and
+// fails with ErrHistorianAlreadyConfigured if a historian already exists, so a
+// retried or misdirected deploy cannot silently overwrite an existing connection
+// (which would also blank its TLS cert paths). Use edit-historian to change one.
 // -----------------------------------------------------------------------------
 
 package actions
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/google/uuid"
@@ -80,8 +82,10 @@ func (a *DeployHistorianAction) Parse(payload interface{}) error {
 
 	a.payload = parsed
 
-	a.actionLogger.Debugf("Parsed DeployHistorian action payload: host=%s port=%d database=%s",
-		a.payload.Host, a.payload.Port, a.payload.Database)
+	if a.payload.Timescale != nil {
+		a.actionLogger.Debugf("Parsed DeployHistorian action payload: timescale host=%s port=%d database=%s",
+			a.payload.Timescale.Host, a.payload.Timescale.Port, a.payload.Timescale.Database)
+	}
 
 	return nil
 }
@@ -117,6 +121,14 @@ func (a *DeployHistorianAction) Execute() (interface{}, map[string]interface{}, 
 		"Writing Historian configuration...", a.outboundChannel, models.DeployHistorian)
 
 	if err := a.configManager.AtomicSetHistorian(ctx, cfg); err != nil {
+		if errors.Is(err, config.ErrHistorianAlreadyConfigured) {
+			errorMsg := "Historian is already configured; use edit-historian to change it"
+			SendActionReplyV2(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedWithFailure,
+				errorMsg, models.ErrValidationFailed, nil, a.outboundChannel, models.DeployHistorian, nil)
+
+			return nil, nil, errors.New(errorMsg)
+		}
+
 		errorMsg := fmt.Sprintf("Failed to write Historian configuration: %v", err)
 		SendActionReplyV2(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedWithFailure,
 			errorMsg, models.ErrRetryConfigWriteFailed, nil, a.outboundChannel, models.DeployHistorian, nil)
@@ -124,6 +136,8 @@ func (a *DeployHistorianAction) Execute() (interface{}, map[string]interface{}, 
 		return nil, nil, fmt.Errorf("%s", errorMsg)
 	}
 
-	// The terminal ActionFinishedSuccessfull reply is sent by the caller (see actions.go).
-	return cfg, nil, nil
+	// Blank the password in the reply: no historian reply sent to the Management
+	// Console carries the credential (write-only), matching get-historian. Redact a
+	// fresh copy so the stored config keeps the real password.
+	return redactHistorianReply(cfg), nil, nil
 }

--- a/umh-core/pkg/communicator/actions/deploy-historian_test.go
+++ b/umh-core/pkg/communicator/actions/deploy-historian_test.go
@@ -40,9 +40,15 @@ var _ = Describe("DeployHistorian", func() {
 
 	validPayload := func() map[string]interface{} {
 		return map[string]interface{}{
-			"host":     "timescale.example.com",
-			"password": "secret",
+			"timescale": map[string]interface{}{
+				"host":     "timescale.example.com",
+				"password": "secret",
+			},
 		}
+	}
+
+	timescaleOf := func(payload map[string]interface{}) map[string]interface{} {
+		return payload["timescale"].(map[string]interface{})
 	}
 
 	BeforeEach(func() {
@@ -87,7 +93,7 @@ var _ = Describe("DeployHistorian", func() {
 
 		It("should fail validation when host is missing", func() {
 			payload := validPayload()
-			delete(payload, "host")
+			delete(timescaleOf(payload), "host")
 
 			Expect(action.Parse(payload)).To(Succeed())
 
@@ -98,7 +104,7 @@ var _ = Describe("DeployHistorian", func() {
 
 		It("should fail validation when password is missing", func() {
 			payload := validPayload()
-			delete(payload, "password")
+			delete(timescaleOf(payload), "password")
 
 			Expect(action.Parse(payload)).To(Succeed())
 
@@ -107,9 +113,17 @@ var _ = Describe("DeployHistorian", func() {
 			Expect(err.Error()).To(ContainSubstring("missing required field password"))
 		})
 
+		It("should fail validation when the timescale section is missing", func() {
+			Expect(action.Parse(map[string]interface{}{})).To(Succeed())
+
+			err := action.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("timescale"))
+		})
+
 		It("should fail validation for an invalid sslmode", func() {
 			payload := validPayload()
-			payload["sslmode"] = "bogus"
+			timescaleOf(payload)["sslmode"] = "bogus"
 
 			Expect(action.Parse(payload)).To(Succeed())
 
@@ -131,14 +145,19 @@ var _ = Describe("DeployHistorian", func() {
 
 			cfg, ok := result.(config.HistorianConfig)
 			Expect(ok).To(BeTrue(), "Result should be a HistorianConfig")
-			Expect(cfg.Host).To(Equal("timescale.example.com"))
-			Expect(cfg.Port).To(Equal(uint16(5432)))
-			Expect(cfg.Database).To(Equal("umh"))
-			Expect(cfg.Username).To(Equal("umh_owner"))
-			Expect(cfg.SSLMode).To(Equal(config.HistorianSSLModeRequire))
+			Expect(cfg.Timescale).NotTo(BeNil())
+			Expect(cfg.Timescale.Host).To(Equal("timescale.example.com"))
+			Expect(cfg.Timescale.Port).To(Equal(uint16(5432)))
+			Expect(cfg.Timescale.Database).To(Equal("umh"))
+			Expect(cfg.Timescale.Username).To(Equal("umh_owner"))
+			Expect(cfg.Timescale.SSLMode).To(Equal(config.HistorianSSLModeRequire))
 
+			// The reply is write-only: it never carries the password back to the
+			// Management Console, but the credential does reach stored config.
+			Expect(cfg.Timescale.Password).To(BeEmpty())
 			Expect(mockConfig.Config.Historian).NotTo(BeNil())
-			Expect(mockConfig.Config.Historian.Host).To(Equal("timescale.example.com"))
+			Expect(mockConfig.Config.Historian.Timescale.Host).To(Equal("timescale.example.com"))
+			Expect(mockConfig.Config.Historian.Timescale.Password).To(Equal("secret"))
 
 			// Execute emits only the progress replies; the terminal success reply is
 			// the dispatcher's job. A self-sent ActionFinishedSuccessfull here would be
@@ -158,6 +177,30 @@ var _ = Describe("DeployHistorian", func() {
 			Expect(err.Error()).To(ContainSubstring("Failed to write Historian configuration"))
 			Expect(result).To(BeNil())
 			Expect(metadata).To(BeNil())
+
+			Eventually(func() []models.ActionReplyState {
+				return historianReplyStates(&messages, &mu)
+			}).Should(Equal([]models.ActionReplyState{models.ActionConfirmed, models.ActionExecuting, models.ActionFinishedWithFailure}))
+		})
+
+		It("should refuse to overwrite an already-configured historian", func() {
+			mockConfig.Config.Historian = &config.HistorianConfig{
+				Timescale: &config.TimescaleConfig{
+					Host:     "existing.example.com",
+					Password: "existing-secret",
+				},
+			}
+
+			Expect(action.Parse(validPayload())).To(Succeed())
+
+			result, metadata, err := action.Execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("already configured"))
+			Expect(result).To(BeNil())
+			Expect(metadata).To(BeNil())
+
+			// The existing historian must be untouched, not overwritten.
+			Expect(mockConfig.Config.Historian.Timescale.Host).To(Equal("existing.example.com"))
 
 			Eventually(func() []models.ActionReplyState {
 				return historianReplyStates(&messages, &mu)

--- a/umh-core/pkg/communicator/actions/deploy-historian_test.go
+++ b/umh-core/pkg/communicator/actions/deploy-historian_test.go
@@ -1,0 +1,155 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package actions_test
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/communicator/actions"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/models"
+)
+
+var _ = Describe("DeployHistorian", func() {
+	var (
+		action          *actions.DeployHistorianAction
+		userEmail       string
+		actionUUID      uuid.UUID
+		instanceUUID    uuid.UUID
+		outboundChannel chan *models.UMHMessage
+		mockConfig      *config.MockConfigManager
+		messages        []*models.UMHMessage
+		mu              sync.Mutex
+	)
+
+	validPayload := func() map[string]interface{} {
+		return map[string]interface{}{
+			"host":     "timescale.example.com",
+			"password": "secret",
+		}
+	}
+
+	BeforeEach(func() {
+		userEmail = "test@example.com"
+		actionUUID = uuid.New()
+		instanceUUID = uuid.New()
+		outboundChannel = make(chan *models.UMHMessage, 10)
+
+		mockConfig = config.NewMockConfigManager().WithConfig(config.FullConfig{})
+
+		action = actions.NewDeployHistorianAction(userEmail, actionUUID, instanceUUID, outboundChannel, mockConfig)
+
+		go actions.ConsumeOutboundMessages(outboundChannel, &messages, &mu, true)
+	})
+
+	AfterEach(func() {
+		for len(outboundChannel) > 0 {
+			<-outboundChannel
+		}
+		close(outboundChannel)
+	})
+
+	Describe("Parse", func() {
+		It("should parse a valid historian payload", func() {
+			err := action.Parse(validPayload())
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should return an error for an invalid payload format", func() {
+			err := action.Parse(make(chan int))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to parse payload"))
+		})
+	})
+
+	Describe("Validate", func() {
+		It("should pass validation for a valid payload", func() {
+			Expect(action.Parse(validPayload())).To(Succeed())
+			Expect(action.Validate()).To(Succeed())
+		})
+
+		It("should fail validation when host is missing", func() {
+			payload := validPayload()
+			delete(payload, "host")
+
+			Expect(action.Parse(payload)).To(Succeed())
+
+			err := action.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("missing required field host"))
+		})
+
+		It("should fail validation when password is missing", func() {
+			payload := validPayload()
+			delete(payload, "password")
+
+			Expect(action.Parse(payload)).To(Succeed())
+
+			err := action.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("missing required field password"))
+		})
+
+		It("should fail validation for an invalid sslmode", func() {
+			payload := validPayload()
+			payload["sslmode"] = "bogus"
+
+			Expect(action.Parse(payload)).To(Succeed())
+
+			err := action.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("invalid sslmode"))
+		})
+	})
+
+	Describe("Execute", func() {
+		It("should write the historian config with defaults applied", func() {
+			Expect(action.Parse(validPayload())).To(Succeed())
+
+			result, metadata, err := action.Execute()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(metadata).To(BeNil())
+
+			Expect(mockConfig.AtomicSetHistorianCalled).To(BeTrue())
+
+			cfg, ok := result.(config.HistorianConfig)
+			Expect(ok).To(BeTrue(), "Result should be a HistorianConfig")
+			Expect(cfg.Host).To(Equal("timescale.example.com"))
+			Expect(cfg.Port).To(Equal(uint16(5432)))
+			Expect(cfg.Database).To(Equal("umh"))
+			Expect(cfg.Username).To(Equal("umh_owner"))
+			Expect(cfg.SSLMode).To(Equal(config.HistorianSSLModeRequire))
+
+			Expect(mockConfig.Config.Historian).NotTo(BeNil())
+			Expect(mockConfig.Config.Historian.Host).To(Equal("timescale.example.com"))
+		})
+
+		It("should handle AtomicSetHistorian failure", func() {
+			mockConfig.WithAtomicSetHistorianError(errors.New("mock write failure"))
+
+			Expect(action.Parse(validPayload())).To(Succeed())
+
+			result, metadata, err := action.Execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Failed to write Historian configuration"))
+			Expect(result).To(BeNil())
+			Expect(metadata).To(BeNil())
+		})
+	})
+})

--- a/umh-core/pkg/communicator/actions/deploy-historian_test.go
+++ b/umh-core/pkg/communicator/actions/deploy-historian_test.go
@@ -36,6 +36,7 @@ var _ = Describe("DeployHistorian", func() {
 		mockConfig      *config.MockConfigManager
 		messages        []*models.UMHMessage
 		mu              sync.Mutex
+		consumerDone    chan struct{}
 	)
 
 	validPayload := func() map[string]interface{} {
@@ -62,14 +63,19 @@ var _ = Describe("DeployHistorian", func() {
 		action = actions.NewDeployHistorianAction(userEmail, actionUUID, instanceUUID, outboundChannel, mockConfig)
 
 		messages = nil
-		go actions.ConsumeOutboundMessages(outboundChannel, &messages, &mu, true)
+		consumerDone = make(chan struct{})
+		go func() {
+			defer GinkgoRecover()
+			actions.ConsumeOutboundMessages(outboundChannel, &messages, &mu, true)
+			close(consumerDone)
+		}()
 	})
 
 	AfterEach(func() {
-		for len(outboundChannel) > 0 {
-			<-outboundChannel
-		}
+		// Close the channel and wait for the consumer to drain and exit before the
+		// next spec resets `messages`, so the reset cannot race a running consumer.
 		close(outboundChannel)
+		<-consumerDone
 	})
 
 	Describe("Parse", func() {

--- a/umh-core/pkg/communicator/actions/deploy-historian_test.go
+++ b/umh-core/pkg/communicator/actions/deploy-historian_test.go
@@ -55,6 +55,7 @@ var _ = Describe("DeployHistorian", func() {
 
 		action = actions.NewDeployHistorianAction(userEmail, actionUUID, instanceUUID, outboundChannel, mockConfig)
 
+		messages = nil
 		go actions.ConsumeOutboundMessages(outboundChannel, &messages, &mu, true)
 	})
 
@@ -138,6 +139,13 @@ var _ = Describe("DeployHistorian", func() {
 
 			Expect(mockConfig.Config.Historian).NotTo(BeNil())
 			Expect(mockConfig.Config.Historian.Host).To(Equal("timescale.example.com"))
+
+			// Execute emits only the progress replies; the terminal success reply is
+			// the dispatcher's job. A self-sent ActionFinishedSuccessfull here would be
+			// the double-reply regression.
+			Eventually(func() []models.ActionReplyState {
+				return historianReplyStates(&messages, &mu)
+			}).Should(Equal([]models.ActionReplyState{models.ActionConfirmed, models.ActionExecuting}))
 		})
 
 		It("should handle AtomicSetHistorian failure", func() {
@@ -150,6 +158,10 @@ var _ = Describe("DeployHistorian", func() {
 			Expect(err.Error()).To(ContainSubstring("Failed to write Historian configuration"))
 			Expect(result).To(BeNil())
 			Expect(metadata).To(BeNil())
+
+			Eventually(func() []models.ActionReplyState {
+				return historianReplyStates(&messages, &mu)
+			}).Should(Equal([]models.ActionReplyState{models.ActionConfirmed, models.ActionExecuting, models.ActionFinishedWithFailure}))
 		})
 	})
 })

--- a/umh-core/pkg/communicator/actions/deploy-historian_test.go
+++ b/umh-core/pkg/communicator/actions/deploy-historian_test.go
@@ -151,7 +151,7 @@ var _ = Describe("DeployHistorian", func() {
 
 			cfg, ok := result.(config.HistorianConfig)
 			Expect(ok).To(BeTrue(), "Result should be a HistorianConfig")
-			Expect(cfg.Timescale).NotTo(BeNil())
+			Expect(cfg.Timescale).NotTo(Equal(config.TimescaleConfig{}))
 			Expect(cfg.Timescale.Host).To(Equal("timescale.example.com"))
 			Expect(cfg.Timescale.Port).To(Equal(uint16(5432)))
 			Expect(cfg.Timescale.Database).To(Equal("umh"))
@@ -191,7 +191,7 @@ var _ = Describe("DeployHistorian", func() {
 
 		It("should refuse to overwrite an already-configured historian", func() {
 			mockConfig.Config.Historian = &config.HistorianConfig{
-				Timescale: &config.TimescaleConfig{
+				Timescale: config.TimescaleConfig{
 					Host:     "existing.example.com",
 					Password: "existing-secret",
 				},
@@ -211,6 +211,31 @@ var _ = Describe("DeployHistorian", func() {
 			Eventually(func() []models.ActionReplyState {
 				return historianReplyStates(&messages, &mu)
 			}).Should(Equal([]models.ActionReplyState{models.ActionConfirmed, models.ActionExecuting, models.ActionFinishedWithFailure}))
+		})
+
+		It("should treat an identical redeploy as a successful no-op", func() {
+			// Seed the exact config a prior deploy would have written (defaults applied),
+			// modelling a replay after the first deploy's terminal reply was lost.
+			seeded := config.HistorianConfig{
+				Timescale: config.TimescaleConfig{Host: "timescale.example.com", Password: "secret"},
+			}.WithDefaults()
+			mockConfig.Config.Historian = &seeded
+
+			Expect(action.Parse(validPayload())).To(Succeed())
+
+			result, metadata, err := action.Execute()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(metadata).To(BeNil())
+
+			cfg, ok := result.(config.HistorianConfig)
+			Expect(ok).To(BeTrue(), "Result should be a HistorianConfig")
+			Expect(cfg.Timescale.Host).To(Equal("timescale.example.com"))
+			Expect(cfg.Timescale.Password).To(BeEmpty())
+			Expect(mockConfig.Config.Historian.Timescale).To(Equal(seeded.Timescale))
+
+			Eventually(func() []models.ActionReplyState {
+				return historianReplyStates(&messages, &mu)
+			}).Should(Equal([]models.ActionReplyState{models.ActionConfirmed, models.ActionExecuting}))
 		})
 	})
 })

--- a/umh-core/pkg/communicator/actions/edit-historian.go
+++ b/umh-core/pkg/communicator/actions/edit-historian.go
@@ -125,7 +125,7 @@ func (a *EditHistorianAction) Execute() (interface{}, map[string]interface{}, er
 			SendActionReplyV2(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedWithFailure,
 				errorMsg, models.ErrValidationFailed, nil, a.outboundChannel, models.EditHistorian, nil)
 
-			return nil, nil, errors.New(errorMsg)
+			return nil, nil, fmt.Errorf("%s", errorMsg)
 		}
 
 		errorMsg := fmt.Sprintf("Failed to update Historian configuration: %v", err)

--- a/umh-core/pkg/communicator/actions/edit-historian.go
+++ b/umh-core/pkg/communicator/actions/edit-historian.go
@@ -1,0 +1,150 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package actions contains implementations of the Action interface that create
+// and manage historian configurations in the UMH system.
+//
+// -----------------------------------------------------------------------------
+// BUSINESS CONTEXT
+// -----------------------------------------------------------------------------
+// "Editing" a historian replaces the existing `historian:` section in
+// config.yaml with new connection settings. Unlike deploy, edit expects the
+// section to already exist — callers should use deploy-historian when creating
+// it for the first time.
+// -----------------------------------------------------------------------------
+
+package actions
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/logger"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/models"
+)
+
+// EditHistorianAction implements the Action interface for updating the historian
+// configuration in config.yaml. All fields are immutable after construction.
+type EditHistorianAction struct {
+	configManager   config.ConfigManager
+	outboundChannel chan *models.UMHMessage
+	actionLogger    *zap.SugaredLogger
+
+	userEmail    string
+	payload      config.HistorianConfig
+	actionUUID   uuid.UUID
+	instanceUUID uuid.UUID
+}
+
+// NewEditHistorianAction returns an un-parsed action instance.
+func NewEditHistorianAction(
+	userEmail string,
+	actionUUID uuid.UUID,
+	instanceUUID uuid.UUID,
+	outboundChannel chan *models.UMHMessage,
+	configManager config.ConfigManager,
+) *EditHistorianAction {
+	return &EditHistorianAction{
+		userEmail:       userEmail,
+		actionUUID:      actionUUID,
+		instanceUUID:    instanceUUID,
+		outboundChannel: outboundChannel,
+		configManager:   configManager,
+		actionLogger:    logger.For(logger.ComponentCommunicator),
+	}
+}
+
+// Parse implements the Action interface.
+func (a *EditHistorianAction) Parse(payload interface{}) error {
+	parsed, err := ParseActionPayload[config.HistorianConfig](payload)
+	if err != nil {
+		return fmt.Errorf("failed to parse payload: %w", err)
+	}
+
+	a.payload = parsed
+
+	a.actionLogger.Debugf("Parsed EditHistorian action payload: host=%s port=%d database=%s",
+		a.payload.Host, a.payload.Port, a.payload.Database)
+
+	return nil
+}
+
+// Validate implements the Action interface.
+func (a *EditHistorianAction) Validate() error {
+	return a.payload.Validate()
+}
+
+// getUserEmail implements the Action interface.
+func (a *EditHistorianAction) getUserEmail() string {
+	return a.userEmail
+}
+
+// getUuid implements the Action interface.
+func (a *EditHistorianAction) getUuid() uuid.UUID {
+	return a.actionUUID
+}
+
+// Execute implements the Action interface by overwriting the historian config.
+func (a *EditHistorianAction) Execute() (interface{}, map[string]interface{}, error) {
+	a.actionLogger.Info("Executing EditHistorian action")
+
+	SendActionReply(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionConfirmed,
+		"Starting edit of Historian", a.outboundChannel, models.EditHistorian)
+
+	ctx, cancel := context.WithTimeout(context.Background(), constants.ActionTimeout)
+	defer cancel()
+
+	// Verify historian section already exists before overwriting.
+	currentCfg, err := a.configManager.GetConfig(ctx, 0)
+	if err != nil {
+		errorMsg := fmt.Sprintf("Failed to read current configuration: %v", err)
+		SendActionReplyV2(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedWithFailure,
+			errorMsg, models.ErrConfigFileInvalid, nil, a.outboundChannel, models.EditHistorian, nil)
+
+		return nil, nil, fmt.Errorf("%s", errorMsg)
+	}
+
+	if currentCfg.Historian == nil {
+		errorMsg := "Historian is not configured; use deploy-historian to create it first"
+		SendActionReplyV2(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedWithFailure,
+			errorMsg, models.ErrValidationFailed, nil, a.outboundChannel, models.EditHistorian, nil)
+
+		return nil, nil, errors.New(errorMsg)
+	}
+
+	cfg := a.payload.WithDefaults()
+
+	SendActionReply(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionExecuting,
+		"Updating Historian configuration...", a.outboundChannel, models.EditHistorian)
+
+	if err := a.configManager.AtomicSetHistorian(ctx, cfg); err != nil {
+		errorMsg := fmt.Sprintf("Failed to update Historian configuration: %v", err)
+		SendActionReplyV2(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedWithFailure,
+			errorMsg, models.ErrRetryConfigWriteFailed, nil, a.outboundChannel, models.EditHistorian, nil)
+
+		return nil, nil, fmt.Errorf("%s", errorMsg)
+	}
+
+	SendActionReply(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedSuccessfull,
+		"Historian updated successfully", a.outboundChannel, models.EditHistorian)
+
+	return cfg, nil, nil
+}
+

--- a/umh-core/pkg/communicator/actions/edit-historian.go
+++ b/umh-core/pkg/communicator/actions/edit-historian.go
@@ -80,10 +80,8 @@ func (a *EditHistorianAction) Parse(payload interface{}) error {
 
 	a.payload = parsed
 
-	if a.payload.Timescale != nil {
-		a.actionLogger.Debugf("Parsed EditHistorian action payload: timescale host=%s port=%d database=%s",
-			a.payload.Timescale.Host, a.payload.Timescale.Port, a.payload.Timescale.Database)
-	}
+	a.actionLogger.Debugf("Parsed EditHistorian action payload: timescale host=%s port=%d database=%s",
+		a.payload.Timescale.Host, a.payload.Timescale.Port, a.payload.Timescale.Database)
 
 	return nil
 }

--- a/umh-core/pkg/communicator/actions/edit-historian.go
+++ b/umh-core/pkg/communicator/actions/edit-historian.go
@@ -80,15 +80,17 @@ func (a *EditHistorianAction) Parse(payload interface{}) error {
 
 	a.payload = parsed
 
-	a.actionLogger.Debugf("Parsed EditHistorian action payload: host=%s port=%d database=%s",
-		a.payload.Host, a.payload.Port, a.payload.Database)
+	if a.payload.Timescale != nil {
+		a.actionLogger.Debugf("Parsed EditHistorian action payload: timescale host=%s port=%d database=%s",
+			a.payload.Timescale.Host, a.payload.Timescale.Port, a.payload.Timescale.Database)
+	}
 
 	return nil
 }
 
 // Validate implements the Action interface.
 func (a *EditHistorianAction) Validate() error {
-	return a.payload.Validate()
+	return a.payload.ValidateForUpdate()
 }
 
 // getUserEmail implements the Action interface.
@@ -135,6 +137,8 @@ func (a *EditHistorianAction) Execute() (interface{}, map[string]interface{}, er
 		return nil, nil, fmt.Errorf("%s", errorMsg)
 	}
 
-	// The terminal ActionFinishedSuccessfull reply is sent by the caller (see actions.go).
-	return cfg, nil, nil
+	// Blank the password in the reply: no historian reply sent to the Management
+	// Console carries the credential (write-only), matching get-historian. When the
+	// edit omitted the password, the stored value is preserved by AtomicEditHistorian.
+	return redactHistorianReply(cfg), nil, nil
 }

--- a/umh-core/pkg/communicator/actions/edit-historian.go
+++ b/umh-core/pkg/communicator/actions/edit-historian.go
@@ -111,30 +111,23 @@ func (a *EditHistorianAction) Execute() (interface{}, map[string]interface{}, er
 	ctx, cancel := context.WithTimeout(context.Background(), constants.ActionTimeout)
 	defer cancel()
 
-	// Verify historian section already exists before overwriting.
-	currentCfg, err := a.configManager.GetConfig(ctx, 0)
-	if err != nil {
-		errorMsg := fmt.Sprintf("Failed to read current configuration: %v", err)
-		SendActionReplyV2(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedWithFailure,
-			errorMsg, models.ErrConfigFileInvalid, nil, a.outboundChannel, models.EditHistorian, nil)
-
-		return nil, nil, fmt.Errorf("%s", errorMsg)
-	}
-
-	if currentCfg.Historian == nil {
-		errorMsg := "Historian is not configured; use deploy-historian to create it first"
-		SendActionReplyV2(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedWithFailure,
-			errorMsg, models.ErrValidationFailed, nil, a.outboundChannel, models.EditHistorian, nil)
-
-		return nil, nil, errors.New(errorMsg)
-	}
-
 	cfg := a.payload.WithDefaults()
 
 	SendActionReply(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionExecuting,
 		"Updating Historian configuration...", a.outboundChannel, models.EditHistorian)
 
-	if err := a.configManager.AtomicSetHistorian(ctx, cfg); err != nil {
+	// AtomicEditHistorian performs the existence check and write under a single lock,
+	// so a concurrent delete cannot slip between the two and let edit resurrect a
+	// removed historian.
+	if err := a.configManager.AtomicEditHistorian(ctx, cfg); err != nil {
+		if errors.Is(err, config.ErrHistorianNotConfigured) {
+			errorMsg := "Historian is not configured; use deploy-historian to create it first"
+			SendActionReplyV2(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedWithFailure,
+				errorMsg, models.ErrValidationFailed, nil, a.outboundChannel, models.EditHistorian, nil)
+
+			return nil, nil, errors.New(errorMsg)
+		}
+
 		errorMsg := fmt.Sprintf("Failed to update Historian configuration: %v", err)
 		SendActionReplyV2(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedWithFailure,
 			errorMsg, models.ErrRetryConfigWriteFailed, nil, a.outboundChannel, models.EditHistorian, nil)
@@ -142,9 +135,6 @@ func (a *EditHistorianAction) Execute() (interface{}, map[string]interface{}, er
 		return nil, nil, fmt.Errorf("%s", errorMsg)
 	}
 
-	SendActionReply(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedSuccessfull,
-		"Historian updated successfully", a.outboundChannel, models.EditHistorian)
-
+	// The terminal ActionFinishedSuccessfull reply is sent by the caller (see actions.go).
 	return cfg, nil, nil
 }
-

--- a/umh-core/pkg/communicator/actions/edit-historian.go
+++ b/umh-core/pkg/communicator/actions/edit-historian.go
@@ -135,8 +135,5 @@ func (a *EditHistorianAction) Execute() (interface{}, map[string]interface{}, er
 		return nil, nil, fmt.Errorf("%s", errorMsg)
 	}
 
-	// Blank the password in the reply: no historian reply sent to the Management
-	// Console carries the credential (write-only), matching get-historian. When the
-	// edit omitted the password, the stored value is preserved by AtomicEditHistorian.
-	return redactHistorianReply(cfg), nil, nil
+	return withoutPasswords(cfg), nil, nil
 }

--- a/umh-core/pkg/communicator/actions/edit-historian_test.go
+++ b/umh-core/pkg/communicator/actions/edit-historian_test.go
@@ -40,18 +40,26 @@ var _ = Describe("EditHistorian", func() {
 
 	validPayload := func() map[string]interface{} {
 		return map[string]interface{}{
-			"host":     "new-host.example.com",
-			"password": "new-secret",
-			"port":     6543,
+			"timescale": map[string]interface{}{
+				"host":     "new-host.example.com",
+				"password": "new-secret",
+				"port":     6543,
+			},
 		}
+	}
+
+	timescaleOf := func(payload map[string]interface{}) map[string]interface{} {
+		return payload["timescale"].(map[string]interface{})
 	}
 
 	// configWithHistorian returns a config that already has a historian section.
 	configWithHistorian := func() config.FullConfig {
 		return config.FullConfig{
 			Historian: &config.HistorianConfig{
-				Host:     "old-host.example.com",
-				Password: "old-secret",
+				Timescale: &config.TimescaleConfig{
+					Host:     "old-host.example.com",
+					Password: "old-secret",
+				},
 			},
 		}
 	}
@@ -78,15 +86,23 @@ var _ = Describe("EditHistorian", func() {
 	})
 
 	Describe("Validate", func() {
-		It("should fail validation when required fields are missing", func() {
+		It("should fail validation when host is missing", func() {
 			payload := validPayload()
-			delete(payload, "password")
+			delete(timescaleOf(payload), "host")
 
 			Expect(action.Parse(payload)).To(Succeed())
 
 			err := action.Validate()
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("missing required field password"))
+			Expect(err.Error()).To(ContainSubstring("missing required field host"))
+		})
+
+		It("should pass validation when the password is omitted (kept unchanged)", func() {
+			payload := validPayload()
+			delete(timescaleOf(payload), "password")
+
+			Expect(action.Parse(payload)).To(Succeed())
+			Expect(action.Validate()).To(Succeed())
 		})
 	})
 
@@ -102,10 +118,11 @@ var _ = Describe("EditHistorian", func() {
 
 			cfg, ok := result.(config.HistorianConfig)
 			Expect(ok).To(BeTrue(), "Result should be a HistorianConfig")
-			Expect(cfg.Host).To(Equal("new-host.example.com"))
-			Expect(cfg.Port).To(Equal(uint16(6543)))
+			Expect(cfg.Timescale).NotTo(BeNil())
+			Expect(cfg.Timescale.Host).To(Equal("new-host.example.com"))
+			Expect(cfg.Timescale.Port).To(Equal(uint16(6543)))
 
-			Expect(mockConfig.Config.Historian.Host).To(Equal("new-host.example.com"))
+			Expect(mockConfig.Config.Historian.Timescale.Host).To(Equal("new-host.example.com"))
 
 			// Execute emits only the progress replies; the terminal success reply is
 			// the dispatcher's job. A self-sent ActionFinishedSuccessfull here would be
@@ -113,6 +130,38 @@ var _ = Describe("EditHistorian", func() {
 			Eventually(func() []models.ActionReplyState {
 				return historianReplyStates(&messages, &mu)
 			}).Should(Equal([]models.ActionReplyState{models.ActionConfirmed, models.ActionExecuting}))
+		})
+
+		It("should keep the existing password when the edit omits it", func() {
+			payload := validPayload()
+			delete(timescaleOf(payload), "password")
+
+			Expect(action.Parse(payload)).To(Succeed())
+
+			result, _, err := action.Execute()
+			Expect(err).NotTo(HaveOccurred())
+
+			cfg, ok := result.(config.HistorianConfig)
+			Expect(ok).To(BeTrue(), "Result should be a HistorianConfig")
+			Expect(cfg.Timescale).NotTo(BeNil())
+			Expect(cfg.Timescale.Host).To(Equal("new-host.example.com"))
+			// The reply never carries the password (write-only); the stored value
+			// (old-secret) is preserved, not blanked.
+			Expect(cfg.Timescale.Password).To(BeEmpty())
+			Expect(mockConfig.Config.Historian.Timescale.Password).To(Equal("old-secret"))
+		})
+
+		It("should set a new password when the edit provides one", func() {
+			Expect(action.Parse(validPayload())).To(Succeed())
+
+			result, _, err := action.Execute()
+			Expect(err).NotTo(HaveOccurred())
+
+			cfg, ok := result.(config.HistorianConfig)
+			Expect(ok).To(BeTrue(), "Result should be a HistorianConfig")
+			// The reply is write-only, but the new password reaches storage.
+			Expect(cfg.Timescale.Password).To(BeEmpty())
+			Expect(mockConfig.Config.Historian.Timescale.Password).To(Equal("new-secret"))
 		})
 
 		It("should fail when no historian is configured yet", func() {

--- a/umh-core/pkg/communicator/actions/edit-historian_test.go
+++ b/umh-core/pkg/communicator/actions/edit-historian_test.go
@@ -57,7 +57,7 @@ var _ = Describe("EditHistorian", func() {
 	configWithHistorian := func() config.FullConfig {
 		return config.FullConfig{
 			Historian: &config.HistorianConfig{
-				Timescale: &config.TimescaleConfig{
+				Timescale: config.TimescaleConfig{
 					Host:     "old-host.example.com",
 					Password: "old-secret",
 				},
@@ -124,7 +124,7 @@ var _ = Describe("EditHistorian", func() {
 
 			cfg, ok := result.(config.HistorianConfig)
 			Expect(ok).To(BeTrue(), "Result should be a HistorianConfig")
-			Expect(cfg.Timescale).NotTo(BeNil())
+			Expect(cfg.Timescale).NotTo(Equal(config.TimescaleConfig{}))
 			Expect(cfg.Timescale.Host).To(Equal("new-host.example.com"))
 			Expect(cfg.Timescale.Port).To(Equal(uint16(6543)))
 
@@ -149,7 +149,7 @@ var _ = Describe("EditHistorian", func() {
 
 			cfg, ok := result.(config.HistorianConfig)
 			Expect(ok).To(BeTrue(), "Result should be a HistorianConfig")
-			Expect(cfg.Timescale).NotTo(BeNil())
+			Expect(cfg.Timescale).NotTo(Equal(config.TimescaleConfig{}))
 			Expect(cfg.Timescale.Host).To(Equal("new-host.example.com"))
 			// The reply never carries the password (write-only); the stored value
 			// (old-secret) is preserved, not blanked.

--- a/umh-core/pkg/communicator/actions/edit-historian_test.go
+++ b/umh-core/pkg/communicator/actions/edit-historian_test.go
@@ -1,0 +1,148 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package actions_test
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/communicator/actions"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/models"
+)
+
+var _ = Describe("EditHistorian", func() {
+	var (
+		action          *actions.EditHistorianAction
+		userEmail       string
+		actionUUID      uuid.UUID
+		instanceUUID    uuid.UUID
+		outboundChannel chan *models.UMHMessage
+		mockConfig      *config.MockConfigManager
+		messages        []*models.UMHMessage
+		mu              sync.Mutex
+	)
+
+	validPayload := func() map[string]interface{} {
+		return map[string]interface{}{
+			"host":     "new-host.example.com",
+			"password": "new-secret",
+			"port":     6543,
+		}
+	}
+
+	// configWithHistorian returns a config that already has a historian section.
+	configWithHistorian := func() config.FullConfig {
+		return config.FullConfig{
+			Historian: &config.HistorianConfig{
+				Host:     "old-host.example.com",
+				Password: "old-secret",
+			},
+		}
+	}
+
+	BeforeEach(func() {
+		userEmail = "test@example.com"
+		actionUUID = uuid.New()
+		instanceUUID = uuid.New()
+		outboundChannel = make(chan *models.UMHMessage, 10)
+
+		mockConfig = config.NewMockConfigManager().WithConfig(configWithHistorian())
+
+		action = actions.NewEditHistorianAction(userEmail, actionUUID, instanceUUID, outboundChannel, mockConfig)
+
+		go actions.ConsumeOutboundMessages(outboundChannel, &messages, &mu, true)
+	})
+
+	AfterEach(func() {
+		for len(outboundChannel) > 0 {
+			<-outboundChannel
+		}
+		close(outboundChannel)
+	})
+
+	Describe("Validate", func() {
+		It("should fail validation when required fields are missing", func() {
+			payload := validPayload()
+			delete(payload, "password")
+
+			Expect(action.Parse(payload)).To(Succeed())
+
+			err := action.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("missing required field password"))
+		})
+	})
+
+	Describe("Execute", func() {
+		It("should overwrite an existing historian config", func() {
+			Expect(action.Parse(validPayload())).To(Succeed())
+
+			result, metadata, err := action.Execute()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(metadata).To(BeNil())
+
+			Expect(mockConfig.AtomicSetHistorianCalled).To(BeTrue())
+
+			cfg, ok := result.(config.HistorianConfig)
+			Expect(ok).To(BeTrue(), "Result should be a HistorianConfig")
+			Expect(cfg.Host).To(Equal("new-host.example.com"))
+			Expect(cfg.Port).To(Equal(uint16(6543)))
+
+			Expect(mockConfig.Config.Historian.Host).To(Equal("new-host.example.com"))
+		})
+
+		It("should fail when no historian is configured yet", func() {
+			mockConfig.WithConfig(config.FullConfig{})
+
+			Expect(action.Parse(validPayload())).To(Succeed())
+
+			result, metadata, err := action.Execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("use deploy-historian to create it first"))
+			Expect(result).To(BeNil())
+			Expect(metadata).To(BeNil())
+
+			Expect(mockConfig.AtomicSetHistorianCalled).To(BeFalse())
+		})
+
+		It("should fail when the current config cannot be read", func() {
+			mockConfig.WithConfigError(errors.New("mock read failure"))
+
+			Expect(action.Parse(validPayload())).To(Succeed())
+
+			result, metadata, err := action.Execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Failed to read current configuration"))
+			Expect(result).To(BeNil())
+			Expect(metadata).To(BeNil())
+		})
+
+		It("should handle AtomicSetHistorian failure", func() {
+			mockConfig.WithAtomicSetHistorianError(errors.New("mock write failure"))
+
+			Expect(action.Parse(validPayload())).To(Succeed())
+
+			result, metadata, err := action.Execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Failed to update Historian configuration"))
+			Expect(result).To(BeNil())
+			Expect(metadata).To(BeNil())
+		})
+	})
+})

--- a/umh-core/pkg/communicator/actions/edit-historian_test.go
+++ b/umh-core/pkg/communicator/actions/edit-historian_test.go
@@ -66,6 +66,7 @@ var _ = Describe("EditHistorian", func() {
 
 		action = actions.NewEditHistorianAction(userEmail, actionUUID, instanceUUID, outboundChannel, mockConfig)
 
+		messages = nil
 		go actions.ConsumeOutboundMessages(outboundChannel, &messages, &mu, true)
 	})
 
@@ -97,7 +98,7 @@ var _ = Describe("EditHistorian", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(metadata).To(BeNil())
 
-			Expect(mockConfig.AtomicSetHistorianCalled).To(BeTrue())
+			Expect(mockConfig.AtomicEditHistorianCalled).To(BeTrue())
 
 			cfg, ok := result.(config.HistorianConfig)
 			Expect(ok).To(BeTrue(), "Result should be a HistorianConfig")
@@ -105,6 +106,13 @@ var _ = Describe("EditHistorian", func() {
 			Expect(cfg.Port).To(Equal(uint16(6543)))
 
 			Expect(mockConfig.Config.Historian.Host).To(Equal("new-host.example.com"))
+
+			// Execute emits only the progress replies; the terminal success reply is
+			// the dispatcher's job. A self-sent ActionFinishedSuccessfull here would be
+			// the double-reply regression.
+			Eventually(func() []models.ActionReplyState {
+				return historianReplyStates(&messages, &mu)
+			}).Should(Equal([]models.ActionReplyState{models.ActionConfirmed, models.ActionExecuting}))
 		})
 
 		It("should fail when no historian is configured yet", func() {
@@ -118,23 +126,16 @@ var _ = Describe("EditHistorian", func() {
 			Expect(result).To(BeNil())
 			Expect(metadata).To(BeNil())
 
-			Expect(mockConfig.AtomicSetHistorianCalled).To(BeFalse())
+			Expect(mockConfig.AtomicEditHistorianCalled).To(BeTrue())
+			Expect(mockConfig.Config.Historian).To(BeNil())
+
+			Eventually(func() []models.ActionReplyState {
+				return historianReplyStates(&messages, &mu)
+			}).Should(Equal([]models.ActionReplyState{models.ActionConfirmed, models.ActionExecuting, models.ActionFinishedWithFailure}))
 		})
 
-		It("should fail when the current config cannot be read", func() {
-			mockConfig.WithConfigError(errors.New("mock read failure"))
-
-			Expect(action.Parse(validPayload())).To(Succeed())
-
-			result, metadata, err := action.Execute()
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("Failed to read current configuration"))
-			Expect(result).To(BeNil())
-			Expect(metadata).To(BeNil())
-		})
-
-		It("should handle AtomicSetHistorian failure", func() {
-			mockConfig.WithAtomicSetHistorianError(errors.New("mock write failure"))
+		It("should handle AtomicEditHistorian failure", func() {
+			mockConfig.WithAtomicEditHistorianError(errors.New("mock write failure"))
 
 			Expect(action.Parse(validPayload())).To(Succeed())
 
@@ -143,6 +144,10 @@ var _ = Describe("EditHistorian", func() {
 			Expect(err.Error()).To(ContainSubstring("Failed to update Historian configuration"))
 			Expect(result).To(BeNil())
 			Expect(metadata).To(BeNil())
+
+			Eventually(func() []models.ActionReplyState {
+				return historianReplyStates(&messages, &mu)
+			}).Should(Equal([]models.ActionReplyState{models.ActionConfirmed, models.ActionExecuting, models.ActionFinishedWithFailure}))
 		})
 	})
 })

--- a/umh-core/pkg/communicator/actions/edit-historian_test.go
+++ b/umh-core/pkg/communicator/actions/edit-historian_test.go
@@ -36,6 +36,7 @@ var _ = Describe("EditHistorian", func() {
 		mockConfig      *config.MockConfigManager
 		messages        []*models.UMHMessage
 		mu              sync.Mutex
+		consumerDone    chan struct{}
 	)
 
 	validPayload := func() map[string]interface{} {
@@ -75,14 +76,19 @@ var _ = Describe("EditHistorian", func() {
 		action = actions.NewEditHistorianAction(userEmail, actionUUID, instanceUUID, outboundChannel, mockConfig)
 
 		messages = nil
-		go actions.ConsumeOutboundMessages(outboundChannel, &messages, &mu, true)
+		consumerDone = make(chan struct{})
+		go func() {
+			defer GinkgoRecover()
+			actions.ConsumeOutboundMessages(outboundChannel, &messages, &mu, true)
+			close(consumerDone)
+		}()
 	})
 
 	AfterEach(func() {
-		for len(outboundChannel) > 0 {
-			<-outboundChannel
-		}
+		// Close the channel and wait for the consumer to drain and exit before the
+		// next spec resets `messages`, so the reset cannot race a running consumer.
 		close(outboundChannel)
+		<-consumerDone
 	})
 
 	Describe("Validate", func() {

--- a/umh-core/pkg/communicator/actions/edit_instance_test.go
+++ b/umh-core/pkg/communicator/actions/edit_instance_test.go
@@ -644,3 +644,11 @@ func (w *writeFailingMockConfigManager) AtomicDeleteStreamProcessor(ctx context.
 func (w *writeFailingMockConfigManager) GetBackupCount() uint64 {
 	return 0
 }
+
+func (w *writeFailingMockConfigManager) AtomicSetHistorian(_ context.Context, _ config.HistorianConfig) error {
+	return w.writeConfig(context.Background(), config.FullConfig{})
+}
+
+func (w *writeFailingMockConfigManager) AtomicDeleteHistorian(_ context.Context) error {
+	return w.writeConfig(context.Background(), config.FullConfig{})
+}

--- a/umh-core/pkg/communicator/actions/edit_instance_test.go
+++ b/umh-core/pkg/communicator/actions/edit_instance_test.go
@@ -649,6 +649,10 @@ func (w *writeFailingMockConfigManager) AtomicSetHistorian(_ context.Context, _ 
 	return w.writeConfig(context.Background(), config.FullConfig{})
 }
 
+func (w *writeFailingMockConfigManager) AtomicEditHistorian(_ context.Context, _ config.HistorianConfig) error {
+	return w.writeConfig(context.Background(), config.FullConfig{})
+}
+
 func (w *writeFailingMockConfigManager) AtomicDeleteHistorian(_ context.Context) error {
 	return w.writeConfig(context.Background(), config.FullConfig{})
 }

--- a/umh-core/pkg/communicator/actions/get-historian.go
+++ b/umh-core/pkg/communicator/actions/get-historian.go
@@ -26,6 +26,7 @@ package actions
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/google/uuid"
@@ -107,13 +108,11 @@ func (a *GetHistorianAction) Execute() (interface{}, map[string]interface{}, err
 		SendActionReplyV2(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedWithFailure,
 			"Historian is not configured", models.ErrValidationFailed, nil, a.outboundChannel, models.GetHistorian, nil)
 
-		return nil, nil, nil
+		return nil, nil, errors.New("historian is not configured")
 	}
 
 	response := *cfg.Historian
 
-	SendActionReply(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedSuccessfull,
-		response, a.outboundChannel, models.GetHistorian)
-
+	// The terminal ActionFinishedSuccessfull reply is sent by the caller (see actions.go).
 	return response, nil, nil
 }

--- a/umh-core/pkg/communicator/actions/get-historian.go
+++ b/umh-core/pkg/communicator/actions/get-historian.go
@@ -111,10 +111,6 @@ func (a *GetHistorianAction) Execute() (interface{}, map[string]interface{}, err
 		return nil, nil, nil
 	}
 
-	// The password is write-only: it is never returned to the Management Console,
-	// so it cannot leak through reply logs, the cloud backend, or the browser. To
-	// change it the user sends a new one via edit-historian; an empty password on
-	// edit keeps the stored value.
 	// The terminal ActionFinishedSuccessfull reply is sent by the caller (see actions.go).
-	return redactHistorianReply(*cfg.Historian), nil, nil
+	return withoutPasswords(*cfg.Historian), nil, nil
 }

--- a/umh-core/pkg/communicator/actions/get-historian.go
+++ b/umh-core/pkg/communicator/actions/get-historian.go
@@ -1,0 +1,119 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package actions contains implementations of the Action interface that create
+// and manage historian configurations in the UMH system.
+//
+// -----------------------------------------------------------------------------
+// BUSINESS CONTEXT
+// -----------------------------------------------------------------------------
+// GetHistorian reads the current `historian:` section from config.yaml and
+// returns it to the caller.
+// -----------------------------------------------------------------------------
+
+package actions
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/logger"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/models"
+)
+
+// GetHistorianAction implements the Action interface for reading the historian
+// configuration. All fields are immutable after construction.
+type GetHistorianAction struct {
+	configManager   config.ConfigManager
+	outboundChannel chan *models.UMHMessage
+	actionLogger    *zap.SugaredLogger
+
+	userEmail    string
+	actionUUID   uuid.UUID
+	instanceUUID uuid.UUID
+}
+
+// NewGetHistorianAction returns an un-parsed action instance.
+func NewGetHistorianAction(
+	userEmail string,
+	actionUUID uuid.UUID,
+	instanceUUID uuid.UUID,
+	outboundChannel chan *models.UMHMessage,
+	configManager config.ConfigManager,
+) *GetHistorianAction {
+	return &GetHistorianAction{
+		userEmail:       userEmail,
+		actionUUID:      actionUUID,
+		instanceUUID:    instanceUUID,
+		outboundChannel: outboundChannel,
+		configManager:   configManager,
+		actionLogger:    logger.For(logger.ComponentCommunicator),
+	}
+}
+
+// Parse implements the Action interface. GetHistorian carries no payload.
+func (a *GetHistorianAction) Parse(_ interface{}) error {
+	return nil
+}
+
+// Validate implements the Action interface. Nothing to validate for a read.
+func (a *GetHistorianAction) Validate() error {
+	return nil
+}
+
+// getUserEmail implements the Action interface.
+func (a *GetHistorianAction) getUserEmail() string {
+	return a.userEmail
+}
+
+// getUuid implements the Action interface.
+func (a *GetHistorianAction) getUuid() uuid.UUID {
+	return a.actionUUID
+}
+
+// Execute implements the Action interface by reading and returning the historian config.
+func (a *GetHistorianAction) Execute() (interface{}, map[string]interface{}, error) {
+	a.actionLogger.Info("Executing GetHistorian action")
+
+	ctx, cancel := context.WithTimeout(context.Background(), constants.ActionTimeout)
+	defer cancel()
+
+	cfg, err := a.configManager.GetConfig(ctx, 0)
+	if err != nil {
+		errorMsg := fmt.Sprintf("Failed to read configuration: %v", err)
+		SendActionReplyV2(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedWithFailure,
+			errorMsg, models.ErrConfigFileInvalid, nil, a.outboundChannel, models.GetHistorian, nil)
+
+		return nil, nil, fmt.Errorf("%s", errorMsg)
+	}
+
+	if cfg.Historian == nil {
+		SendActionReplyV2(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedWithFailure,
+			"Historian is not configured", models.ErrValidationFailed, nil, a.outboundChannel, models.GetHistorian, nil)
+
+		return nil, nil, nil
+	}
+
+	response := *cfg.Historian
+
+	SendActionReply(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedSuccessfull,
+		response, a.outboundChannel, models.GetHistorian)
+
+	return response, nil, nil
+}

--- a/umh-core/pkg/communicator/actions/get-historian.go
+++ b/umh-core/pkg/communicator/actions/get-historian.go
@@ -26,7 +26,6 @@ package actions
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/google/uuid"
@@ -105,14 +104,17 @@ func (a *GetHistorianAction) Execute() (interface{}, map[string]interface{}, err
 	}
 
 	if cfg.Historian == nil {
-		SendActionReplyV2(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedWithFailure,
-			"Historian is not configured", models.ErrValidationFailed, nil, a.outboundChannel, models.GetHistorian, nil)
-
-		return nil, nil, errors.New("historian is not configured")
+		// A missing historian is the normal starting state of the singleton, not an
+		// error. Report success with an absent (null) result so the Management Console
+		// shows the empty "add historian" form instead of a read error, without having
+		// to string-match an error message.
+		return nil, nil, nil
 	}
 
-	response := *cfg.Historian
-
+	// The password is write-only: it is never returned to the Management Console,
+	// so it cannot leak through reply logs, the cloud backend, or the browser. To
+	// change it the user sends a new one via edit-historian; an empty password on
+	// edit keeps the stored value.
 	// The terminal ActionFinishedSuccessfull reply is sent by the caller (see actions.go).
-	return response, nil, nil
+	return redactHistorianReply(*cfg.Historian), nil, nil
 }

--- a/umh-core/pkg/communicator/actions/get-historian_test.go
+++ b/umh-core/pkg/communicator/actions/get-historian_test.go
@@ -36,6 +36,7 @@ var _ = Describe("GetHistorian", func() {
 		mockConfig      *config.MockConfigManager
 		messages        []*models.UMHMessage
 		mu              sync.Mutex
+		consumerDone    chan struct{}
 	)
 
 	BeforeEach(func() {
@@ -60,14 +61,19 @@ var _ = Describe("GetHistorian", func() {
 		action = actions.NewGetHistorianAction(userEmail, actionUUID, instanceUUID, outboundChannel, mockConfig)
 
 		messages = nil
-		go actions.ConsumeOutboundMessages(outboundChannel, &messages, &mu, true)
+		consumerDone = make(chan struct{})
+		go func() {
+			defer GinkgoRecover()
+			actions.ConsumeOutboundMessages(outboundChannel, &messages, &mu, true)
+			close(consumerDone)
+		}()
 	})
 
 	AfterEach(func() {
-		for len(outboundChannel) > 0 {
-			<-outboundChannel
-		}
+		// Close the channel and wait for the consumer to drain and exit before the
+		// next spec resets `messages`, so the reset cannot race a running consumer.
 		close(outboundChannel)
+		<-consumerDone
 	})
 
 	Describe("Parse and Validate", func() {

--- a/umh-core/pkg/communicator/actions/get-historian_test.go
+++ b/umh-core/pkg/communicator/actions/get-historian_test.go
@@ -57,6 +57,7 @@ var _ = Describe("GetHistorian", func() {
 
 		action = actions.NewGetHistorianAction(userEmail, actionUUID, instanceUUID, outboundChannel, mockConfig)
 
+		messages = nil
 		go actions.ConsumeOutboundMessages(outboundChannel, &messages, &mu, true)
 	})
 
@@ -86,15 +87,29 @@ var _ = Describe("GetHistorian", func() {
 			Expect(cfg.Port).To(Equal(uint16(5432)))
 			Expect(cfg.Database).To(Equal("umh"))
 			Expect(cfg.SSLMode).To(Equal(config.HistorianSSLModeRequire))
+
+			// A successful read emits no reply of its own; the dispatcher sends the sole
+			// terminal ActionFinishedSuccessfull carrying the returned config.
+			Consistently(func() []models.ActionReplyState {
+				return historianReplyStates(&messages, &mu)
+			}).Should(BeEmpty())
 		})
 
-		It("should return nil result when no historian is configured", func() {
+		It("should fail when no historian is configured", func() {
 			mockConfig.WithConfig(config.FullConfig{})
 
 			result, metadata, err := action.Execute()
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("not configured"))
 			Expect(result).To(BeNil())
 			Expect(metadata).To(BeNil())
+
+			// The not-configured branch must return a non-nil error so the dispatcher
+			// short-circuits; otherwise it would append a spurious success reply after
+			// this failure.
+			Eventually(func() []models.ActionReplyState {
+				return historianReplyStates(&messages, &mu)
+			}).Should(Equal([]models.ActionReplyState{models.ActionFinishedWithFailure}))
 		})
 
 		It("should fail when the config cannot be read", func() {
@@ -105,6 +120,10 @@ var _ = Describe("GetHistorian", func() {
 			Expect(err.Error()).To(ContainSubstring("Failed to read configuration"))
 			Expect(result).To(BeNil())
 			Expect(metadata).To(BeNil())
+
+			Eventually(func() []models.ActionReplyState {
+				return historianReplyStates(&messages, &mu)
+			}).Should(Equal([]models.ActionReplyState{models.ActionFinishedWithFailure}))
 		})
 	})
 })

--- a/umh-core/pkg/communicator/actions/get-historian_test.go
+++ b/umh-core/pkg/communicator/actions/get-historian_test.go
@@ -46,12 +46,14 @@ var _ = Describe("GetHistorian", func() {
 
 		mockConfig = config.NewMockConfigManager().WithConfig(config.FullConfig{
 			Historian: &config.HistorianConfig{
-				Host:     "timescale.example.com",
-				Password: "secret",
-				Port:     5432,
-				Database: "umh",
-				Username: "umh_owner",
-				SSLMode:  config.HistorianSSLModeRequire,
+				Timescale: &config.TimescaleConfig{
+					Host:     "timescale.example.com",
+					Password: "secret",
+					Port:     5432,
+					Database: "umh",
+					Username: "umh_owner",
+					SSLMode:  config.HistorianSSLModeRequire,
+				},
 			},
 		})
 
@@ -83,10 +85,14 @@ var _ = Describe("GetHistorian", func() {
 
 			cfg, ok := result.(config.HistorianConfig)
 			Expect(ok).To(BeTrue(), "Result should be a HistorianConfig")
-			Expect(cfg.Host).To(Equal("timescale.example.com"))
-			Expect(cfg.Port).To(Equal(uint16(5432)))
-			Expect(cfg.Database).To(Equal("umh"))
-			Expect(cfg.SSLMode).To(Equal(config.HistorianSSLModeRequire))
+			Expect(cfg.Timescale).NotTo(BeNil())
+			Expect(cfg.Timescale.Host).To(Equal("timescale.example.com"))
+			Expect(cfg.Timescale.Port).To(Equal(uint16(5432)))
+			Expect(cfg.Timescale.Database).To(Equal("umh"))
+			Expect(cfg.Timescale.SSLMode).To(Equal(config.HistorianSSLModeRequire))
+			// The password is write-only: get-historian never returns it, so it
+			// cannot leak through reply logs, the cloud backend, or the browser.
+			Expect(cfg.Timescale.Password).To(BeEmpty())
 
 			// A successful read emits no reply of its own; the dispatcher sends the sole
 			// terminal ActionFinishedSuccessfull carrying the returned config.
@@ -95,21 +101,22 @@ var _ = Describe("GetHistorian", func() {
 			}).Should(BeEmpty())
 		})
 
-		It("should fail when no historian is configured", func() {
+		It("should succeed with an absent result when no historian is configured", func() {
 			mockConfig.WithConfig(config.FullConfig{})
 
 			result, metadata, err := action.Execute()
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("not configured"))
+			// A missing historian is the normal empty state, not a failure: Execute
+			// succeeds with a nil result so the dispatcher sends a success reply
+			// carrying a null historian, and the frontend need not string-match errors.
+			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(BeNil())
 			Expect(metadata).To(BeNil())
 
-			// The not-configured branch must return a non-nil error so the dispatcher
-			// short-circuits; otherwise it would append a spurious success reply after
-			// this failure.
-			Eventually(func() []models.ActionReplyState {
+			// Execute emits no reply of its own; the dispatcher sends the sole terminal
+			// ActionFinishedSuccessfull.
+			Consistently(func() []models.ActionReplyState {
 				return historianReplyStates(&messages, &mu)
-			}).Should(Equal([]models.ActionReplyState{models.ActionFinishedWithFailure}))
+			}).Should(BeEmpty())
 		})
 
 		It("should fail when the config cannot be read", func() {

--- a/umh-core/pkg/communicator/actions/get-historian_test.go
+++ b/umh-core/pkg/communicator/actions/get-historian_test.go
@@ -1,0 +1,110 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package actions_test
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/communicator/actions"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/models"
+)
+
+var _ = Describe("GetHistorian", func() {
+	var (
+		action          *actions.GetHistorianAction
+		userEmail       string
+		actionUUID      uuid.UUID
+		instanceUUID    uuid.UUID
+		outboundChannel chan *models.UMHMessage
+		mockConfig      *config.MockConfigManager
+		messages        []*models.UMHMessage
+		mu              sync.Mutex
+	)
+
+	BeforeEach(func() {
+		userEmail = "test@example.com"
+		actionUUID = uuid.New()
+		instanceUUID = uuid.New()
+		outboundChannel = make(chan *models.UMHMessage, 10)
+
+		mockConfig = config.NewMockConfigManager().WithConfig(config.FullConfig{
+			Historian: &config.HistorianConfig{
+				Host:     "timescale.example.com",
+				Password: "secret",
+				Port:     5432,
+				Database: "umh",
+				Username: "umh_owner",
+				SSLMode:  config.HistorianSSLModeRequire,
+			},
+		})
+
+		action = actions.NewGetHistorianAction(userEmail, actionUUID, instanceUUID, outboundChannel, mockConfig)
+
+		go actions.ConsumeOutboundMessages(outboundChannel, &messages, &mu, true)
+	})
+
+	AfterEach(func() {
+		for len(outboundChannel) > 0 {
+			<-outboundChannel
+		}
+		close(outboundChannel)
+	})
+
+	Describe("Parse and Validate", func() {
+		It("should accept an empty payload", func() {
+			Expect(action.Parse(nil)).To(Succeed())
+			Expect(action.Validate()).To(Succeed())
+		})
+	})
+
+	Describe("Execute", func() {
+		It("should return the current historian config", func() {
+			result, metadata, err := action.Execute()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(metadata).To(BeNil())
+
+			cfg, ok := result.(config.HistorianConfig)
+			Expect(ok).To(BeTrue(), "Result should be a HistorianConfig")
+			Expect(cfg.Host).To(Equal("timescale.example.com"))
+			Expect(cfg.Port).To(Equal(uint16(5432)))
+			Expect(cfg.Database).To(Equal("umh"))
+			Expect(cfg.SSLMode).To(Equal(config.HistorianSSLModeRequire))
+		})
+
+		It("should return nil result when no historian is configured", func() {
+			mockConfig.WithConfig(config.FullConfig{})
+
+			result, metadata, err := action.Execute()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeNil())
+			Expect(metadata).To(BeNil())
+		})
+
+		It("should fail when the config cannot be read", func() {
+			mockConfig.WithConfigError(errors.New("mock read failure"))
+
+			result, metadata, err := action.Execute()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Failed to read configuration"))
+			Expect(result).To(BeNil())
+			Expect(metadata).To(BeNil())
+		})
+	})
+})

--- a/umh-core/pkg/communicator/actions/get-historian_test.go
+++ b/umh-core/pkg/communicator/actions/get-historian_test.go
@@ -47,7 +47,7 @@ var _ = Describe("GetHistorian", func() {
 
 		mockConfig = config.NewMockConfigManager().WithConfig(config.FullConfig{
 			Historian: &config.HistorianConfig{
-				Timescale: &config.TimescaleConfig{
+				Timescale: config.TimescaleConfig{
 					Host:     "timescale.example.com",
 					Password: "secret",
 					Port:     5432,
@@ -91,7 +91,7 @@ var _ = Describe("GetHistorian", func() {
 
 			cfg, ok := result.(config.HistorianConfig)
 			Expect(ok).To(BeTrue(), "Result should be a HistorianConfig")
-			Expect(cfg.Timescale).NotTo(BeNil())
+			Expect(cfg.Timescale).NotTo(Equal(config.TimescaleConfig{}))
 			Expect(cfg.Timescale.Host).To(Equal("timescale.example.com"))
 			Expect(cfg.Timescale.Port).To(Equal(uint16(5432)))
 			Expect(cfg.Timescale.Database).To(Equal("umh"))

--- a/umh-core/pkg/communicator/actions/historian.go
+++ b/umh-core/pkg/communicator/actions/historian.go
@@ -1,0 +1,31 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package actions
+
+import "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
+
+// redactHistorianReply returns a copy of the historian config that is safe to send
+// back to the Management Console: the timescale password is blanked (write-only) on
+// a fresh Timescale pointer, so no historian reply carries the credential and the
+// stored config is never mutated by the redaction.
+func redactHistorianReply(h config.HistorianConfig) config.HistorianConfig {
+	if h.Timescale != nil {
+		ts := *h.Timescale
+		ts.Password = ""
+		h.Timescale = &ts
+	}
+
+	return h
+}

--- a/umh-core/pkg/communicator/actions/historian.go
+++ b/umh-core/pkg/communicator/actions/historian.go
@@ -17,15 +17,11 @@ package actions
 import "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
 
 // redactHistorianReply returns a copy of the historian config that is safe to send
-// back to the Management Console: the timescale password is blanked (write-only) on
-// a fresh Timescale pointer, so no historian reply carries the credential and the
-// stored config is never mutated by the redaction.
+// back to the Management Console: the timescale password is blanked (write-only), so
+// no historian reply carries the credential. h and its Timescale are values, so
+// blanking the password on the copy never mutates the stored config.
 func redactHistorianReply(h config.HistorianConfig) config.HistorianConfig {
-	if h.Timescale != nil {
-		ts := *h.Timescale
-		ts.Password = ""
-		h.Timescale = &ts
-	}
+	h.Timescale.Password = ""
 
 	return h
 }

--- a/umh-core/pkg/communicator/actions/historian.go
+++ b/umh-core/pkg/communicator/actions/historian.go
@@ -16,11 +16,9 @@ package actions
 
 import "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
 
-// redactHistorianReply returns a copy of the historian config that is safe to send
-// back to the Management Console: the timescale password is blanked (write-only), so
-// no historian reply carries the credential. h and its Timescale are values, so
-// blanking the password on the copy never mutates the stored config.
-func redactHistorianReply(h config.HistorianConfig) config.HistorianConfig {
+// withoutPasswords returns a copy of the historian config with the timescale password
+// cleared. h and its Timescale are values, so clearing it never mutates the stored config.
+func withoutPasswords(h config.HistorianConfig) config.HistorianConfig {
 	h.Timescale.Password = ""
 
 	return h

--- a/umh-core/pkg/communicator/actions/historian_replies_test.go
+++ b/umh-core/pkg/communicator/actions/historian_replies_test.go
@@ -1,0 +1,51 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package actions_test
+
+import (
+	"sync"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/communicator/pkg/encoding"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/models"
+)
+
+// historianReplyStates decodes the action-reply state of every message captured on
+// the outbound channel, in order. The historian action tests use it to assert on the
+// reply protocol Execute emits — not just the return value — so a regression that
+// self-sends a terminal reply (letting the dispatcher send a second one) is caught.
+func historianReplyStates(messages *[]*models.UMHMessage, mu *sync.Mutex) []models.ActionReplyState {
+	mu.Lock()
+	defer mu.Unlock()
+
+	states := make([]models.ActionReplyState, 0, len(*messages))
+
+	for _, msg := range *messages {
+		decoded, err := encoding.DecodeMessageFromUMHInstanceToUser(msg.Content)
+		if err != nil {
+			continue
+		}
+
+		payload, ok := decoded.Payload.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		if state, ok := payload["actionReplyState"].(string); ok {
+			states = append(states, models.ActionReplyState(state))
+		}
+	}
+
+	return states
+}

--- a/umh-core/pkg/communicator/actions/redact_sensitive_test.go
+++ b/umh-core/pkg/communicator/actions/redact_sensitive_test.go
@@ -1,0 +1,69 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package actions
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestRedactSensitiveMasksSecretKeys(t *testing.T) {
+	payload := map[string]interface{}{
+		"host":     "timescale.example.com",
+		"password": "super-secret",
+		"port":     float64(5432),
+		"apiKey":   "abc123",
+		"nested": map[string]interface{}{
+			"token": "tok-999",
+			"user":  "umh_owner",
+		},
+		"list": []interface{}{
+			map[string]interface{}{"credential": "c-1"},
+		},
+	}
+
+	got := fmt.Sprintf("%v", redactSensitive(payload))
+
+	for _, secret := range []string{"super-secret", "abc123", "tok-999", "c-1"} {
+		if strings.Contains(got, secret) {
+			t.Errorf("redacted output still contains secret %q: %s", secret, got)
+		}
+	}
+	for _, kept := range []string{"timescale.example.com", "umh_owner", "5432"} {
+		if !strings.Contains(got, kept) {
+			t.Errorf("redacted output dropped non-secret %q: %s", kept, got)
+		}
+	}
+}
+
+func TestRedactSensitiveLeavesOriginalUntouched(t *testing.T) {
+	payload := map[string]interface{}{"password": "super-secret"}
+
+	redactSensitive(payload)
+
+	if payload["password"] != "super-secret" {
+		t.Errorf("redactSensitive mutated the original payload: %v", payload)
+	}
+}
+
+func TestRedactSensitivePassesThroughNonMaps(t *testing.T) {
+	if got := redactSensitive("plain"); got != "plain" {
+		t.Errorf("expected passthrough for scalar, got %v", got)
+	}
+	if got := redactSensitive(nil); got != nil {
+		t.Errorf("expected nil passthrough, got %v", got)
+	}
+}

--- a/umh-core/pkg/communicator/pkg/generator/generator.go
+++ b/umh-core/pkg/communicator/pkg/generator/generator.go
@@ -292,6 +292,7 @@ func (s *StatusCollectorType) GenerateStatusMessage(ctx context.Context, isBoots
 					"protocol-converter-metrics",
 					"stream-processor-ignore-health-check",
 					"disable-read-flow",
+					"support-historian",
 				},
 			},
 		},

--- a/umh-core/pkg/config/config.go
+++ b/umh-core/pkg/config/config.go
@@ -40,7 +40,7 @@ type FullConfig struct {
 	ProtocolConverter []ProtocolConverterConfig `yaml:"protocolConverter,omitempty"` // ProtocolConverter config, can be updated while runnnig
 	StreamProcessor   []StreamProcessorConfig   `yaml:"streamProcessor,omitempty"`   // StreamProcessor config, can be updated while running
 	Internal          InternalConfig            `yaml:"internal,omitempty"`          // Internal config, not to be used by the user, only to be used for testing internal components
-	Historian         *HistorianConfig          `yaml:"historian,omitempty"`         // Historian config for TimescaleDB/Postgres connection
+	Historian         *HistorianConfig          `yaml:"historian,omitempty"`         // Historian config; groups the timescale connection (and future backends) under historian:
 }
 
 // TemplatesConfig defines the structure for the templates section.

--- a/umh-core/pkg/config/config.go
+++ b/umh-core/pkg/config/config.go
@@ -40,6 +40,7 @@ type FullConfig struct {
 	ProtocolConverter []ProtocolConverterConfig `yaml:"protocolConverter,omitempty"` // ProtocolConverter config, can be updated while runnnig
 	StreamProcessor   []StreamProcessorConfig   `yaml:"streamProcessor,omitempty"`   // StreamProcessor config, can be updated while running
 	Internal          InternalConfig            `yaml:"internal,omitempty"`          // Internal config, not to be used by the user, only to be used for testing internal components
+	Historian         *HistorianConfig          `yaml:"historian,omitempty"`         // Historian config for TimescaleDB/Postgres connection
 }
 
 // TemplatesConfig defines the structure for the templates section.
@@ -362,6 +363,13 @@ func (c FullConfig) Clone() FullConfig {
 	err = deepcopy.Copy(&clone.Internal, &c.Internal)
 	if err != nil {
 		return FullConfig{}
+	}
+
+	if c.Historian != nil {
+		err = deepcopy.Copy(&clone.Historian, &c.Historian)
+		if err != nil {
+			return FullConfig{}
+		}
 	}
 
 	return clone

--- a/umh-core/pkg/config/config.go
+++ b/umh-core/pkg/config/config.go
@@ -33,14 +33,14 @@ import (
 type FullConfig struct {
 	Templates         TemplatesConfig           `yaml:"templates,omitempty"`         // Templates section with enforced structure for protocol converter
 	PayloadShapes     map[string]PayloadShape   `yaml:"payloadShapes,omitempty"`     // PayloadShapes section with enforced structure for payload shapes
-	Agent             AgentConfig               `yaml:"agent"`                       // Agent config, requires restart to take effect
+	Historian         *HistorianConfig          `yaml:"historian,omitempty"`         // Historian config; groups the timescale connection (and future backends) under historian:
 	DataModels        []DataModelsConfig        `yaml:"dataModels,omitempty"`        // DataModels section with enforced structure for data models
 	DataContracts     []DataContractsConfig     `yaml:"dataContracts,omitempty"`     // DataContracts section with enforced structure for data contracts
 	DataFlow          []DataFlowComponentConfig `yaml:"dataFlow,omitempty"`          // DataFlow components to manage, can be updated while running
 	ProtocolConverter []ProtocolConverterConfig `yaml:"protocolConverter,omitempty"` // ProtocolConverter config, can be updated while runnnig
 	StreamProcessor   []StreamProcessorConfig   `yaml:"streamProcessor,omitempty"`   // StreamProcessor config, can be updated while running
 	Internal          InternalConfig            `yaml:"internal,omitempty"`          // Internal config, not to be used by the user, only to be used for testing internal components
-	Historian         *HistorianConfig          `yaml:"historian,omitempty"`         // Historian config; groups the timescale connection (and future backends) under historian:
+	Agent             AgentConfig               `yaml:"agent"`                       // Agent config, requires restart to take effect
 }
 
 // TemplatesConfig defines the structure for the templates section.

--- a/umh-core/pkg/config/historian_config.go
+++ b/umh-core/pkg/config/historian_config.go
@@ -1,0 +1,109 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"errors"
+	"fmt"
+)
+
+// HistorianSSLMode controls TLS behaviour for the historian Postgres connection.
+type HistorianSSLMode string
+
+const (
+	HistorianSSLModeRequire    HistorianSSLMode = "require"
+	HistorianSSLModeDisable    HistorianSSLMode = "disable"
+	HistorianSSLModeVerifyFull HistorianSSLMode = "verify-full"
+)
+
+// IsValid reports whether s is one of the three allowed SSL modes.
+func (s HistorianSSLMode) IsValid() bool {
+	switch s {
+	case HistorianSSLModeRequire, HistorianSSLModeDisable, HistorianSSLModeVerifyFull:
+		return true
+	default:
+		return false
+	}
+}
+
+// HistorianConfig holds the connection settings for the TimescaleDB/Postgres historian.
+// It maps to the top-level `historian:` key in config.yaml.
+type HistorianConfig struct {
+	// SSLRootCert is the path inside the container to the CA certificate file.
+	SSLRootCert string `yaml:"sslrootcert,omitempty" json:"sslrootcert,omitempty"`
+	// SSLCert is the path inside the container to the client certificate file.
+	SSLCert string `yaml:"sslcert,omitempty" json:"sslcert,omitempty"`
+	// SSLKey is the path inside the container to the client key file.
+	SSLKey string `yaml:"sslkey,omitempty" json:"sslkey,omitempty"`
+	// Host is the TimescaleDB/Postgres hostname or IP address (required).
+	Host string `yaml:"host" json:"host"`
+	// Password is the login role password (required). Redacted in logs.
+	Password string `yaml:"password" json:"password"`
+	// Database is the database name. Defaults to "umh".
+	Database string `yaml:"database,omitempty" json:"database,omitempty"`
+	// Username is the login role. Defaults to "umh_owner".
+	Username string `yaml:"username,omitempty" json:"username,omitempty"`
+	// SSLMode controls TLS behaviour. One of HistorianSSLModeRequire (default), HistorianSSLModeDisable, HistorianSSLModeVerifyFull.
+	SSLMode HistorianSSLMode `yaml:"sslmode,omitempty" json:"sslmode,omitempty"`
+	// Port is the Postgres port. Defaults to 5432.
+	Port uint16 `yaml:"port,omitempty" json:"port,omitempty"`
+}
+
+// Validate returns an error if any required field is missing or any value is invalid.
+func (h HistorianConfig) Validate() error {
+	required := []struct {
+		value  string
+		errMsg string
+	}{
+		{h.Host, "missing required field host"},
+		{h.Password, "missing required field password"},
+	}
+
+	// Check required fields
+	for _, f := range required {
+		if f.value == "" {
+			return errors.New(f.errMsg)
+		}
+	}
+
+	// Validate additional fields where possible
+	if h.SSLMode != "" && !h.SSLMode.IsValid() {
+		return fmt.Errorf("invalid sslmode %q: must be one of require, disable, verify-full", h.SSLMode)
+	}
+
+	return nil
+}
+
+// WithDefaults returns a copy of h with zero-value optional fields set to their
+// documented defaults. Required fields (Host, Password) are left unchanged.
+func (h HistorianConfig) WithDefaults() HistorianConfig {
+	if h.Port == 0 {
+		h.Port = 5432
+	}
+
+	if h.Database == "" {
+		h.Database = "umh"
+	}
+
+	if h.Username == "" {
+		h.Username = "umh_owner"
+	}
+
+	if h.SSLMode == "" {
+		h.SSLMode = HistorianSSLModeRequire
+	}
+
+	return h
+}

--- a/umh-core/pkg/config/historian_config.go
+++ b/umh-core/pkg/config/historian_config.go
@@ -23,6 +23,12 @@ import (
 // section exists to edit.
 var ErrHistorianNotConfigured = errors.New("historian is not configured")
 
+// ErrHistorianAlreadyConfigured is returned by AtomicSetHistorian when a historian
+// section already exists. Deploy is create-only; callers must use edit to change an
+// existing historian, so a retried or misdirected deploy cannot silently overwrite
+// connection settings.
+var ErrHistorianAlreadyConfigured = errors.New("historian is already configured")
+
 // HistorianSSLMode controls TLS behaviour for the historian Postgres connection.
 type HistorianSSLMode string
 
@@ -42,9 +48,18 @@ func (s HistorianSSLMode) IsValid() bool {
 	}
 }
 
-// HistorianConfig holds the connection settings for the TimescaleDB/Postgres historian.
-// It maps to the top-level `historian:` key in config.yaml.
+// HistorianConfig is the top-level `historian:` section in config.yaml. It groups
+// the historian's connection sub-blocks so more backends can be added later without
+// flattening: today it holds the TimescaleDB connection under `timescale:`; a
+// `grafana:` block is expected to sit alongside it at the same level.
 type HistorianConfig struct {
+	// Timescale holds the TimescaleDB/Postgres connection settings.
+	Timescale *TimescaleConfig `yaml:"timescale,omitempty" json:"timescale,omitempty"`
+}
+
+// TimescaleConfig holds the connection settings for the TimescaleDB/Postgres
+// historian. It maps to `historian.timescale` in config.yaml.
+type TimescaleConfig struct {
 	// SSLRootCert is the path inside the container to the CA certificate file.
 	SSLRootCert string `yaml:"sslrootcert,omitempty" json:"sslrootcert,omitempty"`
 	// SSLCert is the path inside the container to the client certificate file.
@@ -53,7 +68,8 @@ type HistorianConfig struct {
 	SSLKey string `yaml:"sslkey,omitempty" json:"sslkey,omitempty"`
 	// Host is the TimescaleDB/Postgres hostname or IP address (required).
 	Host string `yaml:"host" json:"host"`
-	// Password is the login role password (required). Redacted in logs.
+	// Password is the login role password (required). Masked by String() so it
+	// never reaches a %v log line; the raw value is still marshalled to YAML/JSON.
 	Password string `yaml:"password" json:"password"`
 	// Database is the database name. Defaults to "umh".
 	Database string `yaml:"database,omitempty" json:"database,omitempty"`
@@ -65,14 +81,46 @@ type HistorianConfig struct {
 	Port uint16 `yaml:"port,omitempty" json:"port,omitempty"`
 }
 
-// Validate returns an error if any required field is missing or any value is invalid.
+// Validate returns an error if the historian has no timescale section or that
+// section is invalid.
 func (h HistorianConfig) Validate() error {
+	if h.Timescale == nil {
+		return errors.New("missing required section timescale")
+	}
+
+	return h.Timescale.Validate()
+}
+
+// ValidateForUpdate validates an edit payload, requiring the timescale section but
+// not its password (see TimescaleConfig.ValidateForUpdate).
+func (h HistorianConfig) ValidateForUpdate() error {
+	if h.Timescale == nil {
+		return errors.New("missing required section timescale")
+	}
+
+	return h.Timescale.ValidateForUpdate()
+}
+
+// WithDefaults returns a copy of h with defaults applied to its sub-sections. The
+// returned copy owns a fresh Timescale pointer, so callers can redact the reply
+// copy without mutating stored config.
+func (h HistorianConfig) WithDefaults() HistorianConfig {
+	if h.Timescale != nil {
+		ts := h.Timescale.WithDefaults()
+		h.Timescale = &ts
+	}
+
+	return h
+}
+
+// Validate returns an error if any required field is missing or any value is invalid.
+func (t TimescaleConfig) Validate() error {
 	required := []struct {
 		value  string
 		errMsg string
 	}{
-		{h.Host, "missing required field host"},
-		{h.Password, "missing required field password"},
+		{t.Host, "missing required field host"},
+		{t.Password, "missing required field password"},
 	}
 
 	// Check required fields
@@ -82,32 +130,78 @@ func (h HistorianConfig) Validate() error {
 		}
 	}
 
-	// Validate additional fields where possible
-	if h.SSLMode != "" && !h.SSLMode.IsValid() {
-		return fmt.Errorf("invalid sslmode %q: must be one of require, disable, verify-full", h.SSLMode)
+	return t.validateSSL()
+}
+
+// ValidateForUpdate validates an edit payload. Unlike Validate it does not require
+// Password: get-historian never returns the stored password, so the Management
+// Console cannot resend it, and an empty password on edit means "keep the existing
+// one" (see AtomicEditHistorian). Host is still required.
+func (t TimescaleConfig) ValidateForUpdate() error {
+	if t.Host == "" {
+		return errors.New("missing required field host")
+	}
+
+	return t.validateSSL()
+}
+
+// hasTLSCerts reports whether any TLS certificate path is configured.
+func (t TimescaleConfig) hasTLSCerts() bool {
+	return t.SSLRootCert != "" || t.SSLCert != "" || t.SSLKey != ""
+}
+
+// validateSSL checks the sslmode value and its consistency with the configured
+// certificates. Certificates only take effect under verify-full: require encrypts
+// but skips server-certificate verification, and disable skips TLS entirely, so
+// supplying a CA or client certificate with either mode would silently leave the
+// connection open to a man-in-the-middle. Rather than pick a default that could be
+// wrong, reject the contradiction and make the operator choose verify-full.
+func (t TimescaleConfig) validateSSL() error {
+	if t.SSLMode != "" && !t.SSLMode.IsValid() {
+		return fmt.Errorf("invalid sslmode %q: must be one of require, disable, verify-full", t.SSLMode)
+	}
+
+	if t.hasTLSCerts() && t.SSLMode != HistorianSSLModeVerifyFull {
+		mode := string(t.SSLMode)
+		if mode == "" {
+			mode = "unset (defaults to require)"
+		}
+
+		return fmt.Errorf("tls certificate paths are set but sslmode is %s; certificates only verify the server with sslmode %q", mode, HistorianSSLModeVerifyFull)
 	}
 
 	return nil
 }
 
-// WithDefaults returns a copy of h with zero-value optional fields set to their
+// WithDefaults returns a copy of t with zero-value optional fields set to their
 // documented defaults. Required fields (Host, Password) are left unchanged.
-func (h HistorianConfig) WithDefaults() HistorianConfig {
-	if h.Port == 0 {
-		h.Port = 5432
+func (t TimescaleConfig) WithDefaults() TimescaleConfig {
+	if t.Port == 0 {
+		t.Port = 5432
 	}
 
-	if h.Database == "" {
-		h.Database = "umh"
+	if t.Database == "" {
+		t.Database = "umh"
 	}
 
-	if h.Username == "" {
-		h.Username = "umh_owner"
+	if t.Username == "" {
+		t.Username = "umh_owner"
 	}
 
-	if h.SSLMode == "" {
-		h.SSLMode = HistorianSSLModeRequire
+	if t.SSLMode == "" {
+		t.SSLMode = HistorianSSLModeRequire
 	}
 
-	return h
+	return t
+}
+
+// String masks Password so the timescale config is safe to log with %v.
+// It only affects logging; YAML/JSON marshalling still emits the real password.
+func (t TimescaleConfig) String() string {
+	if t.Password != "" {
+		t.Password = "[REDACTED]"
+	}
+
+	type redacted TimescaleConfig
+	return fmt.Sprintf("%+v", redacted(t))
 }

--- a/umh-core/pkg/config/historian_config.go
+++ b/umh-core/pkg/config/historian_config.go
@@ -19,6 +19,10 @@ import (
 	"fmt"
 )
 
+// ErrHistorianNotConfigured is returned by AtomicEditHistorian when no historian
+// section exists to edit.
+var ErrHistorianNotConfigured = errors.New("historian is not configured")
+
 // HistorianSSLMode controls TLS behaviour for the historian Postgres connection.
 type HistorianSSLMode string
 

--- a/umh-core/pkg/config/historian_config.go
+++ b/umh-core/pkg/config/historian_config.go
@@ -53,8 +53,10 @@ func (s HistorianSSLMode) IsValid() bool {
 // flattening: today it holds the TimescaleDB connection under `timescale:`; a
 // `grafana:` block is expected to sit alongside it at the same level.
 type HistorianConfig struct {
-	// Timescale holds the TimescaleDB/Postgres connection settings.
-	Timescale *TimescaleConfig `yaml:"timescale,omitempty" json:"timescale,omitempty"`
+	// Timescale holds the TimescaleDB/Postgres connection settings. It is required:
+	// the historian section is optional as a whole (FullConfig.Historian is a pointer),
+	// but once present it always carries a timescale connection.
+	Timescale TimescaleConfig `yaml:"timescale" json:"timescale"`
 }
 
 // TimescaleConfig holds the connection settings for the TimescaleDB/Postgres
@@ -84,7 +86,7 @@ type TimescaleConfig struct {
 // Validate returns an error if the historian has no timescale section or that
 // section is invalid.
 func (h HistorianConfig) Validate() error {
-	if h.Timescale == nil {
+	if h.Timescale == (TimescaleConfig{}) {
 		return errors.New("missing required section timescale")
 	}
 
@@ -94,21 +96,18 @@ func (h HistorianConfig) Validate() error {
 // ValidateForUpdate validates an edit payload, requiring the timescale section but
 // not its password (see TimescaleConfig.ValidateForUpdate).
 func (h HistorianConfig) ValidateForUpdate() error {
-	if h.Timescale == nil {
+	if h.Timescale == (TimescaleConfig{}) {
 		return errors.New("missing required section timescale")
 	}
 
 	return h.Timescale.ValidateForUpdate()
 }
 
-// WithDefaults returns a copy of h with defaults applied to its sub-sections. The
-// returned copy owns a fresh Timescale pointer, so callers can redact the reply
-// copy without mutating stored config.
+// WithDefaults returns a copy of h with defaults applied to its sub-sections. Both
+// h and its Timescale are values, so the copy is independent of the receiver and
+// callers can redact the reply copy without mutating stored config.
 func (h HistorianConfig) WithDefaults() HistorianConfig {
-	if h.Timescale != nil {
-		ts := h.Timescale.WithDefaults()
-		h.Timescale = &ts
-	}
+	h.Timescale = h.Timescale.WithDefaults()
 
 	return h
 }

--- a/umh-core/pkg/config/historian_config_test.go
+++ b/umh-core/pkg/config/historian_config_test.go
@@ -1,0 +1,172 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("HistorianConfig", func() {
+	// validConfig returns a minimal config that passes Validate.
+	validConfig := func() HistorianConfig {
+		return HistorianConfig{
+			Host:     "timescale.example.com",
+			Password: "secret",
+		}
+	}
+
+	Describe("HistorianSSLMode.IsValid", func() {
+		It("should accept the three documented modes", func() {
+			Expect(HistorianSSLModeRequire.IsValid()).To(BeTrue())
+			Expect(HistorianSSLModeDisable.IsValid()).To(BeTrue())
+			Expect(HistorianSSLModeVerifyFull.IsValid()).To(BeTrue())
+		})
+
+		It("should reject the empty string and unknown modes", func() {
+			Expect(HistorianSSLMode("").IsValid()).To(BeFalse())
+			Expect(HistorianSSLMode("verify-ca").IsValid()).To(BeFalse())
+			Expect(HistorianSSLMode("REQUIRE").IsValid()).To(BeFalse())
+		})
+	})
+
+	Describe("Validate", func() {
+		It("should pass with all required fields set", func() {
+			Expect(validConfig().Validate()).To(Succeed())
+		})
+
+		It("should fail when host is missing", func() {
+			cfg := validConfig()
+			cfg.Host = ""
+
+			err := cfg.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("missing required field host"))
+		})
+
+		It("should fail when password is missing", func() {
+			cfg := validConfig()
+			cfg.Password = ""
+
+			err := cfg.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("missing required field password"))
+		})
+
+		It("should report the missing host before the missing password", func() {
+			cfg := HistorianConfig{}
+
+			err := cfg.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("host"))
+		})
+
+		It("should pass when sslmode is left empty (default applied later)", func() {
+			cfg := validConfig()
+			cfg.SSLMode = ""
+
+			Expect(cfg.Validate()).To(Succeed())
+		})
+
+		It("should pass with a valid explicit sslmode", func() {
+			cfg := validConfig()
+			cfg.SSLMode = HistorianSSLModeVerifyFull
+
+			Expect(cfg.Validate()).To(Succeed())
+		})
+
+		It("should fail with an invalid sslmode", func() {
+			cfg := validConfig()
+			cfg.SSLMode = "bogus"
+
+			err := cfg.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("invalid sslmode"))
+			Expect(err.Error()).To(ContainSubstring("bogus"))
+		})
+	})
+
+	Describe("WithDefaults", func() {
+		It("should fill all optional fields when unset", func() {
+			cfg := validConfig().WithDefaults()
+
+			Expect(cfg.Port).To(Equal(uint16(5432)))
+			Expect(cfg.Database).To(Equal("umh"))
+			Expect(cfg.Username).To(Equal("umh_owner"))
+			Expect(cfg.SSLMode).To(Equal(HistorianSSLModeRequire))
+		})
+
+		It("should leave required fields unchanged", func() {
+			cfg := validConfig().WithDefaults()
+
+			Expect(cfg.Host).To(Equal("timescale.example.com"))
+			Expect(cfg.Password).To(Equal("secret"))
+		})
+
+		It("should not override values that are already set", func() {
+			cfg := HistorianConfig{
+				Host:     "h",
+				Password: "p",
+				Port:     6543,
+				Database: "custom_db",
+				Username: "custom_user",
+				SSLMode:  HistorianSSLModeDisable,
+			}
+
+			out := cfg.WithDefaults()
+			Expect(out.Port).To(Equal(uint16(6543)))
+			Expect(out.Database).To(Equal("custom_db"))
+			Expect(out.Username).To(Equal("custom_user"))
+			Expect(out.SSLMode).To(Equal(HistorianSSLModeDisable))
+		})
+
+		It("should not mutate the receiver", func() {
+			cfg := validConfig()
+			_ = cfg.WithDefaults()
+
+			Expect(cfg.Port).To(Equal(uint16(0)))
+			Expect(cfg.Database).To(BeEmpty())
+			Expect(cfg.Username).To(BeEmpty())
+			Expect(cfg.SSLMode).To(BeEmpty())
+		})
+	})
+
+	Describe("FullConfig.Clone", func() {
+		It("should deep-copy the historian section", func() {
+			original := FullConfig{
+				Historian: &HistorianConfig{
+					Host:     "orig-host",
+					Password: "orig-pass",
+					Port:     5432,
+				},
+			}
+
+			clone := original.Clone()
+			Expect(clone.Historian).NotTo(BeNil())
+			Expect(clone.Historian).NotTo(BeIdenticalTo(original.Historian))
+			Expect(*clone.Historian).To(Equal(*original.Historian))
+
+			// Mutating the clone must not affect the original.
+			clone.Historian.Host = "changed"
+			Expect(original.Historian.Host).To(Equal("orig-host"))
+		})
+
+		It("should keep a nil historian nil", func() {
+			original := FullConfig{}
+			clone := original.Clone()
+			Expect(clone.Historian).To(BeNil())
+		})
+	})
+})

--- a/umh-core/pkg/config/historian_config_test.go
+++ b/umh-core/pkg/config/historian_config_test.go
@@ -266,8 +266,8 @@ var _ = Describe("TimescaleConfig", func() {
 })
 
 var _ = Describe("HistorianConfig", func() {
-	validTimescale := func() *TimescaleConfig {
-		return &TimescaleConfig{Host: "timescale.example.com", Password: "secret"}
+	validTimescale := func() TimescaleConfig {
+		return TimescaleConfig{Host: "timescale.example.com", Password: "secret"}
 	}
 
 	Describe("Validate", func() {
@@ -285,7 +285,7 @@ var _ = Describe("HistorianConfig", func() {
 		})
 
 		It("should surface an invalid timescale section", func() {
-			h := HistorianConfig{Timescale: &TimescaleConfig{Host: "h"}}
+			h := HistorianConfig{Timescale: TimescaleConfig{Host: "h"}}
 
 			err := h.Validate()
 			Expect(err).To(HaveOccurred())
@@ -295,7 +295,7 @@ var _ = Describe("HistorianConfig", func() {
 
 	Describe("ValidateForUpdate", func() {
 		It("should pass without a password when the timescale section is present", func() {
-			h := HistorianConfig{Timescale: &TimescaleConfig{Host: "timescale.example.com"}}
+			h := HistorianConfig{Timescale: TimescaleConfig{Host: "timescale.example.com"}}
 			Expect(h.ValidateForUpdate()).To(Succeed())
 		})
 
@@ -314,23 +314,21 @@ var _ = Describe("HistorianConfig", func() {
 			Expect(h.Timescale.Database).To(Equal("umh"))
 		})
 
-		It("should return a fresh Timescale pointer so the receiver is not mutated", func() {
-			original := validTimescale()
-			h := HistorianConfig{Timescale: original}
+		It("should not mutate the receiver", func() {
+			h := HistorianConfig{Timescale: validTimescale()}
 
-			out := h.WithDefaults()
-			Expect(out.Timescale).NotTo(BeIdenticalTo(original))
-			Expect(original.Port).To(Equal(uint16(0)))
+			_ = h.WithDefaults()
+			Expect(h.Timescale.Port).To(Equal(uint16(0)))
 		})
 
-		It("should tolerate a nil timescale section", func() {
+		It("should tolerate an empty timescale section", func() {
 			Expect(func() { _ = HistorianConfig{}.WithDefaults() }).NotTo(Panic())
 		})
 	})
 
 	Describe("logging", func() {
 		It("should mask the nested timescale password under %v", func() {
-			h := HistorianConfig{Timescale: &TimescaleConfig{Host: "h", Password: "super-secret"}}
+			h := HistorianConfig{Timescale: TimescaleConfig{Host: "h", Password: "super-secret"}}
 			Expect(fmt.Sprintf("%v", h)).NotTo(ContainSubstring("super-secret"))
 		})
 	})
@@ -339,7 +337,7 @@ var _ = Describe("HistorianConfig", func() {
 		It("should deep-copy the historian section", func() {
 			original := FullConfig{
 				Historian: &HistorianConfig{
-					Timescale: &TimescaleConfig{
+					Timescale: TimescaleConfig{
 						Host:     "orig-host",
 						Password: "orig-pass",
 						Port:     5432,
@@ -350,7 +348,7 @@ var _ = Describe("HistorianConfig", func() {
 			clone := original.Clone()
 			Expect(clone.Historian).NotTo(BeNil())
 			Expect(clone.Historian).NotTo(BeIdenticalTo(original.Historian))
-			Expect(*clone.Historian.Timescale).To(Equal(*original.Historian.Timescale))
+			Expect(clone.Historian.Timescale).To(Equal(original.Historian.Timescale))
 
 			// Mutating the clone must not affect the original.
 			clone.Historian.Timescale.Host = "changed"

--- a/umh-core/pkg/config/historian_config_test.go
+++ b/umh-core/pkg/config/historian_config_test.go
@@ -15,14 +15,16 @@
 package config
 
 import (
+	"fmt"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("HistorianConfig", func() {
-	// validConfig returns a minimal config that passes Validate.
-	validConfig := func() HistorianConfig {
-		return HistorianConfig{
+var _ = Describe("TimescaleConfig", func() {
+	// validTimescale returns a minimal timescale config that passes Validate.
+	validTimescale := func() TimescaleConfig {
+		return TimescaleConfig{
 			Host:     "timescale.example.com",
 			Password: "secret",
 		}
@@ -44,11 +46,11 @@ var _ = Describe("HistorianConfig", func() {
 
 	Describe("Validate", func() {
 		It("should pass with all required fields set", func() {
-			Expect(validConfig().Validate()).To(Succeed())
+			Expect(validTimescale().Validate()).To(Succeed())
 		})
 
 		It("should fail when host is missing", func() {
-			cfg := validConfig()
+			cfg := validTimescale()
 			cfg.Host = ""
 
 			err := cfg.Validate()
@@ -57,7 +59,7 @@ var _ = Describe("HistorianConfig", func() {
 		})
 
 		It("should fail when password is missing", func() {
-			cfg := validConfig()
+			cfg := validTimescale()
 			cfg.Password = ""
 
 			err := cfg.Validate()
@@ -66,7 +68,7 @@ var _ = Describe("HistorianConfig", func() {
 		})
 
 		It("should report the missing host before the missing password", func() {
-			cfg := HistorianConfig{}
+			cfg := TimescaleConfig{}
 
 			err := cfg.Validate()
 			Expect(err).To(HaveOccurred())
@@ -74,21 +76,21 @@ var _ = Describe("HistorianConfig", func() {
 		})
 
 		It("should pass when sslmode is left empty (default applied later)", func() {
-			cfg := validConfig()
+			cfg := validTimescale()
 			cfg.SSLMode = ""
 
 			Expect(cfg.Validate()).To(Succeed())
 		})
 
 		It("should pass with a valid explicit sslmode", func() {
-			cfg := validConfig()
+			cfg := validTimescale()
 			cfg.SSLMode = HistorianSSLModeVerifyFull
 
 			Expect(cfg.Validate()).To(Succeed())
 		})
 
 		It("should fail with an invalid sslmode", func() {
-			cfg := validConfig()
+			cfg := validTimescale()
 			cfg.SSLMode = "bogus"
 
 			err := cfg.Validate()
@@ -96,11 +98,95 @@ var _ = Describe("HistorianConfig", func() {
 			Expect(err.Error()).To(ContainSubstring("invalid sslmode"))
 			Expect(err.Error()).To(ContainSubstring("bogus"))
 		})
+
+		It("should pass when certificates are paired with verify-full", func() {
+			cfg := validTimescale()
+			cfg.SSLRootCert = "/certs/ca.pem"
+			cfg.SSLMode = HistorianSSLModeVerifyFull
+
+			Expect(cfg.Validate()).To(Succeed())
+		})
+
+		It("should reject a CA certificate under sslmode require", func() {
+			cfg := validTimescale()
+			cfg.SSLRootCert = "/certs/ca.pem"
+			cfg.SSLMode = HistorianSSLModeRequire
+
+			err := cfg.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("verify-full"))
+		})
+
+		It("should reject certificates when sslmode is left unset (would default to require)", func() {
+			cfg := validTimescale()
+			cfg.SSLRootCert = "/certs/ca.pem"
+			cfg.SSLMode = ""
+
+			err := cfg.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("verify-full"))
+		})
+
+		It("should reject a client certificate under sslmode disable", func() {
+			cfg := validTimescale()
+			cfg.SSLCert = "/certs/client.pem"
+			cfg.SSLKey = "/certs/client.key"
+			cfg.SSLMode = HistorianSSLModeDisable
+
+			err := cfg.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("verify-full"))
+		})
+	})
+
+	Describe("ValidateForUpdate", func() {
+		It("should pass when the password is missing (kept unchanged on edit)", func() {
+			cfg := TimescaleConfig{Host: "timescale.example.com"}
+			Expect(cfg.ValidateForUpdate()).To(Succeed())
+		})
+
+		It("should still fail when host is missing", func() {
+			cfg := TimescaleConfig{Password: "secret"}
+
+			err := cfg.ValidateForUpdate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("missing required field host"))
+		})
+
+		It("should still reject an invalid sslmode", func() {
+			cfg := TimescaleConfig{Host: "timescale.example.com", SSLMode: "bogus"}
+
+			err := cfg.ValidateForUpdate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("invalid sslmode"))
+		})
+
+		It("should reject certificates that are not paired with verify-full", func() {
+			cfg := TimescaleConfig{
+				Host:        "timescale.example.com",
+				SSLRootCert: "/certs/ca.pem",
+				SSLMode:     HistorianSSLModeRequire,
+			}
+
+			err := cfg.ValidateForUpdate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("verify-full"))
+		})
+
+		It("should accept certificates paired with verify-full", func() {
+			cfg := TimescaleConfig{
+				Host:        "timescale.example.com",
+				SSLRootCert: "/certs/ca.pem",
+				SSLMode:     HistorianSSLModeVerifyFull,
+			}
+
+			Expect(cfg.ValidateForUpdate()).To(Succeed())
+		})
 	})
 
 	Describe("WithDefaults", func() {
 		It("should fill all optional fields when unset", func() {
-			cfg := validConfig().WithDefaults()
+			cfg := validTimescale().WithDefaults()
 
 			Expect(cfg.Port).To(Equal(uint16(5432)))
 			Expect(cfg.Database).To(Equal("umh"))
@@ -109,14 +195,14 @@ var _ = Describe("HistorianConfig", func() {
 		})
 
 		It("should leave required fields unchanged", func() {
-			cfg := validConfig().WithDefaults()
+			cfg := validTimescale().WithDefaults()
 
 			Expect(cfg.Host).To(Equal("timescale.example.com"))
 			Expect(cfg.Password).To(Equal("secret"))
 		})
 
 		It("should not override values that are already set", func() {
-			cfg := HistorianConfig{
+			cfg := TimescaleConfig{
 				Host:     "h",
 				Password: "p",
 				Port:     6543,
@@ -133,7 +219,7 @@ var _ = Describe("HistorianConfig", func() {
 		})
 
 		It("should not mutate the receiver", func() {
-			cfg := validConfig()
+			cfg := validTimescale()
 			_ = cfg.WithDefaults()
 
 			Expect(cfg.Port).To(Equal(uint16(0)))
@@ -143,24 +229,132 @@ var _ = Describe("HistorianConfig", func() {
 		})
 	})
 
+	Describe("String", func() {
+		It("should mask the password but keep the other fields", func() {
+			t := TimescaleConfig{
+				Host:     "timescale.example.com",
+				Password: "super-secret",
+				Database: "umh",
+				Username: "umh_owner",
+				Port:     5432,
+			}
+
+			s := t.String()
+			Expect(s).NotTo(ContainSubstring("super-secret"))
+			Expect(s).To(ContainSubstring("[REDACTED]"))
+			Expect(s).To(ContainSubstring("timescale.example.com"))
+			Expect(s).To(ContainSubstring("umh_owner"))
+		})
+
+		It("should not add a redaction marker when no password is set", func() {
+			t := TimescaleConfig{Host: "timescale.example.com"}
+			Expect(t.String()).NotTo(ContainSubstring("[REDACTED]"))
+		})
+
+		It("should be picked up by a %v format verb", func() {
+			t := TimescaleConfig{Host: "h", Password: "super-secret"}
+			Expect(fmt.Sprintf("%v", t)).NotTo(ContainSubstring("super-secret"))
+			Expect(fmt.Sprintf("%v", &t)).NotTo(ContainSubstring("super-secret"))
+		})
+
+		It("should leave the receiver's password untouched", func() {
+			t := TimescaleConfig{Host: "h", Password: "super-secret"}
+			_ = t.String()
+			Expect(t.Password).To(Equal("super-secret"))
+		})
+	})
+})
+
+var _ = Describe("HistorianConfig", func() {
+	validTimescale := func() *TimescaleConfig {
+		return &TimescaleConfig{Host: "timescale.example.com", Password: "secret"}
+	}
+
+	Describe("Validate", func() {
+		It("should pass when the timescale section is valid", func() {
+			h := HistorianConfig{Timescale: validTimescale()}
+			Expect(h.Validate()).To(Succeed())
+		})
+
+		It("should fail when no timescale section is present", func() {
+			h := HistorianConfig{}
+
+			err := h.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("timescale"))
+		})
+
+		It("should surface an invalid timescale section", func() {
+			h := HistorianConfig{Timescale: &TimescaleConfig{Host: "h"}}
+
+			err := h.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("missing required field password"))
+		})
+	})
+
+	Describe("ValidateForUpdate", func() {
+		It("should pass without a password when the timescale section is present", func() {
+			h := HistorianConfig{Timescale: &TimescaleConfig{Host: "timescale.example.com"}}
+			Expect(h.ValidateForUpdate()).To(Succeed())
+		})
+
+		It("should fail when no timescale section is present", func() {
+			err := HistorianConfig{}.ValidateForUpdate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("timescale"))
+		})
+	})
+
+	Describe("WithDefaults", func() {
+		It("should apply defaults to the timescale section", func() {
+			h := HistorianConfig{Timescale: validTimescale()}.WithDefaults()
+
+			Expect(h.Timescale.Port).To(Equal(uint16(5432)))
+			Expect(h.Timescale.Database).To(Equal("umh"))
+		})
+
+		It("should return a fresh Timescale pointer so the receiver is not mutated", func() {
+			original := validTimescale()
+			h := HistorianConfig{Timescale: original}
+
+			out := h.WithDefaults()
+			Expect(out.Timescale).NotTo(BeIdenticalTo(original))
+			Expect(original.Port).To(Equal(uint16(0)))
+		})
+
+		It("should tolerate a nil timescale section", func() {
+			Expect(func() { _ = HistorianConfig{}.WithDefaults() }).NotTo(Panic())
+		})
+	})
+
+	Describe("logging", func() {
+		It("should mask the nested timescale password under %v", func() {
+			h := HistorianConfig{Timescale: &TimescaleConfig{Host: "h", Password: "super-secret"}}
+			Expect(fmt.Sprintf("%v", h)).NotTo(ContainSubstring("super-secret"))
+		})
+	})
+
 	Describe("FullConfig.Clone", func() {
 		It("should deep-copy the historian section", func() {
 			original := FullConfig{
 				Historian: &HistorianConfig{
-					Host:     "orig-host",
-					Password: "orig-pass",
-					Port:     5432,
+					Timescale: &TimescaleConfig{
+						Host:     "orig-host",
+						Password: "orig-pass",
+						Port:     5432,
+					},
 				},
 			}
 
 			clone := original.Clone()
 			Expect(clone.Historian).NotTo(BeNil())
 			Expect(clone.Historian).NotTo(BeIdenticalTo(original.Historian))
-			Expect(*clone.Historian).To(Equal(*original.Historian))
+			Expect(*clone.Historian.Timescale).To(Equal(*original.Historian.Timescale))
 
 			// Mutating the clone must not affect the original.
-			clone.Historian.Host = "changed"
-			Expect(original.Historian.Host).To(Equal("orig-host"))
+			clone.Historian.Timescale.Host = "changed"
+			Expect(original.Historian.Timescale.Host).To(Equal("orig-host"))
 		})
 
 		It("should keep a nil historian nil", func() {

--- a/umh-core/pkg/config/manager.go
+++ b/umh-core/pkg/config/manager.go
@@ -1310,10 +1310,11 @@ func (m *FileConfigManager) getLatestBackupContent(ctx context.Context) []byte {
 	return data
 }
 
-// AtomicSetHistorian creates the historian section in the config atomically. It
-// returns ErrHistorianAlreadyConfigured if one already exists so a retried or
-// misdirected deploy cannot silently overwrite an existing connection (and blank its
-// TLS cert paths); the existence check and the write share a single lock.
+// AtomicSetHistorian creates the historian section in the config atomically. An
+// identical redeploy returns nil (a lost-reply replay is a no-op success), while a
+// deploy that would change an existing connection returns ErrHistorianAlreadyConfigured
+// so a misdirected deploy cannot silently overwrite it (and blank its TLS cert paths);
+// the existence check and the write share a single lock.
 func (m *FileConfigManager) AtomicSetHistorian(ctx context.Context, historian HistorianConfig) error {
 	err := m.mutexAtomicUpdate.Lock(ctx)
 	if err != nil {
@@ -1327,6 +1328,13 @@ func (m *FileConfigManager) AtomicSetHistorian(ctx context.Context, historian Hi
 	}
 
 	if cfg.Historian != nil {
+		// An identical redeploy is a no-op success, not a conflict: a deploy whose
+		// terminal reply was lost can be safely replayed. The create-only guard still
+		// rejects a deploy that would change an existing connection.
+		if *cfg.Historian == historian {
+			return nil
+		}
+
 		return ErrHistorianAlreadyConfigured
 	}
 
@@ -1371,8 +1379,7 @@ func (m *FileConfigManager) AtomicEditHistorian(ctx context.Context, historian H
 	// returns the stored password, so the Management Console cannot resend it on edit.
 	// Preserving it here, under the same lock as the write, keeps the credential
 	// write-only without a separate read that could race a concurrent change.
-	if historian.Timescale != nil && historian.Timescale.Password == "" &&
-		cfg.Historian.Timescale != nil {
+	if historian.Timescale.Password == "" {
 		historian.Timescale.Password = cfg.Historian.Timescale.Password
 	}
 

--- a/umh-core/pkg/config/manager.go
+++ b/umh-core/pkg/config/manager.go
@@ -170,14 +170,14 @@ type FileConfigManager struct {
 
 	cacheConfig FullConfig // struct obtained from that file
 
+	// backupCount tracks the number of config backups created since startup.
+	backupCount atomic.Uint64
+
 	// ---------- in-memory cache (read-only after RLock) ----------
 	cacheMu sync.RWMutex // guards the two fields below
 
 	// ---------- background refresh state ----------
 	refreshMu sync.Mutex // prevents concurrent background refreshes
-
-	// backupCount tracks the number of config backups created since startup.
-	backupCount atomic.Uint64
 
 	// backupEnabled controls whether config backups are created before writes.
 	backupEnabled bool

--- a/umh-core/pkg/config/manager.go
+++ b/umh-core/pkg/config/manager.go
@@ -112,6 +112,10 @@ type ConfigManager interface {
 	WriteYAMLConfigFromString(ctx context.Context, configStr string, expectedModTime string) error
 	// GetBackupCount returns the number of config backups created since startup.
 	GetBackupCount() uint64
+	// AtomicSetHistorian writes or replaces the historian section in the config atomically.
+	AtomicSetHistorian(ctx context.Context, historian HistorianConfig) error
+	// AtomicDeleteHistorian removes the historian section from the config atomically.
+	AtomicDeleteHistorian(ctx context.Context) error
 
 	// TODO: Add AtomicUnlinkFromTemplate method
 	// AtomicUnlinkFromTemplate converts a templated configuration (using YAML anchors/aliases)
@@ -1296,6 +1300,68 @@ func (m *FileConfigManager) getLatestBackupContent(ctx context.Context) []byte {
 	}
 
 	return data
+}
+
+// AtomicSetHistorian writes or replaces the historian section in the config atomically.
+func (m *FileConfigManager) AtomicSetHistorian(ctx context.Context, historian HistorianConfig) error {
+	err := m.mutexAtomicUpdate.Lock(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to lock config file: %w", err)
+	}
+	defer m.mutexAtomicUpdate.Unlock()
+
+	cfg, err := m.GetConfig(ctx, 0)
+	if err != nil {
+		return fmt.Errorf("failed to get config: %w", err)
+	}
+
+	cfg.Historian = &historian
+
+	if err := m.writeConfig(ctx, cfg); err != nil {
+		return fmt.Errorf("failed to write config: %w", err)
+	}
+
+	return nil
+}
+
+// AtomicSetHistorian delegates to the underlying FileConfigManager.
+func (m *FileConfigManagerWithBackoff) AtomicSetHistorian(ctx context.Context, historian HistorianConfig) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
+	return m.configManager.AtomicSetHistorian(ctx, historian)
+}
+
+// AtomicDeleteHistorian removes the historian section from the config atomically.
+func (m *FileConfigManager) AtomicDeleteHistorian(ctx context.Context) error {
+	err := m.mutexAtomicUpdate.Lock(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to lock config file: %w", err)
+	}
+	defer m.mutexAtomicUpdate.Unlock()
+
+	cfg, err := m.GetConfig(ctx, 0)
+	if err != nil {
+		return fmt.Errorf("failed to get config: %w", err)
+	}
+
+	cfg.Historian = nil
+
+	if err := m.writeConfig(ctx, cfg); err != nil {
+		return fmt.Errorf("failed to write config: %w", err)
+	}
+
+	return nil
+}
+
+// AtomicDeleteHistorian delegates to the underlying FileConfigManager.
+func (m *FileConfigManagerWithBackoff) AtomicDeleteHistorian(ctx context.Context) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
+	return m.configManager.AtomicDeleteHistorian(ctx)
 }
 
 // cleanupOldBackups removes the oldest backup files when the total count

--- a/umh-core/pkg/config/manager.go
+++ b/umh-core/pkg/config/manager.go
@@ -114,6 +114,10 @@ type ConfigManager interface {
 	GetBackupCount() uint64
 	// AtomicSetHistorian writes or replaces the historian section in the config atomically.
 	AtomicSetHistorian(ctx context.Context, historian HistorianConfig) error
+	// AtomicEditHistorian replaces an existing historian section atomically, returning
+	// ErrHistorianNotConfigured if none exists. The existence check and write share a
+	// single lock, eliminating the check-then-write race of a separate GetConfig call.
+	AtomicEditHistorian(ctx context.Context, historian HistorianConfig) error
 	// AtomicDeleteHistorian removes the historian section from the config atomically.
 	AtomicDeleteHistorian(ctx context.Context) error
 
@@ -1331,6 +1335,43 @@ func (m *FileConfigManagerWithBackoff) AtomicSetHistorian(ctx context.Context, h
 	}
 
 	return m.configManager.AtomicSetHistorian(ctx, historian)
+}
+
+// AtomicEditHistorian replaces an existing historian section atomically. It returns
+// ErrHistorianNotConfigured if no historian is currently configured, so the existence
+// check and the write happen under a single lock and cannot race a concurrent delete.
+func (m *FileConfigManager) AtomicEditHistorian(ctx context.Context, historian HistorianConfig) error {
+	err := m.mutexAtomicUpdate.Lock(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to lock config file: %w", err)
+	}
+	defer m.mutexAtomicUpdate.Unlock()
+
+	cfg, err := m.GetConfig(ctx, 0)
+	if err != nil {
+		return fmt.Errorf("failed to get config: %w", err)
+	}
+
+	if cfg.Historian == nil {
+		return ErrHistorianNotConfigured
+	}
+
+	cfg.Historian = &historian
+
+	if err := m.writeConfig(ctx, cfg); err != nil {
+		return fmt.Errorf("failed to write config: %w", err)
+	}
+
+	return nil
+}
+
+// AtomicEditHistorian delegates to the underlying FileConfigManager.
+func (m *FileConfigManagerWithBackoff) AtomicEditHistorian(ctx context.Context, historian HistorianConfig) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
+	return m.configManager.AtomicEditHistorian(ctx, historian)
 }
 
 // AtomicDeleteHistorian removes the historian section from the config atomically.

--- a/umh-core/pkg/config/manager.go
+++ b/umh-core/pkg/config/manager.go
@@ -112,11 +112,15 @@ type ConfigManager interface {
 	WriteYAMLConfigFromString(ctx context.Context, configStr string, expectedModTime string) error
 	// GetBackupCount returns the number of config backups created since startup.
 	GetBackupCount() uint64
-	// AtomicSetHistorian writes or replaces the historian section in the config atomically.
+	// AtomicSetHistorian creates the historian section in the config atomically,
+	// returning ErrHistorianAlreadyConfigured if one already exists. It is create-only;
+	// use AtomicEditHistorian to change an existing historian.
 	AtomicSetHistorian(ctx context.Context, historian HistorianConfig) error
 	// AtomicEditHistorian replaces an existing historian section atomically, returning
-	// ErrHistorianNotConfigured if none exists. The existence check and write share a
-	// single lock, eliminating the check-then-write race of a separate GetConfig call.
+	// ErrHistorianNotConfigured if none exists. An empty password is preserved from the
+	// existing section (get-historian never returns it, so edit cannot resend it). The
+	// existence check, password merge, and write share a single lock, eliminating the
+	// check-then-write race of a separate GetConfig call.
 	AtomicEditHistorian(ctx context.Context, historian HistorianConfig) error
 	// AtomicDeleteHistorian removes the historian section from the config atomically.
 	AtomicDeleteHistorian(ctx context.Context) error
@@ -1306,7 +1310,10 @@ func (m *FileConfigManager) getLatestBackupContent(ctx context.Context) []byte {
 	return data
 }
 
-// AtomicSetHistorian writes or replaces the historian section in the config atomically.
+// AtomicSetHistorian creates the historian section in the config atomically. It
+// returns ErrHistorianAlreadyConfigured if one already exists so a retried or
+// misdirected deploy cannot silently overwrite an existing connection (and blank its
+// TLS cert paths); the existence check and the write share a single lock.
 func (m *FileConfigManager) AtomicSetHistorian(ctx context.Context, historian HistorianConfig) error {
 	err := m.mutexAtomicUpdate.Lock(ctx)
 	if err != nil {
@@ -1317,6 +1324,10 @@ func (m *FileConfigManager) AtomicSetHistorian(ctx context.Context, historian Hi
 	cfg, err := m.GetConfig(ctx, 0)
 	if err != nil {
 		return fmt.Errorf("failed to get config: %w", err)
+	}
+
+	if cfg.Historian != nil {
+		return ErrHistorianAlreadyConfigured
 	}
 
 	cfg.Historian = &historian
@@ -1354,6 +1365,15 @@ func (m *FileConfigManager) AtomicEditHistorian(ctx context.Context, historian H
 
 	if cfg.Historian == nil {
 		return ErrHistorianNotConfigured
+	}
+
+	// An empty timescale password means "keep the existing one": get-historian never
+	// returns the stored password, so the Management Console cannot resend it on edit.
+	// Preserving it here, under the same lock as the write, keeps the credential
+	// write-only without a separate read that could race a concurrent change.
+	if historian.Timescale != nil && historian.Timescale.Password == "" &&
+		cfg.Historian.Timescale != nil {
+		historian.Timescale.Password = cfg.Historian.Timescale.Password
 	}
 
 	cfg.Historian = &historian

--- a/umh-core/pkg/config/manager_test.go
+++ b/umh-core/pkg/config/manager_test.go
@@ -1592,7 +1592,7 @@ var _ = Describe("ConfigManager historian mutations", func() {
 			original := HistorianConfig{
 				Timescale: &TimescaleConfig{
 					Host:        "timescale.example.com",
-					Password:    "s3cret",
+					Password:    "secret",
 					SSLMode:     HistorianSSLModeVerifyFull,
 					SSLRootCert: "/certs/ca.pem",
 				},
@@ -1635,7 +1635,7 @@ var _ = Describe("ConfigManager historian mutations", func() {
 			Expect(manager.AtomicSetHistorian(ctx, HistorianConfig{
 				Timescale: &TimescaleConfig{
 					Host:     "timescale.example.com",
-					Password: "s3cret",
+					Password: "secret",
 					Port:     5432,
 				},
 			})).To(Succeed())
@@ -1658,7 +1658,7 @@ var _ = Describe("ConfigManager historian mutations", func() {
 				return *cfg.Historian.Timescale, err
 			}, 2*time.Second, 10*time.Millisecond).Should(And(
 				HaveField("Port", uint16(6543)),
-				HaveField("Password", "s3cret"),
+				HaveField("Password", "secret"),
 			))
 		})
 
@@ -1671,7 +1671,7 @@ var _ = Describe("ConfigManager historian mutations", func() {
 			Expect(manager.AtomicSetHistorian(ctx, HistorianConfig{
 				Timescale: &TimescaleConfig{
 					Host:     "timescale.example.com",
-					Password: "s3cret",
+					Password: "secret",
 				},
 			})).To(Succeed())
 
@@ -1758,7 +1758,7 @@ var _ = Describe("ConfigManager historian mutations", func() {
 			historian := HistorianConfig{
 				Timescale: &TimescaleConfig{
 					Host:     "timescale.example.com",
-					Password: "s3cret",
+					Password: "secret",
 					Database: "umh",
 					Username: "umh_owner",
 					SSLMode:  HistorianSSLModeVerifyFull,

--- a/umh-core/pkg/config/manager_test.go
+++ b/umh-core/pkg/config/manager_test.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -1573,11 +1574,122 @@ var _ = Describe("ConfigManager historian mutations", func() {
 			cancelledCtx, cancelNow := context.WithCancel(context.Background())
 			cancelNow()
 
-			err = backoffManager.AtomicSetHistorian(cancelledCtx, HistorianConfig{Host: "h", Password: "p"})
+			err = backoffManager.AtomicSetHistorian(cancelledCtx, HistorianConfig{Timescale: &TimescaleConfig{Host: "h", Password: "p"}})
 			Expect(err).To(MatchError(context.Canceled))
 
 			err = backoffManager.AtomicDeleteHistorian(cancelledCtx)
 			Expect(err).To(MatchError(context.Canceled))
+		})
+	})
+
+	Describe("AtomicSetHistorian create-only guard", func() {
+		It("creates a historian when none exists, then rejects a second create", func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			manager := newInMemoryConfigManager(ctx)
+
+			original := HistorianConfig{
+				Timescale: &TimescaleConfig{
+					Host:        "timescale.example.com",
+					Password:    "s3cret",
+					SSLMode:     HistorianSSLModeVerifyFull,
+					SSLRootCert: "/certs/ca.pem",
+				},
+			}
+			Expect(manager.AtomicSetHistorian(ctx, original)).To(Succeed())
+
+			// A second deploy must be refused, not silently overwrite the existing
+			// connection (which would blank its verify-full cert path).
+			second := HistorianConfig{Timescale: &TimescaleConfig{Host: "other.example.com", Password: "new"}}
+			Expect(manager.AtomicSetHistorian(ctx, second)).To(MatchError(ErrHistorianAlreadyConfigured))
+
+			Eventually(func() (*TimescaleConfig, error) {
+				cfg, err := manager.GetConfig(ctx, 0)
+				if cfg.Historian == nil {
+					return nil, err
+				}
+
+				return cfg.Historian.Timescale, err
+			}, 2*time.Second, 10*time.Millisecond).Should(HaveValue(Equal(*original.Timescale)))
+		})
+	})
+
+	Describe("AtomicEditHistorian", func() {
+		It("returns ErrHistorianNotConfigured when none exists", func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			manager := newInMemoryConfigManager(ctx)
+
+			err := manager.AtomicEditHistorian(ctx, HistorianConfig{Timescale: &TimescaleConfig{Host: "h", Password: "p"}})
+			Expect(err).To(MatchError(ErrHistorianNotConfigured))
+		})
+
+		It("keeps the stored password when the edit omits it", func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			manager := newInMemoryConfigManager(ctx)
+
+			Expect(manager.AtomicSetHistorian(ctx, HistorianConfig{
+				Timescale: &TimescaleConfig{
+					Host:     "timescale.example.com",
+					Password: "s3cret",
+					Port:     5432,
+				},
+			})).To(Succeed())
+
+			// Edit changes the port but sends no password, as get-historian gave the
+			// Management Console nothing to resend.
+			Expect(manager.AtomicEditHistorian(ctx, HistorianConfig{
+				Timescale: &TimescaleConfig{
+					Host: "timescale.example.com",
+					Port: 6543,
+				},
+			})).To(Succeed())
+
+			Eventually(func() (TimescaleConfig, error) {
+				cfg, err := manager.GetConfig(ctx, 0)
+				if cfg.Historian == nil || cfg.Historian.Timescale == nil {
+					return TimescaleConfig{}, err
+				}
+
+				return *cfg.Historian.Timescale, err
+			}, 2*time.Second, 10*time.Millisecond).Should(And(
+				HaveField("Port", uint16(6543)),
+				HaveField("Password", "s3cret"),
+			))
+		})
+
+		It("replaces the password when the edit provides a new one", func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			manager := newInMemoryConfigManager(ctx)
+
+			Expect(manager.AtomicSetHistorian(ctx, HistorianConfig{
+				Timescale: &TimescaleConfig{
+					Host:     "timescale.example.com",
+					Password: "s3cret",
+				},
+			})).To(Succeed())
+
+			Expect(manager.AtomicEditHistorian(ctx, HistorianConfig{
+				Timescale: &TimescaleConfig{
+					Host:     "timescale.example.com",
+					Password: "rotated",
+				},
+			})).To(Succeed())
+
+			Eventually(func() (string, error) {
+				cfg, err := manager.GetConfig(ctx, 0)
+				if cfg.Historian == nil || cfg.Historian.Timescale == nil {
+					return "", err
+				}
+
+				return cfg.Historian.Timescale.Password, err
+			}, 2*time.Second, 10*time.Millisecond).Should(Equal("rotated"))
 		})
 	})
 
@@ -1588,23 +1700,44 @@ var _ = Describe("ConfigManager historian mutations", func() {
 
 			// Stateful in-memory file: writes replace the stored bytes, and each Stat
 			// returns a strictly increasing mtime so GetConfig always misses its cache
-			// and re-parses the persisted YAML — exercising real serialization, not the
-			// in-memory cache the write left behind.
-			var stored []byte
+			// and re-parses the persisted YAML, exercising real serialization rather
+			// than the in-memory cache the write left behind. Reads below use Eventually
+			// to tolerate the resulting background refresh. The shared state is
+			// mutex-guarded because that refresh runs on its own goroutine.
+			var (
+				mu        sync.Mutex
+				stored    []byte
+				statCalls int
+			)
 
-			statCalls := 0
 			baseTime := time.Unix(1_000_000, 0)
 
 			mockFS := filesystem.NewMockFileSystem()
 			mockFS.WithEnsureDirectoryFunc(func(_ context.Context, _ string) error { return nil })
-			mockFS.WithFileExistsFunc(func(_ context.Context, _ string) (bool, error) { return stored != nil, nil })
-			mockFS.WithReadFileFunc(func(_ context.Context, _ string) ([]byte, error) { return stored, nil })
+			mockFS.WithFileExistsFunc(func(_ context.Context, _ string) (bool, error) {
+				mu.Lock()
+				defer mu.Unlock()
+
+				return stored != nil, nil
+			})
+			mockFS.WithReadFileFunc(func(_ context.Context, _ string) ([]byte, error) {
+				mu.Lock()
+				defer mu.Unlock()
+
+				return stored, nil
+			})
 			mockFS.WithWriteFileFunc(func(_ context.Context, _ string, data []byte, _ os.FileMode) error {
+				mu.Lock()
+				defer mu.Unlock()
+
 				stored = data
 
 				return nil
 			})
 			mockFS.WithStatFunc(func(_ context.Context, _ string) (os.FileInfo, error) {
+				mu.Lock()
+				defer mu.Unlock()
+
 				statCalls++
 
 				return mockFS.NewMockFileInfo("config.yaml", int64(len(stored)), 0644,
@@ -1613,15 +1746,9 @@ var _ = Describe("ConfigManager historian mutations", func() {
 
 			manager := NewFileConfigManager().WithFileSystemService(mockFS)
 
-			// Seed a valid, non-empty serialized config so the read-modify-write cycle
-			// has a base. It must be non-empty: GetConfig reports an empty cached config
-			// as an error.
 			seed := FullConfig{Agent: AgentConfig{Location: map[int]string{0: "enterprise"}}}
 			Expect(manager.writeConfig(ctx, seed)).To(Succeed())
 
-			// The manager was constructed against the real filesystem before the mock
-			// was attached, so its cache carries a stale stat error. Drive GetConfig
-			// until the background refresh reparses the seeded file and clears it.
 			Eventually(func() error {
 				_, err := manager.GetConfig(ctx, 0)
 
@@ -1629,21 +1756,26 @@ var _ = Describe("ConfigManager historian mutations", func() {
 			}, 2*time.Second, 10*time.Millisecond).Should(Succeed())
 
 			historian := HistorianConfig{
-				Host:     "timescale.example.com",
-				Password: "s3cret",
-				Database: "umh",
-				Username: "umh_owner",
-				SSLMode:  HistorianSSLModeVerifyFull,
-				Port:     5432,
+				Timescale: &TimescaleConfig{
+					Host:     "timescale.example.com",
+					Password: "s3cret",
+					Database: "umh",
+					Username: "umh_owner",
+					SSLMode:  HistorianSSLModeVerifyFull,
+					Port:     5432,
+				},
 			}
 
 			Expect(manager.AtomicSetHistorian(ctx, historian)).To(Succeed())
 
-			Eventually(func() (*HistorianConfig, error) {
+			Eventually(func() (*TimescaleConfig, error) {
 				cfg, err := manager.GetConfig(ctx, 0)
+				if cfg.Historian == nil {
+					return nil, err
+				}
 
-				return cfg.Historian, err
-			}, 2*time.Second, 10*time.Millisecond).Should(HaveValue(Equal(historian)))
+				return cfg.Historian.Timescale, err
+			}, 2*time.Second, 10*time.Millisecond).Should(HaveValue(Equal(*historian.Timescale)))
 
 			Expect(manager.AtomicDeleteHistorian(ctx)).To(Succeed())
 
@@ -1655,6 +1787,69 @@ var _ = Describe("ConfigManager historian mutations", func() {
 		})
 	})
 })
+
+// newInMemoryConfigManager returns a FileConfigManager backed by a race-safe
+// in-memory config file, seeded with a minimal valid config and ready for
+// read-modify-write tests. The mtime advances once per write (not per Stat), so
+// reads between writes hit GetConfig's fast path and return the cache writeConfig
+// just set — deterministic for back-to-back mutations like Set-then-Edit, which
+// depend on the second call observing the first. The shared state is mutex-guarded
+// because GetConfig's background refresh goroutine can touch it concurrently.
+func newInMemoryConfigManager(ctx context.Context) *FileConfigManager {
+	var (
+		mu      sync.Mutex
+		stored  []byte
+		modTime = time.Unix(1_000_000, 0)
+	)
+
+	mockFS := filesystem.NewMockFileSystem()
+	mockFS.WithEnsureDirectoryFunc(func(_ context.Context, _ string) error { return nil })
+	mockFS.WithFileExistsFunc(func(_ context.Context, _ string) (bool, error) {
+		mu.Lock()
+		defer mu.Unlock()
+
+		return stored != nil, nil
+	})
+	mockFS.WithReadFileFunc(func(_ context.Context, _ string) ([]byte, error) {
+		mu.Lock()
+		defer mu.Unlock()
+
+		return stored, nil
+	})
+	mockFS.WithWriteFileFunc(func(_ context.Context, _ string, data []byte, _ os.FileMode) error {
+		mu.Lock()
+		defer mu.Unlock()
+
+		stored = data
+		modTime = modTime.Add(time.Second)
+
+		return nil
+	})
+	mockFS.WithStatFunc(func(_ context.Context, _ string) (os.FileInfo, error) {
+		mu.Lock()
+		defer mu.Unlock()
+
+		return mockFS.NewMockFileInfo("config.yaml", int64(len(stored)), 0644, modTime, false), nil
+	})
+
+	manager := NewFileConfigManager().WithFileSystemService(mockFS)
+
+	// Seed a valid, non-empty serialized config: GetConfig reports an empty cached
+	// config as an error, so the read-modify-write cycle needs a base to build on.
+	seed := FullConfig{Agent: AgentConfig{Location: map[int]string{0: "enterprise"}}}
+	ExpectWithOffset(1, manager.writeConfig(ctx, seed)).To(Succeed())
+
+	// The manager was constructed against the real filesystem before the mock was
+	// attached, so its cache carries a stale stat error. Drive GetConfig until the
+	// seeded file reads back cleanly.
+	EventuallyWithOffset(1, func() error {
+		_, err := manager.GetConfig(ctx, 0)
+
+		return err
+	}, 2*time.Second, 10*time.Millisecond).Should(Succeed())
+
+	return manager
+}
 
 // filterBackupDirPaths returns only paths that start with the backup directory.
 func filterBackupDirPaths(paths []string) []string {

--- a/umh-core/pkg/config/manager_test.go
+++ b/umh-core/pkg/config/manager_test.go
@@ -1574,7 +1574,7 @@ var _ = Describe("ConfigManager historian mutations", func() {
 			cancelledCtx, cancelNow := context.WithCancel(context.Background())
 			cancelNow()
 
-			err = backoffManager.AtomicSetHistorian(cancelledCtx, HistorianConfig{Timescale: &TimescaleConfig{Host: "h", Password: "p"}})
+			err = backoffManager.AtomicSetHistorian(cancelledCtx, HistorianConfig{Timescale: TimescaleConfig{Host: "h", Password: "p"}})
 			Expect(err).To(MatchError(context.Canceled))
 
 			err = backoffManager.AtomicDeleteHistorian(cancelledCtx)
@@ -1590,7 +1590,7 @@ var _ = Describe("ConfigManager historian mutations", func() {
 			manager := newInMemoryConfigManager(ctx)
 
 			original := HistorianConfig{
-				Timescale: &TimescaleConfig{
+				Timescale: TimescaleConfig{
 					Host:        "timescale.example.com",
 					Password:    "secret",
 					SSLMode:     HistorianSSLModeVerifyFull,
@@ -1601,17 +1601,42 @@ var _ = Describe("ConfigManager historian mutations", func() {
 
 			// A second deploy must be refused, not silently overwrite the existing
 			// connection (which would blank its verify-full cert path).
-			second := HistorianConfig{Timescale: &TimescaleConfig{Host: "other.example.com", Password: "new"}}
+			second := HistorianConfig{Timescale: TimescaleConfig{Host: "other.example.com", Password: "new"}}
 			Expect(manager.AtomicSetHistorian(ctx, second)).To(MatchError(ErrHistorianAlreadyConfigured))
 
-			Eventually(func() (*TimescaleConfig, error) {
+			Eventually(func() (TimescaleConfig, error) {
 				cfg, err := manager.GetConfig(ctx, 0)
 				if cfg.Historian == nil {
-					return nil, err
+					return TimescaleConfig{}, err
 				}
 
 				return cfg.Historian.Timescale, err
-			}, 2*time.Second, 10*time.Millisecond).Should(HaveValue(Equal(*original.Timescale)))
+			}, 2*time.Second, 10*time.Millisecond).Should(Equal(original.Timescale))
+		})
+
+		It("treats an identical redeploy as a no-op success", func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			manager := newInMemoryConfigManager(ctx)
+
+			original := HistorianConfig{
+				Timescale: TimescaleConfig{Host: "timescale.example.com", Password: "secret"},
+			}
+			Expect(manager.AtomicSetHistorian(ctx, original)).To(Succeed())
+
+			// Replaying the same deploy (e.g. after a lost reply) must succeed, not
+			// conflict, and leave the stored connection unchanged.
+			Expect(manager.AtomicSetHistorian(ctx, original)).To(Succeed())
+
+			Eventually(func() (TimescaleConfig, error) {
+				cfg, err := manager.GetConfig(ctx, 0)
+				if cfg.Historian == nil {
+					return TimescaleConfig{}, err
+				}
+
+				return cfg.Historian.Timescale, err
+			}, 2*time.Second, 10*time.Millisecond).Should(Equal(original.Timescale))
 		})
 	})
 
@@ -1622,7 +1647,7 @@ var _ = Describe("ConfigManager historian mutations", func() {
 
 			manager := newInMemoryConfigManager(ctx)
 
-			err := manager.AtomicEditHistorian(ctx, HistorianConfig{Timescale: &TimescaleConfig{Host: "h", Password: "p"}})
+			err := manager.AtomicEditHistorian(ctx, HistorianConfig{Timescale: TimescaleConfig{Host: "h", Password: "p"}})
 			Expect(err).To(MatchError(ErrHistorianNotConfigured))
 		})
 
@@ -1633,7 +1658,7 @@ var _ = Describe("ConfigManager historian mutations", func() {
 			manager := newInMemoryConfigManager(ctx)
 
 			Expect(manager.AtomicSetHistorian(ctx, HistorianConfig{
-				Timescale: &TimescaleConfig{
+				Timescale: TimescaleConfig{
 					Host:     "timescale.example.com",
 					Password: "secret",
 					Port:     5432,
@@ -1643,7 +1668,7 @@ var _ = Describe("ConfigManager historian mutations", func() {
 			// Edit changes the port but sends no password, as get-historian gave the
 			// Management Console nothing to resend.
 			Expect(manager.AtomicEditHistorian(ctx, HistorianConfig{
-				Timescale: &TimescaleConfig{
+				Timescale: TimescaleConfig{
 					Host: "timescale.example.com",
 					Port: 6543,
 				},
@@ -1651,11 +1676,11 @@ var _ = Describe("ConfigManager historian mutations", func() {
 
 			Eventually(func() (TimescaleConfig, error) {
 				cfg, err := manager.GetConfig(ctx, 0)
-				if cfg.Historian == nil || cfg.Historian.Timescale == nil {
+				if cfg.Historian == nil {
 					return TimescaleConfig{}, err
 				}
 
-				return *cfg.Historian.Timescale, err
+				return cfg.Historian.Timescale, err
 			}, 2*time.Second, 10*time.Millisecond).Should(And(
 				HaveField("Port", uint16(6543)),
 				HaveField("Password", "secret"),
@@ -1669,14 +1694,14 @@ var _ = Describe("ConfigManager historian mutations", func() {
 			manager := newInMemoryConfigManager(ctx)
 
 			Expect(manager.AtomicSetHistorian(ctx, HistorianConfig{
-				Timescale: &TimescaleConfig{
+				Timescale: TimescaleConfig{
 					Host:     "timescale.example.com",
 					Password: "secret",
 				},
 			})).To(Succeed())
 
 			Expect(manager.AtomicEditHistorian(ctx, HistorianConfig{
-				Timescale: &TimescaleConfig{
+				Timescale: TimescaleConfig{
 					Host:     "timescale.example.com",
 					Password: "rotated",
 				},
@@ -1684,7 +1709,7 @@ var _ = Describe("ConfigManager historian mutations", func() {
 
 			Eventually(func() (string, error) {
 				cfg, err := manager.GetConfig(ctx, 0)
-				if cfg.Historian == nil || cfg.Historian.Timescale == nil {
+				if cfg.Historian == nil {
 					return "", err
 				}
 
@@ -1756,7 +1781,7 @@ var _ = Describe("ConfigManager historian mutations", func() {
 			}, 2*time.Second, 10*time.Millisecond).Should(Succeed())
 
 			historian := HistorianConfig{
-				Timescale: &TimescaleConfig{
+				Timescale: TimescaleConfig{
 					Host:     "timescale.example.com",
 					Password: "secret",
 					Database: "umh",
@@ -1768,14 +1793,14 @@ var _ = Describe("ConfigManager historian mutations", func() {
 
 			Expect(manager.AtomicSetHistorian(ctx, historian)).To(Succeed())
 
-			Eventually(func() (*TimescaleConfig, error) {
+			Eventually(func() (TimescaleConfig, error) {
 				cfg, err := manager.GetConfig(ctx, 0)
 				if cfg.Historian == nil {
-					return nil, err
+					return TimescaleConfig{}, err
 				}
 
 				return cfg.Historian.Timescale, err
-			}, 2*time.Second, 10*time.Millisecond).Should(HaveValue(Equal(*historian.Timescale)))
+			}, 2*time.Second, 10*time.Millisecond).Should(Equal(historian.Timescale))
 
 			Expect(manager.AtomicDeleteHistorian(ctx)).To(Succeed())
 

--- a/umh-core/pkg/config/manager_test.go
+++ b/umh-core/pkg/config/manager_test.go
@@ -1580,6 +1580,80 @@ var _ = Describe("ConfigManager historian mutations", func() {
 			Expect(err).To(MatchError(context.Canceled))
 		})
 	})
+
+	Describe("FileConfigManager persistence round-trip", func() {
+		It("writes the historian to disk, reads it back, then deletes it", func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			// Stateful in-memory file: writes replace the stored bytes, and each Stat
+			// returns a strictly increasing mtime so GetConfig always misses its cache
+			// and re-parses the persisted YAML — exercising real serialization, not the
+			// in-memory cache the write left behind.
+			var stored []byte
+
+			statCalls := 0
+			baseTime := time.Unix(1_000_000, 0)
+
+			mockFS := filesystem.NewMockFileSystem()
+			mockFS.WithEnsureDirectoryFunc(func(_ context.Context, _ string) error { return nil })
+			mockFS.WithFileExistsFunc(func(_ context.Context, _ string) (bool, error) { return stored != nil, nil })
+			mockFS.WithReadFileFunc(func(_ context.Context, _ string) ([]byte, error) { return stored, nil })
+			mockFS.WithWriteFileFunc(func(_ context.Context, _ string, data []byte, _ os.FileMode) error {
+				stored = data
+
+				return nil
+			})
+			mockFS.WithStatFunc(func(_ context.Context, _ string) (os.FileInfo, error) {
+				statCalls++
+
+				return mockFS.NewMockFileInfo("config.yaml", int64(len(stored)), 0644,
+					baseTime.Add(time.Duration(statCalls)*time.Second), false), nil
+			})
+
+			manager := NewFileConfigManager().WithFileSystemService(mockFS)
+
+			// Seed a valid, non-empty serialized config so the read-modify-write cycle
+			// has a base. It must be non-empty: GetConfig reports an empty cached config
+			// as an error.
+			seed := FullConfig{Agent: AgentConfig{Location: map[int]string{0: "enterprise"}}}
+			Expect(manager.writeConfig(ctx, seed)).To(Succeed())
+
+			// The manager was constructed against the real filesystem before the mock
+			// was attached, so its cache carries a stale stat error. Drive GetConfig
+			// until the background refresh reparses the seeded file and clears it.
+			Eventually(func() error {
+				_, err := manager.GetConfig(ctx, 0)
+
+				return err
+			}, 2*time.Second, 10*time.Millisecond).Should(Succeed())
+
+			historian := HistorianConfig{
+				Host:     "timescale.example.com",
+				Password: "s3cret",
+				Database: "umh",
+				Username: "umh_owner",
+				SSLMode:  HistorianSSLModeVerifyFull,
+				Port:     5432,
+			}
+
+			Expect(manager.AtomicSetHistorian(ctx, historian)).To(Succeed())
+
+			Eventually(func() (*HistorianConfig, error) {
+				cfg, err := manager.GetConfig(ctx, 0)
+
+				return cfg.Historian, err
+			}, 2*time.Second, 10*time.Millisecond).Should(HaveValue(Equal(historian)))
+
+			Expect(manager.AtomicDeleteHistorian(ctx)).To(Succeed())
+
+			Eventually(func() (*HistorianConfig, error) {
+				cfg, err := manager.GetConfig(ctx, 0)
+
+				return cfg.Historian, err
+			}, 2*time.Second, 10*time.Millisecond).Should(BeNil())
+		})
+	})
 })
 
 // filterBackupDirPaths returns only paths that start with the backup directory.

--- a/umh-core/pkg/config/manager_test.go
+++ b/umh-core/pkg/config/manager_test.go
@@ -1564,6 +1564,24 @@ agent:
 	})
 })
 
+var _ = Describe("ConfigManager historian mutations", func() {
+	Describe("FileConfigManagerWithBackoff delegation", func() {
+		It("should return the context error when the context is already cancelled", func() {
+			backoffManager, err := NewFileConfigManagerWithBackoff()
+			Expect(err).NotTo(HaveOccurred())
+
+			cancelledCtx, cancelNow := context.WithCancel(context.Background())
+			cancelNow()
+
+			err = backoffManager.AtomicSetHistorian(cancelledCtx, HistorianConfig{Host: "h", Password: "p"})
+			Expect(err).To(MatchError(context.Canceled))
+
+			err = backoffManager.AtomicDeleteHistorian(cancelledCtx)
+			Expect(err).To(MatchError(context.Canceled))
+		})
+	})
+})
+
 // filterBackupDirPaths returns only paths that start with the backup directory.
 func filterBackupDirPaths(paths []string) []string {
 	var result []string

--- a/umh-core/pkg/config/mock.go
+++ b/umh-core/pkg/config/mock.go
@@ -51,6 +51,7 @@ type MockConfigManager struct {
 	AtomicDeleteDataModelError         error
 	AtomicAddDataContractError         error
 	AtomicSetHistorianError            error
+	AtomicEditHistorianError           error
 	AtomicDeleteHistorianError         error
 	GetConfigAsStringError             error
 	MockFileSystem                     *filesystem.MockFileSystem
@@ -97,6 +98,7 @@ type MockConfigManager struct {
 	AtomicDeleteDataModelCalled         bool
 	AtomicAddDataContractCalled         bool
 	AtomicSetHistorianCalled            bool
+	AtomicEditHistorianCalled           bool
 	AtomicDeleteHistorianCalled         bool
 	GetConfigAsStringCalled             bool
 }
@@ -373,6 +375,16 @@ func (m *MockConfigManager) WithAtomicSetHistorianError(err error) *MockConfigMa
 	return m
 }
 
+// WithAtomicEditHistorianError configures the mock to return the given error when AtomicEditHistorian is called.
+func (m *MockConfigManager) WithAtomicEditHistorianError(err error) *MockConfigManager {
+	m.mutexReadAndWrite.Lock()
+	defer m.mutexReadAndWrite.Unlock()
+
+	m.AtomicEditHistorianError = err
+
+	return m
+}
+
 // WithAtomicDeleteHistorianError configures the mock to return the given error when AtomicDeleteHistorian is called.
 func (m *MockConfigManager) WithAtomicDeleteHistorianError(err error) *MockConfigManager {
 	m.mutexReadAndWrite.Lock()
@@ -404,6 +416,7 @@ func (m *MockConfigManager) ResetCalls() {
 	m.AtomicDeleteDataModelCalled = false
 	m.AtomicAddDataContractCalled = false
 	m.AtomicSetHistorianCalled = false
+	m.AtomicEditHistorianCalled = false
 	m.AtomicDeleteHistorianCalled = false
 }
 
@@ -1326,6 +1339,27 @@ func (m *MockConfigManager) AtomicSetHistorian(_ context.Context, historian Hist
 
 	if m.AtomicSetHistorianError != nil {
 		return m.AtomicSetHistorianError
+	}
+
+	m.Config.Historian = &historian
+
+	return nil
+}
+
+// AtomicEditHistorian replaces an existing historian section in the mock config,
+// returning ErrHistorianNotConfigured when none is present.
+func (m *MockConfigManager) AtomicEditHistorian(_ context.Context, historian HistorianConfig) error {
+	m.mutexReadAndWrite.Lock()
+	defer m.mutexReadAndWrite.Unlock()
+
+	m.AtomicEditHistorianCalled = true
+
+	if m.AtomicEditHistorianError != nil {
+		return m.AtomicEditHistorianError
+	}
+
+	if m.Config.Historian == nil {
+		return ErrHistorianNotConfigured
 	}
 
 	m.Config.Historian = &historian

--- a/umh-core/pkg/config/mock.go
+++ b/umh-core/pkg/config/mock.go
@@ -50,6 +50,8 @@ type MockConfigManager struct {
 	AtomicEditDataModelError           error
 	AtomicDeleteDataModelError         error
 	AtomicAddDataContractError         error
+	AtomicSetHistorianError            error
+	AtomicDeleteHistorianError         error
 	GetConfigAsStringError             error
 	MockFileSystem                     *filesystem.MockFileSystem
 	logger                             *zap.SugaredLogger
@@ -94,6 +96,8 @@ type MockConfigManager struct {
 	AtomicEditDataModelCalled           bool
 	AtomicDeleteDataModelCalled         bool
 	AtomicAddDataContractCalled         bool
+	AtomicSetHistorianCalled            bool
+	AtomicDeleteHistorianCalled         bool
 	GetConfigAsStringCalled             bool
 }
 
@@ -359,6 +363,26 @@ func (m *MockConfigManager) WithAtomicAddDataContractError(err error) *MockConfi
 	return m
 }
 
+// WithAtomicSetHistorianError configures the mock to return the given error when AtomicSetHistorian is called.
+func (m *MockConfigManager) WithAtomicSetHistorianError(err error) *MockConfigManager {
+	m.mutexReadAndWrite.Lock()
+	defer m.mutexReadAndWrite.Unlock()
+
+	m.AtomicSetHistorianError = err
+
+	return m
+}
+
+// WithAtomicDeleteHistorianError configures the mock to return the given error when AtomicDeleteHistorian is called.
+func (m *MockConfigManager) WithAtomicDeleteHistorianError(err error) *MockConfigManager {
+	m.mutexReadAndWrite.Lock()
+	defer m.mutexReadAndWrite.Unlock()
+
+	m.AtomicDeleteHistorianError = err
+
+	return m
+}
+
 // ResetCalls clears the called flags for testing multiple calls.
 func (m *MockConfigManager) ResetCalls() {
 	m.mutexReadOrWrite.Lock()
@@ -379,6 +403,8 @@ func (m *MockConfigManager) ResetCalls() {
 	m.AtomicEditDataModelCalled = false
 	m.AtomicDeleteDataModelCalled = false
 	m.AtomicAddDataContractCalled = false
+	m.AtomicSetHistorianCalled = false
+	m.AtomicDeleteHistorianCalled = false
 }
 
 // atomic set location.
@@ -1296,6 +1322,12 @@ func (m *MockConfigManager) AtomicSetHistorian(_ context.Context, historian Hist
 	m.mutexReadAndWrite.Lock()
 	defer m.mutexReadAndWrite.Unlock()
 
+	m.AtomicSetHistorianCalled = true
+
+	if m.AtomicSetHistorianError != nil {
+		return m.AtomicSetHistorianError
+	}
+
 	m.Config.Historian = &historian
 
 	return nil
@@ -1305,6 +1337,12 @@ func (m *MockConfigManager) AtomicSetHistorian(_ context.Context, historian Hist
 func (m *MockConfigManager) AtomicDeleteHistorian(_ context.Context) error {
 	m.mutexReadAndWrite.Lock()
 	defer m.mutexReadAndWrite.Unlock()
+
+	m.AtomicDeleteHistorianCalled = true
+
+	if m.AtomicDeleteHistorianError != nil {
+		return m.AtomicDeleteHistorianError
+	}
 
 	m.Config.Historian = nil
 

--- a/umh-core/pkg/config/mock.go
+++ b/umh-core/pkg/config/mock.go
@@ -1330,9 +1330,9 @@ func (m *MockConfigManager) GetBackupCount() uint64 {
 	return 0
 }
 
-// AtomicSetHistorian creates the historian section in the mock config, returning
-// ErrHistorianAlreadyConfigured when one is already present (create-only, matching
-// the real FileConfigManager).
+// AtomicSetHistorian creates the historian section in the mock config. An identical
+// redeploy is a no-op success and a differing one returns ErrHistorianAlreadyConfigured,
+// matching the real FileConfigManager.
 func (m *MockConfigManager) AtomicSetHistorian(_ context.Context, historian HistorianConfig) error {
 	m.mutexReadAndWrite.Lock()
 	defer m.mutexReadAndWrite.Unlock()
@@ -1344,6 +1344,12 @@ func (m *MockConfigManager) AtomicSetHistorian(_ context.Context, historian Hist
 	}
 
 	if m.Config.Historian != nil {
+		// An identical redeploy is a no-op success (lost-reply replay), matching the
+		// real FileConfigManager; only a differing config is a conflict.
+		if *m.Config.Historian == historian {
+			return nil
+		}
+
 		return ErrHistorianAlreadyConfigured
 	}
 
@@ -1369,8 +1375,7 @@ func (m *MockConfigManager) AtomicEditHistorian(_ context.Context, historian His
 	}
 
 	// An empty timescale password keeps the existing one, matching the real FileConfigManager.
-	if historian.Timescale != nil && historian.Timescale.Password == "" &&
-		m.Config.Historian.Timescale != nil {
+	if historian.Timescale.Password == "" {
 		historian.Timescale.Password = m.Config.Historian.Timescale.Password
 	}
 

--- a/umh-core/pkg/config/mock.go
+++ b/umh-core/pkg/config/mock.go
@@ -1330,7 +1330,9 @@ func (m *MockConfigManager) GetBackupCount() uint64 {
 	return 0
 }
 
-// AtomicSetHistorian writes or replaces the historian section in the mock config.
+// AtomicSetHistorian creates the historian section in the mock config, returning
+// ErrHistorianAlreadyConfigured when one is already present (create-only, matching
+// the real FileConfigManager).
 func (m *MockConfigManager) AtomicSetHistorian(_ context.Context, historian HistorianConfig) error {
 	m.mutexReadAndWrite.Lock()
 	defer m.mutexReadAndWrite.Unlock()
@@ -1339,6 +1341,10 @@ func (m *MockConfigManager) AtomicSetHistorian(_ context.Context, historian Hist
 
 	if m.AtomicSetHistorianError != nil {
 		return m.AtomicSetHistorianError
+	}
+
+	if m.Config.Historian != nil {
+		return ErrHistorianAlreadyConfigured
 	}
 
 	m.Config.Historian = &historian
@@ -1360,6 +1366,12 @@ func (m *MockConfigManager) AtomicEditHistorian(_ context.Context, historian His
 
 	if m.Config.Historian == nil {
 		return ErrHistorianNotConfigured
+	}
+
+	// An empty timescale password keeps the existing one, matching the real FileConfigManager.
+	if historian.Timescale != nil && historian.Timescale.Password == "" &&
+		m.Config.Historian.Timescale != nil {
+		historian.Timescale.Password = m.Config.Historian.Timescale.Password
 	}
 
 	m.Config.Historian = &historian

--- a/umh-core/pkg/config/mock.go
+++ b/umh-core/pkg/config/mock.go
@@ -1291,6 +1291,26 @@ func (m *MockConfigManager) GetBackupCount() uint64 {
 	return 0
 }
 
+// AtomicSetHistorian writes or replaces the historian section in the mock config.
+func (m *MockConfigManager) AtomicSetHistorian(_ context.Context, historian HistorianConfig) error {
+	m.mutexReadAndWrite.Lock()
+	defer m.mutexReadAndWrite.Unlock()
+
+	m.Config.Historian = &historian
+
+	return nil
+}
+
+// AtomicDeleteHistorian removes the historian section from the mock config.
+func (m *MockConfigManager) AtomicDeleteHistorian(_ context.Context) error {
+	m.mutexReadAndWrite.Lock()
+	defer m.mutexReadAndWrite.Unlock()
+
+	m.Config.Historian = nil
+
+	return nil
+}
+
 // IsGetConfigCalled returns true if GetConfig has been called (thread-safe).
 func (m *MockConfigManager) IsGetConfigCalled() bool {
 	return atomic.LoadInt32(&m.GetConfigCalled) != 0

--- a/umh-core/pkg/fsmv2/deps/feature.go
+++ b/umh-core/pkg/fsmv2/deps/feature.go
@@ -82,6 +82,10 @@ const (
 	// FSMv2 worker pattern. Mirrors [FeatureFSMv1ConfigManager] for the other
 	// pre-FSMv2 package wired to FSMLogger.
 	FeatureFSMv1Communicator Feature = "fsmv1_communicator"
+
+	// FeatureSupportHistorian covers the historian feature: reading, writing, and
+	// managing historian configurations.
+	FeatureSupportHistorian Feature = "support_historian"
 )
 
 // FeatureForWorker returns the Feature for a specific worker type.

--- a/umh-core/pkg/models/action_models.go
+++ b/umh-core/pkg/models/action_models.go
@@ -218,6 +218,14 @@ const (
 	DeleteStreamProcessor ActionType = "delete-stream-processor"
 	// GetStreamProcessor represents the action type for getting a stream processor.
 	GetStreamProcessor ActionType = "get-stream-processor"
+	// DeployHistorian represents the action type for deploying the historian configuration.
+	DeployHistorian ActionType = "deploy-historian"
+	// EditHistorian represents the action type for editing the historian configuration.
+	EditHistorian ActionType = "edit-historian"
+	// DeleteHistorian represents the action type for removing the historian configuration.
+	DeleteHistorian ActionType = "delete-historian"
+	// GetHistorian represents the action type for getting the historian configuration.
+	GetHistorian ActionType = "get-historian"
 )
 
 // TestNetworkConnectionPayload contains the necessary fields for executing a TestNetworkConnection action.


### PR DESCRIPTION
Closes [ENG-5318](https://linear.app/united-manufacturing-hub/issue/ENG-5318/historian-crud-actions-in-umh-core) (parent [ENG-5098](https://linear.app/united-manufacturing-hub/issue/ENG-5098/rollout-historian-integration-in-management-console)).

Adds the communicator actions the Management Console uses to manage the historian (TimescaleDB/Postgres) connection stored in `config.yaml`. The historian block is a singleton — at most one per instance.

## Config shape

The connection lives under `historian.timescale`, nested so a `grafana:` block can be added at the same level later without a breaking change:

```yaml
historian:
    timescale:
        host: foo.bar.com
        password: secret
        database: umh
        username: umh_owner
        sslmode: require
        port: 5432
```

- `host` and `password` are required on create; `sslmode` is one of `require` (default), `disable`, `verify-full`.
- Optional TLS paths (`sslrootcert`, `sslcert`, `sslkey`) are only honored under `verify-full` — see below.
- `database`/`username`/`sslmode`/`port` default to `umh` / `umh_owner` / `require` / `5432`.

## Actions

| Action type | Behaviour |
|---|---|
| `deploy-historian` | Create the block. **Create-only**: fails with `ErrHistorianAlreadyConfigured` if one exists, so a retried or misdirected deploy cannot overwrite the connection. |
| `edit-historian` | Replace an existing block; fails if none exists. An omitted password keeps the stored one. |
| `get-historian` | Return the block **without the password**. An unconfigured instance returns success with a null result, not an error. |
| `delete-historian` | Remove the block. |

The action payload carries the container, e.g. `{ "timescale": { "host": ..., "password": ... } }`.

## The password is write-only

The instance accepts a password but never hands it back:

- `get-historian` blanks the password; `deploy`/`edit` blank it in their success replies too. No historian reply sent to the cloud carries the credential.
- `TimescaleConfig.String()` masks the password so it can't reach a `%v` log line, and the shared inbound-action log redacts password/secret/token-like keys for every action (not just historian).
- To change the password the operator sends a new one; an empty password on `edit` preserves the stored value, merged under the same lock as the write.

## TLS: certificates require verification

`sslmode: require` encrypts but does not verify the server certificate, and `disable` skips TLS. Supplying a CA or client certificate under either mode would silently leave the connection open to a man-in-the-middle. Rather than guess a default, validation rejects the contradiction: if any of `sslrootcert`/`sslcert`/`sslkey` is set, `sslmode` must be `verify-full`.

## Config manager

Three atomic methods on `ConfigManager` — `AtomicSetHistorian` (create-only guard), `AtomicEditHistorian` (existence check + password preservation), `AtomicDeleteHistorian`. Each takes the update lock once so the read, mutation, and write cannot race a concurrent change.

## Not included

- Template rendering with historian variables — reusing the connection in bridges and redeploying them when it changes.
- FSMv2 watcher on the connection.
- The `grafana:` sub-block (the nesting is in place for it).
- Management Console frontend wiring (tracked under ENG-5098). The get-without-password, create-only, and certs-require-verify-full rules are contracts the frontend must match.

## Follow-up

The package refactor from the ticket (move the actions into `pkg/communicator/actions/historian/` behind a neutral `actionbase` package) is deferred to [ENG-5334](https://linear.app/united-manufacturing-hub/issue/ENG-5334/move-historian-actions-into-dedicated-package-extract-actionbase). This PR keeps the actions in the flat `actions/` directory.

## Tests

Unit tests for each action, the `TimescaleConfig`/`HistorianConfig` types (validation, defaults, log redaction, cert rule), and the three atomic manager methods against the real `FileConfigManager` (create-only guard, edit password preservation, round-trip serialization). The config round-trip test runs clean under `-race`.
