### PR TITLE
feat: reference the shared historian connection in bridges

### DIFF
--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### New Features
 - Preview: an instance can now store a connection to an external TimescaleDB or PostgreSQL historian database (host, port, database, login, and TLS mode), which can be created, viewed, updated, and removed. Storing the connection does not yet route any data to it
+- Bridge templates can now reference the stored historian connection through `{{ .historian.timescale.host }}`, `{{ .historian.timescale.port }}`, and the other connection fields, so a bridge that writes to the historian's TimescaleDB no longer needs those connection details duplicated in its own variables
 
 ### Improvements
 

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter.go
@@ -1150,12 +1150,27 @@ func (a *EditProtocolConverterAction) renderDesiredDFCConfig(pcSnapshot *protoco
 
 	agentLocation := convertIntMapToStringMap(systemSnapshot.CurrentConfig.Agent.Location)
 
+	// The stored system snapshot does not carry the top-level historian section,
+	// so read it straight from the config manager. A read failure is propagated
+	// rather than swallowed: leaving historian nil would make a template that
+	// references {{ .historian.* }} fail this verify render with a misleading
+	// missingkey error, masking the real read failure and rolling back an
+	// otherwise valid edit. Propagating surfaces the true cause to the user.
+	ctx, cancel := context.WithTimeout(context.Background(), constants.ActionTimeout)
+	defer cancel()
+
+	currentConfig, err := a.configManager.GetConfig(ctx, 0)
+	if err != nil {
+		return dataflowcomponentserviceconfig.DataflowComponentServiceConfig{}, fmt.Errorf("failed to read current config for historian variables: %w", err)
+	}
+
 	pcName := a.name
 
 	runtimeConfig, err := runtime_config.BuildRuntimeConfig(
 		modifiedSpec,
 		agentLocation,
 		nil, // TODO: add global vars
+		currentConfig.Historian,
 		runtime_config.BridgedByPlaceholder,
 		pcName,
 	)

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter_test.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter_test.go
@@ -2527,13 +2527,11 @@ var _ = Describe("EditProtocolConverter", func() {
 				Expect(localAction.Parse(historianRefPayload())).To(Succeed())
 				Expect(localAction.Validate()).To(Succeed())
 
-				// Fail the config read only for the verify render, after Parse.
 				mockConfig.WithConfigError(errors.New("mock get config failure"))
 
 				_, renderErr := localAction.CompareProtocolConverterDFCConfig(observedStateWithIPPort("10.0.0.1"))
 
 				Expect(renderErr).To(HaveOccurred())
-				// The read failure must not masquerade as a missingkey / invalid-YAML error.
 				Expect(renderErr.Error()).To(ContainSubstring("failed to read current config for historian variables"))
 			})
 

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter_test.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter_test.go
@@ -2478,6 +2478,65 @@ var _ = Describe("EditProtocolConverter", func() {
 					"the desired config rendered with the new IP must not match the observed config rendered with the old IP")
 			})
 
+			historianRefPayload := func() map[string]interface{} {
+				return map[string]interface{}{
+					"name": pcName,
+					"uuid": pcUUID.String(),
+					"connection": map[string]interface{}{
+						"ip":   "10.0.0.1",
+						"port": 80,
+					},
+					"readDFC": map[string]interface{}{
+						"inputs": map[string]interface{}{
+							"data": "input:\n  http_client:\n    url: 'http://{{ .historian.timescale.host }}'",
+							"type": "http_client",
+						},
+						"pipeline": map[string]interface{}{
+							"processors": map[string]interface{}{
+								"0": map[string]interface{}{
+									"type": "bloblang",
+									"data": "bloblang: root = content()",
+								},
+							},
+						},
+						"state": "active",
+					},
+				}
+			}
+
+			It("verification render succeeds when the edit references the historian and one is configured", func() {
+				historianMock := config.NewMockConfigManager().WithConfig(config.FullConfig{
+					Historian: &config.HistorianConfig{
+						Timescale: config.TimescaleConfig{Host: "timescale.internal", Password: "secret"},
+					},
+				})
+				localAction := actions.NewEditProtocolConverterAction(userEmail, actionUUID, instanceUUID, localOutbound, historianMock, snapshotMgr)
+
+				Expect(localAction.Parse(historianRefPayload())).To(Succeed())
+				Expect(localAction.Validate()).To(Succeed())
+
+				_, renderErr := localAction.CompareProtocolConverterDFCConfig(observedStateWithIPPort("10.0.0.1"))
+
+				Expect(renderErr).NotTo(HaveOccurred(),
+					"render must succeed against a configured historian, not fail with missingkey on {{ .historian.timescale.host }}")
+			})
+
+			It("verification render surfaces the true cause when the historian config read fails", func() {
+				localAction := actions.NewEditProtocolConverterAction(userEmail, actionUUID, instanceUUID, localOutbound, mockConfig, snapshotMgr)
+
+				Expect(localAction.Parse(historianRefPayload())).To(Succeed())
+				Expect(localAction.Validate()).To(Succeed())
+
+				// Fail the config read only for the verify render, after Parse.
+				mockConfig.WithConfigError(errors.New("mock get config failure"))
+
+				_, renderErr := localAction.CompareProtocolConverterDFCConfig(observedStateWithIPPort("10.0.0.1"))
+
+				Expect(renderErr).To(HaveOccurred())
+				// The read failure must not masquerade as a missingkey / invalid-YAML error.
+				Expect(renderErr.Error()).To(ContainSubstring("failed to read current config for historian variables"))
+			})
+
 		})
 
 		Context("persisting merged user variables", func() {

--- a/umh-core/pkg/config/historian_config.go
+++ b/umh-core/pkg/config/historian_config.go
@@ -15,6 +15,7 @@
 package config
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 )
@@ -203,4 +204,41 @@ func (t TimescaleConfig) String() string {
 
 	type redacted TimescaleConfig
 	return fmt.Sprintf("%+v", redacted(t))
+}
+
+// ToTemplateMap returns the historian settings as a nested map for template
+// rendering, mirroring the `historian.timescale` shape in config.yaml. Bridge
+// templates reference the connection as `{{ .historian.timescale.host }}`,
+// `{{ .historian.timescale.port }}`, and the other fields. It returns an empty
+// map when no timescale section is present.
+func (h HistorianConfig) ToTemplateMap() map[string]any {
+	if h.Timescale == (TimescaleConfig{}) {
+		return map[string]any{}
+	}
+
+	return toTemplateMap(h.WithDefaults())
+}
+
+// ToTemplateMap returns the timescale connection settings as a flat map keyed by
+// the config.yaml field names, for template rendering. Defaults are applied first
+// so templates always see resolved values.
+func (t TimescaleConfig) ToTemplateMap() map[string]any {
+	return toTemplateMap(t.WithDefaults())
+}
+
+// toTemplateMap serialises a config value to a map keyed by its json field names.
+// A JSON round-trip keeps the exposed keys in step with the struct tags, so a new
+// field reaches templates without editing this function.
+func toTemplateMap(v any) map[string]any {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return map[string]any{}
+	}
+
+	m := map[string]any{}
+	if err := json.Unmarshal(b, &m); err != nil {
+		return map[string]any{}
+	}
+
+	return m
 }

--- a/umh-core/pkg/config/historian_config.go
+++ b/umh-core/pkg/config/historian_config.go
@@ -15,7 +15,6 @@
 package config
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 )
@@ -216,29 +215,41 @@ func (h HistorianConfig) ToTemplateMap() map[string]any {
 		return map[string]any{}
 	}
 
-	return toTemplateMap(h.WithDefaults())
+	return map[string]any{
+		"timescale": h.Timescale.ToTemplateMap(),
+	}
+}
+
+// TimescaleTemplateKeys is the complete set of keys TimescaleConfig.ToTemplateMap
+// exposes under {{ .historian.timescale.* }}. It is the template-variable contract:
+// bridge templates may reference exactly these keys. Keep it in step with
+// ToTemplateMap — the key-set lock test fails if the two diverge.
+var TimescaleTemplateKeys = []string{
+	"host", "port", "database", "username", "password",
+	"sslmode", "sslrootcert", "sslcert", "sslkey",
 }
 
 // ToTemplateMap returns the timescale connection settings as a flat map keyed by
 // the config.yaml field names, for template rendering. Defaults are applied first
 // so templates always see resolved values.
+//
+// The map is built explicitly, not by marshalling the struct. Bridge templates
+// reference every key unconditionally and RenderTemplate runs with
+// missingkey=error, so the exposed key set must be total and independent of field
+// values. A json:omitempty round-trip would drop an unset optional field (e.g. a
+// TLS certificate path left empty under sslmode=require) and fail the render.
 func (t TimescaleConfig) ToTemplateMap() map[string]any {
-	return toTemplateMap(t.WithDefaults())
-}
+	t = t.WithDefaults()
 
-// toTemplateMap serialises a config value to a map keyed by its json field names.
-// A JSON round-trip keeps the exposed keys in step with the struct tags, so a new
-// field reaches templates without editing this function.
-func toTemplateMap(v any) map[string]any {
-	b, err := json.Marshal(v)
-	if err != nil {
-		return map[string]any{}
+	return map[string]any{
+		"host":        t.Host,
+		"port":        t.Port,
+		"database":    t.Database,
+		"username":    t.Username,
+		"password":    t.Password,
+		"sslmode":     string(t.SSLMode),
+		"sslrootcert": t.SSLRootCert,
+		"sslcert":     t.SSLCert,
+		"sslkey":      t.SSLKey,
 	}
-
-	m := map[string]any{}
-	if err := json.Unmarshal(b, &m); err != nil {
-		return map[string]any{}
-	}
-
-	return m
 }

--- a/umh-core/pkg/config/historian_config.go
+++ b/umh-core/pkg/config/historian_config.go
@@ -15,6 +15,7 @@
 package config
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 )
@@ -62,12 +63,18 @@ type HistorianConfig struct {
 // TimescaleConfig holds the connection settings for the TimescaleDB/Postgres
 // historian. It maps to `historian.timescale` in config.yaml.
 type TimescaleConfig struct {
+	// The three TLS certificate paths deliberately omit json:omitempty (keeping it
+	// only on the yaml tag). ToTemplateMap builds the template scope via a JSON
+	// round-trip, and RenderTemplate runs with missingkey=error: an unset cert must
+	// still surface as an empty key, or a bridge referencing {{ .historian.timescale.sslrootcert }}
+	// fails to render. The key-set lock test guards this.
+	//
 	// SSLRootCert is the path inside the container to the CA certificate file.
-	SSLRootCert string `yaml:"sslrootcert,omitempty" json:"sslrootcert,omitempty"`
+	SSLRootCert string `yaml:"sslrootcert,omitempty" json:"sslrootcert"`
 	// SSLCert is the path inside the container to the client certificate file.
-	SSLCert string `yaml:"sslcert,omitempty" json:"sslcert,omitempty"`
+	SSLCert string `yaml:"sslcert,omitempty" json:"sslcert"`
 	// SSLKey is the path inside the container to the client key file.
-	SSLKey string `yaml:"sslkey,omitempty" json:"sslkey,omitempty"`
+	SSLKey string `yaml:"sslkey,omitempty" json:"sslkey"`
 	// Host is the TimescaleDB/Postgres hostname or IP address (required).
 	Host string `yaml:"host" json:"host"`
 	// Password is the login role password (required). Masked by String() so it
@@ -215,41 +222,42 @@ func (h HistorianConfig) ToTemplateMap() map[string]any {
 		return map[string]any{}
 	}
 
-	return map[string]any{
-		"timescale": h.Timescale.ToTemplateMap(),
-	}
+	return toTemplateMap(h.WithDefaults())
 }
 
 // TimescaleTemplateKeys is the complete set of keys TimescaleConfig.ToTemplateMap
 // exposes under {{ .historian.timescale.* }}. It is the template-variable contract:
-// bridge templates may reference exactly these keys. Keep it in step with
-// ToTemplateMap — the key-set lock test fails if the two diverge.
+// bridge templates may reference exactly these keys. The key-set lock test asserts
+// ToTemplateMap emits exactly these regardless of field values, so it fails if a
+// json:omitempty tag is ever (re-)added to an optional field and drops a key.
 var TimescaleTemplateKeys = []string{
 	"host", "port", "database", "username", "password",
 	"sslmode", "sslrootcert", "sslcert", "sslkey",
 }
 
 // ToTemplateMap returns the timescale connection settings as a flat map keyed by
-// the config.yaml field names, for template rendering. Defaults are applied first
-// so templates always see resolved values.
-//
-// The map is built explicitly, not by marshalling the struct. Bridge templates
-// reference every key unconditionally and RenderTemplate runs with
-// missingkey=error, so the exposed key set must be total and independent of field
-// values. A json:omitempty round-trip would drop an unset optional field (e.g. a
-// TLS certificate path left empty under sslmode=require) and fail the render.
+// the json field names, for template rendering. Defaults are applied first so
+// templates always see resolved values.
 func (t TimescaleConfig) ToTemplateMap() map[string]any {
-	t = t.WithDefaults()
+	return toTemplateMap(t.WithDefaults())
+}
 
-	return map[string]any{
-		"host":        t.Host,
-		"port":        t.Port,
-		"database":    t.Database,
-		"username":    t.Username,
-		"password":    t.Password,
-		"sslmode":     string(t.SSLMode),
-		"sslrootcert": t.SSLRootCert,
-		"sslcert":     t.SSLCert,
-		"sslkey":      t.SSLKey,
+// toTemplateMap serialises a config value to a map keyed by its json field names.
+// A JSON round-trip keeps the exposed keys in step with the struct tags, so a new
+// field reaches templates without editing this function. This is why the optional
+// TLS certificate fields drop json:omitempty (see TimescaleConfig): under
+// RenderTemplate's missingkey=error an unset field must render as an empty value,
+// not vanish from the scope.
+func toTemplateMap(v any) map[string]any {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return map[string]any{}
 	}
+
+	m := map[string]any{}
+	if err := json.Unmarshal(b, &m); err != nil {
+		return map[string]any{}
+	}
+
+	return m
 }

--- a/umh-core/pkg/config/historian_config_test.go
+++ b/umh-core/pkg/config/historian_config_test.go
@@ -283,11 +283,49 @@ var _ = Describe("TimescaleConfig", func() {
 			Expect(m).To(HaveKeyWithValue("sslcert", "/certs/client.pem"))
 			Expect(m).To(HaveKeyWithValue("sslkey", "/certs/client.key"))
 			// Optional fields are resolved to their defaults before exposure.
-			// JSON round-trip decodes numbers as float64.
-			Expect(m).To(HaveKeyWithValue("port", float64(5432)))
+			Expect(m).To(HaveKeyWithValue("port", uint16(5432)))
 			Expect(m).To(HaveKeyWithValue("database", "umh"))
 			Expect(m).To(HaveKeyWithValue("username", "umh_owner"))
 			Expect(m).To(HaveKeyWithValue("sslmode", "require"))
+		})
+
+		It("locks the exposed key set to TimescaleTemplateKeys, regardless of values", func() {
+			keysOf := func(m map[string]any) []string {
+				ks := make([]string, 0, len(m))
+				for k := range m {
+					ks = append(ks, k)
+				}
+
+				return ks
+			}
+
+			// Value-independence is the point: a partially-populated config must
+			// expose exactly the same keys as a fully-populated one, so a template
+			// referencing any documented key never hits missingkey=error.
+			minimal := TimescaleConfig{Host: "h", Password: "p"}.ToTemplateMap()
+			full := TimescaleConfig{
+				Host:        "h",
+				Password:    "p",
+				Port:        6432,
+				Database:    "metrics",
+				Username:    "svc",
+				SSLMode:     HistorianSSLModeVerifyFull,
+				SSLRootCert: "/certs/ca.pem",
+				SSLCert:     "/certs/client.pem",
+				SSLKey:      "/certs/client.key",
+			}.ToTemplateMap()
+
+			Expect(keysOf(minimal)).To(ConsistOf(TimescaleTemplateKeys))
+			Expect(keysOf(full)).To(ConsistOf(TimescaleTemplateKeys))
+		})
+
+		It("exposes the optional TLS cert keys as empty strings when unset", func() {
+			m := validTimescale().ToTemplateMap()
+
+			Expect(m).To(HaveLen(9))
+			Expect(m).To(HaveKeyWithValue("sslrootcert", ""))
+			Expect(m).To(HaveKeyWithValue("sslcert", ""))
+			Expect(m).To(HaveKeyWithValue("sslkey", ""))
 		})
 
 		It("keeps explicit optional values instead of defaults", func() {
@@ -302,7 +340,7 @@ var _ = Describe("TimescaleConfig", func() {
 
 			m := t.ToTemplateMap()
 
-			Expect(m).To(HaveKeyWithValue("port", float64(6432)))
+			Expect(m).To(HaveKeyWithValue("port", uint16(6432)))
 			Expect(m).To(HaveKeyWithValue("database", "metrics"))
 			Expect(m).To(HaveKeyWithValue("username", "svc"))
 			Expect(m).To(HaveKeyWithValue("sslmode", "disable"))
@@ -416,11 +454,21 @@ var _ = Describe("HistorianConfig", func() {
 			ts, ok := m["timescale"].(map[string]any)
 			Expect(ok).To(BeTrue())
 			Expect(ts).To(HaveKeyWithValue("host", "db"))
-			Expect(ts).To(HaveKeyWithValue("port", float64(5432)))
+			Expect(ts).To(HaveKeyWithValue("port", uint16(5432)))
 		})
 
 		It("returns an empty map when no timescale section is present", func() {
 			Expect(HistorianConfig{}.ToTemplateMap()).To(BeEmpty())
+		})
+
+		It("exposes the optional TLS cert keys under timescale even when unset", func() {
+			h := HistorianConfig{Timescale: TimescaleConfig{Host: "db", Password: "pw"}}
+
+			ts, ok := h.ToTemplateMap()["timescale"].(map[string]any)
+			Expect(ok).To(BeTrue())
+			Expect(ts).To(HaveKeyWithValue("sslrootcert", ""))
+			Expect(ts).To(HaveKeyWithValue("sslcert", ""))
+			Expect(ts).To(HaveKeyWithValue("sslkey", ""))
 		})
 	})
 })

--- a/umh-core/pkg/config/historian_config_test.go
+++ b/umh-core/pkg/config/historian_config_test.go
@@ -283,7 +283,8 @@ var _ = Describe("TimescaleConfig", func() {
 			Expect(m).To(HaveKeyWithValue("sslcert", "/certs/client.pem"))
 			Expect(m).To(HaveKeyWithValue("sslkey", "/certs/client.key"))
 			// Optional fields are resolved to their defaults before exposure.
-			Expect(m).To(HaveKeyWithValue("port", uint16(5432)))
+			// JSON round-trip decodes numbers as float64.
+			Expect(m).To(HaveKeyWithValue("port", float64(5432)))
 			Expect(m).To(HaveKeyWithValue("database", "umh"))
 			Expect(m).To(HaveKeyWithValue("username", "umh_owner"))
 			Expect(m).To(HaveKeyWithValue("sslmode", "require"))
@@ -340,7 +341,7 @@ var _ = Describe("TimescaleConfig", func() {
 
 			m := t.ToTemplateMap()
 
-			Expect(m).To(HaveKeyWithValue("port", uint16(6432)))
+			Expect(m).To(HaveKeyWithValue("port", float64(6432)))
 			Expect(m).To(HaveKeyWithValue("database", "metrics"))
 			Expect(m).To(HaveKeyWithValue("username", "svc"))
 			Expect(m).To(HaveKeyWithValue("sslmode", "disable"))
@@ -454,7 +455,7 @@ var _ = Describe("HistorianConfig", func() {
 			ts, ok := m["timescale"].(map[string]any)
 			Expect(ok).To(BeTrue())
 			Expect(ts).To(HaveKeyWithValue("host", "db"))
-			Expect(ts).To(HaveKeyWithValue("port", uint16(5432)))
+			Expect(ts).To(HaveKeyWithValue("port", float64(5432)))
 		})
 
 		It("returns an empty map when no timescale section is present", func() {

--- a/umh-core/pkg/config/historian_config_test.go
+++ b/umh-core/pkg/config/historian_config_test.go
@@ -263,6 +263,51 @@ var _ = Describe("TimescaleConfig", func() {
 			Expect(t.Password).To(Equal("super-secret"))
 		})
 	})
+
+	Describe("ToTemplateMap", func() {
+		It("exposes all nine keys with defaults applied", func() {
+			t := TimescaleConfig{
+				Host:        "timescale.example.com",
+				Password:    "secret",
+				SSLRootCert: "/certs/ca.pem",
+				SSLCert:     "/certs/client.pem",
+				SSLKey:      "/certs/client.key",
+			}
+
+			m := t.ToTemplateMap()
+
+			Expect(m).To(HaveLen(9))
+			Expect(m).To(HaveKeyWithValue("host", "timescale.example.com"))
+			Expect(m).To(HaveKeyWithValue("password", "secret"))
+			Expect(m).To(HaveKeyWithValue("sslrootcert", "/certs/ca.pem"))
+			Expect(m).To(HaveKeyWithValue("sslcert", "/certs/client.pem"))
+			Expect(m).To(HaveKeyWithValue("sslkey", "/certs/client.key"))
+			// Optional fields are resolved to their defaults before exposure.
+			// JSON round-trip decodes numbers as float64.
+			Expect(m).To(HaveKeyWithValue("port", float64(5432)))
+			Expect(m).To(HaveKeyWithValue("database", "umh"))
+			Expect(m).To(HaveKeyWithValue("username", "umh_owner"))
+			Expect(m).To(HaveKeyWithValue("sslmode", "require"))
+		})
+
+		It("keeps explicit optional values instead of defaults", func() {
+			t := TimescaleConfig{
+				Host:     "h",
+				Password: "p",
+				Port:     6432,
+				Database: "metrics",
+				Username: "svc",
+				SSLMode:  HistorianSSLModeDisable,
+			}
+
+			m := t.ToTemplateMap()
+
+			Expect(m).To(HaveKeyWithValue("port", float64(6432)))
+			Expect(m).To(HaveKeyWithValue("database", "metrics"))
+			Expect(m).To(HaveKeyWithValue("username", "svc"))
+			Expect(m).To(HaveKeyWithValue("sslmode", "disable"))
+		})
+	})
 })
 
 var _ = Describe("HistorianConfig", func() {
@@ -359,6 +404,23 @@ var _ = Describe("HistorianConfig", func() {
 			original := FullConfig{}
 			clone := original.Clone()
 			Expect(clone.Historian).To(BeNil())
+		})
+	})
+
+	Describe("ToTemplateMap", func() {
+		It("nests the timescale keys under a timescale sub-map", func() {
+			h := HistorianConfig{Timescale: TimescaleConfig{Host: "db", Password: "pw"}}
+
+			m := h.ToTemplateMap()
+
+			ts, ok := m["timescale"].(map[string]any)
+			Expect(ok).To(BeTrue())
+			Expect(ts).To(HaveKeyWithValue("host", "db"))
+			Expect(ts).To(HaveKeyWithValue("port", float64(5432)))
+		})
+
+		It("returns an empty map when no timescale section is present", func() {
+			Expect(HistorianConfig{}.ToTemplateMap()).To(BeEmpty())
 		})
 	})
 })

--- a/umh-core/pkg/config/historian_config_test.go
+++ b/umh-core/pkg/config/historian_config_test.go
@@ -282,8 +282,6 @@ var _ = Describe("TimescaleConfig", func() {
 			Expect(m).To(HaveKeyWithValue("sslrootcert", "/certs/ca.pem"))
 			Expect(m).To(HaveKeyWithValue("sslcert", "/certs/client.pem"))
 			Expect(m).To(HaveKeyWithValue("sslkey", "/certs/client.key"))
-			// Optional fields are resolved to their defaults before exposure.
-			// JSON round-trip decodes numbers as float64.
 			Expect(m).To(HaveKeyWithValue("port", float64(5432)))
 			Expect(m).To(HaveKeyWithValue("database", "umh"))
 			Expect(m).To(HaveKeyWithValue("username", "umh_owner"))

--- a/umh-core/pkg/config/templating.go
+++ b/umh-core/pkg/config/templating.go
@@ -236,7 +236,13 @@ func (e *TemplateRenderError) Unwrap() error { return e.YAMLErr }
 //
 // Callers **must** supply a fully-merged variable scope; the function does
 // not fetch or inject `.global`, `.internal`, or `.location` keys.
-func RenderTemplate[T any](tmpl T, scope map[string]any) (T, error) {
+//
+// Any non-empty value in secrets is masked in the returned error snippet. The
+// snippet echoes the rendered output, which may contain substituted credentials
+// (e.g. a Postgres DSN with an inlined password), and that snippet is logged
+// every reconcile tick and forwarded to the Management Console via the status
+// reason, so secrets must not survive into it.
+func RenderTemplate[T any](tmpl T, scope map[string]any, secrets ...string) (T, error) {
 	if scope == nil {
 		return *new(T), errors.New("scope cannot be nil")
 	}
@@ -263,7 +269,7 @@ func RenderTemplate[T any](tmpl T, scope map[string]any) (T, error) {
 	if err := yaml.Unmarshal(buf.Bytes(), &out); err != nil {
 		return *new(T), &TemplateRenderError{
 			YAMLErr: err,
-			Snippet: renderedRegionSnippet(buf.Bytes(), err),
+			Snippet: redactSecrets(renderedRegionSnippet(buf.Bytes(), err), secrets),
 		}
 	}
 
@@ -273,6 +279,19 @@ func RenderTemplate[T any](tmpl T, scope map[string]any) (T, error) {
 	}
 
 	return out, nil
+}
+
+// redactSecrets replaces every non-empty secret value in s with a fixed marker.
+// It is a plain substring replacement, so it masks a secret wherever it lands in
+// the rendered output, including inside a connection string.
+func redactSecrets(s string, secrets []string) string {
+	for _, secret := range secrets {
+		if secret != "" {
+			s = strings.ReplaceAll(s, secret, "[REDACTED]")
+		}
+	}
+
+	return s
 }
 
 // yamlErrorLineRegex extracts the line number from yaml.v3 error messages,

--- a/umh-core/pkg/config/templating_test.go
+++ b/umh-core/pkg/config/templating_test.go
@@ -89,6 +89,39 @@ var _ = Describe("RenderTemplate", func() {
 		})
 	})
 
+	Describe("secret redaction in the failing snippet", func() {
+		var (
+			in    renderFixture
+			scope map[string]any
+		)
+
+		BeforeEach(func() {
+			// The secret renders one line above the malformed YAML, so it lands
+			// in the reported snippet region.
+			in = renderFixture{A: "line1\n{{ .inject }}", B: "tail"}
+			scope = map[string]any{"inject": "s3cr3t-pw\nbroken: ["}
+		})
+
+		It("leaks the value into the snippet when no secrets are supplied", func() {
+			_, err := config.RenderTemplate(in, scope)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("s3cr3t-pw"))
+		})
+
+		It("masks the value when it is supplied as a secret", func() {
+			_, err := config.RenderTemplate(in, scope, "s3cr3t-pw")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).NotTo(ContainSubstring("s3cr3t-pw"))
+			Expect(err.Error()).To(ContainSubstring("[REDACTED]"))
+		})
+
+		It("ignores empty secrets", func() {
+			_, err := config.RenderTemplate(in, scope, "")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("s3cr3t-pw"))
+		})
+	})
+
 	Describe("errors before the unmarshal step", func() {
 		It("does not attach a snippet to template execution errors", func() {
 			in := renderFixture{A: "{{ .missing }}", B: "static"}

--- a/umh-core/pkg/config/templating_test.go
+++ b/umh-core/pkg/config/templating_test.go
@@ -96,8 +96,6 @@ var _ = Describe("RenderTemplate", func() {
 		)
 
 		BeforeEach(func() {
-			// The secret renders one line above the malformed YAML, so it lands
-			// in the reported snippet region.
 			in = renderFixture{A: "line1\n{{ .inject }}", B: "tail"}
 			scope = map[string]any{"inject": "s3cr3t-pw\nbroken: ["}
 		})

--- a/umh-core/pkg/fsm/protocolconverter/actions.go
+++ b/umh-core/pkg/fsm/protocolconverter/actions.go
@@ -334,6 +334,7 @@ func (p *ProtocolConverterInstance) UpdateObservedStateOfInstance(ctx context.Co
 		p.specConfig,
 		agentLocationStr,
 		nil, // TODO: add global vars
+		snapshot.CurrentConfig.Historian,
 		runtime_config.BridgedByPlaceholder,
 		p.baseFSMInstance.GetID(),
 	)

--- a/umh-core/pkg/service/protocolconverter/protocolconverter_test.go
+++ b/umh-core/pkg/service/protocolconverter/protocolconverter_test.go
@@ -117,7 +117,7 @@ var _ = Describe("DataFlowComponentService", func() {
 			mockConn.ServiceExistsResult = false
 
 			var err error
-			runtimeCfg, err = runtime_config.BuildRuntimeConfig(cfg, nil, nil, "", protConvName)
+			runtimeCfg, err = runtime_config.BuildRuntimeConfig(cfg, nil, nil, nil, "", protConvName)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -210,7 +210,7 @@ var _ = Describe("DataFlowComponentService", func() {
 			}
 
 			var err error
-			runtimeCfg, err = runtime_config.BuildRuntimeConfig(cfg, nil, nil, "", protConvName)
+			runtimeCfg, err = runtime_config.BuildRuntimeConfig(cfg, nil, nil, nil, "", protConvName)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Use the official mock manager from the FSM package
@@ -298,10 +298,10 @@ var _ = Describe("DataFlowComponentService", func() {
 			}
 
 			var err error
-			runtimeCfg, err = runtime_config.BuildRuntimeConfig(config, nil, nil, "", protConvName)
+			runtimeCfg, err = runtime_config.BuildRuntimeConfig(config, nil, nil, nil, "", protConvName)
 			Expect(err).NotTo(HaveOccurred())
 
-			updatedRuntimeCfg, err = runtime_config.BuildRuntimeConfig(updatedConfig, nil, nil, "", protConvName)
+			updatedRuntimeCfg, err = runtime_config.BuildRuntimeConfig(updatedConfig, nil, nil, nil, "", protConvName)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Add the component first
@@ -388,7 +388,7 @@ var _ = Describe("DataFlowComponentService", func() {
 			}
 
 			var err error
-			runtimeCfg, err = runtime_config.BuildRuntimeConfig(cfg, nil, nil, "", protConvName)
+			runtimeCfg, err = runtime_config.BuildRuntimeConfig(cfg, nil, nil, nil, "", protConvName)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Add the component first
@@ -495,7 +495,7 @@ var _ = Describe("DataFlowComponentService", func() {
 			}
 
 			var err error
-			runtimeCfg, err = runtime_config.BuildRuntimeConfig(cfg, nil, nil, "", protConvName)
+			runtimeCfg, err = runtime_config.BuildRuntimeConfig(cfg, nil, nil, nil, "", protConvName)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Add the component first
@@ -554,7 +554,7 @@ var _ = Describe("DataFlowComponentService", func() {
 				},
 			}
 
-			runtimeCfg, err := runtime_config.BuildRuntimeConfig(cfg, nil, nil, "", protConvName)
+			runtimeCfg, err := runtime_config.BuildRuntimeConfig(cfg, nil, nil, nil, "", protConvName)
 			Expect(err).NotTo(HaveOccurred())
 
 			err = service.AddToManager(ctx, mockSvcRegistry.GetFileSystem(), &runtimeCfg, protConvName, false)
@@ -613,7 +613,7 @@ var _ = Describe("DataFlowComponentService", func() {
 				},
 			}
 
-			runtimeCfg, err := runtime_config.BuildRuntimeConfig(cfg, nil, nil, "", testComponentName)
+			runtimeCfg, err := runtime_config.BuildRuntimeConfig(cfg, nil, nil, nil, "", testComponentName)
 			Expect(err).NotTo(HaveOccurred())
 
 			err = testService.AddToManager(ctx, mockSvcRegistry.GetFileSystem(), &runtimeCfg, testComponentName, false)
@@ -698,7 +698,7 @@ var _ = Describe("DataFlowComponentService", func() {
 			}
 
 			// Build the runtime config
-			runtimeCfg, err := runtime_config.BuildRuntimeConfig(spec, agentLocation, globalVars, "test-node", "test-pc")
+			runtimeCfg, err := runtime_config.BuildRuntimeConfig(spec, agentLocation, globalVars, nil, "test-node", "test-pc")
 			Expect(err).NotTo(HaveOccurred())
 
 			// 1. Verify user variables are rendered
@@ -719,7 +719,7 @@ var _ = Describe("DataFlowComponentService", func() {
 
 		It("should handle nil inputs gracefully", func() {
 			// Test with nil spec
-			_, err := runtime_config.BuildRuntimeConfig(protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec{}, nil, nil, "", "")
+			_, err := runtime_config.BuildRuntimeConfig(protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec{}, nil, nil, nil, "", "")
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("nil spec"))
 
@@ -748,7 +748,7 @@ var _ = Describe("DataFlowComponentService", func() {
 					},
 				},
 			}
-			runtimeCfg, err := runtime_config.BuildRuntimeConfig(spec, nil, nil, "", "test-pc")
+			runtimeCfg, err := runtime_config.BuildRuntimeConfig(spec, nil, nil, nil, "", "test-pc")
 			Expect(err).NotTo(HaveOccurred())
 			// User variable rendered
 			Expect(runtimeCfg.ConnectionServiceConfig.NmapServiceConfig.Target).To(Equal("test-value"))
@@ -778,12 +778,12 @@ var _ = Describe("DataFlowComponentService", func() {
 			}
 
 			// Test with special characters
-			runtimeCfg, err := runtime_config.BuildRuntimeConfig(spec, nil, nil, "test@node", "test.pc")
+			runtimeCfg, err := runtime_config.BuildRuntimeConfig(spec, nil, nil, nil, "test@node", "test.pc")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(runtimeCfg.DataflowComponentReadServiceConfig.BenthosConfig.Input["random_input"].(map[string]interface{})["bridged_by"]).To(Equal("protocol-converter_test-node_test-pc"))
 
 			// Test with multiple special characters
-			runtimeCfg, err = runtime_config.BuildRuntimeConfig(spec, nil, nil, "test@node#1", "test.pc@2")
+			runtimeCfg, err = runtime_config.BuildRuntimeConfig(spec, nil, nil, nil, "test@node#1", "test.pc@2")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(runtimeCfg.DataflowComponentReadServiceConfig.BenthosConfig.Input["random_input"].(map[string]interface{})["bridged_by"]).To(Equal("protocol-converter_test-node-1_test-pc-2"))
 		})

--- a/umh-core/pkg/service/protocolconverter/runtime_config/runtime_config.go
+++ b/umh-core/pkg/service/protocolconverter/runtime_config/runtime_config.go
@@ -81,6 +81,7 @@ func BuildRuntimeConfig(
 	spec protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec,
 	agentLocation map[string]string,
 	globalVars map[string]any,
+	historian *config.HistorianConfig,
 	nodeName string,
 	pcName string,
 ) (protocolconverterserviceconfig.ProtocolConverterServiceConfigRuntime, error) {
@@ -183,6 +184,29 @@ func BuildRuntimeConfig(
 	vb.User["location"] = loc
 	vb.User["location_path"] = locationPath
 
+	// Expose historian settings so bridge templates can reference the connection
+	// as `{{ .historian.timescale.host }}`, mirroring the `historian.timescale`
+	// shape in config.yaml. `historian` is a reserved template variable: like
+	// `location` and `location_path` above, it overrides any user variable of the
+	// same name.
+	//
+	// A present-but-invalid historian is treated as absent, so injection happens
+	// only when Validate passes. Injecting an invalid historian would render
+	// empty required fields (host/password) into a silently broken connection;
+	// leaving it out instead makes a template that references the historian fail
+	// the render with a missingkey error, which BuildRuntimeConfig rewrites into
+	// an actionable message below. A bridge that does not reference the historian
+	// is unaffected either way.
+	var secrets []string
+
+	historianUsable := historian != nil && historian.Validate() == nil
+	if historianUsable {
+		vb.User["historian"] = historian.ToTemplateMap()
+		if historian.Timescale.Password != "" {
+			secrets = append(secrets, historian.Timescale.Password)
+		}
+	}
+
 	if len(globalVars) != 0 {
 		vb.Global = globalVars
 	}
@@ -206,7 +230,20 @@ func BuildRuntimeConfig(
 	//----------------------------------------------------------------------
 	scope := vb.Flatten()
 
-	return renderConfig(spec, scope) // unexported helper that enforces UNS
+	runtime, err := renderConfig(spec, scope, secrets) // unexported helper that enforces UNS
+	if err != nil && !historianUsable && referencesMissingHistorian(err) {
+		return runtime, fmt.Errorf(
+			"this bridge references {{ .historian.* }} but no valid historian: section is configured in config.yaml; add or fix it: %w", err)
+	}
+
+	return runtime, err
+}
+
+// referencesMissingHistorian reports whether err is the text/template
+// missingkey failure raised when a template references `{{ .historian.* }}`
+// while the `historian` key is absent from the render scope.
+func referencesMissingHistorian(err error) bool {
+	return err != nil && strings.Contains(err.Error(), `no entry for key "historian"`)
 }
 
 // renderConfig turns the **author-facing** specification (*Spec*) into the
@@ -271,6 +308,7 @@ func BuildRuntimeConfig(
 func renderConfig(
 	spec protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec,
 	scope map[string]any,
+	secrets []string,
 ) (
 	protocolconverterserviceconfig.ProtocolConverterServiceConfigRuntime,
 	error,
@@ -284,7 +322,7 @@ func renderConfig(
 
 	// 1. Render the connection template with variable substitution
 	// This converts template strings like "{{ .PORT }}" to actual values
-	conn, err := config.RenderTemplate(spec.GetConnectionServiceConfig(), scope)
+	conn, err := config.RenderTemplate(spec.GetConnectionServiceConfig(), scope, secrets...)
 	if err != nil {
 		return protocolconverterserviceconfig.ProtocolConverterServiceConfigRuntime{}, err
 	}
@@ -296,7 +334,7 @@ func renderConfig(
 		return protocolconverterserviceconfig.ProtocolConverterServiceConfigRuntime{}, fmt.Errorf("failed to convert connection template to runtime: %w", err)
 	}
 
-	read, err := config.RenderTemplate(spec.GetDFCReadServiceConfig(), scope)
+	read, err := config.RenderTemplate(spec.GetDFCReadServiceConfig(), scope, secrets...)
 	if err != nil {
 		return protocolconverterserviceconfig.ProtocolConverterServiceConfigRuntime{}, err
 	}
@@ -310,7 +348,7 @@ func renderConfig(
 	}
 
 	// Render the write DFC template (resolves {{ .IP }}, {{ .PORT }}, etc. in Source.Topics and Destination.Code).
-	renderedWriteConfig, err := config.RenderTemplate(spec.Config.DataflowComponentWriteServiceConfig, scope)
+	renderedWriteConfig, err := config.RenderTemplate(spec.Config.DataflowComponentWriteServiceConfig, scope, secrets...)
 	if err != nil {
 		return protocolconverterserviceconfig.ProtocolConverterServiceConfigRuntime{}, err
 	}

--- a/umh-core/pkg/service/protocolconverter/runtime_config/runtime_config_test.go
+++ b/umh-core/pkg/service/protocolconverter/runtime_config/runtime_config_test.go
@@ -76,7 +76,7 @@ var _ = Describe("BuildRuntimeConfig", func() {
 
 	Describe("BuildRuntimeConfig", func() {
 		It("should successfully build runtime config from example config", func() {
-			result, err := runtime_config.BuildRuntimeConfig(spec, agentLocation, globalVars, nodeName, pcName)
+			result, err := runtime_config.BuildRuntimeConfig(spec, agentLocation, globalVars, nil, nodeName, pcName)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Verify the runtime config structure
@@ -93,7 +93,7 @@ var _ = Describe("BuildRuntimeConfig", func() {
 		})
 
 		It("should properly merge agent and PC locations", func() {
-			result, err := runtime_config.BuildRuntimeConfig(spec, agentLocation, globalVars, nodeName, pcName)
+			result, err := runtime_config.BuildRuntimeConfig(spec, agentLocation, globalVars, nil, nodeName, pcName)
 			Expect(err).NotTo(HaveOccurred())
 
 			// The location should be properly merged and accessible via variables
@@ -102,7 +102,7 @@ var _ = Describe("BuildRuntimeConfig", func() {
 		})
 
 		It("should handle template variable substitution", func() {
-			result, err := runtime_config.BuildRuntimeConfig(spec, agentLocation, globalVars, nodeName, pcName)
+			result, err := runtime_config.BuildRuntimeConfig(spec, agentLocation, globalVars, nil, nodeName, pcName)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Check that template variables {{ .IP }} and {{ .PORT }} have been substituted
@@ -111,7 +111,7 @@ var _ = Describe("BuildRuntimeConfig", func() {
 		})
 
 		It("should generate proper bridged_by header", func() {
-			result, err := runtime_config.BuildRuntimeConfig(spec, agentLocation, globalVars, nodeName, pcName)
+			result, err := runtime_config.BuildRuntimeConfig(spec, agentLocation, globalVars, nil, nodeName, pcName)
 			Expect(err).NotTo(HaveOccurred())
 
 			// We can't directly check the bridged_by header, but the function should succeed
@@ -126,7 +126,7 @@ var _ = Describe("BuildRuntimeConfig", func() {
 				"3": "workstation-5", // Gap at levels 1,2
 			}
 
-			result, err := runtime_config.BuildRuntimeConfig(spec, incompleteLocation, globalVars, nodeName, pcName)
+			result, err := runtime_config.BuildRuntimeConfig(spec, incompleteLocation, globalVars, nil, nodeName, pcName)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Should fill gaps with "unknown" and not fail
@@ -136,20 +136,20 @@ var _ = Describe("BuildRuntimeConfig", func() {
 		It("should return error for empty spec", func() {
 			emptySpec := protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec{}
 
-			result, err := runtime_config.BuildRuntimeConfig(emptySpec, agentLocation, globalVars, nodeName, pcName)
+			result, err := runtime_config.BuildRuntimeConfig(emptySpec, agentLocation, globalVars, nil, nodeName, pcName)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("nil spec"))
 			Expect(result).To(Equal(protocolconverterserviceconfig.ProtocolConverterServiceConfigRuntime{}))
 		})
 
 		It("should handle empty global vars", func() {
-			result, err := runtime_config.BuildRuntimeConfig(spec, agentLocation, nil, nodeName, pcName)
+			result, err := runtime_config.BuildRuntimeConfig(spec, agentLocation, nil, nil, nodeName, pcName)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).NotTo(BeZero())
 		})
 
 		It("should handle empty node name", func() {
-			result, err := runtime_config.BuildRuntimeConfig(spec, agentLocation, globalVars, "", pcName)
+			result, err := runtime_config.BuildRuntimeConfig(spec, agentLocation, globalVars, nil, "", pcName)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).NotTo(BeZero())
 		})
@@ -157,12 +157,102 @@ var _ = Describe("BuildRuntimeConfig", func() {
 
 	Describe("Variable expansion", func() {
 		It("should expand all template variables correctly", func() {
-			result, err := runtime_config.BuildRuntimeConfig(spec, agentLocation, globalVars, nodeName, pcName)
+			result, err := runtime_config.BuildRuntimeConfig(spec, agentLocation, globalVars, nil, nodeName, pcName)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Verify that no template strings remain (no {{ }} patterns)
 			Expect(result.ConnectionServiceConfig.NmapServiceConfig.Target).NotTo(ContainSubstring("{{"))
 			Expect(result.ConnectionServiceConfig.NmapServiceConfig.Target).NotTo(ContainSubstring("}}"))
+		})
+	})
+
+	Describe("Historian variable injection", func() {
+		historianRefSpec := func(target, port string) protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec {
+			return protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec{
+				Config: protocolconverterserviceconfig.ProtocolConverterServiceConfigTemplate{
+					ConnectionServiceConfig: connectionserviceconfig.ConnectionServiceConfigTemplate{
+						NmapTemplate: &connectionserviceconfig.NmapConfigTemplate{
+							Target: target,
+							Port:   port,
+						},
+					},
+				},
+			}
+		}
+
+		It("should expose historian settings as {{ .historian.timescale.* }} in templates", func() {
+			historian := &config.HistorianConfig{
+				Timescale: config.TimescaleConfig{
+					Host:     "timescale.internal",
+					Password: "secret",
+					Port:     6432,
+				},
+			}
+
+			result, err := runtime_config.BuildRuntimeConfig(
+				historianRefSpec("{{ .historian.timescale.host }}", "{{ .historian.timescale.port }}"),
+				agentLocation, globalVars, historian, nodeName, pcName)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(result.ConnectionServiceConfig.NmapServiceConfig.Target).To(Equal("timescale.internal"))
+			Expect(result.ConnectionServiceConfig.NmapServiceConfig.Port).To(Equal(uint16(6432)))
+		})
+
+		It("should apply historian defaults before rendering", func() {
+			historian := &config.HistorianConfig{
+				Timescale: config.TimescaleConfig{Host: "h", Password: "p"},
+			}
+
+			result, err := runtime_config.BuildRuntimeConfig(
+				historianRefSpec("{{ .historian.timescale.database }}", "{{ .historian.timescale.port }}"),
+				agentLocation, globalVars, historian, nodeName, pcName)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(result.ConnectionServiceConfig.NmapServiceConfig.Target).To(Equal("umh"))
+			Expect(result.ConnectionServiceConfig.NmapServiceConfig.Port).To(Equal(uint16(5432)))
+		})
+
+		It("should fail with an actionable error when historian is referenced but not configured", func() {
+			_, err := runtime_config.BuildRuntimeConfig(
+				historianRefSpec("{{ .historian.timescale.host }}", "8080"),
+				agentLocation, globalVars, nil, nodeName, pcName)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("no valid historian: section is configured"))
+		})
+
+		It("should treat a present-but-invalid historian as absent for a referencing template", func() {
+			// Missing required Password, so Validate fails and it is not injected.
+			invalid := &config.HistorianConfig{Timescale: config.TimescaleConfig{Host: "timescale.internal"}}
+
+			_, err := runtime_config.BuildRuntimeConfig(
+				historianRefSpec("{{ .historian.timescale.host }}", "8080"),
+				agentLocation, globalVars, invalid, nodeName, pcName)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("no valid historian: section is configured"))
+		})
+
+		It("should not fail a non-referencing template when historian is present-but-invalid", func() {
+			invalid := &config.HistorianConfig{Timescale: config.TimescaleConfig{Host: "timescale.internal"}}
+
+			result, err := runtime_config.BuildRuntimeConfig(
+				historianRefSpec("static-host", "8080"),
+				agentLocation, globalVars, invalid, nodeName, pcName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.ConnectionServiceConfig.NmapServiceConfig.Target).To(Equal("static-host"))
+		})
+
+		It("should render the historian password into the runtime config so Benthos can connect", func() {
+			historian := &config.HistorianConfig{
+				Timescale: config.TimescaleConfig{Host: "h", Password: "s3cr3t-pw"},
+			}
+
+			result, err := runtime_config.BuildRuntimeConfig(
+				historianRefSpec("{{ .historian.timescale.password }}", "{{ .historian.timescale.port }}"),
+				agentLocation, globalVars, historian, nodeName, pcName)
+			Expect(err).NotTo(HaveOccurred())
+			// Redaction only masks the error snippet; the real value must still
+			// reach the rendered runtime config.
+			Expect(result.ConnectionServiceConfig.NmapServiceConfig.Target).To(Equal("s3cr3t-pw"))
 		})
 	})
 
@@ -186,7 +276,7 @@ var _ = Describe("BuildRuntimeConfig", func() {
 				},
 			}
 
-			result, err := runtime_config.BuildRuntimeConfig(testSpec, agentLocation, globalVars, nodeName, pcName)
+			result, err := runtime_config.BuildRuntimeConfig(testSpec, agentLocation, globalVars, nil, nodeName, pcName)
 			Expect(err).NotTo(HaveOccurred())
 
 			writeInput := result.DataflowComponentWriteServiceConfig.BenthosConfig.Input
@@ -208,7 +298,7 @@ var _ = Describe("BuildRuntimeConfig", func() {
 				},
 			}
 
-			result, err := runtime_config.BuildRuntimeConfig(testSpec, agentLocation, globalVars, nodeName, pcName)
+			result, err := runtime_config.BuildRuntimeConfig(testSpec, agentLocation, globalVars, nil, nodeName, pcName)
 			Expect(err).NotTo(HaveOccurred())
 
 			writeInput := result.DataflowComponentWriteServiceConfig.BenthosConfig.Input
@@ -226,7 +316,7 @@ var _ = Describe("BuildRuntimeConfig", func() {
 				},
 			}
 
-			result, err := runtime_config.BuildRuntimeConfig(testSpec, agentLocation, globalVars, nodeName, pcName)
+			result, err := runtime_config.BuildRuntimeConfig(testSpec, agentLocation, globalVars, nil, nodeName, pcName)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.DataflowComponentWriteServiceConfig.BenthosConfig.Input).To(BeEmpty())
 		})
@@ -262,7 +352,7 @@ var _ = Describe("BuildRuntimeConfig", func() {
 				},
 			}
 
-			result, err := runtime_config.BuildRuntimeConfig(testSpec, agentLocation, globalVars, nodeName, pcName)
+			result, err := runtime_config.BuildRuntimeConfig(testSpec, agentLocation, globalVars, nil, nodeName, pcName)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Check that NO downsampler was injected (since no tag_processor)
@@ -303,7 +393,7 @@ var _ = Describe("BuildRuntimeConfig", func() {
 				},
 			}
 
-			result, err := runtime_config.BuildRuntimeConfig(testSpec, agentLocation, globalVars, nodeName, pcName)
+			result, err := runtime_config.BuildRuntimeConfig(testSpec, agentLocation, globalVars, nil, nodeName, pcName)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Check that NO downsampler was injected (multiple processors = custom)
@@ -364,7 +454,7 @@ var _ = Describe("BuildRuntimeConfig", func() {
 				},
 			}
 
-			result, err := runtime_config.BuildRuntimeConfig(testSpec, agentLocation, globalVars, nodeName, pcName)
+			result, err := runtime_config.BuildRuntimeConfig(testSpec, agentLocation, globalVars, nil, nodeName, pcName)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Should not inject additional downsampler
@@ -414,7 +504,7 @@ var _ = Describe("BuildRuntimeConfig", func() {
 				},
 			}
 
-			result, err := runtime_config.BuildRuntimeConfig(testSpec, agentLocation, globalVars, nodeName, pcName)
+			result, err := runtime_config.BuildRuntimeConfig(testSpec, agentLocation, globalVars, nil, nodeName, pcName)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Check that NO downsampler was injected (nodered_js is relational, not timeseries)
@@ -449,7 +539,7 @@ var _ = Describe("BuildRuntimeConfig", func() {
 				},
 			}
 
-			result, err := runtime_config.BuildRuntimeConfig(testSpec, agentLocation, globalVars, nodeName, pcName)
+			result, err := runtime_config.BuildRuntimeConfig(testSpec, agentLocation, globalVars, nil, nodeName, pcName)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Should NOT create pipeline with downsampler (no tag_processor)
@@ -479,7 +569,7 @@ var _ = Describe("BuildRuntimeConfig", func() {
 				},
 			}
 
-			_, err := runtime_config.BuildRuntimeConfig(testSpec, agentLocation, globalVars, nodeName, pcName)
+			_, err := runtime_config.BuildRuntimeConfig(testSpec, agentLocation, globalVars, nil, nodeName, pcName)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -494,7 +584,7 @@ var _ = Describe("BuildRuntimeConfig", func() {
 				},
 			}
 
-			_, err := runtime_config.BuildRuntimeConfig(testSpec, agentLocation, globalVars, nodeName, pcName)
+			_, err := runtime_config.BuildRuntimeConfig(testSpec, agentLocation, globalVars, nil, nodeName, pcName)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -509,7 +599,7 @@ var _ = Describe("BuildRuntimeConfig", func() {
 				},
 			}
 
-			runtimeConfig, err := runtime_config.BuildRuntimeConfig(testSpec, agentLocation, globalVars, nodeName, pcName)
+			runtimeConfig, err := runtime_config.BuildRuntimeConfig(testSpec, agentLocation, globalVars, nil, nodeName, pcName)
 			Expect(err).NotTo(HaveOccurred())
 
 			writeDFC := runtimeConfig.DataflowComponentWriteServiceConfig

--- a/umh-core/pkg/service/protocolconverter/runtime_config/runtime_config_test.go
+++ b/umh-core/pkg/service/protocolconverter/runtime_config/runtime_config_test.go
@@ -212,6 +212,31 @@ var _ = Describe("BuildRuntimeConfig", func() {
 			Expect(result.ConnectionServiceConfig.NmapServiceConfig.Port).To(Equal(uint16(5432)))
 		})
 
+		It("should resolve a template referencing every historian field when the TLS certs are unset", func() {
+			historian := &config.HistorianConfig{
+				Timescale: config.TimescaleConfig{Host: "timescale.internal", Password: "secret"},
+			}
+
+			allFields := "{{ .historian.timescale.host }}|" +
+				"{{ .historian.timescale.port }}|" +
+				"{{ .historian.timescale.database }}|" +
+				"{{ .historian.timescale.username }}|" +
+				"{{ .historian.timescale.password }}|" +
+				"{{ .historian.timescale.sslmode }}|" +
+				"{{ .historian.timescale.sslrootcert }}|" +
+				"{{ .historian.timescale.sslcert }}|" +
+				"{{ .historian.timescale.sslkey }}"
+
+			result, err := runtime_config.BuildRuntimeConfig(
+				historianRefSpec(allFields, "{{ .historian.timescale.port }}"),
+				agentLocation, globalVars, historian, nodeName, pcName)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(result.ConnectionServiceConfig.NmapServiceConfig.Target).To(
+				Equal("timescale.internal|5432|umh|umh_owner|secret|require|||"))
+			Expect(result.ConnectionServiceConfig.NmapServiceConfig.Port).To(Equal(uint16(5432)))
+		})
+
 		It("should fail with an actionable error when historian is referenced but not configured", func() {
 			_, err := runtime_config.BuildRuntimeConfig(
 				historianRefSpec("{{ .historian.timescale.host }}", "8080"),

--- a/umh-core/test/fsm/protocolconverter/logging_inversion_test.go
+++ b/umh-core/test/fsm/protocolconverter/logging_inversion_test.go
@@ -103,6 +103,7 @@ var _ = Describe("ConfigDivergence reset and staging", func() {
 			cfg,
 			map[string]string{},
 			nil,
+			nil,
 			runtime_config.BridgedByPlaceholder,
 			componentName,
 		)
@@ -247,6 +248,7 @@ var _ = Describe("ConfigDivergence composition into StatusReason", func() {
 			cfg,
 			map[string]string{},
 			nil,
+			nil,
 			runtime_config.BridgedByPlaceholder,
 			componentName,
 		)
@@ -366,6 +368,7 @@ var _ = Describe("ConfigDivergence composition into StatusReason", func() {
 		rendered, err := runtime_config.BuildRuntimeConfig(
 			cfg,
 			map[string]string{},
+			nil,
 			nil,
 			runtime_config.BridgedByPlaceholder,
 			componentName,
@@ -516,6 +519,7 @@ var _ = Describe("Heartbeat WARN on the PC divergence branch", func() {
 			cfg,
 			map[string]string{},
 			nil,
+			nil,
 			runtime_config.BridgedByPlaceholder,
 			componentName,
 		)
@@ -652,6 +656,7 @@ var _ = Describe("Capstone: full Reconcile lifecycle under sustained divergence"
 		rendered, err := runtime_config.BuildRuntimeConfig(
 			cfg,
 			map[string]string{},
+			nil,
 			nil,
 			runtime_config.BridgedByPlaceholder,
 			componentName,


### PR DESCRIPTION
Lets a bridge reference the shared historian connection from `config.yaml`, so a bridge that saves to the historian no longer re-enters the TimescaleDB credentials. umh-core side of "Save to Historian" in [ENG-5098](https://linear.app/united-manufacturing-hub/issue/ENG-5098).

## What it does

- Bridge templates reference the connection as `{{ .historian.timescale.host }}`, `{{ .historian.timescale.port }}`, and the other fields, mirroring the `historian.timescale` block in `config.yaml`.
- A bridge re-renders (and re-deploys) when the shared `historian` block changes.
- A bridge that references the historian while none is configured fails with an actionable error naming the missing `historian:` section, not a raw template error.

## Hardening (from review)

- The historian password stays out of logs and the Management Console status reason: it is masked in the render-error snippet. The real value still reaches the on-disk runtime config so Benthos can connect. Complements the get-historian reply redaction in the base PR.
- Only a valid historian is injected. A present-but-invalid one is treated as absent, so a referencing bridge fails loudly instead of rendering empty credentials; a bridge that does not reference it is unaffected.
- The edit verify-render propagates a config-read failure instead of continuing with no historian. Previously that could roll a valid edit back with a misleading "invalid YAML" message.

## Base

Stacked on [ENG-5318](https://linear.app/united-manufacturing-hub/issue/ENG-5318) (`eng-5318-historian-crud-actions-in-umh-core`); rebased onto its `historian.timescale` nesting.

## For ManagementConsole

The generated historian benthos template must emit `{{ .historian.timescale.* }}` to match this shape.

## Tests

Template map contract (key set is now value-independent, locked by `TimescaleTemplateKeys`), secret redaction, present-but-invalid handling, the config-read-failure path, and the edit verify-render wiring. A `BuildRuntimeConfig` test also renders a bridge that references every `{{ .historian.timescale.* }}` field — including the `ssl*` cert paths — with no TLS certs configured, and asserts it resolves: the regression guard for the deploy timeout (re-adding `json:omitempty` makes it fail with the original `map has no entry for key "sslrootcert"`).

## Review follow-ups

- `ToTemplateMap` keeps the `json.Marshal`/`json.Unmarshal` round-trip, so a new connection field (or a future `grafana:` sub-block) reaches templates without editing the function. The optional TLS cert fields (`sslrootcert`/`sslcert`/`sslkey`) drop `json:omitempty` so an unset cert survives the round-trip as an empty key instead of vanishing — otherwise, under the default `sslmode=require`, a bridge referencing `{{ .historian.timescale.sslrootcert }}` trips `RenderTemplate`'s `missingkey=error`, renders an empty benthos config, and times out on deploy. `yaml:omitempty` stays, so `config.yaml` still omits unset certs; the `get-historian` reply now carries the empty cert fields. A `TimescaleTemplateKeys` test locks the exposed key set and fails if `omitempty` is re-added.
