### PR TITLE
fix: missing datacontract no longer skips all newer contracts

### DIFF
--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- A misconfigured data contract no longer stops your other data contracts from being set up. Valid contracts are now registered and validated as usual, while the misconfigured one is skipped and reported as a warning
+
 ## [0.44.31]
 
 ### Improvements
@@ -22,16 +26,11 @@
 ## [0.44.29]
 
 ### New Features
-
 - Preview: an instance can now store a connection to an external TimescaleDB or PostgreSQL historian database (host, port, database, login, and TLS mode), which can be created, viewed, updated, and removed. Storing the connection does not yet route any data to it
 
 ### Improvements
 
 - The full bridge and stream-processor configuration is no longer written to the umh-core log at INFO on every internal re-apply (moved to DEBUG), removing a source of log flooding and CPU pressure when a config keeps being re-applied. While a bridge's observed config differs from its desired config, its status in the Management Console now shows a bounded summary of what differs, and the umh-core log carries one warning per bridge per minute, so the cause is visible without enabling debug logging
-
-### Fixes
-
-- A misconfigured data contract no longer stops your other data contracts from being set up. Valid contracts are now registered and validated as usual, while the misconfigured one is skipped and reported as a warning
 
 ## [0.44.28]
 

--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -22,11 +22,16 @@
 ## [0.44.29]
 
 ### New Features
+
 - Preview: an instance can now store a connection to an external TimescaleDB or PostgreSQL historian database (host, port, database, login, and TLS mode), which can be created, viewed, updated, and removed. Storing the connection does not yet route any data to it
 
 ### Improvements
 
 - The full bridge and stream-processor configuration is no longer written to the umh-core log at INFO on every internal re-apply (moved to DEBUG), removing a source of log flooding and CPU pressure when a config keeps being re-applied. While a bridge's observed config differs from its desired config, its status in the Management Console now shows a bounded summary of what differs, and the umh-core log carries one warning per bridge per minute, so the cause is visible without enabling debug logging
+
+### Fixes
+
+- A data contract with a missing data model no longer blocks your other contracts from getting their schemas. Previously one broken contract stopped schema registration for all of them, so the UNS output skipped validation and accepted wrong data types. Valid contracts now register normally; broken ones are logged and skipped
 
 ## [0.44.28]
 

--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -31,7 +31,7 @@
 
 ### Fixes
 
-- A data contract with a missing data model no longer blocks your other contracts from getting their schemas. Previously one broken contract stopped schema registration for all of them, so the UNS output skipped validation and accepted wrong data types. Valid contracts now register normally; broken ones are logged and skipped
+- A misconfigured data contract no longer stops your other data contracts from being set up. Valid contracts are now registered and validated as usual, while the misconfigured one is skipped and reported as a warning
 
 ## [0.44.28]
 

--- a/umh-core/docs/reference/environment-variables.md
+++ b/umh-core/docs/reference/environment-variables.md
@@ -4,7 +4,7 @@ This is the reference for all environment variables used by umh-core. These vari
 
 | Name             | Values                                                                 | Description                                          |
 | ---------------- | ---------------------------------------------------------------------- | ---------------------------------------------------- |
-| LOGGING\_LEVEL   | PRODUCTION, DEBUG                                                      | Controls log verbosity. DEBUG shows detailed internal operations |
+| LOGGING\_LEVEL   | ERROR, WARN, INFO, DEBUG                                                      | Controls log verbosity. DEBUG shows detailed internal operations |
 | AUTH\_TOKEN      | (Base64 encoded token)                                                 | Management Console authentication token. Overrides auth token from config.yaml |
 | API\_URL         | https://management.umh.app/api, https://staging.management.umh.app/api | Management Console API endpoint. Use staging for testing environments |
 | RELEASE\_CHANNEL | enterprise, stable, nightly                                            | Auto-update channel. Enterprise = most stable, nightly = latest features |

--- a/umh-core/pkg/service/redpanda/redpanda_test.go
+++ b/umh-core/pkg/service/redpanda/redpanda_test.go
@@ -693,8 +693,8 @@ var _ = Describe("SchemaRegistry translation", func() {
 				},
 			}
 			dataContracts := []config.DataContractsConfig{
+				{Name: "_work_order_v1", Model: &config.ModelRef{Name: "work_order", Version: "v1"}},
 				{Name: "_typevalidation_v1", Model: &config.ModelRef{Name: "typevalidation", Version: "v1"}},
-				{Name: "_work_order_v1", Model: &config.ModelRef{Name: "work_order", Version: "v1"}}, // model deleted
 			}
 
 			schemas, skipPrefixes, err := registry.translateToSchemas(context.Background(), dataModels, dataContracts, map[string]config.PayloadShape{})

--- a/umh-core/pkg/service/redpanda/redpanda_test.go
+++ b/umh-core/pkg/service/redpanda/redpanda_test.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/redpandaserviceconfig"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/s6serviceconfig"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants"
@@ -75,7 +76,8 @@ var _ = Describe("Redpanda Service", func() {
 
 		schemaRegistry := NewSchemaRegistry(WithSchemaRegistryAddress(mockSchemaRegistry.URL()))
 
-		service = NewDefaultRedpandaService("redpanda",
+		service = NewDefaultRedpandaService(
+			"redpanda",
 			WithSchemaRegistryManager(schemaRegistry),
 		)
 		tick = 0
@@ -163,7 +165,8 @@ var _ = Describe("Redpanda Service", func() {
 
 			schemaRegistry := NewSchemaRegistry(WithSchemaRegistryAddress(mockSchemaRegistry.URL()))
 
-			service = NewDefaultRedpandaService("redpanda",
+			service = NewDefaultRedpandaService(
+				"redpanda",
 				WithS6Service(mockS6Service),
 				WithSchemaRegistryManager(schemaRegistry),
 			)
@@ -275,7 +278,8 @@ var _ = Describe("Redpanda Service", func() {
 
 			schemaRegistry := NewSchemaRegistry(WithSchemaRegistryAddress(mockSchemaRegistry.URL()))
 
-			service = NewDefaultRedpandaService("redpanda",
+			service = NewDefaultRedpandaService(
+				"redpanda",
 				WithSchemaRegistryManager(schemaRegistry),
 			)
 
@@ -405,7 +409,8 @@ var _ = Describe("Redpanda Service", func() {
 		)
 
 		BeforeEach(func() {
-			service = NewDefaultRedpandaService("redpanda",
+			service = NewDefaultRedpandaService(
+				"redpanda",
 				WithSchemaRegistryManager(NewNoOpSchemaRegistry()),
 			)
 			currentTime = time.Now()
@@ -618,7 +623,8 @@ var _ = Describe("Redpanda Service", func() {
 
 			schemaRegistry := NewSchemaRegistry(WithSchemaRegistryAddress(mockSchemaRegistry.URL()))
 
-			service = NewDefaultRedpandaService("redpanda",
+			service = NewDefaultRedpandaService(
+				"redpanda",
 				WithS6Service(mockS6Service),
 				WithSchemaRegistryManager(schemaRegistry),
 			)
@@ -661,6 +667,63 @@ var _ = Describe("Redpanda Service", func() {
 
 			// Verify error is propagated
 			Expect(err).To(MatchError(mockError))
+		})
+	})
+})
+
+var _ = Describe("SchemaRegistry translation", func() {
+	var registry *SchemaRegistry
+
+	BeforeEach(func() {
+		registry = NewSchemaRegistry()
+	})
+
+	Context("when one data contract references a missing model", func() {
+		It("still translates the valid contracts and reports the broken one", func() {
+			dataModels := []config.DataModelsConfig{
+				{
+					Name: "typevalidation",
+					Versions: map[string]config.DataModelVersion{
+						"v1": {Structure: map[string]config.Field{
+							"count": {PayloadShape: "timeseries-number"},
+							"name":  {PayloadShape: "timeseries-string"},
+							"truth": {PayloadShape: "timeseries-boolean"},
+						}},
+					},
+				},
+			}
+			dataContracts := []config.DataContractsConfig{
+				{Name: "_typevalidation_v1", Model: &config.ModelRef{Name: "typevalidation", Version: "v1"}},
+				{Name: "_work_order_v1", Model: &config.ModelRef{Name: "work_order", Version: "v1"}}, // model deleted
+			}
+
+			schemas, skipPrefixes, err := registry.translateToSchemas(context.Background(), dataModels, dataContracts, map[string]config.PayloadShape{})
+
+			Expect(schemas).To(HaveKey(SubjectName("_typevalidation_v1-timeseries-number")))
+			Expect(schemas).To(HaveKey(SubjectName("_typevalidation_v1-timeseries-string")))
+			Expect(schemas).To(HaveKey(SubjectName("_typevalidation_v1-timeseries-boolean")))
+			Expect(schemas).ToNot(HaveKey(SubjectName("_work_order_v1-timeseries-number")))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("_work_order_v1"))
+			Expect(err.Error()).To(ContainSubstring("unknown model 'work_order'"))
+			Expect(skipPrefixes).To(ContainElement("_work_order_v1-"))
+		})
+	})
+
+	Context("when comparing against the registry", func() {
+		It("keeps a broken contract's subjects while still deleting truly orphaned ones", func() {
+			registry.skipPrefixes = []string{"_work_order_v1-"}
+			registry.registrySubjects = []SubjectName{
+				"_work_order_v1-timeseries-number",
+				"_orphan_v1-timeseries-number",
+			}
+
+			err, changePhase := registry.compare(context.Background(), map[SubjectName]JSONSchemaDefinition{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(changePhase).To(BeTrue())
+
+			Expect(registry.inRegistryButUnknownLocally).ToNot(HaveKey(SubjectName("_work_order_v1-timeseries-number")))
+			Expect(registry.inRegistryButUnknownLocally).To(HaveKey(SubjectName("_orphan_v1-timeseries-number")))
 		})
 	})
 })

--- a/umh-core/pkg/service/redpanda/schema_registry.go
+++ b/umh-core/pkg/service/redpanda/schema_registry.go
@@ -39,14 +39,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"strings"
 	"sync"
 	"time"
-
-	"errors"
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/datamodel"
@@ -178,6 +177,9 @@ type SchemaRegistry struct {
 	// Comparison results (populated during reconcile with current expectedSubjects)
 	missingInRegistry           map[SubjectName]JSONSchemaDefinition // Subject -> schema (we have, registry doesn't)
 	inRegistryButUnknownLocally map[SubjectName]bool                 // Registry has, we don't expect
+
+	// used for broken contracts
+	skipPrefixes []string
 
 	httpClient http.Client
 
@@ -373,9 +375,10 @@ func WithSchemaRegistryAddress(address string) func(*SchemaRegistry) {
 //		// Handle reconciliation error
 //	}
 func (s *SchemaRegistry) Reconcile(ctx context.Context, dataModels []config.DataModelsConfig, dataContracts []config.DataContractsConfig, payloadShapes map[string]config.PayloadShape) error {
-	// Translate data models and contracts to expected schemas
-	expectedSubjects, err := s.translateToSchemas(ctx, dataModels, dataContracts, payloadShapes)
-	if err != nil {
+	expectedSubjects, skipPrefixes, err := s.translateToSchemas(ctx, dataModels, dataContracts, payloadShapes)
+
+	// On cancellation, don't touch the registry.
+	if expectedSubjects == nil && err != nil {
 		s.mu.Lock()
 		defer s.mu.Unlock()
 
@@ -387,7 +390,17 @@ func (s *SchemaRegistry) Reconcile(ctx context.Context, dataModels []config.Data
 		return fmt.Errorf("failed to translate data models to schemas: %w", err)
 	}
 
-	return s.ReconcileWithSchemas(ctx, expectedSubjects)
+	s.mu.Lock()
+	s.skipPrefixes = skipPrefixes
+	s.mu.Unlock()
+
+	reconcileErr := s.ReconcileWithSchemas(ctx, expectedSubjects)
+
+	if err != nil {
+		return fmt.Errorf("some data contracts could not be translated to schemas: %w", errors.Join(err, reconcileErr))
+	}
+
+	return reconcileErr
 }
 
 func (s *SchemaRegistry) ReconcileWithSchemas(ctx context.Context, schemas map[SubjectName]JSONSchemaDefinition) error {
@@ -426,20 +439,12 @@ func (s *SchemaRegistry) ReconcileWithSchemas(ctx context.Context, schemas map[S
 //  4. Extract the generated schemas and convert subject names to SubjectName type
 //  5. Aggregate all schemas from all contracts into a single map
 //
-// Error handling:
-//   - Missing model references: Contract references non-existent model or version
-//   - Translation failures: Invalid model structure, circular references, context cancellation
-//   - Empty contracts: Returns empty map (valid case for cleanup-only reconciliation)
+// Per-contract failures are collected and skipped so one broken contract can't block the valid ones;
+// only context cancellation is fatal (returns a nil map so the caller aborts without touching the registry).
 //
-// Performance characteristics:
-//   - Leverages high-performance datamodel.Translator (13K-400K translations/sec)
-//   - Builds model reference map once and reuses for all contracts
-//   - Pre-allocates result map based on contract count for efficiency
-//
-// Returns:
-//   - Map of SubjectName to JSONSchemaDefinition for use by existing reconciliation logic
-//   - Error if translation fails or model references are invalid
-func (s *SchemaRegistry) translateToSchemas(ctx context.Context, dataModels []config.DataModelsConfig, dataContracts []config.DataContractsConfig, payloadShapes map[string]config.PayloadShape) (map[SubjectName]JSONSchemaDefinition, error) {
+// Returns the valid contracts' schemas, the subject-name prefixes of the failed contracts (whose existing
+// schemas must be preserved from deletion), and the joined per-contract error.
+func (s *SchemaRegistry) translateToSchemas(ctx context.Context, dataModels []config.DataModelsConfig, dataContracts []config.DataContractsConfig, payloadShapes map[string]config.PayloadShape) (map[SubjectName]JSONSchemaDefinition, []string, error) {
 	// Build map of all available data models for reference resolution
 	allDataModels := make(map[string]config.DataModelsConfig, len(dataModels))
 	for _, model := range dataModels {
@@ -449,12 +454,18 @@ func (s *SchemaRegistry) translateToSchemas(ctx context.Context, dataModels []co
 	// Pre-allocate result map based on contract count (estimate 2-3 schemas per contract)
 	expectedSubjects := make(map[SubjectName]JSONSchemaDefinition, len(dataContracts)*3)
 
+	// Used for: broken contracts cannot block valid ones
+	var (
+		skipErrs     []error
+		skipPrefixes []string
+	)
+
 	// Translate each data contract to schemas
 	for _, contract := range dataContracts {
 		// Check context cancellation during translation loop
 		select {
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			return nil, nil, ctx.Err()
 		default:
 		}
 
@@ -466,13 +477,19 @@ func (s *SchemaRegistry) translateToSchemas(ctx context.Context, dataModels []co
 		// Find the referenced data model
 		referencedModel, exists := allDataModels[contract.Model.Name]
 		if !exists {
-			return nil, fmt.Errorf("data contract '%s' references unknown model '%s'", contract.Name, contract.Model.Name)
+			skipErrs = append(skipErrs, fmt.Errorf("data contract '%s' references unknown model '%s'", contract.Name, contract.Model.Name))
+			skipPrefixes = append(skipPrefixes, contract.Name+"-")
+
+			continue
 		}
 
 		// Find the referenced version
 		modelVersion, versionExists := referencedModel.Versions[contract.Model.Version]
 		if !versionExists {
-			return nil, fmt.Errorf("data contract '%s' references unknown version '%s' of model '%s'", contract.Name, contract.Model.Version, contract.Model.Name)
+			skipErrs = append(skipErrs, fmt.Errorf("data contract '%s' references unknown version '%s' of model '%s'", contract.Name, contract.Model.Version, contract.Model.Name))
+			skipPrefixes = append(skipPrefixes, contract.Name+"-")
+
+			continue
 		}
 
 		// Translate the data model to JSON schemas
@@ -485,11 +502,17 @@ func (s *SchemaRegistry) translateToSchemas(ctx context.Context, dataModels []co
 			allDataModels,
 		)
 		if err != nil {
-			return nil, fmt.Errorf("failed to translate data contract '%s': %w", contract.Name, err)
+			skipErrs = append(skipErrs, fmt.Errorf("failed to translate data contract '%s': %w", contract.Name, err))
+			skipPrefixes = append(skipPrefixes, contract.Name+"-")
+
+			continue
 		}
 
 		if result == nil {
-			return nil, fmt.Errorf("translator returned nil result for data contract '%s'", contract.Name)
+			skipErrs = append(skipErrs, fmt.Errorf("translator returned nil result for data contract '%s'", contract.Name))
+			skipPrefixes = append(skipPrefixes, contract.Name+"-")
+
+			continue
 		}
 
 		// Add all generated schemas to the result map
@@ -497,14 +520,17 @@ func (s *SchemaRegistry) translateToSchemas(ctx context.Context, dataModels []co
 			// Convert schema to JSON string for registry format
 			schemaBytes, err := json.Marshal(schema)
 			if err != nil {
-				return nil, fmt.Errorf("failed to marshal schema for subject '%s': %w", subjectName, err)
+				skipErrs = append(skipErrs, fmt.Errorf("failed to marshal schema for subject '%s': %w", subjectName, err))
+				skipPrefixes = append(skipPrefixes, contract.Name+"-")
+
+				continue
 			}
 
 			expectedSubjects[SubjectName(subjectName)] = JSONSchemaDefinition(string(schemaBytes))
 		}
 	}
 
-	return expectedSubjects, nil
+	return expectedSubjects, skipPrefixes, errors.Join(skipErrs...)
 }
 
 // getNextPhase calculates the next phase based on current phase and whether to change phase.
@@ -854,14 +880,32 @@ func (s *SchemaRegistry) compare(ctx context.Context, expectedSubjects map[Subje
 		}
 	}
 
-	// Find unknown in registry (registry has, we don't expect)
+	// Find unknown in registry (registry has, we don't expect).
 	for _, subject := range s.registrySubjects {
-		if _, expected := expectedSubjects[subject]; !expected {
-			s.inRegistryButUnknownLocally[subject] = true
+		if _, expected := expectedSubjects[subject]; expected {
+			continue
 		}
+
+		if s.isSkippedSubject(subject) {
+			// do not delete schemas of broken ones
+			continue
+		}
+
+		s.inRegistryButUnknownLocally[subject] = true
 	}
 
 	return nil, true // Analyzed differences, advance to next phase
+}
+
+// isSkippedSubject guards a broken contract's subjects from deletion.
+func (s *SchemaRegistry) isSkippedSubject(subject SubjectName) bool {
+	for _, prefix := range s.skipPrefixes {
+		if strings.HasPrefix(string(subject), prefix) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // removeUnknown deletes schemas from the registry that exist but are not in our expected set.


### PR DESCRIPTION
# Description

## Origin topic

When having a data-model which uses e.g. timeseries-number as datatype for its tag:

- if you then tried to write with e.g. `timeseries-string` into the tag the error-message was very unintuitive
- it printed each tag of the data-contract + datatype
- but you had to guess the real issue here, because it only stated that the `virtual_path` is "wrong"

For reference ENG-5347

## After Fix

I implemented the fix within benthos-umh [schema-validation-error](https://github.com/united-manufacturing-hub/benthos-umh/pull/414), but when i wanted to recreate this i ran into this issue here:

- already had 2 data-contracts pre-existing
- deleted the correpsonding datamodels
- created a new data-contract ("typevalidation")
- added the datamodel ("typevalidation_v1")
- the tag appeared in topic-browser in the correct data-contract
- BUT it got a value of `true` whenever the datamodel was `timeseries-number`
- checked on metadata -> `bypass_reason` was `no schema found`

Conclusion: 

Whenever you had pre-existing datamodels, which were deleted, the whole chain of other datamodels, which should be applied to redpanda were skipped, due to a translation-error.

## Now

This PR introduces that datamodels, which cannot get translated / have missing schemas are getting skipped and do not block anymore the appliance / translation for newer datamodels.


Fixes ENG-5319