### PR TITLE
chore(codeowners): add @FalconTube as umh-core co-owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,7 +4,8 @@
 *       @JeremyTheocharis
 
 # Jeremy is responsible for the Go code
-/umh-core/ @JeremyTheocharis
+# Yannic Falke (@FalconTube) is co-owner of umh-core so he can approve PRs while Jeremy is on vacation
+/umh-core/ @JeremyTheocharis @FalconTube
 /deployment/ @JeremyTheocharis
 
 # Remaining files are owned by Jeremy


### PR DESCRIPTION
## Problem

Jeremy is the sole CODEOWNER for `/umh-core/`. When he is on vacation, no one else can satisfy the codeowner review requirement on umh-core PRs, so the merge queue stalls.

## Shipping

Add Yannic Falke (`@FalconTube`) as a **co-owner** of `/umh-core/`. GitHub requests review from both owners, but only one approval is required to satisfy the codeowner rule — so Yannic can approve umh-core PRs while Jeremy is away.

## Scope

- `/umh-core/ @JeremyTheocharis @FalconTube` — the only functional change.
- `/deployment/`, root files, and the `*` default remain `@JeremyTheocharis` only. Scoped to the literal request (umh-core).
- `@FalconTube` verified: real GitHub user, active member of the `united-manufacturing-hub` org, so review requests will reach him.

## Notes

- CODEOWNERS-only change, no user-visible behavior → `skip-changelog-guard` applied.
- Merge path: this PR touches `CODEOWNERS`, owned by `@JeremyTheocharis`. Self-approval is not possible under branch protection; an admin merge or a second pair of eyes may be needed to land it before vacation.