### PR TITLE
fix: fsmv2 nmap connection can now be deleted

### DIFF
--- a/umh-core/pkg/config/config.go
+++ b/umh-core/pkg/config/config.go
@@ -121,6 +121,13 @@ type FSMInstanceConfig struct {
 	DesiredFSMState string `yaml:"desiredState,omitempty"`
 }
 
+// GetDesiredFSMState returns the configured desired fsmv1 state, satisfying the
+// fsmv2 adapter's StateConfig constraint. The name differs from GetState() on
+// purpose: WorkerBase duck-types GetState() and validates it against the
+// lifecycle vocabulary ("running"/"stopped"), which a domain literal like
+// "open" would fail.
+func (c FSMInstanceConfig) GetDesiredFSMState() string { return c.DesiredFSMState }
+
 // ContainerConfig is the config for a container instance.
 type ContainerConfig struct {
 	Name            string `yaml:"name"`

--- a/umh-core/pkg/fsmv2/adapter/manager.go
+++ b/umh-core/pkg/fsmv2/adapter/manager.go
@@ -29,17 +29,18 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/serviceregistry"
 )
 
-// stoppedState is the desired-state literal that marks a config as disabled and
-// serves as the default desired state's opposite: a config whose GetState()
-// returns this is not Upserted into the fsmv2 runtime.
+// stoppedState is the desired-state literal that disables a config: a config
+// whose desired state is this is not Upserted into the fsmv2 runtime.
 const stoppedState = "stopped"
 
-// stateAccessor is the duck-typed desired-state seam. A domain config that
-// carries a desired state satisfies it structurally, letting the manager derive
-// each instance's desired state and the default enabled/disabled decision
-// without importing the config package.
-type stateAccessor interface {
-	GetState() string
+// StateConfig is the compile-time desired-state seam every managed config must
+// satisfy. It replaces an optional duck-typed accessor whose absence silently
+// fell back to "running": a stopped worker was reported running and its fsmv1
+// FSM hung waiting for a stop that never came. Requiring the method makes that
+// case a compile error. config.FSMInstanceConfig satisfies it, so every config
+// embedding it (NmapConfig, BenthosConfig, …) qualifies for free.
+type StateConfig interface {
+	GetDesiredFSMState() string
 }
 
 // WorkerManagerSpec describes the domain-specific behaviour WorkerManager needs
@@ -48,9 +49,10 @@ type stateAccessor interface {
 // Upsert/Delete diffing; the developer supplies the required mapping functions
 // and may override the defaulted ones.
 //
-// TConfig is the domain config type flowing through the fsmv1 control loop.
+// TConfig is the domain config type flowing through the fsmv1 control loop; it
+// must satisfy StateConfig so the manager can always read its desired state.
 // TStatus is the worker's stored status type (e.g. simple.Status[Raw]).
-type WorkerManagerSpec[TConfig, TStatus any] struct {
+type WorkerManagerSpec[TConfig StateConfig, TStatus any] struct {
 	// ExtractConfigs pulls the relevant config slice from a SystemSnapshot.
 	// Required.
 	ExtractConfigs func(snapshot publicfsm.SystemSnapshot) []TConfig
@@ -78,8 +80,8 @@ type WorkerManagerSpec[TConfig, TStatus any] struct {
 	// IsEnabled reports whether a config entry should run in the fsmv2 runtime.
 	// Disabled entries stay in the fsmv1 instance map (so their state is
 	// visible) but are not Upserted; existing registrations are Deleted.
-	// Optional; defaults to duck-typing the config's desired state
-	// (GetState()=="stopped" => disabled, otherwise enabled).
+	// Optional; defaults to GetDesiredFSMState()=="stopped" => disabled,
+	// otherwise enabled.
 	IsEnabled func(cfg TConfig) bool
 
 	// Log is the FSMLogger; optional, defaults to a no-op logger.
@@ -95,7 +97,7 @@ type WorkerManagerSpec[TConfig, TStatus any] struct {
 // WorkerManager is a generic fsmv1-compatible manager that drives a fleet of
 // fsmv2 child workers via the global FSMv2Client (Upsert/Delete) and exposes
 // each child as an AdaptedInstance. It satisfies publicfsm.FSMManager[TConfig].
-type WorkerManager[TConfig, TStatus any] struct {
+type WorkerManager[TConfig StateConfig, TStatus any] struct {
 	instances     map[string]publicfsm.FSMInstance
 	domainConfigs map[string]TConfig
 	spec          WorkerManagerSpec[TConfig, TStatus]
@@ -108,11 +110,10 @@ type WorkerManager[TConfig, TStatus any] struct {
 
 // NewWorkerManager builds a WorkerManager, filling every optional spec field
 // with its default: ConfigEqual=reflect.DeepEqual, CfgFor=JSON round-trip,
-// IsEnabled=desired-state duck-typing (GetState()=="stopped" => disabled), and
-// Log=a no-op logger. It panics when a required field is missing, so a
-// misconfigured spec fails at construction instead of a nil-call panic inside
-// Reconcile.
-func NewWorkerManager[TConfig, TStatus any](spec WorkerManagerSpec[TConfig, TStatus]) *WorkerManager[TConfig, TStatus] {
+// IsEnabled=GetDesiredFSMState()=="stopped" => disabled, and Log=a no-op
+// logger. It panics when a required field is missing, so a misconfigured spec
+// fails at construction instead of a nil-call panic inside Reconcile.
+func NewWorkerManager[TConfig StateConfig, TStatus any](spec WorkerManagerSpec[TConfig, TStatus]) *WorkerManager[TConfig, TStatus] {
 	if spec.WorkerType == "" {
 		panic("adapter: WorkerManagerSpec.WorkerType is required")
 	}
@@ -160,25 +161,17 @@ func defaultCfgFor[TConfig any](cfg TConfig) (map[string]any, error) {
 	return out, nil
 }
 
-// defaultIsEnabled duck-types the config's desired state: a config whose
-// GetState() returns "stopped" is disabled, otherwise it is enabled. A config
-// without a GetState() accessor is always enabled.
-func defaultIsEnabled[TConfig any](cfg TConfig) bool {
-	if sa, ok := any(cfg).(stateAccessor); ok {
-		return sa.GetState() != stoppedState
-	}
-
-	return true
+// defaultIsEnabled reads the config's desired state: a config whose
+// GetDesiredFSMState() returns "stopped" is disabled, otherwise it is enabled.
+func defaultIsEnabled[TConfig StateConfig](cfg TConfig) bool {
+	return cfg.GetDesiredFSMState() != stoppedState
 }
 
-// desiredStateOf derives the instance desired state from the config's GetState()
-// accessor, falling back to runningState when the config has no accessor or
-// returns an empty string.
-func desiredStateOf[TConfig any](cfg TConfig) string {
-	if sa, ok := any(cfg).(stateAccessor); ok {
-		if s := sa.GetState(); s != "" {
-			return s
-		}
+// desiredStateOf returns the config's desired state, falling back to
+// defaultDesiredState ("running") only when the config leaves it empty.
+func desiredStateOf[TConfig StateConfig](cfg TConfig) string {
+	if s := cfg.GetDesiredFSMState(); s != "" {
+		return s
 	}
 
 	return defaultDesiredState

--- a/umh-core/pkg/fsmv2/adapter/manager_test.go
+++ b/umh-core/pkg/fsmv2/adapter/manager_test.go
@@ -51,11 +51,10 @@ import (
 //     Name: spec.NameOf(cfg)}. There is NO RefFor and NO NewInstance field; the
 //     manager constructs each AdaptedInstance via the internal newAdaptedInstance.
 //   - GetManagerName() returns spec.WorkerType (there is no ManagerName field).
-//   - The default IsEnabled (when nil) reads the config's desired state by
-//     duck-typing `interface{ GetState() string }`: GetState()=="stopped" =>
-//     disabled, otherwise enabled. mgrConfig below carries a GetState() so the
-//     default resolves.
-//   - The instance's desired state is derived from the config's GetState() (the
+//   - Every config must satisfy adapter.StateConfig (GetDesiredFSMState()). The
+//     default IsEnabled (when nil) reads it: GetDesiredFSMState()=="stopped" =>
+//     disabled, otherwise enabled. mgrConfig below implements it.
+//   - The instance's desired state is derived from GetDesiredFSMState() (the
 //     disabled shortcut in AdaptedInstance returns desiredState verbatim). A
 //     config with State "running" yields DesiredState "running".
 //   - RETRY FIX: on a CfgFor/Upsert failure in the config-CHANGE branch the
@@ -65,12 +64,12 @@ import (
 //     default CfgFor.
 //
 // TStatus reuses probeStatus / probeObserved / stubReader from instance_test.go
-// (same package). mgrConfig is local because the default IsEnabled needs a
-// GetState() accessor that testConfig (Target-only) lacks.
+// (same package). mgrConfig is local because it must satisfy adapter.StateConfig,
+// which testConfig (Target-only) does not.
 // -----------------------------------------------------------------------------
 
-// mgrConfig is a domain TConfig with a desired-state accessor so the default
-// IsEnabled (GetState()=="stopped" => disabled) resolves. Value forces a
+// mgrConfig is a domain TConfig satisfying adapter.StateConfig so the default
+// IsEnabled (GetDesiredFSMState()=="stopped" => disabled) resolves. Value forces a
 // ConfigEqual difference without touching name or state.
 type mgrConfig struct {
 	Name  string `json:"name"`
@@ -78,9 +77,9 @@ type mgrConfig struct {
 	Value string `json:"value"`
 }
 
-// GetState makes mgrConfig satisfy the duck-typed desired-state interface the
-// default IsEnabled reads.
-func (c mgrConfig) GetState() string { return c.State }
+// GetDesiredFSMState makes mgrConfig satisfy adapter.StateConfig, the constraint
+// every managed config must meet; the default IsEnabled and desiredStateOf read it.
+func (c mgrConfig) GetDesiredFSMState() string { return c.State }
 
 var _ = Describe("WorkerManager", func() {
 	const workerType = "adapter-mgr-probe" // unregistered => staleAfter 1s fallback
@@ -323,6 +322,24 @@ var _ = Describe("WorkerManager", func() {
 
 		_, ok = mgr.GetInstance("gamma")
 		Expect(ok).To(BeTrue()) // still visible in the map
+	})
+
+	It("a disabled instance reports its actual desired state, not a running fallback (nmap removal fix)", func() {
+		// The StateConfig constraint guarantees desiredStateOf reads the real
+		// desired state, so a stopped entry reports "stopped". Before the guard a
+		// config the adapter could not introspect fell back to "running": a
+		// stopped nmap was reported running and the connection FSM hung in
+		// stopping, never completing protocol-converter removal.
+		setupClient(&stubReader{})
+		mgr := NewWorkerManager(baseSpec())
+
+		desired = []mgrConfig{{Name: "beta", State: "stopped"}}
+		_, _ = mgr.Reconcile(ctx, publicfsm.SystemSnapshot{}, nil)
+
+		state, err := mgr.GetCurrentFSMState("beta")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(state).To(Equal("stopped"),
+			"a disabled instance must report its actual desired state, not the running fallback")
 	})
 
 	It("GetManagerName returns WorkerType; CreateSnapshot exposes per-worker current/desired state", func() {

--- a/umh-core/pkg/fsmv2/nmap/manager.go
+++ b/umh-core/pkg/fsmv2/nmap/manager.go
@@ -30,10 +30,6 @@ import (
 	nmapservice "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/nmap"
 )
 
-// stoppedState is the desired-state literal that disables a config: an nmap
-// worker whose DesiredFSMState is this is not run in the fsmv2 runtime.
-const stoppedState = "stopped"
-
 // NewFsmv2NmapManager builds the fsmv1-compatible manager that drives the
 // fsmv2 nmap workers. It extracts NmapConfig entries from the snapshot, upserts
 // enabled workers into the fsmv2 runtime, and maps their stored status back to
@@ -45,11 +41,10 @@ func NewFsmv2NmapManager(managerName string) *adapter.WorkerManager[config.NmapC
 		ExtractConfigs: func(s publicfsm.SystemSnapshot) []config.NmapConfig {
 			return s.CurrentConfig.Internal.Nmap
 		},
-		NameOf:         func(c config.NmapConfig) string { return c.Name },
-		IsEnabled:      func(c config.NmapConfig) bool { return c.DesiredFSMState != stoppedState },
-		CfgFor:         cfgFor,
-		MapFresh:       mapFresh,
-		MapObserved:    mapObserved,
+		NameOf:      func(c config.NmapConfig) string { return c.Name },
+		CfgFor:      cfgFor,
+		MapFresh:    mapFresh,
+		MapObserved: mapObserved,
 	})
 }
 

--- a/umh-core/pkg/fsmv2/nmap/nmap.go
+++ b/umh-core/pkg/fsmv2/nmap/nmap.go
@@ -14,18 +14,21 @@
 
 // Package fsmv2nmap is the nmap monitor built on the fsmv2 simple framework.
 // Behind the fsmv2 flag, it observes a single TCP target by dialing it once per
-// tick: a successful dial reports the port open, a failed dial drives the worker
-// degraded.
+// tick: a successful dial reports the port open, a failed dial reports it
+// closed. A single TCP connect cannot tell a refused port apart from a dropped
+// probe, so any non-open outcome reports closed.
 package fsmv2nmap
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"strconv"
 	"time"
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
+	nmapfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/nmap"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/simple"
 )
 
@@ -35,13 +38,17 @@ const (
 
 	// pollInterval is the cadence at which the framework calls Poll.
 	pollInterval = 1 * time.Second
+
+	// The dialer sets no timeout: the collector already bounds every Poll with
+	// its ObservationTimeout, which cancels the dial context.
 )
 
 // NmapStatus is the result of one TCP-dial observation of the target port.
 type NmapStatus struct {
-	// PortState is "open" on a successful dial; empty otherwise.
+	// PortState is one of nmapfsm.PortStateOpen or nmapfsm.PortStateClosed.
 	PortState string `json:"port_state"`
-	// LatencyMs is the dial round-trip time in milliseconds.
+	// LatencyMs is the dial round-trip time in milliseconds. Zero unless the
+	// port is open.
 	LatencyMs float64 `json:"latency_ms"`
 	// Port is the scanned target port.
 	Port uint16 `json:"port"`
@@ -49,28 +56,41 @@ type NmapStatus struct {
 	IsRunning bool `json:"is_running"`
 }
 
-// Poll dials the configured target once and reports the port state. On a
-// successful dial it returns an "open"/running status with the measured
-// latency; on a dial error it returns a non-open status carrying the port and
-// wraps the error, which the framework persists as a degraded verdict
-// ("poll error: ...").
+// Poll dials the configured target once and reports the port state. A
+// successful dial yields an open/running status with the measured latency; any
+// dial failure yields a closed port. A closed port is a legitimate scan
+// outcome, not a poll failure, so Poll returns it with a nil error. Poll
+// returns an error only when the context is cancelled (worker shutdown), so the
+// framework does not misreport a shutdown as a port state.
 func Poll(ctx context.Context, _ struct{}, cfg config.NmapConfig) (NmapStatus, error) {
 	target := net.JoinHostPort(cfg.NmapServiceConfig.Target, strconv.Itoa(int(cfg.NmapServiceConfig.Port)))
 
 	start := time.Now()
 
-	var dialer net.Dialer
+	dialer := net.Dialer{}
 
 	conn, err := dialer.DialContext(ctx, "tcp", target)
 	if err != nil {
-		return NmapStatus{Port: cfg.NmapServiceConfig.Port}, fmt.Errorf("nmap dial %s: %w", target, err)
+		// Worker shutdown cancels the context; surface it as an error so the
+		// framework does not misreport a shutdown as a port state. This
+		// deliberately masks the port result: a dial that fails at the same tick
+		// as shutdown reports cancelled, not closed. A deadline
+		// (ObservationTimeout) is not a shutdown: it falls through to closed.
+		if errors.Is(ctx.Err(), context.Canceled) {
+			return NmapStatus{Port: cfg.NmapServiceConfig.Port}, fmt.Errorf("scan cancelled: %w", ctx.Err())
+		}
+
+		return NmapStatus{
+			PortState: string(nmapfsm.PortStateClosed),
+			Port:      cfg.NmapServiceConfig.Port,
+		}, nil
 	}
 
 	elapsedMs := float64(time.Since(start).Microseconds()) / 1000.0
 	_ = conn.Close()
 
 	return NmapStatus{
-		PortState: "open",
+		PortState: string(nmapfsm.PortStateOpen),
 		LatencyMs: elapsedMs,
 		Port:      cfg.NmapServiceConfig.Port,
 		IsRunning: true,

--- a/umh-core/pkg/fsmv2/nmap/nmap_test.go
+++ b/umh-core/pkg/fsmv2/nmap/nmap_test.go
@@ -71,17 +71,47 @@ var _ = Describe("Nmap Poll", func() {
 		Expect(status.LatencyMs).To(BeNumerically(">=", 0))
 	})
 
-	It("returns an error and a non-open status when the port is unreachable", func() {
-		// Port 0 is not connectable, so the dial fails deterministically with no
-		// listener to bind/free (avoids a port-reuse race between close and dial).
-		cfg := newNmapConfig("127.0.0.1", 0)
+	It("reports a closed port without an error when the connection is refused", func() {
+		// Bind a listener to grab a free loopback port, then close it so the
+		// kernel answers the dial with a TCP RST (connection refused). A refused
+		// connection is a legitimate scan outcome, not a poll failure, so Poll
+		// returns a nil error.
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		Expect(err).NotTo(HaveOccurred())
+
+		host, port := hostPort(ln.Addr().String())
+		Expect(ln.Close()).To(Succeed())
+
+		cfg := newNmapConfig(host, port)
 
 		ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 		defer cancel()
 
 		status, err := fsmv2nmap.Poll(ctx, struct{}{}, cfg)
-		Expect(err).To(HaveOccurred())
-		Expect(status.PortState).NotTo(Equal("open"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(status.PortState).To(Equal("closed"))
+		Expect(status.IsRunning).To(BeFalse())
+	})
+
+	It("reports a closed port without an error when the deadline is already exceeded", func() {
+		// A deadline (the collector's ObservationTimeout) is not a shutdown: the
+		// dial fails with context.DeadlineExceeded, which must fall through to a
+		// closed port, not the cancelled-context error path. An expired deadline
+		// makes DialContext fail deterministically without a network round-trip.
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		Expect(err).NotTo(HaveOccurred())
+
+		defer func() { _ = ln.Close() }()
+
+		host, port := hostPort(ln.Addr().String())
+		cfg := newNmapConfig(host, port)
+
+		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Hour))
+		defer cancel()
+
+		status, err := fsmv2nmap.Poll(ctx, struct{}{}, cfg)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(status.PortState).To(Equal("closed"))
 		Expect(status.IsRunning).To(BeFalse())
 	})
 


### PR DESCRIPTION
- Improve the fsmv2 `nmap` worker
- Problem was, that nmap connection workers where not properly removed -> One could not remove a bridge

Closes ENG-5379