### PR TITLE
Historian bridge: infer connection health check from shared historian config (ENG-5368)

### DIFF
--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Improvements
 
 - Persistent connection failures now log the HTTP status code and a sanitized snippet of the upstream response, so the cause of a flapping connection (such as a 502 from a reverse proxy) is visible in the worker's logs
+- A bridge that writes to the historian now derives its connection health check from the instance's stored historian connection instead of a host/port entered on the bridge. The check targets the configured historian database automatically, so it can no longer be pointed at the wrong host, and it follows the historian connection if that is later changed. The bridges list and detail view show the resolved historian host and port for these bridges rather than the connection placeholder.
 
 ## [0.44.29]
 

--- a/umh-core/pkg/communicator/actions/connectiontemplate_historian_test.go
+++ b/umh-core/pkg/communicator/actions/connectiontemplate_historian_test.go
@@ -1,0 +1,69 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package actions
+
+// This test lives in package actions (not actions_test) to exercise the unexported
+// connection-template selector directly. The actions package declares its own Label
+// helper, which collides with a ginkgo dot-import, so ginkgo/gomega are imported qualified.
+
+import (
+	ginkgo "github.com/onsi/ginkgo/v2"
+	gomega "github.com/onsi/gomega"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/dataflowcomponentserviceconfig"
+)
+
+var _ = ginkgo.Describe("connectionTemplateForWriteOutput", func() {
+	ginkgo.It("targets the shared historian section when the output inherits the historian connection", func() {
+		tmpl := connectionTemplateForWriteOutput(
+			dataflowcomponentserviceconfig.WriteConfigDestination{
+				Protocol: "historian",
+				Code:     "host: '{{ .historian.timescale.host }}'\nport: {{ .historian.timescale.port }}",
+			},
+		)
+		gomega.Expect(tmpl.NmapTemplate).NotTo(gomega.BeNil())
+		gomega.Expect(tmpl.NmapTemplate.Target).To(gomega.Equal("{{ .historian.timescale.host }}"))
+		gomega.Expect(tmpl.NmapTemplate.Port).To(gomega.Equal("{{ .historian.timescale.port }}"))
+	})
+
+	ginkgo.It("uses the standard IP/PORT template for a manual historian output that uses {{ .IP }}", func() {
+		// The manual TimescaleDB template writes through the historian plugin but supplies
+		// its own connection, so it must NOT be retargeted at the shared historian.
+		tmpl := connectionTemplateForWriteOutput(
+			dataflowcomponentserviceconfig.WriteConfigDestination{
+				Protocol: "historian",
+				Code:     "host: {{ .IP }}\nport: {{ .PORT }}",
+			},
+		)
+		gomega.Expect(tmpl.NmapTemplate).NotTo(gomega.BeNil())
+		gomega.Expect(tmpl.NmapTemplate.Target).To(gomega.Equal("{{ .IP }}"))
+		gomega.Expect(tmpl.NmapTemplate.Port).To(gomega.Equal("{{ .PORT }}"))
+	})
+
+	ginkgo.It("uses the standard IP/PORT template for a non-historian write output", func() {
+		tmpl := connectionTemplateForWriteOutput(
+			dataflowcomponentserviceconfig.WriteConfigDestination{Protocol: "kafka", Code: "topic: t"},
+		)
+		gomega.Expect(tmpl.NmapTemplate).NotTo(gomega.BeNil())
+		gomega.Expect(tmpl.NmapTemplate.Target).To(gomega.Equal("{{ .IP }}"))
+		gomega.Expect(tmpl.NmapTemplate.Port).To(gomega.Equal("{{ .PORT }}"))
+	})
+
+	ginkgo.It("uses the standard IP/PORT template when no write output is set", func() {
+		tmpl := connectionTemplateForWriteOutput(dataflowcomponentserviceconfig.WriteConfigDestination{})
+		gomega.Expect(tmpl.NmapTemplate).NotTo(gomega.BeNil())
+		gomega.Expect(tmpl.NmapTemplate.Target).To(gomega.Equal("{{ .IP }}"))
+	})
+})

--- a/umh-core/pkg/communicator/actions/deploy-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/deploy-protocolconverter.go
@@ -128,12 +128,19 @@ func (a *DeployProtocolConverterAction) Validate() error {
 		return errors.New("missing required field Name")
 	}
 
-	if a.payload.Connection.IP == "" {
-		return errors.New("missing required field Connection.IP")
-	}
+	// A bridge that inherits the historian connection derives its health check from the
+	// shared historian configuration, so it does not require a user-supplied host/port.
+	isHistorian := a.payload.WriteDFCPayload != nil &&
+		inheritsHistorianConnection(a.payload.WriteDFCPayload.Destination)
 
-	if a.payload.Connection.Port == 0 {
-		return errors.New("missing required field Connection.Port")
+	if !isHistorian {
+		if a.payload.Connection.IP == "" {
+			return errors.New("missing required field Connection.IP")
+		}
+
+		if a.payload.Connection.Port == 0 {
+			return errors.New("missing required field Connection.Port")
+		}
 	}
 
 	if err := config.ValidateComponentName(a.payload.Name); err != nil {
@@ -290,8 +297,15 @@ func buildProtocolConverterConfig(payload models.ProtocolConverter) (config.Prot
 	userVars["IP"] = payload.Connection.IP
 	userVars["PORT"] = strconv.FormatUint(uint64(payload.Connection.Port), 10)
 
+	// Historian bridges get an Nmap target resolved from the shared historian section; all
+	// others get the standard {{ .IP }}/{{ .PORT }} template fed by the connection variables.
+	var writeDestination dataflowcomponentserviceconfig.WriteConfigDestination
+	if payload.WriteDFCPayload != nil {
+		writeDestination = payload.WriteDFCPayload.Destination
+	}
+
 	tmpl := protocolconverterserviceconfig.ProtocolConverterServiceConfigTemplate{
-		ConnectionServiceConfig:             newIPPortConnectionTemplate(),
+		ConnectionServiceConfig:             connectionTemplateForWriteOutput(writeDestination),
 		DataflowComponentReadServiceConfig:  dataflowcomponentserviceconfig.DataflowComponentServiceConfig{},
 		DataflowComponentWriteServiceConfig: dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{},
 	}

--- a/umh-core/pkg/communicator/actions/deploy-protocolconverter_test.go
+++ b/umh-core/pkg/communicator/actions/deploy-protocolconverter_test.go
@@ -218,6 +218,77 @@ var _ = Describe("DeployProtocolConverter", func() {
 			Expect(err.Error()).To(ContainSubstring("missing required field Name"))
 		})
 
+		It("should not require connection IP/port for a bridge that inherits the historian connection", func() {
+			// The auto-connect historian template references {{ .historian.* }} in its output,
+			// so the wizard sends no host/port and validation must not reject that.
+			payload := map[string]interface{}{
+				"name":     pcName,
+				"location": pcLocation,
+				"writeDFC": map[string]interface{}{
+					"destination": map[string]interface{}{
+						"protocol": "historian",
+						"code":     "host: '{{ .historian.timescale.host }}'\ndata_contract_name: historian",
+					},
+					"source": map[string]interface{}{
+						"topics": "umh.v1.*",
+					},
+				},
+			}
+
+			err := action.Parse(payload)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = action.Validate()
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should still require connection IP for a manual historian bridge (uses {{ .IP }})", func() {
+			// The manual TimescaleDB template writes through the historian plugin but supplies
+			// its own connection, so it must still require a host/port.
+			payload := map[string]interface{}{
+				"name":     pcName,
+				"location": pcLocation,
+				"writeDFC": map[string]interface{}{
+					"destination": map[string]interface{}{
+						"protocol": "historian",
+						"code":     "host: {{ .IP }}\ndata_contract_name: historian",
+					},
+					"source": map[string]interface{}{
+						"topics": "umh.v1.*",
+					},
+				},
+			}
+
+			err := action.Parse(payload)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = action.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("missing required field Connection.IP"))
+		})
+
+		It("should still require connection IP for a non-historian bridge", func() {
+			payload := map[string]interface{}{
+				"name":     pcName,
+				"location": pcLocation,
+				"writeDFC": map[string]interface{}{
+					"destination": map[string]interface{}{
+						"protocol": "kafka",
+					},
+					"source": map[string]interface{}{
+						"topics": "umh.v1.*",
+					},
+				},
+			}
+
+			err := action.Parse(payload)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = action.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("missing required field Connection.IP"))
+		})
+
 		It("should pass validation when input_topics contains golang template vars", func() {
 			// Regression test: {{ .IP }}, {{ .location_path }} etc. in input_topics must not
 			// cause validation to fail — full rendering happens later in BuildRuntimeConfig.

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter.go
@@ -113,12 +113,6 @@ type EditProtocolConverterAction struct {
 	// a render (for example while Benthos restarts) keep the captured cause.
 	lastRenderErr error
 
-	// lastFailedDFCType records which DFC (read/write) produced the most
-	// recent render error. It is set alongside lastRenderErr and used to
-	// embed the flow name in the prose of user-facing error messages without
-	// prefixing the technical detail trail.
-	lastFailedDFCType DFCType
-
 	outboundChannel chan *models.UMHMessage
 	location        map[int]string
 
@@ -133,6 +127,12 @@ type EditProtocolConverterAction struct {
 	// writeDFCInput is the raw template-string form of the write config, persisted to the spec.
 	// nil means no write DFC was provided.
 	writeDFCInput *dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput
+
+	// lastFailedDFCType records which DFC (read/write) produced the most
+	// recent render error. It is set alongside lastRenderErr and used to
+	// embed the flow name in the prose of user-facing error messages without
+	// prefixing the technical detail trail.
+	lastFailedDFCType DFCType
 
 	userEmail      string
 	name           string // protocol converter name (optional for updates)
@@ -162,6 +162,11 @@ type EditProtocolConverterAction struct {
 
 	// Atomic edit UUID used for configuration updates and rollbacks
 	atomicEditUUID uuid.UUID
+
+	// isHistorianBridge is set in applyMutation from the resulting write output. Historian
+	// bridges probe the shared historian DB, so awaitRollout must not wait for the Nmap port
+	// to equal the sent connectionPort (that port is ignored for them).
+	isHistorianBridge bool
 
 	// rolloutSentryReported tells Execute to skip the generic rollout_failed
 	// Sentry event for this abort. Every awaitRollout abort path fires its own
@@ -440,8 +445,12 @@ func (a *EditProtocolConverterAction) applyMutation() (config.ProtocolConverterC
 		instanceToModify.ProtocolConverterServiceConfig.Config.DataflowComponentWriteServiceConfig = *a.writeDFCInput
 	}
 
-	// Add the connection details to the template
-	instanceToModify.ProtocolConverterServiceConfig.Config.ConnectionServiceConfig = newIPPortConnectionTemplate()
+	// Select the connection template from the resulting write output. Reading it from the
+	// merged config (after the write DFC is applied above) covers state-only edits too, where
+	// writeDFCInput is nil and the existing Historian destination is preserved.
+	writeDestination := instanceToModify.ProtocolConverterServiceConfig.Config.DataflowComponentWriteServiceConfig.Destination
+	a.isHistorianBridge = inheritsHistorianConnection(writeDestination)
+	instanceToModify.ProtocolConverterServiceConfig.Config.ConnectionServiceConfig = connectionTemplateForWriteOutput(writeDestination)
 
 	instanceToModify.ProtocolConverterServiceConfig.Location = convertIntMapToStringMap(a.location)
 
@@ -625,8 +634,10 @@ func (a *EditProtocolConverterAction) awaitRollout(pcConfig config.ProtocolConve
 				if a.dfcType == DFCTypeEmpty {
 					// For empty DFC type (connection/location/state update only)
 					// Only check the nmap port when activating; when stopping, nmap is also
-					// stopped so it will never update to the new port.
-					if desiredPCState != protocolconverter.OperationalStateStopped {
+					// stopped so it will never update to the new port. Historian bridges probe
+					// the shared historian host/port (not the sent connectionPort), so the port
+					// equality check would never match — skip it and just wait for active.
+					if desiredPCState != protocolconverter.OperationalStateStopped && !a.isHistorianBridge {
 						nmapPort := strconv.FormatUint(
 							uint64(pcSnapshot.ServiceInfo.ConnectionObservedState.ServiceInfo.NmapObservedState.ObservedNmapServiceConfig.Port),
 							10,

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter.go
@@ -113,6 +113,12 @@ type EditProtocolConverterAction struct {
 	// a render (for example while Benthos restarts) keep the captured cause.
 	lastRenderErr error
 
+	// lastFailedDFCType records which DFC (read/write) produced the most
+	// recent render error. It is set alongside lastRenderErr and used to
+	// embed the flow name in the prose of user-facing error messages without
+	// prefixing the technical detail trail.
+	lastFailedDFCType DFCType
+
 	outboundChannel chan *models.UMHMessage
 	location        map[int]string
 
@@ -127,12 +133,6 @@ type EditProtocolConverterAction struct {
 	// writeDFCInput is the raw template-string form of the write config, persisted to the spec.
 	// nil means no write DFC was provided.
 	writeDFCInput *dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput
-
-	// lastFailedDFCType records which DFC (read/write) produced the most
-	// recent render error. It is set alongside lastRenderErr and used to
-	// embed the flow name in the prose of user-facing error messages without
-	// prefixing the technical detail trail.
-	lastFailedDFCType DFCType
 
 	userEmail      string
 	name           string // protocol converter name (optional for updates)

--- a/umh-core/pkg/communicator/actions/get-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/get-protocolconverter.go
@@ -51,12 +51,14 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/google/uuid"
 	"go.uber.org/zap"
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/dataflowcomponentserviceconfig"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/nmapserviceconfig"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/protocolconverterserviceconfig"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
@@ -192,8 +194,12 @@ func determineProtocol(readDFC *models.ProtocolConverterDFC) string {
 // connectionInfoFromSpec extracts IP, port, and template metadata from a
 // ProtocolConverterServiceConfigSpec. Variables.User is the primary source; if
 // it is empty the Nmap connection template is used as a fallback for non-templated PCs.
+// resolvedConn is the connection's already-rendered config; it supplies the concrete
+// host:port for inferred-connection bridges whose template references a non-variable
+// namespace (e.g. {{ .historian.timescale.host }}) that has no user variable to resolve.
 func connectionInfoFromSpec(
 	spec protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec,
+	resolvedConn nmapserviceconfig.NmapServiceConfig,
 	logger *zap.SugaredLogger,
 ) (ip string, port uint32, templateInfo *models.ProtocolConverterTemplateInfo) {
 	var (
@@ -243,6 +249,18 @@ func connectionInfoFromSpec(
 				}
 			}
 		}
+	}
+
+	// Inferred-connection bridges (e.g. Historian auto-connect) carry system-injected
+	// but empty IP/PORT variables (IP:"", PORT:"0"), so hasConnectionVars is true yet the
+	// variable path yields no usable host:port; their connection template references a
+	// non-variable namespace like {{ .historian.timescale.host }}. Fall back to the
+	// rendered connection config, which holds the concrete host:port the connection FSM
+	// is probing. A normal bridge keeps its resolved IP/PORT (port != 0, ip set), so this
+	// never overrides a real connection.
+	if resolvedConn.Target != "" && (port == 0 || ip == "" || strings.Contains(ip, "{{")) {
+		ip = resolvedConn.Target
+		port = uint32(resolvedConn.Port)
 	}
 
 	templateInfo = &models.ProtocolConverterTemplateInfo{
@@ -341,7 +359,8 @@ func (a *GetProtocolConverterAction) Execute() (interface{}, map[string]interfac
 
 				// Get IP, port, and template info from observed, rendered spec config
 				specConfig := observedState.ObservedProtocolConverterSpecConfig
-				ip, port, templateInfo := connectionInfoFromSpec(specConfig, a.actionLogger)
+				resolvedConn := observedState.ServiceInfo.ConnectionObservedState.ObservedConnectionConfig.NmapServiceConfig
+				ip, port, templateInfo := connectionInfoFromSpec(specConfig, resolvedConn, a.actionLogger)
 
 				// Build ReadDFC from observed, rendered spec config, if present
 				var readDFC *models.ProtocolConverterDFC

--- a/umh-core/pkg/communicator/actions/get-protocolconverter_test.go
+++ b/umh-core/pkg/communicator/actions/get-protocolconverter_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/connectionserviceconfig"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/dataflowcomponentserviceconfig"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/nmapserviceconfig"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/protocolconverterserviceconfig"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/variables"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants"
@@ -294,6 +295,75 @@ var _ = Describe("GetProtocolConverter", func() {
 				Expect(response.Meta.ProcessingMode).To(Equal("custom")) // Determined from read DFC
 				Expect(response.Meta.Protocol).To(Equal("modbus"))       // Determined from read DFC input type
 
+			})
+		})
+
+		Context("when the bridge infers its connection from the historian", func() {
+			It("reports the rendered host:port instead of the raw {{ .historian.* }} template", func() {
+				testPCName := "test-historian-auto-connect"
+
+				observedState := &protocolconverter.ProtocolConverterObservedStateSnapshot{
+					ObservedProtocolConverterSpecConfig: protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec{
+						Config: protocolconverterserviceconfig.ProtocolConverterServiceConfigTemplate{
+							ConnectionServiceConfig: connectionserviceconfig.ConnectionServiceConfigTemplate{
+								NmapTemplate: &connectionserviceconfig.NmapConfigTemplate{
+									Target: "{{ .historian.timescale.host }}",
+									Port:   "{{ .historian.timescale.port }}",
+								},
+							},
+						},
+						// Historian bridges still get system-injected IP/PORT variables, but empty
+						// (IP:"", PORT:"0"); the real connection comes from {{ .historian.* }}.
+						Variables: variables.VariableBundle{
+							User: map[string]interface{}{
+								"IP":   "",
+								"PORT": "0",
+							},
+						},
+					},
+					ServiceInfo: protocolconvertersvc.ServiceInfo{
+						ConnectionFSMState: "up",
+						ConnectionObservedState: connectionfsm.ConnectionObservedState{
+							// Rendered connection config the connection FSM is actually probing.
+							ObservedConnectionConfig: connectionserviceconfig.ConnectionServiceConfig{
+								NmapServiceConfig: nmapserviceconfig.NmapServiceConfig{
+									Target: "pgbouncer",
+									Port:   5432,
+								},
+							},
+						},
+					},
+				}
+
+				instance := &fsm.FSMInstanceSnapshot{
+					ID:                testPCName,
+					CurrentState:      protocolconverter.OperationalStateActive,
+					DesiredState:      protocolconverter.OperationalStateActive,
+					LastObservedState: observedState,
+				}
+
+				pcManagerSnapshot := &actions.MockManagerSnapshot{
+					Instances: map[string]*fsm.FSMInstanceSnapshot{testPCName: instance},
+				}
+				systemSnapshot := &fsm.SystemSnapshot{
+					Managers: map[string]fsm.ManagerSnapshot{
+						constants.ProtocolConverterManagerName: pcManagerSnapshot,
+					},
+					CurrentConfig: config.FullConfig{},
+				}
+				snapshotManager.UpdateSnapshot(systemSnapshot)
+
+				actualUUID := dataflowcomponentserviceconfig.GenerateUUIDFromName(testPCName)
+				err := action.Parse(map[string]interface{}{"uuid": actualUUID.String()})
+				Expect(err).NotTo(HaveOccurred())
+
+				result, _, err := action.Execute()
+				Expect(err).NotTo(HaveOccurred())
+
+				response, ok := result.(models.ProtocolConverter)
+				Expect(ok).To(BeTrue())
+				Expect(response.Connection.IP).To(Equal("pgbouncer"))
+				Expect(response.Connection.Port).To(Equal(uint32(5432)))
 			})
 		})
 

--- a/umh-core/pkg/communicator/actions/historian_connection_render_test.go
+++ b/umh-core/pkg/communicator/actions/historian_connection_render_test.go
@@ -1,0 +1,129 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package actions
+
+// Cross-module coverage over the deploy config-builder and the runtime renderer (fast,
+// in-process — not a Testcontainers integration test): a historian bridge deployed with
+// NO connection must produce a connection whose Nmap target resolves
+// to the configured historian (host:port from the shared historian.timescale section) —
+// i.e. the exact target the connection FSM will probe. A non-historian bridge must still
+// resolve to the user-supplied IP/PORT. This lives in package actions to reach the
+// unexported buildProtocolConverterConfig; ginkgo/gomega are imported qualified because
+// the package declares its own Label.
+
+import (
+	ginkgo "github.com/onsi/ginkgo/v2"
+	gomega "github.com/onsi/gomega"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/dataflowcomponentserviceconfig"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/models"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/protocolconverter/runtime_config"
+)
+
+var _ = ginkgo.Describe("historian bridge connection (deploy build + runtime render)", func() {
+	ginkgo.It("resolves the connection to the configured historian when the bridge sends no connection", func() {
+		payload := models.ProtocolConverter{
+			Name: "historian-bridge",
+			// No Connection is sent for a historian bridge.
+			WriteDFCPayload: &models.WriteDFCPayload{
+				DataflowComponentWriteConfigInput: dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
+					Destination: dataflowcomponentserviceconfig.WriteConfigDestination{
+						Protocol: "historian",
+						Code:     "host: '{{ .historian.timescale.host }}'\ndata_contract_name: pump",
+					},
+					Source: dataflowcomponentserviceconfig.WriteConfigSource{Topics: "umh.v1.*"},
+				},
+				State: "active",
+			},
+		}
+
+		cfg, err := buildProtocolConverterConfig(payload)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		historian := &config.HistorianConfig{
+			Timescale: config.TimescaleConfig{
+				Host:     "timescale.internal",
+				Password: "secret",
+				Port:     6432,
+			},
+		}
+
+		runtime, err := runtime_config.BuildRuntimeConfig(
+			cfg.ProtocolConverterServiceConfig,
+			map[string]string{}, nil, historian, "test-node", "historian-bridge",
+		)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// The connection FSM probes this target; it must be the historian, not a user host.
+		gomega.Expect(runtime.ConnectionServiceConfig.NmapServiceConfig.Target).To(gomega.Equal("timescale.internal"))
+		gomega.Expect(runtime.ConnectionServiceConfig.NmapServiceConfig.Port).To(gomega.Equal(uint16(6432)))
+	})
+
+	ginkgo.It("fails with an actionable error when a historian bridge is deployed with no historian configured", func() {
+		payload := models.ProtocolConverter{
+			Name: "historian-bridge",
+			WriteDFCPayload: &models.WriteDFCPayload{
+				DataflowComponentWriteConfigInput: dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
+					Destination: dataflowcomponentserviceconfig.WriteConfigDestination{
+						Protocol: "historian",
+						Code:     "host: '{{ .historian.timescale.host }}'\ndata_contract_name: pump",
+					},
+					Source: dataflowcomponentserviceconfig.WriteConfigSource{Topics: "umh.v1.*"},
+				},
+				State: "active",
+			},
+		}
+
+		cfg, err := buildProtocolConverterConfig(payload)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		_, err = runtime_config.BuildRuntimeConfig(
+			cfg.ProtocolConverterServiceConfig,
+			map[string]string{}, nil, nil, "test-node", "historian-bridge",
+		)
+		gomega.Expect(err).To(gomega.HaveOccurred())
+		gomega.Expect(err.Error()).To(gomega.ContainSubstring("no valid historian: section is configured"))
+	})
+
+	ginkgo.It("resolves the connection to the user IP/PORT for a non-historian bridge", func() {
+		payload := models.ProtocolConverter{
+			Name:       "modbus-bridge",
+			Connection: models.ProtocolConverterConnection{IP: "10.0.0.5", Port: 502},
+			WriteDFCPayload: &models.WriteDFCPayload{
+				DataflowComponentWriteConfigInput: dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
+					Destination: dataflowcomponentserviceconfig.WriteConfigDestination{
+						Protocol: "kafka",
+						Code:     "topic: t",
+					},
+					Source: dataflowcomponentserviceconfig.WriteConfigSource{Topics: "umh.v1.*"},
+				},
+				State: "active",
+			},
+		}
+
+		cfg, err := buildProtocolConverterConfig(payload)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		runtime, err := runtime_config.BuildRuntimeConfig(
+			cfg.ProtocolConverterServiceConfig,
+			map[string]string{}, nil, nil, "test-node", "modbus-bridge",
+		)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		gomega.Expect(runtime.ConnectionServiceConfig.NmapServiceConfig.Target).To(gomega.Equal("10.0.0.5"))
+		gomega.Expect(runtime.ConnectionServiceConfig.NmapServiceConfig.Port).To(gomega.Equal(uint16(502)))
+	})
+})

--- a/umh-core/pkg/communicator/actions/protocolconverter_helpers.go
+++ b/umh-core/pkg/communicator/actions/protocolconverter_helpers.go
@@ -17,6 +17,7 @@ package actions
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"strconv"
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/benthosserviceconfig"
@@ -76,6 +77,13 @@ func validateReadProtocolConverterDFC(dfc *models.ProtocolConverterDFC) error {
 	return nil
 }
 
+// historianConnectionRef matches a Go-template reference into the shared historian
+// namespace, e.g. {{ .historian.timescale.host }}. A bridge whose write output config
+// contains such a reference inherits its connection from the shared historian.timescale
+// section, so its health check targets the configured Historian rather than a
+// user-supplied host/port (see connectionTemplateForWriteOutput).
+var historianConnectionRef = regexp.MustCompile(`\{\{\s*\.historian\.`)
+
 // newIPPortConnectionTemplate returns the standard {{ .IP }}/{{ .PORT }} Nmap connection template
 // used by all protocol converters.
 func newIPPortConnectionTemplate() connectionserviceconfig.ConnectionServiceConfigTemplate {
@@ -85,6 +93,43 @@ func newIPPortConnectionTemplate() connectionserviceconfig.ConnectionServiceConf
 			Port:   "{{ .PORT }}",
 		},
 	}
+}
+
+// newHistorianConnectionTemplate returns the Nmap connection template for a Historian bridge.
+// The target resolves from the shared historian.timescale section at render time, so the
+// health check probes the configured Historian database without the user supplying a host/port.
+// The connection is rendered with the full scope (which includes the historian namespace), so
+// these placeholders resolve like the ones in the write output config.
+func newHistorianConnectionTemplate() connectionserviceconfig.ConnectionServiceConfigTemplate {
+	return connectionserviceconfig.ConnectionServiceConfigTemplate{
+		NmapTemplate: &connectionserviceconfig.NmapConfigTemplate{
+			Target: "{{ .historian.timescale.host }}",
+			Port:   "{{ .historian.timescale.port }}",
+		},
+	}
+}
+
+// inheritsHistorianConnection reports whether a write output inherits its connection from
+// the shared historian.timescale section — its config references {{ .historian.* }} (as the
+// "Historian (auto-connect)" template does). The manual TimescaleDB template writes through
+// the same historian plugin but uses {{ .IP }}/{{ .PORT }}, so it is treated as a normal
+// bridge that supplies its own connection.
+func inheritsHistorianConnection(dest dataflowcomponentserviceconfig.WriteConfigDestination) bool {
+	return historianConnectionRef.MatchString(dest.Code)
+}
+
+// connectionTemplateForWriteOutput selects the connection (Nmap) template for a bridge based on
+// its write output. A bridge that inherits the historian connection probes the shared Historian
+// database (resolved from the historian.timescale section); every other bridge uses the standard
+// {{ .IP }}/{{ .PORT }} template fed by the connection variables. Using one selector keeps the
+// deploy and edit paths in step so an inherited-connection bridge is never reverted to {{ .IP }}
+// on edit.
+func connectionTemplateForWriteOutput(dest dataflowcomponentserviceconfig.WriteConfigDestination) connectionserviceconfig.ConnectionServiceConfigTemplate {
+	if inheritsHistorianConnection(dest) {
+		return newHistorianConnectionTemplate()
+	}
+
+	return newIPPortConnectionTemplate()
 }
 
 // buildReadDFCServiceConfig validates a CDFCPayload and converts it into a

--- a/umh-core/pkg/communicator/pkg/generator/protocolconverter.go
+++ b/umh-core/pkg/communicator/pkg/generator/protocolconverter.go
@@ -17,6 +17,8 @@ package generator
 import (
 	"fmt"
 	"regexp"
+	"strconv"
+	"strings"
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/dataflowcomponentserviceconfig"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants"
@@ -119,6 +121,15 @@ func buildProtocolConverterAsDfc(
 					port = strValue
 				}
 			}
+		}
+
+		// An unresolved {{ }} in target means the template references a non-variable
+		// namespace (inferred-connection bridge, e.g. {{ .historian.timescale.host }}).
+		// Use the rendered connection config, which holds the concrete host:port the
+		// connection FSM is probing.
+		if resolved := observed.ServiceInfo.ConnectionObservedState.ObservedConnectionConfig.NmapServiceConfig; strings.Contains(target, "{{") && resolved.Target != "" {
+			target = resolved.Target
+			port = strconv.Itoa(int(resolved.Port))
 		}
 
 		connection := models.Connection{

--- a/umh-core/pkg/communicator/pkg/generator/protocolconverter_test.go
+++ b/umh-core/pkg/communicator/pkg/generator/protocolconverter_test.go
@@ -17,10 +17,15 @@ package generator
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/connectionserviceconfig"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/dataflowcomponentserviceconfig"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/nmapserviceconfig"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/protocolconverterserviceconfig"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/variables"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
+	connectionfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/connection"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/protocolconverter"
+	pcservice "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/protocolconverter"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
@@ -258,5 +263,53 @@ var _ = Describe("auditability: debug-logs when a configured side resolves to an
 		Expect(err).NotTo(HaveOccurred())
 		Expect(logs.FilterMessageSnippet("Code-without-Protocol").All()).
 			To(HaveLen(1), "must debug-log the HasOutput-true/Protocol-empty divergence")
+	})
+})
+
+var _ = Describe("connection URI resolution", func() {
+	log := zap.NewNop().Sugar()
+
+	connSnap := func(specTarget, specPort, resolvedTarget string, resolvedPort uint16, user map[string]any) *protocolconverter.ProtocolConverterObservedStateSnapshot {
+		return &protocolconverter.ProtocolConverterObservedStateSnapshot{
+			ObservedProtocolConverterSpecConfig: protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec{
+				Config: protocolconverterserviceconfig.ProtocolConverterServiceConfigTemplate{
+					ConnectionServiceConfig: connectionserviceconfig.ConnectionServiceConfigTemplate{
+						NmapTemplate: &connectionserviceconfig.NmapConfigTemplate{Target: specTarget, Port: specPort},
+					},
+				},
+				Variables: variables.VariableBundle{User: user},
+			},
+			ServiceInfo: pcservice.ServiceInfo{
+				ConnectionObservedState: connectionfsm.ConnectionObservedState{
+					ObservedConnectionConfig: connectionserviceconfig.ConnectionServiceConfig{
+						NmapServiceConfig: nmapserviceconfig.NmapServiceConfig{Target: resolvedTarget, Port: resolvedPort},
+					},
+				},
+			},
+		}
+	}
+
+	It("resolves an inferred-historian target from the rendered connection config", func() {
+		snap := connSnap("{{ .historian.timescale.host }}", "{{ .historian.timescale.port }}", "pgbouncer", 5432, nil)
+		dfc, err := buildProtocolConverterAsDfc(toInstance("pc-historian", snap), log)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(dfc.Connections).To(HaveLen(1))
+		Expect(dfc.Connections[0].URI).To(Equal("pgbouncer:5432"), "unresolved {{ .historian.* }} falls back to the rendered host:port")
+	})
+
+	It("leaves a normal bridge on user-variable substitution (no fallback)", func() {
+		snap := connSnap("{{ .IP }}", "{{ .PORT }}", "should-not-be-used", 9999, map[string]any{"IP": "10.0.0.5", "PORT": "502"})
+		dfc, err := buildProtocolConverterAsDfc(toInstance("pc-modbus", snap), log)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(dfc.Connections).To(HaveLen(1))
+		Expect(dfc.Connections[0].URI).To(Equal("10.0.0.5:502"), "user-variable path stays authoritative when it resolves")
+	})
+
+	It("does not fall back when the rendered config is still empty", func() {
+		snap := connSnap("{{ .historian.timescale.host }}", "{{ .historian.timescale.port }}", "", 0, nil)
+		dfc, err := buildProtocolConverterAsDfc(toInstance("pc-unrendered", snap), log)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(dfc.Connections).To(HaveLen(1))
+		Expect(dfc.Connections[0].URI).To(Equal("{{ .historian.timescale.host }}:{{ .historian.timescale.port }}"), "no regression: keeps prior raw behavior until the connection renders")
 	})
 })


### PR DESCRIPTION
## What

Make a historian bridge's connection health check fully inferred from the instance's shared historian config, and show the resolved host:port for these bridges.

## Changes

- The nmap connection target for a bridge whose write output is the `historian` plugin is taken from `{{ .historian.timescale.host }}` / `.port` instead of the fixed `{{ .IP }}` template, via one shared selector used by both the deploy and edit paths.
- Connection IP/port validation guards are relaxed for these bridges; the edit rollout wait no longer blocks on the sent port.
- The bridges list (status generator) and the bridge detail reply resolve the concrete host:port from the rendered connection config, so these bridges show the real historian host:port instead of the raw `{{ .historian.* }}` template (list) or dashes (detail). The detail path resolves even though the bridge carries empty system-injected IP/PORT variables.

## Testing

- Unit tests for the shared selector, deploy/edit guards, connection render, generator resolution, and the get-protocol-converter reply. Affected packages pass; gofmt and go vet clean.

## Rollout

Deploy umh-core before the ManagementConsole change — the relaxed guards must be live before the frontend omits the connection, or the deploy is rejected.

Part of ENG-5368.
