### PR TITLE
fix: string auth state instead of bool

### DIFF
--- a/umh-core/pkg/communicator/models/statusmessagev2.go
+++ b/umh-core/pkg/communicator/models/statusmessagev2.go
@@ -59,14 +59,26 @@ type Historian struct {
 	Timescale Timescale `json:"timescale"`
 }
 
+// TimescaleAuthState classifies whether the timescale endpoint accepted the
+// supplied credentials and database name. It is tri-state: a network or timeout
+// fault leaves authentication unverified (TimescaleAuthUnknown) rather than
+// proven invalid.
+type TimescaleAuthState string
+
+const (
+	TimescaleAuthUnknown TimescaleAuthState = "unknown"
+	TimescaleAuthValid   TimescaleAuthState = "valid"
+	TimescaleAuthInvalid TimescaleAuthState = "invalid"
+)
+
 // Timescale holds the health verdict and last dialed target for the timescale endpoint.
 type Timescale struct {
-	Health    Health  `json:"health"`
-	Host      string  `json:"host"`
-	Latency   float64 `json:"latency"`
-	Port      uint16  `json:"port"`
-	Reachable bool    `json:"reachable"`
-	AuthValid bool    `json:"authValid"`
+	Health    Health             `json:"health"`
+	Host      string             `json:"host"`
+	Auth      TimescaleAuthState `json:"auth"`
+	Latency   float64            `json:"latency"`
+	Port      uint16             `json:"port"`
+	Reachable bool               `json:"reachable"`
 }
 
 type Agent struct {

--- a/umh-core/pkg/communicator/pkg/generator/historian.go
+++ b/umh-core/pkg/communicator/pkg/generator/historian.go
@@ -81,10 +81,10 @@ func HistorianFromFSMv2(ctx context.Context, log *zap.SugaredLogger) *models.His
 				Category:      healthCat,
 			},
 			Host:      result.Host,
+			Auth:      result.Auth,
 			Latency:   result.LatencyMs,
 			Port:      result.Port,
 			Reachable: result.Reachable,
-			AuthValid: result.AuthValid,
 		},
 	}
 }

--- a/umh-core/pkg/fsmv2/historian/historian_suite_test.go
+++ b/umh-core/pkg/fsmv2/historian/historian_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fsmv2timescale
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestHistorianTimescale(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Historian Timescale Suite")
+}

--- a/umh-core/pkg/fsmv2/historian/timescale.go
+++ b/umh-core/pkg/fsmv2/historian/timescale.go
@@ -17,7 +17,8 @@
 // pool against the TimescaleDB/Postgres endpoint: a successful query reports the
 // endpoint reachable and credentials valid, a failure drives the worker
 // degraded. Authentication and missing-database errors are classified as
-// configuration faults (AuthValid=false) rather than transient network faults.
+// configuration faults (Auth=TimescaleAuthInvalid) rather than transient network
+// faults, which leave authentication unverified (Auth=TimescaleAuthUnknown).
 //
 // # Scope: connection health only
 //
@@ -41,11 +42,7 @@
 //     integration.
 //
 // Running two workers adds only one extra pooled connection to the database, so
-// the overhead is minimal and worth the isolation. When the metrics worker lands
-// it should reuse this package's DSN/pool conventions; consider renaming this
-// file to timescale_connection.go and the metrics one to timescale_metrics.go so
-// the split is obvious from the filenames (the current timescale.go name reads
-// as if it did both).
+// the overhead is minimal and worth the isolation.
 package fsmv2timescale
 
 import (
@@ -63,6 +60,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/simple"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/configworker/dynamicchildren"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/logger"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/models"
 )
 
 const (
@@ -99,6 +97,11 @@ const (
 type TimescaleStatus struct {
 	// Host is the observed timescale host.
 	Host string `json:"host"`
+	// Auth reports whether the endpoint accepted the credentials and database
+	// name. It is TimescaleAuthUnknown when nothing answered (a network or timeout
+	// fault), TimescaleAuthInvalid when the server answered but rejected the
+	// config, and TimescaleAuthValid on a successful query.
+	Auth models.TimescaleAuthState `json:"auth"`
 	// LatencyMs is the query round-trip time in milliseconds.
 	LatencyMs float64 `json:"latency_ms"`
 	// Port is the observed timescale port.
@@ -107,10 +110,6 @@ type TimescaleStatus struct {
 	// or the server rejected the credentials/database (an auth fault). It is
 	// false only for network or timeout faults, where nothing answered.
 	Reachable bool `json:"reachable"`
-	// AuthValid is false when the endpoint answered but rejected the supplied
-	// credentials or database name (a configuration fault, not a network fault).
-	// It is true on a successful query.
-	AuthValid bool `json:"auth_valid"`
 }
 
 // Deps carries the poll dependencies, shared across ticks. The pool holder
@@ -172,6 +171,10 @@ const (
 	// pgCodeInvalidCatalogName is Postgres SQLSTATE 3D000: the server rejected
 	// the connection because the requested database does not exist.
 	pgCodeInvalidCatalogName = "3D000"
+
+	// pgBouncerCodeInvalidCatalogName is the SQLSTATE PgBouncer returns (08P01,
+	// protocol violation) when the requested database does not exist in its pool.
+	pgBouncerCodeInvalidCatalogName = "08P01"
 )
 
 // serverRejected reports whether err is the server rejecting the supplied
@@ -185,7 +188,7 @@ func serverRejected(err error) bool {
 	}
 
 	badCredentials := strings.HasPrefix(pgErr.Code, pgClassInvalidAuthorization)
-	unknownDatabase := pgErr.Code == pgCodeInvalidCatalogName
+	unknownDatabase := pgErr.Code == pgCodeInvalidCatalogName || pgErr.Code == pgBouncerCodeInvalidCatalogName
 
 	return badCredentials || unknownDatabase
 }
@@ -194,8 +197,9 @@ func serverRejected(err error) bool {
 // successful query returns a reachable, auth-valid status with the measured
 // latency. On error it returns an unreachable status and wraps the error, which
 // the framework persists as a degraded verdict; an authentication or
-// unknown-database error additionally sets AuthValid=false to flag a
-// configuration fault rather than a transient network problem.
+// unknown-database error additionally sets Auth=TimescaleAuthInvalid to flag a
+// configuration fault, while a network or timeout error leaves
+// Auth=TimescaleAuthUnknown.
 func Poll(ctx context.Context, d Deps, cfg config.HistorianConfig) (TimescaleStatus, error) {
 	cfg = cfg.WithDefaults()
 	host, port := cfg.Timescale.Host, cfg.Timescale.Port
@@ -207,7 +211,7 @@ func Poll(ctx context.Context, d Deps, cfg config.HistorianConfig) (TimescaleSta
 			deps.Bool("reachable", false),
 			deps.Err(err))
 
-		return TimescaleStatus{Host: host, Port: port}, fmt.Errorf("timescale pool: %w", err)
+		return TimescaleStatus{Host: host, Port: port, Auth: models.TimescaleAuthUnknown}, fmt.Errorf("timescale pool: %w", err)
 	}
 
 	start := time.Now()
@@ -215,30 +219,36 @@ func Poll(ctx context.Context, d Deps, cfg config.HistorianConfig) (TimescaleSta
 	var one int
 	if err := pool.QueryRow(ctx, "SELECT 1").Scan(&one); err != nil {
 		// An auth fault means the server answered but rejected the credentials or
-		// database name: the endpoint is reachable, only the config is wrong.
+		// database name: the endpoint is reachable, only the config is wrong. A
+		// non-rejection error (network, timeout) means nothing answered, so
+		// authentication stays unverified rather than proven invalid.
 		reachable := serverRejected(err)
+		auth := models.TimescaleAuthUnknown
+		if reachable {
+			auth = models.TimescaleAuthInvalid
+		}
 		d.Logger.Info("timescale connection check",
 			deps.String("host", host),
 			deps.Bool("reachable", reachable),
-			deps.Bool("auth_valid", false),
+			deps.String("auth", string(auth)),
 			deps.Err(err))
 
-		return TimescaleStatus{Host: host, Port: port, Reachable: reachable, AuthValid: false}, fmt.Errorf("timescale query %s: %w", host, err)
+		return TimescaleStatus{Host: host, Port: port, Reachable: reachable, Auth: auth}, fmt.Errorf("timescale query %s: %w", host, err)
 	}
 
 	elapsedMs := float64(time.Since(start).Microseconds()) / 1000.0
 	d.Logger.Info("timescale connection check",
 		deps.String("host", host),
 		deps.Bool("reachable", true),
-		deps.Bool("auth_valid", true),
+		deps.String("auth", string(models.TimescaleAuthValid)),
 		deps.Float64("latency_ms", elapsedMs))
 
 	return TimescaleStatus{
 		Host:      host,
+		Auth:      models.TimescaleAuthValid,
 		LatencyMs: elapsedMs,
 		Port:      port,
 		Reachable: true,
-		AuthValid: true,
 	}, nil
 }
 

--- a/umh-core/pkg/fsmv2/historian/timescale.go
+++ b/umh-core/pkg/fsmv2/historian/timescale.go
@@ -174,21 +174,40 @@ const (
 
 	// pgBouncerCodeInvalidCatalogName is the SQLSTATE PgBouncer returns (08P01,
 	// protocol violation) when the requested database does not exist in its pool.
+	// The bare code is also used for unrelated protocol violations, so a match
+	// requires pgBouncerMissingDBPrefix in the message as well.
 	pgBouncerCodeInvalidCatalogName = "08P01"
+
+	// pgBouncerMissingDBPrefix is the message prefix PgBouncer pairs with 08P01
+	// when the requested database is not in its pool. Requiring it prevents
+	// unrelated 08P01 protocol violations from being misread as a missing database.
+	pgBouncerMissingDBPrefix = "no such database"
 )
 
-// serverRejected reports whether err is the server rejecting the supplied
-// credentials or database name, rather than a network or timeout fault where
-// nothing answered. A rejection means the endpoint is reachable but the config
-// is wrong.
-func serverRejected(err error) bool {
+// serverAnswered reports whether err carries a server-side PgError, meaning the
+// endpoint is reachable, rather than a network or timeout fault where nothing
+// answered.
+func serverAnswered(err error) bool {
+	var pgErr *pgconn.PgError
+
+	return errors.As(err, &pgErr)
+}
+
+// authRejected reports whether err is the server rejecting the supplied
+// credentials or database name. It is a narrower condition than serverAnswered:
+// a server-side error outside the supported auth (class 28), missing-database
+// (3D000), and PgBouncer missing-database (08P01 with pgBouncerMissingDBPrefix)
+// classes leaves the endpoint reachable but the credentials unproven.
+func authRejected(err error) bool {
 	var pgErr *pgconn.PgError
 	if !errors.As(err, &pgErr) {
 		return false
 	}
 
 	badCredentials := strings.HasPrefix(pgErr.Code, pgClassInvalidAuthorization)
-	unknownDatabase := pgErr.Code == pgCodeInvalidCatalogName || pgErr.Code == pgBouncerCodeInvalidCatalogName
+	pgBouncerMissingDB := pgErr.Code == pgBouncerCodeInvalidCatalogName &&
+		strings.Contains(strings.ToLower(pgErr.Message), pgBouncerMissingDBPrefix)
+	unknownDatabase := pgErr.Code == pgCodeInvalidCatalogName || pgBouncerMissingDB
 
 	return badCredentials || unknownDatabase
 }
@@ -218,13 +237,13 @@ func Poll(ctx context.Context, d Deps, cfg config.HistorianConfig) (TimescaleSta
 
 	var one int
 	if err := pool.QueryRow(ctx, "SELECT 1").Scan(&one); err != nil {
-		// An auth fault means the server answered but rejected the credentials or
-		// database name: the endpoint is reachable, only the config is wrong. A
-		// non-rejection error (network, timeout) means nothing answered, so
-		// authentication stays unverified rather than proven invalid.
-		reachable := serverRejected(err)
+		// Any server-side PgError means the endpoint is reachable. Auth is proven
+		// invalid only when the server rejected the credentials or database name;
+		// other server errors leave the config unverified. A non-PgError (network,
+		// timeout) means nothing answered, so both stay false/unknown.
+		reachable := serverAnswered(err)
 		auth := models.TimescaleAuthUnknown
-		if reachable {
+		if authRejected(err) {
 			auth = models.TimescaleAuthInvalid
 		}
 		d.Logger.Info("timescale connection check",

--- a/umh-core/pkg/fsmv2/historian/timescale_test.go
+++ b/umh-core/pkg/fsmv2/historian/timescale_test.go
@@ -1,0 +1,99 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fsmv2timescale
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+func TestErrorClassification(t *testing.T) {
+	tests := []struct {
+		err          error
+		name         string
+		wantAnswered bool
+		wantAuth     bool
+	}{
+		{
+			name:         "auth: invalid password (28P01)",
+			err:          &pgconn.PgError{Code: "28P01", Message: "password authentication failed"},
+			wantAnswered: true,
+			wantAuth:     true,
+		},
+		{
+			name:         "auth: invalid authorization class (28000)",
+			err:          &pgconn.PgError{Code: "28000", Message: "invalid authorization specification"},
+			wantAnswered: true,
+			wantAuth:     true,
+		},
+		{
+			name:         "unknown database: postgres invalid catalog (3D000)",
+			err:          &pgconn.PgError{Code: "3D000", Message: `database "nope" does not exist`},
+			wantAnswered: true,
+			wantAuth:     true,
+		},
+		{
+			name:         "unknown database: pgbouncer missing database (08P01)",
+			err:          &pgconn.PgError{Code: "08P01", Message: "no such database: nope"},
+			wantAnswered: true,
+			wantAuth:     true,
+		},
+		{
+			name:         "protocol violation: unrelated 08P01 reachable but not auth",
+			err:          &pgconn.PgError{Code: "08P01", Message: "invalid startup packet"},
+			wantAnswered: true,
+			wantAuth:     false,
+		},
+		{
+			name:         "server error: syntax error (42601) reachable but not auth",
+			err:          &pgconn.PgError{Code: "42601", Message: "syntax error"},
+			wantAnswered: true,
+			wantAuth:     false,
+		},
+		{
+			name:         "timeout: context deadline exceeded unreachable",
+			err:          context.DeadlineExceeded,
+			wantAnswered: false,
+			wantAuth:     false,
+		},
+		{
+			name:         "network: plain error unreachable",
+			err:          errors.New("dial tcp: connection refused"),
+			wantAnswered: false,
+			wantAuth:     false,
+		},
+		{
+			name:         "wrapped: pgbouncer missing database through fmt.Errorf",
+			err:          fmt.Errorf("timescale query: %w", &pgconn.PgError{Code: "08P01", Message: "no such database: nope"}),
+			wantAnswered: true,
+			wantAuth:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := serverAnswered(tt.err); got != tt.wantAnswered {
+				t.Errorf("serverAnswered() = %v, want %v", got, tt.wantAnswered)
+			}
+			if got := authRejected(tt.err); got != tt.wantAuth {
+				t.Errorf("authRejected() = %v, want %v", got, tt.wantAuth)
+			}
+		})
+	}
+}

--- a/umh-core/pkg/fsmv2/historian/timescale_test.go
+++ b/umh-core/pkg/fsmv2/historian/timescale_test.go
@@ -18,82 +18,42 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	"github.com/jackc/pgx/v5/pgconn"
 )
 
-func TestErrorClassification(t *testing.T) {
-	tests := []struct {
+var _ = Describe("Error classification", func() {
+	type tc struct {
 		err          error
-		name         string
 		wantAnswered bool
 		wantAuth     bool
-	}{
-		{
-			name:         "auth: invalid password (28P01)",
-			err:          &pgconn.PgError{Code: "28P01", Message: "password authentication failed"},
-			wantAnswered: true,
-			wantAuth:     true,
-		},
-		{
-			name:         "auth: invalid authorization class (28000)",
-			err:          &pgconn.PgError{Code: "28000", Message: "invalid authorization specification"},
-			wantAnswered: true,
-			wantAuth:     true,
-		},
-		{
-			name:         "unknown database: postgres invalid catalog (3D000)",
-			err:          &pgconn.PgError{Code: "3D000", Message: `database "nope" does not exist`},
-			wantAnswered: true,
-			wantAuth:     true,
-		},
-		{
-			name:         "unknown database: pgbouncer missing database (08P01)",
-			err:          &pgconn.PgError{Code: "08P01", Message: "no such database: nope"},
-			wantAnswered: true,
-			wantAuth:     true,
-		},
-		{
-			name:         "protocol violation: unrelated 08P01 reachable but not auth",
-			err:          &pgconn.PgError{Code: "08P01", Message: "invalid startup packet"},
-			wantAnswered: true,
-			wantAuth:     false,
-		},
-		{
-			name:         "server error: syntax error (42601) reachable but not auth",
-			err:          &pgconn.PgError{Code: "42601", Message: "syntax error"},
-			wantAnswered: true,
-			wantAuth:     false,
-		},
-		{
-			name:         "timeout: context deadline exceeded unreachable",
-			err:          context.DeadlineExceeded,
-			wantAnswered: false,
-			wantAuth:     false,
-		},
-		{
-			name:         "network: plain error unreachable",
-			err:          errors.New("dial tcp: connection refused"),
-			wantAnswered: false,
-			wantAuth:     false,
-		},
-		{
-			name:         "wrapped: pgbouncer missing database through fmt.Errorf",
-			err:          fmt.Errorf("timescale query: %w", &pgconn.PgError{Code: "08P01", Message: "no such database: nope"}),
-			wantAnswered: true,
-			wantAuth:     true,
-		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := serverAnswered(tt.err); got != tt.wantAnswered {
-				t.Errorf("serverAnswered() = %v, want %v", got, tt.wantAnswered)
-			}
-			if got := authRejected(tt.err); got != tt.wantAuth {
-				t.Errorf("authRejected() = %v, want %v", got, tt.wantAuth)
-			}
-		})
-	}
-}
+	DescribeTable("serverAnswered and authRejected",
+		func(t tc) {
+			Expect(serverAnswered(t.err)).To(Equal(t.wantAnswered), "serverAnswered")
+			Expect(authRejected(t.err)).To(Equal(t.wantAuth), "authRejected")
+		},
+		Entry("auth: invalid password (28P01)",
+			tc{err: &pgconn.PgError{Code: "28P01", Message: "password authentication failed"}, wantAnswered: true, wantAuth: true}),
+		Entry("auth: invalid authorization class (28000)",
+			tc{err: &pgconn.PgError{Code: "28000", Message: "invalid authorization specification"}, wantAnswered: true, wantAuth: true}),
+		Entry("unknown database: postgres invalid catalog (3D000)",
+			tc{err: &pgconn.PgError{Code: "3D000", Message: `database "nope" does not exist`}, wantAnswered: true, wantAuth: true}),
+		Entry("unknown database: pgbouncer missing database (08P01)",
+			tc{err: &pgconn.PgError{Code: "08P01", Message: "no such database: nope"}, wantAnswered: true, wantAuth: true}),
+		Entry("protocol violation: unrelated 08P01 reachable but not auth",
+			tc{err: &pgconn.PgError{Code: "08P01", Message: "invalid startup packet"}, wantAnswered: true, wantAuth: false}),
+		Entry("server error: syntax error (42601) reachable but not auth",
+			tc{err: &pgconn.PgError{Code: "42601", Message: "syntax error"}, wantAnswered: true, wantAuth: false}),
+		Entry("timeout: context deadline exceeded unreachable",
+			tc{err: context.DeadlineExceeded, wantAnswered: false, wantAuth: false}),
+		Entry("network: plain error unreachable",
+			tc{err: errors.New("dial tcp: connection refused"), wantAnswered: false, wantAuth: false}),
+		Entry("wrapped: pgbouncer missing database through fmt.Errorf",
+			tc{err: fmt.Errorf("timescale query: %w", &pgconn.PgError{Code: "08P01", Message: "no such database: nope"}), wantAnswered: true, wantAuth: true}),
+	)
+})

--- a/umh-core/pkg/models/status_message.go
+++ b/umh-core/pkg/models/status_message.go
@@ -41,14 +41,26 @@ type Historian struct {
 	Timescale Timescale `json:"timescale"`
 }
 
+// TimescaleAuthState classifies whether the timescale endpoint accepted the
+// supplied credentials and database name. It is tri-state: a network or timeout
+// fault leaves authentication unverified (TimescaleAuthUnknown) rather than
+// proven invalid.
+type TimescaleAuthState string
+
+const (
+	TimescaleAuthUnknown TimescaleAuthState = "unknown"
+	TimescaleAuthValid   TimescaleAuthState = "valid"
+	TimescaleAuthInvalid TimescaleAuthState = "invalid"
+)
+
 // Timescale holds the health verdict and last dialed target for the timescale endpoint.
 type Timescale struct {
-	Health    *Health `json:"health"`
-	Host      string  `json:"host"`
-	Latency   float64 `json:"latency"`
-	Port      uint16  `json:"port"`
-	Reachable bool    `json:"reachable"`
-	AuthValid bool    `json:"authValid"`
+	Health    *Health            `json:"health"`
+	Host      string             `json:"host"`
+	Auth      TimescaleAuthState `json:"auth"`
+	Latency   float64            `json:"latency"`
+	Port      uint16             `json:"port"`
+	Reachable bool               `json:"reachable"`
 }
 
 type Agent struct {


### PR DESCRIPTION
As discussed, now shows auth state `valid | invalid | unknown` instead of a `bool`