### PR TITLE
dedup to separate logger

### DIFF
--- a/umh-core/internal/fsm/baseFSM.go
+++ b/umh-core/internal/fsm/baseFSM.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/backoff"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants"
+	umhlogger "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/logger"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/sentry"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/filesystem"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/serviceregistry"
@@ -37,9 +38,9 @@ import (
 // BaseFSMInstance implements the public fsm.FSM interface.
 type BaseFSMInstance struct {
 
-	// lastSuppressionSummary is the time the most recent suppression summary was
-	// emitted, used to throttle the periodic WARN summary.
-	lastSuppressionSummary time.Time
+	// DedupLogger deduplicates repeating reconcile-loop error logs. Embedded so
+	// LogErrorDedup is promoted onto BaseFSMInstance.
+	*umhlogger.DedupLogger
 
 	// fsm is the finite state machine that manages instance state
 	fsm *fsm.FSM
@@ -57,28 +58,13 @@ type BaseFSMInstance struct {
 	// Note: this is only temporary and should be replaced by a generalized implementation of the archive storage
 	lastObservedLifecycleState string
 
-	// lastLoggedErrorMsg is used to deduplicate error logs in the reconcile loop.
-	// Error on first/changed occurrence, Debug on repeats.
-	lastLoggedErrorMsg string
-
 	cfg BaseFSMInstanceConfig
 
 	// transientStreakCounter is the number of ticks a FSM has remained in a transient state
 	transientStreakCounter uint64
 
-	// suppressedErrorCount counts repeats of lastLoggedErrorMsg that were
-	// demoted to Debug since the last periodic summary (or since suppression
-	// began). It is reported and reset by the periodic WARN summary and by the
-	// final summary emitted when the error changes or clears.
-	suppressedErrorCount uint64
-
 	// mu is a mutex for protecting concurrent access to fields
 	mu sync.RWMutex
-
-	// errorSuppressionAnnounced records whether the "repeats suppressed" notice
-	// has already been logged for the current lastLoggedErrorMsg, so it is
-	// emitted exactly once (on the first repeat) rather than every repeat.
-	errorSuppressionAnnounced bool
 }
 
 type BaseFSMInstanceConfig struct {
@@ -112,9 +98,10 @@ func NewBaseFSMInstance(cfg BaseFSMInstanceConfig, backoffConfig backoff.Config,
 	}
 
 	baseInstance := &BaseFSMInstance{
-		cfg:       cfg,
-		callbacks: make(map[string]fsm.Callback),
-		logger:    logger,
+		cfg:              cfg,
+		callbacks:        make(map[string]fsm.Callback),
+		logger:      logger,
+		DedupLogger: umhlogger.NewDedupLogger(logger),
 	}
 
 	// Initialize backoff manager with appropriate configuration
@@ -363,60 +350,12 @@ func (s *BaseFSMInstance) ShouldSkipReconcileBecauseOfError(tick uint64) bool {
 	return s.backoffManager.ShouldSkipOperation(tick)
 }
 
-// ResetState clears the error and backoff after a successful reconcile.
+// ResetState clears the error and backoff after a successful reconcile. It also
+// ends the LogErrorDedup cycle, emitting a final summary of any suppressed
+// repeats.
 func (s *BaseFSMInstance) ResetState() {
 	s.backoffManager.Reset()
-	s.emitSuppressionSummary()
-	s.lastLoggedErrorMsg = ""
-	s.errorSuppressionAnnounced = false
-}
-
-// errorSuppressionSummaryInterval bounds how often a periodic WARN summary is
-// emitted while identical reconcile errors keep repeating, so an ongoing
-// failure stays visible at normal log levels without flooding the log.
-const errorSuppressionSummaryInterval = 60 * time.Second
-
-// LogErrorDedup logs reconcile-loop errors without spamming: first occurrence
-// at Error, first repeat at Error with a suppression note, further repeats at
-// Debug plus a periodic Error summary (once per errorSuppressionSummaryInterval)
-// of the suppressed count. A changed message or ResetState resets the cycle and
-// emits a final Error summary of what was suppressed.
-func (s *BaseFSMInstance) LogErrorDedup(format string, args ...any) {
-	msg := fmt.Sprintf(format, args...)
-	switch {
-	case msg != s.lastLoggedErrorMsg:
-		s.emitSuppressionSummary()
-		s.logger.Errorf("%s", msg)
-		s.lastLoggedErrorMsg = msg
-		s.errorSuppressionAnnounced = false
-		s.suppressedErrorCount = 0
-		s.lastSuppressionSummary = time.Now()
-	case !s.errorSuppressionAnnounced:
-		s.logger.Errorf("%s (further repeats suppressed to debug until it changes or clears)", msg)
-		s.errorSuppressionAnnounced = true
-		s.lastSuppressionSummary = time.Now()
-	default:
-		s.logger.Debugf("%s", msg)
-		s.suppressedErrorCount++
-		if time.Since(s.lastSuppressionSummary) >= errorSuppressionSummaryInterval {
-			s.logger.Errorf("repeated reconcile error suppressed %d times in the last %s (still failing): %s",
-				s.suppressedErrorCount, time.Since(s.lastSuppressionSummary).Round(time.Second), msg)
-			s.suppressedErrorCount = 0
-			s.lastSuppressionSummary = time.Now()
-		}
-	}
-}
-
-// emitSuppressionSummary logs a final WARN summary when a suppressed error
-// changes or clears, so the scale of an ongoing failure is not hidden. It is a
-// no-op when no repeats were suppressed since the last summary.
-func (s *BaseFSMInstance) emitSuppressionSummary() {
-	if s.suppressedErrorCount == 0 {
-		return
-	}
-	s.logger.Errorf("previous reconcile error cleared or changed after %d further suppressed repeats: %s",
-		s.suppressedErrorCount, s.lastLoggedErrorMsg)
-	s.suppressedErrorCount = 0
+	s.DedupLogger.Reset()
 }
 
 // IsPermanentlyFailed returns true if the FSM has reached a permanent failure state

--- a/umh-core/internal/fsm/baseFSM.go
+++ b/umh-core/internal/fsm/baseFSM.go
@@ -38,9 +38,10 @@ import (
 // BaseFSMInstance implements the public fsm.FSM interface.
 type BaseFSMInstance struct {
 
-	// DedupLogger deduplicates repeating reconcile-loop error logs. Embedded so
-	// LogErrorDedup is promoted onto BaseFSMInstance.
-	*umhlogger.DedupLogger
+	// Logger is the FSM logger. It is a *zap.SugaredLogger with the added
+	// LogErrorDedup method, which deduplicates repeating reconcile-loop error
+	// logs so a persistent failure does not flood the log every tick.
+	Logger *umhlogger.DedupLogger
 
 	// fsm is the finite state machine that manages instance state
 	fsm *fsm.FSM
@@ -50,9 +51,6 @@ type BaseFSMInstance struct {
 
 	// backoffManager is the backoff manager for handling error retries and permanent failures
 	backoffManager *backoff.BackoffManager
-
-	// logger is the logger for the FSM
-	logger *zap.SugaredLogger
 
 	// lastObservedLifecycleState is the last state that was observed by the FSM
 	// Note: this is only temporary and should be replaced by a generalized implementation of the archive storage
@@ -91,17 +89,16 @@ type BaseFSMInstanceConfig struct {
 }
 
 // NewBaseFSMInstance creates a new FSM instance.
-func NewBaseFSMInstance(cfg BaseFSMInstanceConfig, backoffConfig backoff.Config, logger *zap.SugaredLogger) *BaseFSMInstance {
+func NewBaseFSMInstance(cfg BaseFSMInstanceConfig, backoffConfig backoff.Config, logger *umhlogger.DedupLogger) *BaseFSMInstance {
 	// Set default max ticks to remain in transient state if not set
 	if cfg.MaxTicksToRemainInTransientState == 0 {
 		cfg.MaxTicksToRemainInTransientState = constants.DefaultMaxTicksToRemainInTransientState
 	}
 
 	baseInstance := &BaseFSMInstance{
-		cfg:              cfg,
-		callbacks:        make(map[string]fsm.Callback),
-		logger:      logger,
-		DedupLogger: umhlogger.NewDedupLogger(logger),
+		cfg:       cfg,
+		callbacks: make(map[string]fsm.Callback),
+		Logger:    logger,
 	}
 
 	// Initialize backoff manager with appropriate configuration
@@ -134,19 +131,19 @@ func NewBaseFSMInstance(cfg BaseFSMInstanceConfig, backoffConfig backoff.Config,
 	// Register default lifecycle callbacks
 
 	baseInstance.AddCallback("enter_"+LifecycleStateRemoved, func(ctx context.Context, e *fsm.Event) {
-		baseInstance.logger.Debugf("Entering removed state for FSM %s", baseInstance.cfg.ID)
+		baseInstance.Logger.Debugf("Entering removed state for FSM %s", baseInstance.cfg.ID)
 	})
 
 	baseInstance.AddCallback("enter_"+LifecycleStateCreating, func(ctx context.Context, e *fsm.Event) {
-		baseInstance.logger.Debugf("Entering creating state for FSM %s", baseInstance.cfg.ID)
+		baseInstance.Logger.Debugf("Entering creating state for FSM %s", baseInstance.cfg.ID)
 	})
 
 	baseInstance.AddCallback("enter_"+LifecycleStateToBeCreated, func(ctx context.Context, e *fsm.Event) {
-		baseInstance.logger.Debugf("Entering to be created state for FSM %s", baseInstance.cfg.ID)
+		baseInstance.Logger.Debugf("Entering to be created state for FSM %s", baseInstance.cfg.ID)
 	})
 
 	baseInstance.AddCallback("enter_"+LifecycleStateRemoving, func(ctx context.Context, e *fsm.Event) {
-		baseInstance.logger.Debugf("Entering removing state for FSM %s", baseInstance.cfg.ID)
+		baseInstance.Logger.Debugf("Entering removing state for FSM %s", baseInstance.cfg.ID)
 	})
 
 	return baseInstance
@@ -167,7 +164,7 @@ func (s *BaseFSMInstance) GetError() error {
 func (s *BaseFSMInstance) SetError(err error, tick uint64) bool {
 	isPermanent := s.backoffManager.SetError(err, tick)
 	if isPermanent {
-		sentry.ReportFSMErrorf(s.logger, s.cfg.ID, "BaseFSM", "permanent_failure", "FSM has reached permanent failure state: %v", err)
+		sentry.ReportFSMErrorf(s.Logger.SugaredLogger, s.cfg.ID, "BaseFSM", "permanent_failure", "FSM has reached permanent failure state: %v", err)
 	}
 
 	return isPermanent
@@ -180,7 +177,7 @@ func (s *BaseFSMInstance) SetDesiredFSMState(state string) {
 	defer s.mu.Unlock()
 
 	s.cfg.DesiredFSMState = state
-	s.logger.Infof("Setting desired state of FSM %s to %s", s.cfg.ID, state)
+	s.Logger.Infof("Setting desired state of FSM %s to %s", s.cfg.ID, state)
 }
 
 // GetDesiredFSMState returns the desired state of the FSM.
@@ -242,7 +239,7 @@ func (s *BaseFSMInstance) SendEvent(ctx context.Context, eventName string, args 
 	instanceID := s.GetID()
 
 	// Log the transition attempt for debugging
-	s.logger.Debugf("FSM %s attempting transition: current_state='%s' -> event='%s' (desired_state='%s')",
+	s.Logger.Debugf("FSM %s attempting transition: current_state='%s' -> event='%s' (desired_state='%s')",
 		instanceID, currentState, eventName, desiredState)
 
 	// CRITICAL: Always give FSM a fresh context to prevent "previous transition did not complete" errors
@@ -258,7 +255,7 @@ func (s *BaseFSMInstance) SendEvent(ctx context.Context, eventName string, args 
 
 	// Check if parent context expired while we were executing
 	if err == nil && ctx.Err() != nil {
-		s.logger.Warnf("FSM transition completed successfully but parent context expired - prevented stuck transition but now outside of cycle time (preventing bigger impact)")
+		s.Logger.Warnf("FSM transition completed successfully but parent context expired - prevented stuck transition but now outside of cycle time (preventing bigger impact)")
 	}
 
 	if err != nil {
@@ -267,7 +264,7 @@ func (s *BaseFSMInstance) SendEvent(ctx context.Context, eventName string, args 
 			instanceID, currentState, eventName, desiredState, err)
 
 		// Log the failure with full context
-		s.logger.Errorf("FSM transition failed (test): %s", enhancedErr.Error())
+		s.Logger.Errorf("FSM transition failed (test): %s", enhancedErr.Error())
 
 		return enhancedErr
 	}
@@ -275,7 +272,7 @@ func (s *BaseFSMInstance) SendEvent(ctx context.Context, eventName string, args 
 	// Log successful transition
 	newState := s.fsm.Current()
 	if newState != currentState {
-		s.logger.Debugf("FSM %s successful transition: '%s' -> '%s' via event='%s' (desired_state='%s')",
+		s.Logger.Debugf("FSM %s successful transition: '%s' -> '%s' via event='%s' (desired_state='%s')",
 			instanceID, currentState, newState, eventName, desiredState)
 	}
 
@@ -323,7 +320,7 @@ func (s *BaseFSMInstance) Remove(ctx context.Context) error {
 
 				// Record it; tick value is irrelevant here (we pass 0)
 				s.SetError(perr, 0)
-				sentry.ReportFSMErrorf(s.logger, s.cfg.ID, "BaseFSM", "permanent_failure", "auto-remove of %s failed: %v", s.cfg.ID, err)
+				sentry.ReportFSMErrorf(s.Logger.SugaredLogger, s.cfg.ID, "BaseFSM", "permanent_failure", "auto-remove of %s failed: %v", s.cfg.ID, err)
 			}
 
 			delete(s.callbacks, cb) // detach – run only once
@@ -355,7 +352,7 @@ func (s *BaseFSMInstance) ShouldSkipReconcileBecauseOfError(tick uint64) bool {
 // repeats.
 func (s *BaseFSMInstance) ResetState() {
 	s.backoffManager.Reset()
-	s.DedupLogger.Reset()
+	s.Logger.Reset()
 }
 
 // IsPermanentlyFailed returns true if the FSM has reached a permanent failure state
@@ -376,7 +373,7 @@ func (s *BaseFSMInstance) GetID() string {
 }
 
 func (s *BaseFSMInstance) GetLogger() *zap.SugaredLogger {
-	return s.logger
+	return s.Logger.SugaredLogger
 }
 
 func (s *BaseFSMInstance) GetLastError() error {
@@ -591,7 +588,7 @@ func (s *BaseFSMInstance) IsDeadlineExceededAndHandle(err error, tick uint64, lo
 	if errors.Is(err, context.DeadlineExceeded) {
 		// Context deadline exceeded should be retried with backoff, not ignored
 		s.SetError(err, tick)
-		s.logger.Warnf("Context deadline exceeded in %s, will retry with backoff", location)
+		s.Logger.Warnf("Context deadline exceeded in %s, will retry with backoff", location)
 
 		return true // handled, return early
 	}

--- a/umh-core/internal/fsm/baseFSM_test.go
+++ b/umh-core/internal/fsm/baseFSM_test.go
@@ -27,6 +27,7 @@ import (
 	"go.uber.org/zap/zaptest"
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/backoff"
+	umhlogger "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/logger"
 )
 
 func TestBaseFSM(t *testing.T) {
@@ -58,7 +59,7 @@ var _ = Describe("BaseFSMInstance", func() {
 
 		logger := logger.Sugar()
 		backoffConfig := backoff.DefaultConfig(config.ID, logger)
-		fsmInstance = NewBaseFSMInstance(config, backoffConfig, logger)
+		fsmInstance = NewBaseFSMInstance(config, backoffConfig, umhlogger.NewDedupLogger(logger))
 
 		tick = 0
 	})
@@ -95,7 +96,7 @@ var _ = Describe("BaseFSMInstance", func() {
 
 			logger := logger.Sugar()
 			backoffConfig := backoff.NewBackoffConfig(config.ID, 1, 600, 2, logger)
-			specialInstance := NewBaseFSMInstance(config, backoffConfig, logger)
+			specialInstance := NewBaseFSMInstance(config, backoffConfig, umhlogger.NewDedupLogger(logger))
 			// Replace the default backoffManager with one that has fewer retries for testing
 			//	backoffConfig := backoff.DefaultConfig(specialInstance.cfg.ID, logger.Sugar())
 			//	backoffConfig.MaxRetries = 2 // Only allow 2 retries

--- a/umh-core/pkg/fsm/agent_monitor/machine.go
+++ b/umh-core/pkg/fsm/agent_monitor/machine.go
@@ -66,7 +66,7 @@ func NewAgentInstanceWithService(config config.AgentMonitorConfig, service agent
 	}
 
 	// Construct the base instance
-	baseFSM := internal_fsm.NewBaseFSMInstance(fsmCfg, backoff.DefaultConfig(metrics.ComponentAgentMonitor, logger.For(config.Name)), logger.For(config.Name))
+	baseFSM := internal_fsm.NewBaseFSMInstance(fsmCfg, backoff.DefaultConfig(metrics.ComponentAgentMonitor, logger.For(config.Name)), logger.NewDedupLogger(logger.For(config.Name)))
 
 	// Create our instance
 	instance := &AgentInstance{

--- a/umh-core/pkg/fsm/agent_monitor/reconcile.go
+++ b/umh-core/pkg/fsm/agent_monitor/reconcile.go
@@ -115,7 +115,7 @@ func (a *AgentInstance) Reconcile(ctx context.Context, snapshot fsm.SystemSnapsh
 		}
 
 		a.baseFSMInstance.SetError(err, snapshot.Tick)
-		a.baseFSMInstance.LogErrorDedup("error reconciling state: %s", err)
+		a.baseFSMInstance.Logger.LogErrorDedup("error reconciling state: %s", err)
 
 		return nil, false // We don't want to return an error here, because we want to continue reconciling
 	}

--- a/umh-core/pkg/fsm/benthos/machine.go
+++ b/umh-core/pkg/fsm/benthos/machine.go
@@ -78,8 +78,8 @@ func NewBenthosInstanceWithService(
 		},
 	}
 
-	logger := logger.For(config.Name)
-	backoffConfig := backoff.DefaultConfig(cfg.ID, logger)
+	logger := logger.NewDedupLogger(logger.For(config.Name))
+	backoffConfig := backoff.DefaultConfig(cfg.ID, logger.SugaredLogger)
 
 	instance := &BenthosInstance{
 		baseFSMInstance: internal_fsm.NewBaseFSMInstance(cfg, backoffConfig, logger),

--- a/umh-core/pkg/fsm/benthos/reconcile.go
+++ b/umh-core/pkg/fsm/benthos/reconcile.go
@@ -130,7 +130,7 @@ func (b *BenthosInstance) Reconcile(ctx context.Context, snapshot fsm.SystemSnap
 		}
 
 		b.baseFSMInstance.SetError(err, snapshot.Tick)
-		b.baseFSMInstance.LogErrorDedup("error reconciling state: %s", err)
+		b.baseFSMInstance.Logger.LogErrorDedup("error reconciling state: %s", err)
 
 		return nil, false // We don't want to return an error here, because we want to continue reconciling
 	}
@@ -144,7 +144,7 @@ func (b *BenthosInstance) Reconcile(ctx context.Context, snapshot fsm.SystemSnap
 		}
 
 		b.baseFSMInstance.SetError(s6Err, snapshot.Tick)
-		b.baseFSMInstance.LogErrorDedup("error reconciling s6Manager: %s", s6Err)
+		b.baseFSMInstance.Logger.LogErrorDedup("error reconciling s6Manager: %s", s6Err)
 
 		return nil, false
 	}

--- a/umh-core/pkg/fsm/benthos_monitor/machine.go
+++ b/umh-core/pkg/fsm/benthos_monitor/machine.go
@@ -72,7 +72,7 @@ func NewBenthosMonitorInstanceWithService(config config.BenthosMonitorConfig, se
 	}
 
 	// Construct the base instance
-	baseFSM := internal_fsm.NewBaseFSMInstance(fsmCfg, backoff.DefaultConfig(metrics.ComponentAgentMonitor, logger.For(config.Name)), logger.For(config.Name))
+	baseFSM := internal_fsm.NewBaseFSMInstance(fsmCfg, backoff.DefaultConfig(metrics.ComponentAgentMonitor, logger.For(config.Name)), logger.NewDedupLogger(logger.For(config.Name)))
 
 	// Create our instance
 	instance := &BenthosMonitorInstance{

--- a/umh-core/pkg/fsm/benthos_monitor/reconcile.go
+++ b/umh-core/pkg/fsm/benthos_monitor/reconcile.go
@@ -120,7 +120,7 @@ func (b *BenthosMonitorInstance) Reconcile(ctx context.Context, snapshot fsm.Sys
 		}
 
 		b.baseFSMInstance.SetError(err, snapshot.Tick)
-		b.baseFSMInstance.LogErrorDedup("error reconciling state: %s", err)
+		b.baseFSMInstance.Logger.LogErrorDedup("error reconciling state: %s", err)
 
 		return nil, false // We don't want to return an error here, because we want to continue reconciling
 	}
@@ -136,7 +136,7 @@ func (b *BenthosMonitorInstance) Reconcile(ctx context.Context, snapshot fsm.Sys
 		}
 
 		b.baseFSMInstance.SetError(s6Err, snapshot.Tick)
-		b.baseFSMInstance.LogErrorDedup("error reconciling s6Manager: %s", s6Err)
+		b.baseFSMInstance.Logger.LogErrorDedup("error reconciling s6Manager: %s", s6Err)
 
 		return nil, false
 	}

--- a/umh-core/pkg/fsm/connection/machine.go
+++ b/umh-core/pkg/fsm/connection/machine.go
@@ -106,8 +106,8 @@ func NewConnectionInstance(
 		},
 	}
 
-	logger := logger.For(config.Name)
-	backoffConfig := backoff.DefaultConfig(cfg.ID, logger)
+	logger := logger.NewDedupLogger(logger.For(config.Name))
+	backoffConfig := backoff.DefaultConfig(cfg.ID, logger.SugaredLogger)
 
 	instance := &ConnectionInstance{
 		baseFSMInstance: internal_fsm.NewBaseFSMInstance(cfg, backoffConfig, logger),

--- a/umh-core/pkg/fsm/connection/reconcile.go
+++ b/umh-core/pkg/fsm/connection/reconcile.go
@@ -132,7 +132,7 @@ func (c *ConnectionInstance) Reconcile(ctx context.Context, snapshot fsm.SystemS
 		}
 
 		c.baseFSMInstance.SetError(err, snapshot.Tick)
-		c.baseFSMInstance.LogErrorDedup("error reconciling state: %s", err)
+		c.baseFSMInstance.Logger.LogErrorDedup("error reconciling state: %s", err)
 
 		return nil, false // We don't want to return an error here, because we want to continue reconciling
 	}
@@ -145,7 +145,7 @@ func (c *ConnectionInstance) Reconcile(ctx context.Context, snapshot fsm.SystemS
 		}
 
 		c.baseFSMInstance.SetError(nmapErr, snapshot.Tick)
-		c.baseFSMInstance.LogErrorDedup("error reconciling nmapManager: %s", nmapErr)
+		c.baseFSMInstance.Logger.LogErrorDedup("error reconciling nmapManager: %s", nmapErr)
 
 		return nil, false
 	}

--- a/umh-core/pkg/fsm/container/machine.go
+++ b/umh-core/pkg/fsm/container/machine.go
@@ -65,8 +65,8 @@ func NewContainerInstanceWithService(config config.ContainerConfig, service cont
 	}
 
 	// Construct the base instance
-	logger := logger.For(config.Name)
-	backoffConfig := backoff.DefaultConfig(fsmCfg.ID, logger)
+	logger := logger.NewDedupLogger(logger.For(config.Name))
+	backoffConfig := backoff.DefaultConfig(fsmCfg.ID, logger.SugaredLogger)
 	baseFSM := internal_fsm.NewBaseFSMInstance(fsmCfg, backoffConfig, logger)
 
 	// Create our instance

--- a/umh-core/pkg/fsm/container/reconcile.go
+++ b/umh-core/pkg/fsm/container/reconcile.go
@@ -124,7 +124,7 @@ func (c *ContainerInstance) Reconcile(ctx context.Context, snapshot fsm.SystemSn
 		}
 
 		c.baseFSMInstance.SetError(err, snapshot.Tick)
-		c.baseFSMInstance.LogErrorDedup("error reconciling state: %s", err)
+		c.baseFSMInstance.Logger.LogErrorDedup("error reconciling state: %s", err)
 
 		return nil, false // We don't want to return an error here, because we want to continue reconciling
 	}

--- a/umh-core/pkg/fsm/dataflowcomponent/machine.go
+++ b/umh-core/pkg/fsm/dataflowcomponent/machine.go
@@ -81,8 +81,8 @@ func NewDataflowComponentInstance(
 		},
 	}
 
-	logger := logger.For(config.Name)
-	backoffConfig := backoff.DefaultConfig(cfg.ID, logger)
+	logger := logger.NewDedupLogger(logger.For(config.Name))
+	backoffConfig := backoff.DefaultConfig(cfg.ID, logger.SugaredLogger)
 
 	serviceConfig := config.DataFlowComponentServiceConfig
 	serviceConfig.DebugLevel = config.DebugLevel

--- a/umh-core/pkg/fsm/dataflowcomponent/reconcile.go
+++ b/umh-core/pkg/fsm/dataflowcomponent/reconcile.go
@@ -132,7 +132,7 @@ func (d *DataflowComponentInstance) Reconcile(ctx context.Context, snapshot fsm.
 		}
 
 		d.baseFSMInstance.SetError(err, snapshot.Tick)
-		d.baseFSMInstance.LogErrorDedup("error reconciling state: %s", err)
+		d.baseFSMInstance.Logger.LogErrorDedup("error reconciling state: %s", err)
 
 		return nil, false // We don't want to return an error here, because we want to continue reconciling
 	}
@@ -150,7 +150,7 @@ func (d *DataflowComponentInstance) Reconcile(ctx context.Context, snapshot fsm.
 		}
 
 		d.baseFSMInstance.SetError(benthosErr, snapshot.Tick)
-		d.baseFSMInstance.LogErrorDedup("error reconciling benthosManager: %s", benthosErr)
+		d.baseFSMInstance.Logger.LogErrorDedup("error reconciling benthosManager: %s", benthosErr)
 
 		return nil, false
 	}

--- a/umh-core/pkg/fsm/nmap/machine.go
+++ b/umh-core/pkg/fsm/nmap/machine.go
@@ -189,7 +189,7 @@ func NewNmapInstanceWithService(config config.NmapConfig, service nmap_service.I
 		},
 	}
 
-	logger := logger.For(config.Name)
+	logger := logger.NewDedupLogger(logger.For(config.Name))
 
 	// Construct the base instance
 	// Adjust the Backoff-Configuration regarding to the FSM's needs
@@ -197,7 +197,7 @@ func NewNmapInstanceWithService(config config.NmapConfig, service nmap_service.I
 	// InitialInterval: 10 (ticks) -> 1 second
 	// MaxInterval: 40 (ticks) -> 4 seconds
 	// MaxRetries: 2  -> fails for 3rd error
-	backoffConfig := backoff.NewBackoffConfig(fsmCfg.ID, 10, 20, 2, logger)
+	backoffConfig := backoff.NewBackoffConfig(fsmCfg.ID, 10, 20, 2, logger.SugaredLogger)
 	baseFSM := internal_fsm.NewBaseFSMInstance(fsmCfg, backoffConfig, logger)
 
 	// Create our instance

--- a/umh-core/pkg/fsm/nmap/reconcile.go
+++ b/umh-core/pkg/fsm/nmap/reconcile.go
@@ -121,7 +121,7 @@ func (n *NmapInstance) Reconcile(ctx context.Context, snapshot fsm.SystemSnapsho
 		}
 
 		n.baseFSMInstance.SetError(err, snapshot.Tick)
-		n.baseFSMInstance.LogErrorDedup("error reconciling state: %s", err)
+		n.baseFSMInstance.Logger.LogErrorDedup("error reconciling state: %s", err)
 
 		return nil, false // We don't want to return an error here, because we want to continue reconciling
 	}
@@ -134,7 +134,7 @@ func (n *NmapInstance) Reconcile(ctx context.Context, snapshot fsm.SystemSnapsho
 		}
 
 		n.baseFSMInstance.SetError(s6Err, snapshot.Tick)
-		n.baseFSMInstance.LogErrorDedup("error reconciling monitorService: %s", s6Err)
+		n.baseFSMInstance.Logger.LogErrorDedup("error reconciling monitorService: %s", s6Err)
 
 		return nil, false
 	}

--- a/umh-core/pkg/fsm/protocolconverter/machine.go
+++ b/umh-core/pkg/fsm/protocolconverter/machine.go
@@ -116,8 +116,8 @@ func NewProtocolConverterInstance(
 		},
 	}
 
-	logger := logger.For(config.Name)
-	backoffConfig := backoff.DefaultConfig(cfg.ID, logger)
+	logger := logger.NewDedupLogger(logger.For(config.Name))
+	backoffConfig := backoff.DefaultConfig(cfg.ID, logger.SugaredLogger)
 
 	instance := &ProtocolConverterInstance{
 		baseFSMInstance: internal_fsm.NewBaseFSMInstance(cfg, backoffConfig, logger),

--- a/umh-core/pkg/fsm/protocolconverter/reconcile.go
+++ b/umh-core/pkg/fsm/protocolconverter/reconcile.go
@@ -155,7 +155,7 @@ func (p *ProtocolConverterInstance) Reconcile(ctx context.Context, snapshot fsm.
 		// Enhanced error logging with state context
 		currentState := p.baseFSMInstance.GetCurrentFSMState()
 		desiredState := p.baseFSMInstance.GetDesiredFSMState()
-		p.baseFSMInstance.LogErrorDedup("error reconciling state transition: current_state='%s', desired_state='%s', error: %s",
+		p.baseFSMInstance.Logger.LogErrorDedup("error reconciling state transition: current_state='%s', desired_state='%s', error: %s",
 			currentState, desiredState, err)
 
 		p.baseFSMInstance.SetError(err, snapshot.Tick)
@@ -176,7 +176,7 @@ func (p *ProtocolConverterInstance) Reconcile(ctx context.Context, snapshot fsm.
 		}
 
 		p.baseFSMInstance.SetError(managerErr, snapshot.Tick)
-		p.baseFSMInstance.LogErrorDedup("error reconciling manager: %s", managerErr)
+		p.baseFSMInstance.Logger.LogErrorDedup("error reconciling manager: %s", managerErr)
 
 		return nil, false
 	}

--- a/umh-core/pkg/fsm/redpanda/machine.go
+++ b/umh-core/pkg/fsm/redpanda/machine.go
@@ -72,8 +72,8 @@ func NewRedpandaInstance(
 		},
 	}
 
-	logger := logger.For(config.Name)
-	backoffConfig := backoff.DefaultConfig(cfg.ID, logger)
+	logger := logger.NewDedupLogger(logger.For(config.Name))
+	backoffConfig := backoff.DefaultConfig(cfg.ID, logger.SugaredLogger)
 
 	instance := &RedpandaInstance{
 		baseFSMInstance:       internal_fsm.NewBaseFSMInstance(cfg, backoffConfig, logger),

--- a/umh-core/pkg/fsm/redpanda/reconcile.go
+++ b/umh-core/pkg/fsm/redpanda/reconcile.go
@@ -132,7 +132,7 @@ func (r *RedpandaInstance) Reconcile(ctx context.Context, snapshot fsm.SystemSna
 		}
 
 		r.baseFSMInstance.SetError(err, snapshot.Tick)
-		r.baseFSMInstance.LogErrorDedup("error reconciling state: %s", err)
+		r.baseFSMInstance.Logger.LogErrorDedup("error reconciling state: %s", err)
 
 		return nil, false // We don't want to return an error here, because we want to continue reconciling
 	}
@@ -145,7 +145,7 @@ func (r *RedpandaInstance) Reconcile(ctx context.Context, snapshot fsm.SystemSna
 			// For schema registry errors, only set the error if we're in running states
 			if r.IsRunning() {
 				r.baseFSMInstance.SetError(s6Err, snapshot.Tick)
-				r.baseFSMInstance.LogErrorDedup("error reconciling s6Manager: %s", s6Err)
+				r.baseFSMInstance.Logger.LogErrorDedup("error reconciling s6Manager: %s", s6Err)
 
 				return nil, false
 			}
@@ -157,7 +157,7 @@ func (r *RedpandaInstance) Reconcile(ctx context.Context, snapshot fsm.SystemSna
 			}
 			// For non-schema registry errors, always set the error
 			r.baseFSMInstance.SetError(s6Err, snapshot.Tick)
-			r.baseFSMInstance.LogErrorDedup("error reconciling s6Manager: %s", s6Err)
+			r.baseFSMInstance.Logger.LogErrorDedup("error reconciling s6Manager: %s", s6Err)
 
 			return nil, false
 		}

--- a/umh-core/pkg/fsm/redpanda_monitor/machine.go
+++ b/umh-core/pkg/fsm/redpanda_monitor/machine.go
@@ -68,7 +68,7 @@ func NewRedpandaMonitorInstanceWithService(config config.RedpandaMonitorConfig, 
 	}
 
 	// Construct the base instance
-	baseFSM := internal_fsm.NewBaseFSMInstance(fsmCfg, backoff.DefaultConfig(metrics.ComponentAgentMonitor, logger.For(config.Name)), logger.For(config.Name))
+	baseFSM := internal_fsm.NewBaseFSMInstance(fsmCfg, backoff.DefaultConfig(metrics.ComponentAgentMonitor, logger.For(config.Name)), logger.NewDedupLogger(logger.For(config.Name)))
 
 	// Create our instance
 	instance := &RedpandaMonitorInstance{

--- a/umh-core/pkg/fsm/redpanda_monitor/reconcile.go
+++ b/umh-core/pkg/fsm/redpanda_monitor/reconcile.go
@@ -118,7 +118,7 @@ func (b *RedpandaMonitorInstance) Reconcile(ctx context.Context, snapshot fsm.Sy
 		}
 
 		b.baseFSMInstance.SetError(err, snapshot.Tick)
-		b.baseFSMInstance.LogErrorDedup("error reconciling state: %s", err)
+		b.baseFSMInstance.Logger.LogErrorDedup("error reconciling state: %s", err)
 
 		return nil, false // We don't want to return an error here, because we want to continue reconciling
 	}
@@ -130,7 +130,7 @@ func (b *RedpandaMonitorInstance) Reconcile(ctx context.Context, snapshot fsm.Sy
 		}
 
 		b.baseFSMInstance.SetError(s6Err, snapshot.Tick)
-		b.baseFSMInstance.LogErrorDedup("error reconciling monitorService: %s", s6Err)
+		b.baseFSMInstance.Logger.LogErrorDedup("error reconciling monitorService: %s", s6Err)
 
 		return nil, false
 	}

--- a/umh-core/pkg/fsm/s6/machine.go
+++ b/umh-core/pkg/fsm/s6/machine.go
@@ -51,8 +51,8 @@ func NewS6Instance(
 		MaxTicksToRemainInTransientState: 20, // 20 ticks = 20 * 100ms = 2s
 	}
 
-	logger := logger.For(config.Name)
-	backoffConfig := backoff.DefaultConfig(cfg.ID, logger)
+	logger := logger.NewDedupLogger(logger.For(config.Name))
+	backoffConfig := backoff.DefaultConfig(cfg.ID, logger.SugaredLogger)
 
 	instance := &S6Instance{
 		baseFSMInstance: internal_fsm.NewBaseFSMInstance(cfg, backoffConfig, logger),

--- a/umh-core/pkg/fsm/s6/reconcile.go
+++ b/umh-core/pkg/fsm/s6/reconcile.go
@@ -151,7 +151,7 @@ func (s *S6Instance) Reconcile(ctx context.Context, snapshot fsm.SystemSnapshot,
 		}
 
 		s.baseFSMInstance.SetError(err, snapshot.Tick)
-		s.baseFSMInstance.LogErrorDedup("error reconciling state: %s", err)
+		s.baseFSMInstance.Logger.LogErrorDedup("error reconciling state: %s", err)
 
 		return nil, false // We don't want to return an error here, because we want to continue reconciling
 	}

--- a/umh-core/pkg/fsm/streamprocessor/machine.go
+++ b/umh-core/pkg/fsm/streamprocessor/machine.go
@@ -151,8 +151,8 @@ func NewInstance(
 		},
 	}
 
-	logger := logger.For(config.Name)
-	backoffConfig := backoff.DefaultConfig(cfg.ID, logger)
+	logger := logger.NewDedupLogger(logger.For(config.Name))
+	backoffConfig := backoff.DefaultConfig(cfg.ID, logger.SugaredLogger)
 
 	instance := &Instance{
 		baseFSMInstance: internal_fsm.NewBaseFSMInstance(cfg, backoffConfig, logger),

--- a/umh-core/pkg/fsm/streamprocessor/reconcile.go
+++ b/umh-core/pkg/fsm/streamprocessor/reconcile.go
@@ -130,7 +130,7 @@ func (i *Instance) Reconcile(ctx context.Context, snapshot fsm.SystemSnapshot, s
 		// Enhanced error logging with state context
 		currentState := i.baseFSMInstance.GetCurrentFSMState()
 		desiredState := i.baseFSMInstance.GetDesiredFSMState()
-		i.baseFSMInstance.LogErrorDedup("error reconciling state transition: current_state='%s', desired_state='%s', error: %s",
+		i.baseFSMInstance.Logger.LogErrorDedup("error reconciling state transition: current_state='%s', desired_state='%s', error: %s",
 			currentState, desiredState, err)
 
 		i.baseFSMInstance.SetError(err, snapshot.Tick)
@@ -142,7 +142,7 @@ func (i *Instance) Reconcile(ctx context.Context, snapshot fsm.SystemSnapshot, s
 	managerErr, managerReconciled := i.service.ReconcileManager(ctx, services, snapshot)
 	if managerErr != nil {
 		i.baseFSMInstance.SetError(managerErr, snapshot.Tick)
-		i.baseFSMInstance.LogErrorDedup("error reconciling manager: %s", managerErr)
+		i.baseFSMInstance.Logger.LogErrorDedup("error reconciling manager: %s", managerErr)
 
 		return nil, false
 	}

--- a/umh-core/pkg/fsm/topicbrowser/machine.go
+++ b/umh-core/pkg/fsm/topicbrowser/machine.go
@@ -148,8 +148,8 @@ func NewInstance(
 		},
 	}
 
-	logger := logger.For(config.Name)
-	backoffConfig := backoff.DefaultConfig(cfg.ID, logger)
+	logger := logger.NewDedupLogger(logger.For(config.Name))
+	backoffConfig := backoff.DefaultConfig(cfg.ID, logger.SugaredLogger)
 
 	instance := &TopicBrowserInstance{
 		baseFSMInstance: internal_fsm.NewBaseFSMInstance(cfg, backoffConfig, logger),

--- a/umh-core/pkg/fsm/topicbrowser/reconcile.go
+++ b/umh-core/pkg/fsm/topicbrowser/reconcile.go
@@ -141,7 +141,7 @@ func (i *TopicBrowserInstance) Reconcile(ctx context.Context, snapshot fsm.Syste
 		}
 
 		i.baseFSMInstance.SetError(err, snapshot.Tick)
-		i.baseFSMInstance.LogErrorDedup("error reconciling state: %s", err)
+		i.baseFSMInstance.Logger.LogErrorDedup("error reconciling state: %s", err)
 
 		return nil, false // We don't want to return an error here, because we want to continue reconciling
 	}
@@ -158,7 +158,7 @@ func (i *TopicBrowserInstance) Reconcile(ctx context.Context, snapshot fsm.Syste
 		}
 
 		i.baseFSMInstance.SetError(managerErr, snapshot.Tick)
-		i.baseFSMInstance.LogErrorDedup("error reconciling manager: %s", managerErr)
+		i.baseFSMInstance.Logger.LogErrorDedup("error reconciling manager: %s", managerErr)
 
 		return nil, false
 	}

--- a/umh-core/pkg/fsmv2/deps/logger_impl.go
+++ b/umh-core/pkg/fsmv2/deps/logger_impl.go
@@ -55,7 +55,9 @@ func NewFSMLogger(sugar *zap.SugaredLogger) FSMLogger {
 		panic("NewFSMLogger: sugar cannot be nil")
 	}
 
-	sampled := sugar.Desugar().WithOptions(zap.WrapCore(samplerWrap)).Sugar()
+	// AddCallerSkip(1) so the reported caller is the code calling the FSMLogger
+	// method, not the zapLogger wrapper in this file.
+	sampled := sugar.Desugar().WithOptions(zap.WrapCore(samplerWrap), zap.AddCallerSkip(1)).Sugar()
 
 	return &zapLogger{sugar: sampled}
 }
@@ -69,7 +71,9 @@ func NewUnsampledFSMLogger(sugar *zap.SugaredLogger) FSMLogger {
 		panic("NewUnsampledFSMLogger: sugar cannot be nil")
 	}
 
-	return &zapLogger{sugar: sugar}
+	// AddCallerSkip(1) so the reported caller is the code calling the FSMLogger
+	// method, not the zapLogger wrapper in this file.
+	return &zapLogger{sugar: sugar.Desugar().WithOptions(zap.AddCallerSkip(1)).Sugar()}
 }
 
 func (l *zapLogger) Debug(msg string, fields ...Field) {

--- a/umh-core/pkg/logger/dedup.go
+++ b/umh-core/pkg/logger/dedup.go
@@ -49,6 +49,12 @@ const DefaultErrorDedupResetInterval = 5 * time.Minute
 type DedupLogger struct {
 	*zap.SugaredLogger
 
+	// dedupSugar is SugaredLogger with one extra caller-skip frame, used for the
+	// LogErrorDedup path so the reported caller is the code that called
+	// LogErrorDedup rather than dedup.go itself. Promoted methods on the embedded
+	// SugaredLogger keep the normal caller depth.
+	dedupSugar *zap.SugaredLogger
+
 	// lastSuppressionSummary is the time the most recent suppression summary was
 	// emitted, used to throttle the periodic summary.
 	lastSuppressionSummary time.Time
@@ -81,6 +87,7 @@ type DedupLogger struct {
 func NewDedupLogger(l *zap.SugaredLogger) *DedupLogger {
 	return &DedupLogger{
 		SugaredLogger:   l,
+		dedupSugar:      l.WithOptions(zap.AddCallerSkip(1)),
 		summaryInterval: DefaultErrorSuppressionSummaryInterval,
 		resetInterval:   DefaultErrorDedupResetInterval,
 	}
@@ -106,20 +113,20 @@ func (d *DedupLogger) LogErrorDedup(format string, args ...any) {
 	switch {
 	case msg != d.lastLoggedErrorMsg:
 		d.emitSuppressionSummary()
-		d.SugaredLogger.Errorf("%s", msg)
+		d.dedupSugar.Errorf("%s", msg)
 		d.lastLoggedErrorMsg = msg
 		d.errorSuppressionAnnounced = false
 		d.suppressedErrorCount = 0
 		d.lastSuppressionSummary = now
 	case !d.errorSuppressionAnnounced:
-		d.SugaredLogger.Errorf("%s (further repeats suppressed to debug until it changes or clears)", msg)
+		d.dedupSugar.Errorf("%s (further repeats suppressed to debug until it changes or clears)", msg)
 		d.errorSuppressionAnnounced = true
 		d.lastSuppressionSummary = now
 	default:
-		d.SugaredLogger.Debugf("%s", msg)
+		d.dedupSugar.Debugf("%s", msg)
 		d.suppressedErrorCount++
 		if now.Sub(d.lastSuppressionSummary) >= d.summaryInterval {
-			d.SugaredLogger.Errorf("repeated error suppressed %d times in the last %s (still failing): %s",
+			d.dedupSugar.Errorf("repeated error suppressed %d times in the last %s (still failing): %s",
 				d.suppressedErrorCount, now.Sub(d.lastSuppressionSummary).Round(time.Second), msg)
 			d.suppressedErrorCount = 0
 			d.lastSuppressionSummary = now
@@ -134,7 +141,7 @@ func (d *DedupLogger) emitSuppressionSummary() {
 	if d.suppressedErrorCount == 0 {
 		return
 	}
-	d.SugaredLogger.Errorf("previous error cleared or changed after %d further suppressed repeats: %s",
+	d.dedupSugar.Errorf("previous error cleared or changed after %d further suppressed repeats: %s",
 		d.suppressedErrorCount, d.lastLoggedErrorMsg)
 	d.suppressedErrorCount = 0
 }

--- a/umh-core/pkg/logger/dedup.go
+++ b/umh-core/pkg/logger/dedup.go
@@ -22,76 +22,46 @@ import (
 )
 
 // DefaultErrorSuppressionSummaryInterval bounds how often a periodic summary is
-// emitted while identical errors keep repeating, so an ongoing failure stays
-// visible at normal log levels without flooding the log.
+// emitted while identical errors keep repeating.
 const DefaultErrorSuppressionSummaryInterval = 60 * time.Second
 
 // DefaultErrorDedupResetInterval is how long LogErrorDedup waits without being
-// called before treating the next call as a fresh error cycle. When a caller
-// stops reporting an error (because it cleared), the following call after this
-// interval restarts deduplication automatically, so callers never need to call
-// Reset by hand.
+// called before treating the next call as a fresh error cycle.
 const DefaultErrorDedupResetInterval = 5 * time.Minute
 
-// DedupLogger is a *zap.SugaredLogger that additionally deduplicates repeating
-// error logs from a hot loop (such as an FSM reconcile loop). It embeds the
-// SugaredLogger, so all standard logging methods are available directly, plus
-// LogErrorDedup for the deduplicated path.
+// DedupLogger is a *zap.SugaredLogger that also deduplicates repeating error
+// logs from a hot loop (such as an FSM reconcile loop)
 //
-// LogErrorDedup logs the first occurrence and first repeat at Error, demotes
-// further repeats to Debug, and emits a periodic Error summary of the
-// suppressed count. A changed message ends the cycle with a final summary. When
-// the error clears the caller simply stops calling LogErrorDedup; the next call
-// after DefaultErrorDedupResetInterval starts a fresh cycle automatically.
-//
-// It is not safe for concurrent use; callers that share it across goroutines
-// must serialize access.
+// It is not safe for concurrent use.
 type DedupLogger struct {
 	*zap.SugaredLogger
 
-	// dedupSugar is SugaredLogger with one extra caller-skip frame, used for the
-	// LogErrorDedup path so the reported caller is the code that called
-	// LogErrorDedup rather than dedup.go itself. Promoted methods on the embedded
-	// SugaredLogger keep the normal caller depth.
+	// dedupSugar skips one extra caller frame so LogErrorDedup reports the
+	// caller's site rather than dedup.go.
 	dedupSugar *zap.SugaredLogger
 
-	// lastSuppressionSummary is the time the most recent suppression summary was
-	// emitted, used to throttle the periodic summary.
 	lastSuppressionSummary time.Time
 
-	// lastLogTime is the time LogErrorDedup was last called, used to restart the
+	// lastLogTime is when LogErrorDedup was last called, used to restart the
 	// cycle after the error has been quiet for resetInterval.
 	lastLogTime time.Time
 
-	// lastLoggedErrorMsg is the message of the currently deduplicated error.
 	lastLoggedErrorMsg string
 
-	// summaryInterval bounds how often the periodic summary is emitted.
 	summaryInterval time.Duration
+	resetInterval   time.Duration
 
-	// resetInterval is the quiet period after which the next LogErrorDedup call
-	// is treated as a fresh error cycle.
-	resetInterval time.Duration
-
-	// suppressedErrorCount counts repeats demoted to Debug since the last
-	// summary. Reported and reset by the periodic and final summaries.
+	// suppressedErrorCount counts repeats demoted to Debug since the last summary.
 	suppressedErrorCount uint64
 
-	// errorSuppressionAnnounced records whether the "repeats suppressed" notice
-	// was already logged for the current message, so it is emitted exactly once.
 	errorSuppressionAnnounced bool
 
-	// resetPending records that Reset was called since the last LogErrorDedup.
-	// The reset is applied lazily on the next LogErrorDedup call, and only if the
-	// message actually changed. A repeat of the same message cancels it, so a
-	// caller that reports success every tick (e.g. an FSM reconcile loop) while
-	// the same error keeps being logged from a swallowed path does not restart
-	// the dedup cycle and re-log at Error every tick.
+	// resetPending records that Reset was called; applied lazily on the next
+	// LogErrorDedup call, and only if the message changed. See Reset.
 	resetPending bool
 }
 
-// NewDedupLogger returns a DedupLogger writing to l with the default summary and
-// reset intervals.
+// NewDedupLogger returns a DedupLogger writing to l with the default intervals.
 func NewDedupLogger(l *zap.SugaredLogger) *DedupLogger {
 	return &DedupLogger{
 		SugaredLogger:   l,
@@ -101,26 +71,21 @@ func NewDedupLogger(l *zap.SugaredLogger) *DedupLogger {
 	}
 }
 
-// LogErrorDedup logs an error without spamming: first occurrence at Error, first
-// repeat at Error with a suppression note, further repeats at Debug plus a
-// periodic Error summary of the suppressed count. A changed message resets the
-// cycle and emits a final Error summary of what was suppressed. When the caller
-// stops reporting for resetInterval (because the error cleared), the next call
-// starts a fresh cycle automatically.
+// LogErrorDedup logs an error without spamming: first occurrence and first
+// repeat at Error (the latter with a suppression note), further repeats at Debug
+// plus a periodic Error summary of the suppressed count. A changed message or a
+// quiet period of resetInterval ends the cycle with a final summary.
 func (d *DedupLogger) LogErrorDedup(format string, args ...any) {
 	msg := fmt.Sprintf(format, args...)
 	now := time.Now()
 
-	// If the error has been quiet long enough, it is considered cleared: emit a
-	// final summary and start over.
+	// Quiet long enough: treat the error as cleared and start over.
 	if !d.lastLogTime.IsZero() && now.Sub(d.lastLogTime) >= d.resetInterval {
 		d.endCycle()
 	}
 
-	// Apply a pending Reset lazily: honor it only when the message changed. A
-	// repeat of the same message means the caller's success signal was spurious
-	// (the error is still occurring), so the cycle continues and the repeat is
-	// suppressed as usual.
+	// Honor a pending Reset only when the message changed; a repeat of the same
+	// message means the success signal was spurious.
 	if d.resetPending {
 		if msg != d.lastLoggedErrorMsg {
 			d.endCycle()
@@ -154,9 +119,8 @@ func (d *DedupLogger) LogErrorDedup(format string, args ...any) {
 	}
 }
 
-// emitSuppressionSummary logs a final Error summary when a suppressed error
-// changes or clears, so the scale of an ongoing failure is not hidden. It is a
-// no-op when no repeats were suppressed since the last summary.
+// emitSuppressionSummary logs a final Error summary of suppressed repeats.
+// No-op when nothing was suppressed since the last summary.
 func (d *DedupLogger) emitSuppressionSummary() {
 	if d.suppressedErrorCount == 0 {
 		return
@@ -166,20 +130,17 @@ func (d *DedupLogger) emitSuppressionSummary() {
 	d.suppressedErrorCount = 0
 }
 
-// Reset signals that the caller considers the current error cleared (for
-// example, a reconcile loop that just succeeded). The reset is applied lazily:
-// the cycle is not ended until the next LogErrorDedup call, and only if the
-// message has changed. This makes dedup robust to unreliable success signals —
-// a caller that reports success every tick while the same error keeps being
-// logged from a swallowed path does not restart the cycle. A genuinely cleared
-// error is also ended by the quiet reset interval automatically.
+// Reset signals that the caller considers the current error cleared (e.g. a
+// reconcile loop that just succeeded). Applied lazily on the next LogErrorDedup
+// call, and only if the message changed, so an unreliable success signal
+// reported every tick while the same error keeps firing does not restart the
+// cycle. A genuinely cleared error is also ended by the quiet resetInterval.
 func (d *DedupLogger) Reset() {
 	d.resetPending = true
 }
 
-// endCycle ends the current dedup cycle, emitting a final summary of any
-// suppressed repeats and clearing the message identity so the next call starts
-// a fresh cycle.
+// endCycle emits a final summary and clears message identity so the next call
+// starts a fresh cycle.
 func (d *DedupLogger) endCycle() {
 	d.emitSuppressionSummary()
 	d.lastLoggedErrorMsg = ""

--- a/umh-core/pkg/logger/dedup.go
+++ b/umh-core/pkg/logger/dedup.go
@@ -1,0 +1,150 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logger
+
+import (
+	"fmt"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// DefaultErrorSuppressionSummaryInterval bounds how often a periodic summary is
+// emitted while identical errors keep repeating, so an ongoing failure stays
+// visible at normal log levels without flooding the log.
+const DefaultErrorSuppressionSummaryInterval = 60 * time.Second
+
+// DefaultErrorDedupResetInterval is how long LogErrorDedup waits without being
+// called before treating the next call as a fresh error cycle. When a caller
+// stops reporting an error (because it cleared), the following call after this
+// interval restarts deduplication automatically, so callers never need to call
+// Reset by hand.
+const DefaultErrorDedupResetInterval = 5 * time.Minute
+
+// DedupLogger is a *zap.SugaredLogger that additionally deduplicates repeating
+// error logs from a hot loop (such as an FSM reconcile loop). It embeds the
+// SugaredLogger, so all standard logging methods are available directly, plus
+// LogErrorDedup for the deduplicated path.
+//
+// LogErrorDedup logs the first occurrence and first repeat at Error, demotes
+// further repeats to Debug, and emits a periodic Error summary of the
+// suppressed count. A changed message ends the cycle with a final summary. When
+// the error clears the caller simply stops calling LogErrorDedup; the next call
+// after DefaultErrorDedupResetInterval starts a fresh cycle automatically.
+//
+// It is not safe for concurrent use; callers that share it across goroutines
+// must serialize access.
+type DedupLogger struct {
+	*zap.SugaredLogger
+
+	// lastSuppressionSummary is the time the most recent suppression summary was
+	// emitted, used to throttle the periodic summary.
+	lastSuppressionSummary time.Time
+
+	// lastLogTime is the time LogErrorDedup was last called, used to restart the
+	// cycle after the error has been quiet for resetInterval.
+	lastLogTime time.Time
+
+	// lastLoggedErrorMsg is the message of the currently deduplicated error.
+	lastLoggedErrorMsg string
+
+	// summaryInterval bounds how often the periodic summary is emitted.
+	summaryInterval time.Duration
+
+	// resetInterval is the quiet period after which the next LogErrorDedup call
+	// is treated as a fresh error cycle.
+	resetInterval time.Duration
+
+	// suppressedErrorCount counts repeats demoted to Debug since the last
+	// summary. Reported and reset by the periodic and final summaries.
+	suppressedErrorCount uint64
+
+	// errorSuppressionAnnounced records whether the "repeats suppressed" notice
+	// was already logged for the current message, so it is emitted exactly once.
+	errorSuppressionAnnounced bool
+}
+
+// NewDedupLogger returns a DedupLogger writing to l with the default summary and
+// reset intervals.
+func NewDedupLogger(l *zap.SugaredLogger) *DedupLogger {
+	return &DedupLogger{
+		SugaredLogger:   l,
+		summaryInterval: DefaultErrorSuppressionSummaryInterval,
+		resetInterval:   DefaultErrorDedupResetInterval,
+	}
+}
+
+// LogErrorDedup logs an error without spamming: first occurrence at Error, first
+// repeat at Error with a suppression note, further repeats at Debug plus a
+// periodic Error summary of the suppressed count. A changed message resets the
+// cycle and emits a final Error summary of what was suppressed. When the caller
+// stops reporting for resetInterval (because the error cleared), the next call
+// starts a fresh cycle automatically.
+func (d *DedupLogger) LogErrorDedup(format string, args ...any) {
+	msg := fmt.Sprintf(format, args...)
+	now := time.Now()
+
+	// If the error has been quiet long enough, it is considered cleared: emit a
+	// final summary and start over.
+	if !d.lastLogTime.IsZero() && now.Sub(d.lastLogTime) >= d.resetInterval {
+		d.Reset()
+	}
+	d.lastLogTime = now
+
+	switch {
+	case msg != d.lastLoggedErrorMsg:
+		d.emitSuppressionSummary()
+		d.SugaredLogger.Errorf("%s", msg)
+		d.lastLoggedErrorMsg = msg
+		d.errorSuppressionAnnounced = false
+		d.suppressedErrorCount = 0
+		d.lastSuppressionSummary = now
+	case !d.errorSuppressionAnnounced:
+		d.SugaredLogger.Errorf("%s (further repeats suppressed to debug until it changes or clears)", msg)
+		d.errorSuppressionAnnounced = true
+		d.lastSuppressionSummary = now
+	default:
+		d.SugaredLogger.Debugf("%s", msg)
+		d.suppressedErrorCount++
+		if now.Sub(d.lastSuppressionSummary) >= d.summaryInterval {
+			d.SugaredLogger.Errorf("repeated error suppressed %d times in the last %s (still failing): %s",
+				d.suppressedErrorCount, now.Sub(d.lastSuppressionSummary).Round(time.Second), msg)
+			d.suppressedErrorCount = 0
+			d.lastSuppressionSummary = now
+		}
+	}
+}
+
+// emitSuppressionSummary logs a final Error summary when a suppressed error
+// changes or clears, so the scale of an ongoing failure is not hidden. It is a
+// no-op when no repeats were suppressed since the last summary.
+func (d *DedupLogger) emitSuppressionSummary() {
+	if d.suppressedErrorCount == 0 {
+		return
+	}
+	d.SugaredLogger.Errorf("previous error cleared or changed after %d further suppressed repeats: %s",
+		d.suppressedErrorCount, d.lastLoggedErrorMsg)
+	d.suppressedErrorCount = 0
+}
+
+// Reset clears the dedup cycle, emitting a final summary of any suppressed
+// repeats. Callers with an explicit success signal (such as a reconcile loop
+// that just succeeded) may call it directly; otherwise the reset interval
+// handles it automatically.
+func (d *DedupLogger) Reset() {
+	d.emitSuppressionSummary()
+	d.lastLoggedErrorMsg = ""
+	d.errorSuppressionAnnounced = false
+}

--- a/umh-core/pkg/logger/dedup.go
+++ b/umh-core/pkg/logger/dedup.go
@@ -80,6 +80,14 @@ type DedupLogger struct {
 	// errorSuppressionAnnounced records whether the "repeats suppressed" notice
 	// was already logged for the current message, so it is emitted exactly once.
 	errorSuppressionAnnounced bool
+
+	// resetPending records that Reset was called since the last LogErrorDedup.
+	// The reset is applied lazily on the next LogErrorDedup call, and only if the
+	// message actually changed. A repeat of the same message cancels it, so a
+	// caller that reports success every tick (e.g. an FSM reconcile loop) while
+	// the same error keeps being logged from a swallowed path does not restart
+	// the dedup cycle and re-log at Error every tick.
+	resetPending bool
 }
 
 // NewDedupLogger returns a DedupLogger writing to l with the default summary and
@@ -106,8 +114,20 @@ func (d *DedupLogger) LogErrorDedup(format string, args ...any) {
 	// If the error has been quiet long enough, it is considered cleared: emit a
 	// final summary and start over.
 	if !d.lastLogTime.IsZero() && now.Sub(d.lastLogTime) >= d.resetInterval {
-		d.Reset()
+		d.endCycle()
 	}
+
+	// Apply a pending Reset lazily: honor it only when the message changed. A
+	// repeat of the same message means the caller's success signal was spurious
+	// (the error is still occurring), so the cycle continues and the repeat is
+	// suppressed as usual.
+	if d.resetPending {
+		if msg != d.lastLoggedErrorMsg {
+			d.endCycle()
+		}
+		d.resetPending = false
+	}
+
 	d.lastLogTime = now
 
 	switch {
@@ -146,12 +166,23 @@ func (d *DedupLogger) emitSuppressionSummary() {
 	d.suppressedErrorCount = 0
 }
 
-// Reset clears the dedup cycle, emitting a final summary of any suppressed
-// repeats. Callers with an explicit success signal (such as a reconcile loop
-// that just succeeded) may call it directly; otherwise the reset interval
-// handles it automatically.
+// Reset signals that the caller considers the current error cleared (for
+// example, a reconcile loop that just succeeded). The reset is applied lazily:
+// the cycle is not ended until the next LogErrorDedup call, and only if the
+// message has changed. This makes dedup robust to unreliable success signals —
+// a caller that reports success every tick while the same error keeps being
+// logged from a swallowed path does not restart the cycle. A genuinely cleared
+// error is also ended by the quiet reset interval automatically.
 func (d *DedupLogger) Reset() {
+	d.resetPending = true
+}
+
+// endCycle ends the current dedup cycle, emitting a final summary of any
+// suppressed repeats and clearing the message identity so the next call starts
+// a fresh cycle.
+func (d *DedupLogger) endCycle() {
 	d.emitSuppressionSummary()
 	d.lastLoggedErrorMsg = ""
 	d.errorSuppressionAnnounced = false
+	d.resetPending = false
 }

--- a/umh-core/pkg/logger/dedup_test.go
+++ b/umh-core/pkg/logger/dedup_test.go
@@ -1,0 +1,86 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logger
+
+import (
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("DedupLogger", func() {
+	var (
+		logs  *observer.ObservedLogs
+		dedup *DedupLogger
+	)
+
+	BeforeEach(func() {
+		core, recorded := observer.New(zapcore.DebugLevel)
+		logs = recorded
+		dedup = NewDedupLogger(zap.New(core).Sugar())
+	})
+
+	levels := func() []zapcore.Level {
+		out := make([]zapcore.Level, 0)
+		for _, e := range logs.All() {
+			out = append(out, e.Level)
+		}
+		return out
+	}
+
+	It("logs first occurrence and first repeat at Error, then demotes to Debug", func() {
+		for range 4 {
+			dedup.LogErrorDedup("boom %d", 1)
+		}
+
+		Expect(levels()).To(Equal([]zapcore.Level{
+			zapcore.ErrorLevel, // first occurrence
+			zapcore.ErrorLevel, // first repeat (suppression notice)
+			zapcore.DebugLevel, // further repeats
+			zapcore.DebugLevel,
+		}))
+	})
+
+	It("does not restart the cycle when Reset is called between identical messages", func() {
+		// Simulates an FSM reconcile loop that reports success (Reset) every tick
+		// while the same error keeps being logged from a swallowed path.
+		dedup.LogErrorDedup("still broken")
+		dedup.Reset()
+		dedup.LogErrorDedup("still broken")
+		dedup.Reset()
+		dedup.LogErrorDedup("still broken")
+
+		// Only the first two are Error; the spurious Resets must not re-promote.
+		Expect(levels()).To(Equal([]zapcore.Level{
+			zapcore.ErrorLevel,
+			zapcore.ErrorLevel,
+			zapcore.DebugLevel,
+		}))
+	})
+
+	It("starts a fresh Error cycle when the message changes after a Reset", func() {
+		dedup.LogErrorDedup("error A")
+		dedup.Reset()
+		dedup.LogErrorDedup("error B")
+
+		Expect(levels()).To(Equal([]zapcore.Level{
+			zapcore.ErrorLevel, // A
+			zapcore.ErrorLevel, // B (changed message ends prior cycle, logs fresh)
+		}))
+	})
+})

--- a/umh-core/pkg/service/redpanda/redpanda.go
+++ b/umh-core/pkg/service/redpanda/redpanda.go
@@ -39,7 +39,6 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/monitor"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/redpanda_monitor"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/serviceregistry"
-	"go.uber.org/zap"
 
 	redpanda_monitor_fsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/redpanda_monitor"
 	s6fsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/s6"
@@ -176,7 +175,7 @@ type RedpandaService struct {
 	httpClient httpclient.HTTPClient
 
 	schemaRegistryManager ISchemaRegistry
-	logger                *zap.SugaredLogger
+	logger                *logger.DedupLogger
 
 	s6Manager *s6fsm.S6Manager
 
@@ -239,8 +238,8 @@ func WithSchemaRegistryManager(schemaRegistryManager ISchemaRegistry) RedpandaSe
 func NewDefaultRedpandaService(redpandaName string, opts ...RedpandaServiceOption) *RedpandaService {
 	managerName := fmt.Sprintf("%s%s", logger.ComponentRedpandaService, redpandaName)
 	service := &RedpandaService{
-		logger:                 logger.For(managerName),
-		s6Manager:              s6fsm.NewS6Manager(managerName),
+		logger:    logger.NewDedupLogger(logger.For(managerName)),
+		s6Manager: s6fsm.NewS6Manager(managerName),
 		s6Service:              s6service.NewDefaultService(),
 		httpClient:             httpclient.NewDefaultHTTPClient(),
 		baseDir:                constants.DefaultRedpandaBaseDir,
@@ -945,8 +944,9 @@ func (s *RedpandaService) ReconcileManager(ctx context.Context, services service
 
 		schemaRegistryErr := s.schemaRegistryManager.Reconcile(ctx, dataModels, dataContracts, payloadShapes)
 		if schemaRegistryErr != nil {
-			// Only log them, don't return an error
-			s.logger.Warnf("failed to reconcile schema registry: %v", schemaRegistryErr)
+			// Only log them, don't return an error. Deduplicate so a persistent
+			// failure does not flood the log every tick.
+			s.logger.LogErrorDedup("failed to reconcile schema registry: %v", schemaRegistryErr)
 		}
 	} else {
 		s.logger.Debugf("Skipping schema registry reconciliation - no running redpanda services")
@@ -1033,7 +1033,7 @@ func (s *RedpandaService) ServiceExists(ctx context.Context, filesystemService f
 
 	exists, err := s.s6Service.ServiceExists(ctx, s6ServicePath, filesystemService)
 	if err != nil {
-		sentry.ReportIssuef(sentry.IssueTypeError, s.logger, "Error checking if service exists for %s: %v", s6ServiceName, err)
+		sentry.ReportIssuef(sentry.IssueTypeError, s.logger.SugaredLogger, "Error checking if service exists for %s: %v", s6ServiceName, err)
 
 		return false
 	}


### PR DESCRIPTION
- Exposes the `LogErrorDedup` function outside of the `reconcile.go` files