### PR TITLE
feat: add historian adoption fields to FeatureUsage (ENG-5398)

### DIFF
--- a/umh-core/cmd/main.go
+++ b/umh-core/cmd/main.go
@@ -178,6 +178,8 @@ func main() {
 		FSMv2MemoryCleanupEnabled:     configData.Agent.UseFSMv2MemoryCleanup,
 		FSMv2ProtocolConverterEnabled: configData.Agent.UseFSMv2ProtocolConverter,
 		ResourceLimitBlockingEnabled:  configData.Agent.EnableResourceLimitBlocking,
+		HistorianConfigured:           configData.Historian != nil,
+		HistorianBridgeCount:          countHistorianBridges(configData),
 	}
 
 	// Ensure the S6 repository directory exists
@@ -329,6 +331,19 @@ func main() {
 	<-fsmv2Done
 
 	log.Info("umh-core completed")
+}
+
+// countHistorianBridges returns the number of bridges whose write DFC targets the historian output.
+func countHistorianBridges(cfg config.FullConfig) int {
+	n := 0
+
+	for _, pc := range cfg.ProtocolConverter {
+		if pc.ProtocolConverterServiceConfig.GetDFCWriteServiceConfig().WritesToHistorian() {
+			n++
+		}
+	}
+
+	return n
 }
 
 // ensureS6RepositoryDirectory ensures that the S6 repository directory exists with proper permissions.

--- a/umh-core/cmd/main_test.go
+++ b/umh-core/cmd/main_test.go
@@ -25,6 +25,8 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/communicator/pkg/tools/watchdog"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/communicator/topicbrowser"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/dataflowcomponentserviceconfig"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/protocolconverterserviceconfig"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/control"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/logger"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/models"
@@ -112,6 +114,58 @@ var _ = Describe("Backend Connection", Ordered, func() {
 			// runs in a separate goroutine (via 'go' keyword)
 			Eventually(controlLoopReached, 500*time.Millisecond).Should(Receive(BeTrue()),
 				"Control loop should be reached immediately, but was blocked by synchronous backend connection")
+		})
+	})
+
+	Context("counting historian bridges", func() {
+		historianBridge := func() config.ProtocolConverterConfig {
+			return config.ProtocolConverterConfig{
+				ProtocolConverterServiceConfig: protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec{
+					Config: protocolconverterserviceconfig.ProtocolConverterServiceConfigTemplate{
+						DataflowComponentWriteServiceConfig: dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
+							Destination: dataflowcomponentserviceconfig.WriteConfigDestination{
+								Protocol: dataflowcomponentserviceconfig.HistorianDestinationProtocol,
+							},
+						},
+					},
+				},
+			}
+		}
+
+		nonHistorianBridge := func() config.ProtocolConverterConfig {
+			return config.ProtocolConverterConfig{
+				ProtocolConverterServiceConfig: protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec{
+					Config: protocolconverterserviceconfig.ProtocolConverterServiceConfigTemplate{
+						DataflowComponentWriteServiceConfig: dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
+							Destination: dataflowcomponentserviceconfig.WriteConfigDestination{
+								Protocol: "kafka",
+							},
+						},
+					},
+				},
+			}
+		}
+
+		It("counts only bridges writing to the historian", func() {
+			cfg := config.FullConfig{
+				ProtocolConverter: []config.ProtocolConverterConfig{
+					historianBridge(),
+					nonHistorianBridge(),
+					historianBridge(),
+				},
+			}
+
+			Expect(countHistorianBridges(cfg)).To(Equal(2))
+		})
+
+		It("returns zero when no bridges write to the historian", func() {
+			cfg := config.FullConfig{
+				ProtocolConverter: []config.ProtocolConverterConfig{
+					nonHistorianBridge(),
+				},
+			}
+
+			Expect(countHistorianBridges(cfg)).To(Equal(0))
 		})
 	})
 

--- a/umh-core/pkg/models/feature_usage.go
+++ b/umh-core/pkg/models/feature_usage.go
@@ -17,16 +17,15 @@ package models
 // FeatureUsage reports which feature flags are active on this instance and
 // tracks per-feature usage metrics.
 //
-// Bool fields ending in Enabled are auto-mapped to feature_{snake_case} PostHog
-// properties by the MC frontend. To add a new flag: add a bool field ending in
-// Enabled here, set it in cmd/main.go, and add the field to the TS interface
-// in statusMessage.svelte.ts.
-//
-// Non-bool usage metrics (like ConfigBackupCount) are mapped manually with a
-// usage_ prefix in instanceTelemetry.ts.
+// The MC frontend auto-maps these fields to PostHog properties by JSON type: every
+// bool becomes feature_{snake_case}, every number becomes usage_{snake_case} (see
+// buildProperties in instanceTelemetry.ts). To add a metric: add a field here, set
+// it in cmd/main.go, and add the field to the TS FeatureUsage interface.
 type FeatureUsage struct {
 	// ConfigBackupCount tracks the number of config backups created since startup.
 	ConfigBackupCount int `json:"configBackupCount"`
+	// HistorianBridgeCount reports the number of bridges writing to the historian.
+	HistorianBridgeCount int `json:"historianBridgeCount"`
 	// ConfigBackupEnabled reports whether ENABLE_CONFIG_BACKUP is set.
 	ConfigBackupEnabled bool `json:"configBackupEnabled"`
 	// FSMv2TransportEnabled reports whether USE_FSMV2_TRANSPORT is set.
@@ -37,4 +36,6 @@ type FeatureUsage struct {
 	FSMv2ProtocolConverterEnabled bool `json:"fsmv2ProtocolConverterEnabled"`
 	// ResourceLimitBlockingEnabled reports the value of agent.enableResourceLimitBlocking in config.yaml (defaults to true).
 	ResourceLimitBlockingEnabled bool `json:"resourceLimitBlockingEnabled"`
+	// HistorianConfigured reports whether a historian section exists in config.yaml.
+	HistorianConfigured bool `json:"historianConfigured"`
 }

--- a/umh-core/pkg/models/feature_usage_test.go
+++ b/umh-core/pkg/models/feature_usage_test.go
@@ -36,4 +36,20 @@ var _ = Describe("FeatureUsage", func() {
 
 		Expect(raw).NotTo(HaveKey("featureUsage"))
 	})
+
+	It("serializes the historian adoption fields", func() {
+		usage := models.FeatureUsage{
+			HistorianConfigured:  true,
+			HistorianBridgeCount: 3,
+		}
+
+		data, err := json.Marshal(usage)
+		Expect(err).NotTo(HaveOccurred())
+
+		var raw map[string]interface{}
+		Expect(json.Unmarshal(data, &raw)).To(Succeed())
+
+		Expect(raw).To(HaveKeyWithValue("historianConfigured", true))
+		Expect(raw).To(HaveKeyWithValue("historianBridgeCount", float64(3)))
+	})
 })


### PR DESCRIPTION
## TL;DR
- added HistorianConfigured bool to be emitted in the status message
- added HistorianBridgeCount int to be emitted in the status message and a function to count the bridges using the historian
- metrics are sent to PostHog in the Management Console

## What

Adds two historian adoption fields to the umh-core status message so the Management Console can report historian usage to PostHog:

- `HistorianConfigured` (bool) — whether `config.yaml` has a `historian:` section.
- `HistorianBridgeCount` (int) — number of bridges whose write DFC targets the historian output.

This is the umh-core half of the historian PostHog work (PR 2 of 2). The MC frontend PR adds the matching TS interface fields; the two are independent and either can merge first (MC reads a missing field as absent).

## How it reaches PostHog

umh-core makes no PostHog call. The fields ride on the status message; MC's `buildProperties` (`instanceTelemetry.ts`) auto-maps `FeatureUsage` by JSON type — every bool becomes `feature_<snake_case>`, every number `usage_<snake_case>` — so these surface as `feature_historian_configured` and `usage_historian_bridge_count` on the `instance_feature_snapshot` event. No mapping code is needed on either side.

`HistorianBridgeCount` uses a small extracted `countHistorianBridges` helper that reads `WritesToHistorian()` off each converter's stored spec, mirroring the two existing callers (`protocolconverter_helpers.go`, `generator/protocolconverter.go`). Template-based converters are covered: `ParseConfig` inlines a converter's template `Config` before the count runs, so `Destination.Protocol` is populated for both inline and `templateRef` bridges.

## Behavior

Both fields are computed from the config loaded at startup, like every other `FeatureUsage` field. Runtime historian changes (`deploy-historian` etc.) do not re-run startup, so the values refresh on the next process/container restart rather than immediately.

## Tests

- `pkg/models/feature_usage_test.go` — serialization spec for the two JSON keys.
- `cmd/main_test.go` — `countHistorianBridges` counts only historian-writing bridges, and returns 0 when none.

`golangci-lint run`, `go vet ./...`, `ginkgo --fail-on-focused`, and `make betteralign-fix` all clean for the changed packages.

## Changelog

Telemetry-only, no user-visible behavior change — `skip-changelog-guard` applied instead of a user-facing entry.
