### PR TITLE
fix(bridge): roll back a renamed bridge under its new UUID (ENG-5444)

### DIFF
--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Renaming a bridge whose deployment then fails no longer leaves it unsaveable. The rename was kept even though the deployment was reported as rolled back, so every later save (including Save Anyway) failed with "bridge not found" and the only way out was to leave the page. The rename is now reverted with the rest of the configuration, so retrying works
+- Renaming a bridge whose deployment then fails no longer leaves it unsaveable. The rename was kept even though the deployment was reported as rolled back, so every later save failed with "bridge not found" and the only way out was to leave the page. A failed deployment now reverts the rename along with the rest of the configuration, and Save Anyway stores the new name as before
 
 ## [0.44.34]
 

--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Renaming a bridge whose deployment then fails no longer leaves it unsaveable. The rename was kept even though the deployment was reported as rolled back, so every later save (including Save Anyway) failed with "bridge not found" and the only way out was to leave the page. The rename is now reverted with the rest of the configuration, so retrying works
+
 ## [0.44.34]
 
 ### Improvements

--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Renaming a bridge whose deployment then fails no longer leaves it unsaveable. The rename was kept even though the deployment was reported as rolled back, so every later save failed with "bridge not found" and the only way out was to leave the page. A failed deployment now reverts the rename along with the rest of the configuration, and Save Anyway stores the new name as before
+- Renaming a bridge whose deployment then fails no longer leaves it impossible to edit or save. A failed deployment now undoes the rename along with the rest of the configuration, while Save Anyway keeps the new name as before
 
 ## [0.44.34]
 

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter.go
@@ -57,6 +57,8 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/s6"
 )
 
+var errBridgeNotFound = errors.New("not found")
+
 // DFCType represents the type of dataflow component configuration.
 type DFCType string
 
@@ -318,8 +320,14 @@ func (a *EditProtocolConverterAction) Execute() (interface{}, map[string]interfa
 	newSpec, atomicEditUUID, desiredPCState, err := a.applyMutation()
 	if err != nil {
 		errorMsg := fmt.Sprintf("Failed to apply configuration mutation: %v", err)
-		SendActionReply(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedWithFailure,
-			errorMsg, a.outboundChannel, models.EditProtocolConverter)
+
+		errCode := ""
+		if errors.Is(err, errBridgeNotFound) {
+			errCode = models.ErrBridgeNotFound
+		}
+
+		SendActionReplyV2(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedWithFailure,
+			errorMsg, errCode, nil, a.outboundChannel, models.EditProtocolConverter, nil)
 		a.fsmLogger.SentryError(deps.FeatureDisableReadFlows, "", err, "edit_protocol_converter_apply_mutation_failed",
 			deps.String("new pcConfig", newSpec.String()))
 
@@ -402,7 +410,7 @@ func (a *EditProtocolConverterAction) applyMutation() (config.ProtocolConverterC
 	}
 
 	if !found {
-		return config.ProtocolConverterConfig{}, uuid.Nil, "", fmt.Errorf("bridge with UUID %s not found", a.protocolConverterUUID)
+		return config.ProtocolConverterConfig{}, uuid.Nil, "", fmt.Errorf("bridge with UUID %s %w", a.protocolConverterUUID, errBridgeNotFound)
 	}
 
 	// Currently, we cannot reuse templates, so we need to create a new one

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter.go
@@ -160,9 +160,6 @@ type EditProtocolConverterAction struct {
 	// Parsed request payload (only populated after Parse)
 	protocolConverterUUID uuid.UUID
 
-	// Atomic edit UUID used for configuration updates and rollbacks
-	atomicEditUUID uuid.UUID
-
 	// rolloutSentryReported tells Execute to skip the generic rollout_failed
 	// Sentry event for this abort. Every awaitRollout abort path fires its own
 	// dedicated event; only the render-failure paths (added for ENG-5103) set
@@ -328,9 +325,6 @@ func (a *EditProtocolConverterAction) Execute() (interface{}, map[string]interfa
 
 		return nil, nil, fmt.Errorf("%s", errorMsg)
 	}
-
-	// Store the atomic edit UUID for use in rollback operations
-	a.atomicEditUUID = atomicEditUUID
 
 	oldConfig, err := a.persistConfig(atomicEditUUID, newSpec)
 	if err != nil {
@@ -965,7 +959,7 @@ func (a *EditProtocolConverterAction) rollbackEdit(pcConfig config.ProtocolConve
 	ctx, cancel := context.WithTimeout(context.Background(), constants.ActionTimeout)
 	defer cancel()
 
-	_, err := a.configManager.AtomicEditProtocolConverter(ctx, a.atomicEditUUID, pcConfig)
+	_, err := a.configManager.AtomicEditProtocolConverter(ctx, dataflowcomponentserviceconfig.GenerateUUIDFromName(a.name), pcConfig)
 
 	return err
 }

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter_test.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter_test.go
@@ -1113,6 +1113,100 @@ var _ = Describe("EditProtocolConverter", func() {
 				Expect(err.Error()).NotTo(ContainSubstring("not found"))
 				Expect(err.Error()).To(ContainSubstring("Rolled back to previous configuration"))
 			})
+
+			It("persists the rename when the read flow ignores errors, without waiting for the rollout", func() {
+				Expect(renameWithFailingRollout()).To(HaveOccurred())
+
+				saveAnyway := actions.NewEditProtocolConverterAction(
+					userEmail, actionUUID, instanceUUID, outboundChannel, mockConfig, snapshotMgr)
+				saveAnyway.SetTickInterval(50 * time.Millisecond)
+				saveAnyway.SetAwaitTimeout(300 * time.Millisecond)
+
+				payload := map[string]interface{}{
+					"name": renamedName,
+					"uuid": pcUUID.String(),
+					"connection": map[string]interface{}{
+						"ip":   "wttr.in",
+						"port": 80,
+					},
+					"readDFC": map[string]interface{}{
+						"inputs": map[string]interface{}{
+							"data": "input:\n  http_client:\n    url: http://example.com",
+							"type": "http_client",
+						},
+						"pipeline": map[string]interface{}{
+							"processors": map[string]interface{}{
+								"0": map[string]interface{}{
+									"type": "bloblang",
+									"data": "bloblang: |-\n  root = content()",
+								},
+							},
+						},
+						"ignoreErrors": true,
+					},
+				}
+
+				Expect(saveAnyway.Parse(payload)).To(Succeed())
+				Expect(saveAnyway.Validate()).To(Succeed())
+
+				start := time.Now()
+				response, _, err := saveAnyway.Execute()
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(time.Since(start)).To(BeNumerically("<", 300*time.Millisecond))
+				Expect(protocolConverterNames()).To(ConsistOf(renamedName))
+
+				reply, ok := response.(map[string]any)
+				Expect(ok).To(BeTrue())
+				Expect(reply["uuid"]).To(Equal(dataflowcomponentserviceconfig.GenerateUUIDFromName(renamedName)))
+			})
+
+			It("reports ERR_BRIDGE_NOT_FOUND when the targeted UUID no longer exists", func() {
+				localOut := make(chan *models.UMHMessage, 100)
+
+				stale := actions.NewEditProtocolConverterAction(
+					userEmail, actionUUID, instanceUUID, localOut, mockConfig, snapshotMgr)
+
+				payload := map[string]interface{}{
+					"name": renamedName,
+					"uuid": dataflowcomponentserviceconfig.GenerateUUIDFromName("never-deployed").String(),
+					"connection": map[string]interface{}{
+						"ip":   "wttr.in",
+						"port": 80,
+					},
+				}
+
+				Expect(stale.Parse(payload)).To(Succeed())
+				Expect(stale.Validate()).To(Succeed())
+
+				_, _, err := stale.Execute()
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("not found"))
+
+				var codes []string
+
+				for len(localOut) > 0 {
+					msg := <-localOut
+
+					dec, decErr := encoding.DecodeMessageFromUMHInstanceToUser(msg.Content)
+					if decErr != nil {
+						continue
+					}
+
+					reply, isMap := dec.Payload.(map[string]interface{})
+					if !isMap {
+						continue
+					}
+
+					if v2, hasV2 := reply["actionReplyPayloadV2"].(map[string]interface{}); hasV2 {
+						if code, isString := v2["errorCode"].(string); isString && code != "" {
+							codes = append(codes, code)
+						}
+					}
+				}
+
+				Expect(codes).To(ContainElement(models.ErrBridgeNotFound))
+			})
 		})
 
 		Context("deriveDFCType smart diff", func() {

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter_test.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter_test.go
@@ -1049,6 +1049,72 @@ var _ = Describe("EditProtocolConverter", func() {
 			Expect(metadata).To(BeNil())
 		})
 
+		Context("when the edited bridge was renamed", func() {
+			var (
+				renamedName string
+				snapshotMgr *fsm.SnapshotManager
+			)
+
+			BeforeEach(func() {
+				renamedName = pcName + "-renamed"
+				snapshotMgr = fsm.NewSnapshotManager()
+			})
+
+			renameWithFailingRollout := func() error {
+				renameAction := actions.NewEditProtocolConverterAction(
+					userEmail, actionUUID, instanceUUID, outboundChannel, mockConfig, snapshotMgr)
+				renameAction.SetTickInterval(50 * time.Millisecond)
+				renameAction.SetAwaitTimeout(300 * time.Millisecond)
+
+				payload := map[string]interface{}{
+					"name": renamedName,
+					"uuid": pcUUID.String(),
+					"connection": map[string]interface{}{
+						"ip":   "wttr.in",
+						"port": 80,
+					},
+				}
+
+				Expect(renameAction.Parse(payload)).To(Succeed())
+				Expect(renameAction.Validate()).To(Succeed())
+
+				_, _, err := renameAction.Execute()
+
+				return err
+			}
+
+			protocolConverterNames := func() []string {
+				cfg, err := mockConfig.GetConfig(context.Background(), 0)
+				Expect(err).NotTo(HaveOccurred())
+
+				names := make([]string, 0, len(cfg.ProtocolConverter))
+				for _, pc := range cfg.ProtocolConverter {
+					names = append(names, pc.Name)
+				}
+
+				return names
+			}
+
+			It("rolls the rename back so the bridge keeps its pre-rename name", func() {
+				err := renameWithFailingRollout()
+
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Rolled back to previous configuration"))
+				Expect(err.Error()).NotTo(ContainSubstring("Rolling back to previous configuration failed"))
+				Expect(protocolConverterNames()).To(ConsistOf(pcName))
+			})
+
+			It("keeps the pre-rename UUID resolvable, so a retry is not stuck", func() {
+				Expect(renameWithFailingRollout()).To(HaveOccurred())
+
+				err := renameWithFailingRollout()
+
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).NotTo(ContainSubstring("not found"))
+				Expect(err.Error()).To(ContainSubstring("Rolled back to previous configuration"))
+			})
+		})
+
 		Context("deriveDFCType smart diff", func() {
 			// deployReadDFC executes a first edit that stores the given read DFC payload
 			// into the mock config so the next Parse can detect "no change".

--- a/umh-core/pkg/models/action_models.go
+++ b/umh-core/pkg/models/action_models.go
@@ -787,6 +787,7 @@ const (
 	ErrDeployTimeout = "ERR_DEPLOY_TIMEOUT"
 	// ErrConfigFileInvalid is sent when the deployment of a dfc fails because the config file is invalid.
 	ErrConfigFileInvalid = "ERR_CONFIG_FILE_INVALID"
+	ErrBridgeNotFound = "ERR_BRIDGE_NOT_FOUND"
 	// ErrRetryConfigWriteFailed is the error code for a config file write failure.
 	// It is retryable because the write failure might be caused by temporary filesystem issues.
 	ErrRetryConfigWriteFailed = "ERR_RETRY_CONFIG_WRITE_FAILED"


### PR DESCRIPTION
## TL;DR
- Today renaming a bridge whose deployment fails results in an endless loop on the save anyway button, because the UUID in the frontend for the rollback cannot be found aynmore
- Now we changed the backend to not use the saved UUID for the rollback, but instead derive the UUID from the name
- We also cleaned up the error output by moving the error message to a constant 

Fixes [ENG-5444](https://linear.app/united-manufacturing-hub/issue/ENG-5444/cannot-save-modbus-bridge-after-failed-rename-deployment). Frontend half: ManagementConsole#3367.

## What breaks today

Rename a bridge whose deployment then fails, and the bridge becomes unsaveable. umh-core reports the edit as rolled back, but keeps the new name. The frontend still holds the pre-rename UUID, so every later save fails with `bridge with UUID ... not found`, including Save Anyway, which re-sends the same UUID. The only way out is to leave the page.

Reported against a Modbus bridge whose first deploy failed on a degraded WAGO connection (ENG-5446), but the trigger is the rename, not the protocol.

## Root cause

A bridge's UUID is a hash of its name (`GenerateUUIDFromName`), so a rename changes its identity. `Execute` persists the rename first, then waits for the rollout, then rolls back on failure:

- `persistConfig` commits the new name; the bridge now answers to `uuid(new-name)`
- `awaitRollout` times out (connection never reaches `active`)
- `rollbackEdit` looks the bridge up under `a.atomicEditUUID`, the pre-rename UUID, and misses

The rollback returns `protocol converter with UUID ... not found`, the config keeps the new name, and the failure carries no error code, so the frontend treats it as ignorable and keeps offering Save Anyway for a request that can never succeed.

## Changes

**Roll back under the name the edit persisted.**

```go
_, err := a.configManager.AtomicEditProtocolConverter(
    ctx, dataflowcomponentserviceconfig.GenerateUUIDFromName(a.name), pcConfig)
```

`persistConfig` guarantees the bridge is stored under `a.name`, so the lookup always resolves; `pcConfig` is the pre-edit config, so the restore puts the old name and old UUID back. When the name did not change, this is the same value `atomicEditUUID` held, so behaviour is unchanged. All three abort paths (rollout timeout, render fail-fast, Benthos config error) share `rollbackEdit`, so one change covers them. `atomicEditUUID` existed only to carry that value and is now removed; `persistConfig` keeps taking the pre-rename UUID, which is correct for it.

`edit-dataflowcomponent.go` already keys its rollback off the post-rename UUID and documents why.

**Report a missing bridge with a code.** `applyMutation` wraps a sentinel error, leaving the message text unchanged, and `Execute` sends `ERR_BRIDGE_NOT_FOUND` so the frontend can stop offering a retry that cannot succeed. It does not let the frontend recover: the reply carries no payload, so there is no replacement UUID to follow. See the second known gap below.

## Resulting behaviour

- Save Anyway not pressed: the rename is reverted with the rest of the configuration, and the bridge keeps serving its previous config
- Save Anyway pressed: `ignoreErrors` skips the rollout wait, so the rename is stored and the reply carries the new UUID

## Tests

Four specs under `EditProtocolConverter > Execute > when the edited bridge was renamed`:

- rename plus failed rollout restores the pre-rename name
- the pre-rename UUID stays resolvable, so a retry reaches the rollout rather than dying on a dead UUID
- with the read flow ignoring errors, the rename is persisted without waiting for the rollout
- a stale UUID reports `ERR_BRIDGE_NOT_FOUND`

The first two fail on staging with the exact strings from the report. Full `pkg/communicator/actions` suite passes; the render fail-fast specs still assert their existing rollback behaviour unchanged.

## Known gaps, deliberately out of scope

**`ERR_BRIDGE_NOT_FOUND` tells the frontend to stop, not where to go** (ENG-5635, raised by CodeRabbit on ManagementConsole#3367). The reply passes `nil` as `payloadV2`, so the frontend cannot learn the bridge's new UUID and cannot offer to follow it; it drops the user back onto the same stale editor. Neither flow in this ticket reaches that state, since a failed deploy now reverts the rename and Save Anyway returns the post-rename UUID. It needs the bridge to move from elsewhere, such as a second tab or a direct config edit. Attaching the current UUID to this reply would be one way to close it, and is worth deciding on its own rather than here.

Save Anyway is a no-op for a bridge with **no flow configured at all**: `ignoreErrors` only arrives inside `readDFC`/`writeDFC`, so such a request cannot express "skip the health check" and waits out the full rollout. Closing that needs an action-scoped field on the wire; worth its own ticket rather than riding along here.
