### PR TITLE
fsmv2: attach framework metrics and action history from collector locals to every worker

### DIFF
--- a/umh-core/pkg/fsmv2/CLAUDE.md
+++ b/umh-core/pkg/fsmv2/CLAUDE.md
@@ -244,12 +244,13 @@ func (w *MyWorker) GetDependencies() *MyDependencies {
 | `DeriveDesiredState` | Custom children specs (application, communicator) or non-standard config parsing |
 | `GetInitialState` | Worker does NOT register via fsmv2.RegisterInitialState (e.g., push, pull) |
 
-Never override `GetDependenciesAny`. Before attaching framework metrics and action
-history, the collector checks whether the bound deps can carry framework state;
-`struct{}{}` and `nil` both fail that check identically, so returning nil changes
-nothing. A worker that needs framework telemetry must bind a `TDeps` embedding
-`*deps.BaseDependencies`; leaving `TDeps` as `struct{}` means no telemetry, whatever
-the accessor returns.
+Never override `GetDependenciesAny`. Framework metrics and action history are
+attached to the Observation by the collector from its own locals, before the deps
+guard, so every worker carries them on its Observation regardless of its `TDeps`
+and regardless of what `GetDependenciesAny` returns (`struct{}{}` and `nil` behave
+identically). The deps guard gates only worker-metric accumulation: a `TDeps`
+embedding `*deps.BaseDependencies` gives the collector a `MetricsRecorder` to drain
+for the worker's own counters; a `struct{}` deps worker simply records none.
 
 ## Worker Registration
 

--- a/umh-core/pkg/fsmv2/DEPENDENCIES.md
+++ b/umh-core/pkg/fsmv2/DEPENDENCIES.md
@@ -9,12 +9,12 @@ This guide covers dependency injection patterns for FSMv2 workers.
 | `Logger` | `deps.FSMLogger` | Structured logging with worker context | All workers via `BaseDependencies` |
 | `StateReader` | `deps.StateReader` | Read-only access to observed state from CSE | All workers via `BaseDependencies` |
 | `MetricsRecorder` | `*deps.MetricsRecorder` | Buffer and record per-tick metrics | All workers via `BaseDependencies` |
-| `FrameworkMetrics` | `*deps.FrameworkMetrics` | Supervisor-tracked metrics (read-only) | Injected via `deps.GetFrameworkState()` |
+| `FrameworkMetrics` | `*deps.FrameworkMetrics` | Supervisor-tracked metrics (read-only) | On the Observation for every worker; also via `deps.GetFrameworkState()` when `TDeps` embeds `BaseDependencies` |
 | `ChildrenView` | `config.ChildrenView` | Access child worker info (read-only) | Injected by the supervisor via `ChildrenViewConsumer.SetChildrenView`; read in `State.Next()` from `snapshot.Observed.ChildrenView` |
 | `WorkerType` | `string` | Worker type identifier | All workers via `BaseDependencies` |
 | `WorkerID` | `string` | Worker instance ID | All workers via `BaseDependencies` |
 
-**ActionHistory** follows the same pattern as FrameworkMetrics: Supervisor records → `ActionHistorySetter` injects into deps → Worker reads via `deps.GetActionHistory()` → Worker assigns in CollectObservedState. The collector never modifies ObservedState.
+**ActionHistory** follows the same pattern as FrameworkMetrics. The collector holds both values and writes them onto the Observation after `CollectObservedState` returns. That happens for every worker, whatever its `TDeps` is. It also writes them into the deps before `CollectObservedState`. A worker that reads `deps.GetActionHistory()` or `deps.GetFrameworkState()` during collection therefore still works. That second path needs a `TDeps` embedding `*deps.BaseDependencies`, so a worker with no dependencies does not get it.
 
 Custom dependencies (e.g., `Transport`, `ConnectionPool`, channels) can be added by embedding `BaseDependencies` in your own struct. See `workers/communicator/dependencies.go` for an example.
 
@@ -313,11 +313,11 @@ All workers automatically receive these via `BaseDependencies`:
 | Logger | Structured logging | `deps.GetLogger()`, `deps.ActionLogger(name)` | N/A |
 | StateReader | Read state from CSE | `deps.GetStateReader()` | N/A (query) |
 | MetricsRecorder | Record custom metrics | `deps.MetricsRecorder().IncrementCounter()` | Actions |
-| FrameworkMetrics | Supervisor metrics | `deps.GetFrameworkState()` | Supervisor |
+| FrameworkMetrics | Supervisor metrics | `deps.GetFrameworkState()`, or `snapshot.Observed.Metrics.Framework` | Supervisor |
 | ChildrenView | Access child info | `snapshot.Observed.ChildrenView` (set by supervisor via `ChildrenViewConsumer.SetChildrenView`) | Supervisor |
 | WorkerType/ID | Worker identity | `deps.GetWorkerType()`, `deps.GetWorkerID()` | N/A |
 
-**ActionHistory** is accessed via `deps.GetActionHistory()` which returns `[]ActionResult` (read-only). The supervisor injects the data via `ActionHistorySetter` before `CollectObservedState` is called. Workers read and assign: `ObservedState.LastActionResults = deps.GetActionHistory()`. This matches the FrameworkMetrics pattern exactly.
+**ActionHistory** is accessed via `deps.GetActionHistory()` which returns `[]ActionResult` (read-only). The supervisor writes the data into the deps via `ActionHistorySetter` before `CollectObservedState` is called. Workers read and assign: `ObservedState.LastActionResults = deps.GetActionHistory()`. The collector also writes its own copy onto the Observation afterwards, so the field is populated even for a worker that never reads the deps. This matches the FrameworkMetrics pattern exactly.
 
 ## Optional Patterns for Worker-Specific Dependencies
 
@@ -435,12 +435,13 @@ func (w *MyWorker) CollectObservedState(ctx context.Context) (fsmv2.ObservedStat
 
 // Data flow (Provider/Setter pattern):
 // 1. ActionExecutor records to supervisor's buffer after Execute()
-// 2. Before CollectObservedState: ActionHistorySetter injects into deps
+// 2. Before CollectObservedState: ActionHistorySetter writes into deps
 // 3. During CollectObservedState: Worker calls deps.GetActionHistory() and assigns
-// 4. Collector saves what CollectObservedState returned (no modifications)
+// 4. After CollectObservedState: collector writes its own copy onto the Observation
+// 5. Collector saves the Observation
 ```
 
-This mirrors `FrameworkMetrics` exactly - supervisor owns the data, injects into deps, worker reads and assigns in CollectObservedState.
+This mirrors `FrameworkMetrics` exactly. The supervisor owns the data. The collector writes it onto the Observation for every worker, and into the deps as well for workers that read it during collection.
 
 ### Key Differences from FSMv1
 

--- a/umh-core/pkg/fsmv2/supervisor/api.go
+++ b/umh-core/pkg/fsmv2/supervisor/api.go
@@ -134,12 +134,12 @@ func (s *Supervisor[TObserved, TDesired]) AddWorker(identity deps.Identity, work
 	s.logger.Debug("identity_saved")
 
 	// Read the prior StartupCount from the stored observation BEFORE the initial
-	// SaveObserved below overwrites it. The initial COS run (line 100) carries no
-	// framework metrics, so saving it first would clobber the count we are about
-	// to read back and StartupCount would never advance past 1 on re-created
-	// workers.
-	//
-	// Survives restarts, incremented on each AddWorker().
+	// SaveObserved below overwrites it. The initial COS run carries no framework
+	// metrics (AddWorker bypasses the collector), so saving it first would clobber
+	// the count we are about to read back and StartupCount would never advance
+	// past 1 on re-created workers. A load error other than "not yet present" is
+	// surfaced, so a transient store failure does not silently look like a fresh
+	// worker.
 	var startupCount int64 = 1
 
 	loadCtx, loadCancel := context.WithTimeout(context.Background(), 2*time.Second)
@@ -155,6 +155,17 @@ func (s *Supervisor[TObserved, TDesired]) AddWorker(identity deps.Identity, work
 				startupCount = fm.StartupCount + 1
 			}
 		}
+	} else if !errors.Is(loadErr, persistence.ErrNotFound) {
+		s.logger.SentryWarn(deps.FeatureFSMv2, identity.HierarchyPath, "worker_add_load_prev_observation_failed", deps.Err(loadErr))
+	}
+
+	// Persist the computed StartupCount on the initial observation so a crash
+	// between this save and the first collector tick does not reset it. The
+	// collector still owns the full framework metrics on every later tick.
+	if setter, ok := observed.(interface {
+		SetFrameworkMetrics(deps.FrameworkMetrics) fsmv2.ObservedState
+	}); ok {
+		observed = setter.SetFrameworkMetrics(deps.FrameworkMetrics{StartupCount: startupCount})
 	}
 
 	observedJSON, err := json.Marshal(observed)
@@ -328,15 +339,15 @@ func (s *Supervisor[TObserved, TDesired]) AddWorker(identity deps.Identity, work
 		},
 		FrameworkMetricsSetter: func(fm *deps.FrameworkMetrics) {
 			// Must use GetDependenciesAny() (returns any), not GetDependencies() (returns D).
-			// Injection reaches a worker only when its bound deps implement
-			// SetFrameworkState. NoDeps workers (TDeps = struct{}) return struct{}{}
-			// here, which does not, so they get no framework telemetry and no error
-			// either. Overriding GetDependenciesAny() to return nil has the same
-			// effect: correct for application, which holds no dependencies, and a
-			// mislabel for configworker, which holds two as plain struct fields and is
-			// skipped despite them. A worker built on pkg/fsmv2/simple is injected only
-			// when its spec declares a NewDeps returning a TDeps that embeds
-			// BaseDependencies: historian does, nmap does not.
+			// This write feeds a worker that reads deps.GetFrameworkState() during
+			// CollectObservedState, so it reaches only a bound deps that implements
+			// SetFrameworkState (a deps embedding *deps.BaseDependencies). It is
+			// separate from the Observation injection, which the collector performs
+			// from its own local in wrapNewObservation regardless of the deps shape —
+			// a struct{}-deps worker (nmap) still carries framework metrics on its
+			// Observation. Application and configworker bind no deps and so simply
+			// get no pre-COS write; returning nil or struct{}{} from
+			// GetDependenciesAny is equivalent and neither is overridden.
 			type depsGetter interface {
 				GetDependenciesAny() any
 			}

--- a/umh-core/pkg/fsmv2/supervisor/api.go
+++ b/umh-core/pkg/fsmv2/supervisor/api.go
@@ -133,13 +133,11 @@ func (s *Supervisor[TObserved, TDesired]) AddWorker(identity deps.Identity, work
 
 	s.logger.Debug("identity_saved")
 
-	// Read the prior StartupCount from the stored observation BEFORE the initial
-	// SaveObserved below overwrites it. The initial COS run carries no framework
-	// metrics (AddWorker bypasses the collector), so saving it first would clobber
-	// the count we are about to read back and StartupCount would never advance
-	// past 1 on re-created workers. A load error other than "not yet present" is
-	// surfaced, so a transient store failure does not silently look like a fresh
-	// worker.
+	// Read the prior StartupCount before the SaveObserved below, which would
+	// otherwise overwrite it. The ordering is pinned by "StartupCount persistence
+	// advances across a worker respawn instead of resetting to 1". A load error other
+	// than "not yet present" is surfaced, so a transient store failure does not
+	// silently look like a fresh worker.
 	var startupCount int64 = 1
 
 	loadCtx, loadCancel := context.WithTimeout(context.Background(), 2*time.Second)
@@ -560,6 +558,7 @@ func (s *Supervisor[TObserved, TDesired]) GetWorkers() []deps.Identity {
 }
 
 // GetCurrentState returns the current state of the first worker.
+//
 // Deprecated: Use GetCurrentStateName() for interface compatibility, or
 // GetWorkerState(workerID) for full state information including reason.
 // This method will be removed in a future version.

--- a/umh-core/pkg/fsmv2/supervisor/api.go
+++ b/umh-core/pkg/fsmv2/supervisor/api.go
@@ -133,6 +133,30 @@ func (s *Supervisor[TObserved, TDesired]) AddWorker(identity deps.Identity, work
 
 	s.logger.Debug("identity_saved")
 
+	// Read the prior StartupCount from the stored observation BEFORE the initial
+	// SaveObserved below overwrites it. The initial COS run (line 100) carries no
+	// framework metrics, so saving it first would clobber the count we are about
+	// to read back and StartupCount would never advance past 1 on re-created
+	// workers.
+	//
+	// Survives restarts, incremented on each AddWorker().
+	var startupCount int64 = 1
+
+	loadCtx, loadCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer loadCancel()
+
+	var prevObserved TObserved
+
+	loadErr := s.store.LoadObservedTyped(loadCtx, s.workerType, identity.ID, &prevObserved)
+	if loadErr == nil {
+		if holder, ok := any(prevObserved).(deps.MetricsHolder); ok {
+			fm := holder.GetFrameworkMetrics()
+			if fm.StartupCount > 0 {
+				startupCount = fm.StartupCount + 1
+			}
+		}
+	}
+
 	observedJSON, err := json.Marshal(observed)
 	if err != nil {
 		s.logger.SentryError(deps.FeatureFSMv2, identity.HierarchyPath, err, "worker_add_marshal_observed_failed")
@@ -386,24 +410,6 @@ func (s *Supervisor[TObserved, TDesired]) AddWorker(identity deps.Identity, work
 			}
 		}
 	})
-
-	// Survives restarts, incremented on each AddWorker().
-	var startupCount int64 = 1
-
-	loadCtx, loadCancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer loadCancel()
-
-	var prevObserved TObserved
-
-	loadErr := s.store.LoadObservedTyped(loadCtx, s.workerType, identity.ID, &prevObserved)
-	if loadErr == nil {
-		if holder, ok := any(prevObserved).(deps.MetricsHolder); ok {
-			fm := holder.GetFrameworkMetrics()
-			if fm.StartupCount > 0 {
-				startupCount = fm.StartupCount + 1
-			}
-		}
-	}
 
 	initialState := worker.GetInitialState()
 

--- a/umh-core/pkg/fsmv2/supervisor/internal/collection/collector.go
+++ b/umh-core/pkg/fsmv2/supervisor/internal/collection/collector.go
@@ -426,14 +426,11 @@ func (c *Collector[TObserved]) collectAndSaveObservedState(ctx context.Context) 
 	c.logTrace("observation_collection_starting",
 		deps.String("collection_start_time", collectionStartTime.Format(time.RFC3339Nano)))
 
-	// Fetch framework metrics into a local so wrapNewObservation can inject them
-	// onto the Observation before the deps guard (a worker whose deps fail the
-	// baseDepsAccessor type assertion carries no framework state of its own). The
-	// Setter still runs when non-nil, so workers that read deps.GetFrameworkState()
-	// during CollectObservedState keep working. The Setter is nested inside the
-	// Provider guard, so it fires only when both are non-nil; fetching on the
-	// Provider alone keeps the provider called exactly once per tick even when the
-	// Setter is nil.
+	// A worker whose deps fail the baseDepsAccessor assertion (step 4 in
+	// wrapNewObservation) carries no framework state of its own. So fetch the metrics
+	// into a local here, ahead of that guard, and wrapNewObservation injects them
+	// whatever the deps shape. Fetching on the Provider alone calls the provider
+	// exactly once per tick even when the Setter is nil.
 	var frameworkMetrics *deps.FrameworkMetrics
 	if c.config.FrameworkMetricsProvider != nil {
 		frameworkMetrics = c.config.FrameworkMetricsProvider()
@@ -445,8 +442,7 @@ func (c *Collector[TObserved]) collectAndSaveObservedState(ctx context.Context) 
 	}
 
 	// Fetch action history into a local for the same reason and with the same
-	// split guard. Fetching on the Provider alone keeps the provider called exactly
-	// once per tick even when the Setter is nil.
+	// split guard.
 	var actionHistory []deps.ActionResult
 	if c.config.ActionHistoryProvider != nil {
 		actionHistory = c.config.ActionHistoryProvider()
@@ -619,8 +615,7 @@ func (c *Collector[TObserved]) collectAndSaveObservedState(ctx context.Context) 
 }
 
 // baseDepsAccessor accesses a worker's MetricsRecorder for step 5 (worker-metric
-// accumulation). Framework metrics and action history come from the collector's
-// own locals, so the deps guard needs only the recorder.
+// accumulation).
 type baseDepsAccessor interface {
 	MetricsRecorder() *deps.MetricsRecorder
 }
@@ -639,10 +634,8 @@ func (c *Collector[TObserved]) wrapNewObservation(ctx context.Context, observed 
 		observed = setter.SetCollectedAt(time.Now())
 	}
 
-	// Step 2: Inject framework metrics from the collector's local. This runs
-	// before the deps guard so a worker whose GetDependenciesAny returns a value
-	// that fails the baseDepsAccessor type assertion (nil or a non-accessor) still
-	// gets the metrics the supervisor captured.
+	// Step 2: Inject framework metrics from the collector's local, ahead of the deps
+	// guard at step 4.
 	if frameworkMetrics != nil {
 		if setter, ok := observed.(interface {
 			SetFrameworkMetrics(deps.FrameworkMetrics) fsmv2.ObservedState

--- a/umh-core/pkg/fsmv2/supervisor/internal/collection/collector.go
+++ b/umh-core/pkg/fsmv2/supervisor/internal/collection/collector.go
@@ -71,20 +71,28 @@ type CollectorConfig[TObserved any] struct {
 	// workers that need per-child detail.
 	ChildrenViewProvider func() config.ChildrenView
 	// FrameworkMetricsProvider returns current framework metrics from supervisor.
-	// Called BEFORE collection to inject into worker dependencies.
-	// The provider captures workerCtx and acquires RLock when called (thread-safe).
+	// Called before collection; the value is captured into a collector local and
+	// injected onto the Observation in wrapNewObservation, so this must be set for
+	// any worker that needs framework metrics on its Observation. The provider
+	// captures workerCtx and acquires RLock when called (thread-safe).
 	FrameworkMetricsProvider func() *deps.FrameworkMetrics
-	// FrameworkMetricsSetter sets framework metrics on worker dependencies.
-	// Called BEFORE CollectObservedState so workers can access via deps.GetFrameworkState().
-	// Replaces the duck-typing injection pattern for explicit metrics copying.
+	// FrameworkMetricsSetter writes the captured framework metrics into worker
+	// dependencies before CollectObservedState, so a worker can read
+	// deps.GetFrameworkState() during collection. It does not feed the Observation
+	// injection, which uses the same collector local. Invoked only when the
+	// Provider is also set.
 	FrameworkMetricsSetter func(*deps.FrameworkMetrics)
-	// ActionHistoryProvider returns buffered action results from supervisor's workerCtx.
-	// Called BEFORE CollectObservedState to get action results for injection into deps.
-	// The supervisor auto-records action results via ActionExecutor callback.
+	// ActionHistoryProvider returns buffered action results from supervisor's
+	// workerCtx. Called before collection; the value is captured into a collector
+	// local and injected onto the Observation in wrapNewObservation, so this must
+	// be set for any worker that needs action history on its Observation. The
+	// supervisor auto-records action results via ActionExecutor callback.
 	ActionHistoryProvider func() []deps.ActionResult
-	// ActionHistorySetter sets action history on worker dependencies BEFORE CollectObservedState.
-	// Workers then access via deps.GetActionHistory() and assign to their ObservedState.
-	// This follows the same pattern as FrameworkMetricsSetter.
+	// ActionHistorySetter writes the captured action history into worker
+	// dependencies before CollectObservedState, so a worker can read
+	// deps.GetActionHistory() during collection. It does not feed the Observation
+	// injection, which uses the same collector local. Invoked only when the
+	// Provider is also set.
 	ActionHistorySetter func([]deps.ActionResult)
 	// DesiredStateProvider returns the current desired state from the CSE store.
 	// Called BEFORE CollectObservedState so workers can access configuration
@@ -418,16 +426,33 @@ func (c *Collector[TObserved]) collectAndSaveObservedState(ctx context.Context) 
 	c.logTrace("observation_collection_starting",
 		deps.String("collection_start_time", collectionStartTime.Format(time.RFC3339Nano)))
 
-	// Inject framework metrics before CollectObservedState so workers can access via deps.GetFrameworkState()
-	if c.config.FrameworkMetricsProvider != nil && c.config.FrameworkMetricsSetter != nil {
-		fm := c.config.FrameworkMetricsProvider()
-		c.config.FrameworkMetricsSetter(fm)
+	// Fetch framework metrics into a local so wrapNewObservation can inject them
+	// onto the Observation before the deps guard (a worker whose deps fail the
+	// baseDepsAccessor type assertion carries no framework state of its own). The
+	// Setter still runs when non-nil, so workers that read deps.GetFrameworkState()
+	// during CollectObservedState keep working. Fetch and set are guarded
+	// independently: fetch on the Provider, set on the Setter.
+	var frameworkMetrics *deps.FrameworkMetrics
+	if c.config.FrameworkMetricsProvider != nil {
+		frameworkMetrics = c.config.FrameworkMetricsProvider()
+		if c.config.FrameworkMetricsSetter != nil {
+			// Preserved for workers that read deps.GetFrameworkState() during
+			// CollectObservedState.
+			c.config.FrameworkMetricsSetter(frameworkMetrics)
+		}
 	}
 
-	// Inject action history before CollectObservedState so workers can access via deps.GetActionHistory()
-	if c.config.ActionHistoryProvider != nil && c.config.ActionHistorySetter != nil {
-		actionHistory := c.config.ActionHistoryProvider()
-		c.config.ActionHistorySetter(actionHistory)
+	// Fetch action history into a local for the same reason and with the same
+	// split guard. Fetching on the Provider alone keeps the provider called exactly
+	// once per tick even when the Setter is nil.
+	var actionHistory []deps.ActionResult
+	if c.config.ActionHistoryProvider != nil {
+		actionHistory = c.config.ActionHistoryProvider()
+		if c.config.ActionHistorySetter != nil {
+			// Preserved for workers that read deps.GetActionHistory() during
+			// CollectObservedState.
+			c.config.ActionHistorySetter(actionHistory)
+		}
 	}
 
 	// Load desired state to pass to CollectObservedState.
@@ -485,7 +510,7 @@ func (c *Collector[TObserved]) collectAndSaveObservedState(ctx context.Context) 
 	// Post-COS framework wrapping for NewObservation-based workers.
 	// Gate: zero CollectedAt means NewObservation (not WrapStatus).
 	if observed.GetTimestamp().IsZero() {
-		observed = c.wrapNewObservation(ctx, observed)
+		observed = c.wrapNewObservation(ctx, observed, frameworkMetrics, actionHistory)
 	}
 
 	// Inject FSM state via callback to preserve "Collector-only writes ObservedState" boundary
@@ -591,11 +616,10 @@ func (c *Collector[TObserved]) collectAndSaveObservedState(ctx context.Context) 
 	return nil
 }
 
-// baseDepsAccessor is a duck-type interface for extracting framework data from
-// any worker's dependencies (BaseDependencies or a struct embedding it).
+// baseDepsAccessor accesses a worker's MetricsRecorder for step 5 (worker-metric
+// accumulation). Frameworks metrics and action history come from the collector's
+// own locals, so the deps guard needs only the recorder.
 type baseDepsAccessor interface {
-	GetFrameworkState() *deps.FrameworkMetrics
-	GetActionHistory() []deps.ActionResult
 	MetricsRecorder() *deps.MetricsRecorder
 }
 
@@ -605,7 +629,7 @@ type baseDepsAccessor interface {
 //
 // Steps: set CollectedAt, inject framework metrics + action history,
 // accumulate worker metrics (load previous from CSE, drain recorder, merge).
-func (c *Collector[TObserved]) wrapNewObservation(ctx context.Context, observed fsmv2.ObservedState) fsmv2.ObservedState {
+func (c *Collector[TObserved]) wrapNewObservation(ctx context.Context, observed fsmv2.ObservedState, frameworkMetrics *deps.FrameworkMetrics, actionHistory []deps.ActionResult) fsmv2.ObservedState {
 	// Step 1: Set CollectedAt to now.
 	if setter, ok := observed.(interface {
 		SetCollectedAt(time.Time) fsmv2.ObservedState
@@ -613,7 +637,31 @@ func (c *Collector[TObserved]) wrapNewObservation(ctx context.Context, observed 
 		observed = setter.SetCollectedAt(time.Now())
 	}
 
-	// Step 2: Get BaseDependencies from worker via DependencyProvider → baseDepsAccessor.
+	// Step 2: Inject framework metrics from the collector's local. This runs
+	// before the deps guard so a worker whose GetDependenciesAny returns a value
+	// that fails the baseDepsAccessor type assertion (nil or a non-accessor) still
+	// gets the metrics the supervisor captured.
+	if frameworkMetrics != nil {
+		if setter, ok := observed.(interface {
+			SetFrameworkMetrics(deps.FrameworkMetrics) fsmv2.ObservedState
+		}); ok {
+			observed = setter.SetFrameworkMetrics(*frameworkMetrics)
+		}
+	}
+
+	// Step 3: Inject action history from the collector's local, before the deps
+	// guard, for the same reason.
+	if actionHistory != nil {
+		if setter, ok := observed.(interface {
+			SetActionHistory([]deps.ActionResult) fsmv2.ObservedState
+		}); ok {
+			observed = setter.SetActionHistory(actionHistory)
+		}
+	}
+
+	// Step 4: deps guard  -  DependencyProvider → baseDepsAccessor gates step 5
+	// (worker-metric accumulation) only. Framework metrics and action history
+	// are already injected from the collector locals above.
 	depProvider, ok := c.config.Worker.(fsmv2.DependencyProvider)
 	if !ok {
 		c.config.Logger.Debug("wrap_new_observation_no_dependency_provider",
@@ -630,24 +678,6 @@ func (c *Collector[TObserved]) wrapNewObservation(ctx context.Context, observed 
 			deps.String("deps_type", fmt.Sprintf("%T", depsAny)))
 
 		return observed
-	}
-
-	// Step 3: Inject framework metrics.
-	if fm := bd.GetFrameworkState(); fm != nil {
-		if setter, ok := observed.(interface {
-			SetFrameworkMetrics(deps.FrameworkMetrics) fsmv2.ObservedState
-		}); ok {
-			observed = setter.SetFrameworkMetrics(*fm)
-		}
-	}
-
-	// Step 4: Inject action history.
-	if ah := bd.GetActionHistory(); ah != nil {
-		if setter, ok := observed.(interface {
-			SetActionHistory([]deps.ActionResult) fsmv2.ObservedState
-		}); ok {
-			observed = setter.SetActionHistory(ah)
-		}
 	}
 
 	// Step 5: Accumulate worker metrics (load previous → drain → merge).

--- a/umh-core/pkg/fsmv2/supervisor/internal/collection/collector.go
+++ b/umh-core/pkg/fsmv2/supervisor/internal/collection/collector.go
@@ -430,8 +430,10 @@ func (c *Collector[TObserved]) collectAndSaveObservedState(ctx context.Context) 
 	// onto the Observation before the deps guard (a worker whose deps fail the
 	// baseDepsAccessor type assertion carries no framework state of its own). The
 	// Setter still runs when non-nil, so workers that read deps.GetFrameworkState()
-	// during CollectObservedState keep working. Fetch and set are guarded
-	// independently: fetch on the Provider, set on the Setter.
+	// during CollectObservedState keep working. The Setter is nested inside the
+	// Provider guard, so it fires only when both are non-nil; fetching on the
+	// Provider alone keeps the provider called exactly once per tick even when the
+	// Setter is nil.
 	var frameworkMetrics *deps.FrameworkMetrics
 	if c.config.FrameworkMetricsProvider != nil {
 		frameworkMetrics = c.config.FrameworkMetricsProvider()
@@ -617,7 +619,7 @@ func (c *Collector[TObserved]) collectAndSaveObservedState(ctx context.Context) 
 }
 
 // baseDepsAccessor accesses a worker's MetricsRecorder for step 5 (worker-metric
-// accumulation). Frameworks metrics and action history come from the collector's
+// accumulation). Framework metrics and action history come from the collector's
 // own locals, so the deps guard needs only the recorder.
 type baseDepsAccessor interface {
 	MetricsRecorder() *deps.MetricsRecorder

--- a/umh-core/pkg/fsmv2/supervisor/internal/collection/collector.go
+++ b/umh-core/pkg/fsmv2/supervisor/internal/collection/collector.go
@@ -473,9 +473,8 @@ func (c *Collector[TObserved]) collectAndSaveObservedState(ctx context.Context) 
 			// fire SentryError on every tick (~1/s/worker) and exhaust Sentry quota
 			// during brief store outages. Sentry escalation happens upstream in api.go's
 			// DesiredStateProvider closure, which fires SentryWarn at the source.
-			// (Sticky-error dedup at that layer is deferred to a follow-up ticket;
-			// FSMLogger lacks a Loki-only Warn method today, which is why Info is the
-			// current best fit.)
+			// (Sticky-error dedup at that layer is ENG-5658; FSMLogger lacks a
+			// Loki-only Warn method today, which is why Info is the current best fit.)
 			c.config.Logger.Info("collector_skipped_desired_state_error",
 				deps.Err(providerErr))
 

--- a/umh-core/pkg/fsmv2/supervisor/internal/collection/collector_wrapping_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/internal/collection/collector_wrapping_test.go
@@ -554,7 +554,7 @@ var _ = Describe("Collector post-COS wrapping", func() {
 		// FrameworkMetricsSetter is also asserted to fire exactly once per tick, so
 		// deleting the pre-COS Setter invocation silently redden this test.
 		It("(a) injects framework metrics from the collector local onto a struct{}-deps worker", func() {
-			id := wrappingTestIdentity("rung1-struct-deps-a")
+			id := wrappingTestIdentity("struct-deps-a")
 
 			var fmSetterCalls int
 
@@ -580,7 +580,7 @@ var _ = Describe("Collector post-COS wrapping", func() {
 		// from the collector's local even when the Setter is nil (split guard:
 		// fetch on Provider != nil alone).
 		It("(b) injects action history from the collector local onto a struct{}-deps worker", func() {
-			id := wrappingTestIdentity("rung1-struct-deps-b")
+			id := wrappingTestIdentity("struct-deps-b")
 
 			coll, store := newWrappingCollector(&wrappingTestWorkerStructDeps{observed: testWrappingObservedState{}}, id, deps.NewNopFSMLogger(), func(cfg *collection.CollectorConfig[testWrappingObservedState]) {
 				cfg.ActionHistoryProvider = func() []deps.ActionResult {
@@ -603,7 +603,7 @@ var _ = Describe("Collector post-COS wrapping", func() {
 		// tick guards against cross-tick fetch suppression (e.g. a misguided
 		// sync.Once that fetches only on tick 1).
 		It("(c) calls ActionHistoryProvider exactly once per tick when the Setter is nil", func() {
-			id := wrappingTestIdentity("rung1-struct-deps-c")
+			id := wrappingTestIdentity("struct-deps-c")
 
 			var ahCalls int
 
@@ -635,7 +635,7 @@ var _ = Describe("Collector post-COS wrapping", func() {
 		// FrameworkMetricsProvider is set but the Setter is nil (split guard:
 		// fetch on Provider != nil alone).
 		It("(d) puts framework metrics on the Observation when FrameworkMetricsSetter is nil", func() {
-			id := wrappingTestIdentity("rung1-split-guard")
+			id := wrappingTestIdentity("split-guard")
 
 			coll, store := newWrappingCollector(&wrappingTestWorkerStructDeps{observed: testWrappingObservedState{}}, id, deps.NewNopFSMLogger(), func(cfg *collection.CollectorConfig[testWrappingObservedState]) {
 				cfg.FrameworkMetricsProvider = func() *deps.FrameworkMetrics { return &deps.FrameworkMetrics{TimeInCurrentStateMs: 111222} }
@@ -657,7 +657,7 @@ var _ = Describe("Collector post-COS wrapping", func() {
 		It("(e) preserves both deps-guard debug keys", func() {
 			// key 1: worker without DependencyProvider emits no_dependency_provider.
 			noProvLogger := &severityCapturingLogger{}
-			noProvID := wrappingTestIdentity("rung1-no-provider")
+			noProvID := wrappingTestIdentity("no-provider")
 
 			noProvColl, _ := newWrappingCollector(&wrappingTestWorkerNoDeps{observed: testWrappingObservedState{}}, noProvID, noProvLogger, func(*collection.CollectorConfig[testWrappingObservedState]) {})
 			runSyncTick(ctx, noProvColl)
@@ -667,7 +667,7 @@ var _ = Describe("Collector post-COS wrapping", func() {
 
 			// key 2: struct{}-deps worker emits no_base_deps_accessor.
 			structDepsLogger := &severityCapturingLogger{}
-			structDepsID := wrappingTestIdentity("rung1-struct-deps-e")
+			structDepsID := wrappingTestIdentity("struct-deps-e")
 
 			structDepsColl, _ := newWrappingCollector(&wrappingTestWorkerStructDeps{observed: testWrappingObservedState{}}, structDepsID, structDepsLogger, func(cfg *collection.CollectorConfig[testWrappingObservedState]) {
 				cfg.StateProvider = func() string { return "running" }
@@ -681,7 +681,7 @@ var _ = Describe("Collector post-COS wrapping", func() {
 
 	Context("pre-COS write reaches a worker that reads deps during COS (GUARD)", func() {
 		It("makes deps.GetFrameworkState and deps.GetActionHistory readable as worker-authored state during CollectObservedState", func() {
-			id := wrappingTestIdentity("rung2-precos")
+			id := wrappingTestIdentity("precos")
 			store := supervisor.CreateTestTriangularStoreForWorkerType("testwrapping")
 
 			bd := deps.NewBaseDependencies(deps.NewNopFSMLogger(), nil, id)
@@ -698,7 +698,7 @@ var _ = Describe("Collector post-COS wrapping", func() {
 				FrameworkMetricsProvider: func() *deps.FrameworkMetrics { return &deps.FrameworkMetrics{TimeInCurrentStateMs: 987654} },
 				FrameworkMetricsSetter:   func(fm *deps.FrameworkMetrics) { bd.SetFrameworkState(fm) },
 				ActionHistoryProvider: func() []deps.ActionResult {
-					return []deps.ActionResult{{ActionType: "rung2-action", Success: true}}
+					return []deps.ActionResult{{ActionType: "precos-action", Success: true}}
 				},
 				ActionHistorySetter: func(ah []deps.ActionResult) { bd.SetActionHistory(ah) },
 			})
@@ -709,10 +709,10 @@ var _ = Describe("Collector post-COS wrapping", func() {
 			// from its locals, so it stays green even if the Setter were deleted).
 			// This is what makes a deleted Setter invocation visible.
 			Expect(worker.fmSeen).To(Equal(int64(987654)),
-				"(rung2) pre-COS FrameworkMetricsSetter write must be readable via deps.GetFrameworkState() during COS")
+				"pre-COS FrameworkMetricsSetter write must be readable via deps.GetFrameworkState() during COS")
 			Expect(worker.ahSeen).To(HaveLen(1))
-			Expect(worker.ahSeen[0].ActionType).To(Equal("rung2-action"),
-				"(rung2) pre-COS ActionHistorySetter write must be readable via deps.GetActionHistory() during COS")
+			Expect(worker.ahSeen[0].ActionType).To(Equal("precos-action"),
+				"pre-COS ActionHistorySetter write must be readable via deps.GetActionHistory() during COS")
 		})
 	})
 })

--- a/umh-core/pkg/fsmv2/supervisor/internal/collection/collector_wrapping_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/internal/collection/collector_wrapping_test.go
@@ -115,6 +115,35 @@ func (w *wrappingTestWorkerNoDeps) GetInitialState() fsmv2.State[any, any] {
 	return &supervisor.TestState{}
 }
 
+// wrappingTestWorkerStructDeps implements Worker + DependencyProvider but returns
+// struct{}{} — a non-accessor value that fails the baseDepsAccessor type
+// assertion. struct{}{} and nil fail the assertion identically, so the deps
+// guard in wrapNewObservation skips step 5 (worker-metric accumulation) for this
+// worker. Framework metrics and action history still reach its Observation
+// because they are injected from the collector's locals before the guard.
+type wrappingTestWorkerStructDeps struct {
+	observed fsmv2.ObservedState
+}
+
+func (w *wrappingTestWorkerStructDeps) CollectObservedState(_ context.Context, _ fsmv2.DesiredState) (fsmv2.ObservedState, error) {
+	return w.observed, nil
+}
+
+func (w *wrappingTestWorkerStructDeps) DeriveDesiredState(_ interface{}) (fsmv2.DesiredState, error) {
+	return &config.DesiredState{BaseDesiredState: config.BaseDesiredState{}}, nil
+}
+
+func (w *wrappingTestWorkerStructDeps) GetInitialState() fsmv2.State[any, any] {
+	return &supervisor.TestState{}
+}
+
+// GetDependenciesAny returns struct{}{}, the non-accessor value. This type
+// implements DependencyProvider but its deps carry no framework state, so it
+// must NOT satisfy baseDepsAccessor.
+func (w *wrappingTestWorkerStructDeps) GetDependenciesAny() any {
+	return struct{}{}
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -127,6 +156,36 @@ func wrappingDesiredProvider() func() (fsmv2.DesiredState, error) {
 	return func() (fsmv2.DesiredState, error) {
 		return &config.DesiredState{BaseDesiredState: config.BaseDesiredState{}}, nil
 	}
+}
+
+// newWrappingCollector builds a collector with the shared wrapping-test defaults
+// (Hour interval so no background ticks fire; one synchronous tick runs via
+// CollectFinalObservation, 3s timeout, no-op desired provider) and the given
+// worker. The overrides closure sets the provider/setter fields under test.
+// It returns the collector and the freshly created store so the caller can load
+// the saved observation.
+func newWrappingCollector(worker fsmv2.Worker, id deps.Identity, logger deps.FSMLogger, overrides func(*collection.CollectorConfig[testWrappingObservedState])) (*collection.Collector[testWrappingObservedState], *storage.TriangularStore) {
+	store := supervisor.CreateTestTriangularStoreForWorkerType("testwrapping")
+	cfg := collection.CollectorConfig[testWrappingObservedState]{
+		Worker:               worker,
+		Identity:             id,
+		Store:                store,
+		Logger:               logger,
+		ObservationInterval:  time.Hour,
+		ObservationTimeout:   3 * time.Second,
+		DesiredStateProvider: wrappingDesiredProvider(),
+	}
+
+	overrides(&cfg)
+
+	return collection.NewCollector[testWrappingObservedState](cfg), store
+}
+
+// runSyncTick starts the collector, runs one synchronous observation, and stops it.
+func runSyncTick(ctx context.Context, coll *collection.Collector[testWrappingObservedState]) {
+	Expect(coll.Start(ctx)).To(Succeed())
+	defer coll.Stop(context.Background())
+	Expect(coll.CollectFinalObservation(context.Background())).To(Succeed())
 }
 
 // ---------------------------------------------------------------------------
@@ -440,6 +499,147 @@ var _ = Describe("Collector post-COS wrapping", func() {
 			Expect(store.LoadObservedTyped(ctx, "testwrapping", identity.ID, &loaded)).To(Succeed())
 			Expect(loaded.Metrics.Worker.Counters).To(BeEmpty())
 			Expect(loaded.Metrics.Worker.Gauges).To(BeEmpty())
+		})
+	})
+
+	// collectAndSaveObservedState captures framework metrics + action history
+	// into locals and passes them into wrapNewObservation, which injects them
+	// onto the Observation BEFORE the deps guard. The deps guard
+	// (DependencyProvider -> baseDepsAccessor) gates ONLY step 5 (worker-metric
+	// accumulation). The two pre-COS compound guards split: fetch when the
+	// Provider != nil, set when the Setter != nil.
+	//
+	// Assertions (a)-(d) verify the injection and split-guard behavior; (e) is a
+	// regression guard preserving the two distinct debug keys the deps guard
+	// emits.
+	Context("struct{}-deps worker gets framework metrics + action history; deps guard gates step 5; compound guard split; both debug keys preserved", func() {
+		// (a) A struct{}-deps worker must receive framework metrics from the
+		// collector's local, not from its deps (it has no MetricsRecorder). The
+		// FrameworkMetricsSetter is also asserted to fire exactly once per tick, so
+		// deleting the pre-COS Setter invocation silently redden this test.
+		It("(a) injects framework metrics from the collector local onto a struct{}-deps worker", func() {
+			id := wrappingTestIdentity("rung1-struct-deps-a")
+
+			var fmSetterCalls int
+
+			coll, store := newWrappingCollector(&wrappingTestWorkerStructDeps{observed: testWrappingObservedState{}}, id, deps.NewNopFSMLogger(), func(cfg *collection.CollectorConfig[testWrappingObservedState]) {
+				cfg.FrameworkMetricsProvider = func() *deps.FrameworkMetrics { return &deps.FrameworkMetrics{TimeInCurrentStateMs: 987654} }
+				cfg.FrameworkMetricsSetter = func(_ *deps.FrameworkMetrics) {
+					fmSetterCalls++
+				}
+				cfg.StateProvider = func() string { return "running" }
+			})
+			runSyncTick(ctx, coll)
+
+			Expect(fmSetterCalls).To(Equal(1),
+				"(a) FrameworkMetricsSetter must be called exactly once per tick (the pre-COS write that feeds workers reading deps.GetFrameworkState())")
+
+			var loaded testWrappingObservedState
+			Expect(store.LoadObservedTyped(ctx, "testwrapping", id.ID, &loaded)).To(Succeed())
+			Expect(loaded.Metrics.Framework.TimeInCurrentStateMs).To(Equal(int64(987654)),
+				"(a) struct{}-deps worker must carry framework metrics from the collector's local, not from its deps")
+		})
+
+		// (b) A struct{}-deps worker must receive the drained action history
+		// from the collector's local even when the Setter is nil (split guard:
+		// fetch on Provider != nil alone).
+		It("(b) injects action history from the collector local onto a struct{}-deps worker", func() {
+			id := wrappingTestIdentity("rung1-struct-deps-b")
+
+			coll, store := newWrappingCollector(&wrappingTestWorkerStructDeps{observed: testWrappingObservedState{}}, id, deps.NewNopFSMLogger(), func(cfg *collection.CollectorConfig[testWrappingObservedState]) {
+				cfg.ActionHistoryProvider = func() []deps.ActionResult {
+					return []deps.ActionResult{{ActionType: "test-action", Success: true}}
+				}
+				// ActionHistorySetter left nil: the split guard still fetches.
+				cfg.StateProvider = func() string { return "running" }
+			})
+			runSyncTick(ctx, coll)
+
+			var loaded testWrappingObservedState
+			Expect(store.LoadObservedTyped(ctx, "testwrapping", id.ID, &loaded)).To(Succeed())
+			Expect(loaded.ActionResults).To(HaveLen(1),
+				"(b) struct{}-deps worker must carry the pre-COS-drained action history")
+			Expect(loaded.ActionResults[0].ActionType).To(Equal("test-action"))
+		})
+
+		// (c) The split guard fetches on Provider != nil alone, so the provider
+		// is invoked exactly once per tick even when the Setter is nil. A second
+		// tick guards against cross-tick fetch suppression (e.g. a misguided
+		// sync.Once that fetches only on tick 1).
+		It("(c) calls ActionHistoryProvider exactly once per tick when the Setter is nil", func() {
+			id := wrappingTestIdentity("rung1-struct-deps-c")
+
+			var ahCalls int
+
+			coll, _ := newWrappingCollector(&wrappingTestWorkerStructDeps{observed: testWrappingObservedState{}}, id, deps.NewNopFSMLogger(), func(cfg *collection.CollectorConfig[testWrappingObservedState]) {
+				cfg.ActionHistoryProvider = func() []deps.ActionResult {
+					ahCalls++
+
+					return []deps.ActionResult{{ActionType: "test-action", Success: true}}
+				}
+				// ActionHistorySetter left nil: fetch must still happen once.
+				cfg.StateProvider = func() string { return "running" }
+			})
+
+			Expect(coll.Start(ctx)).To(Succeed())
+			defer coll.Stop(context.Background())
+
+			Expect(coll.CollectFinalObservation(context.Background())).To(Succeed())
+			Expect(ahCalls).To(Equal(1),
+				"(c) ActionHistoryProvider must be called exactly once on the first tick (not zero, not re-fetched)")
+
+			// Second tick: a cross-tick suppression regression (e.g. sync.Once)
+			// would leave the count at 1 instead of 2.
+			Expect(coll.CollectFinalObservation(context.Background())).To(Succeed())
+			Expect(ahCalls).To(Equal(2),
+				"(c) ActionHistoryProvider must be called exactly once per tick across ticks (no cross-tick suppression)")
+		})
+
+		// (d) Framework metrics reach the Observation when the
+		// FrameworkMetricsProvider is set but the Setter is nil (split guard:
+		// fetch on Provider != nil alone).
+		It("(d) puts framework metrics on the Observation when FrameworkMetricsSetter is nil", func() {
+			id := wrappingTestIdentity("rung1-split-guard")
+
+			coll, store := newWrappingCollector(&wrappingTestWorkerStructDeps{observed: testWrappingObservedState{}}, id, deps.NewNopFSMLogger(), func(cfg *collection.CollectorConfig[testWrappingObservedState]) {
+				cfg.FrameworkMetricsProvider = func() *deps.FrameworkMetrics { return &deps.FrameworkMetrics{TimeInCurrentStateMs: 111222} }
+				// FrameworkMetricsSetter left nil: the split-guard case.
+				cfg.StateProvider = func() string { return "running" }
+			})
+			runSyncTick(ctx, coll)
+
+			var loaded testWrappingObservedState
+			Expect(store.LoadObservedTyped(ctx, "testwrapping", id.ID, &loaded)).To(Succeed())
+			Expect(loaded.Metrics.Framework.TimeInCurrentStateMs).To(Equal(int64(111222)),
+				"(d) a collector with FrameworkMetricsProvider set but FrameworkMetricsSetter nil must still put framework metrics on the Observation (split-guard)")
+		})
+
+		// (e) Regression guard: the deps guard still emits its two distinct
+		// debug keys — no_dependency_provider for a worker without
+		// DependencyProvider, and no_base_deps_accessor for a struct{}-deps
+		// worker. These keys must survive the guard relocation.
+		It("(e) preserves both deps-guard debug keys", func() {
+			// key 1: worker without DependencyProvider emits no_dependency_provider.
+			noProvLogger := &severityCapturingLogger{}
+			noProvID := wrappingTestIdentity("rung1-no-provider")
+
+			noProvColl, _ := newWrappingCollector(&wrappingTestWorkerNoDeps{observed: testWrappingObservedState{}}, noProvID, noProvLogger, func(*collection.CollectorConfig[testWrappingObservedState]) {})
+			runSyncTick(ctx, noProvColl)
+
+			Expect(noProvLogger.has("debug", "wrap_new_observation_no_dependency_provider")).To(BeTrue(),
+				"(e) a worker without DependencyProvider must emit the wrap_new_observation_no_dependency_provider debug key")
+
+			// key 2: struct{}-deps worker emits no_base_deps_accessor.
+			structDepsLogger := &severityCapturingLogger{}
+			structDepsID := wrappingTestIdentity("rung1-struct-deps-e")
+
+			structDepsColl, _ := newWrappingCollector(&wrappingTestWorkerStructDeps{observed: testWrappingObservedState{}}, structDepsID, structDepsLogger, func(cfg *collection.CollectorConfig[testWrappingObservedState]) {
+				cfg.StateProvider = func() string { return "running" }
+			})
+			runSyncTick(ctx, structDepsColl)
+
+			Expect(structDepsLogger.has("debug", "wrap_new_observation_no_base_deps_accessor")).To(BeTrue(),
+				"(e) the struct{}-deps worker must emit the wrap_new_observation_no_base_deps_accessor debug key")
 		})
 	})
 })

--- a/umh-core/pkg/fsmv2/supervisor/internal/collection/collector_wrapping_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/internal/collection/collector_wrapping_test.go
@@ -144,6 +144,42 @@ func (w *wrappingTestWorkerStructDeps) GetDependenciesAny() any {
 	return struct{}{}
 }
 
+// wrappingTestWorkerDepsReader implements Worker + DependencyProvider with a real
+// *BaseDependencies, and during CollectObservedState reads the pre-COS-written
+// framework state and action history out of it into worker-authored fields.
+// It is the GUARD fixture: it proves a worker that reads deps.GetFrameworkState()
+// / deps.GetActionHistory() during collection actually sees the values the
+// collector's Setters wrote before COS. Asserting on these worker-authored fields
+// (not Observation.Metrics.Framework, which the collector fills from its own
+// locals) is what makes a deleted Setter invocation visible.
+type wrappingTestWorkerDepsReader struct {
+	baseDeps *deps.BaseDependencies
+	fmSeen   int64
+	ahSeen   []deps.ActionResult
+}
+
+func (w *wrappingTestWorkerDepsReader) CollectObservedState(_ context.Context, _ fsmv2.DesiredState) (fsmv2.ObservedState, error) {
+	if fm := w.baseDeps.GetFrameworkState(); fm != nil {
+		w.fmSeen = fm.TimeInCurrentStateMs
+	}
+
+	w.ahSeen = w.baseDeps.GetActionHistory()
+
+	return testWrappingObservedState{}, nil
+}
+
+func (w *wrappingTestWorkerDepsReader) DeriveDesiredState(_ interface{}) (fsmv2.DesiredState, error) {
+	return &config.DesiredState{BaseDesiredState: config.BaseDesiredState{}}, nil
+}
+
+func (w *wrappingTestWorkerDepsReader) GetInitialState() fsmv2.State[any, any] {
+	return &supervisor.TestState{}
+}
+
+func (w *wrappingTestWorkerDepsReader) GetDependenciesAny() any {
+	return w.baseDeps
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -640,6 +676,43 @@ var _ = Describe("Collector post-COS wrapping", func() {
 
 			Expect(structDepsLogger.has("debug", "wrap_new_observation_no_base_deps_accessor")).To(BeTrue(),
 				"(e) the struct{}-deps worker must emit the wrap_new_observation_no_base_deps_accessor debug key")
+		})
+	})
+
+	Context("pre-COS write reaches a worker that reads deps during COS (GUARD)", func() {
+		It("makes deps.GetFrameworkState and deps.GetActionHistory readable as worker-authored state during CollectObservedState", func() {
+			id := wrappingTestIdentity("rung2-precos")
+			store := supervisor.CreateTestTriangularStoreForWorkerType("testwrapping")
+
+			bd := deps.NewBaseDependencies(deps.NewNopFSMLogger(), nil, id)
+			worker := &wrappingTestWorkerDepsReader{baseDeps: bd}
+
+			c := collection.NewCollector[testWrappingObservedState](collection.CollectorConfig[testWrappingObservedState]{
+				Worker:                   worker,
+				Identity:                 id,
+				Store:                    store,
+				Logger:                   deps.NewNopFSMLogger(),
+				ObservationInterval:      time.Hour,
+				ObservationTimeout:       3 * time.Second,
+				DesiredStateProvider:     wrappingDesiredProvider(),
+				FrameworkMetricsProvider: func() *deps.FrameworkMetrics { return &deps.FrameworkMetrics{TimeInCurrentStateMs: 987654} },
+				FrameworkMetricsSetter:   func(fm *deps.FrameworkMetrics) { bd.SetFrameworkState(fm) },
+				ActionHistoryProvider: func() []deps.ActionResult {
+					return []deps.ActionResult{{ActionType: "rung2-action", Success: true}}
+				},
+				ActionHistorySetter: func(ah []deps.ActionResult) { bd.SetActionHistory(ah) },
+			})
+			runSyncTick(ctx, c)
+
+			// Assert on the worker's own read of the pre-COS write, not on
+			// Observation.Metrics.Framework (which the post-change collector fills
+			// from its locals, so it stays green even if the Setter were deleted).
+			// This is what makes a deleted Setter invocation visible.
+			Expect(worker.fmSeen).To(Equal(int64(987654)),
+				"(rung2) pre-COS FrameworkMetricsSetter write must be readable via deps.GetFrameworkState() during COS")
+			Expect(worker.ahSeen).To(HaveLen(1))
+			Expect(worker.ahSeen[0].ActionType).To(Equal("rung2-action"),
+				"(rung2) pre-COS ActionHistorySetter write must be readable via deps.GetActionHistory() during COS")
 		})
 	})
 })

--- a/umh-core/pkg/fsmv2/supervisor/internal/collection/framework_metrics_enumeration_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/internal/collection/framework_metrics_enumeration_test.go
@@ -1,0 +1,284 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Rung 3 (RED) of PR B: proves property 1 of the design  -  every registered
+// worker type gets framework metrics on its Observation whatever its TDeps and
+// whatever GetDependenciesAny returns. The collector now injects framework
+// metrics from its own locals before the deps guard (rung 1), so this test is
+// green when written; it is red against the pre-rung-1 parent, which is how the
+// rung's own (a)-(d) assertions already prove the mechanism absent there.
+//
+// The registry is populated by package init()  -  a missing blank import returns
+// zero types and this test would pass trivially  -  so the HaveLen(15) floor
+// below is mandatory, not cosmetic.
+
+package collection_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
+	fsmv2config "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/config"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/factory"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/register"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/supervisor"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/supervisor/internal/collection"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/configworker/dynamicchildren"
+
+	// Named imports for the config types these workers' DesiredState requires;
+	// the import itself triggers init(), which is the registration these package
+	// names contribute to the factory registry.
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/examplefailing"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/examplepanic"
+	// helloworld and exampleslow declare their package names as hello_world and
+	// example_slow respectively; the aliases below match the config type names.
+	exampleslow "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/exampleslow"
+	helloworld "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/helloworld"
+
+	// Blank imports populate the factory registry via init(). If any of these is
+	// forgotten, ListRegisteredTypes() returns fewer types and the HaveLen(15)
+	// floor below fails loudly instead of letting the test pass trivially.
+	_ "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/historian"
+	_ "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/nmap"
+	_ "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/application"
+	_ "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator"
+	_ "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/configworker"
+	_ "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/examplechild"
+	_ "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/exampleparent"
+	_ "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/persistence"
+	_ "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport"
+	_ "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/pull"
+	_ "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/push"
+)
+
+// registeredFloor is the hard lower bound on the number of registered worker
+// types. factory.ListRegisteredTypes() is populated by package init(), so a
+// test that forgets a blank import returns zero types and passes trivially;
+// asserting an exact count catches both a missing import (returns 0) and a new
+// 16th registration (returns 16). Measured at this HEAD: exactly 15, and the
+// registered historian type is "historian-timescale", not "historian".
+const registeredFloor = 15
+
+// panicOnConstruction names the five types that panic rather than error when
+// built via factory.NewWorkerByType in this isolated test process, because
+// register.Worker wraps constructor failure in a panic. Each constructor's
+// dependency is published by a parent or the transport channel singleton that
+// this test does not wire up. They are skipped below with the stated reason; a
+// silent continue would imply full coverage and hide a regression in the other
+// ten. transport, communicator and persistence are cheaply rescuable later;
+// pull and push follow once transport deps are published.
+var panicOnConstruction = map[string]string{
+	"communicator": "ChannelProvider is not set in this test process",
+	"transport":    "ChannelProvider is not set in this test process",
+	"persistence":  "requires a store, which only its parent's deployment publishes",
+	"pull":         "parent transport deps are not published",
+	"push":         "parent transport deps are not published",
+}
+
+// targetWorkers are the three workers the design exists to fix: they are the
+// types whose Observation carried no framework metrics before this change
+// (application and configworker return nil deps, nmap returns struct{}). They
+// are named explicitly here rather than relying on the enumeration to reach
+// them silently.
+var targetWorkers = []string{"application", "configworker", "nmap"}
+
+type observedFrameworkProbe struct {
+	Metrics deps.MetricsContainer `json:"metrics"`
+}
+
+// desiredProviderFor returns a DesiredStateProvider that yields the concrete
+// desired type each worker's CollectObservedState expects. Workers that call
+// fsmv2.ExtractConfig panic if handed the wrong WrappedDesiredState, so the
+// provider must match per type; workers that ignore the desired state accept
+// the generic DesiredState.
+func desiredProviderFor(workerType string) func() (fsmv2.DesiredState, error) {
+	generic := func() (fsmv2.DesiredState, error) {
+		return &fsmv2config.DesiredState{BaseDesiredState: fsmv2config.BaseDesiredState{}}, nil
+	}
+
+	switch workerType {
+	case "helloworld":
+		return func() (fsmv2.DesiredState, error) {
+			return &fsmv2.WrappedDesiredState[helloworld.HelloworldConfig]{Config: helloworld.HelloworldConfig{}}, nil
+		}
+	case "examplepanic":
+		return func() (fsmv2.DesiredState, error) {
+			return &fsmv2.WrappedDesiredState[examplepanic.ExamplepanicConfig]{Config: examplepanic.ExamplepanicConfig{}}, nil
+		}
+	case "examplefailing":
+		return func() (fsmv2.DesiredState, error) {
+			return &fsmv2.WrappedDesiredState[examplefailing.ExamplefailingConfig]{Config: examplefailing.ExamplefailingConfig{}}, nil
+		}
+	case "exampleslow":
+		return func() (fsmv2.DesiredState, error) {
+			return &fsmv2.WrappedDesiredState[exampleslow.ExampleslowConfig]{Config: exampleslow.ExampleslowConfig{}}, nil
+		}
+	case "nmap":
+		return func() (fsmv2.DesiredState, error) {
+			return &fsmv2.WrappedDesiredState[config.NmapConfig]{Config: config.NmapConfig{}}, nil
+		}
+	case "historian-timescale":
+		return func() (fsmv2.DesiredState, error) {
+			return &fsmv2.WrappedDesiredState[config.HistorianConfig]{Config: config.HistorianConfig{}}, nil
+		}
+	default:
+		return generic
+	}
+}
+
+// constructWorker builds the worker for workerType through the real factory
+// registry, recovering any construction panic (register.Worker wraps
+// constructor failure in a panic). It never lets the panic escape; the caller
+// decides whether a recovered panic is a named skip or an unexpected failure.
+func constructWorker(workerType string) (fsmv2.Worker, interface{}) {
+	id := deps.Identity{ID: workerType + "-probe", WorkerType: workerType, Name: workerType + "-probe"}
+
+	var (
+		worker fsmv2.Worker
+		panick interface{}
+	)
+
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				panick = r
+			}
+		}()
+
+		w, err := factory.NewWorkerByType(workerType, id, deps.NewNopFSMLogger(), nil, nil)
+		if err != nil {
+			panick = fmt.Sprintf("NewWorkerByType(%q): %v", workerType, err)
+			return
+		}
+		worker = w
+	}()
+
+	return worker, panick
+}
+
+// probeFrameworkMetrics drives one real synchronous collection tick through the
+// real collector, loading the saved Observation back out of the real store, and
+// returns the framework TimeInCurrentStateMs that survived. The provider
+// injects sentinel into the collector's FrameworkMetricsProvider; recovering
+// exactly sentinel back proves framework metrics are present on the
+// Observation, not merely that the worker produced an observation.
+//
+// TObserved is fsmv2.ObservedState (the interface): every worker's
+// CollectObservedState returns the interface, so observed.(fsmv2.ObservedState)
+// always holds, and the generic save path marshals the underlying concrete
+// Observation  -  the same non-generic path the collector uses in production.
+func probeFrameworkMetrics(workerType string, w fsmv2.Worker, sentinel int64) int64 {
+	id := deps.Identity{ID: workerType + "-probe", WorkerType: workerType, Name: workerType + "-probe"}
+	store := supervisor.CreateTestTriangularStoreForWorkerType(workerType)
+
+	cfg := collection.CollectorConfig[fsmv2.ObservedState]{
+		Worker:               w,
+		Identity:             id,
+		Store:                store,
+		Logger:               deps.NewNopFSMLogger(),
+		ObservationInterval:  time.Hour, // No background ticks; exactly one synchronous tick below.
+		ObservationTimeout:   3 * time.Second,
+		DesiredStateProvider: desiredProviderFor(workerType),
+		FrameworkMetricsProvider: func() *deps.FrameworkMetrics {
+			return &deps.FrameworkMetrics{TimeInCurrentStateMs: sentinel}
+		},
+	}
+
+	c := collection.NewCollector[fsmv2.ObservedState](cfg)
+
+	ctx := context.Background()
+	Expect(c.Start(ctx)).To(Succeed())
+	defer c.Stop(context.Background())
+	Expect(c.CollectFinalObservation(context.Background())).To(Succeed())
+
+	var probe observedFrameworkProbe
+	Expect(store.LoadObservedTyped(ctx, workerType, id.ID, &probe)).To(Succeed())
+
+	return probe.Metrics.Framework.TimeInCurrentStateMs
+}
+
+var _ = Describe("Framework metrics on every registered worker type", func() {
+	It("enumerates exactly the registered worker types (hard floor: catches a missing blank import or a 16th type)", func() {
+		Expect(factory.ListRegisteredTypes()).To(HaveLen(registeredFloor))
+	})
+
+	It("attaches framework metrics to the Observation of every buildable registered type", func() {
+		// configworker is the one buildable worker whose constructor first needs
+		// one line of setup: a published dynamic-children registry. Without it
+		// the constructor fails (wrapped in a panic). Its ConfigManager is
+		// optional, so nil is fine.
+		register.SetDeps[*dynamicchildren.Registry]("configworker", &dynamicchildren.Registry{})
+
+		types := factory.ListRegisteredTypes()
+		Expect(types).To(HaveLen(registeredFloor))
+
+		covered := map[string]int64{}
+		skipped := map[string]interface{}{}
+
+		for _, workerType := range types {
+			worker, panick := constructWorker(workerType)
+			if panick != nil {
+				reason, expected := panicOnConstruction[workerType]
+				if !expected {
+					// A construction panic we did not anticipate must fail loudly,
+					// not be swallowed as a skip.
+					Fail(fmt.Sprintf("unexpected construction panic for %q: %v", workerType, panick))
+				}
+
+				skipped[workerType] = reason
+
+				continue
+			}
+
+			if worker == nil {
+				Fail(fmt.Sprintf("construction of %q produced a nil worker", workerType))
+			}
+
+			Expect(worker).NotTo(BeNil(), "construction of %q produced a nil worker", workerType)
+
+			// Deterministic, type-distinct sentinel: proves the exact injected value
+			// survived, not merely that some metric is non-zero.
+			sentinel := int64(900000) + int64(len(workerType))
+			Expect(probeFrameworkMetrics(workerType, worker, sentinel)).To(Equal(sentinel),
+				"framework TimeInCurrentStateMs sentinel did not survive on %q's Observation", workerType)
+
+			covered[workerType] = sentinel
+		}
+
+		// The two expectation halves must agree: all five dependency-bound types
+		// were skipped, and each was skipped for the reason this test states.
+		Expect(skipped).To(HaveLen(len(panicOnConstruction)))
+		for workerType, reason := range panicOnConstruction {
+			Expect(skipped).To(HaveKey(workerType), "expected %q to be skipped (%s)", workerType, reason)
+		}
+
+		// The three workers this design exists to fix must carry framework
+		// metrics, named explicitly rather than trusting the enumeration.
+		for _, workerType := range targetWorkers {
+			Expect(covered).To(HaveKey(workerType),
+				"target worker %q did not carry framework metrics on its Observation", workerType)
+		}
+
+		// The other seven buildable types prove the property generalises: ten
+		// covered in total (all fifteen registered, minus the five skipped).
+		Expect(covered).To(HaveLen(registeredFloor - len(panicOnConstruction)))
+	})
+})

--- a/umh-core/pkg/fsmv2/supervisor/internal/collection/framework_metrics_enumeration_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/internal/collection/framework_metrics_enumeration_test.go
@@ -12,16 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Rung 3 (RED) of PR B: proves property 1 of the design  -  every registered
-// worker type gets framework metrics on its Observation whatever its TDeps and
-// whatever GetDependenciesAny returns. The collector now injects framework
-// metrics from its own locals before the deps guard (rung 1), so this test is
-// green when written; it is red against the pre-rung-1 parent, which is how the
-// rung's own (a)-(d) assertions already prove the mechanism absent there.
+// Every registered worker type gets framework metrics on its Observation,
+// whatever its TDeps and whatever GetDependenciesAny returns. The collector
+// injects framework metrics from its own locals before the deps guard, so a
+// struct{}-deps worker (nmap) carries them like any other.
 //
-// The registry is populated by package init()  -  a missing blank import returns
-// zero types and this test would pass trivially  -  so the HaveLen(15) floor
-// below is mandatory, not cosmetic.
+// The registry is populated by package init(). A missing blank import leaves it
+// empty, so the HaveLen(15) floor below is what makes a forgotten import fail
+// loudly instead of passing trivially; a 16th registration also reddens it.
 
 package collection_test
 
@@ -81,20 +79,19 @@ const registeredFloor = 15
 // built via factory.NewWorkerByType in this isolated test process, because
 // register.Worker wraps constructor failure in a panic. Each constructor's
 // dependency is published by a parent or the transport channel singleton that
-// this test does not wire up. They are skipped below with the stated reason; a
-// silent continue would imply full coverage and hide a regression in the other
-// ten. transport, communicator and persistence are cheaply rescuable later;
-// pull and push follow once transport deps are published.
+// this test does not wire up. They are skipped below with the stated reason, and
+// the recovered panic is asserted to match that reason, so a skip cannot hide a
+// constructor regression inside one of them.
 var panicOnConstruction = map[string]string{
-	"communicator": "ChannelProvider is not set in this test process",
-	"transport":    "ChannelProvider is not set in this test process",
-	"persistence":  "requires a store, which only its parent's deployment publishes",
-	"pull":         "parent transport deps are not published",
-	"push":         "parent transport deps are not published",
+	"communicator": "ChannelProvider must be set",
+	"transport":    "ChannelProvider must be set",
+	"persistence":  "requires a store",
+	"pull":         "deps builder returned",
+	"push":         "deps builder returned",
 }
 
 // targetWorkers are the three workers the design exists to fix: they are the
-// types whose Observation carried no framework metrics before this change
+// types whose Observation lacked framework metrics before this change
 // (application and configworker return nil deps, nmap returns struct{}). They
 // are named explicitly here rather than relying on the enumeration to reach
 // them silently.
@@ -176,7 +173,7 @@ func constructWorker(workerType string) (fsmv2.Worker, interface{}) {
 
 // probeFrameworkMetrics drives one real synchronous collection tick through the
 // real collector, loading the saved Observation back out of the real store, and
-// returns the framework TimeInCurrentStateMs that survived. The provider
+// returns the framework TimeInCurrentStateMs on it. The provider
 // injects sentinel into the collector's FrameworkMetricsProvider; recovering
 // exactly sentinel back proves framework metrics are present on the
 // Observation, not merely that the worker produced an observation.
@@ -184,7 +181,12 @@ func constructWorker(workerType string) (fsmv2.Worker, interface{}) {
 // TObserved is fsmv2.ObservedState (the interface): every worker's
 // CollectObservedState returns the interface, so observed.(fsmv2.ObservedState)
 // always holds, and the generic save path marshals the underlying concrete
-// Observation  -  the same non-generic path the collector uses in production.
+// Observation, the same non-generic path the collector uses in production.
+//
+// This assumes the worker is a NewObservation worker (zero CollectedAt), so the
+// collector's zero-time gate fires and framework metrics are injected. All ten
+// buildable types are NewObservation workers today; a migration to WrapStatus
+// would fail this probe with a sentinel mismatch rather than a clear message.
 func probeFrameworkMetrics(workerType string, w fsmv2.Worker, sentinel int64) int64 {
 	id := deps.Identity{ID: workerType + "-probe", WorkerType: workerType, Name: workerType + "-probe"}
 	store := supervisor.CreateTestTriangularStoreForWorkerType(workerType)
@@ -243,6 +245,12 @@ var _ = Describe("Framework metrics on every registered worker type", func() {
 					Fail(fmt.Sprintf("unexpected construction panic for %q: %v", workerType, panick))
 				}
 
+				// The recovered panic must match the expected dependency-absence
+				// cause, so a constructor regression inside one of these workers
+				// cannot hide behind a silent skip.
+				Expect(fmt.Sprint(panick)).To(ContainSubstring(reason),
+					"worker %q panicked for an unexpected reason (want %q); actual: %q", workerType, reason, fmt.Sprint(panick))
+
 				skipped[workerType] = reason
 
 				continue
@@ -255,10 +263,10 @@ var _ = Describe("Framework metrics on every registered worker type", func() {
 			Expect(worker).NotTo(BeNil(), "construction of %q produced a nil worker", workerType)
 
 			// Deterministic, type-distinct sentinel: proves the exact injected value
-			// survived, not merely that some metric is non-zero.
+			// is present, not merely that some metric is non-zero.
 			sentinel := int64(900000) + int64(len(workerType))
 			Expect(probeFrameworkMetrics(workerType, worker, sentinel)).To(Equal(sentinel),
-				"framework TimeInCurrentStateMs sentinel did not survive on %q's Observation", workerType)
+				"framework TimeInCurrentStateMs sentinel is not present on %q's Observation", workerType)
 
 			covered[workerType] = sentinel
 		}

--- a/umh-core/pkg/fsmv2/supervisor/internal/collection/framework_metrics_nmap_capstone_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/internal/collection/framework_metrics_nmap_capstone_test.go
@@ -12,26 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Rung 5 (capstone) of PR B: the positive-controlled end-to-end proof for
-// property 1 of the design -  a REAL nmap worker, built through its real
-// registration, driven through a REAL Collector and a REAL TriangularStore,
-// carrying framework metrics on its saved Observation.
+// Positive-controlled end-to-end proof that every registered worker gets
+// framework metrics on its Observation: a real nmap worker, built through its
+// real registration, driven through a real Collector and a real TriangularStore,
+// with framework metrics present on the saved Observation.
 //
-// nmap is the sharpest case the design exists to fix: it registers
+// nmap is the sharpest case the design addresses: it registers
 // MonitorSpec[config.NmapConfig, NmapStatus, struct{}] with no NewDeps
 // (nmap/nmap.go:101), so its bound deps are struct{} and fail the
-// baseDepsAccessor assertion. Before rung 1 the collector's guard sat in front
-// of the framework-metrics injection, so nmap's Observation carried a zero
-// FrameworkMetrics struct and its drained action history was discarded. After
-// rung 1 the collector injects both from its own locals before the deps guard.
+// baseDepsAccessor assertion. Without the collector change, the guard sat in
+// front of the framework-metrics injection, so nmap's Observation carried a zero
+// FrameworkMetrics struct and its drained action history was discarded. With it,
+// the collector injects both from its own locals before the deps guard.
 //
 // The assertion is a sentinel: the collector's FrameworkMetricsProvider returns
 // a value carrying TimeInCurrentStateMs = 987654, and recovering exactly that
 // back off the saved Observation proves framework metrics are present, not
 // merely that the worker produced an Observation. The sentinel is what makes
-// the positive control meaningful: the same spec reports ABSENT (the sentinel
-// is lost) against the pre-rung-1 parent commit 47062a084, where the guard
-// still sits in front of step 3.
+// the positive control meaningful: the same spec reports the sentinel absent
+// (TimeInCurrentStateMs is 0) against the parent commit 47062a084, where the
+// guard sat in front of the framework-metrics injection.
 
 package collection_test
 
@@ -111,9 +111,10 @@ var _ = Describe("Capstone: real nmap worker gets framework metrics through a re
 		var probe nmapObservedProbe
 		Expect(store.LoadObservedTyped(ctx, workerType, id.ID, &probe)).To(Succeed())
 
-		// The positive assertion: the sentinel survived the full pipeline. If the
-		// guard still sat in front of step 3, TimeInCurrentStateMs would be 0.
+		// The positive assertion: the sentinel is present after the full pipeline.
+		// If the guard sat in front of the framework-metrics injection,
+		// TimeInCurrentStateMs would be 0.
 		Expect(probe.Metrics.Framework.TimeInCurrentStateMs).To(Equal(nmapCapstoneSentinel),
-			"framework TimeInCurrentStateMs sentinel did not survive on the real nmap worker's Observation")
+			"framework TimeInCurrentStateMs sentinel is not present on the real nmap worker's Observation")
 	})
 })

--- a/umh-core/pkg/fsmv2/supervisor/internal/collection/framework_metrics_nmap_capstone_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/internal/collection/framework_metrics_nmap_capstone_test.go
@@ -1,0 +1,119 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Rung 5 (capstone) of PR B: the positive-controlled end-to-end proof for
+// property 1 of the design -  a REAL nmap worker, built through its real
+// registration, driven through a REAL Collector and a REAL TriangularStore,
+// carrying framework metrics on its saved Observation.
+//
+// nmap is the sharpest case the design exists to fix: it registers
+// MonitorSpec[config.NmapConfig, NmapStatus, struct{}] with no NewDeps
+// (nmap/nmap.go:101), so its bound deps are struct{} and fail the
+// baseDepsAccessor assertion. Before rung 1 the collector's guard sat in front
+// of the framework-metrics injection, so nmap's Observation carried a zero
+// FrameworkMetrics struct and its drained action history was discarded. After
+// rung 1 the collector injects both from its own locals before the deps guard.
+//
+// The assertion is a sentinel: the collector's FrameworkMetricsProvider returns
+// a value carrying TimeInCurrentStateMs = 987654, and recovering exactly that
+// back off the saved Observation proves framework metrics are present, not
+// merely that the worker produced an Observation. The sentinel is what makes
+// the positive control meaningful: the same spec reports ABSENT (the sentinel
+// is lost) against the pre-rung-1 parent commit 47062a084, where the guard
+// still sits in front of step 3.
+
+package collection_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/factory"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/supervisor"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/supervisor/internal/collection"
+
+	// Populates the factory registry via init(); without it NewWorkerByType
+	// returns "unknown worker type" and the test fails loudly rather than
+	// silently proving nothing.
+	_ "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/nmap"
+)
+
+// nmapCapstoneSentinel is the value injected through the collector's
+// FrameworkMetricsProvider. Recovering exactly this off the saved Observation
+// is the positive proof that framework metrics reached nmap's Observation.
+const nmapCapstoneSentinel int64 = 987654
+
+// nmapObservedProbe mirrors the JSON shape the collector persists for a
+// framework-flattened Observation, so a generic LoadObservedTyped read can
+// recover just the metrics block.
+type nmapObservedProbe struct {
+	Metrics deps.MetricsContainer `json:"metrics"`
+}
+
+var _ = Describe("Capstone: real nmap worker gets framework metrics through a real collector", func() {
+	It("persists framework metrics on the Observation of a real nmap worker carrying sentinel TimeInCurrentStateMs", func() {
+		const workerType = "nmap"
+
+		id := deps.Identity{ID: "nmap-capstone", WorkerType: workerType, Name: "nmap-capstone"}
+
+		// Build a REAL nmap worker through its real registration. deps nil:
+		// nmap's MonitorSpec has no NewDeps, so it needs no dependency payload.
+		worker, err := factory.NewWorkerByType(workerType, id, deps.NewNopFSMLogger(), nil, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(worker).NotTo(BeNil())
+
+		store := supervisor.CreateTestTriangularStoreForWorkerType(workerType)
+
+		cfg := collection.CollectorConfig[fsmv2.ObservedState]{
+			Worker:   worker,
+			Identity: id,
+			Store:    store,
+			Logger:   deps.NewNopFSMLogger(),
+			// No background ticks; exactly one synchronous tick below.
+			ObservationInterval: time.Hour,
+			ObservationTimeout:  3 * time.Second,
+			DesiredStateProvider: func() (fsmv2.DesiredState, error) {
+				return &fsmv2.WrappedDesiredState[config.NmapConfig]{Config: config.NmapConfig{}}, nil
+			},
+			// The sentinel: what the supervisor captured for this worker this
+			// tick. Recovering it proves the collector's own values landed on the
+			// Observation rather than something read back out of the worker's deps
+			// (nmap has a struct{} deps that cannot carry framework state).
+			FrameworkMetricsProvider: func() *deps.FrameworkMetrics {
+				return &deps.FrameworkMetrics{TimeInCurrentStateMs: nmapCapstoneSentinel}
+			},
+		}
+
+		c := collection.NewCollector[fsmv2.ObservedState](cfg)
+
+		ctx := context.Background()
+		Expect(c.Start(ctx)).To(Succeed())
+		defer c.Stop(context.Background())
+		Expect(c.CollectFinalObservation(context.Background())).To(Succeed())
+
+		var probe nmapObservedProbe
+		Expect(store.LoadObservedTyped(ctx, workerType, id.ID, &probe)).To(Succeed())
+
+		// The positive assertion: the sentinel survived the full pipeline. If the
+		// guard still sat in front of step 3, TimeInCurrentStateMs would be 0.
+		Expect(probe.Metrics.Framework.TimeInCurrentStateMs).To(Equal(nmapCapstoneSentinel),
+			"framework TimeInCurrentStateMs sentinel did not survive on the real nmap worker's Observation")
+	})
+})

--- a/umh-core/pkg/fsmv2/supervisor/internal/collection/framework_metrics_nmap_e2e_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/internal/collection/framework_metrics_nmap_e2e_test.go
@@ -55,10 +55,10 @@ import (
 	_ "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/nmap"
 )
 
-// nmapCapstoneSentinel is the value injected through the collector's
+// nmapSentinel is the value injected through the collector's
 // FrameworkMetricsProvider. Recovering exactly this off the saved Observation
 // is the positive proof that framework metrics reached nmap's Observation.
-const nmapCapstoneSentinel int64 = 987654
+const nmapSentinel int64 = 987654
 
 // nmapObservedProbe mirrors the JSON shape the collector persists for a
 // framework-flattened Observation, so a generic LoadObservedTyped read can
@@ -67,11 +67,11 @@ type nmapObservedProbe struct {
 	Metrics deps.MetricsContainer `json:"metrics"`
 }
 
-var _ = Describe("Capstone: real nmap worker gets framework metrics through a real collector", func() {
+var _ = Describe("End-to-end: real nmap worker gets framework metrics through a real collector", func() {
 	It("persists framework metrics on the Observation of a real nmap worker carrying sentinel TimeInCurrentStateMs", func() {
 		const workerType = "nmap"
 
-		id := deps.Identity{ID: "nmap-capstone", WorkerType: workerType, Name: "nmap-capstone"}
+		id := deps.Identity{ID: "nmap-e2e", WorkerType: workerType, Name: "nmap-e2e"}
 
 		// Build a REAL nmap worker through its real registration. deps nil:
 		// nmap's MonitorSpec has no NewDeps, so it needs no dependency payload.
@@ -97,7 +97,7 @@ var _ = Describe("Capstone: real nmap worker gets framework metrics through a re
 			// Observation rather than something read back out of the worker's deps
 			// (nmap has a struct{} deps that cannot carry framework state).
 			FrameworkMetricsProvider: func() *deps.FrameworkMetrics {
-				return &deps.FrameworkMetrics{TimeInCurrentStateMs: nmapCapstoneSentinel}
+				return &deps.FrameworkMetrics{TimeInCurrentStateMs: nmapSentinel}
 			},
 		}
 
@@ -114,7 +114,7 @@ var _ = Describe("Capstone: real nmap worker gets framework metrics through a re
 		// The positive assertion: the sentinel is present after the full pipeline.
 		// If the guard sat in front of the framework-metrics injection,
 		// TimeInCurrentStateMs would be 0.
-		Expect(probe.Metrics.Framework.TimeInCurrentStateMs).To(Equal(nmapCapstoneSentinel),
+		Expect(probe.Metrics.Framework.TimeInCurrentStateMs).To(Equal(nmapSentinel),
 			"framework TimeInCurrentStateMs sentinel is not present on the real nmap worker's Observation")
 	})
 })

--- a/umh-core/pkg/fsmv2/supervisor/startup_count_persistence_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/startup_count_persistence_test.go
@@ -55,7 +55,7 @@ func (w *startupCountWorker) GetInitialState() fsmv2.State[any, any] {
 
 var _ = Describe("StartupCount persistence", func() {
 	It("advances across a worker respawn instead of resetting to 1", func() {
-		const workerType = "startupcount-rung4"
+		const workerType = "startupcount-recreate"
 		const workerID = "startup-count-worker"
 
 		// Collapse the observation cadence so the collector saves promptly; the

--- a/umh-core/pkg/fsmv2/supervisor/startup_count_persistence_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/startup_count_persistence_test.go
@@ -1,0 +1,119 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package supervisor_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/config"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/supervisor"
+)
+
+// startupCountStatus is the developer status payload of the NewObservation
+// worker used here. It carries no business data in this test - the assertion
+// reads framework metrics off the wrapped Observation, not this status.
+type startupCountStatus struct {
+	ID string `json:"id"`
+}
+
+// startupCountWorker is a minimal NewObservation worker: CollectObservedState
+// returns fsmv2.NewObservation, whose CollectedAt is zero, so the collector's
+// post-COS wrapping fires and injects framework metrics - including StartupCount
+// taken from workerCtx. Its TObserved is Observation[startupCountStatus] (value),
+// which is what the supervisor persists and reloads on AddWorker.
+type startupCountWorker struct{}
+
+func (w *startupCountWorker) CollectObservedState(_ context.Context, _ fsmv2.DesiredState) (fsmv2.ObservedState, error) {
+	return fsmv2.NewObservation(startupCountStatus{ID: "startup-count-worker"}), nil
+}
+
+func (w *startupCountWorker) DeriveDesiredState(_ interface{}) (fsmv2.DesiredState, error) {
+	return &config.DesiredState{BaseDesiredState: config.BaseDesiredState{}, State: "running"}, nil
+}
+
+func (w *startupCountWorker) GetInitialState() fsmv2.State[any, any] {
+	return &supervisor.TestState{}
+}
+
+var _ = Describe("StartupCount persistence", func() {
+	It("advances across a worker respawn instead of resetting to 1", func() {
+		const workerType = "startupcount-rung4"
+		const workerID = "startup-count-worker"
+
+		// Collapse the observation cadence so the collector saves promptly; the
+		// default is 1s, which would make the Eventually polls needlessly slow.
+		fsmv2.RegisterObservationInterval(workerType, 20*time.Millisecond)
+
+		store := supervisor.CreateTestTriangularStoreForWorkerType(workerType)
+
+		sup := supervisor.NewSupervisor[fsmv2.Observation[startupCountStatus], *config.DesiredState](supervisor.Config{
+			WorkerType: workerType,
+			Store:      store,
+			Logger:     deps.NewNopFSMLogger(),
+		})
+
+		ctx := context.Background()
+		identity := deps.Identity{ID: workerID, Name: "Startup Count Worker", WorkerType: workerType}
+
+		// First spawn: AddWorker reads no prior observation, so StartupCount is 1.
+		Expect(sup.AddWorker(identity, &startupCountWorker{})).To(Succeed())
+
+		// Start the collector only (no reconcile tick loop) so it saves an
+		// Observation carrying the framework metrics from workerCtx, StartupCount
+		// injected as 1.
+		sup.TestMarkAsStarted()
+		DeferCleanup(func() {
+			_ = sup.RemoveWorker(context.Background(), workerID)
+		})
+
+		Eventually(func() int64 {
+			var loaded fsmv2.Observation[startupCountStatus]
+			if err := store.LoadObservedTyped(ctx, workerType, workerID, &loaded); err != nil {
+				return 0
+			}
+
+			return loaded.Metrics.Framework.StartupCount
+		}, 3*time.Second, 25*time.Millisecond).Should(Equal(int64(1)),
+			"first spawn should persist StartupCount=1")
+
+		// Despawn and respawn the same worker ID. RemoveWorker stops worker1's
+		// collector; AddWorker reads the persisted StartupCount=1 from the store
+		// before writing its own initial observation, so workerCtx.startupCount
+		// becomes 2 (not reset to 1).
+		Expect(sup.RemoveWorker(ctx, workerID)).To(Succeed())
+		Expect(sup.AddWorker(identity, &startupCountWorker{})).To(Succeed())
+
+		// The respawned worker owns a fresh collector; start it the same way.
+		sup.TestMarkAsStarted()
+
+		// The observation the respawned worker's collector saves must carry
+		// StartupCount=2, proving the count survives the despawn/respawn cycle.
+		Eventually(func() int64 {
+			var loaded fsmv2.Observation[startupCountStatus]
+			if err := store.LoadObservedTyped(ctx, workerType, workerID, &loaded); err != nil {
+				return 0
+			}
+
+			return loaded.Metrics.Framework.StartupCount
+		}, 3*time.Second, 25*time.Millisecond).Should(Equal(int64(2)),
+			"respawned worker should persist StartupCount=2, not reset to 1")
+	})
+})

--- a/umh-core/pkg/fsmv2/worker_base_test.go
+++ b/umh-core/pkg/fsmv2/worker_base_test.go
@@ -422,9 +422,10 @@ var _ = Describe("WorkerBase", func() {
 	})
 })
 
-// NoDepsWorker embeds WorkerBase with struct{} as TDeps — the zero-value footgun.
-// A no-deps worker that needs true nil from GetDependenciesAny (e.g., so the
-// framework skips dependency injection) must override GetDependenciesAny.
+// NoDepsWorker embeds WorkerBase with struct{} as TDeps, so its GetDependenciesAny
+// returns a non-nil interface boxing struct{}{}. Returning nil instead changes
+// nothing: the collector attaches framework metrics and action history from its
+// own locals before the deps guard, so a no-deps worker has no reason to override.
 type NoDepsWorker struct {
 	fsmv2.WorkerBase[wbTestConfig, wbTestStatus, struct{}]
 }
@@ -438,13 +439,9 @@ var _ = Describe("WorkerBase no-deps footgun", func() {
 		It("returns non-nil any wrapping struct{}{} even without BindDeps", func() {
 			// WorkerBase[..., struct{}] zero-initialises typedDeps to struct{}{}.
 			// GetDependenciesAny boxes struct{}{} into a non-nil interface value.
-			// Any framework code that gates on `deps == nil` will NOT skip
-			// injection for no-deps workers — they see a non-nil interface
-			// pointing at an empty struct.
-			//
-			// Workers that genuinely have no dependencies and need true nil
-			// (so the framework skips injection) must override GetDependenciesAny
-			// to return nil, or use a pointer TDeps type instead of struct{}.
+			// This is inert now: the collector attaches framework metrics and action
+			// history from its own locals before the deps guard, so a worker no
+			// longer needs a nil override to opt out of injection.
 			id := wbMakeIdentity("noop-worker-type")
 			logger := deps.NewNopFSMLogger()
 			sr := wbMakeStateReader()
@@ -454,7 +451,7 @@ var _ = Describe("WorkerBase no-deps footgun", func() {
 
 			got := w.GetDependenciesAny()
 			Expect(got).NotTo(BeNil(),
-				"struct{}{} boxes to a non-nil interface; override GetDependenciesAny to return nil for no-deps workers")
+				"struct{}{} boxes to a non-nil interface value")
 		})
 	})
 })

--- a/umh-core/pkg/fsmv2/workers/application/worker.go
+++ b/umh-core/pkg/fsmv2/workers/application/worker.go
@@ -158,11 +158,6 @@ func (w *ApplicationWorker) DeriveDesiredState(spec interface{}) (fsmv2.DesiredS
 	}, nil
 }
 
-// GetDependenciesAny returns nil because the application worker has no custom dependencies.
-func (w *ApplicationWorker) GetDependenciesAny() any {
-	return nil
-}
-
 // SupervisorConfig contains configuration for creating an application supervisor.
 type SupervisorConfig struct {
 	Store        storage.TriangularStoreInterface

--- a/umh-core/pkg/fsmv2/workers/application/worker_test.go
+++ b/umh-core/pkg/fsmv2/workers/application/worker_test.go
@@ -264,11 +264,4 @@ children:
 			Expect(cfg.YAMLConfig).To(ContainSubstring("child-1"))
 		})
 	})
-
-	Describe("GetDependenciesAny", func() {
-		It("should return nil because the application worker has no custom dependencies", func() {
-			w := &ApplicationWorker{}
-			Expect(w.GetDependenciesAny()).To(BeNil())
-		})
-	})
 })

--- a/umh-core/pkg/fsmv2/workers/configworker/worker.go
+++ b/umh-core/pkg/fsmv2/workers/configworker/worker.go
@@ -117,12 +117,6 @@ func (w *ConfigworkerWorker) Registry() *dynamicchildren.Registry {
 	return w.registry
 }
 
-// GetDependenciesAny returns nil so the framework skips metrics injection for
-// this no-deps worker (a boxed struct{}{} would be non-nil).
-func (w *ConfigworkerWorker) GetDependenciesAny() any {
-	return nil
-}
-
 // CollectObservedState reconciles the historian monitor child from the live
 // config, then returns the observed state. It reads config through the config
 // manager and upserts or deletes the historian child in the shared registry so

--- a/umh-core/pkg/fsmv2/workers/configworker/worker_test.go
+++ b/umh-core/pkg/fsmv2/workers/configworker/worker_test.go
@@ -105,17 +105,6 @@ func TestNewConfigworkerWorkerFailsWithoutRegistry(t *testing.T) {
 	}
 }
 
-// TestGetDependenciesAnyReturnsNil verifies the no-deps override returns a true
-// nil so the framework skips metrics injection (a boxed register.NoDeps would
-// be non-nil and silently re-enable it).
-func TestGetDependenciesAnyReturnsNil(t *testing.T) {
-	w := newConstructedWorker(t)
-
-	if got := w.GetDependenciesAny(); got != nil {
-		t.Fatalf("GetDependenciesAny() = %v, want nil", got)
-	}
-}
-
 // TestCollectObservedState verifies the per-tick observed-state contract:
 // a live context yields a non-nil observation of the worker's status type,
 // and a cancelled context surfaces ctx.Err().


### PR DESCRIPTION
## Problem

This problem statement is deliberately long, because it needs background on fsmv2 internals that I explain here rather than assume.

Every fsmv2 worker should get framework metrics on its saved Observation: time spent in the current state, number of state changes, and number of restarts. The supervisor computes them, so a worker never sets them itself. Today they reach the Observation by a detour:

```
supervisor computes the framework metrics
  → writes them into the worker's dependencies
  → reads them back out of those dependencies
  → puts them on the Observation
```

Both middle steps need the worker to have dependencies. Three workers need none: `application`, `configworker` and `nmap`. For those three the framework metrics never arrive, so the saved Observation holds an empty block. They still show on `/debug/fsmv2`, which reads the supervisor directly, but they are not stored, so the worker cannot read them back, the restart count cannot survive a restart, and nothing could stream them to the frontend later.

The restart count is also wrong for every worker, for a second reason. The order in `AddWorker` is inverted:

```
AddWorker
  → saves the initial Observation
  → reads the previous restart count   (from the row it just wrote → 0)
  → count is 1, every time
```

## What we're shipping

- **`application`, `configworker` and `nmap` carry framework metrics on their stored Observation.** The collector writes them from the value it already holds.
- **The restart count survives a restart, for every worker.** `AddWorker` reads the previous count before saving, and writes the new count onto the initial Observation so a crash before the first collection does not reset it.
- **Action history takes the same path and gets the same fix.** These three workers emit no actions today, so their history is empty either way.
- **A failed read of the previous count raises `SentryWarn`** instead of passing as a fresh worker.
- **`application` and `configworker` stop overriding `GetDependenciesAny`.** The override never changed anything: `nil` and `struct{}{}` both fail the collector's check.
- **`DEPENDENCIES.md` now describes the contract the code has.** Two of its statements were false: "The collector never modifies ObservedState" and "Collector saves what CollectObservedState returned (no modifications)".
- Tests cover framework metrics across every worker shape, a real `nmap` worker through a real collector and store, and the restart count across a re-create.

## What we're NOT shipping

- **Worker metrics stay as they are.** A counter an author records still travels through that worker's own dependencies, because the collector has to drain the same recorder the author wrote to. A worker with no dependencies records nothing, so it has nothing to drain.
- **No new Prometheus series.** Framework metrics are never exported there, before or after. `Framework` appears 0 times in `supervisor/metrics/metrics.go`, `Metrics` 12 times.
- **Nothing on the wire to the Management Console.** `framework` appears 0 times in `pkg/communicator/`. This is CSE only.
- **No fix for the action-history drain ordering (ENG-5578).** The collector drains the buffer before the desired-state guard, so a tick that returns early loses the entries. That ordering is live on `staging` today and predates this branch.
- **No change to `pull` and `push`,** which each carry a second unused `BaseDependencies`. That deserves a ticket.
- **No removal of the pre-COS write into worker dependencies.** Workers that read `deps.GetFrameworkState()` during `CollectObservedState` still need it.
