### PR TITLE
fix: count written messages, not accepted ones, in write-flow throughput (ENG-5507)

### DIFF
--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Write throughput for a bridge no longer counts messages the bridge accepted and then discarded, so a historian bridge subscribed to topics outside its data contract reports zero throughput instead of a healthy figure
+
 ## [0.44.32]
 
 ### New Features

--- a/umh-core/docs/usage/data-flows/bridges.md
+++ b/umh-core/docs/usage/data-flows/bridges.md
@@ -96,6 +96,10 @@ Track performance and throughput:
 
 ![Bridge Metrics](./images/bridges-metrics.png)
 
+Write throughput counts the messages the bridge wrote to its destination, not the messages it read.
+A bridge that discards what it receives, such as a historian bridge subscribed to topics outside its
+data contract, therefore reports zero write throughput. Read throughput counts messages received.
+
 ### Enable Debug Logging
 
 When troubleshooting connection or data issues, enable debug logging in your bridge configuration:

--- a/umh-core/pkg/communicator/actions/get-dataflowcomponent-metrics.go
+++ b/umh-core/pkg/communicator/actions/get-dataflowcomponent-metrics.go
@@ -129,6 +129,7 @@ func (a *GetDataflowcomponentMetricsAction) Execute() (interface{}, map[string]i
 			DfcMetric{ValueType: DfcMetricTypeNumber, Value: out.ConnectionUp, ComponentType: DfcMetricComponentTypeOutput, Path: outputPath, Name: "connection_up"},
 			DfcMetric{ValueType: DfcMetricTypeNumber, Value: out.Error, ComponentType: DfcMetricComponentTypeOutput, Path: outputPath, Name: "error"},
 			DfcMetric{ValueType: DfcMetricTypeNumber, Value: out.Sent, ComponentType: DfcMetricComponentTypeOutput, Path: outputPath, Name: "sent"},
+			DfcMetric{ValueType: DfcMetricTypeNumber, Value: out.Dropped, ComponentType: DfcMetricComponentTypeOutput, Path: outputPath, Name: "dropped"},
 			DfcMetric{ValueType: DfcMetricTypeNumber, Value: out.LatencyNS.P50, ComponentType: DfcMetricComponentTypeOutput, Path: outputPath, Name: "latency_ns_p50"},
 			DfcMetric{ValueType: DfcMetricTypeNumber, Value: out.LatencyNS.P90, ComponentType: DfcMetricComponentTypeOutput, Path: outputPath, Name: "latency_ns_p90"},
 			DfcMetric{ValueType: DfcMetricTypeNumber, Value: out.LatencyNS.P99, ComponentType: DfcMetricComponentTypeOutput, Path: outputPath, Name: "latency_ns_p99"},

--- a/umh-core/pkg/communicator/actions/get-dataflowcomponent-metrics_test.go
+++ b/umh-core/pkg/communicator/actions/get-dataflowcomponent-metrics_test.go
@@ -407,8 +407,8 @@ var _ = Describe("GetDataflowcomponentMetricsAction", func() {
 			metricsResult, ok := result.(actions.DfcMetrics)
 			Expect(ok).To(BeTrue())
 
-			// Check number of metrics (9 for input, 11 for output, 11*2=22 for processors)
-			Expect(metricsResult.Metrics).To(HaveLen(9 + 11 + 22))
+			// Check number of metrics (9 for input, 12 for output, 11*2=22 for processors)
+			Expect(metricsResult.Metrics).To(HaveLen(9 + 12 + 22))
 
 			// Check some specific metrics values
 			var inputReceivedMetric *actions.DfcMetric

--- a/umh-core/pkg/service/benthos_monitor/benthos_monitor.go
+++ b/umh-core/pkg/service/benthos_monitor/benthos_monitor.go
@@ -80,6 +80,7 @@ type OutputInstance struct {
 	Error            int64   `json:"error"`
 	LatencyNS        Latency `json:"latency_ns"`
 	Sent             int64   `json:"sent"`
+	Dropped          int64   `json:"dropped"`
 }
 
 // ProcessMetrics contains processor-specific metrics.
@@ -142,6 +143,24 @@ func (m Metrics) OutputSentTotal() int64 {
 	var total int64
 	for _, out := range m.Outputs {
 		total += out.Sent
+	}
+
+	return total
+}
+
+func (m Metrics) OutputWrittenTotal() int64 {
+	written := m.OutputSentTotal() - m.OutputDroppedTotal()
+	if written < 0 {
+		return 0
+	}
+
+	return written
+}
+
+func (m Metrics) OutputDroppedTotal() int64 {
+	var total int64
+	for _, out := range m.Outputs {
+		total += out.Dropped
 	}
 
 	return total
@@ -1062,6 +1081,8 @@ func ParseMetricsFromBytes(raw []byte) (Metrics, error) {
 	m.Inputs = make(map[string]InputInstance, 1)
 	m.Outputs = make(map[string]OutputInstance, 1)
 
+	drops := make(map[string]int64, 1)
+
 	lineStart := 0
 
 	for i, b := range raw {
@@ -1286,6 +1307,19 @@ func ParseMetricsFromBytes(raw []byte) (Metrics, error) {
 
 			m.Outputs[path] = out
 
+		case name == "messages_dropped":
+			path := extractLabel(labelsRegion, "path")
+			if path == "" {
+				continue
+			}
+
+			count, err := TailInt(line)
+			if err != nil {
+				return Metrics{}, fmt.Errorf("failed to parse messages dropped: %w", err)
+			}
+
+			drops[path] += count
+
 		default:
 			if !bytes.HasPrefix(line, []byte("processor_")) {
 				continue
@@ -1378,6 +1412,13 @@ func ParseMetricsFromBytes(raw []byte) (Metrics, error) {
 			}
 
 			m.Process.Processors[path] = pm
+		}
+	}
+
+	for path, count := range drops {
+		if out, ok := m.Outputs[path]; ok {
+			out.Dropped = count
+			m.Outputs[path] = out
 		}
 	}
 

--- a/umh-core/pkg/service/benthos_monitor/dropped_messages_test.go
+++ b/umh-core/pkg/service/benthos_monitor/dropped_messages_test.go
@@ -1,0 +1,151 @@
+// Copyright 2026 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package benthos_monitor_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/benthos_monitor"
+)
+
+const mixedDropMetrics = `# HELP input_received Benthos Counter metric
+# TYPE input_received counter
+input_received{label="",path="root.input"} 4676
+# HELP messages_dropped Benthos Counter metric
+# TYPE messages_dropped counter
+messages_dropped{label="",path="root.output",reason="contract_mismatch"} 3666
+messages_dropped{label="",path="root.output",reason="missing_timestamp"} 10
+messages_dropped{label="",path="root.input",reason="unsupported_datatype"} 5
+messages_dropped{label="",path="root.pipeline.processors.0",reason="deliberate"} 20
+# HELP output_connection_up Benthos Counter metric
+# TYPE output_connection_up counter
+output_connection_up{label="",path="root.output"} 1
+# HELP output_sent Benthos Counter metric
+# TYPE output_sent counter
+output_sent{label="",path="root.output"} 4676
+# HELP output_batch_sent Benthos Counter metric
+# TYPE output_batch_sent counter
+output_batch_sent{label="",path="root.output"} 999
+`
+
+const allDroppedMetrics = `# HELP input_received Benthos Counter metric
+# TYPE input_received counter
+input_received{label="",path="root.input"} 4676
+# HELP messages_dropped Benthos Counter metric
+# TYPE messages_dropped counter
+messages_dropped{label="",path="root.output",reason="contract_mismatch"} 4676
+# HELP output_connection_up Benthos Counter metric
+# TYPE output_connection_up counter
+output_connection_up{label="",path="root.output"} 1
+# HELP output_sent Benthos Counter metric
+# TYPE output_sent counter
+output_sent{label="",path="root.output"} 4676
+`
+
+var _ = Describe("Dropped output messages", Label("metrics_state"), func() {
+	Context("parsing", func() {
+		It("attributes output-path drops to the output and ignores the rest", func() {
+			m, err := benthos_monitor.ParseMetricsFromBytes([]byte(mixedDropMetrics))
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(m.OutputSentTotal()).To(Equal(int64(4676)))
+			Expect(m.OutputDroppedTotal()).To(Equal(int64(3676)), "both output-path reasons sum; the input and processor drops are excluded")
+			Expect(m.Outputs["root.output"].Dropped).To(Equal(int64(3676)))
+		})
+
+		It("reports the messages actually written", func() {
+			m, err := benthos_monitor.ParseMetricsFromBytes([]byte(mixedDropMetrics))
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(m.OutputWrittenTotal()).To(Equal(int64(1000)))
+		})
+
+		It("reports zero written when every accepted message was dropped", func() {
+			m, err := benthos_monitor.ParseMetricsFromBytes([]byte(allDroppedMetrics))
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(m.OutputSentTotal()).To(Equal(int64(4676)), "benthos still counts them as sent")
+			Expect(m.OutputWrittenTotal()).To(BeZero())
+		})
+
+		It("does not create an output instance for a drop on a path that has no output", func() {
+			m, err := benthos_monitor.ParseMetricsFromBytes([]byte(mixedDropMetrics))
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(m.Outputs).To(HaveLen(1))
+			Expect(m.Outputs).To(HaveKey("root.output"))
+		})
+
+		It("never reports a negative number of written messages", func() {
+			m := benthos_monitor.Metrics{
+				Outputs: map[string]benthos_monitor.OutputInstance{
+					"root.output": {Sent: 4, Dropped: 10},
+				},
+			}
+
+			Expect(m.OutputWrittenTotal()).To(BeZero())
+		})
+	})
+
+	Context("throughput", func() {
+		It("counts written messages, not accepted ones", func() {
+			state := benthos_monitor.NewBenthosMetricsState()
+
+			m, err := benthos_monitor.ParseMetricsFromBytes([]byte(mixedDropMetrics))
+			Expect(err).NotTo(HaveOccurred())
+
+			state.UpdateFromMetrics(m, 0)
+
+			Expect(state.Output.LastCount).To(Equal(int64(1000)))
+			Expect(state.Output.MessagesPerTick).To(Equal(float64(1000)))
+		})
+
+		It("reports no write throughput for a bridge that drops everything", func() {
+			state := benthos_monitor.NewBenthosMetricsState()
+
+			m, err := benthos_monitor.ParseMetricsFromBytes([]byte(allDroppedMetrics))
+			Expect(err).NotTo(HaveOccurred())
+
+			state.UpdateFromMetrics(m, 0)
+
+			Expect(state.Output.LastCount).To(BeZero())
+			Expect(state.Output.MessagesPerTick).To(BeZero())
+		})
+
+		It("holds write throughput at zero while the drops keep pace with the sends", func() {
+			state := benthos_monitor.NewBenthosMetricsState()
+
+			m, err := benthos_monitor.ParseMetricsFromBytes([]byte(allDroppedMetrics))
+			Expect(err).NotTo(HaveOccurred())
+
+			state.UpdateFromMetrics(m, 0)
+
+			later := benthos_monitor.Metrics{
+				Inputs: map[string]benthos_monitor.InputInstance{
+					"root.input": {Received: 9352},
+				},
+				Outputs: map[string]benthos_monitor.OutputInstance{
+					"root.output": {Sent: 9352, Dropped: 9352, BatchSent: 2000},
+				},
+			}
+
+			state.UpdateFromMetrics(later, 1)
+
+			Expect(state.Output.MessagesPerTick).To(BeZero())
+			Expect(state.Input.MessagesPerTick).NotTo(BeZero(), "the bridge is still receiving; only its writes are zero")
+		})
+	})
+})

--- a/umh-core/pkg/service/benthos_monitor/metrics_state.go
+++ b/umh-core/pkg/service/benthos_monitor/metrics_state.go
@@ -75,7 +75,7 @@ func (s *BenthosMetricsState) UpdateFromMetrics(metrics Metrics, tick uint64) {
 	// Sum across per-path maps so switch / broker / fallback configs
 	// report the correct total, not last-wins.
 	s.updateComponentThroughput(&s.Input, metrics.InputReceivedTotal(), 0, tick)
-	s.updateComponentThroughput(&s.Output, metrics.OutputSentTotal(), metrics.OutputBatchSentTotal(), tick)
+	s.updateComponentThroughput(&s.Output, metrics.OutputWrittenTotal(), metrics.OutputBatchSentTotal(), tick)
 
 	// Update processor throughput
 	newProcessors := make(map[string]ComponentThroughput)


### PR DESCRIPTION
## TL;DR

- write throughput counted the messages an output *accepted*, not the ones it wrote, so a bridge that discards most of what it receives reported a healthy rate
- umh-core now reads the `messages_dropped` counter the plugins already export and subtracts the output-path drops
- needs benthos-umh [#425](https://github.com/united-manufacturing-hub/benthos-umh/pull/425) and the `BENTHOS_UMH_VERSION` bump before it does anything; safe to merge ahead of both

## What

A bridge reports two throughput numbers: read counts messages the input received, write counts messages the output sent. The write number came from benthos's `output_sent`, which counts messages the output accepted, because benthos adds the whole batch as soon as `WriteBatch` returns nil.

A historian bridge subscribed to more of the UNS than its data contract covers accepts every message and writes only the matching ones, so the two figures diverge badly. Measured on a live instance: 13924 accepted, 3032 rows written, 10892 discarded for a wrong contract. The console showed the full rate, so a bridge storing almost nothing looked like a healthy one.

Write throughput is now accepted minus dropped. A bridge that discards everything reports zero instead of its input rate.

Pairs with benthos-umh [#425](https://github.com/united-manufacturing-hub/benthos-umh/pull/425), which renames `historian_messages_dropped` to the shared `messages_dropped` so one metric case here serves every plugin. Merge order is that PR, then the version bump, then this takes effect. Until then no plugin emits the counter at an output path and the subtraction is always zero.

## Why the plugin can't fix this itself

`output_sent` is incremented by benthos, not by the plugin: `mSent.Incr(MessageCollapsedCount(payload))` fires whenever `WriteBatch` returns nil, and on a non-nil error nothing is added even for a partial `batch.Error`. The only lever a plugin has is failing the batch, which nacks the messages back to the Kafka input for endless redelivery. So the correction belongs here.

## How

- `ParseMetricsFromBytes` gained a `messages_dropped` case. The counter carries a `reason` label, so the per-path counts are summed.
- Drops are collected in a temp map and merged only into paths that already have an `OutputInstance`. An output always emits `output_connection_up` on connect, so every live output path has one. Anything else belongs to an input or a processor: the sparkplug input and five processors export `messages_dropped` too, and those messages never reached an output, so subtracting them would remove them twice.
- `OutputWrittenTotal()` is `OutputSentTotal() - OutputDroppedTotal()`, clamped at zero, and feeds the output throughput window instead of `OutputSentTotal()`.
- The raw metrics view (`get-dataflowcomponent-metrics`) gained a `dropped` entry per output path. The parsed struct keeps `Sent` and `Dropped` separately, so nothing loses the raw numbers.

## Behavior

No ManagementConsole change: the existing `avgOutputThroughputPerMinuteInMsgSec` carries the corrected number, and a zero already renders as zero in both the bridges table and the overview.

Read throughput is untouched. It has the same gap, since `input_received` is counted before the pipeline runs and a read bridge whose tag processor discards most messages also over-reports, but fixing it needs a decision on whether read throughput should come from the `uns` output instead. Out of scope here.

Known gap: `historian_rows_poisoned` counts rows discarded after validation passed, so they are not in `messages_dropped` and still inflate the figure. Rare and per-row.

## Tests

- `pkg/service/benthos_monitor/dropped_messages_test.go`: the mixed batch, the all-dropped case, summing across drop reasons, the input- and processor-path decoys, the clamp, and that a drop on a non-output path creates no output instance.
- Swapping the subtraction back to `OutputSentTotal()` fails the two throughput specs, so they pin the behaviour rather than passing incidentally.
- A real scrape from a live historian bridge, with the counter renamed, parses to 3032 written, matching `historian_value_rows_written` in the same scrape. That series is ground truth the parser never reads.

`golangci-lint run`, `go vet ./...`, `betteralign`, and `ginkgo --fail-on-focused` are clean for the changed packages. `benthos_monitor`, `communicator/actions`, `topicbrowser`, `dataflowcomponent`, and `communicator/pkg/generator` specs run green.

## Changelog

Added under `## Unreleased`:

> Write throughput for a bridge no longer counts messages the bridge accepted and then discarded, so a historian bridge subscribed to topics outside its data contract reports zero throughput instead of a healthy figure
