### PR TITLE
chore: add PR description template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+Write it like you're explaining the PR to a teammate over coffee — as short as
+the PR is big. A tiny fix gets one problem sentence and one or two bullets, a
+big feature a few more. Never repeat what the diff already shows. Always say
+what you deliberately didn't do.
+
+## Problem
+
+_A sentence or two on why this exists — like explaining it to a teammate._
+
+## What we are shipping
+
+_A few bullets of what changes for the user. A general introduction, not a
+code map — the diff already shows the mechanics. Fewer bullets the smaller
+the PR._
+
+## What we are NOT shipping
+
+_What you deliberately left out — a deferred refactor, a known limitation.
+Only include if there's something to say._
+
+Fixes ENG-####


### PR DESCRIPTION
## Problem

Our PR descriptions drifted from the agreed rollout-ticket format (Problem / What we are shipping / What we are NOT shipping). Nothing in the repos enforces or reminds of it, so PRs — including AI-generated ones — fall back to arbitrary formats.

## What we are shipping

- Adds `.github/PULL_REQUEST_TEMPLATE.md` so every new PR starts from the standard three-section skeleton.
- The template carries the "as short as the PR is big" rule and a `Fixes ENG-####` line so Linear issues auto-close.
- Identical content across umh-core, ManagementConsole and benthos-umh so the format stays consistent repo-to-repo.

## What we are NOT shipping

- No changes to commit messages, changelogs, or CI behavior — strictly the PR body template.
