### PR TITLE
adapter: every worker declares its own fsmv1 state vocabulary

### DIFF
--- a/umh-core/pkg/fsmv2/adapter/doc.go
+++ b/umh-core/pkg/fsmv2/adapter/doc.go
@@ -36,11 +36,11 @@
 //  6. Fresh and healthy                          -> the developer's MapFresh
 //
 // Every managed worker declares its own fsmv1 state words via
-// WorkerManagerSpec.States for the exits the adapter decides (2-5); there are no
-// framework defaults, so a worker that does not declare its vocabulary reads as
-// an empty state. Each declared word must be one the consuming FSM's
-// Is<State>State predicates recognize. This output vocabulary is distinct from a
-// simple worker's own state machine.
+// WorkerManagerSpec.States for the exits the adapter decides (2-5). There are no
+// framework defaults: an incomplete vocabulary fails at construction, so a worker
+// always reports the words its own FSM recognizes. Each declared word must be one
+// the consuming FSM's Is<State>State predicates recognize. This output vocabulary
+// is distinct from a simple worker's own state machine.
 //
 // The verdict is read off the stored status through the HealthReporter interface,
 // so the adapter imports nothing from the worker package and stays generic over
@@ -51,7 +51,8 @@
 //
 // # The Spec
 //
-// Five functions and the state vocabulary are required; three fields default:
+// WorkerType, the four functions, and the state vocabulary are required;
+// ConfigEqual, CfgFor, IsEnabled, MinRequiredTime and Log default:
 //
 //	WorkerManagerSpec[TConfig, TStatus]{
 //	    WorkerType     string                                                    // required
@@ -82,6 +83,12 @@
 //	    },
 //	    MapObserved: func(_ Config, s simple.Status[Status]) publicfsm.ObservedState {
 //	        return ObservedState{Open: s.Result.Open}
+//	    },
+//	    States: adapter.StateVocabulary{
+//	        Starting:       "starting",
+//	        Degraded:       "degraded",
+//	        Stopped:        "stopped",
+//	        DesiredRunning: "running",
 //	    },
 //	})
 //

--- a/umh-core/pkg/fsmv2/adapter/doc.go
+++ b/umh-core/pkg/fsmv2/adapter/doc.go
@@ -29,15 +29,18 @@
 // resolves in this precedence; the developer only ever touches the last case:
 //
 //  1. disabled (desired state stopped)          -> the desired state, no store read
-//  2. Unknown (nil client / read hiccup)        -> hold the last known state ("starting" if none)
-//  3. degraded verdict (poll error or Health)   -> "degraded"
-//  4. Unregistered / NeverObserved (bootstrap)  -> "starting"
-//  5. Stale (~3 missed polls)                    -> "degraded"
+//  2. Unknown (nil client / read hiccup)        -> hold the last known state (the declared Starting word if none)
+//  3. degraded verdict (poll error or Health)   -> the declared Degraded word
+//  4. Unregistered / NeverObserved (bootstrap)  -> the declared Starting word
+//  5. Stale (~3 missed polls)                    -> the declared Degraded word
 //  6. Fresh and healthy                          -> the developer's MapFresh
 //
-// The non-Fresh literals ("starting"/"degraded") are the fleet-wide fsmv1
-// lifecycle states every consuming FSM understands; they are the adapter's
-// output vocabulary, distinct from a simple worker's own state machine.
+// Every managed worker declares its own fsmv1 state words via
+// WorkerManagerSpec.States for the exits the adapter decides (2-5); there are no
+// framework defaults, so a worker that does not declare its vocabulary reads as
+// an empty state. Each declared word must be one the consuming FSM's
+// Is<State>State predicates recognize. This output vocabulary is distinct from a
+// simple worker's own state machine.
 //
 // The verdict is read off the stored status through the HealthReporter interface,
 // so the adapter imports nothing from the worker package and stays generic over
@@ -48,7 +51,7 @@
 //
 // # The Spec
 //
-// Five functions are required; four fields default:
+// Five functions and the state vocabulary are required; three fields default:
 //
 //	WorkerManagerSpec[TConfig, TStatus]{
 //	    WorkerType     string                                                    // required
@@ -56,6 +59,7 @@
 //	    NameOf         func(cfg TConfig) string                                  // required
 //	    MapFresh       func(cfg TConfig, status TStatus) string                  // required (Fresh case only)
 //	    MapObserved    func(cfg TConfig, status TStatus) publicfsm.ObservedState // required
+//	    States         StateVocabulary{Starting, Degraded, Stopped, DesiredRunning string} // required
 //	    ConfigEqual    func(a, b TConfig) bool                    // default reflect.DeepEqual
 //	    CfgFor         func(cfg TConfig) (map[string]any, error)  // default JSON round-trip
 //	    IsEnabled      func(cfg TConfig) bool                     // default from the desired state

--- a/umh-core/pkg/fsmv2/adapter/instance.go
+++ b/umh-core/pkg/fsmv2/adapter/instance.go
@@ -38,12 +38,6 @@ const (
 	// type has no registered observation interval. Hardcoded (rather than reading
 	// the supervisor's DefaultObservationInterval) to keep the adapter cycle-free.
 	unregisteredStaleFallback = 1 * time.Second
-
-	// defaultDesiredState is the desired fsmv1 state used when a config exposes no
-	// desired state of its own. It is a lifecycle target ("running"), distinct
-	// from the observed-state literals above. Workers that require a different
-	// empty-config target declare it via StateVocabulary.DesiredRunning.
-	defaultDesiredState = "running"
 )
 
 // HealthReporter is the verdict-reading seam the adapter owns. The stored status

--- a/umh-core/pkg/fsmv2/adapter/instance.go
+++ b/umh-core/pkg/fsmv2/adapter/instance.go
@@ -39,19 +39,10 @@ const (
 	// the supervisor's DefaultObservationInterval) to keep the adapter cycle-free.
 	unregisteredStaleFallback = 1 * time.Second
 
-	// startingState and degradedState are the fsmv1 state literals the resolution
-	// ladder returns outside the Fresh+healthy leaf. They are the fleet-wide
-	// fsmv1 lifecycle literals every consuming FSM understands (e.g. the
-	// connection FSM's IsStartingState/IsRunningState, nmap's OperationalState*):
-	// a not-yet-observed worker reads as "starting" and a degraded/stale one as
-	// "degraded". This is the adapter's fsmv1 output vocabulary, distinct from the
-	// simple worker's own {running, degraded, stopped} state machine.
-	startingState = "starting"
-	degradedState = "degraded"
-
 	// defaultDesiredState is the desired fsmv1 state used when a config exposes no
 	// desired state of its own. It is a lifecycle target ("running"), distinct
-	// from the observed-ladder literals above.
+	// from the observed-state literals above. Workers that require a different
+	// empty-config target declare it via StateVocabulary.DesiredRunning.
 	defaultDesiredState = "running"
 )
 
@@ -69,7 +60,7 @@ type HealthReporter interface {
 // All lifecycle methods (CreateInstance, RemoveInstance, etc.) are no-ops: an
 // fsmv2 worker manages its own lifecycle through the shared global runtime. The
 // instance reads state via GetFresh and resolves it through a fixed
-// framework-owned ladder; the developer supplies only mapFresh (the Fresh +
+// framework-owned resolution; the developer supplies only mapFresh (the Fresh +
 // healthy leaf) and mapObserved (the full ObservedState).
 //
 // TConfig is the domain config type flowing through the fsmv1 control loop.
@@ -78,6 +69,15 @@ type AdaptedInstance[TConfig, TStatus any] struct {
 	mapFresh    func(cfg TConfig, status TStatus) string
 	mapObserved func(cfg TConfig, status TStatus) publicfsm.ObservedState
 	log         deps.FSMLogger
+
+	// states carries the worker's declared fsmv1 state words for the
+	// adapter-decided exits (bootstrap, unknown, degraded verdict, stale). It
+	// comes from WorkerManagerSpec.States; every field it uses is required there,
+	// so the worker always declares the words a consuming fsmv1 FSM recognizes.
+	// The isDisabled exit (returns desiredState) and the Fresh+healthy leaf
+	// (returns mapFresh) are developer-owned and deliberately outside this
+	// vocabulary.
+	states StateVocabulary
 
 	cfg TConfig
 
@@ -169,11 +169,14 @@ func (i *AdaptedInstance[TConfig, TStatus]) getFreshStatus() (TStatus, fsmv2clie
 
 // --- publicfsm.FSMInstance implementation ---
 
-// GetCurrentFSMState resolves the fsmv1 state via the framework-owned ladder.
-// Output ∈ {running, degraded, stopped} ∪ mapFresh domain states. Every resolved
-// state (except the isDisabled shortcut) is cached into lastState.
+// GetCurrentFSMState resolves the fsmv1 state via the framework-owned resolution.
+// The isDisabled exit returns desiredState; the adapter-decided Starting and
+// Degraded exits return the declared StateVocabulary word when set, defaulting
+// to "starting"/"degraded"; and the Fresh+healthy leaf returns the developer's
+// mapFresh output. Every resolved state (except the isDisabled shortcut) is
+// cached into lastState.
 func (i *AdaptedInstance[TConfig, TStatus]) GetCurrentFSMState() string {
-	// Rung 1: disabled → desired state directly, without reading the client.
+	// Step 1: disabled → desired state directly, without reading the client.
 	if i.isDisabled {
 		return i.desiredState
 	}
@@ -197,37 +200,37 @@ func (i *AdaptedInstance[TConfig, TStatus]) GetCurrentFSMState() string {
 	return resolved
 }
 
-// resolve implements rungs 2–6 of the ladder. mu is held by the caller.
+// resolve classifies a (status, freshness) pair into an fsmv1 state. mu is held by the caller.
 func (i *AdaptedInstance[TConfig, TStatus]) resolve(status TStatus, freshness fsmv2client.Freshness) string {
-	// Rung 2: Unknown (nil client / read error) → hold last known state.
+	// Step 2: Unknown (nil client / read error) → hold last known state.
 	if freshness == fsmv2client.Unknown {
 		if i.lastState == "" {
-			return startingState
+			return i.states.Starting
 		}
 
 		return i.lastState
 	}
 
-	// Rung 3: degraded verdict on the stored status → degraded.
+	// Step 3: degraded verdict on the stored status → degraded.
 	if hr, ok := any(status).(HealthReporter); ok {
 		if degraded, _ := hr.HealthVerdict(); degraded {
-			return degradedState
+			return i.states.Degraded
 		}
 	}
 
-	// Rung 4: bootstrap (no observation yet) → starting. The consuming fsmv1 FSM
+	// Step 4: bootstrap (no observation yet) → starting. The consuming fsmv1 FSM
 	// reads this as "coming up" (e.g. nmap's IsStartingState) until the first
 	// observation lands.
 	if freshness == fsmv2client.Unregistered || freshness == fsmv2client.NeverObserved {
-		return startingState
+		return i.states.Starting
 	}
 
-	// Rung 5: stale (missed polls) → degraded.
+	// Step 5: stale (missed polls) → degraded.
 	if freshness == fsmv2client.Stale {
-		return degradedState
+		return i.states.Degraded
 	}
 
-	// Rung 6: Fresh + not degraded → developer's Fresh-case mapping.
+	// Step 6: Fresh + not degraded → developer's Fresh-case mapping.
 	return i.mapFresh(i.cfg, status)
 }
 

--- a/umh-core/pkg/fsmv2/adapter/instance.go
+++ b/umh-core/pkg/fsmv2/adapter/instance.go
@@ -99,8 +99,10 @@ type AdaptedInstance[TConfig, TStatus any] struct {
 }
 
 // newAdaptedInstance builds an AdaptedInstance. ref must match the Ref used in
-// Upsert/Delete so reads resolve to the correct child observation. Construction
-// is unexported: the WorkerManager builds instances internally from a spec.
+// Upsert/Delete so reads resolve to the correct child observation. states is the
+// worker's declared vocabulary, required so the adapter-decided exits always have
+// a word to return. Construction is unexported: the WorkerManager builds
+// instances internally from a spec.
 func newAdaptedInstance[TConfig, TStatus any](
 	ref dynamicchildren.Ref,
 	cfg TConfig,
@@ -110,6 +112,7 @@ func newAdaptedInstance[TConfig, TStatus any](
 	mapObserved func(cfg TConfig, status TStatus) publicfsm.ObservedState,
 	isDisabled bool,
 	log deps.FSMLogger,
+	states StateVocabulary,
 ) *AdaptedInstance[TConfig, TStatus] {
 	if log == nil {
 		log = deps.NewNopFSMLogger()
@@ -125,6 +128,7 @@ func newAdaptedInstance[TConfig, TStatus any](
 		mapObserved:     mapObserved,
 		isDisabled:      isDisabled,
 		log:             log,
+		states:          states,
 	}
 }
 
@@ -165,10 +169,9 @@ func (i *AdaptedInstance[TConfig, TStatus]) getFreshStatus() (TStatus, fsmv2clie
 
 // GetCurrentFSMState resolves the fsmv1 state via the framework-owned resolution.
 // The isDisabled exit returns desiredState; the adapter-decided Starting and
-// Degraded exits return the declared StateVocabulary word when set, defaulting
-// to "starting"/"degraded"; and the Fresh+healthy leaf returns the developer's
-// mapFresh output. Every resolved state (except the isDisabled shortcut) is
-// cached into lastState.
+// Degraded exits return the declared StateVocabulary words (required, so always
+// set); and the Fresh+healthy leaf returns the developer's mapFresh output.
+// Every resolved state (except the isDisabled shortcut) is cached into lastState.
 func (i *AdaptedInstance[TConfig, TStatus]) GetCurrentFSMState() string {
 	// Step 1: disabled → desired state directly, without reading the client.
 	if i.isDisabled {
@@ -205,21 +208,21 @@ func (i *AdaptedInstance[TConfig, TStatus]) resolve(status TStatus, freshness fs
 		return i.lastState
 	}
 
-	// Step 3: degraded verdict on the stored status → degraded.
+	// Step 3: degraded verdict on the stored status → the declared Degraded word.
 	if hr, ok := any(status).(HealthReporter); ok {
 		if degraded, _ := hr.HealthVerdict(); degraded {
 			return i.states.Degraded
 		}
 	}
 
-	// Step 4: bootstrap (no observation yet) → starting. The consuming fsmv1 FSM
-	// reads this as "coming up" (e.g. nmap's IsStartingState) until the first
-	// observation lands.
+	// Step 4: bootstrap (no observation yet) → the declared Starting word. The
+	// consuming fsmv1 FSM reads this as "coming up" (e.g. nmap's IsStartingState)
+	// until the first observation lands.
 	if freshness == fsmv2client.Unregistered || freshness == fsmv2client.NeverObserved {
 		return i.states.Starting
 	}
 
-	// Step 5: stale (missed polls) → degraded.
+	// Step 5: stale (missed polls) → the declared Degraded word.
 	if freshness == fsmv2client.Stale {
 		return i.states.Degraded
 	}

--- a/umh-core/pkg/fsmv2/adapter/instance_test.go
+++ b/umh-core/pkg/fsmv2/adapter/instance_test.go
@@ -40,6 +40,8 @@ import (
 //	    mapFresh        func(cfg TConfig, status TStatus) string,
 //	    mapObserved     func(cfg TConfig, status TStatus) publicfsm.ObservedState,
 //	    isDisabled      bool,
+//	    log             deps.FSMLogger,
+//	    states          StateVocabulary,
 //	) *AdaptedInstance[TConfig, TStatus]
 //
 // Type param ORDER is [TConfig, TStatus] (matches the brief's
@@ -120,24 +122,21 @@ var _ = Describe("AdaptedInstance", func() {
 		return probeObserved{State: s.PortState}
 	}
 
-	// newInstance builds the instance under test with the assumed constructor.
-	// newInstance builds the instance under test with the assumed constructor and
-	// today's four fsmv1 literals declared as its vocabulary, so the resolution exits
-	// return them. Inlined (not the package constants) so the pre-C0 workflow and
-	// the post-C0 workflow both see the same words, independent of any constant
-	// the implementation may later delete.
+	// newInstance builds the instance under test with today's four fsmv1 literals
+	// as its declared vocabulary, so the adapter-decided resolution exits return
+	// them. The words are inlined (not the package constants) so the specs see
+	// stable values independent of any constant the implementation may later
+	// delete.
 	newInstance := func(desiredState string, isDisabled bool) *AdaptedInstance[testConfig, probeStatus] {
-		inst := newAdaptedInstance(
+		return newAdaptedInstance(
 			ref, cfg, desiredState, 0, mapFresh, mapObserved, isDisabled, nil,
+			StateVocabulary{
+				Starting:       "starting",
+				Degraded:       "degraded",
+				Stopped:        "stopped",
+				DesiredRunning: "running",
+			},
 		)
-		inst.states = StateVocabulary{
-			Starting:       "starting",
-			Degraded:       "degraded",
-			Stopped:        "stopped",
-			DesiredRunning: "running",
-		}
-
-		return inst
 	}
 
 	// stageClient publishes a global client whose store returns the given

--- a/umh-core/pkg/fsmv2/adapter/instance_test.go
+++ b/umh-core/pkg/fsmv2/adapter/instance_test.go
@@ -53,7 +53,7 @@ import (
 //
 // mapFresh / mapObserved take (cfg, status) ONLY — the verdict is NOT a mapper
 // input. The framework reads the degraded verdict off the stored status via the
-// adapter-defined HealthReporter interface, and the whole freshness ladder is
+// adapter-defined HealthReporter interface, and the whole freshness resolution is
 // framework-owned. mapFresh only handles the Fresh+healthy leaf.
 // -----------------------------------------------------------------------------
 
@@ -121,10 +121,23 @@ var _ = Describe("AdaptedInstance", func() {
 	}
 
 	// newInstance builds the instance under test with the assumed constructor.
+	// newInstance builds the instance under test with the assumed constructor and
+	// today's four fsmv1 literals declared as its vocabulary, so the resolution exits
+	// return them. Inlined (not the package constants) so the pre-C0 workflow and
+	// the post-C0 workflow both see the same words, independent of any constant
+	// the implementation may later delete.
 	newInstance := func(desiredState string, isDisabled bool) *AdaptedInstance[testConfig, probeStatus] {
-		return newAdaptedInstance(
+		inst := newAdaptedInstance(
 			ref, cfg, desiredState, 0, mapFresh, mapObserved, isDisabled, nil,
 		)
+		inst.states = StateVocabulary{
+			Starting:       "starting",
+			Degraded:       "degraded",
+			Stopped:        "stopped",
+			DesiredRunning: "running",
+		}
+
+		return inst
 	}
 
 	// stageClient publishes a global client whose store returns the given
@@ -153,9 +166,9 @@ var _ = Describe("AdaptedInstance", func() {
 		fsmv2client.SetClient(nil)
 	})
 
-	// --- GetCurrentFSMState ladder (brief precedence, one It per rung) ---
+	// --- GetCurrentFSMState resolution (brief precedence, one It per branch) ---
 
-	It("rung 1: isDisabled returns desiredState verbatim without reading the client", func() {
+	It("isDisabled returns desiredState verbatim without reading the client", func() {
 		// Even a degraded observation staged in the client must be ignored.
 		stageClient(true, freshObs(probeStatus{PortState: "open", Degraded: true, Reason: "boom"}), nil)
 
@@ -164,7 +177,7 @@ var _ = Describe("AdaptedInstance", func() {
 		Expect(inst.GetCurrentFSMState()).To(Equal("stopped"))
 	})
 
-	It("rung 2: GetClient()==nil with no prior state returns starting", func() {
+	It("a nil client with no prior state returns the Starting word", func() {
 		fsmv2client.SetClient(nil)
 
 		inst := newInstance("running", false)
@@ -172,7 +185,7 @@ var _ = Describe("AdaptedInstance", func() {
 		Expect(inst.GetCurrentFSMState()).To(Equal("starting"))
 	})
 
-	It("rung 3: a degraded verdict on a Fresh observation returns degraded", func() {
+	It("a degraded verdict on a Fresh observation returns the Degraded word", func() {
 		stageClient(true, freshObs(probeStatus{PortState: "open", Degraded: true, Reason: "boom"}), nil)
 
 		inst := newInstance("running", false)
@@ -180,7 +193,7 @@ var _ = Describe("AdaptedInstance", func() {
 		Expect(inst.GetCurrentFSMState()).To(Equal("degraded"))
 	})
 
-	It("rung 4: Unregistered (ref never upserted) returns starting (bootstrap)", func() {
+	It("Unregistered (ref never upserted) returns the Starting word (bootstrap)", func() {
 		stageClient(false, nil, nil)
 
 		inst := newInstance("running", false)
@@ -188,7 +201,7 @@ var _ = Describe("AdaptedInstance", func() {
 		Expect(inst.GetCurrentFSMState()).To(Equal("starting"))
 	})
 
-	It("rung 4: NeverObserved (upserted but store ErrNotFound) returns starting", func() {
+	It("NeverObserved (upserted but store ErrNotFound) returns the Starting word", func() {
 		stageClient(true, nil, persistence.ErrNotFound)
 
 		inst := newInstance("running", false)
@@ -196,7 +209,7 @@ var _ = Describe("AdaptedInstance", func() {
 		Expect(inst.GetCurrentFSMState()).To(Equal("starting"))
 	})
 
-	It("rung 5: a Stale observation (older than staleAfter) returns degraded", func() {
+	It("a Stale observation (older than staleAfter) returns the Degraded word", func() {
 		stale := &fsmv2.Observation[probeStatus]{
 			CollectedAt: time.Now().Add(-5 * time.Second), // > 1s fallback staleAfter
 			Status:      probeStatus{PortState: "open"},
@@ -208,7 +221,7 @@ var _ = Describe("AdaptedInstance", func() {
 		Expect(inst.GetCurrentFSMState()).To(Equal("degraded"))
 	})
 
-	It("rung 6: a Fresh healthy observation returns the mapFresh output", func() {
+	It("a Fresh healthy observation returns the mapFresh output", func() {
 		stageClient(true, freshObs(probeStatus{PortState: "open"}), nil)
 
 		inst := newInstance("running", false)

--- a/umh-core/pkg/fsmv2/adapter/manager.go
+++ b/umh-core/pkg/fsmv2/adapter/manager.go
@@ -43,6 +43,31 @@ type StateConfig interface {
 	GetDesiredFSMState() string
 }
 
+// StateVocabulary is the set of fsmv1 state words a worker declares for every
+// exit the resolution decides on the worker's behalf. There are no
+// framework defaults — a worker must declare all four, so it never silently
+// reports a state its FSM does not have.
+//
+//   - Starting is the word for the not-yet-observed exits: bootstrap
+//     (Unregistered / NeverObserved) and an Unknown read with no prior state.
+//   - Degraded is the word for the degraded-verdict and Stale exits.
+//   - Stopped is the word this worker uses for a deliberately stopped instance;
+//     it is what the default disable gate (GetDesiredFSMState()=="stopped")
+//     no longer assumes — see IsEnabled.
+//   - DesiredRunning is the desired state reported when a config leaves its
+//     desired state empty.
+//
+// Each word must be one the consuming fsmv1 FSM's Is<State>State predicates
+// recognize (e.g. nmap's OperationalState*); the adapter does not validate it.
+// The isDisabled exit (returns desiredState) and the Fresh+healthy leaf (return
+// the developer's MapFresh) are developer-owned and outside this vocabulary.
+type StateVocabulary struct {
+	Starting       string
+	Degraded       string
+	Stopped        string
+	DesiredRunning string
+}
+
 // WorkerManagerSpec describes the domain-specific behaviour WorkerManager needs
 // to manage a fleet of fsmv2 child workers behind the fsmv1 FSMManager
 // interface. The framework owns ref derivation, instance construction, and the
@@ -92,6 +117,12 @@ type WorkerManagerSpec[TConfig StateConfig, TStatus any] struct {
 
 	// MinRequiredTime is passed to each built instance. Optional; defaults to 0.
 	MinRequiredTime time.Duration
+
+	// States overrides the fsmv1 state words the resolution returns for its
+	// adapter-decided exits (bootstrap, unknown, degraded verdict, stale).
+	// Optional; an empty word falls back to the adapter's default literals. See
+	// StateVocabulary for the contract with the consumer's predicate table.
+	States StateVocabulary
 }
 
 // WorkerManager is a generic fsmv1-compatible manager that drives a fleet of
@@ -184,7 +215,7 @@ func (m *WorkerManager[TConfig, TStatus]) refFor(cfg TConfig) dynamicchildren.Re
 
 // buildInstance constructs an AdaptedInstance for a config entry.
 func (m *WorkerManager[TConfig, TStatus]) buildInstance(cfg TConfig, enabled bool) publicfsm.FSMInstance {
-	return newAdaptedInstance(
+	inst := newAdaptedInstance(
 		m.refFor(cfg),
 		cfg,
 		desiredStateOf(cfg),
@@ -194,6 +225,9 @@ func (m *WorkerManager[TConfig, TStatus]) buildInstance(cfg TConfig, enabled boo
 		!enabled,
 		m.spec.Log,
 	)
+	inst.states = m.spec.States
+
+	return inst
 }
 
 // GetInstances returns a snapshot copy of the managed instances. A copy (not the

--- a/umh-core/pkg/fsmv2/adapter/manager.go
+++ b/umh-core/pkg/fsmv2/adapter/manager.go
@@ -29,10 +29,6 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/serviceregistry"
 )
 
-// stoppedState is the desired-state literal that disables a config: a config
-// whose desired state is this is not Upserted into the fsmv2 runtime.
-const stoppedState = "stopped"
-
 // StateConfig is the compile-time desired-state seam every managed config must
 // satisfy. It replaces an optional duck-typed accessor whose absence silently
 // fell back to "running": a stopped worker was reported running and its fsmv1
@@ -118,10 +114,12 @@ type WorkerManagerSpec[TConfig StateConfig, TStatus any] struct {
 	// MinRequiredTime is passed to each built instance. Optional; defaults to 0.
 	MinRequiredTime time.Duration
 
-	// States overrides the fsmv1 state words the resolution returns for its
-	// adapter-decided exits (bootstrap, unknown, degraded verdict, stale).
-	// Optional; an empty word falls back to the adapter's default literals. See
-	// StateVocabulary for the contract with the consumer's predicate table.
+	// States declares this worker's four fsmv1 state words. The manager uses
+	// them for its adapter-decided exits (bootstrap, unknown, degraded verdict,
+	// stale), for the default disable gate (Stopped), and as the empty-config
+	// desired-state fallback (DesiredRunning). Required; an incomplete vocabulary
+	// fails at construction. See StateVocabulary for the contract with the
+	// consumer's predicate table.
 	States StateVocabulary
 }
 
@@ -162,7 +160,9 @@ func NewWorkerManager[TConfig StateConfig, TStatus any](spec WorkerManagerSpec[T
 	}
 
 	if spec.IsEnabled == nil {
-		spec.IsEnabled = defaultIsEnabled[TConfig]
+		spec.IsEnabled = func(cfg TConfig) bool {
+			return cfg.GetDesiredFSMState() != spec.States.Stopped
+		}
 	}
 
 	if spec.Log == nil {
@@ -192,20 +192,14 @@ func defaultCfgFor[TConfig any](cfg TConfig) (map[string]any, error) {
 	return out, nil
 }
 
-// defaultIsEnabled reads the config's desired state: a config whose
-// GetDesiredFSMState() returns "stopped" is disabled, otherwise it is enabled.
-func defaultIsEnabled[TConfig StateConfig](cfg TConfig) bool {
-	return cfg.GetDesiredFSMState() != stoppedState
-}
-
-// desiredStateOf returns the config's desired state, falling back to
-// defaultDesiredState ("running") only when the config leaves it empty.
-func desiredStateOf[TConfig StateConfig](cfg TConfig) string {
+// desiredStateOf returns the config's desired state, falling back to the
+// worker's declared DesiredRunning word only when the config leaves it empty.
+func (m *WorkerManager[TConfig, TStatus]) desiredStateOf(cfg TConfig) string {
 	if s := cfg.GetDesiredFSMState(); s != "" {
 		return s
 	}
 
-	return defaultDesiredState
+	return m.spec.States.DesiredRunning
 }
 
 // refFor builds the ref for a config entry from the worker type and its name.
@@ -218,7 +212,7 @@ func (m *WorkerManager[TConfig, TStatus]) buildInstance(cfg TConfig, enabled boo
 	inst := newAdaptedInstance(
 		m.refFor(cfg),
 		cfg,
-		desiredStateOf(cfg),
+		m.desiredStateOf(cfg),
 		m.spec.MinRequiredTime,
 		m.spec.MapFresh,
 		m.spec.MapObserved,

--- a/umh-core/pkg/fsmv2/adapter/manager.go
+++ b/umh-core/pkg/fsmv2/adapter/manager.go
@@ -74,6 +74,10 @@ type StateVocabulary struct {
 // must satisfy StateConfig so the manager can always read its desired state.
 // TStatus is the worker's stored status type (e.g. simple.Status[Raw]).
 type WorkerManagerSpec[TConfig StateConfig, TStatus any] struct {
+
+	// Log is the FSMLogger; optional, defaults to a no-op logger.
+	Log deps.FSMLogger
+
 	// ExtractConfigs pulls the relevant config slice from a SystemSnapshot.
 	// Required.
 	ExtractConfigs func(snapshot publicfsm.SystemSnapshot) []TConfig
@@ -104,15 +108,6 @@ type WorkerManagerSpec[TConfig StateConfig, TStatus any] struct {
 	// Optional; defaults to GetDesiredFSMState() != States.Stopped => enabled.
 	IsEnabled func(cfg TConfig) bool
 
-	// Log is the FSMLogger; optional, defaults to a no-op logger.
-	Log deps.FSMLogger
-
-	// WorkerType builds the ref and names the manager. Required.
-	WorkerType string
-
-	// MinRequiredTime is passed to each built instance. Optional; defaults to 0.
-	MinRequiredTime time.Duration
-
 	// States declares this worker's four fsmv1 state words. The manager uses
 	// them for its adapter-decided exits (bootstrap, unknown, degraded verdict,
 	// stale), for the default disable gate (Stopped), and as the empty-config
@@ -120,6 +115,12 @@ type WorkerManagerSpec[TConfig StateConfig, TStatus any] struct {
 	// fails at construction. See StateVocabulary for the contract with the
 	// consumer's predicate table.
 	States StateVocabulary
+
+	// WorkerType builds the ref and names the manager. Required.
+	WorkerType string
+
+	// MinRequiredTime is passed to each built instance. Optional; defaults to 0.
+	MinRequiredTime time.Duration
 }
 
 // WorkerManager is a generic fsmv1-compatible manager that drives a fleet of

--- a/umh-core/pkg/fsmv2/adapter/manager.go
+++ b/umh-core/pkg/fsmv2/adapter/manager.go
@@ -55,8 +55,11 @@ type StateConfig interface {
 //
 // Each word must be one the consuming fsmv1 FSM's Is<State>State predicates
 // recognize (e.g. nmap's OperationalState*); the adapter does not validate it.
-// The isDisabled exit (returns desiredState) and the Fresh+healthy leaf (return
-// the developer's MapFresh) are developer-owned and outside this vocabulary.
+// The four words must be distinct: reusing one word for two exits would collapse
+// the lifecycle states the adapter reports into a single string, so construction
+// rejects any vocabulary that is not pairwise distinct. The isDisabled exit
+// (returns desiredState) and the Fresh+healthy leaf (return the developer's
+// MapFresh) are developer-owned and outside this vocabulary.
 type StateVocabulary struct {
 	Starting       string
 	Degraded       string
@@ -153,6 +156,15 @@ func NewWorkerManager[TConfig StateConfig, TStatus any](spec WorkerManagerSpec[T
 
 	if spec.States.Starting == "" || spec.States.Degraded == "" || spec.States.Stopped == "" || spec.States.DesiredRunning == "" {
 		panic("adapter: WorkerManagerSpec.States requires a full StateVocabulary (Starting, Degraded, Stopped, DesiredRunning)")
+	}
+
+	if spec.States.Starting == spec.States.Degraded ||
+		spec.States.Starting == spec.States.Stopped ||
+		spec.States.Starting == spec.States.DesiredRunning ||
+		spec.States.Degraded == spec.States.Stopped ||
+		spec.States.Degraded == spec.States.DesiredRunning ||
+		spec.States.Stopped == spec.States.DesiredRunning {
+		panic("adapter: WorkerManagerSpec.States words must be distinct")
 	}
 
 	if spec.ConfigEqual == nil {

--- a/umh-core/pkg/fsmv2/adapter/manager.go
+++ b/umh-core/pkg/fsmv2/adapter/manager.go
@@ -40,16 +40,16 @@ type StateConfig interface {
 }
 
 // StateVocabulary is the set of fsmv1 state words a worker declares for every
-// exit the resolution decides on the worker's behalf. There are no
-// framework defaults — a worker must declare all four, so it never silently
-// reports a state its FSM does not have.
+// exit the resolution decides on the worker's behalf. There are no framework
+// defaults; a worker must declare all four, so it can never report a state its
+// FSM does not have.
 //
 //   - Starting is the word for the not-yet-observed exits: bootstrap
 //     (Unregistered / NeverObserved) and an Unknown read with no prior state.
 //   - Degraded is the word for the degraded-verdict and Stale exits.
-//   - Stopped is the word this worker uses for a deliberately stopped instance;
-//     it is what the default disable gate (GetDesiredFSMState()=="stopped")
-//     no longer assumes — see IsEnabled.
+//   - Stopped is the word this worker uses for a deliberately stopped instance.
+//     The default disable gate treats a config whose desired state equals it as
+//     disabled. See IsEnabled.
 //   - DesiredRunning is the desired state reported when a config leaves its
 //     desired state empty.
 //
@@ -101,8 +101,7 @@ type WorkerManagerSpec[TConfig StateConfig, TStatus any] struct {
 	// IsEnabled reports whether a config entry should run in the fsmv2 runtime.
 	// Disabled entries stay in the fsmv1 instance map (so their state is
 	// visible) but are not Upserted; existing registrations are Deleted.
-	// Optional; defaults to GetDesiredFSMState()=="stopped" => disabled,
-	// otherwise enabled.
+	// Optional; defaults to GetDesiredFSMState() != States.Stopped => enabled.
 	IsEnabled func(cfg TConfig) bool
 
 	// Log is the FSMLogger; optional, defaults to a no-op logger.
@@ -152,7 +151,7 @@ func NewWorkerManager[TConfig StateConfig, TStatus any](spec WorkerManagerSpec[T
 	}
 
 	if spec.States.Starting == "" || spec.States.Degraded == "" || spec.States.Stopped == "" || spec.States.DesiredRunning == "" {
-		panic("adapter: WorkerManagerSpec.StateVocabulary requires Starting, Degraded, Stopped, and DesiredRunning")
+		panic("adapter: WorkerManagerSpec.States requires a full StateVocabulary (Starting, Degraded, Stopped, DesiredRunning)")
 	}
 
 	if spec.ConfigEqual == nil {
@@ -213,7 +212,7 @@ func (m *WorkerManager[TConfig, TStatus]) refFor(cfg TConfig) dynamicchildren.Re
 
 // buildInstance constructs an AdaptedInstance for a config entry.
 func (m *WorkerManager[TConfig, TStatus]) buildInstance(cfg TConfig, enabled bool) publicfsm.FSMInstance {
-	inst := newAdaptedInstance(
+	return newAdaptedInstance(
 		m.refFor(cfg),
 		cfg,
 		m.desiredStateOf(cfg),
@@ -222,10 +221,8 @@ func (m *WorkerManager[TConfig, TStatus]) buildInstance(cfg TConfig, enabled boo
 		m.spec.MapObserved,
 		!enabled,
 		m.spec.Log,
+		m.spec.States,
 	)
-	inst.states = m.spec.States
-
-	return inst
 }
 
 // GetInstances returns a snapshot copy of the managed instances. A copy (not the

--- a/umh-core/pkg/fsmv2/adapter/manager.go
+++ b/umh-core/pkg/fsmv2/adapter/manager.go
@@ -151,6 +151,10 @@ func NewWorkerManager[TConfig StateConfig, TStatus any](spec WorkerManagerSpec[T
 		panic("adapter: WorkerManagerSpec requires ExtractConfigs, NameOf, MapFresh, and MapObserved")
 	}
 
+	if spec.States.Starting == "" || spec.States.Degraded == "" || spec.States.Stopped == "" || spec.States.DesiredRunning == "" {
+		panic("adapter: WorkerManagerSpec.StateVocabulary requires Starting, Degraded, Stopped, and DesiredRunning")
+	}
+
 	if spec.ConfigEqual == nil {
 		spec.ConfigEqual = func(a, b TConfig) bool { return reflect.DeepEqual(a, b) }
 	}

--- a/umh-core/pkg/fsmv2/adapter/manager_test.go
+++ b/umh-core/pkg/fsmv2/adapter/manager_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/fsmv2client"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/configworker/dynamicchildren"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/persistence"
 )
 
 // -----------------------------------------------------------------------------
@@ -101,7 +102,10 @@ var _ = Describe("WorkerManager", func() {
 
 	// baseSpec supplies only the required fields plus a no-op logger, leaving the
 	// optional fields (ConfigEqual/CfgFor/IsEnabled/MinRequiredTime) nil so the
-	// defaults apply unless a spec overrides them.
+	// states are today's four fsmv1 literals, declared so the resolution returns them.
+	// Inlined (not the package constants) so the specs see stable words independent
+	// of any constant the implementation may later delete. baseSpec supplies only
+	// the required fields plus the vocabulary and a no-op logger.
 	baseSpec := func() WorkerManagerSpec[mgrConfig, probeStatus] {
 		return WorkerManagerSpec[mgrConfig, probeStatus]{
 			WorkerType:     workerType,
@@ -109,7 +113,13 @@ var _ = Describe("WorkerManager", func() {
 			NameOf:         nameOf,
 			MapFresh:       mapFresh,
 			MapObserved:    mapObserved,
-			Log:            deps.NewNopFSMLogger(),
+			States: StateVocabulary{
+				Starting:       "starting",
+				Degraded:       "degraded",
+				Stopped:        "stopped",
+				DesiredRunning: "running",
+			},
+			Log: deps.NewNopFSMLogger(),
 		}
 	}
 
@@ -382,6 +392,67 @@ var _ = Describe("WorkerManager", func() {
 
 		_, err = mgr.GetLastObservedState("missing")
 		Expect(err).To(HaveOccurred())
+	})
+
+	It("prefixed Starting and Degraded vocabulary words reach all four adapter-decided exits as raw strings", func() {
+		// Vocabulary whose words share no prefix with the current adapter's
+		// literals ("starting"/"degraded"), so the bare constant returning values
+		// cannot satisfy any assertion here.
+		spec := baseSpec()
+		spec.States = StateVocabulary{
+			Starting: "benthos_monitoring_starting",
+			Degraded: "benthos_monitoring_degraded",
+		}
+		mgr := NewWorkerManager(spec)
+
+		reconcile := func(name string) {
+			desired = []mgrConfig{{Name: name, State: "running"}}
+			err, _ := mgr.Reconcile(ctx, publicfsm.SystemSnapshot{}, nil)
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		stateOf := func(name string) string {
+			inst, ok := mgr.GetInstance(name)
+			Expect(ok).To(BeTrue())
+
+			return inst.GetCurrentFSMState()
+		}
+
+		// (1) BOOTSTRAP (via NeverObserved): reader returns persistence.ErrNotFound
+		// => NeverObserved => the worker's declared Starting word.
+		setupClient(&stubReader{err: persistence.ErrNotFound})
+		reconcile("r1-bootstrap")
+		Expect(stateOf("r1-bootstrap")).To(Equal("benthos_monitoring_starting"))
+
+		// (2) UNKNOWN-WITH-EMPTY-LAST-STATE: reconcile creates the instance, then
+		// the reader errs on the FIRST GetCurrentFSMState read so lastState is
+		// still empty => the worker's declared Starting word.
+		sr := &stubReader{}
+		setupClient(sr)
+		reconcile("r1-unknown")
+		sr.err = errors.New("generic read boom")
+		Expect(stateOf("r1-unknown")).To(Equal("benthos_monitoring_starting"))
+
+		// (3) DEGRADED VERDICT: Fresh observation whose stored status reports
+		// degraded => the worker's declared Degraded word.
+		setupClient(freshReader(probeStatus{PortState: "open", Degraded: true, Reason: "boom"}))
+		reconcile("r1-degraded")
+		Expect(stateOf("r1-degraded")).To(Equal("benthos_monitoring_degraded"))
+
+		// (4) STALE: observation older than the 1s unregistered fallback staleAfter
+		// => the worker's declared Degraded word.
+		setupClient(&stubReader{obs: &fsmv2.Observation[probeStatus]{
+			CollectedAt: time.Now().Add(-5 * time.Second),
+			Status:      probeStatus{PortState: "open"},
+		}})
+		reconcile("r1-stale")
+		Expect(stateOf("r1-stale")).To(Equal("benthos_monitoring_degraded"))
+
+		// (5) FRESH+HEALTHY is outside the vocabulary: it returns the developer's
+		// MapFresh output untouched, not the declared Starting/Degraded words.
+		setupClient(freshReader(probeStatus{PortState: "open"}))
+		reconcile("r1-fresh")
+		Expect(stateOf("r1-fresh")).To(Equal("open"))
 	})
 })
 

--- a/umh-core/pkg/fsmv2/adapter/manager_test.go
+++ b/umh-core/pkg/fsmv2/adapter/manager_test.go
@@ -100,12 +100,12 @@ var _ = Describe("WorkerManager", func() {
 		return dynamicchildren.Ref{WorkerType: workerType, Name: name}
 	}
 
-	// baseSpec supplies only the required fields plus a no-op logger, leaving the
-	// optional fields (ConfigEqual/CfgFor/IsEnabled/MinRequiredTime) nil so the
-	// states are today's four fsmv1 literals, declared so the resolution returns them.
-	// Inlined (not the package constants) so the specs see stable words independent
-	// of any constant the implementation may later delete. baseSpec supplies only
-	// the required fields plus the vocabulary and a no-op logger.
+	// baseSpec supplies the required fields, today's four fsmv1 literals declared
+	// as the vocabulary, and a no-op logger. The optional fields
+	// (ConfigEqual/CfgFor/IsEnabled/MinRequiredTime) are left nil to apply their
+	// defaults. The vocabulary words are inlined, not the package constants, so
+	// the specs see stable values independent of any constant the implementation
+	// may later delete.
 	baseSpec := func() WorkerManagerSpec[mgrConfig, probeStatus] {
 		return WorkerManagerSpec[mgrConfig, probeStatus]{
 			WorkerType:     workerType,

--- a/umh-core/pkg/fsmv2/adapter/manager_test.go
+++ b/umh-core/pkg/fsmv2/adapter/manager_test.go
@@ -180,6 +180,16 @@ var _ = Describe("WorkerManager", func() {
 		}
 	})
 
+	It("NewWorkerManager panics when the StateVocabulary words are not distinct", func() {
+		// A vocabulary that reuses one word for two exits silently collapses the
+		// adapter-decided states together; reject it at construction.
+		spec := baseSpec()
+		spec.States.Starting = "monitor"
+		spec.States.Degraded = "monitor"
+
+		Expect(func() { NewWorkerManager(spec) }).To(PanicWith(ContainSubstring("distinct")))
+	})
+
 	It("Reconcile adds a new worker: instance registered and ref Upserted", func() {
 		w := setupClient(&stubReader{})
 		mgr := NewWorkerManager(baseSpec())

--- a/umh-core/pkg/fsmv2/adapter/manager_test.go
+++ b/umh-core/pkg/fsmv2/adapter/manager_test.go
@@ -161,6 +161,25 @@ var _ = Describe("WorkerManager", func() {
 		Expect(func() { NewWorkerManager(spec) }).To(PanicWith(ContainSubstring("requires ExtractConfigs")))
 	})
 
+	It("NewWorkerManager panics when the StateVocabulary is incomplete, for each of the four fields", func() {
+		fields := []struct {
+			name  string
+			blank func(*StateVocabulary)
+		}{
+			{"Starting", func(v *StateVocabulary) { v.Starting = "" }},
+			{"Degraded", func(v *StateVocabulary) { v.Degraded = "" }},
+			{"Stopped", func(v *StateVocabulary) { v.Stopped = "" }},
+			{"DesiredRunning", func(v *StateVocabulary) { v.DesiredRunning = "" }},
+		}
+
+		for _, f := range fields {
+			spec := baseSpec()
+			f.blank(&spec.States)
+
+			Expect(func() { NewWorkerManager(spec) }).To(PanicWith(ContainSubstring("StateVocabulary")), "field: %s", f.name)
+		}
+	})
+
 	It("Reconcile adds a new worker: instance registered and ref Upserted", func() {
 		w := setupClient(&stubReader{})
 		mgr := NewWorkerManager(baseSpec())
@@ -399,10 +418,8 @@ var _ = Describe("WorkerManager", func() {
 		// literals ("starting"/"degraded"), so the bare constant returning values
 		// cannot satisfy any assertion here.
 		spec := baseSpec()
-		spec.States = StateVocabulary{
-			Starting: "benthos_monitoring_starting",
-			Degraded: "benthos_monitoring_degraded",
-		}
+		spec.States.Starting = "benthos_monitoring_starting"
+		spec.States.Degraded = "benthos_monitoring_degraded"
 		mgr := NewWorkerManager(spec)
 
 		reconcile := func(name string) {

--- a/umh-core/pkg/fsmv2/adapter/manager_test.go
+++ b/umh-core/pkg/fsmv2/adapter/manager_test.go
@@ -454,6 +454,43 @@ var _ = Describe("WorkerManager", func() {
 		reconcile("r1-fresh")
 		Expect(stateOf("r1-fresh")).To(Equal("open"))
 	})
+
+	It("a config whose desired state is the declared Stopped word is disabled, not Upserted", func() {
+		w := setupClient(&stubReader{})
+		spec := baseSpec()
+		spec.States.Stopped = "benthos_monitoring_stopped"
+		mgr := NewWorkerManager(spec)
+
+		desired = []mgrConfig{{Name: "alpha", State: "benthos_monitoring_stopped"}}
+
+		err, changed := mgr.Reconcile(ctx, publicfsm.SystemSnapshot{}, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(changed).To(BeTrue())
+
+		// A disabled worker is not Upserted into the fsmv2 runtime...
+		Expect(w.Registry().Contains(refFor("alpha"))).To(BeFalse())
+
+		// ...but it stays visible, reading as the desired (stopped) state.
+		inst, ok := mgr.GetInstance("alpha")
+		Expect(ok).To(BeTrue())
+		Expect(inst.GetCurrentFSMState()).To(Equal("benthos_monitoring_stopped"))
+	})
+
+	It("a config with an empty desired state reports the declared DesiredRunning word", func() {
+		setupClient(&stubReader{})
+		spec := baseSpec()
+		spec.States.DesiredRunning = "benthos_monitoring_active"
+		mgr := NewWorkerManager(spec)
+
+		desired = []mgrConfig{{Name: "alpha", State: ""}}
+
+		err, _ := mgr.Reconcile(ctx, publicfsm.SystemSnapshot{}, nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		inst, ok := mgr.GetInstance("alpha")
+		Expect(ok).To(BeTrue())
+		Expect(inst.GetDesiredFSMState()).To(Equal("benthos_monitoring_active"))
+	})
 })
 
 // Compile-time proof that WorkerManager satisfies the fsmv1 FSMManager

--- a/umh-core/pkg/fsmv2/nmap/manager.go
+++ b/umh-core/pkg/fsmv2/nmap/manager.go
@@ -45,6 +45,15 @@ func NewFsmv2NmapManager(managerName string) *adapter.WorkerManager[config.NmapC
 		CfgFor:      cfgFor,
 		MapFresh:    mapFresh,
 		MapObserved: mapObserved,
+		// DesiredRunning is the state reported when a config leaves desiredState
+		// empty; it is nmap's "open", not "running" — nmap's own FSM accepts only
+		// open/stopped as a desired state (fsm/nmap/machine.go).
+		States: adapter.StateVocabulary{
+			Starting:       nmapfsm.OperationalStateStarting,
+			Degraded:       nmapfsm.OperationalStateDegraded,
+			Stopped:        nmapfsm.OperationalStateStopped,
+			DesiredRunning: nmapfsm.OperationalStateOpen,
+		},
 	})
 }
 

--- a/umh-core/pkg/fsmv2/nmap/manager.go
+++ b/umh-core/pkg/fsmv2/nmap/manager.go
@@ -46,7 +46,7 @@ func NewFsmv2NmapManager(managerName string) *adapter.WorkerManager[config.NmapC
 		MapFresh:    mapFresh,
 		MapObserved: mapObserved,
 		// DesiredRunning is the state reported when a config leaves desiredState
-		// empty; it is nmap's "open", not "running" — nmap's own FSM accepts only
+		// empty. It is nmap's "open", not "running": nmap's own FSM accepts only
 		// open/stopped as a desired state (fsm/nmap/machine.go).
 		States: adapter.StateVocabulary{
 			Starting:       nmapfsm.OperationalStateStarting,

--- a/umh-core/pkg/fsmv2/nmap/manager_test.go
+++ b/umh-core/pkg/fsmv2/nmap/manager_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/fsmv2client"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/simple"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/configworker/dynamicchildren"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/persistence"
 )
 
 // stubManagerReader is a deps.StateReader that returns a fixed
@@ -213,5 +214,57 @@ var _ = Describe("NewFsmv2NmapManager", func() {
 		Expect(back.NmapServiceConfig.Target).To(Equal(target))
 		Expect(back.NmapServiceConfig.Port).To(Equal(port))
 		Expect(back.Name).To(Equal(name))
+	})
+
+	It("returns nmap's own operational states for the adapter-decided exits (parity)", func() {
+		// One registered client, held across the three reads; only the reader's
+		// observation/error changes, so the ref stays registered and each read is
+		// classified by freshness rather than as Unregistered bootstrap.
+		reader := &stubManagerReader{err: persistence.ErrNotFound}
+		writer := dynamicchildren.NewWriter()
+		fsmv2client.SetClient(fsmv2client.NewFSMv2Client(writer, reader))
+
+		mgr := NewFsmv2NmapManager("test")
+		err, _ := mgr.Reconcile(context.Background(), snapshotWith(nmapConfig("running")), nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		// BOOTSTRAP: no observation yet (NeverObserved) => the starting state.
+		state, gerr := mgr.GetCurrentFSMState(name)
+		Expect(gerr).NotTo(HaveOccurred())
+		Expect(state).To(Equal(nmapfsm.OperationalStateStarting))
+
+		// DEGRADED verdict on a Fresh observation => the degraded state.
+		reader.err = nil
+		reader.obs = &fsmv2.Observation[simple.Status[NmapStatus]]{
+			CollectedAt: time.Now().Add(-100 * time.Millisecond),
+			Status:      simple.Status[NmapStatus]{Result: NmapStatus{PortState: "open"}, Degraded: true, Reason: "poll error"},
+		}
+
+		state, gerr = mgr.GetCurrentFSMState(name)
+		Expect(gerr).NotTo(HaveOccurred())
+		Expect(state).To(Equal(nmapfsm.OperationalStateDegraded))
+
+		// STALE (missed polls) => the degraded state.
+		reader.obs = &fsmv2.Observation[simple.Status[NmapStatus]]{
+			CollectedAt: time.Now().Add(-5 * time.Second),
+			Status:      simple.Status[NmapStatus]{Result: NmapStatus{PortState: "open"}},
+		}
+
+		state, gerr = mgr.GetCurrentFSMState(name)
+		Expect(gerr).NotTo(HaveOccurred())
+		Expect(state).To(Equal(nmapfsm.OperationalStateDegraded))
+	})
+
+	It("falls back to the open desired state when a config leaves it empty", func() {
+		stageClient(freshStatus(NmapStatus{PortState: "open", IsRunning: true, Port: port, LatencyMs: 3}), nil)
+
+		mgr := NewFsmv2NmapManager("test")
+
+		err, _ := mgr.Reconcile(context.Background(), snapshotWith(nmapConfig("")), nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		inst, ok := mgr.GetInstance(name)
+		Expect(ok).To(BeTrue())
+		Expect(inst.GetDesiredFSMState()).To(Equal(nmapfsm.OperationalStateOpen))
 	})
 })


### PR DESCRIPTION
## Problem

The adapter hardcodes nmap's fsmv1 states, because nmap is what it was developed for. The next component we migrate has different ones (`benthos_monitoring_starting`), so the states need to be configurable.

## What we're shipping

- `StateVocabulary` on `adapter.WorkerManagerSpec`: every worker declares its own four fsmv1 state words (`Starting`, `Degraded`, `Stopped`, `DesiredRunning`).
- Required, not defaulted — an incomplete vocabulary panics at construction, like the spec's other required fields. No worker can silently inherit nmap's states.
- nmap declares its own from its own constants, including `open` as its empty-config fallback. The adapter previously defaulted the empty config to `"running"`, which nmap's own FSM rejects (`pkg/fsm/nmap/machine.go` allows only `open` or `stopped`). Unreachable in production — every `NmapConfig` sets its desired state explicitly — so no behaviour change.
- Tests: nmap resolves identically for every one of its operational constants; a prefixed vocabulary survives all four adapter-decided exits; an omitted vocabulary panics.

## What we're NOT shipping

- No new workers, and no change to any state nmap actually reports.
- No change to the resolution precedence — same exits, same order, only the returned strings.
- No renames in `pkg/fsm/*`.
- No user-visible change, so `skip-changelog-guard`.
