### PR TITLE
docs: fix GraphQL default state and mark it early access

### DIFF
--- a/umh-core/docs/reference/configuration-reference.md
+++ b/umh-core/docs/reference/configuration-reference.md
@@ -257,7 +257,7 @@ GraphQL API for querying Unified Namespace topics.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `enabled` | `bool` | `true` | Enable GraphQL API |
+| `enabled` | `bool` | `false` | Enable GraphQL API (Early Access; opt in) |
 | `port` | `int` | `8090` | HTTP port for GraphQL endpoint |
 | `debug` | `bool` | `false` | Enable GraphiQL playground at `/` |
 | `corsOrigins` | `[]string` | `[]` | CORS origins (empty = allow all) |
@@ -265,7 +265,7 @@ GraphQL API for querying Unified Namespace topics.
 ```yaml
 agent:
   graphql:
-    enabled: true
+    enabled: false   # Default: false; set true to opt in (Early Access)
     port: 8090
     debug: false
     corsOrigins: 

--- a/umh-core/docs/reference/http-api/README.md
+++ b/umh-core/docs/reference/http-api/README.md
@@ -1,7 +1,7 @@
 # HTTP API Reference
 
 {% hint style="info" %}
-**Early Access.** We built the GraphQL API for developers who want to query the Unified Namespace programmatically. It's experimental, so it's off by default. Switch it on with `graphql.enabled: true` and give it a try. Tell us what you think.
+**Early Access.** We built the GraphQL API for developers who want to query the Unified Namespace programmatically. It's experimental, so it's off by default. Switch it on with `agent.graphql.enabled: true` and give it a try. Tell us what you think.
 {% endhint %}
 
 ## GraphQL API

--- a/umh-core/docs/reference/http-api/README.md
+++ b/umh-core/docs/reference/http-api/README.md
@@ -1,7 +1,7 @@
 # HTTP API Reference
 
 {% hint style="info" %}
-**Early Access.** We built the GraphQL API for developers who want to query the Unified Namespace programmatically. It's experimental, so it's off by default. Switch it on with `agent.graphql.enabled: true` and give it a try. Tell us what you think.
+**Early Access.** The GraphQL API lets developers query the Unified Namespace programmatically. It's experimental and off by default. To turn it on, set `agent.graphql.enabled: true` in the `agent:` block of your `umh-core` instance configuration. See [Configuration](topic-browser-graphql.md#configuration) for all options. Tell us what you think.
 {% endhint %}
 
 ## GraphQL API

--- a/umh-core/docs/reference/http-api/README.md
+++ b/umh-core/docs/reference/http-api/README.md
@@ -1,7 +1,11 @@
 # HTTP API Reference
 
+{% hint style="info" %}
+**Early Access.** We built the GraphQL API for developers who want to query the Unified Namespace programmatically. It's experimental, so it's off by default. Switch it on with `graphql.enabled: true` and give it a try. Tell us what you think.
+{% endhint %}
+
 ## GraphQL API
-- **Default:** Enabled on port 8090
+- **Default:** Disabled; enable with `agent.graphql.enabled: true` (port 8090)
 - **Endpoint:** `POST /graphql`
 - **GraphiQL:** Available at `/` when debug enabled
 - **Purpose:** Query Unified Namespace topics

--- a/umh-core/docs/reference/http-api/topic-browser-graphql.md
+++ b/umh-core/docs/reference/http-api/topic-browser-graphql.md
@@ -1,14 +1,14 @@
 # Topic Browser GraphQL API
 
 {% hint style="info" %}
-**Early Access.** We built the GraphQL API for developers who want to query the Unified Namespace programmatically. It's experimental, so it's off by default. Switch it on with `graphql.enabled: true` and give it a try. Tell us what you think.
+**Early Access.** We built the GraphQL API for developers who want to query the Unified Namespace programmatically. It's experimental, so it's off by default. Switch it on with `agent.graphql.enabled: true` and give it a try. Tell us what you think.
 {% endhint %}
 
 ## Overview
 Query Unified Namespace topics and metadata in real-time.
 
 - **Endpoint:** `http://localhost:8090/graphql`
-- **Default:** Disabled; opt in with `graphql.enabled: true`
+- **Default:** Disabled; opt in with `agent.graphql.enabled: true`
 - **Authentication:** None (open by default)
 
 ## Schema
@@ -131,7 +131,7 @@ curl -X POST http://localhost:8090/graphql \
 ```yaml
 agent:
   graphql:
-    enabled: true    # Default: true
+    enabled: false   # Default: false; set true to opt in
     port: 8090      # Default: 8090
     debug: false    # Set true for GraphiQL UI
     corsOrigins: [] # Default: allows all origins

--- a/umh-core/docs/reference/http-api/topic-browser-graphql.md
+++ b/umh-core/docs/reference/http-api/topic-browser-graphql.md
@@ -1,7 +1,7 @@
 # Topic Browser GraphQL API
 
 {% hint style="info" %}
-**Early Access.** We built the GraphQL API for developers who want to query the Unified Namespace programmatically. It's experimental, so it's off by default. Switch it on with `agent.graphql.enabled: true` and give it a try. Tell us what you think.
+**Early Access.** The GraphQL API lets developers query the Unified Namespace programmatically. It's experimental and off by default. To turn it on, set `agent.graphql.enabled: true` in the `agent:` block of your `umh-core` instance configuration. See [Configuration](#configuration) for all options. Tell us what you think.
 {% endhint %}
 
 ## Overview

--- a/umh-core/docs/reference/http-api/topic-browser-graphql.md
+++ b/umh-core/docs/reference/http-api/topic-browser-graphql.md
@@ -1,10 +1,14 @@
 # Topic Browser GraphQL API
 
+{% hint style="info" %}
+**Early Access.** We built the GraphQL API for developers who want to query the Unified Namespace programmatically. It's experimental, so it's off by default. Switch it on with `graphql.enabled: true` and give it a try. Tell us what you think.
+{% endhint %}
+
 ## Overview
 Query Unified Namespace topics and metadata in real-time.
 
 - **Endpoint:** `http://localhost:8090/graphql`
-- **Default:** Enabled (`graphql.enabled: true`)
+- **Default:** Disabled; opt in with `graphql.enabled: true`
 - **Authentication:** None (open by default)
 
 ## Schema

--- a/umh-core/docs/usage/unified-namespace/topic-browser.md
+++ b/umh-core/docs/usage/unified-namespace/topic-browser.md
@@ -33,7 +33,9 @@ When selecting a topic, view:
 
 Programmatic access at `http://localhost:8090/graphql` (per instance).
 
-> **Note:** The GraphQL API is disabled by default. You must enable it in your configuration before using the examples below.
+{% hint style="info" %}
+**Early Access.** We built the GraphQL API for developers who want to query the Unified Namespace programmatically. It's experimental, so it's off by default. See the instructions below and give it a try. Tell us what you think.
+{% endhint %}
 
 ### Configuration
 


### PR DESCRIPTION
## Problem

Two HTTP API reference pages said the GraphQL API was enabled by default. It's off by default, so a customer who followed the docs found no config to reach it.

## What we are shipping

- Corrected the default to "disabled; opt in via `graphql.enabled`" on both reference pages, so all three GraphQL pages now agree.
- Added an "Early Access" note to the three GraphQL pages so the feature reads as an opt-in preview.

Fixes ENG-5527
