### PR TITLE
fix(ENG-3670): S6 directory health message varies only by trigger

### DIFF
--- a/umh-core/pkg/fsm/benthos/actions.go
+++ b/umh-core/pkg/fsm/benthos/actions.go
@@ -308,10 +308,8 @@ func (b *BenthosInstance) logS6DirectoryStateAsync(
 	)
 }
 
-// s6DirectoryHealthError builds the error Sentry groups the S6 directory health
-// diagnostics by. Sentry fingerprints on the message, so it carries only the
-// trigger, which has five bounded literals; the service name and S6 state travel
-// as tags in the diagnostic context instead.
+// Sentry fingerprints on the message, so this must not interpolate per-service or
+// per-state values — they travel as tags instead. Guarded by s6_diagnostic_message_test.go.
 func s6DirectoryHealthError(trigger string) error {
 	return fmt.Errorf("S6 directory health issue: trigger=%s", trigger)
 }

--- a/umh-core/pkg/fsm/benthos/actions.go
+++ b/umh-core/pkg/fsm/benthos/actions.go
@@ -301,12 +301,19 @@ func (b *BenthosInstance) logS6DirectoryStateAsync(
 	}
 
 	sentry.ReportIssueWithContext(
-		fmt.Errorf("S6 directory health issue: service=%s, state='%s', trigger=%s",
-			serviceName, s6State, trigger),
+		s6DirectoryHealthError(trigger),
 		sentry.IssueTypeWarning,
 		logger,
 		diagnosticContext,
 	)
+}
+
+// s6DirectoryHealthError builds the error Sentry groups the S6 directory health
+// diagnostics by. Sentry fingerprints on the message, so it carries only the
+// trigger, which has five bounded literals; the service name and S6 state travel
+// as tags in the diagnostic context instead.
+func s6DirectoryHealthError(trigger string) error {
+	return fmt.Errorf("S6 directory health issue: trigger=%s", trigger)
 }
 
 // CreateInstance attempts to add the Benthos to the S6 manager.

--- a/umh-core/pkg/fsm/benthos/s6_diagnostic_message_test.go
+++ b/umh-core/pkg/fsm/benthos/s6_diagnostic_message_test.go
@@ -1,0 +1,62 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package benthos
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	benthos_service "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/benthos"
+)
+
+// Sentry groups issues by the error message, so any per-service or per-state value
+// interpolated into this message mints a fresh issue for every bridge in every fleet.
+// The message may therefore vary only by trigger, which has five bounded literals
+// declared at the five logS6DirectoryState call sites.
+var _ = Describe("S6 directory health diagnostic message", func() {
+	It("varies only by trigger, never by service name or S6 state", func() {
+		Expect(s6DirectoryHealthError("degraded_before_restart").Error()).
+			To(Equal("S6 directory health issue: trigger=degraded_before_restart"))
+
+		// The five call sites: actions.go:569, actions.go:594,
+		// reconcile.go:434, reconcile.go:439, reconcile.go:485.
+		triggers := []string{
+			"IsBenthosS6Running_empty_state",
+			"IsBenthosS6Stopped_empty_state",
+			"degraded_before_restart",
+			"degraded_restart_failed",
+			"stopping_not_existing",
+		}
+		serviceNames := []string{
+			"bridge-line-3-oven",
+			"protocolconverter-press-07",
+			"streamprocessor-oee-rollup",
+		}
+
+		for _, trigger := range triggers {
+			message := s6DirectoryHealthError(trigger).Error()
+
+			Expect(message).To(ContainSubstring("trigger=" + trigger))
+
+			for _, serviceName := range serviceNames {
+				Expect(message).NotTo(ContainSubstring(serviceName),
+					"service name leaked into the message for trigger %s", trigger)
+			}
+
+			Expect(message).NotTo(ContainSubstring(benthos_service.S6StateNotExisting),
+				"S6 state leaked into the message for trigger %s", trigger)
+		}
+	})
+})


### PR DESCRIPTION
## Problem

Sentry alerts are too noisy. S6 directory health has >100 distinct Sentry issues because the service name is interpolated into the error message, and Sentry fingerprints on the message — so every new bridge name mints a new permanent issue.

## What we're shipping

The message now carries only `trigger`, which has five bounded literals across the five `logS6DirectoryState` call sites. Service name and S6 state continue to travel in `diagnosticContext`, which `pkg/sentry` promotes to searchable event tags — so nothing is lost on the Sentry side.

Plus a regression test that was observed failing before believing it: re-adding `service=%s` to the format string turns it red.

## What we're NOT shipping

* Not touching `pkg/sentry/sentry.go` / `{{ default }}` — that fingerprint is shared by \~146 FSMv1 call sites, and removing the default there would collapse unrelated errors into one issue per level.
* Not deleting any call site. The empty-state call on the `IsBenthosS6Stopped` success branch is separate work.
* No behaviour change: severity, control flow, retry and the 2h debounce are untouched.
* No retroactive merge. Existing issues keep their fingerprints and go quiet; bulk-resolving them is a separate step and must be resolve-in-release, or the next event regresses them.
* The WARN log line loses the service name. Accepted: that line is already debounce-gated, and the Debug diagnostics retain full detail.

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)