### PR TITLE
fix(fsmv2): Sentry stack traces name the caller, not the logger

### DIFF
--- a/umh-core/pkg/fsmv2/sentry/hook.go
+++ b/umh-core/pkg/fsmv2/sentry/hook.go
@@ -513,6 +513,8 @@ func IsInternalFrame(frame sentry.Frame) bool {
 
 	if strings.Contains(frame.Function, "captureToSentry") ||
 		strings.Contains(frame.Function, "SentryHook.Write") ||
+		strings.Contains(frame.Function, "SentryError") ||
+		strings.Contains(frame.Function, "SentryWarn") ||
 		strings.Contains(frame.Function, "zapcore.") {
 		return true
 	}

--- a/umh-core/pkg/fsmv2/sentry/hook_test.go
+++ b/umh-core/pkg/fsmv2/sentry/hook_test.go
@@ -155,6 +155,32 @@ main.second()
 			}
 			Expect(sentry.IsInternalFrame(frame)).To(BeFalse())
 		})
+
+		// The FSMLogger lives in pkg/fsmv2/deps, so without these two specs every
+		// fsmv2 Sentry issue attributes its culprit to (*zapLogger).SentryError
+		// rather than to the code that raised it.
+		It("should filter the fsmv2 deps logger frames", func() {
+			for _, fn := range []string{"(*zapLogger).SentryError", "(*zapLogger).SentryWarn"} {
+				frame := sentrygo.Frame{
+					Module:   "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps",
+					Function: fn,
+				}
+				Expect(sentry.IsInternalFrame(frame)).To(BeTrue(), "expected %s to be filtered", fn)
+			}
+		})
+
+		// Guards the tempting-but-wrong fix. Adding pkg/fsmv2/deps to
+		// internalPackagePrefixes would satisfy the spec above while erasing
+		// scheduler, history and metrics frames from every stack trace.
+		It("should NOT filter non-logger frames in the same deps package", func() {
+			for _, fn := range []string{"(*scheduler).Next", "(*history).Append", "RecordTick"} {
+				frame := sentrygo.Frame{
+					Module:   "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps",
+					Function: fn,
+				}
+				Expect(sentry.IsInternalFrame(frame)).To(BeFalse(), "expected %s to survive", fn)
+			}
+		})
 	})
 
 	Describe("extractErrorTypes", func() {


### PR DESCRIPTION
## Problem

Every FSMv2 Sentry issue shows its culprit as `(*zapLogger).SentryError`.

<img src="https://uploads.linear.app/b841b06f-b7b7-4eb1-85a2-13aa492de906/35372e58-c8a3-4c4c-b934-de492be1e428/4c5752fb-8025-4483-a4dd-417320ac4326?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiL2I4NDFiMDZmLWI3YjctNGViMS04NWEyLTEzYWE0OTJkZTkwNi8zNTM3MmU1OC1jOGEzLTRjNGMtYjkzNC1kZTQ5MmJlMWU0MjgvNGM1NzUyZmItODAyNS00NDgzLWE0ZGQtNDE3MzIwYWM0MzI2IiwiaWF0IjoxNzg2MzY4NzEyLCJleHAiOjE4MTc5MzkyNzJ9.OW7qaTJl2vD1qjQ046IfmPtZH2_Y27O-Zjm8a3XKSSo " alt="Screenshot 2026-08-10 at 15.31.47.png" width="1028" data-linear-height="101" />

## What we're shipping

Two terms added to the existing `frame.Function` check, beside `captureToSentry` / `SentryHook.Write` / `zapcore.`:

```go
strings.Contains(frame.Function, "SentryError") ||
strings.Contains(frame.Function, "SentryWarn") ||
```

## What we're NOT shipping

* No change to what is captured, grouped, or reported. Stack-trace contents only.