### PR TITLE
Memoize the rendered runtime config per bridge

### DIFF
--- a/umh-core/pkg/service/nmap/nmap.go
+++ b/umh-core/pkg/service/nmap/nmap.go
@@ -22,6 +22,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
@@ -37,6 +38,33 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/standarderrors"
 	"go.uber.org/zap"
 )
+
+// Compiled once. These used to be built inside parseScanLogs, which runs for every
+// bridge on every tick.
+var (
+	targetRegex    = regexp.MustCompile(`nmap -n -Pn -p \d+ ([^ ]+) -v`)
+	portRegex      = regexp.MustCompile(`-p (\d+)`)
+	timestampRegex = regexp.MustCompile(`NMAP_TIMESTAMP: (.+)`)
+	durationRegex  = regexp.MustCompile(`NMAP_DURATION: ([0-9.]+)`)
+	latencyRegex   = regexp.MustCompile(`Host is up \(([0-9.]+)s latency\).`)
+	errorRegex     = regexp.MustCompile(`(?im)^.*error.*$`)
+)
+
+// portStateRegexes caches the one pattern that depends on the port, so a bridge
+// compiles it once instead of on every tick.
+var portStateRegexes sync.Map // map[uint16]*regexp.Regexp
+
+func portStateRegex(port uint16) *regexp.Regexp {
+	if cached, found := portStateRegexes.Load(port); found {
+		return cached.(*regexp.Regexp)
+	}
+
+	re := regexp.MustCompile(`(?i)` + strconv.Itoa(int(port)) +
+		`/tcp\s+(open|closed|filtered|unfiltered|open\|filtered|closed\|filtered)`)
+	portStateRegexes.Store(port, re)
+
+	return re
+}
 
 // NmapService is the implementation of the INmapService interface.
 type NmapService struct {
@@ -151,13 +179,11 @@ func (s *NmapService) GetConfig(ctx context.Context, filesystemService filesyste
 	result := nmapserviceconfig.NmapServiceConfig{}
 
 	// Extract target
-	targetRegex := regexp.MustCompile(`nmap -n -Pn -p \d+ ([^ ]+) -v`)
 	if matches := targetRegex.FindStringSubmatch(string(scriptData)); len(matches) > 1 {
 		result.Target = matches[1]
 	}
 
 	// Extract port
-	portRegex := regexp.MustCompile(`-p (\d+)`)
 	if matches := portRegex.FindStringSubmatch(string(scriptData)); len(matches) > 1 {
 		port, err := strconv.Atoi(matches[1])
 		if err == nil {
@@ -174,39 +200,38 @@ func (s *NmapService) parseScanLogs(logs []s6service.LogEntry, port uint16) *Nma
 		return nil
 	}
 
-	// We'll reconstruct scan blocks from the logs
-	var (
-		currentScan []string
-		scanBlocks  [][]string
-	)
+	// Only the newest complete scan is used, so search from the end instead of
+	// collecting every block forward. The forward version touched all retained lines
+	// on every tick, and the buffer holds up to S6MaxLines of them.
+	//
+	// A block runs from a START to the first END after it. Searching from the last
+	// END instead would be wrong: after "START x END END" the forward version closed
+	// at the first END and ignored the second.
+	start, end := -1, -1
 
-	inScanBlock := false
-
-	// First, extract complete scan blocks from logs
-	for _, log := range logs {
-		switch {
-		case strings.Contains(log.Content, "NMAP_SCAN_START"):
-			inScanBlock = true
-			currentScan = []string{log.Content}
-		case strings.Contains(log.Content, "NMAP_SCAN_END"):
-			if inScanBlock {
-				currentScan = append(currentScan, log.Content)
-				scanBlocks = append(scanBlocks, currentScan)
-				currentScan = []string{}
-				inScanBlock = false
-			}
-		case inScanBlock:
-			currentScan = append(currentScan, log.Content)
+	for i := len(logs) - 1; i >= 0 && end < 0; i-- {
+		if !strings.Contains(logs[i].Content, "NMAP_SCAN_START") {
+			continue
 		}
+
+		for j := i + 1; j < len(logs); j++ {
+			if strings.Contains(logs[j].Content, "NMAP_SCAN_END") {
+				start, end = i, j
+				break
+			}
+		}
+		// No END after this START: it never closed, so keep looking further back.
 	}
 
-	// If no complete scans, return nil
-	if len(scanBlocks) == 0 {
+	if end < 0 {
 		return nil
 	}
 
-	// Parse the most recent complete scan
-	latestScan := scanBlocks[len(scanBlocks)-1]
+	latestScan := make([]string, 0, end-start+1)
+	for _, log := range logs[start : end+1] {
+		latestScan = append(latestScan, log.Content)
+	}
+
 	scanOutput := strings.Join(latestScan, "\n")
 
 	// Create the scan result
@@ -219,7 +244,6 @@ func (s *NmapService) parseScanLogs(logs []s6service.LogEntry, port uint16) *Nma
 	}
 
 	// Extract timestamp
-	timestampRegex := regexp.MustCompile(`NMAP_TIMESTAMP: (.+)`)
 	if matches := timestampRegex.FindStringSubmatch(scanOutput); len(matches) > 1 {
 		timestamp, err := time.Parse(time.RFC3339, matches[1])
 		if err == nil {
@@ -228,7 +252,6 @@ func (s *NmapService) parseScanLogs(logs []s6service.LogEntry, port uint16) *Nma
 	}
 
 	// Extract duration
-	durationRegex := regexp.MustCompile(`NMAP_DURATION: ([0-9.]+)`)
 	if matches := durationRegex.FindStringSubmatch(scanOutput); len(matches) > 1 {
 		duration, err := strconv.ParseFloat(matches[1], 64)
 		if err == nil {
@@ -237,15 +260,13 @@ func (s *NmapService) parseScanLogs(logs []s6service.LogEntry, port uint16) *Nma
 	}
 
 	// Extract port state
-	portStateRegex := regexp.MustCompile(`(?i)` + strconv.Itoa(int(port)) + `/tcp\s+(open|closed|filtered|unfiltered|open\|filtered|closed\|filtered)`)
-	if matches := portStateRegex.FindStringSubmatch(scanOutput); len(matches) > 1 {
+	if matches := portStateRegex(port).FindStringSubmatch(scanOutput); len(matches) > 1 {
 		result.PortResult.State = matches[1]
 	} else {
 		result.PortResult.State = "unknown"
 	}
 
 	// Extract latency (sample line: "Host is up (0.016s latency).")
-	latencyRegex := regexp.MustCompile(`Host is up \(([0-9.]+)s latency\).`)
 
 	matches := latencyRegex.FindStringSubmatch(scanOutput)
 	if len(matches) >= 2 {
@@ -258,7 +279,6 @@ func (s *NmapService) parseScanLogs(logs []s6service.LogEntry, port uint16) *Nma
 	}
 
 	// Extract errors if occurred (case-insensitive)
-	errorRegex := regexp.MustCompile(`(?im)^.*error.*$`)
 	if matches := errorRegex.FindString(scanOutput); matches != "" {
 		result.Error = matches
 	}

--- a/umh-core/pkg/service/protocolconverter/runtime_config/runtime_config.go
+++ b/umh-core/pkg/service/protocolconverter/runtime_config/runtime_config.go
@@ -20,6 +20,8 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/connectionserviceconfig"
@@ -77,6 +79,72 @@ const BridgedByPlaceholder = "unimplemented"
 //     Protocol-Converter FSM.
 //
 // It does NOT belong to the service.
+
+// renderMemoEntry is one bridge's last render plus every input that produced it,
+// so a hit can be proven by comparison rather than assumed.
+type renderMemoEntry struct {
+	historian     *config.HistorianConfig
+	agentLocation map[string]string
+	globalVars    map[string]any
+	nodeName      string
+	spec          protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec
+	result        protocolconverterserviceconfig.ProtocolConverterServiceConfigRuntime
+}
+
+// renderMemo caches the last render per bridge, keyed by pcName. BuildRuntimeConfig
+// runs for every bridge on every tick and is a pure function of its arguments, which
+// only change when the config file does. A profile attributed 12.9% of all CPU to the
+// render it repeats.
+//
+// Two preconditions hold today, neither of them enforced by the compiler.
+//
+// BuildRuntimeConfig must stay pure, and the guard must compare every argument. Specs
+// in runtime_config_test.go cover each one. A new argument needs a new case.
+//
+// The result must be treated as read-only. Its nested maps (BenthosConfig.Input,
+// Output, Pipeline) are shared with the cached value, so mutating one poisons later
+// ticks for that bridge. Callers that need to mutate must deep-copy first.
+
+// renderMemoMaxEntries bounds the map. Keys are bridge names, entries are never
+// removed on their own, and each one holds a fully rendered config. Live bridges stay
+// far below this, so reaching it means stale names have accumulated.
+const renderMemoMaxEntries = 512
+
+var (
+	renderMemo    sync.Map // map[string]renderMemoEntry
+	renderMemoLen atomic.Int64
+)
+
+// storeRenderMemo adds an entry and evicts once the map exceeds its bound. Order is
+// unspecified and may drop a live bridge, which then pays one render and is cached
+// again.
+func storeRenderMemo(pcName string, entry renderMemoEntry) {
+	if _, existed := renderMemo.Swap(pcName, entry); !existed {
+		renderMemoLen.Add(1)
+	}
+
+	if renderMemoLen.Load() <= renderMemoMaxEntries {
+		return
+	}
+
+	// Down to half, so eviction stays rare instead of running on nearly every store.
+	renderMemo.Range(func(key, _ any) bool {
+		if renderMemoLen.Load() <= renderMemoMaxEntries/2 {
+			return false
+		}
+
+		if key == pcName {
+			return true
+		}
+
+		if _, existed := renderMemo.LoadAndDelete(key); existed {
+			renderMemoLen.Add(-1)
+		}
+
+		return true
+	})
+}
+
 func BuildRuntimeConfig(
 	spec protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec,
 	agentLocation map[string]string,
@@ -88,6 +156,17 @@ func BuildRuntimeConfig(
 	if reflect.DeepEqual(spec, protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec{}) {
 		return protocolconverterserviceconfig.ProtocolConverterServiceConfigRuntime{},
 			errors.New("nil spec")
+	}
+
+	if cached, found := renderMemo.Load(pcName); found {
+		if entry, ok := cached.(renderMemoEntry); ok &&
+			entry.nodeName == nodeName &&
+			reflect.DeepEqual(entry.spec, spec) &&
+			reflect.DeepEqual(entry.agentLocation, agentLocation) &&
+			reflect.DeepEqual(entry.globalVars, globalVars) &&
+			reflect.DeepEqual(entry.historian, historian) {
+			return entry.result, nil
+		}
 	}
 
 	pcLocation := make(map[string]string, len(spec.Location))
@@ -234,6 +313,20 @@ func BuildRuntimeConfig(
 	if err != nil && !historianUsable && referencesMissingHistorian(err) {
 		return runtime, fmt.Errorf(
 			"this bridge references {{ .historian.* }} but no valid historian: section is configured in config.yaml; add or fix it: %w", err)
+	}
+
+	// Only successful renders are memoised. Caching a failure would pin the error
+	// until the config changed, hiding a recovery (e.g. the historian section being
+	// fixed), and errors are the rare path anyway.
+	if err == nil {
+		storeRenderMemo(pcName, renderMemoEntry{
+			spec:          spec,
+			agentLocation: agentLocation,
+			globalVars:    globalVars,
+			historian:     historian,
+			nodeName:      nodeName,
+			result:        runtime,
+		})
 	}
 
 	return runtime, err

--- a/umh-core/pkg/service/protocolconverter/runtime_config/runtime_config_test.go
+++ b/umh-core/pkg/service/protocolconverter/runtime_config/runtime_config_test.go
@@ -635,4 +635,106 @@ var _ = Describe("BuildRuntimeConfig", func() {
 			Expect(firstProc).To(HaveKey("nodered_js"))
 		})
 	})
+
+	// The memo is only sound while BuildRuntimeConfig stays a pure function of its
+	// arguments and its guard compares every one of them. Nothing enforces either: a
+	// later argument, or a read of some global, would make the cache serve a stale
+	// config indefinitely — a wrong config, not a slow one. These specs are the
+	// guard; add a case whenever an argument is added.
+	Describe("memoisation", func() {
+		// pcName reaches the rendered output through bridged_by, so a comparison is
+		// only meaningful under one and the same name.
+		var userVars func(port string) map[string]any
+
+		BeforeEach(func() {
+			userVars = func(port string) map[string]any {
+				out := map[string]any{}
+				for k, v := range spec.Variables.User {
+					out[k] = v
+				}
+
+				out["PORT"] = port
+
+				return out
+			}
+		})
+
+		It("replays an answer indistinguishable from the rendered one", func() {
+			name := "memo-guard-replay"
+
+			rendered, err := runtime_config.BuildRuntimeConfig(
+				spec, agentLocation, globalVars, nil, nodeName, name)
+			Expect(err).NotTo(HaveOccurred())
+
+			replayed, err := runtime_config.BuildRuntimeConfig(
+				spec, agentLocation, globalVars, nil, nodeName, name)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(replayed).To(Equal(rendered))
+		})
+
+		It("renders again after an argument changes back", func() {
+			name := "memo-guard-roundtrip"
+
+			original, err := runtime_config.BuildRuntimeConfig(
+				spec, agentLocation, globalVars, nil, nodeName, name)
+			Expect(err).NotTo(HaveOccurred())
+
+			changed := spec
+			changed.Variables.User = userVars("9999")
+
+			_, err = runtime_config.BuildRuntimeConfig(
+				changed, agentLocation, globalVars, nil, nodeName, name)
+			Expect(err).NotTo(HaveOccurred())
+
+			back, err := runtime_config.BuildRuntimeConfig(
+				spec, agentLocation, globalVars, nil, nodeName, name)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(back).To(Equal(original),
+				"the cache must re-render, not keep serving the intermediate answer")
+		})
+
+		DescribeTable("notices a changed argument",
+			func(label string, mutate func() (protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec,
+				map[string]string, map[string]any, *config.HistorianConfig, string)) {
+				name := "memo-guard-" + label
+
+				before, err := runtime_config.BuildRuntimeConfig(
+					spec, agentLocation, globalVars, nil, nodeName, name)
+				Expect(err).NotTo(HaveOccurred())
+
+				mSpec, mLoc, mVars, mHist, mNode := mutate()
+
+				after, err := runtime_config.BuildRuntimeConfig(
+					mSpec, mLoc, mVars, mHist, mNode, name)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(after).NotTo(Equal(before),
+					"the cache replayed its entry although %s changed", label)
+			},
+			Entry("spec", "spec", func() (protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec,
+				map[string]string, map[string]any, *config.HistorianConfig, string) {
+				changed := spec
+				changed.Variables.User = userVars("9999")
+
+				return changed, agentLocation, globalVars, nil, nodeName
+			}),
+			Entry("agentLocation", "agentLocation", func() (protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec,
+				map[string]string, map[string]any, *config.HistorianConfig, string) {
+				changed := map[string]string{}
+				for k, v := range agentLocation {
+					changed[k] = v
+				}
+
+				changed["0"] = "somewhere-else"
+
+				return spec, changed, globalVars, nil, nodeName
+			}),
+			Entry("nodeName", "nodeName", func() (protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec,
+				map[string]string, map[string]any, *config.HistorianConfig, string) {
+				return spec, agentLocation, globalVars, nil, "a-different-node"
+			}),
+		)
+	})
 })


### PR DESCRIPTION
## Problem

Based on PR #2692 

Two things in the reconcile loop redo their full work on every tick, whether or not
anything they depend on has changed. Each bridge's configuration is rebuilt from its
template, and each nmap check re-scans everything still sitting in that service's log
buffer to work out the result of the newest scan. On instances with many bridges the
two together are most of what the loop does.

## What we are shipping

- A bridge's built configuration is kept and reused until one of the inputs that
  produced it actually differs. Instances with many bridges get noticeably more
  reconcile time back, and CPU drops with it.
- Reuse is never assumed. Every input is stored alongside the result and compared on
  each call, so a stale answer cannot survive a config change even if nothing notifies
  us about it. What is kept is bounded, so bridges created and deleted over a long
  time cannot accumulate.
- Reading an nmap result no longer depends on how much log history a service has kept.
  It looks for the newest scan from the end and stops there instead of walking
  everything, and the patterns it matches with are prepared once rather than rebuilt on
  every check.

## What we are NOT shipping

- Anything that reduces how often the loop compares a bridge's desired and running
  configuration. That comparison is the point of reconciling and has to happen every
  tick. Only the work in front of it is now skipped.
- The same treatment for benthos, which reads its service logs the same way and was
  not touched here.
- A change to how service logs are handed to the code that reads them. Each read still
  copies the whole retained buffer even when almost none of it is new. That is the next
  thing worth looking at and needs its own change.

Fixes ENG-5561
