### PR TITLE
allowInsecureTLS reaches the transport again (groundwork)

### DIFF
--- a/umh-core/cmd/renderer.go
+++ b/umh-core/cmd/renderer.go
@@ -41,6 +41,11 @@ type communicatorSpec struct {
 	AuthToken    string `yaml:"authToken"`
 	Timeout      string `yaml:"timeout"`
 	State        string `yaml:"state"`
+	// AllowInsecureTLS forwards agent.allowInsecureTLS to the communicator,
+	// which passes it to its transport child. The legacy communicator read the
+	// config field directly; with that path deleted, this is the only route
+	// from config.yaml to the HTTP client that honours it.
+	AllowInsecureTLS bool `yaml:"allowInsecureTLS"`
 }
 
 // renderSupervisorChildrenYAML renders the FSMv2 supervisor children document.
@@ -60,11 +65,12 @@ func renderSupervisorChildrenYAML(cfg config.AgentConfig, instanceUUID string) (
 
 	if cfg.APIURL != "" && cfg.AuthToken != "" {
 		specBytes, err := yaml.Marshal(communicatorSpec{
-			RelayURL:     cfg.APIURL,
-			InstanceUUID: instanceUUID,
-			AuthToken:    cfg.AuthToken,
-			Timeout:      "10s",
-			State:        "running",
+			RelayURL:         cfg.APIURL,
+			InstanceUUID:     instanceUUID,
+			AuthToken:        cfg.AuthToken,
+			Timeout:          "10s",
+			State:            "running",
+			AllowInsecureTLS: cfg.AllowInsecureTLS,
 		})
 		if err != nil {
 			return "", fmt.Errorf("marshal communicator userSpec config: %w", err)

--- a/umh-core/cmd/renderer_test.go
+++ b/umh-core/cmd/renderer_test.go
@@ -43,9 +43,10 @@ var _ = Describe("renderSupervisorChildrenYAML", func() {
 		Children []decodedChild `yaml:"children"`
 	}
 	type decodedUserConfig struct {
-		RelayURL     string `yaml:"relayURL"`
-		InstanceUUID string `yaml:"instanceUUID"`
-		AuthToken    string `yaml:"authToken"`
+		RelayURL         string `yaml:"relayURL"`
+		InstanceUUID     string `yaml:"instanceUUID"`
+		AuthToken        string `yaml:"authToken"`
+		AllowInsecureTLS bool   `yaml:"allowInsecureTLS"`
 	}
 
 	childNames := func(doc string) []string {
@@ -97,10 +98,13 @@ var _ = Describe("renderSupervisorChildrenYAML", func() {
 			authToken       = "token\"with\\backslash\nand-newline"
 			placeholderUUID = "placeholder-1234"
 		)
-		credentialed := config.AgentConfig{CommunicatorConfig: config.CommunicatorConfig{
-			APIURL:    relayURL,
-			AuthToken: authToken,
-		}}
+		credentialed := config.AgentConfig{
+			CommunicatorConfig: config.CommunicatorConfig{
+				APIURL:           relayURL,
+				AuthToken:        authToken,
+				AllowInsecureTLS: true,
+			},
+		}
 		doc := render(credentialed, placeholderUUID)
 		Expect(childNames(doc)).To(ContainElement("persistence"))
 		Expect(childNames(doc)).To(ContainElement("communicator"))
@@ -121,6 +125,11 @@ var _ = Describe("renderSupervisorChildrenYAML", func() {
 		Expect(userCfg.RelayURL).To(Equal(relayURL))
 		Expect(userCfg.AuthToken).To(Equal(authToken))
 		Expect(userCfg.InstanceUUID).To(Equal(placeholderUUID))
+		// agent.allowInsecureTLS has no other route to the HTTP client since the
+		// legacy communicator that read it directly was deleted. If it stops
+		// being emitted here, the flag goes quietly dead again.
+		Expect(userCfg.AllowInsecureTLS).To(BeTrue(),
+			"allowInsecureTLS must be rendered into the communicator's userSpec")
 
 		// Partial credentials (only API URL) are treated as no credentials
 		// (E2): the existing && contract must be preserved in the renderer.

--- a/umh-core/pkg/fsmv2/workers/communicator/children.go
+++ b/umh-core/pkg/fsmv2/workers/communicator/children.go
@@ -28,11 +28,12 @@ import (
 // The child is never removed because it holds connection buffers and retry state.
 func RenderChildren(cfg CommunicatorConfig, enabled bool) ([]config.ChildSpec, error) {
 	childCfg := transport.TransportUserSpec{
-		BaseUserSpec: cfg.BaseUserSpec,
-		RelayURL:     cfg.RelayURL,
-		InstanceUUID: cfg.InstanceUUID,
-		AuthToken:    cfg.AuthToken,
-		Timeout:      cfg.Timeout,
+		BaseUserSpec:     cfg.BaseUserSpec,
+		RelayURL:         cfg.RelayURL,
+		InstanceUUID:     cfg.InstanceUUID,
+		AuthToken:        cfg.AuthToken,
+		Timeout:          cfg.Timeout,
+		AllowInsecureTLS: cfg.AllowInsecureTLS,
 	}
 
 	spec, err := config.NewChildSpec("transport", "transport", childCfg, enabled)

--- a/umh-core/pkg/fsmv2/workers/communicator/children_test.go
+++ b/umh-core/pkg/fsmv2/workers/communicator/children_test.go
@@ -38,10 +38,11 @@ var _ = Describe("communicator RenderChildren 4-field round-trip", func() {
 
 	BeforeEach(func() {
 		cfg = communicator.CommunicatorConfig{
-			RelayURL:     "https://relay.example.com:8080",
-			InstanceUUID: "test-uuid-1234",
-			AuthToken:    "secret-auth-token-xyz",
-			Timeout:      42 * time.Second,
+			RelayURL:         "https://relay.example.com:8080",
+			InstanceUUID:     "test-uuid-1234",
+			AuthToken:        "secret-auth-token-xyz",
+			Timeout:          42 * time.Second,
+			AllowInsecureTLS: true,
 		}
 	})
 
@@ -69,6 +70,10 @@ var _ = Describe("communicator RenderChildren 4-field round-trip", func() {
 			"AuthToken missing = unauthenticated transport child after the cutover")
 		Expect(recovered.Timeout).To(Equal(42*time.Second),
 			"Timeout must survive the round-trip")
+		Expect(recovered.AllowInsecureTLS).To(BeTrue(),
+			"AllowInsecureTLS dropped here means an operator with a self-signed "+
+				"Management Console certificate silently cannot connect: the transport "+
+				"child owns the HTTP client, and this is the only route to it")
 	})
 
 	It("sets Enabled=true when enabled=true", func() {

--- a/umh-core/pkg/fsmv2/workers/communicator/config.go
+++ b/umh-core/pkg/fsmv2/workers/communicator/config.go
@@ -29,6 +29,10 @@ type CommunicatorConfig struct {
 	InstanceUUID string        `json:"instanceUUID" yaml:"instanceUUID"`
 	AuthToken    string        `json:"authToken"    yaml:"authToken"`
 	Timeout      time.Duration `json:"timeout"      yaml:"timeout"`
+	// AllowInsecureTLS is agent.allowInsecureTLS. The communicator does not use
+	// it itself; it forwards it to the transport child, which owns the HTTP
+	// client that either verifies the certificate or does not.
+	AllowInsecureTLS bool `json:"allowInsecureTLS" yaml:"allowInsecureTLS"`
 }
 
 // CommunicatorStatus holds the runtime observation data for the communicator worker.

--- a/umh-core/pkg/fsmv2/workers/transport/action/authenticate.go
+++ b/umh-core/pkg/fsmv2/workers/transport/action/authenticate.go
@@ -53,20 +53,26 @@ type AuthenticateAction struct {
 	InstanceUUID string
 	AuthToken    string
 	Timeout      time.Duration
+	// AllowInsecureTLS carries agent.allowInsecureTLS through to the transport
+	// this action constructs. It exists so an operator pointing umh-core at a
+	// Management Console with a self-signed certificate can still connect;
+	// without it the transport always verifies and there is no way to opt out.
+	AllowInsecureTLS bool
 }
 
 // NewAuthenticateAction creates a new authentication action.
 // Timeout defaults to DefaultAuthenticateTimeout if 0. Dependencies injected via Execute().
-func NewAuthenticateAction(relayURL, instanceUUID, authToken string, timeout time.Duration) *AuthenticateAction {
+func NewAuthenticateAction(relayURL, instanceUUID, authToken string, timeout time.Duration, allowInsecureTLS bool) *AuthenticateAction {
 	if timeout == 0 {
 		timeout = DefaultAuthenticateTimeout
 	}
 
 	return &AuthenticateAction{
-		RelayURL:     relayURL,
-		InstanceUUID: instanceUUID,
-		AuthToken:    authToken,
-		Timeout:      timeout,
+		RelayURL:         relayURL,
+		InstanceUUID:     instanceUUID,
+		AuthToken:        authToken,
+		Timeout:          timeout,
+		AllowInsecureTLS: allowInsecureTLS,
 	}
 }
 
@@ -87,7 +93,7 @@ func (a *AuthenticateAction) Execute(ctx context.Context, depsAny any) error {
 	}
 
 	if deps.GetTransport() == nil {
-		newTransport := httpTransport.NewHTTPTransport(a.RelayURL, a.Timeout, false)
+		newTransport := httpTransport.NewHTTPTransport(a.RelayURL, a.Timeout, a.AllowInsecureTLS)
 		deps.SetTransport(newTransport)
 	}
 

--- a/umh-core/pkg/fsmv2/workers/transport/action/authenticate_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/action/authenticate_test.go
@@ -48,6 +48,7 @@ var _ = Describe("AuthenticateAction", func() {
 			"test-uuid",
 			"test-token",
 			10*time.Second,
+			false,
 		)
 	})
 
@@ -62,8 +63,8 @@ var _ = Describe("AuthenticateAction", func() {
 			// AuthenticateAction should only have config fields, no mutable state
 			// This is verified by the architecture test, but we confirm the constructor
 			// sets fields correctly without any runtime state
-			act1 := action.NewAuthenticateAction("url1", "uuid1", "token1", 5*time.Second)
-			act2 := action.NewAuthenticateAction("url2", "uuid2", "token2", 15*time.Second)
+			act1 := action.NewAuthenticateAction("url1", "uuid1", "token1", 5*time.Second, false)
+			act2 := action.NewAuthenticateAction("url2", "uuid2", "token2", 15*time.Second, false)
 
 			// Different instances should have different config
 			Expect(act1.RelayURL).To(Equal("url1"))
@@ -71,8 +72,22 @@ var _ = Describe("AuthenticateAction", func() {
 		})
 
 		It("should default timeout to 10s if zero", func() {
-			act := action.NewAuthenticateAction("url", "uuid", "token", 0)
+			act := action.NewAuthenticateAction("url", "uuid", "token", 0, false)
 			Expect(act.Timeout).To(Equal(10 * time.Second))
+		})
+
+		// The transport this action builds is the only place certificate
+		// verification can be relaxed, and it was previously constructed with a
+		// hardcoded false. If the flag stops arriving here, an operator with a
+		// self-signed Management Console certificate silently cannot connect.
+		It("carries allowInsecureTLS through to the transport it constructs", func() {
+			secure := action.NewAuthenticateAction("url", "uuid", "token", 0, false)
+			Expect(secure.AllowInsecureTLS).To(BeFalse(),
+				"the safe default must stay false when not asked for")
+
+			insecure := action.NewAuthenticateAction("url", "uuid", "token", 0, true)
+			Expect(insecure.AllowInsecureTLS).To(BeTrue(),
+				"agent.allowInsecureTLS must reach the action that builds the HTTP transport")
 		})
 	})
 
@@ -109,6 +124,7 @@ var _ = Describe("AuthenticateAction", func() {
 				"test-uuid",
 				"test-token",
 				10*time.Second,
+				false,
 			)
 
 			ctx := context.Background()

--- a/umh-core/pkg/fsmv2/workers/transport/snapshot/snapshot.go
+++ b/umh-core/pkg/fsmv2/workers/transport/snapshot/snapshot.go
@@ -82,6 +82,10 @@ type TransportDesiredState struct {
 	// adding a CSE secret tier to persist locally but exclude from delta sync.
 	AuthToken string `json:"authToken"`
 	RelayURL  string `json:"relayURL"`
+	// AllowInsecureTLS mirrors agent.allowInsecureTLS so the transport this
+	// worker builds can skip certificate verification when an operator has
+	// deliberately asked for it (self-signed Management Console certificate).
+	AllowInsecureTLS bool `json:"allowInsecureTLS"`
 
 	// State is the desired lifecycle state ("stopped" or "running").
 	//

--- a/umh-core/pkg/fsmv2/workers/transport/state/state_starting.go
+++ b/umh-core/pkg/fsmv2/workers/transport/state/state_starting.go
@@ -73,6 +73,7 @@ func (s *StartingState) Next(snapAny any) fsmv2.NextResult[any, any] {
 			snap.Config.InstanceUUID,
 			snap.Config.AuthToken,
 			snap.Config.Timeout,
+			snap.Config.AllowInsecureTLS,
 		)
 
 		return fsmv2.Transition(s, fsmv2.SignalNone, authAction, "No valid token, authenticating with relay", childrenAlive(snap.Config, snap.Status))

--- a/umh-core/pkg/fsmv2/workers/transport/userspec.go
+++ b/umh-core/pkg/fsmv2/workers/transport/userspec.go
@@ -28,4 +28,7 @@ type TransportUserSpec struct {
 	InstanceUUID        string        `json:"instanceUUID" yaml:"instanceUUID"`
 	AuthToken           string        `json:"authToken"    yaml:"authToken"`
 	Timeout             time.Duration `json:"timeout"      yaml:"timeout"`
+	// AllowInsecureTLS is agent.allowInsecureTLS, forwarded by the communicator
+	// parent. Absent means verify, which is the safe default.
+	AllowInsecureTLS bool `json:"allowInsecureTLS" yaml:"allowInsecureTLS"`
 }

--- a/umh-core/pkg/fsmv2/workers/transport/worker.go
+++ b/umh-core/pkg/fsmv2/workers/transport/worker.go
@@ -203,10 +203,11 @@ func (w *TransportWorker) DeriveDesiredState(spec interface{}) (fsmv2.DesiredSta
 
 	return &fsmv2.WrappedDesiredState[snapshot.TransportDesiredState]{
 		Config: snapshot.TransportDesiredState{
-			RelayURL:     transportSpec.RelayURL,
-			InstanceUUID: transportSpec.InstanceUUID,
-			AuthToken:    transportSpec.AuthToken,
-			Timeout:      transportSpec.Timeout,
+			RelayURL:         transportSpec.RelayURL,
+			InstanceUUID:     transportSpec.InstanceUUID,
+			AuthToken:        transportSpec.AuthToken,
+			Timeout:          transportSpec.Timeout,
+			AllowInsecureTLS: transportSpec.AllowInsecureTLS,
 		},
 	}, nil
 }


### PR DESCRIPTION
> Stacked on #2687. ⚠️ **Groundwork only — not ready for review.** The finished change will be built via VSDD from a spec; this branch exists so the wiring is not lost and so #2698 does not have to carry it.

### Problem

`ALLOW_INSECURE_TLS` lets an operator connect umh-core to a Management Console with a self-signed certificate, or through a corporate TLS-inspecting proxy. It has been silently dead on default installs since FSMv2 became the default in v0.44.9 — the FSMv2 transport had no insecure option at all. #2698 gives the transport that option but passes a hardcoded `false`, and deletes the legacy communicator that was the only code reading the config value. So the flag reads as supported, is documented as supported, and does nothing.

### What we're shipping

- **The value reaches the client.** `agent.communicator.allowInsecureTLS` now travels from `config.yaml` through the renderer, the communicator, the transport worker and the authenticate action to `NewHTTPTransport`.
- Verified end to end rather than field-copied: `AuthenticateAction.Execute` against an `httptest.NewTLSServer` obtains a JWT with the flag on and no token with it off.
- Push and pull need no change — both return the parent's transport, so they inherit the setting.

### What we're NOT shipping

Four known defects, deliberately left for the VSDD pass rather than bolted on here:

- **`Reset()` discards the operator's choice.** `http.go:493` rebuilds the client with `insecure` hardcoded `false`, so any transport reset silently re-enables verification. The trigger is routine (five accumulated network errors) and it does not self-heal: the parent error counter only clears on auth success, and auth fails too once the client verifies.
- **The TLS 1.0 floor is gone.** The legacy client dropped to TLS 1.0 on the insecure path; the floor is now Go's default 1.2, while `deployment-security.md:94` still promises 1.0. That breaks exactly the operators the flag exists for. Jeremy's call: restore the floor.
- **Three of eight hops have no runtime guard**, including the `NewHTTPTransport` argument itself — the original bug can be reinstated with the whole suite green.
- **A cross-type yaml tag contract is untested.** `renderer.go` marshals its own `communicatorSpec`; `communicator/worker.go` unmarshals `CommunicatorConfig`. Two independently declared tags must agree by string and nothing compares them.

Also unfixed: six comments say `agent.allowInsecureTLS` when the real key is `agent.communicator.allowInsecureTLS`, and `docs/getting-started/README.md:65` tells operators to set it unnested.

### Confidence

`TODO — for Jeremy. This section is human-only; please fill it in.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
