### PR TITLE
nmap: report the config the scan actually dialled, not the requested one (ENG-5579)

### DIFF
--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Bridge connection edits to an unreachable port no longer report the deployment as successful and skip the rollback, on instances running the FSMv2 connection probe (`NMAP_BACKEND=fsmv2`, off by default). The check compared the requested port against itself instead of against the port that was actually probed, so it passed on the first attempt
+
 ## [0.44.34]
 
 ### Improvements

--- a/umh-core/pkg/fsmv2/nmap/manager.go
+++ b/umh-core/pkg/fsmv2/nmap/manager.go
@@ -21,6 +21,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/nmapserviceconfig"
 	publicfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
 	nmapfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/nmap"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/adapter"
@@ -92,12 +93,18 @@ func mapFresh(_ config.NmapConfig, s simple.Status[NmapStatus]) string {
 	}
 }
 
-// mapObserved builds a nmapfsm.NmapObservedState from the config and the stored
-// status: the observed service config comes from the config entry, and the
-// ServiceInfo mirrors the last scan (port state, port, latency, running).
-func mapObserved(cfg config.NmapConfig, s simple.Status[NmapStatus]) publicfsm.ObservedState {
+// mapObserved builds a nmapfsm.NmapObservedState from the stored status. Both
+// Target and Port come from the status — what the scan actually dialled — with
+// no echo of the requested config. A requested edit that has not yet been
+// dialled therefore reads as unobserved, so a target-diffing consumer (the
+// deploy gate) keeps waiting for a genuine scan. The ServiceInfo mirrors the
+// last scan (port state, port, latency, running).
+func mapObserved(_ config.NmapConfig, s simple.Status[NmapStatus]) publicfsm.ObservedState {
 	return nmapfsm.NmapObservedState{
-		ObservedNmapServiceConfig: cfg.NmapServiceConfig,
+		ObservedNmapServiceConfig: nmapserviceconfig.NmapServiceConfig{
+			Target: s.Result.Target,
+			Port:   s.Result.Port,
+		},
 		ServiceInfo: nmapservice.ServiceInfo{
 			NmapStatus: nmapservice.NmapServiceInfo{
 				IsRunning: s.Result.IsRunning,

--- a/umh-core/pkg/fsmv2/nmap/manager_test.go
+++ b/umh-core/pkg/fsmv2/nmap/manager_test.go
@@ -146,7 +146,7 @@ var _ = Describe("NewFsmv2NmapManager", func() {
 	})
 
 	It("builds a NmapObservedState reflecting the status and config", func() {
-		stageClient(freshStatus(NmapStatus{PortState: "open", IsRunning: true, Port: port, LatencyMs: 7}), nil)
+		stageClient(freshStatus(NmapStatus{Target: target, PortState: "open", IsRunning: true, Port: port, LatencyMs: 7}), nil)
 
 		mgr := NewFsmv2NmapManager("test")
 
@@ -166,6 +166,38 @@ var _ = Describe("NewFsmv2NmapManager", func() {
 		Expect(nmapObserved.ServiceInfo.NmapStatus.LastScan).NotTo(BeNil())
 		Expect(nmapObserved.ServiceInfo.NmapStatus.LastScan.PortResult.State).To(Equal("open"))
 		Expect(nmapObserved.ServiceInfo.NmapStatus.LastScan.PortResult.Port).To(Equal(port))
+	})
+
+	It("reports the config the scan actually dialled, not the requested config", func() {
+		// Stage a scan reported at 10.0.0.1:502 while the snapshot asks for
+		// 10.0.0.2:445. mapObserved must reflect what the scan dialled, so a
+		// consumer (the deploy gate) can see that a requested edit has not yet
+		// taken effect.
+		stageClient(freshStatus(NmapStatus{
+			PortState: "open",
+			IsRunning: true,
+			Port:      502,
+			Target:    "10.0.0.1",
+			LatencyMs: 7,
+		}), nil)
+
+		mgr := NewFsmv2NmapManager("test")
+
+		requested := nmapConfig("running")
+		requested.NmapServiceConfig.Target = "10.0.0.2"
+		requested.NmapServiceConfig.Port = 445
+
+		err, _ := mgr.Reconcile(context.Background(), snapshotWith(requested), nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		observed, err := mgr.GetLastObservedState(name)
+		Expect(err).NotTo(HaveOccurred())
+
+		nmapObserved, ok := observed.(nmapfsm.NmapObservedState)
+		Expect(ok).To(BeTrue(), "expected a nmapfsm.NmapObservedState")
+
+		Expect(nmapObserved.ObservedNmapServiceConfig.Port).To(Equal(uint16(502)), "observed port must be the port the scan dialled, not the requested one")
+		Expect(nmapObserved.ObservedNmapServiceConfig.Target).To(Equal("10.0.0.1"), "observed target must be the target the scan dialled, not the requested one")
 	})
 
 	It("extracts configs from the snapshot and Upserts the enabled worker's ref", func() {

--- a/umh-core/pkg/fsmv2/nmap/nmap.go
+++ b/umh-core/pkg/fsmv2/nmap/nmap.go
@@ -45,6 +45,8 @@ const (
 
 // NmapStatus is the result of one TCP-dial observation of the target port.
 type NmapStatus struct {
+	// Target is the hostname or IP address the scan dialled.
+	Target string `json:"target"`
 	// PortState is one of nmapfsm.PortStateOpen or nmapfsm.PortStateClosed.
 	PortState string `json:"port_state"`
 	// LatencyMs is the dial round-trip time in milliseconds. Zero unless the
@@ -77,10 +79,11 @@ func Poll(ctx context.Context, _ struct{}, cfg config.NmapConfig) (NmapStatus, e
 		// as shutdown reports cancelled, not closed. A deadline
 		// (ObservationTimeout) is not a shutdown: it falls through to closed.
 		if errors.Is(ctx.Err(), context.Canceled) {
-			return NmapStatus{Port: cfg.NmapServiceConfig.Port}, fmt.Errorf("scan cancelled: %w", ctx.Err())
+			return NmapStatus{Target: cfg.NmapServiceConfig.Target, Port: cfg.NmapServiceConfig.Port}, fmt.Errorf("scan cancelled: %w", ctx.Err())
 		}
 
 		return NmapStatus{
+			Target:    cfg.NmapServiceConfig.Target,
 			PortState: string(nmapfsm.PortStateClosed),
 			Port:      cfg.NmapServiceConfig.Port,
 		}, nil
@@ -90,6 +93,7 @@ func Poll(ctx context.Context, _ struct{}, cfg config.NmapConfig) (NmapStatus, e
 	_ = conn.Close()
 
 	return NmapStatus{
+		Target:    cfg.NmapServiceConfig.Target,
 		PortState: string(nmapfsm.PortStateOpen),
 		LatencyMs: elapsedMs,
 		Port:      cfg.NmapServiceConfig.Port,

--- a/umh-core/pkg/fsmv2/nmap/nmap_test.go
+++ b/umh-core/pkg/fsmv2/nmap/nmap_test.go
@@ -71,6 +71,25 @@ var _ = Describe("Nmap Poll", func() {
 		Expect(status.LatencyMs).To(BeNumerically(">=", 0))
 	})
 
+	It("records the target and port it dialled", func() {
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		Expect(err).NotTo(HaveOccurred())
+
+		defer func() { _ = ln.Close() }()
+
+		host, p := hostPort(ln.Addr().String())
+		cfg := newNmapConfig(host, p)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		st, err := fsmv2nmap.Poll(ctx, struct{}{}, cfg)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(st.Target).To(Equal(host), "Poll must record the target it dialled")
+		Expect(st.Port).To(Equal(uint16(p)), "Poll must record the port it dialled") //nolint:unconvert // verbatim rung assertion: choose only uint16 to spell the port type
+	})
+
 	It("reports a closed port without an error when the connection is refused", func() {
 		// Bind a listener to grab a free loopback port, then close it so the
 		// kernel answers the dial with a TCP RST (connection refused). A refused


### PR DESCRIPTION
## Problem

On instances running the FSMv2 connection probe (`NMAP_BACKEND=fsmv2`, off by default), `mapObserved` built the observed nmap config out of the **requested** config entry rather than out of the scan result. Observed and desired were therefore equal by construction, so a consumer that diffs them to decide "has this edit rolled out yet" got `true` before any scan had run. The connection-edit deploy gate is such a consumer: it reported the deployment as rolled out on the first attempt and skipped the rollback.

## Shipping

`mapObserved` reads `Target` and `Port` from the stored status, so it reports the address the scan actually dialled. `NmapStatus` gains a `Target` field and `Poll` populates it on every return path. Before the first scan of an edited config the status is empty, so the observed config no longer matches the requested one and a target-diffing consumer keeps waiting for a genuine observation.

Tests: `manager_test.go` asserts the observed config comes from the status and not the config entry; `nmap_test.go` asserts `Poll` reports the dialled target on the open, closed and cancelled paths. Both new guards were mutation-checked in both directions.

## Not shipping

- **The freshness half.** `GetFresh` decides staleness on age alone and has no config identity, so an observation taken before an in-place edit can still be served afterwards. That is `ENG-5580` and it is deliberately a separate change — it does not fix this bug, and landing it first would hide this one.
- **The `awaitRollout` gate itself.** Comparing the whole rendered desired config against the observed config in `edit-protocolconverter.go` is a second seam, built but not included here, so this PR stays at the reported defect.

## Open question for review

On the closed-port path `Poll` still fills `Target` and `Port` from the config, because that is the address it attempted. Once a scan has run against an edited-but-unreachable port, desired and observed match again and a pure config-diff gate will report "rolled out" — leaving the rollback to depend on `PortState: closed` rather than on config identity. This PR closes the before-any-scan case; whether the after-first-scan case needs the gate to consider port state is the thing to decide in review.
