### PR TITLE
nmap: verify the connection before reporting a bridge edit rolled out (ENG-5579, ENG-5586)

### DIFF
--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -4,8 +4,7 @@
 
 ### Fixes
 
-- Editing a bridge's connection to a port that does not answer now fails and restores the previous configuration, instead of reporting a successful deploy. The deploy waits for a scan that finds the new port open, so a port that is closed or filtered is no longer accepted
-- Repointing a bridge to a different host on the same port is now checked too. The deploy waits for a scan taken after the change, so the previous host's scan can no longer satisfy it
+- Repointing a bridge to a different host on the same port now waits for a check of the new host, so the previous host can no longer make the deploy report success
 
 ## [0.44.38]
 

--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Bridge connection edits to an unreachable port no longer report the deployment as successful and skip the rollback, on instances running the FSMv2 connection probe (`NMAP_BACKEND=fsmv2`, off by default). The rollout now keeps waiting until a scan finds the new port open, not merely until the requested port number has been probed
+- A connection edit no longer completes on a stale reading of the old connection. The rollout waits for a scan of the new port that finds it open
 
 ## [0.44.38]
 

--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Editing a bridge's connection to a port that does not answer now fails and restores the previous configuration, instead of reporting a successful deploy. The deploy waits for a scan that finds the new port open, so a port that is closed or filtered is no longer accepted
+- Repointing a bridge to a different host on the same port is now checked too. The deploy waits for a scan taken after the change, so the previous host's scan can no longer satisfy it
 
 ## [0.44.38]
 

--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Bridge connection edits to an unreachable port no longer report the deployment as successful and skip the rollback, on instances running the FSMv2 connection probe (`NMAP_BACKEND=fsmv2`, off by default). The check compared the requested port against itself instead of against the port that was actually probed, so it passed on the first attempt
+- Bridge connection edits to an unreachable port no longer report the deployment as successful and skip the rollback, on instances running the FSMv2 connection probe (`NMAP_BACKEND=fsmv2`, off by default). The rollout now keeps waiting until a scan finds the new port open, not merely until the requested port number has been probed
 
 ## [0.44.38]
 

--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- A connection edit to a port that does not answer no longer completes. The rollout waits for a scan of the new port that finds it open
+- Editing a bridge's connection to a port that does not answer now fails and restores the previous configuration, instead of reporting a successful deploy. The deploy waits for a scan that finds the new port open, so a port that is closed or filtered is no longer accepted
 
 ## [0.44.38]
 

--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- A connection edit no longer completes on a stale reading of the old connection. The rollout waits for a scan of the new port that finds it open
+- A connection edit to a port that does not answer no longer completes. The rollout waits for a scan of the new port that finds it open
 
 ## [0.44.38]
 

--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Bridge connection edits to an unreachable port no longer report the deployment as successful and skip the rollback, on instances running the FSMv2 connection probe (`NMAP_BACKEND=fsmv2`, off by default). The check compared the requested port against itself instead of against the port that was actually probed, so it passed on the first attempt
+
 ## [0.44.38]
 
 ### Improvements

--- a/umh-core/internal/fsmtest/nmap.go
+++ b/umh-core/internal/fsmtest/nmap.go
@@ -125,42 +125,42 @@ func TransitionToNmapState(mockService *nmap.MockNmapService, serviceName string
 			IsS6Running: true,
 			IsRunning:   true,
 			S6FSMState:  s6fsm.OperationalStateRunning,
-			PortState:   string(nmapfsm.PortStateOpen),
+			PortState:   string(nmap.PortStateOpen),
 		})
 	case nmapfsm.OperationalStateOpenFiltered:
 		SetupNmapServiceState(mockService, serviceName, nmap.ServiceStateFlags{
 			IsS6Running: true,
 			IsRunning:   true,
 			S6FSMState:  s6fsm.OperationalStateRunning,
-			PortState:   string(nmapfsm.PortStateOpenFiltered),
+			PortState:   string(nmap.PortStateOpenFiltered),
 		})
 	case nmapfsm.OperationalStateFiltered:
 		SetupNmapServiceState(mockService, serviceName, nmap.ServiceStateFlags{
 			IsS6Running: true,
 			IsRunning:   true,
 			S6FSMState:  s6fsm.OperationalStateRunning,
-			PortState:   string(nmapfsm.PortStateFiltered),
+			PortState:   string(nmap.PortStateFiltered),
 		})
 	case nmapfsm.OperationalStateUnfiltered:
 		SetupNmapServiceState(mockService, serviceName, nmap.ServiceStateFlags{
 			IsS6Running: true,
 			IsRunning:   true,
 			S6FSMState:  s6fsm.OperationalStateRunning,
-			PortState:   string(nmapfsm.PortStateUnfiltered),
+			PortState:   string(nmap.PortStateUnfiltered),
 		})
 	case nmapfsm.OperationalStateClosed:
 		SetupNmapServiceState(mockService, serviceName, nmap.ServiceStateFlags{
 			IsS6Running: true,
 			IsRunning:   true,
 			S6FSMState:  s6fsm.OperationalStateRunning,
-			PortState:   string(nmapfsm.PortStateClosed),
+			PortState:   string(nmap.PortStateClosed),
 		})
 	case nmapfsm.OperationalStateClosedFiltered:
 		SetupNmapServiceState(mockService, serviceName, nmap.ServiceStateFlags{
 			IsS6Running: true,
 			IsRunning:   true,
 			S6FSMState:  s6fsm.OperationalStateRunning,
-			PortState:   string(nmapfsm.PortStateClosedFiltered),
+			PortState:   string(nmap.PortStateClosedFiltered),
 		})
 	case nmapfsm.OperationalStateStopping:
 		SetupNmapServiceState(mockService, serviceName, nmap.ServiceStateFlags{

--- a/umh-core/internal/fsmtest/nmap.go
+++ b/umh-core/internal/fsmtest/nmap.go
@@ -25,7 +25,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
 	nmapfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/nmap"
 	s6fsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/s6"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/nmap"
+	nmapservice "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/nmap"
 	s6svc "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/s6"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/serviceregistry"
 )
@@ -46,16 +46,16 @@ func CreateNmapTestConfig(name string, desiredState string) config.NmapConfig {
 
 // SetupNmapServiceState configures the mock service state for Nmap instance tests
 func SetupNmapServiceState(
-	mockService *nmap.MockNmapService,
+	mockService *nmapservice.MockNmapService,
 	serviceName string,
-	flags nmap.ServiceStateFlags,
+	flags nmapservice.ServiceStateFlags,
 ) {
 	// Ensure service exists in mock
 	mockService.ExistingServices[serviceName] = true
 
 	// Create service info if it doesn't exist
 	if mockService.ServiceStates[serviceName] == nil {
-		mockService.ServiceStates[serviceName] = &nmap.ServiceInfo{}
+		mockService.ServiceStates[serviceName] = &nmapservice.ServiceInfo{}
 	}
 
 	// Set S6 FSM state
@@ -84,8 +84,8 @@ func SetupNmapServiceState(
 	}
 
 	if flags.PortState != "" {
-		mockService.ServiceStates[serviceName].NmapStatus.LastScan = &nmap.NmapScanResult{
-			PortResult: nmap.PortResult{
+		mockService.ServiceStates[serviceName].NmapStatus.LastScan = &nmapservice.NmapScanResult{
+			PortResult: nmapservice.PortResult{
 				State: flags.PortState,
 			},
 		}
@@ -96,7 +96,7 @@ func SetupNmapServiceState(
 }
 
 // ConfigureNmapServiceConfig configures the mock service with a default Nmap config
-func ConfigureNmapServiceConfig(mockService *nmap.MockNmapService) {
+func ConfigureNmapServiceConfig(mockService *nmapservice.MockNmapService) {
 	mockService.GetConfigResult = nmapserviceconfig.NmapServiceConfig{
 		Target: "localhost",
 		Port:   443,
@@ -104,16 +104,16 @@ func ConfigureNmapServiceConfig(mockService *nmap.MockNmapService) {
 }
 
 // TransitionToNmapState is a helper to configure a service for a given high-level state
-func TransitionToNmapState(mockService *nmap.MockNmapService, serviceName string, state string) {
+func TransitionToNmapState(mockService *nmapservice.MockNmapService, serviceName string, state string) {
 	switch state {
 	case nmapfsm.OperationalStateStopped,
 		nmapfsm.OperationalStateStarting:
-		SetupNmapServiceState(mockService, serviceName, nmap.ServiceStateFlags{
+		SetupNmapServiceState(mockService, serviceName, nmapservice.ServiceStateFlags{
 			IsS6Running: false,
 			S6FSMState:  s6fsm.OperationalStateStopped,
 		})
 	case nmapfsm.OperationalStateDegraded:
-		SetupNmapServiceState(mockService, serviceName, nmap.ServiceStateFlags{
+		SetupNmapServiceState(mockService, serviceName, nmapservice.ServiceStateFlags{
 			IsS6Running: true,
 			IsRunning:   false,
 			S6FSMState:  s6fsm.OperationalStateRunning,
@@ -121,49 +121,49 @@ func TransitionToNmapState(mockService *nmap.MockNmapService, serviceName string
 			PortState:   "",
 		})
 	case nmapfsm.OperationalStateOpen:
-		SetupNmapServiceState(mockService, serviceName, nmap.ServiceStateFlags{
+		SetupNmapServiceState(mockService, serviceName, nmapservice.ServiceStateFlags{
 			IsS6Running: true,
 			IsRunning:   true,
 			S6FSMState:  s6fsm.OperationalStateRunning,
-			PortState:   string(nmap.PortStateOpen),
+			PortState:   string(nmapservice.PortStateOpen),
 		})
 	case nmapfsm.OperationalStateOpenFiltered:
-		SetupNmapServiceState(mockService, serviceName, nmap.ServiceStateFlags{
+		SetupNmapServiceState(mockService, serviceName, nmapservice.ServiceStateFlags{
 			IsS6Running: true,
 			IsRunning:   true,
 			S6FSMState:  s6fsm.OperationalStateRunning,
-			PortState:   string(nmap.PortStateOpenFiltered),
+			PortState:   string(nmapservice.PortStateOpenFiltered),
 		})
 	case nmapfsm.OperationalStateFiltered:
-		SetupNmapServiceState(mockService, serviceName, nmap.ServiceStateFlags{
+		SetupNmapServiceState(mockService, serviceName, nmapservice.ServiceStateFlags{
 			IsS6Running: true,
 			IsRunning:   true,
 			S6FSMState:  s6fsm.OperationalStateRunning,
-			PortState:   string(nmap.PortStateFiltered),
+			PortState:   string(nmapservice.PortStateFiltered),
 		})
 	case nmapfsm.OperationalStateUnfiltered:
-		SetupNmapServiceState(mockService, serviceName, nmap.ServiceStateFlags{
+		SetupNmapServiceState(mockService, serviceName, nmapservice.ServiceStateFlags{
 			IsS6Running: true,
 			IsRunning:   true,
 			S6FSMState:  s6fsm.OperationalStateRunning,
-			PortState:   string(nmap.PortStateUnfiltered),
+			PortState:   string(nmapservice.PortStateUnfiltered),
 		})
 	case nmapfsm.OperationalStateClosed:
-		SetupNmapServiceState(mockService, serviceName, nmap.ServiceStateFlags{
+		SetupNmapServiceState(mockService, serviceName, nmapservice.ServiceStateFlags{
 			IsS6Running: true,
 			IsRunning:   true,
 			S6FSMState:  s6fsm.OperationalStateRunning,
-			PortState:   string(nmap.PortStateClosed),
+			PortState:   string(nmapservice.PortStateClosed),
 		})
 	case nmapfsm.OperationalStateClosedFiltered:
-		SetupNmapServiceState(mockService, serviceName, nmap.ServiceStateFlags{
+		SetupNmapServiceState(mockService, serviceName, nmapservice.ServiceStateFlags{
 			IsS6Running: true,
 			IsRunning:   true,
 			S6FSMState:  s6fsm.OperationalStateRunning,
-			PortState:   string(nmap.PortStateClosedFiltered),
+			PortState:   string(nmapservice.PortStateClosedFiltered),
 		})
 	case nmapfsm.OperationalStateStopping:
-		SetupNmapServiceState(mockService, serviceName, nmap.ServiceStateFlags{
+		SetupNmapServiceState(mockService, serviceName, nmapservice.ServiceStateFlags{
 			IsS6Running: false,
 			IsRunning:   false,
 			S6FSMState:  s6fsm.OperationalStateStopping,
@@ -173,22 +173,22 @@ func TransitionToNmapState(mockService *nmap.MockNmapService, serviceName string
 
 // SetupNmapInstance creates and configures a Nmap instance for testing.
 // Returns the instance, the mock service, and the config used to create it.
-func SetupNmapInstance(serviceName string, desiredState string) (*nmapfsm.NmapInstance, *nmap.MockNmapService, config.NmapConfig) {
+func SetupNmapInstance(serviceName string, desiredState string) (*nmapfsm.NmapInstance, *nmapservice.MockNmapService, config.NmapConfig) {
 	// Create test config
 	cfg := CreateNmapTestConfig(serviceName, desiredState)
 
 	// Create mock service
-	mockService := nmap.NewMockNmapService()
+	mockService := nmapservice.NewMockNmapService()
 
 	// Set up initial service states
 	mockService.ExistingServices = make(map[string]bool)
-	mockService.ServiceStates = make(map[string]*nmap.ServiceInfo)
+	mockService.ServiceStates = make(map[string]*nmapservice.ServiceInfo)
 
 	// Configure service with default config
 	ConfigureNmapServiceConfig(mockService)
 
 	// Add default service info
-	mockService.ServiceStates[serviceName] = &nmap.ServiceInfo{}
+	mockService.ServiceStates[serviceName] = &nmapservice.ServiceInfo{}
 
 	// Create new instance directly using the specialized constructor
 	instance := setUpMockNmapInstance(cfg, mockService)
@@ -197,7 +197,7 @@ func SetupNmapInstance(serviceName string, desiredState string) (*nmapfsm.NmapIn
 }
 
 // setUpMockNmapInstance creates a NmapInstance with a mock service
-func setUpMockNmapInstance(cfg config.NmapConfig, mockService *nmap.MockNmapService) *nmapfsm.NmapInstance {
+func setUpMockNmapInstance(cfg config.NmapConfig, mockService *nmapservice.MockNmapService) *nmapfsm.NmapInstance {
 	// First create the instance normally
 	instance := nmapfsm.NewNmapInstance(cfg)
 
@@ -212,7 +212,7 @@ func setUpMockNmapInstance(cfg config.NmapConfig, mockService *nmap.MockNmapServ
 func TestNmapStateTransition(
 	ctx context.Context,
 	instance *nmapfsm.NmapInstance,
-	mockService *nmap.MockNmapService,
+	mockService *nmapservice.MockNmapService,
 	services serviceregistry.Provider,
 	serviceName string,
 	fromState string,
@@ -254,7 +254,7 @@ func VerifyNmapStableState(
 	ctx context.Context,
 	snapshot fsm.SystemSnapshot,
 	instance *nmapfsm.NmapInstance,
-	mockService *nmap.MockNmapService,
+	mockService *nmapservice.MockNmapService,
 	services serviceregistry.Provider,
 	serviceName string,
 	expectedState string,
@@ -286,7 +286,7 @@ func VerifyNmapStableState(
 }
 
 // ResetNmapInstanceError resets the error and backoff state of a NmapInstance.
-func ResetNmapInstanceError(mockService *nmap.MockNmapService) {
+func ResetNmapInstanceError(mockService *nmapservice.MockNmapService) {
 	mockService.AddServiceError = nil
 	mockService.StartServiceError = nil
 	mockService.StopServiceError = nil
@@ -299,7 +299,7 @@ func ResetNmapInstanceError(mockService *nmap.MockNmapService) {
 // Note: This creates a standard instance without replacing the service component.
 // In actual tests, the pattern is to use the manager's functionality rather than
 // working with individual instances.
-func CreateMockNmapInstance(serviceName string, mockService nmap.INmapService, desiredState string) *nmapfsm.NmapInstance {
+func CreateMockNmapInstance(serviceName string, mockService nmapservice.INmapService, desiredState string) *nmapfsm.NmapInstance {
 	cfg := CreateNmapTestConfig(serviceName, desiredState)
 	return nmapfsm.NewNmapInstance(cfg)
 }
@@ -309,7 +309,7 @@ func StabilizeNmapInstance(
 	ctx context.Context,
 	snapshot fsm.SystemSnapshot,
 	instance *nmapfsm.NmapInstance,
-	mockService *nmap.MockNmapService,
+	mockService *nmapservice.MockNmapService,
 	services serviceregistry.Provider,
 	serviceName string,
 	targetState string,
@@ -374,7 +374,7 @@ func ReconcileNmapUntilError(
 	ctx context.Context,
 	snapshot fsm.SystemSnapshot,
 	instance *nmapfsm.NmapInstance,
-	mockService *nmap.MockNmapService,
+	mockService *nmapservice.MockNmapService,
 	services serviceregistry.Provider,
 	serviceName string,
 	maxAttempts int,

--- a/umh-core/internal/fsmtest/protocolconverter.go
+++ b/umh-core/internal/fsmtest/protocolconverter.go
@@ -30,9 +30,9 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
 	connectionservicefsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/connection"
 	dataflowcomponentfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/dataflowcomponent"
-	nmapfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/nmap"
 	protocolconverterfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/protocolconverter"
 	redpandafsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/redpanda"
+	nmapservice "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/nmap"
 	protocolconvertersvc "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/protocolconverter"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/serviceregistry"
 )
@@ -183,7 +183,7 @@ func TransitionToProtocolConverterState(mockService *protocolconvertersvc.MockPr
 			DfcFSMWriteState:   dataflowcomponentfsm.OperationalStateStopped,
 			ConnectionFSMState: connectionservicefsm.OperationalStateStopped,
 			RedpandaFSMState:   redpandafsm.OperationalStateStopped,
-			PortState:          nmapfsm.PortStateClosed,
+			PortState:          nmapservice.PortStateClosed,
 		})
 		ConfigureProtocolConverterServiceConfig(mockService)
 	case protocolconverterfsm.OperationalStateStartingConnection:
@@ -195,7 +195,7 @@ func TransitionToProtocolConverterState(mockService *protocolconvertersvc.MockPr
 			DfcFSMWriteState:   dataflowcomponentfsm.OperationalStateStopped,
 			ConnectionFSMState: connectionservicefsm.OperationalStateStarting,
 			RedpandaFSMState:   redpandafsm.OperationalStateStopped,
-			PortState:          nmapfsm.PortStateClosed,
+			PortState:          nmapservice.PortStateClosed,
 		})
 		ConfigureProtocolConverterServiceConfig(mockService)
 	case protocolconverterfsm.OperationalStateStartingRedpanda:
@@ -207,7 +207,7 @@ func TransitionToProtocolConverterState(mockService *protocolconvertersvc.MockPr
 			DfcFSMWriteState:   dataflowcomponentfsm.OperationalStateStopped,
 			ConnectionFSMState: connectionservicefsm.OperationalStateUp,
 			RedpandaFSMState:   redpandafsm.OperationalStateStarting,
-			PortState:          nmapfsm.PortStateOpen,
+			PortState:          nmapservice.PortStateOpen,
 		})
 		ConfigureProtocolConverterServiceConfig(mockService)
 	case protocolconverterfsm.OperationalStateStartingDFC:
@@ -219,7 +219,7 @@ func TransitionToProtocolConverterState(mockService *protocolconvertersvc.MockPr
 			DfcFSMWriteState:   dataflowcomponentfsm.OperationalStateStarting,
 			ConnectionFSMState: connectionservicefsm.OperationalStateUp,
 			RedpandaFSMState:   redpandafsm.OperationalStateIdle,
-			PortState:          nmapfsm.PortStateOpen,
+			PortState:          nmapservice.PortStateOpen,
 		})
 		ConfigureProtocolConverterServiceConfig(mockService)
 	case protocolconverterfsm.OperationalStateStartingFailedDFC:
@@ -231,7 +231,7 @@ func TransitionToProtocolConverterState(mockService *protocolconvertersvc.MockPr
 			DfcFSMWriteState:   dataflowcomponentfsm.OperationalStateStartingFailed,
 			ConnectionFSMState: connectionservicefsm.OperationalStateUp,
 			RedpandaFSMState:   redpandafsm.OperationalStateIdle,
-			PortState:          nmapfsm.PortStateOpen,
+			PortState:          nmapservice.PortStateOpen,
 		})
 		ConfigureProtocolConverterServiceConfig(mockService)
 	case protocolconverterfsm.OperationalStateStartingFailedDFCMissing:
@@ -243,7 +243,7 @@ func TransitionToProtocolConverterState(mockService *protocolconvertersvc.MockPr
 			DfcFSMWriteState:   "",
 			ConnectionFSMState: connectionservicefsm.OperationalStateUp,
 			RedpandaFSMState:   redpandafsm.OperationalStateIdle,
-			PortState:          nmapfsm.PortStateOpen,
+			PortState:          nmapservice.PortStateOpen,
 		})
 		ConfigureProtocolConverterServiceConfigWithMissingDfc(mockService) // missing DFC
 	case protocolconverterfsm.OperationalStateIdle:
@@ -255,7 +255,7 @@ func TransitionToProtocolConverterState(mockService *protocolconvertersvc.MockPr
 			DfcFSMWriteState:   dataflowcomponentfsm.OperationalStateIdle,
 			ConnectionFSMState: connectionservicefsm.OperationalStateUp,
 			RedpandaFSMState:   redpandafsm.OperationalStateIdle,
-			PortState:          nmapfsm.PortStateOpen,
+			PortState:          nmapservice.PortStateOpen,
 		})
 		ConfigureProtocolConverterServiceConfig(mockService)
 	case protocolconverterfsm.OperationalStateActive:
@@ -267,7 +267,7 @@ func TransitionToProtocolConverterState(mockService *protocolconvertersvc.MockPr
 			DfcFSMWriteState:   dataflowcomponentfsm.OperationalStateActive,
 			ConnectionFSMState: connectionservicefsm.OperationalStateUp,
 			RedpandaFSMState:   redpandafsm.OperationalStateActive,
-			PortState:          nmapfsm.PortStateOpen,
+			PortState:          nmapservice.PortStateOpen,
 		})
 		ConfigureProtocolConverterServiceConfig(mockService)
 	case protocolconverterfsm.OperationalStateDegradedConnection:
@@ -280,7 +280,7 @@ func TransitionToProtocolConverterState(mockService *protocolconvertersvc.MockPr
 			DfcFSMWriteState:   dataflowcomponentfsm.OperationalStateDegraded,
 			ConnectionFSMState: connectionservicefsm.OperationalStateDegraded,
 			RedpandaFSMState:   redpandafsm.OperationalStateActive,
-			PortState:          nmapfsm.PortStateOpen,
+			PortState:          nmapservice.PortStateOpen,
 		})
 		ConfigureProtocolConverterServiceConfig(mockService)
 	case protocolconverterfsm.OperationalStateDegradedRedpanda:
@@ -292,7 +292,7 @@ func TransitionToProtocolConverterState(mockService *protocolconvertersvc.MockPr
 			DfcFSMWriteState:   dataflowcomponentfsm.OperationalStateActive,
 			ConnectionFSMState: connectionservicefsm.OperationalStateUp,
 			RedpandaFSMState:   redpandafsm.OperationalStateDegraded,
-			PortState:          nmapfsm.PortStateOpen,
+			PortState:          nmapservice.PortStateOpen,
 		})
 		ConfigureProtocolConverterServiceConfig(mockService)
 	case protocolconverterfsm.OperationalStateDegradedDFC:
@@ -304,7 +304,7 @@ func TransitionToProtocolConverterState(mockService *protocolconvertersvc.MockPr
 			DfcFSMWriteState:   dataflowcomponentfsm.OperationalStateDegraded,
 			ConnectionFSMState: connectionservicefsm.OperationalStateUp,
 			RedpandaFSMState:   redpandafsm.OperationalStateActive,
-			PortState:          nmapfsm.PortStateOpen,
+			PortState:          nmapservice.PortStateOpen,
 		})
 		ConfigureProtocolConverterServiceConfig(mockService)
 	case protocolconverterfsm.OperationalStateDegradedOther:
@@ -316,7 +316,7 @@ func TransitionToProtocolConverterState(mockService *protocolconvertersvc.MockPr
 			DfcFSMWriteState:   dataflowcomponentfsm.OperationalStateActive,
 			ConnectionFSMState: connectionservicefsm.OperationalStateDegraded,
 			RedpandaFSMState:   redpandafsm.OperationalStateActive,
-			PortState:          nmapfsm.PortStateOpen,
+			PortState:          nmapservice.PortStateOpen,
 		})
 		ConfigureProtocolConverterServiceConfig(mockService)
 	}

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter.go
@@ -583,6 +583,11 @@ func (a *EditProtocolConverterAction) awaitRollout(previousConfig config.Protoco
 		// consecutive identical failures instead of burning the full timeout.
 		prevRenderErrMsg     string
 		identicalRenderFails int
+
+		// currentStateReason holds what the most recent tick was waiting for. The
+		// timeout branch reads it, so a rollback message names the half that never
+		// arrived instead of only saying the bridge did not become active.
+		currentStateReason string
 	)
 
 	const maxIdenticalRenderFails = 3
@@ -606,6 +611,10 @@ func (a *EditProtocolConverterAction) awaitRollout(previousConfig config.Protoco
 			}
 
 			stateMessage := fmt.Sprintf("Bridge '%s' edit timeout reached. It did not become %s in time. Rolled back to previous configuration", a.name, desiredPCState)
+			if currentStateReason != "" {
+				stateMessage += fmt.Sprintf(" (last check: %s)", currentStateReason)
+			}
+
 			if a.lastRenderErr != nil {
 				stateMessage += fmt.Sprintf(" (root cause: %v)", a.lastRenderErr)
 			}
@@ -662,7 +671,7 @@ func (a *EditProtocolConverterAction) awaitRollout(previousConfig config.Protoco
 				}
 
 				found = true
-				currentStateReason := "current state: " + instance.CurrentState
+				currentStateReason = "current state: " + instance.CurrentState
 
 				if a.dfcType == DFCTypeEmpty {
 					// Unreachable today: applyMutation forces the bridge to

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter.go
@@ -49,6 +49,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/protocolconverterserviceconfig"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
+	nmapfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/nmap"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/protocolconverter"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/logger"
@@ -634,13 +635,45 @@ func (a *EditProtocolConverterAction) awaitRollout(pcConfig config.ProtocolConve
 					// Only check the nmap port when activating; when stopping, nmap is also
 					// stopped so it will never update to the new port.
 					if desiredPCState != protocolconverter.OperationalStateStopped {
+						nmapObs := pcSnapshot.ServiceInfo.ConnectionObservedState.ServiceInfo.NmapObservedState
 						nmapPort := strconv.FormatUint(
-							uint64(pcSnapshot.ServiceInfo.ConnectionObservedState.ServiceInfo.NmapObservedState.ObservedNmapServiceConfig.Port),
+							uint64(nmapObs.ObservedNmapServiceConfig.Port),
 							10,
 						)
 
+						// A scanned-and-open port is the only guarantee that the
+						// edit converged. The observed config merely echoes what
+						// the scan was asked to dial, so port equality alone
+						// cannot tell a live port from a refused one. Requiring
+						// open matches the connection FSM, which defines up as
+						// open and counts every other state as down. Do NOT use
+						// IsRunning: it is overloaded across backends (open on
+						// fsmv2, "scanner process up" on fsmv1).
+						portIsOpen := nmapObs.ServiceInfo.NmapStatus.LastScan != nil &&
+							nmapObs.ServiceInfo.NmapStatus.LastScan.PortResult.State == string(nmapfsm.PortStateOpen)
+
 						if nmapPort != a.connectionPort {
 							currentStateReason = "waiting for nmap to connect to port " + a.connectionPort
+							SendActionReply(
+								a.instanceUUID,
+								a.userEmail,
+								a.actionUUID,
+								models.ActionExecuting,
+								RemainingPrefixSec(remainingSeconds)+currentStateReason,
+								a.outboundChannel,
+								models.EditProtocolConverter,
+							)
+
+							continue
+						}
+
+						if !portIsOpen {
+							lastState := "no scan yet"
+							if nmapObs.ServiceInfo.NmapStatus.LastScan != nil {
+								lastState = nmapObs.ServiceInfo.NmapStatus.LastScan.PortResult.State
+							}
+
+							currentStateReason = "waiting for nmap to report port " + a.connectionPort + " open (last scan: " + lastState + ")"
 							SendActionReply(
 								a.instanceUUID,
 								a.userEmail,

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter.go
@@ -109,11 +109,13 @@ type EditProtocolConverterAction struct {
 	configManager config.ConfigManager
 
 	fsmLogger deps.FSMLogger
-	// lastRenderErr holds the most recent renderDesiredDFCConfig error so the
-	// awaitRollout timeout message can surface the real cause instead of just
-	// "did not become active in time". It is sticky: compareSingleDFCConfig
-	// clears it only when a later render succeeds, so ticks that never reach
-	// a render (for example while Benthos restarts) keep the captured cause.
+	// lastRenderErr holds the most recent render error — from
+	// renderDesiredDFCConfig, or from the connection render that resolves the
+	// nmap gate's expected port — so the awaitRollout timeout message can
+	// surface the real cause instead of just "did not become active in time".
+	// It is sticky: compareSingleDFCConfig clears it only when a later render
+	// succeeds, so ticks that never reach a render (for example while Benthos
+	// restarts) keep the captured cause.
 	lastRenderErr error
 
 	// lastFailedDFCType records which DFC (read/write) produced the most
@@ -349,7 +351,7 @@ func (a *EditProtocolConverterAction) Execute() (interface{}, map[string]interfa
 
 	// Await rollout and perform health checks
 	if a.systemSnapshotManager != nil && !a.ignoreHealthCheck {
-		errCode, err := a.awaitRollout(oldConfig, desiredPCState)
+		errCode, err := a.awaitRollout(oldConfig, newSpec.ProtocolConverterServiceConfig, desiredPCState)
 		if err != nil {
 			errorMsg := fmt.Sprintf("Failed during rollout: %v", err)
 			SendActionReplyV2(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedWithFailure,
@@ -508,7 +510,11 @@ func (a *EditProtocolConverterAction) persistConfig(atomicEditUUID uuid.UUID, ne
 // The function returns the error code and the error message via an error object.
 // The error code is a string that is sent to the frontend to allow it to determine if the action can be retried or not.
 // The error message is sent to the frontend to allow the user to see the error message.
-func (a *EditProtocolConverterAction) awaitRollout(pcConfig config.ProtocolConverterConfig, desiredPCState string) (string, error) {
+//
+// pcConfig is the pre-edit configuration, used to roll back on failure. newSpec is
+// the specification this edit just persisted, used to resolve the endpoint the nmap
+// gate expects the scan to dial.
+func (a *EditProtocolConverterAction) awaitRollout(pcConfig config.ProtocolConverterConfig, newSpec protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec, desiredPCState string) (string, error) {
 	SendActionReply(
 		a.instanceUUID,
 		a.userEmail,
@@ -539,6 +545,30 @@ func (a *EditProtocolConverterAction) awaitRollout(pcConfig config.ProtocolConve
 	timeout := time.After(timeoutInterval)
 	startTime := time.Now()
 	timeoutDuration := timeoutInterval
+
+	// wantConnectionPort is the port the nmap gate below requires the scan to
+	// have dialed and found open. It is rendered from the spec this edit just
+	// persisted, not taken from the action payload: a bridge whose connection is
+	// templated resolves its endpoint only at render time. A historian bridge
+	// scans {{ .historian.timescale.host }}:{{ .historian.timescale.port }} and
+	// keeps no IP/PORT user variables, so its payload carries an unresolved
+	// target and port 0 while the scan dials the resolved port — comparing the
+	// two would never match, burn the whole timeout and roll back a healthy edit.
+	//
+	// A render failure falls back to the payload port and is recorded in
+	// lastRenderErr so the timeout message names the real cause: the agent
+	// renders the same spec, so a spec that fails here cannot roll out either.
+	wantConnectionPort := a.connectionPort
+
+	if a.dfcType == DFCTypeEmpty && desiredPCState != protocolconverter.OperationalStateStopped {
+		resolvedPort, renderErr := a.resolvedConnectionPort(newSpec)
+		if renderErr != nil {
+			a.actionLogger.Warnf("Failed to resolve the connection endpoint for the rollout gate, falling back to the payload port %s: %v", a.connectionPort, renderErr)
+			a.lastRenderErr = renderErr
+		} else {
+			wantConnectionPort = resolvedPort
+		}
+	}
 
 	var (
 		logs     []s6.LogEntry
@@ -652,8 +682,8 @@ func (a *EditProtocolConverterAction) awaitRollout(pcConfig config.ProtocolConve
 						portIsOpen := nmapObs.ServiceInfo.NmapStatus.LastScan != nil &&
 							nmapObs.ServiceInfo.NmapStatus.LastScan.PortResult.State == string(nmapfsm.PortStateOpen)
 
-						if nmapPort != a.connectionPort {
-							currentStateReason = "waiting for nmap to connect to port " + a.connectionPort
+						if nmapPort != wantConnectionPort {
+							currentStateReason = "waiting for nmap to connect to port " + wantConnectionPort
 							SendActionReply(
 								a.instanceUUID,
 								a.userEmail,
@@ -673,7 +703,7 @@ func (a *EditProtocolConverterAction) awaitRollout(pcConfig config.ProtocolConve
 								lastState = nmapObs.ServiceInfo.NmapStatus.LastScan.PortResult.State
 							}
 
-							currentStateReason = "waiting for nmap to report port " + a.connectionPort + " open (last scan: " + lastState + ")"
+							currentStateReason = "waiting for nmap to report port " + wantConnectionPort + " open (last scan: " + lastState + ")"
 							SendActionReply(
 								a.instanceUUID,
 								a.userEmail,
@@ -1168,6 +1198,46 @@ func (a *EditProtocolConverterAction) mergeUserVariables(base map[string]any, in
 	}
 
 	return merged
+}
+
+// resolvedConnectionPort renders the connection template of the just-persisted
+// spec and returns the port the nmap scan is expected to dial, as the decimal
+// string the observed scan config is compared against.
+//
+// It renders with the same inputs the agent uses — the persisted spec (which
+// already carries the edit's merged variables), the agent location and the
+// historian section read from the config manager — so the port returned here is
+// the port the control loop will make the scanner dial.
+func (a *EditProtocolConverterAction) resolvedConnectionPort(newSpec protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec) (string, error) {
+	systemSnapshot := a.systemSnapshotManager.GetDeepCopySnapshot()
+	agentLocation := convertIntMapToStringMap(systemSnapshot.CurrentConfig.Agent.Location)
+
+	// The stored system snapshot does not carry the top-level historian section,
+	// so read it straight from the config manager (see renderDesiredDFCConfig).
+	ctx, cancel := context.WithTimeout(context.Background(), constants.ActionTimeout)
+	defer cancel()
+
+	currentConfig, err := a.configManager.GetConfig(ctx, 0)
+	if err != nil {
+		return "", fmt.Errorf("failed to read current config for historian variables: %w", err)
+	}
+
+	runtimeConfig, err := runtime_config.BuildRuntimeConfig(
+		newSpec,
+		agentLocation,
+		nil, // TODO: add global vars
+		currentConfig.Historian,
+		runtime_config.BridgedByPlaceholder,
+		a.name,
+	)
+	if err != nil {
+		return "", fmt.Errorf("failed to build runtime config: %w", err)
+	}
+
+	return strconv.FormatUint(
+		uint64(runtimeConfig.ConnectionServiceConfig.NmapServiceConfig.Port),
+		10,
+	), nil
 }
 
 // renderDesiredDFCConfig renders the template variables in the desired DFC config

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter.go
@@ -110,13 +110,8 @@ type EditProtocolConverterAction struct {
 	configManager config.ConfigManager
 
 	fsmLogger deps.FSMLogger
-	// lastRenderErr holds the most recent render error, from
-	// renderDesiredDFCConfig or from the connection render that resolves the
-	// connection check's expected port, so the awaitRollout timeout message can
-	// name the real cause instead of just "did not become active in time".
-	// It is sticky: compareSingleDFCConfig clears it only when a later render
-	// succeeds, so ticks that never reach a render (for example while Benthos
-	// restarts) keep the captured cause.
+	// Sticky: compareSingleDFCConfig clears it only when a later render succeeds,
+	// so a tick that never reaches a render keeps the captured cause.
 	lastRenderErr error
 
 	// lastFailedDFCType records which DFC (read/write) produced the most
@@ -166,11 +161,9 @@ type EditProtocolConverterAction struct {
 	// Parsed request payload (only populated after Parse)
 	protocolConverterUUID uuid.UUID
 
-	// persistedAt is when the edit reached config.yaml. The connection check needs
-	// it because a scan is only evidence about the new endpoint if it started
-	// after the config changed: nmap's observed endpoint is re-read from the
-	// generated scan script, which is rewritten at persist time, so it names the
-	// new endpoint several ticks before anything dials it.
+	// nmap's observed endpoint is re-read from the generated scan script, which is
+	// rewritten at persist time, so it names the new endpoint several ticks before
+	// anything dials it. Only a scan started after this is evidence.
 	persistedAt time.Time
 
 	// rolloutSentryReported tells Execute to skip the generic rollout_failed
@@ -518,10 +511,6 @@ func (a *EditProtocolConverterAction) persistConfig(atomicEditUUID uuid.UUID, ne
 // The function returns the error code and the error message via an error object.
 // The error code is a string that is sent to the frontend to allow it to determine if the action can be retried or not.
 // The error message is sent to the frontend to allow the user to see the error message.
-//
-// previousConfig is the pre-edit configuration, written back verbatim to roll back on
-// failure. newConfig is the configuration this edit just persisted; its spec resolves
-// the endpoint the nmap connection check expects the scan to dial.
 func (a *EditProtocolConverterAction) awaitRollout(previousConfig config.ProtocolConverterConfig, newConfig config.ProtocolConverterConfig, desiredPCState string) (string, error) {
 	SendActionReply(
 		a.instanceUUID,
@@ -564,9 +553,6 @@ func (a *EditProtocolConverterAction) awaitRollout(previousConfig config.Protoco
 		prevRenderErrMsg     string
 		identicalRenderFails int
 
-		// currentStateReason holds what the most recent tick was waiting for. The
-		// timeout branch reads it, so a rollback message names the half that never
-		// arrived instead of only saying the bridge did not become active.
 		currentStateReason string
 	)
 
@@ -654,9 +640,8 @@ func (a *EditProtocolConverterAction) awaitRollout(previousConfig config.Protoco
 				currentStateReason = "current state: " + instance.CurrentState
 
 				if a.dfcType == DFCTypeEmpty {
-					// Unreachable today: applyMutation forces the bridge to
-					// active, so desiredPCState is never stopped here. Kept
-					// because a stopped bridge stops its nmap service too and
+					// Unreachable while applyMutation forces the bridge active.
+					// Kept because a stopped bridge stops its nmap service and
 					// would never report the new port.
 					if desiredPCState != protocolconverter.OperationalStateStopped {
 						if waitingFor := a.connectionCheckWait(newConfig, pcSnapshot); waitingFor != "" {
@@ -1160,12 +1145,10 @@ func (a *EditProtocolConverterAction) mergeUserVariables(base map[string]any, in
 // connectionCheckWait reports what the connection check is still waiting for,
 // or "" when the scan agrees with the endpoint this edit persisted.
 //
-// The endpoint comes from the persisted spec, not from the action payload: a
-// templated connection resolves only at render time, and get-protocolconverter
-// hands the raw template back when the spec carries no IP/PORT variables, so
-// the payload can name a target and port 0 that no scan will ever report.
-// Called once per tick, so a transient config-read failure heals instead of
-// failing the edit; a deterministic one repeats and the timeout names it.
+// The endpoint is rendered from the persisted spec, never taken from the action
+// payload: get-protocolconverter hands back the raw connection template when
+// the spec carries no IP/PORT variables, so a payload can name an unresolved
+// target on port 0 that no scan will ever report.
 func (a *EditProtocolConverterAction) connectionCheckWait(
 	newConfig config.ProtocolConverterConfig,
 	pcSnapshot *protocolconverter.ProtocolConverterObservedStateSnapshot,
@@ -1183,27 +1166,21 @@ func (a *EditProtocolConverterAction) connectionCheckWait(
 	scannedEndpoint := nmapObs.ObservedNmapServiceConfig.Target + ":" +
 		strconv.FormatUint(uint64(nmapObs.ObservedNmapServiceConfig.Port), 10)
 
-	// Both halves must match. The port alone accepts a move to a different host
-	// on the same port: the number agrees, the old host's scan says that port is
-	// open, and nothing has dialed the new host (ENG-5586).
+	// Comparing the port alone accepts a move to a different host on the same
+	// port: the old host's scan reports it open and nothing dialed the new host.
 	if scannedEndpoint != wantEndpoint {
 		return "waiting for nmap to scan " + wantEndpoint
 	}
 
-	// The observed endpoint is re-read from the generated scan script, which is
-	// rewritten when the edit is persisted, so it names the new endpoint before
-	// the scanner has been rebuilt and dialed it. Requiring the scan to have
-	// started after the persist is what makes the endpoint match evidence rather
-	// than an echo. A bridge with no scan at all fails here too.
+	// The observed endpoint echoes the regenerated scan script, so it names the
+	// new endpoint before the scanner has dialed it.
 	lastScan := nmapObs.ServiceInfo.NmapStatus.LastScan
 	if lastScan == nil || !lastScan.Timestamp.After(a.persistedAt) {
 		return "waiting for a scan of " + wantEndpoint + " taken after the edit"
 	}
 
-	// Endpoint equality alone cannot tell a live port from a refused one, so
-	// require the scan to report open. Do not use IsRunning: it means the port
-	// accepted the connection on fsmv2 and "the scanner process is up" on fsmv1,
-	// so on fsmv1 it is true for a port that never answered.
+	// Do not use IsRunning instead: it means the port answered on fsmv2 but only
+	// "the scanner process is up" on fsmv1, where a refused port reads true.
 	if lastScan.PortResult.State != string(nmapservice.PortStateOpen) {
 		return "waiting for nmap to report " + wantEndpoint + " open (last scan: " + lastScan.PortResult.State + ")"
 	}
@@ -1211,14 +1188,11 @@ func (a *EditProtocolConverterAction) connectionCheckWait(
 	return ""
 }
 
-// resolvedConnectionEndpoint renders the connection template of the
-// just-persisted spec and returns the endpoint the nmap scan is expected to
-// dial, in the same type the observed scan config carries.
+// resolvedConnectionEndpoint renders the just-persisted spec's connection
+// template and returns the endpoint the scan is expected to dial.
 //
-// It renders with the same inputs the agent uses: the persisted spec (which
-// already carries the edit's merged variables), the agent location, and the
-// historian section read from the config manager. So the endpoint returned here
-// is the endpoint the control loop will make the scanner dial.
+// It renders with the same inputs the agent uses, so the endpoint returned here
+// is the one the control loop will make the scanner dial.
 func (a *EditProtocolConverterAction) resolvedConnectionEndpoint(newSpec protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec) (nmapserviceconfig.NmapServiceConfig, error) {
 	systemSnapshot := a.systemSnapshotManager.GetDeepCopySnapshot()
 	agentLocation := convertIntMapToStringMap(systemSnapshot.CurrentConfig.Agent.Location)

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter.go
@@ -511,7 +511,11 @@ func (a *EditProtocolConverterAction) persistConfig(atomicEditUUID uuid.UUID, ne
 // The function returns the error code and the error message via an error object.
 // The error code is a string that is sent to the frontend to allow it to determine if the action can be retried or not.
 // The error message is sent to the frontend to allow the user to see the error message.
-func (a *EditProtocolConverterAction) awaitRollout(previousConfig config.ProtocolConverterConfig, newConfig config.ProtocolConverterConfig, desiredPCState string) (string, error) {
+func (a *EditProtocolConverterAction) awaitRollout(
+	rollbackConfig config.ProtocolConverterConfig,
+	rolloutConfig config.ProtocolConverterConfig,
+	desiredPCState string,
+) (string, error) {
 	SendActionReply(
 		a.instanceUUID,
 		a.userEmail,
@@ -566,12 +570,12 @@ func (a *EditProtocolConverterAction) awaitRollout(previousConfig config.Protoco
 		select {
 		case <-timeout:
 			// rollback to previous configuration
-			rollbackErr := a.rollbackEdit(previousConfig)
+			rollbackErr := a.rollbackEdit(rollbackConfig)
 			if rollbackErr != nil {
 				a.actionLogger.Errorf("Failed to rollback to previous configuration: %v", rollbackErr)
 				stateMessage := fmt.Sprintf("Bridge '%s' edit timeout reached. It did not become %s in time. Rolling back to previous configuration failed: %v", a.name, desiredPCState, rollbackErr)
 				a.fsmLogger.SentryError(deps.FeatureDisableReadFlows, "", rollbackErr, "edit_protocol_converter_rollback_failed",
-					deps.String("previousConfig", previousConfig.String()))
+					deps.String("rollbackConfig", rollbackConfig.String()))
 
 				return models.ErrRetryRollbackTimeout, fmt.Errorf("%s", stateMessage)
 			}
@@ -586,7 +590,7 @@ func (a *EditProtocolConverterAction) awaitRollout(previousConfig config.Protoco
 			}
 
 			a.fsmLogger.SentryWarn(deps.FeatureDisableReadFlows, "", "edit_protocol_converter_rollback_on_timeout",
-				deps.String("previousConfig", previousConfig.String()),
+				deps.String("rollbackConfig", rollbackConfig.String()),
 				deps.String("desiredPCState", desiredPCState),
 			)
 
@@ -644,7 +648,7 @@ func (a *EditProtocolConverterAction) awaitRollout(previousConfig config.Protoco
 					// Kept because a stopped bridge stops its nmap service and
 					// would never report the new port.
 					if desiredPCState != protocolconverter.OperationalStateStopped {
-						if waitingFor := a.connectionCheckWait(newConfig, pcSnapshot); waitingFor != "" {
+						if waitingFor := a.connectionCheckWait(rolloutConfig, pcSnapshot); waitingFor != "" {
 							currentStateReason = waitingFor
 							SendActionReply(
 								a.instanceUUID,
@@ -774,7 +778,7 @@ func (a *EditProtocolConverterAction) awaitRollout(previousConfig config.Protoco
 								models.EditProtocolConverter,
 							)
 
-							rollbackErr := a.rollbackEdit(previousConfig)
+							rollbackErr := a.rollbackEdit(rollbackConfig)
 							if rollbackErr != nil {
 								a.actionLogger.Errorf("failed to roll back protocol converter %s: %v", a.name, rollbackErr)
 								a.fsmLogger.SentryError(deps.FeatureDisableReadFlows, "", rollbackErr, "edit_protocol_converter_render_failure_rollback_failed",
@@ -920,19 +924,19 @@ func (a *EditProtocolConverterAction) awaitRollout(previousConfig config.Protoco
 						models.EditProtocolConverter,
 					)
 
-					a.actionLogger.Infof("rolling back to previous configuration with user variables: %v", previousConfig.ProtocolConverterServiceConfig.Variables.User)
+					a.actionLogger.Infof("rolling back to previous configuration with user variables: %v", rollbackConfig.ProtocolConverterServiceConfig.Variables.User)
 
-					err := a.rollbackEdit(previousConfig)
+					err := a.rollbackEdit(rollbackConfig)
 					if err != nil {
 						a.actionLogger.Errorf("failed to roll back protocol converter %s: %v", a.name, err)
 						a.fsmLogger.SentryError(deps.FeatureDisableReadFlows, "", err, "edit_protocol_converter_config_error_rollback_failed",
-							deps.String("previousConfig", previousConfig.String()))
+							deps.String("rollbackConfig", rollbackConfig.String()))
 
 						return models.ErrConfigFileInvalid, fmt.Errorf("bridge '%s' has invalid configuration but could not be rolled back: %w. Please check your logs and consider manually restoring the previous configuration", a.name, err)
 					}
 
 					a.fsmLogger.SentryWarn(deps.FeatureDisableReadFlows, "", "edit_protocol_converter_config_error_rolled_back",
-						deps.String("previousConfig", previousConfig.String()))
+						deps.String("rollbackConfig", rollbackConfig.String()))
 
 					return models.ErrConfigFileInvalid, fmt.Errorf("bridge '%s' was rolled back to its previous configuration due to configuration errors. Please check the component logs, fix the configuration issues, and try editing again", a.name)
 				}

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter.go
@@ -49,11 +49,11 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/protocolconverterserviceconfig"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
-	nmapfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/nmap"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/protocolconverter"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/logger"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/models"
+	nmapservice "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/nmap"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/protocolconverter/runtime_config"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/s6"
 )
@@ -676,7 +676,7 @@ func (a *EditProtocolConverterAction) awaitRollout(previousConfig config.Protoco
 						// on fsmv2 and "the scanner process is up" on fsmv1, so on
 						// fsmv1 it is true for a port that never answered.
 						portIsOpen := nmapObs.ServiceInfo.NmapStatus.LastScan != nil &&
-							nmapObs.ServiceInfo.NmapStatus.LastScan.PortResult.State == string(nmapfsm.PortStateOpen)
+							nmapObs.ServiceInfo.NmapStatus.LastScan.PortResult.State == string(nmapservice.PortStateOpen)
 
 						if nmapPort != wantConnectionPort {
 							currentStateReason = "waiting for nmap to connect to port " + wantConnectionPort

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter.go
@@ -554,31 +554,6 @@ func (a *EditProtocolConverterAction) awaitRollout(previousConfig config.Protoco
 	startTime := time.Now()
 	timeoutDuration := timeoutInterval
 
-	// wantTarget and wantPort are the host and port the connection check below requires
-	// the scan to have dialed and found open. They are rendered from the spec
-	// this edit just persisted, not taken from the action payload: a bridge whose
-	// connection template holds a template string rather than a literal resolves
-	// its endpoint only at render time. get-protocolconverter falls back to that
-	// raw template when the spec carries no IP/PORT user variables, so the
-	// payload comes back with an unresolved target and, because the port string
-	// does not parse, port 0 — while the scan dials the resolved endpoint.
-	// Comparing the two would never match, burn the whole timeout and roll back a
-	// healthy edit.
-	//
-	// A historian bridge is the case that keeps no IP/PORT variables: its
-	// connection is {{ .historian.timescale.host }}:{{ .historian.timescale.port }},
-	// inherited from the shared section. get-protocolconverter special-cases it
-	// and returns the resolved endpoint, so a console edit of one does carry a
-	// literal host and port; rendering here is what keeps every other templated
-	// bridge, and any client that sends the raw template back, from timing out.
-	//
-	// The endpoint is resolved on every tick rather than once up front. Reading
-	// the config can fail transiently, and a single failure used to fall back to
-	// the payload endpoint — which for a templated bridge is an unresolved target
-	// on port 0, an endpoint no scan can ever match, so a healthy edit waited out
-	// the whole timeout and rolled back. Resolving per tick lets a transient
-	// failure heal; a deterministic one repeats and the timeout message names it.
-
 	var (
 		logs     []s6.LogEntry
 		lastLogs []s6.LogEntry
@@ -684,6 +659,13 @@ func (a *EditProtocolConverterAction) awaitRollout(previousConfig config.Protoco
 					// because a stopped bridge stops its nmap service too and
 					// would never report the new port.
 					if desiredPCState != protocolconverter.OperationalStateStopped {
+						// The endpoint comes from the spec this edit persisted, not from the
+						// action payload: a templated connection resolves only at render
+						// time, and get-protocolconverter hands the raw template back when
+						// the spec carries no IP/PORT variables, so the payload can name a
+						// target and port 0 that no scan will ever report. Re-rendered every
+						// tick, so a transient config-read failure heals instead of failing
+						// the edit; a deterministic one repeats and the timeout names it.
 						resolved, renderErr := a.resolvedConnectionEndpoint(newConfig.ProtocolConverterServiceConfig)
 						if renderErr != nil {
 							a.lastRenderErr = renderErr

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter.go
@@ -564,24 +564,12 @@ func (a *EditProtocolConverterAction) awaitRollout(previousConfig config.Protoco
 	// the two would never match, burn the whole timeout and roll back a healthy
 	// edit.
 	//
-	// A render failure falls back to the payload endpoint and is recorded in
-	// lastRenderErr so the timeout message names the real cause: the agent
-	// renders the same spec, so a spec that fails here cannot roll out either.
-	wantTarget := a.connectionIP
-	wantPort := a.connectionPort
-
-	if a.dfcType == DFCTypeEmpty && desiredPCState != protocolconverter.OperationalStateStopped {
-		resolved, renderErr := a.resolvedConnectionEndpoint(newSpec)
-		if renderErr != nil {
-			a.actionLogger.Warnf("Failed to resolve the connection endpoint for the rollout gate, falling back to the payload endpoint %s:%s: %v", a.connectionIP, a.connectionPort, renderErr)
-			a.lastRenderErr = renderErr
-		} else {
-			wantTarget = resolved.Target
-			wantPort = strconv.FormatUint(uint64(resolved.Port), 10)
-		}
-	}
-
-	wantEndpoint := wantTarget + ":" + wantPort
+	// The endpoint is resolved on every tick rather than once up front. Reading
+	// the config can fail transiently, and a single failure used to fall back to
+	// the payload endpoint — which for a templated bridge is an unresolved target
+	// on port 0, an endpoint no scan can ever match, so a healthy edit waited out
+	// the whole timeout and rolled back. Resolving per tick lets a transient
+	// failure heal; a deterministic one repeats and the timeout message names it.
 
 	var (
 		logs     []s6.LogEntry
@@ -688,6 +676,25 @@ func (a *EditProtocolConverterAction) awaitRollout(previousConfig config.Protoco
 					// because a stopped bridge stops its nmap service too and
 					// would never report the new port.
 					if desiredPCState != protocolconverter.OperationalStateStopped {
+						resolved, renderErr := a.resolvedConnectionEndpoint(newSpec)
+						if renderErr != nil {
+							a.lastRenderErr = renderErr
+							currentStateReason = "waiting to resolve the bridge's connection endpoint"
+							SendActionReply(
+								a.instanceUUID,
+								a.userEmail,
+								a.actionUUID,
+								models.ActionExecuting,
+								RemainingPrefixSec(remainingSeconds)+currentStateReason,
+								a.outboundChannel,
+								models.EditProtocolConverter,
+							)
+
+							continue
+						}
+
+						wantEndpoint := resolved.Target + ":" + strconv.FormatUint(uint64(resolved.Port), 10)
+
 						nmapObs := pcSnapshot.ServiceInfo.ConnectionObservedState.ServiceInfo.NmapObservedState
 						scannedEndpoint := nmapObs.ObservedNmapServiceConfig.Target + ":" +
 							strconv.FormatUint(uint64(nmapObs.ObservedNmapServiceConfig.Port), 10)

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter.go
@@ -110,10 +110,10 @@ type EditProtocolConverterAction struct {
 	configManager config.ConfigManager
 
 	fsmLogger deps.FSMLogger
-	// lastRenderErr holds the most recent render error — from
-	// renderDesiredDFCConfig, or from the connection render that resolves the
-	// connection check's expected port — so the awaitRollout timeout message can
-	// surface the real cause instead of just "did not become active in time".
+	// lastRenderErr holds the most recent render error, from
+	// renderDesiredDFCConfig or from the connection render that resolves the
+	// connection check's expected port, so the awaitRollout timeout message can
+	// name the real cause instead of just "did not become active in time".
 	// It is sticky: compareSingleDFCConfig clears it only when a later render
 	// succeeds, so ticks that never reach a render (for example while Benthos
 	// restarts) keep the captured cause.
@@ -1215,10 +1215,10 @@ func (a *EditProtocolConverterAction) connectionCheckWait(
 // just-persisted spec and returns the endpoint the nmap scan is expected to
 // dial, in the same type the observed scan config carries.
 //
-// It renders with the same inputs the agent uses — the persisted spec (which
-// already carries the edit's merged variables), the agent location and the
-// historian section read from the config manager — so the endpoint returned
-// here is the endpoint the control loop will make the scanner dial.
+// It renders with the same inputs the agent uses: the persisted spec (which
+// already carries the edit's merged variables), the agent location, and the
+// historian section read from the config manager. So the endpoint returned here
+// is the endpoint the control loop will make the scanner dial.
 func (a *EditProtocolConverterAction) resolvedConnectionEndpoint(newSpec protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec) (nmapserviceconfig.NmapServiceConfig, error) {
 	systemSnapshot := a.systemSnapshotManager.GetDeepCopySnapshot()
 	agentLocation := convertIntMapToStringMap(systemSnapshot.CurrentConfig.Agent.Location)

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter.go
@@ -1142,6 +1142,12 @@ func (a *EditProtocolConverterAction) mergeUserVariables(base map[string]any, in
 	return merged
 }
 
+// formatEndpoint renders a scan config as target:port, the form the connection
+// check compares and the reply messages carry.
+func formatEndpoint(config nmapserviceconfig.NmapServiceConfig) string {
+	return config.Target + ":" + strconv.FormatUint(uint64(config.Port), 10)
+}
+
 // connectionCheckWait reports what the connection check is still waiting for,
 // or "" when the scan agrees with the endpoint this edit persisted.
 //
@@ -1160,11 +1166,10 @@ func (a *EditProtocolConverterAction) connectionCheckWait(
 		return "waiting to resolve the bridge's connection endpoint"
 	}
 
-	wantEndpoint := resolved.Target + ":" + strconv.FormatUint(uint64(resolved.Port), 10)
+	wantEndpoint := formatEndpoint(resolved)
 
 	nmapObs := pcSnapshot.ServiceInfo.ConnectionObservedState.ServiceInfo.NmapObservedState
-	scannedEndpoint := nmapObs.ObservedNmapServiceConfig.Target + ":" +
-		strconv.FormatUint(uint64(nmapObs.ObservedNmapServiceConfig.Port), 10)
+	scannedEndpoint := formatEndpoint(nmapObs.ObservedNmapServiceConfig)
 
 	// Comparing the port alone accepts a move to a different host on the same
 	// port: the old host's scan reports it open and nothing dialed the new host.

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter.go
@@ -111,7 +111,7 @@ type EditProtocolConverterAction struct {
 	fsmLogger deps.FSMLogger
 	// lastRenderErr holds the most recent render error — from
 	// renderDesiredDFCConfig, or from the connection render that resolves the
-	// nmap gate's expected port — so the awaitRollout timeout message can
+	// rollout gate's expected port — so the awaitRollout timeout message can
 	// surface the real cause instead of just "did not become active in time".
 	// It is sticky: compareSingleDFCConfig clears it only when a later render
 	// succeeds, so ticks that never reach a render (for example while Benthos
@@ -275,8 +275,6 @@ func (a *EditProtocolConverterAction) Validate() error {
 		return err
 	}
 
-	// Validate read DFC state — validate independently of whether config was provided,
-	// so state-only edits (readDFCSvcCfg == nil) are also checked.
 	if a.readDFCState != "" {
 		if err := ValidateDataFlowComponentState(a.readDFCState); err != nil {
 			return fmt.Errorf("invalid read DFC state: %w", err)
@@ -511,10 +509,10 @@ func (a *EditProtocolConverterAction) persistConfig(atomicEditUUID uuid.UUID, ne
 // The error code is a string that is sent to the frontend to allow it to determine if the action can be retried or not.
 // The error message is sent to the frontend to allow the user to see the error message.
 //
-// pcConfig is the pre-edit configuration, used to roll back on failure. newSpec is
+// previousConfig is the pre-edit configuration, used to roll back on failure. newSpec is
 // the specification this edit just persisted, used to resolve the endpoint the nmap
 // gate expects the scan to dial.
-func (a *EditProtocolConverterAction) awaitRollout(pcConfig config.ProtocolConverterConfig, newSpec protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec, desiredPCState string) (string, error) {
+func (a *EditProtocolConverterAction) awaitRollout(previousConfig config.ProtocolConverterConfig, newSpec protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec, desiredPCState string) (string, error) {
 	SendActionReply(
 		a.instanceUUID,
 		a.userEmail,
@@ -591,12 +589,12 @@ func (a *EditProtocolConverterAction) awaitRollout(pcConfig config.ProtocolConve
 		select {
 		case <-timeout:
 			// rollback to previous configuration
-			rollbackErr := a.rollbackEdit(pcConfig)
+			rollbackErr := a.rollbackEdit(previousConfig)
 			if rollbackErr != nil {
 				a.actionLogger.Errorf("Failed to rollback to previous configuration: %v", rollbackErr)
 				stateMessage := fmt.Sprintf("Bridge '%s' edit timeout reached. It did not become %s in time. Rolling back to previous configuration failed: %v", a.name, desiredPCState, rollbackErr)
 				a.fsmLogger.SentryError(deps.FeatureDisableReadFlows, "", rollbackErr, "edit_protocol_converter_rollback_failed",
-					deps.String("pcConfig", pcConfig.String()))
+					deps.String("previousConfig", previousConfig.String()))
 
 				return models.ErrRetryRollbackTimeout, fmt.Errorf("%s", stateMessage)
 			}
@@ -607,7 +605,7 @@ func (a *EditProtocolConverterAction) awaitRollout(pcConfig config.ProtocolConve
 			}
 
 			a.fsmLogger.SentryWarn(deps.FeatureDisableReadFlows, "", "edit_protocol_converter_rollback_on_timeout",
-				deps.String("pcConfig", pcConfig.String()),
+				deps.String("previousConfig", previousConfig.String()),
 				deps.String("desiredPCState", desiredPCState),
 			)
 
@@ -661,9 +659,10 @@ func (a *EditProtocolConverterAction) awaitRollout(pcConfig config.ProtocolConve
 				currentStateReason := "current state: " + instance.CurrentState
 
 				if a.dfcType == DFCTypeEmpty {
-					// For empty DFC type (connection/location/state update only)
-					// Only check the nmap port when activating; when stopping, nmap is also
-					// stopped so it will never update to the new port.
+					// Unreachable today: applyMutation forces the bridge to
+					// active, so desiredPCState is never stopped here. Kept
+					// because a stopped bridge stops its nmap service too and
+					// would never report the new port.
 					if desiredPCState != protocolconverter.OperationalStateStopped {
 						nmapObs := pcSnapshot.ServiceInfo.ConnectionObservedState.ServiceInfo.NmapObservedState
 						nmapPort := strconv.FormatUint(
@@ -671,14 +670,11 @@ func (a *EditProtocolConverterAction) awaitRollout(pcConfig config.ProtocolConve
 							10,
 						)
 
-						// A scanned-and-open port is the only guarantee that the
-						// edit converged. The observed config merely echoes what
-						// the scan was asked to dial, so port equality alone
-						// cannot tell a live port from a refused one. Requiring
-						// open matches the connection FSM, which defines up as
-						// open and counts every other state as down. Do NOT use
-						// IsRunning: it is overloaded across backends (open on
-						// fsmv2, "scanner process up" on fsmv1).
+						// Port equality alone cannot tell a live port from a
+						// refused one, so require the scan to report open. Do not
+						// use IsRunning: it means the port accepted the connection
+						// on fsmv2 and "the scanner process is up" on fsmv1, so on
+						// fsmv1 it is true for a port that never answered.
 						portIsOpen := nmapObs.ServiceInfo.NmapStatus.LastScan != nil &&
 							nmapObs.ServiceInfo.NmapStatus.LastScan.PortResult.State == string(nmapfsm.PortStateOpen)
 
@@ -832,7 +828,7 @@ func (a *EditProtocolConverterAction) awaitRollout(pcConfig config.ProtocolConve
 								models.EditProtocolConverter,
 							)
 
-							rollbackErr := a.rollbackEdit(pcConfig)
+							rollbackErr := a.rollbackEdit(previousConfig)
 							if rollbackErr != nil {
 								a.actionLogger.Errorf("failed to roll back protocol converter %s: %v", a.name, rollbackErr)
 								a.fsmLogger.SentryError(deps.FeatureDisableReadFlows, "", rollbackErr, "edit_protocol_converter_render_failure_rollback_failed",
@@ -978,19 +974,19 @@ func (a *EditProtocolConverterAction) awaitRollout(pcConfig config.ProtocolConve
 						models.EditProtocolConverter,
 					)
 
-					a.actionLogger.Infof("rolling back to previous configuration with user variables: %v", pcConfig.ProtocolConverterServiceConfig.Variables.User)
+					a.actionLogger.Infof("rolling back to previous configuration with user variables: %v", previousConfig.ProtocolConverterServiceConfig.Variables.User)
 
-					err := a.rollbackEdit(pcConfig)
+					err := a.rollbackEdit(previousConfig)
 					if err != nil {
 						a.actionLogger.Errorf("failed to roll back protocol converter %s: %v", a.name, err)
 						a.fsmLogger.SentryError(deps.FeatureDisableReadFlows, "", err, "edit_protocol_converter_config_error_rollback_failed",
-							deps.String("pcConfig", pcConfig.String()))
+							deps.String("previousConfig", previousConfig.String()))
 
 						return models.ErrConfigFileInvalid, fmt.Errorf("bridge '%s' has invalid configuration but could not be rolled back: %w. Please check your logs and consider manually restoring the previous configuration", a.name, err)
 					}
 
 					a.fsmLogger.SentryWarn(deps.FeatureDisableReadFlows, "", "edit_protocol_converter_config_error_rolled_back",
-						deps.String("pcConfig", pcConfig.String()))
+						deps.String("previousConfig", previousConfig.String()))
 
 					return models.ErrConfigFileInvalid, fmt.Errorf("bridge '%s' was rolled back to its previous configuration due to configuration errors. Please check the component logs, fix the configuration issues, and try editing again", a.name)
 				}
@@ -1225,7 +1221,7 @@ func (a *EditProtocolConverterAction) resolvedConnectionPort(newSpec protocolcon
 	runtimeConfig, err := runtime_config.BuildRuntimeConfig(
 		newSpec,
 		agentLocation,
-		nil, // TODO: add global vars
+		nil, // TODO(ENG-5855): add global vars
 		currentConfig.Historian,
 		runtime_config.BridgedByPlaceholder,
 		a.name,
@@ -1305,7 +1301,7 @@ func (a *EditProtocolConverterAction) renderDesiredDFCConfig(pcSnapshot *protoco
 	runtimeConfig, err := runtime_config.BuildRuntimeConfig(
 		modifiedSpec,
 		agentLocation,
-		nil, // TODO: add global vars
+		nil, // TODO(ENG-5855): add global vars
 		currentConfig.Historian,
 		runtime_config.BridgedByPlaceholder,
 		pcName,

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter.go
@@ -166,6 +166,13 @@ type EditProtocolConverterAction struct {
 	// Parsed request payload (only populated after Parse)
 	protocolConverterUUID uuid.UUID
 
+	// persistedAt is when the edit reached config.yaml. The rollout gate needs
+	// it because a scan is only evidence about the new endpoint if it started
+	// after the config changed: nmap's observed endpoint is re-read from the
+	// generated scan script, which is rewritten at persist time, so it names the
+	// new endpoint several ticks before anything dials it.
+	persistedAt time.Time
+
 	// rolloutSentryReported tells Execute to skip the generic rollout_failed
 	// Sentry event for this abort. Every awaitRollout abort path fires its own
 	// dedicated event; only the render-failure paths (added for ENG-5103) set
@@ -482,6 +489,8 @@ func (a *EditProtocolConverterAction) persistConfig(atomicEditUUID uuid.UUID, ne
 		return config.ProtocolConverterConfig{}, fmt.Errorf("failed to update protocol converter: %w", err)
 	}
 
+	a.persistedAt = time.Now()
+
 	// deep copy the old config therefore setup a full config
 	// this may seem hacky but like that we can reuse the Clone() function
 	// and we do not need to implement a custom Clone() function for the ProtocolConverterConfig
@@ -688,8 +697,10 @@ func (a *EditProtocolConverterAction) awaitRollout(previousConfig config.Protoco
 						// use IsRunning: it means the port accepted the connection
 						// on fsmv2 and "the scanner process is up" on fsmv1, so on
 						// fsmv1 it is true for a port that never answered.
-						portIsOpen := nmapObs.ServiceInfo.NmapStatus.LastScan != nil &&
-							nmapObs.ServiceInfo.NmapStatus.LastScan.PortResult.State == string(nmapservice.PortStateOpen)
+						lastScan := nmapObs.ServiceInfo.NmapStatus.LastScan
+						scanIsPostEdit := lastScan != nil && lastScan.Timestamp.After(a.persistedAt)
+						portIsOpen := lastScan != nil &&
+							lastScan.PortResult.State == string(nmapservice.PortStateOpen)
 
 						// Both halves must match. The port alone accepts a move
 						// to a different host on the same port: the number
@@ -697,6 +708,27 @@ func (a *EditProtocolConverterAction) awaitRollout(previousConfig config.Protoco
 						// and nothing has dialed the new host (ENG-5586).
 						if scannedEndpoint != wantEndpoint {
 							currentStateReason = "waiting for nmap to scan " + wantEndpoint
+							SendActionReply(
+								a.instanceUUID,
+								a.userEmail,
+								a.actionUUID,
+								models.ActionExecuting,
+								RemainingPrefixSec(remainingSeconds)+currentStateReason,
+								a.outboundChannel,
+								models.EditProtocolConverter,
+							)
+
+							continue
+						}
+
+						// The observed endpoint is re-read from the generated
+						// scan script, which is rewritten when the edit is
+						// persisted, so it names the new endpoint before the
+						// scanner has been rebuilt and dialed it. Requiring the
+						// scan to have started after the persist is what makes
+						// the endpoint match evidence rather than an echo.
+						if !scanIsPostEdit {
+							currentStateReason = "waiting for a scan of " + wantEndpoint + " taken after the edit"
 							SendActionReply(
 								a.instanceUUID,
 								a.userEmail,

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter.go
@@ -1146,52 +1146,53 @@ func (a *EditProtocolConverterAction) mergeUserVariables(base map[string]any, in
 	return merged
 }
 
-// formatEndpoint renders a scan config as target:port, the form the connection
-// check compares and the reply messages carry.
-func formatEndpoint(config nmapserviceconfig.NmapServiceConfig) string {
-	return config.Target + ":" + strconv.FormatUint(uint64(config.Port), 10)
+// formatEndpoint renders a target and port as target:port, the form the
+// connection check compares and the reply messages carry.
+func formatEndpoint(target string, port uint16) string {
+	return target + ":" + strconv.FormatUint(uint64(port), 10)
 }
 
 // connectionCheckWait reports what the connection check is still waiting for,
-// or "" when the scan agrees with the endpoint this edit persisted.
+// or "" when the check reached the endpoint this edit persisted.
 //
 // The endpoint is rendered from the persisted spec, never taken from the action
 // payload: get-protocolconverter hands back the raw connection template when
 // the spec carries no IP/PORT variables, so a payload can name an unresolved
-// target on port 0 that no scan will ever report.
+// target on port 0 that no check will ever report.
 func (a *EditProtocolConverterAction) connectionCheckWait(
-	newConfig config.ProtocolConverterConfig,
+	pcConfig config.ProtocolConverterConfig,
 	pcSnapshot *protocolconverter.ProtocolConverterObservedStateSnapshot,
 ) string {
-	resolved, renderErr := a.resolvedConnectionEndpoint(newConfig.ProtocolConverterServiceConfig)
+	resolved, renderErr := a.resolvedConnectionEndpoint(pcConfig.ProtocolConverterServiceConfig)
 	if renderErr != nil {
 		a.lastRenderErr = renderErr
 
-		return "waiting to resolve the bridge's connection endpoint"
+		return "reading the bridge's connection details"
 	}
 
-	wantEndpoint := formatEndpoint(resolved)
+	wantEndpoint := formatEndpoint(resolved.Target, resolved.Port)
 
-	nmapObs := pcSnapshot.ServiceInfo.ConnectionObservedState.ServiceInfo.NmapObservedState
-	scannedEndpoint := formatEndpoint(nmapObs.ObservedNmapServiceConfig)
-
-	// Comparing the port alone accepts a move to a different host on the same
-	// port: the old host's scan reports it open and nothing dialed the new host.
-	if scannedEndpoint != wantEndpoint {
-		return "waiting for nmap to scan " + wantEndpoint
-	}
-
-	// The observed endpoint echoes the regenerated scan script, so it names the
-	// new endpoint before the scanner has dialed it.
-	lastScan := nmapObs.ServiceInfo.NmapStatus.LastScan
+	lastScan := pcSnapshot.ServiceInfo.ConnectionObservedState.ServiceInfo.NmapObservedState.ServiceInfo.NmapStatus.LastScan
 	if lastScan == nil || !lastScan.Timestamp.After(a.persistedAt) {
-		return "waiting for a scan of " + wantEndpoint + " taken after the edit"
+		return "checking " + wantEndpoint
+	}
+
+	// Never compare against ObservedNmapServiceConfig here: on fsmv1 it is
+	// parsed from the scan script on disk, so it names the new endpoint from the
+	// moment that script is rewritten, while the old scanner keeps reporting the
+	// old endpoint as open until s6 restarts it. Only the scan itself records
+	// what was dialed.
+	//
+	// Comparing the port alone would accept a move to a different host on the
+	// same port for the same reason.
+	if formatEndpoint(lastScan.Target, lastScan.PortResult.Port) != wantEndpoint {
+		return "checking " + wantEndpoint
 	}
 
 	// Do not use IsRunning instead: it means the port answered on fsmv2 but only
 	// "the scanner process is up" on fsmv1, where a refused port reads true.
 	if lastScan.PortResult.State != string(nmapservice.PortStateOpen) {
-		return "waiting for nmap to report " + wantEndpoint + " open (last scan: " + lastScan.PortResult.State + ")"
+		return "cannot reach " + wantEndpoint + " (port " + lastScan.PortResult.State + ")"
 	}
 
 	return ""

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter.go
@@ -357,7 +357,7 @@ func (a *EditProtocolConverterAction) Execute() (interface{}, map[string]interfa
 
 	// Await rollout and perform health checks
 	if a.systemSnapshotManager != nil && !a.ignoreHealthCheck {
-		errCode, err := a.awaitRollout(oldConfig, newSpec.ProtocolConverterServiceConfig, desiredPCState)
+		errCode, err := a.awaitRollout(oldConfig, newSpec, desiredPCState)
 		if err != nil {
 			errorMsg := fmt.Sprintf("Failed during rollout: %v", err)
 			SendActionReplyV2(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedWithFailure,
@@ -519,10 +519,10 @@ func (a *EditProtocolConverterAction) persistConfig(atomicEditUUID uuid.UUID, ne
 // The error code is a string that is sent to the frontend to allow it to determine if the action can be retried or not.
 // The error message is sent to the frontend to allow the user to see the error message.
 //
-// previousConfig is the pre-edit configuration, used to roll back on failure. newSpec is
-// the specification this edit just persisted, used to resolve the endpoint the nmap
-// gate expects the scan to dial.
-func (a *EditProtocolConverterAction) awaitRollout(previousConfig config.ProtocolConverterConfig, newSpec protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec, desiredPCState string) (string, error) {
+// previousConfig is the pre-edit configuration, written back verbatim to roll back on
+// failure. newConfig is the configuration this edit just persisted; its spec resolves
+// the endpoint the nmap gate expects the scan to dial.
+func (a *EditProtocolConverterAction) awaitRollout(previousConfig config.ProtocolConverterConfig, newConfig config.ProtocolConverterConfig, desiredPCState string) (string, error) {
 	SendActionReply(
 		a.instanceUUID,
 		a.userEmail,
@@ -676,7 +676,7 @@ func (a *EditProtocolConverterAction) awaitRollout(previousConfig config.Protoco
 					// because a stopped bridge stops its nmap service too and
 					// would never report the new port.
 					if desiredPCState != protocolconverter.OperationalStateStopped {
-						resolved, renderErr := a.resolvedConnectionEndpoint(newSpec)
+						resolved, renderErr := a.resolvedConnectionEndpoint(newConfig.ProtocolConverterServiceConfig)
 						if renderErr != nil {
 							a.lastRenderErr = renderErr
 							currentStateReason = "waiting to resolve the bridge's connection endpoint"

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter.go
@@ -46,6 +46,7 @@ import (
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/dataflowcomponentserviceconfig"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/nmapserviceconfig"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/protocolconverterserviceconfig"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
@@ -544,29 +545,34 @@ func (a *EditProtocolConverterAction) awaitRollout(previousConfig config.Protoco
 	startTime := time.Now()
 	timeoutDuration := timeoutInterval
 
-	// wantConnectionPort is the port the nmap gate below requires the scan to
-	// have dialed and found open. It is rendered from the spec this edit just
-	// persisted, not taken from the action payload: a bridge whose connection is
-	// templated resolves its endpoint only at render time. A historian bridge
-	// scans {{ .historian.timescale.host }}:{{ .historian.timescale.port }} and
-	// keeps no IP/PORT user variables, so its payload carries an unresolved
-	// target and port 0 while the scan dials the resolved port — comparing the
-	// two would never match, burn the whole timeout and roll back a healthy edit.
+	// wantTarget and wantPort are the host and port the nmap gate below requires
+	// the scan to have dialed and found open. They are rendered from the spec
+	// this edit just persisted, not taken from the action payload: a bridge whose
+	// connection is templated resolves its endpoint only at render time. A
+	// historian bridge scans {{ .historian.timescale.host }}:{{ .historian.timescale.port }}
+	// and keeps no IP/PORT user variables, so its payload carries an unresolved
+	// target and port 0 while the scan dials the resolved endpoint — comparing
+	// the two would never match, burn the whole timeout and roll back a healthy
+	// edit.
 	//
-	// A render failure falls back to the payload port and is recorded in
+	// A render failure falls back to the payload endpoint and is recorded in
 	// lastRenderErr so the timeout message names the real cause: the agent
 	// renders the same spec, so a spec that fails here cannot roll out either.
-	wantConnectionPort := a.connectionPort
+	wantTarget := a.connectionIP
+	wantPort := a.connectionPort
 
 	if a.dfcType == DFCTypeEmpty && desiredPCState != protocolconverter.OperationalStateStopped {
-		resolvedPort, renderErr := a.resolvedConnectionPort(newSpec)
+		resolved, renderErr := a.resolvedConnectionEndpoint(newSpec)
 		if renderErr != nil {
-			a.actionLogger.Warnf("Failed to resolve the connection endpoint for the rollout gate, falling back to the payload port %s: %v", a.connectionPort, renderErr)
+			a.actionLogger.Warnf("Failed to resolve the connection endpoint for the rollout gate, falling back to the payload endpoint %s:%s: %v", a.connectionIP, a.connectionPort, renderErr)
 			a.lastRenderErr = renderErr
 		} else {
-			wantConnectionPort = resolvedPort
+			wantTarget = resolved.Target
+			wantPort = strconv.FormatUint(uint64(resolved.Port), 10)
 		}
 	}
+
+	wantEndpoint := wantTarget + ":" + wantPort
 
 	var (
 		logs     []s6.LogEntry
@@ -665,10 +671,8 @@ func (a *EditProtocolConverterAction) awaitRollout(previousConfig config.Protoco
 					// would never report the new port.
 					if desiredPCState != protocolconverter.OperationalStateStopped {
 						nmapObs := pcSnapshot.ServiceInfo.ConnectionObservedState.ServiceInfo.NmapObservedState
-						nmapPort := strconv.FormatUint(
-							uint64(nmapObs.ObservedNmapServiceConfig.Port),
-							10,
-						)
+						scannedEndpoint := nmapObs.ObservedNmapServiceConfig.Target + ":" +
+							strconv.FormatUint(uint64(nmapObs.ObservedNmapServiceConfig.Port), 10)
 
 						// Port equality alone cannot tell a live port from a
 						// refused one, so require the scan to report open. Do not
@@ -678,8 +682,12 @@ func (a *EditProtocolConverterAction) awaitRollout(previousConfig config.Protoco
 						portIsOpen := nmapObs.ServiceInfo.NmapStatus.LastScan != nil &&
 							nmapObs.ServiceInfo.NmapStatus.LastScan.PortResult.State == string(nmapservice.PortStateOpen)
 
-						if nmapPort != wantConnectionPort {
-							currentStateReason = "waiting for nmap to connect to port " + wantConnectionPort
+						// Both halves must match. The port alone accepts a move
+						// to a different host on the same port: the number
+						// agrees, the old host's scan says that port is open,
+						// and nothing has dialed the new host (ENG-5586).
+						if scannedEndpoint != wantEndpoint {
+							currentStateReason = "waiting for nmap to scan " + wantEndpoint
 							SendActionReply(
 								a.instanceUUID,
 								a.userEmail,
@@ -699,7 +707,7 @@ func (a *EditProtocolConverterAction) awaitRollout(previousConfig config.Protoco
 								lastState = nmapObs.ServiceInfo.NmapStatus.LastScan.PortResult.State
 							}
 
-							currentStateReason = "waiting for nmap to report port " + wantConnectionPort + " open (last scan: " + lastState + ")"
+							currentStateReason = "waiting for nmap to report " + wantEndpoint + " open (last scan: " + lastState + ")"
 							SendActionReply(
 								a.instanceUUID,
 								a.userEmail,
@@ -1196,15 +1204,15 @@ func (a *EditProtocolConverterAction) mergeUserVariables(base map[string]any, in
 	return merged
 }
 
-// resolvedConnectionPort renders the connection template of the just-persisted
-// spec and returns the port the nmap scan is expected to dial, as the decimal
-// string the observed scan config is compared against.
+// resolvedConnectionEndpoint renders the connection template of the
+// just-persisted spec and returns the endpoint the nmap scan is expected to
+// dial, in the same type the observed scan config carries.
 //
 // It renders with the same inputs the agent uses — the persisted spec (which
 // already carries the edit's merged variables), the agent location and the
-// historian section read from the config manager — so the port returned here is
-// the port the control loop will make the scanner dial.
-func (a *EditProtocolConverterAction) resolvedConnectionPort(newSpec protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec) (string, error) {
+// historian section read from the config manager — so the endpoint returned
+// here is the endpoint the control loop will make the scanner dial.
+func (a *EditProtocolConverterAction) resolvedConnectionEndpoint(newSpec protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec) (nmapserviceconfig.NmapServiceConfig, error) {
 	systemSnapshot := a.systemSnapshotManager.GetDeepCopySnapshot()
 	agentLocation := convertIntMapToStringMap(systemSnapshot.CurrentConfig.Agent.Location)
 
@@ -1215,7 +1223,7 @@ func (a *EditProtocolConverterAction) resolvedConnectionPort(newSpec protocolcon
 
 	currentConfig, err := a.configManager.GetConfig(ctx, 0)
 	if err != nil {
-		return "", fmt.Errorf("failed to read current config for historian variables: %w", err)
+		return nmapserviceconfig.NmapServiceConfig{}, fmt.Errorf("failed to read current config for historian variables: %w", err)
 	}
 
 	runtimeConfig, err := runtime_config.BuildRuntimeConfig(
@@ -1227,13 +1235,10 @@ func (a *EditProtocolConverterAction) resolvedConnectionPort(newSpec protocolcon
 		a.name,
 	)
 	if err != nil {
-		return "", fmt.Errorf("failed to build runtime config: %w", err)
+		return nmapserviceconfig.NmapServiceConfig{}, fmt.Errorf("failed to build runtime config: %w", err)
 	}
 
-	return strconv.FormatUint(
-		uint64(runtimeConfig.ConnectionServiceConfig.NmapServiceConfig.Port),
-		10,
-	), nil
+	return runtimeConfig.ConnectionServiceConfig.NmapServiceConfig, nil
 }
 
 // renderDesiredDFCConfig renders the template variables in the desired DFC config

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter.go
@@ -557,12 +557,20 @@ func (a *EditProtocolConverterAction) awaitRollout(previousConfig config.Protoco
 	// wantTarget and wantPort are the host and port the nmap gate below requires
 	// the scan to have dialed and found open. They are rendered from the spec
 	// this edit just persisted, not taken from the action payload: a bridge whose
-	// connection is templated resolves its endpoint only at render time. A
-	// historian bridge scans {{ .historian.timescale.host }}:{{ .historian.timescale.port }}
-	// and keeps no IP/PORT user variables, so its payload carries an unresolved
-	// target and port 0 while the scan dials the resolved endpoint — comparing
-	// the two would never match, burn the whole timeout and roll back a healthy
-	// edit.
+	// connection template holds a template string rather than a literal resolves
+	// its endpoint only at render time. get-protocolconverter falls back to that
+	// raw template when the spec carries no IP/PORT user variables, so the
+	// payload comes back with an unresolved target and, because the port string
+	// does not parse, port 0 — while the scan dials the resolved endpoint.
+	// Comparing the two would never match, burn the whole timeout and roll back a
+	// healthy edit.
+	//
+	// A historian bridge is the case that keeps no IP/PORT variables: its
+	// connection is {{ .historian.timescale.host }}:{{ .historian.timescale.port }},
+	// inherited from the shared section. get-protocolconverter special-cases it
+	// and returns the resolved endpoint, so a console edit of one does carry a
+	// literal host and port; rendering here is what keeps every other templated
+	// bridge, and any client that sends the raw template back, from timing out.
 	//
 	// The endpoint is resolved on every tick rather than once up front. Reading
 	// the config can fail transiently, and a single failure used to fall back to

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter.go
@@ -112,7 +112,7 @@ type EditProtocolConverterAction struct {
 	fsmLogger deps.FSMLogger
 	// lastRenderErr holds the most recent render error — from
 	// renderDesiredDFCConfig, or from the connection render that resolves the
-	// rollout gate's expected port — so the awaitRollout timeout message can
+	// connection check's expected port — so the awaitRollout timeout message can
 	// surface the real cause instead of just "did not become active in time".
 	// It is sticky: compareSingleDFCConfig clears it only when a later render
 	// succeeds, so ticks that never reach a render (for example while Benthos
@@ -166,7 +166,7 @@ type EditProtocolConverterAction struct {
 	// Parsed request payload (only populated after Parse)
 	protocolConverterUUID uuid.UUID
 
-	// persistedAt is when the edit reached config.yaml. The rollout gate needs
+	// persistedAt is when the edit reached config.yaml. The connection check needs
 	// it because a scan is only evidence about the new endpoint if it started
 	// after the config changed: nmap's observed endpoint is re-read from the
 	// generated scan script, which is rewritten at persist time, so it names the
@@ -521,7 +521,7 @@ func (a *EditProtocolConverterAction) persistConfig(atomicEditUUID uuid.UUID, ne
 //
 // previousConfig is the pre-edit configuration, written back verbatim to roll back on
 // failure. newConfig is the configuration this edit just persisted; its spec resolves
-// the endpoint the nmap gate expects the scan to dial.
+// the endpoint the nmap connection check expects the scan to dial.
 func (a *EditProtocolConverterAction) awaitRollout(previousConfig config.ProtocolConverterConfig, newConfig config.ProtocolConverterConfig, desiredPCState string) (string, error) {
 	SendActionReply(
 		a.instanceUUID,
@@ -554,7 +554,7 @@ func (a *EditProtocolConverterAction) awaitRollout(previousConfig config.Protoco
 	startTime := time.Now()
 	timeoutDuration := timeoutInterval
 
-	// wantTarget and wantPort are the host and port the nmap gate below requires
+	// wantTarget and wantPort are the host and port the connection check below requires
 	// the scan to have dialed and found open. They are rendered from the spec
 	// this edit just persisted, not taken from the action payload: a bridge whose
 	// connection template holds a template string rather than a literal resolves

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter.go
@@ -659,93 +659,8 @@ func (a *EditProtocolConverterAction) awaitRollout(previousConfig config.Protoco
 					// because a stopped bridge stops its nmap service too and
 					// would never report the new port.
 					if desiredPCState != protocolconverter.OperationalStateStopped {
-						// The endpoint comes from the spec this edit persisted, not from the
-						// action payload: a templated connection resolves only at render
-						// time, and get-protocolconverter hands the raw template back when
-						// the spec carries no IP/PORT variables, so the payload can name a
-						// target and port 0 that no scan will ever report. Re-rendered every
-						// tick, so a transient config-read failure heals instead of failing
-						// the edit; a deterministic one repeats and the timeout names it.
-						resolved, renderErr := a.resolvedConnectionEndpoint(newConfig.ProtocolConverterServiceConfig)
-						if renderErr != nil {
-							a.lastRenderErr = renderErr
-							currentStateReason = "waiting to resolve the bridge's connection endpoint"
-							SendActionReply(
-								a.instanceUUID,
-								a.userEmail,
-								a.actionUUID,
-								models.ActionExecuting,
-								RemainingPrefixSec(remainingSeconds)+currentStateReason,
-								a.outboundChannel,
-								models.EditProtocolConverter,
-							)
-
-							continue
-						}
-
-						wantEndpoint := resolved.Target + ":" + strconv.FormatUint(uint64(resolved.Port), 10)
-
-						nmapObs := pcSnapshot.ServiceInfo.ConnectionObservedState.ServiceInfo.NmapObservedState
-						scannedEndpoint := nmapObs.ObservedNmapServiceConfig.Target + ":" +
-							strconv.FormatUint(uint64(nmapObs.ObservedNmapServiceConfig.Port), 10)
-
-						// Port equality alone cannot tell a live port from a
-						// refused one, so require the scan to report open. Do not
-						// use IsRunning: it means the port accepted the connection
-						// on fsmv2 and "the scanner process is up" on fsmv1, so on
-						// fsmv1 it is true for a port that never answered.
-						lastScan := nmapObs.ServiceInfo.NmapStatus.LastScan
-						scanIsPostEdit := lastScan != nil && lastScan.Timestamp.After(a.persistedAt)
-						portIsOpen := lastScan != nil &&
-							lastScan.PortResult.State == string(nmapservice.PortStateOpen)
-
-						// Both halves must match. The port alone accepts a move
-						// to a different host on the same port: the number
-						// agrees, the old host's scan says that port is open,
-						// and nothing has dialed the new host (ENG-5586).
-						if scannedEndpoint != wantEndpoint {
-							currentStateReason = "waiting for nmap to scan " + wantEndpoint
-							SendActionReply(
-								a.instanceUUID,
-								a.userEmail,
-								a.actionUUID,
-								models.ActionExecuting,
-								RemainingPrefixSec(remainingSeconds)+currentStateReason,
-								a.outboundChannel,
-								models.EditProtocolConverter,
-							)
-
-							continue
-						}
-
-						// The observed endpoint is re-read from the generated
-						// scan script, which is rewritten when the edit is
-						// persisted, so it names the new endpoint before the
-						// scanner has been rebuilt and dialed it. Requiring the
-						// scan to have started after the persist is what makes
-						// the endpoint match evidence rather than an echo.
-						if !scanIsPostEdit {
-							currentStateReason = "waiting for a scan of " + wantEndpoint + " taken after the edit"
-							SendActionReply(
-								a.instanceUUID,
-								a.userEmail,
-								a.actionUUID,
-								models.ActionExecuting,
-								RemainingPrefixSec(remainingSeconds)+currentStateReason,
-								a.outboundChannel,
-								models.EditProtocolConverter,
-							)
-
-							continue
-						}
-
-						if !portIsOpen {
-							lastState := "no scan yet"
-							if nmapObs.ServiceInfo.NmapStatus.LastScan != nil {
-								lastState = nmapObs.ServiceInfo.NmapStatus.LastScan.PortResult.State
-							}
-
-							currentStateReason = "waiting for nmap to report " + wantEndpoint + " open (last scan: " + lastState + ")"
+						if waitingFor := a.connectionCheckWait(newConfig, pcSnapshot); waitingFor != "" {
+							currentStateReason = waitingFor
 							SendActionReply(
 								a.instanceUUID,
 								a.userEmail,
@@ -1240,6 +1155,60 @@ func (a *EditProtocolConverterAction) mergeUserVariables(base map[string]any, in
 	}
 
 	return merged
+}
+
+// connectionCheckWait reports what the connection check is still waiting for,
+// or "" when the scan agrees with the endpoint this edit persisted.
+//
+// The endpoint comes from the persisted spec, not from the action payload: a
+// templated connection resolves only at render time, and get-protocolconverter
+// hands the raw template back when the spec carries no IP/PORT variables, so
+// the payload can name a target and port 0 that no scan will ever report.
+// Called once per tick, so a transient config-read failure heals instead of
+// failing the edit; a deterministic one repeats and the timeout names it.
+func (a *EditProtocolConverterAction) connectionCheckWait(
+	newConfig config.ProtocolConverterConfig,
+	pcSnapshot *protocolconverter.ProtocolConverterObservedStateSnapshot,
+) string {
+	resolved, renderErr := a.resolvedConnectionEndpoint(newConfig.ProtocolConverterServiceConfig)
+	if renderErr != nil {
+		a.lastRenderErr = renderErr
+
+		return "waiting to resolve the bridge's connection endpoint"
+	}
+
+	wantEndpoint := resolved.Target + ":" + strconv.FormatUint(uint64(resolved.Port), 10)
+
+	nmapObs := pcSnapshot.ServiceInfo.ConnectionObservedState.ServiceInfo.NmapObservedState
+	scannedEndpoint := nmapObs.ObservedNmapServiceConfig.Target + ":" +
+		strconv.FormatUint(uint64(nmapObs.ObservedNmapServiceConfig.Port), 10)
+
+	// Both halves must match. The port alone accepts a move to a different host
+	// on the same port: the number agrees, the old host's scan says that port is
+	// open, and nothing has dialed the new host (ENG-5586).
+	if scannedEndpoint != wantEndpoint {
+		return "waiting for nmap to scan " + wantEndpoint
+	}
+
+	// The observed endpoint is re-read from the generated scan script, which is
+	// rewritten when the edit is persisted, so it names the new endpoint before
+	// the scanner has been rebuilt and dialed it. Requiring the scan to have
+	// started after the persist is what makes the endpoint match evidence rather
+	// than an echo. A bridge with no scan at all fails here too.
+	lastScan := nmapObs.ServiceInfo.NmapStatus.LastScan
+	if lastScan == nil || !lastScan.Timestamp.After(a.persistedAt) {
+		return "waiting for a scan of " + wantEndpoint + " taken after the edit"
+	}
+
+	// Endpoint equality alone cannot tell a live port from a refused one, so
+	// require the scan to report open. Do not use IsRunning: it means the port
+	// accepted the connection on fsmv2 and "the scanner process is up" on fsmv1,
+	// so on fsmv1 it is true for a port that never answered.
+	if lastScan.PortResult.State != string(nmapservice.PortStateOpen) {
+		return "waiting for nmap to report " + wantEndpoint + " open (last scan: " + lastScan.PortResult.State + ")"
+	}
+
+	return ""
 }
 
 // resolvedConnectionEndpoint renders the connection template of the

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter_awaitrollout_test.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter_awaitrollout_test.go
@@ -56,38 +56,40 @@ var _ = Describe("EditProtocolConverter awaitRollout (config-as-truth gate)", fu
 		mu        sync.Mutex
 	)
 
-	// stageSnapshot writes a protocol-converter snapshot with an explicit
+	// stageSnapshotOnPort writes a protocol-converter snapshot with an explicit
 	// desired connection config (the rendered config the bridge should be
 	// running, i.e. the "system of truth"), an explicit observed nmap config
-	// (what the scan has actually dialed), the port state the last scan
-	// reported (open/closed/filtered), and the PC FSM state. Giving the desired
-	// and observed sides independently is what lets a test stage the anomaly: a
-	// connection edited to a new target whose nmap scan has not yet caught up.
-	// Staging PortResult.State is what distinguishes "not yet scanned" from
-	// "scanned and found closed" — the two reasons awaitRollout must treat
-	// differently.
-	stageSnapshot := func(desiredTarget string, observedTarget string, pcState string, portState string) {
+	// (what the scan has actually dialed), the port the scan ran against, the
+	// port state the last scan reported (open/closed/filtered), and the PC FSM
+	// state. Giving the desired and observed sides independently is what lets a
+	// test stage the anomaly: a connection edited to a new target whose nmap
+	// scan has not yet caught up. Staging PortResult.State is what distinguishes
+	// "not yet scanned" from "scanned and found closed" — the two reasons
+	// awaitRollout must treat differently. Staging the scanned port separately
+	// from the payload port is what lets a test stage a templated connection,
+	// whose resolved port is not the one the payload carries.
+	stageSnapshotOnPort := func(desiredTarget string, observedTarget string, pcState string, portState string, scannedPort uint16) {
 		observed := &protocolconverter.ProtocolConverterObservedStateSnapshot{
 			ServiceInfo: protocolconvertersvc.ServiceInfo{
 				ConnectionObservedState: connfsm.ConnectionObservedState{
 					ObservedConnectionConfig: connectionserviceconfig.ConnectionServiceConfig{
 						NmapServiceConfig: nmapserviceconfig.NmapServiceConfig{
 							Target: desiredTarget,
-							Port:   port,
+							Port:   scannedPort,
 						},
 					},
 					ServiceInfo: connsvc.ServiceInfo{
 						NmapObservedState: nmapfsm.NmapObservedState{
 							ObservedNmapServiceConfig: nmapserviceconfig.NmapServiceConfig{
 								Target: observedTarget,
-								Port:   port,
+								Port:   scannedPort,
 							},
 							ServiceInfo: nmapsvc.ServiceInfo{
 								NmapStatus: nmapsvc.NmapServiceInfo{
 									LastScan: &nmapsvc.NmapScanResult{
 										PortResult: nmapsvc.PortResult{
 											State: portState,
-											Port:  port,
+											Port:  scannedPort,
 										},
 									},
 								},
@@ -113,9 +115,16 @@ var _ = Describe("EditProtocolConverter awaitRollout (config-as-truth gate)", fu
 		})
 	}
 
-	// runAwaitRollout drives a real awaitRollout Execute in a goroutine and
-	// returns the resulting error and the wall-clock time it took.
-	runAwaitRollout := func(ip string) (time.Duration, error) {
+	// stageSnapshot stages a scan of the port the payload asks for, the case
+	// every non-templated connection is in.
+	stageSnapshot := func(desiredTarget string, observedTarget string, pcState string, portState string) {
+		stageSnapshotOnPort(desiredTarget, observedTarget, pcState, portState, port)
+	}
+
+	// runAwaitRolloutOnPort drives a real awaitRollout Execute in a goroutine
+	// with the given payload connection, and returns the resulting error and the
+	// wall-clock time it took.
+	runAwaitRolloutOnPort := func(ip string, payloadPort uint32) (time.Duration, error) {
 		a := actions.NewEditProtocolConverterAction(
 			"probe@example.com", uuid.New(), uuid.New(), outbound, mockCfg, snapMgr)
 		a.SetTickInterval(tickInterval)
@@ -126,7 +135,7 @@ var _ = Describe("EditProtocolConverter awaitRollout (config-as-truth gate)", fu
 			"uuid": probeUUID.String(),
 			"connection": map[string]interface{}{
 				"ip":   ip,
-				"port": port,
+				"port": payloadPort,
 			},
 		}
 		Expect(a.Parse(payload)).To(Succeed())
@@ -147,6 +156,12 @@ var _ = Describe("EditProtocolConverter awaitRollout (config-as-truth gate)", fu
 		Eventually(ch, "15s").Should(Receive(&got))
 
 		return got.elapsed, got.err
+	}
+
+	// runAwaitRollout edits a connection to ip on the payload port, the case
+	// every non-templated connection is in.
+	runAwaitRollout := func(ip string) (time.Duration, error) {
+		return runAwaitRolloutOnPort(ip, uint32(port))
 	}
 
 	BeforeEach(func() {
@@ -221,5 +236,69 @@ var _ = Describe("EditProtocolConverter awaitRollout (config-as-truth gate)", fu
 		_, err := runAwaitRollout("dest.example.com")
 		Expect(err).To(HaveOccurred(),
 			"a filtered port is down by the connection FSM's own definition and must not report success")
+	})
+
+	Describe("a bridge whose connection is templated", func() {
+		// A bridge that writes to the historian scans the shared
+		// historian.timescale endpoint, so its connection template carries no
+		// {{ .IP }}/{{ .PORT }} and its spec keeps no IP/PORT user variables.
+		// get-protocolconverter therefore hands the Management Console the raw
+		// template string as the connection IP and a port of 0 (a template
+		// string does not parse as a number), and that is what returns in the
+		// edit payload. The gate must compare the scan against the rendered
+		// endpoint; comparing it against the payload can never match.
+		const (
+			timescaleHost = "timescale.example.com"
+			// Deliberately not the 5432 default, so a port that only matches by
+			// coincidence cannot pass this spec.
+			timescalePort = uint16(5433)
+		)
+
+		BeforeEach(func() {
+			mockCfg = config.NewMockConfigManager().WithConfig(config.FullConfig{
+				Agent: config.AgentConfig{MetricsPort: 8080},
+				Historian: &config.HistorianConfig{
+					Timescale: config.TimescaleConfig{
+						Host:     timescaleHost,
+						Port:     timescalePort,
+						Password: "probe-password",
+					},
+				},
+				ProtocolConverter: []config.ProtocolConverterConfig{{
+					FSMInstanceConfig: config.FSMInstanceConfig{
+						Name:            probeName,
+						DesiredFSMState: "active",
+					},
+					ProtocolConverterServiceConfig: protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec{
+						Config: protocolconverterserviceconfig.ProtocolConverterServiceConfigTemplate{
+							ConnectionServiceConfig: connectionserviceconfig.ConnectionServiceConfigTemplate{
+								NmapTemplate: &connectionserviceconfig.NmapConfigTemplate{
+									Target: "{{ .historian.timescale.host }}",
+									Port:   "{{ .historian.timescale.port }}",
+								},
+							},
+							DataflowComponentWriteServiceConfig: dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
+								Destination: dataflowcomponentserviceconfig.WriteConfigDestination{
+									Protocol: dataflowcomponentserviceconfig.HistorianDestinationProtocol,
+									Code:     "data_contract_name: pump",
+								},
+								Source: dataflowcomponentserviceconfig.WriteConfigSource{Topics: "umh.v1.*"},
+							},
+						},
+						Variables: variables.VariableBundle{User: map[string]interface{}{}},
+					},
+				}},
+			})
+		})
+
+		It("reports a scanned-and-open resolved endpoint as a successful rollout, promptly", func() {
+			stageSnapshotOnPort(timescaleHost, timescaleHost, protocolconverter.OperationalStateStartingFailedDFCMissing, string(nmapfsm.PortStateOpen), timescalePort)
+
+			elapsed, err := runAwaitRolloutOnPort("{{ .historian.timescale.host }}", 0)
+			Expect(err).NotTo(HaveOccurred(),
+				"the gate must compare the scan against the rendered endpoint, not the unresolved payload")
+			Expect(elapsed).To(BeNumerically("<", 5*time.Second),
+				"a healthy edit of a templated connection must not wait out the rollout timeout")
+		})
 	})
 })

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter_awaitrollout_test.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter_awaitrollout_test.go
@@ -1,0 +1,225 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package actions_test
+
+import (
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/communicator/actions"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/connectionserviceconfig"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/dataflowcomponentserviceconfig"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/nmapserviceconfig"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/protocolconverterserviceconfig"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/variables"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
+	connfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/connection"
+	nmapfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/nmap"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/protocolconverter"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/models"
+	connsvc "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/connection"
+	nmapsvc "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/nmap"
+	protocolconvertersvc "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/protocolconverter"
+)
+
+var _ = Describe("EditProtocolConverter awaitRollout (config-as-truth gate)", func() {
+	const (
+		probeName    = "awaitrollout-bridge"
+		port         = uint16(445)
+		tickInterval = 1 * time.Second
+	)
+
+	var (
+		probeUUID uuid.UUID
+		mockCfg   *config.MockConfigManager
+		snapMgr   *fsm.SnapshotManager
+		outbound  chan *models.UMHMessage
+		msgs      []*models.UMHMessage
+		mu        sync.Mutex
+	)
+
+	// stageSnapshot writes a protocol-converter snapshot with an explicit
+	// desired connection config (the rendered config the bridge should be
+	// running, i.e. the "system of truth"), an explicit observed nmap config
+	// (what the scan has actually dialed), the port state the last scan
+	// reported (open/closed/filtered), and the PC FSM state. Giving the desired
+	// and observed sides independently is what lets a test stage the anomaly: a
+	// connection edited to a new target whose nmap scan has not yet caught up.
+	// Staging PortResult.State is what distinguishes "not yet scanned" from
+	// "scanned and found closed" — the two reasons awaitRollout must treat
+	// differently.
+	stageSnapshot := func(desiredTarget string, observedTarget string, pcState string, portState string) {
+		observed := &protocolconverter.ProtocolConverterObservedStateSnapshot{
+			ServiceInfo: protocolconvertersvc.ServiceInfo{
+				ConnectionObservedState: connfsm.ConnectionObservedState{
+					ObservedConnectionConfig: connectionserviceconfig.ConnectionServiceConfig{
+						NmapServiceConfig: nmapserviceconfig.NmapServiceConfig{
+							Target: desiredTarget,
+							Port:   port,
+						},
+					},
+					ServiceInfo: connsvc.ServiceInfo{
+						NmapObservedState: nmapfsm.NmapObservedState{
+							ObservedNmapServiceConfig: nmapserviceconfig.NmapServiceConfig{
+								Target: observedTarget,
+								Port:   port,
+							},
+							ServiceInfo: nmapsvc.ServiceInfo{
+								NmapStatus: nmapsvc.NmapServiceInfo{
+									LastScan: &nmapsvc.NmapScanResult{
+										PortResult: nmapsvc.PortResult{
+											State: portState,
+											Port:  port,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		snapMgr.UpdateSnapshot(&fsm.SystemSnapshot{
+			Managers: map[string]fsm.ManagerSnapshot{
+				constants.ProtocolConverterManagerName: &actions.MockManagerSnapshot{
+					Instances: map[string]*fsm.FSMInstanceSnapshot{
+						probeName: {
+							ID:                probeName,
+							CurrentState:      pcState,
+							DesiredState:      protocolconverter.OperationalStateActive,
+							LastObservedState: observed,
+						},
+					},
+				},
+			},
+		})
+	}
+
+	// runAwaitRollout drives a real awaitRollout Execute in a goroutine and
+	// returns the resulting error and the wall-clock time it took.
+	runAwaitRollout := func(ip string) (time.Duration, error) {
+		a := actions.NewEditProtocolConverterAction(
+			"probe@example.com", uuid.New(), uuid.New(), outbound, mockCfg, snapMgr)
+		a.SetTickInterval(tickInterval)
+		a.SetAwaitTimeout(6 * time.Second)
+
+		payload := map[string]interface{}{
+			"name": probeName,
+			"uuid": probeUUID.String(),
+			"connection": map[string]interface{}{
+				"ip":   ip,
+				"port": port,
+			},
+		}
+		Expect(a.Parse(payload)).To(Succeed())
+		Expect(a.Validate()).To(Succeed())
+		Expect(a.GetDFCType()).To(Equal("empty"))
+
+		type res struct {
+			err     error
+			elapsed time.Duration
+		}
+		ch := make(chan res, 1)
+		start := time.Now()
+		go func() {
+			_, _, err := a.Execute()
+			ch <- res{err, time.Since(start)}
+		}()
+		var got res
+		Eventually(ch, "15s").Should(Receive(&got))
+
+		return got.elapsed, got.err
+	}
+
+	BeforeEach(func() {
+		probeUUID = dataflowcomponentserviceconfig.GenerateUUIDFromName(probeName)
+		outbound = make(chan *models.UMHMessage, 200)
+		mu.Lock()
+		msgs = nil
+		mu.Unlock()
+
+		mockCfg = config.NewMockConfigManager().WithConfig(config.FullConfig{
+			Agent: config.AgentConfig{MetricsPort: 8080},
+			ProtocolConverter: []config.ProtocolConverterConfig{{
+				FSMInstanceConfig: config.FSMInstanceConfig{
+					Name:            probeName,
+					DesiredFSMState: "active",
+				},
+				ProtocolConverterServiceConfig: protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec{
+					Config: protocolconverterserviceconfig.ProtocolConverterServiceConfigTemplate{
+						ConnectionServiceConfig: connectionserviceconfig.ConnectionServiceConfigTemplate{
+							NmapTemplate: &connectionserviceconfig.NmapConfigTemplate{
+								Target: "{{ .IP }}",
+								Port:   "{{ .PORT }}",
+							},
+						},
+					},
+					Variables: variables.VariableBundle{
+						User: map[string]interface{}{"IP": "src.example.com", "PORT": "443"},
+					},
+				},
+			}},
+		})
+
+		snapMgr = fsm.NewSnapshotManager()
+		go actions.ConsumeOutboundMessages(outbound, &msgs, &mu, true)
+	})
+
+	AfterEach(func() { close(outbound) })
+
+	It("reports a scanned-and-open port as a successful rollout, promptly", func() {
+		// Regression guard: when the observed scan has caught up to the
+		// requested port and reports it open, awaitRollout must succeed on the
+		// first tick rather than wait out the timeout. This guards the opposite
+		// error: a check that never matches would fail every healthy edit after
+		// 30s, which is worse than the bug it replaces.
+		stageSnapshot("dest.example.com", "dest.example.com", protocolconverter.OperationalStateStartingFailedDFCMissing, string(nmapfsm.PortStateOpen))
+
+		elapsed, err := runAwaitRollout("dest.example.com")
+		Expect(err).NotTo(HaveOccurred(),
+			"a scanned-and-open port must still be reported as a successful rollout, promptly")
+		Expect(elapsed).To(BeNumerically("<", 5*time.Second),
+			"a healthy edit must not wait out the rollout timeout")
+	})
+
+	It("reports failure when the port was scanned but found closed", func() {
+		// The bug: the gate's only condition was port-number equality. Poll
+		// stamps the requested port onto a closed result too, so one poll after
+		// the edit the numbers match regardless of whether anything answered. A
+		// confirmed-closed port must not report a successful rollout.
+		stageSnapshot("dest.example.com", "dest.example.com", protocolconverter.OperationalStateStartingFailedDFCMissing, string(nmapfsm.PortStateClosed))
+
+		_, err := runAwaitRollout("dest.example.com")
+		Expect(err).To(HaveOccurred(),
+			"a scanned-but-closed port must not be reported as a successful rollout")
+	})
+
+	It("reports failure when the port was scanned but found filtered", func() {
+		// The connection FSM defines up as open and counts filtered (and all
+		// five non-open states) as down. Requiring open here makes the gate
+		// agree with that definition rather than inventing a second one.
+		stageSnapshot("dest.example.com", "dest.example.com", protocolconverter.OperationalStateStartingFailedDFCMissing, string(nmapfsm.PortStateFiltered))
+
+		_, err := runAwaitRollout("dest.example.com")
+		Expect(err).To(HaveOccurred(),
+			"a filtered port is down by the connection FSM's own definition and must not report success")
+	})
+})

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter_awaitrollout_test.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter_awaitrollout_test.go
@@ -206,7 +206,7 @@ var _ = Describe("EditProtocolConverter awaitRollout (rollout gate)", func() {
 		// first tick rather than wait out the timeout. This guards the opposite
 		// error: a check that never matches would fail every healthy edit after
 		// 30s, which is worse than the bug it replaces.
-		stageSnapshot("dest.example.com", "dest.example.com", protocolconverter.OperationalStateStartingFailedDFCMissing, string(nmapfsm.PortStateOpen))
+		stageSnapshot("dest.example.com", "dest.example.com", protocolconverter.OperationalStateStartingFailedDFCMissing, string(nmapsvc.PortStateOpen))
 
 		elapsed, err := runAwaitRollout("dest.example.com")
 		Expect(err).NotTo(HaveOccurred(),
@@ -220,7 +220,7 @@ var _ = Describe("EditProtocolConverter awaitRollout (rollout gate)", func() {
 		// stamps the requested port onto a closed result too, so one poll after
 		// the edit the numbers match regardless of whether anything answered. A
 		// confirmed-closed port must not report a successful rollout.
-		stageSnapshot("dest.example.com", "dest.example.com", protocolconverter.OperationalStateStartingFailedDFCMissing, string(nmapfsm.PortStateClosed))
+		stageSnapshot("dest.example.com", "dest.example.com", protocolconverter.OperationalStateStartingFailedDFCMissing, string(nmapsvc.PortStateClosed))
 
 		_, err := runAwaitRollout("dest.example.com")
 		Expect(err).To(HaveOccurred(),
@@ -253,7 +253,7 @@ var _ = Describe("EditProtocolConverter awaitRollout (rollout gate)", func() {
 									IsRunning: true,
 									LastScan: &nmapsvc.NmapScanResult{
 										PortResult: nmapsvc.PortResult{
-											State: string(nmapfsm.PortStateClosed),
+											State: string(nmapsvc.PortStateClosed),
 											Port:  port,
 										},
 									},
@@ -288,7 +288,7 @@ var _ = Describe("EditProtocolConverter awaitRollout (rollout gate)", func() {
 		// The connection FSM defines up as open and counts filtered (and all
 		// five non-open states) as down. Requiring open here makes the gate
 		// agree with that definition rather than inventing a second one.
-		stageSnapshot("dest.example.com", "dest.example.com", protocolconverter.OperationalStateStartingFailedDFCMissing, string(nmapfsm.PortStateFiltered))
+		stageSnapshot("dest.example.com", "dest.example.com", protocolconverter.OperationalStateStartingFailedDFCMissing, string(nmapsvc.PortStateFiltered))
 
 		_, err := runAwaitRollout("dest.example.com")
 		Expect(err).To(HaveOccurred(),
@@ -349,7 +349,7 @@ var _ = Describe("EditProtocolConverter awaitRollout (rollout gate)", func() {
 		})
 
 		It("reports a scanned-and-open resolved endpoint as a successful rollout, promptly", func() {
-			stageSnapshotOnPort(timescaleHost, timescaleHost, protocolconverter.OperationalStateStartingFailedDFCMissing, string(nmapfsm.PortStateOpen), timescalePort)
+			stageSnapshotOnPort(timescaleHost, timescaleHost, protocolconverter.OperationalStateStartingFailedDFCMissing, string(nmapsvc.PortStateOpen), timescalePort)
 
 			elapsed, err := runAwaitRolloutOnPort("{{ .historian.timescale.host }}", 0)
 			Expect(err).NotTo(HaveOccurred(),

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter_awaitrollout_test.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter_awaitrollout_test.go
@@ -56,13 +56,8 @@ var _ = Describe("EditProtocolConverter awaitRollout (connection check)", func()
 		mu        sync.Mutex
 	)
 
-	// stageSnapshotScannedAt stages the desired connection config and the
-	// observed scan separately, so a spec can stage a connection edited to a new
-	// target whose scan has not caught up yet. portState distinguishes "not yet
-	// scanned" from "scanned and found closed", which awaitRollout treats
-	// differently; scannedPort can differ from the payload port, which is how a
-	// templated connection is staged; scannedAt is explicit because a spec
-	// stages its snapshot before Execute persists the config.
+	// Desired and observed sides are staged independently, so a spec can stage a
+	// connection edited to a target whose scan has not caught up yet.
 	stageSnapshotScannedAt := func(desiredTarget string, observedTarget string, pcState string, portState string, scannedPort uint16, scannedAt time.Time) {
 		observed := &protocolconverter.ProtocolConverterObservedStateSnapshot{
 			ServiceInfo: protocolconvertersvc.ServiceInfo{
@@ -111,21 +106,15 @@ var _ = Describe("EditProtocolConverter awaitRollout (connection check)", func()
 		})
 	}
 
-	// stageSnapshotOnPort stamps the scan after the edit, the case every spec
-	// about a converged rollout is in.
 	stageSnapshotOnPort := func(desiredTarget string, observedTarget string, pcState string, portState string, scannedPort uint16) {
 		stageSnapshotScannedAt(desiredTarget, observedTarget, pcState, portState, scannedPort, time.Now().Add(time.Minute))
 	}
 
-	// stageSnapshot stages a scan of the port the payload asks for, the case
-	// every non-templated connection is in.
 	stageSnapshot := func(desiredTarget string, observedTarget string, pcState string, portState string) {
 		stageSnapshotOnPort(desiredTarget, observedTarget, pcState, portState, port)
 	}
 
-	// runAwaitRolloutOnPort drives a real awaitRollout Execute in a goroutine
-	// with the given payload connection, and returns the resulting error and the
-	// wall-clock time it took.
+	// Drives a real Execute in a goroutine and returns the error and elapsed time.
 	runAwaitRolloutOnPort := func(ip string, payloadPort uint32) (time.Duration, error) {
 		a := actions.NewEditProtocolConverterAction(
 			"probe@example.com", uuid.New(), uuid.New(), outbound, mockCfg, snapMgr)
@@ -160,8 +149,6 @@ var _ = Describe("EditProtocolConverter awaitRollout (connection check)", func()
 		return got.elapsed, got.err
 	}
 
-	// runAwaitRollout edits a connection to ip on the payload port, the case
-	// every non-templated connection is in.
 	runAwaitRollout := func(ip string) (time.Duration, error) {
 		return runAwaitRolloutOnPort(ip, uint32(port))
 	}
@@ -203,11 +190,8 @@ var _ = Describe("EditProtocolConverter awaitRollout (connection check)", func()
 	AfterEach(func() { close(outbound) })
 
 	It("reports a scanned-and-open port as a successful rollout, promptly", func() {
-		// Regression guard: when the observed scan has caught up to the
-		// requested port and reports it open, awaitRollout must succeed on the
-		// first tick rather than wait out the timeout. This guards the opposite
-		// error: a check that never matches would fail every healthy edit after
-		// 30s, which is worse than the bug it replaces.
+		// A check that never matches would fail every healthy edit after 30s,
+		// which is worse than the bug it replaces.
 		stageSnapshot("dest.example.com", "dest.example.com", protocolconverter.OperationalStateStartingFailedDFCMissing, string(nmapservice.PortStateOpen))
 
 		elapsed, err := runAwaitRollout("dest.example.com")
@@ -218,10 +202,8 @@ var _ = Describe("EditProtocolConverter awaitRollout (connection check)", func()
 	})
 
 	It("reports failure when the port was scanned but found closed", func() {
-		// The bug: the check's only condition was port-number equality. Poll
-		// stamps the requested port onto a closed result too, so one poll after
-		// the edit the numbers match regardless of whether anything answered. A
-		// confirmed-closed port must not report a successful rollout.
+		// Poll stamps the requested port onto a closed result too, so the numbers
+		// match one poll after the edit whether or not anything answered.
 		stageSnapshot("dest.example.com", "dest.example.com", protocolconverter.OperationalStateStartingFailedDFCMissing, string(nmapservice.PortStateClosed))
 
 		_, err := runAwaitRollout("dest.example.com")
@@ -230,12 +212,8 @@ var _ = Describe("EditProtocolConverter awaitRollout (connection check)", func()
 	})
 
 	It("reports failure when the only open scan on record predates the edit", func() {
-		// nmap's observed endpoint is re-read from the generated scan script,
-		// which is rewritten when the edit is persisted, so it names the new
-		// endpoint before the scanner has been rebuilt and dialed it. Staging an
-		// open scan from before the edit reproduces that window: both halves of
-		// the endpoint match and the scan says open, yet nothing has dialed the
-		// new endpoint.
+		// Stages the window where the observed endpoint already echoes the new
+		// scan script and the scan says open, yet nothing has dialed it.
 		stageSnapshotScannedAt(
 			"dest.example.com",
 			"dest.example.com",
@@ -251,11 +229,8 @@ var _ = Describe("EditProtocolConverter awaitRollout (connection check)", func()
 	})
 
 	It("reports failure when the scanner is running but the port is not open", func() {
-		// IsRunning means different things per backend: the port accepted the
-		// connection on fsmv2, but only "the scanner process is up" on fsmv1.
-		// A check keyed on it would pass on fsmv1 for a port that never answered,
-		// and the other specs cannot catch that swap because they leave
-		// IsRunning false, so the healthy spec would be the only one to redden.
+		// The other specs leave IsRunning false, so swapping the check to trust it
+		// would redden only the healthy spec. This one catches that swap.
 		observed := &protocolconverter.ProtocolConverterObservedStateSnapshot{
 			ServiceInfo: protocolconvertersvc.ServiceInfo{
 				ConnectionObservedState: connfsm.ConnectionObservedState{
@@ -308,9 +283,9 @@ var _ = Describe("EditProtocolConverter awaitRollout (connection check)", func()
 	})
 
 	It("reports failure when the port was scanned but found filtered", func() {
-		// The connection FSM defines up as open and counts filtered (and all
-		// five non-open states) as down. Requiring open here makes the check
-		// agree with that definition rather than inventing a second one.
+		// The connection FSM counts filtered, and every other non-open state, as
+		// down. Requiring open here agrees with that instead of inventing a
+		// second definition.
 		stageSnapshot("dest.example.com", "dest.example.com", protocolconverter.OperationalStateStartingFailedDFCMissing, string(nmapservice.PortStateFiltered))
 
 		_, err := runAwaitRollout("dest.example.com")

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter_awaitrollout_test.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter_awaitrollout_test.go
@@ -295,6 +295,19 @@ var _ = Describe("EditProtocolConverter awaitRollout (rollout gate)", func() {
 			"a filtered port is down by the connection FSM's own definition and must not report success")
 	})
 
+	It("reports failure when the only open port on record belongs to the previous host", func() {
+		// ENG-5586. The gate compared the port number and nothing else. So
+		// repointing a bridge from one host to another on the same port was
+		// accepted by the OLD host's scan: the number matches, that port is
+		// open, and nothing has dialled the new host. If the new host refuses
+		// the connection the edit still reported success.
+		stageSnapshot("dest.example.com", "src.example.com", protocolconverter.OperationalStateStartingFailedDFCMissing, string(nmapsvc.PortStateOpen))
+
+		_, err := runAwaitRollout("dest.example.com")
+		Expect(err).To(HaveOccurred(),
+			"an open port on the previous host must not be reported as a successful rollout of the new one")
+	})
+
 	Describe("a bridge whose connection is templated", func() {
 		// A bridge that writes to the historian scans the shared
 		// historian.timescale endpoint, so its connection template carries no

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter_awaitrollout_test.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter_awaitrollout_test.go
@@ -68,7 +68,11 @@ var _ = Describe("EditProtocolConverter awaitRollout (rollout gate)", func() {
 	// awaitRollout must treat differently. Staging the scanned port separately
 	// from the payload port is what lets a test stage a templated connection,
 	// whose resolved port is not the one the payload carries.
-	stageSnapshotOnPort := func(desiredTarget string, observedTarget string, pcState string, portState string, scannedPort uint16) {
+	// stageSnapshotOnPort stamps the staged scan ahead of the edit, because a
+	// spec stages its snapshot before Execute persists the config and the gate
+	// requires a scan taken after that persist. stageSnapshotScannedAt takes the
+	// scan time explicitly, for specs about a scan that predates the edit.
+	stageSnapshotScannedAt := func(desiredTarget string, observedTarget string, pcState string, portState string, scannedPort uint16, scannedAt time.Time) {
 		observed := &protocolconverter.ProtocolConverterObservedStateSnapshot{
 			ServiceInfo: protocolconvertersvc.ServiceInfo{
 				ConnectionObservedState: connfsm.ConnectionObservedState{
@@ -87,6 +91,7 @@ var _ = Describe("EditProtocolConverter awaitRollout (rollout gate)", func() {
 							ServiceInfo: nmapsvc.ServiceInfo{
 								NmapStatus: nmapsvc.NmapServiceInfo{
 									LastScan: &nmapsvc.NmapScanResult{
+										Timestamp: scannedAt,
 										PortResult: nmapsvc.PortResult{
 											State: portState,
 											Port:  scannedPort,
@@ -113,6 +118,10 @@ var _ = Describe("EditProtocolConverter awaitRollout (rollout gate)", func() {
 				},
 			},
 		})
+	}
+
+	stageSnapshotOnPort := func(desiredTarget string, observedTarget string, pcState string, portState string, scannedPort uint16) {
+		stageSnapshotScannedAt(desiredTarget, observedTarget, pcState, portState, scannedPort, time.Now().Add(time.Minute))
 	}
 
 	// stageSnapshot stages a scan of the port the payload asks for, the case
@@ -225,6 +234,27 @@ var _ = Describe("EditProtocolConverter awaitRollout (rollout gate)", func() {
 		_, err := runAwaitRollout("dest.example.com")
 		Expect(err).To(HaveOccurred(),
 			"a scanned-but-closed port must not be reported as a successful rollout")
+	})
+
+	It("reports failure when the only open scan on record predates the edit", func() {
+		// nmap's observed endpoint is re-read from the generated scan script,
+		// which is rewritten when the edit is persisted, so it names the new
+		// endpoint before the scanner has been rebuilt and dialed it. Staging an
+		// open scan from before the edit reproduces that window: both halves of
+		// the endpoint match and the scan says open, yet nothing has dialed the
+		// new endpoint.
+		stageSnapshotScannedAt(
+			"dest.example.com",
+			"dest.example.com",
+			protocolconverter.OperationalStateStartingFailedDFCMissing,
+			string(nmapsvc.PortStateOpen),
+			port,
+			time.Now().Add(-time.Hour),
+		)
+
+		_, err := runAwaitRollout("dest.example.com")
+		Expect(err).To(HaveOccurred(),
+			"a scan taken before the edit is not evidence about the new endpoint")
 	})
 
 	It("reports failure when the scanner is running but the port is not open", func() {

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter_awaitrollout_test.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter_awaitrollout_test.go
@@ -306,6 +306,11 @@ var _ = Describe("EditProtocolConverter awaitRollout (rollout gate)", func() {
 		_, err := runAwaitRollout("dest.example.com")
 		Expect(err).To(HaveOccurred(),
 			"an open port on the previous host must not be reported as a successful rollout of the new one")
+		// A bare HaveOccurred() would also be satisfied by a timeout for any other
+		// reason, so it cannot tell this spec passing from this spec passing by
+		// accident. The rollback message names what the last tick was waiting for.
+		Expect(err.Error()).To(ContainSubstring("waiting for nmap to scan dest.example.com"),
+			"the rollout must have timed out on the host comparison, not on something else")
 	})
 
 	Describe("a bridge whose connection is templated", func() {

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter_awaitrollout_test.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter_awaitrollout_test.go
@@ -56,22 +56,13 @@ var _ = Describe("EditProtocolConverter awaitRollout (connection check)", func()
 		mu        sync.Mutex
 	)
 
-	// stageSnapshotOnPort writes a protocol-converter snapshot with an explicit
-	// desired connection config (the rendered config the bridge should be
-	// running), an explicit observed nmap config
-	// (what the scan has actually dialed), the port the scan ran against, the
-	// port state the last scan reported (open/closed/filtered), and the PC FSM
-	// state. Giving the desired and observed sides independently is what lets a
-	// test stage the anomaly: a connection edited to a new target whose nmap
-	// scan has not yet caught up. Staging PortResult.State is what distinguishes
-	// "not yet scanned" from "scanned and found closed" — the two reasons
-	// awaitRollout must treat differently. Staging the scanned port separately
-	// from the payload port is what lets a test stage a templated connection,
-	// whose resolved port is not the one the payload carries.
-	// stageSnapshotOnPort stamps the staged scan ahead of the edit, because a
-	// spec stages its snapshot before Execute persists the config and the check
-	// requires a scan taken after that persist. stageSnapshotScannedAt takes the
-	// scan time explicitly, for specs about a scan that predates the edit.
+	// stageSnapshotScannedAt stages the desired connection config and the
+	// observed scan separately, so a spec can stage a connection edited to a new
+	// target whose scan has not caught up yet. portState distinguishes "not yet
+	// scanned" from "scanned and found closed", which awaitRollout treats
+	// differently; scannedPort can differ from the payload port, which is how a
+	// templated connection is staged; scannedAt is explicit because a spec
+	// stages its snapshot before Execute persists the config.
 	stageSnapshotScannedAt := func(desiredTarget string, observedTarget string, pcState string, portState string, scannedPort uint16, scannedAt time.Time) {
 		observed := &protocolconverter.ProtocolConverterObservedStateSnapshot{
 			ServiceInfo: protocolconvertersvc.ServiceInfo{
@@ -120,6 +111,8 @@ var _ = Describe("EditProtocolConverter awaitRollout (connection check)", func()
 		})
 	}
 
+	// stageSnapshotOnPort stamps the scan after the edit, the case every spec
+	// about a converged rollout is in.
 	stageSnapshotOnPort := func(desiredTarget string, observedTarget string, pcState string, portState string, scannedPort uint16) {
 		stageSnapshotScannedAt(desiredTarget, observedTarget, pcState, portState, scannedPort, time.Now().Add(time.Minute))
 	}

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter_awaitrollout_test.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter_awaitrollout_test.go
@@ -40,7 +40,7 @@ import (
 	protocolconvertersvc "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/protocolconverter"
 )
 
-var _ = Describe("EditProtocolConverter awaitRollout (rollout gate)", func() {
+var _ = Describe("EditProtocolConverter awaitRollout (connection check)", func() {
 	const (
 		probeName    = "awaitrollout-bridge"
 		port         = uint16(445)
@@ -69,7 +69,7 @@ var _ = Describe("EditProtocolConverter awaitRollout (rollout gate)", func() {
 	// from the payload port is what lets a test stage a templated connection,
 	// whose resolved port is not the one the payload carries.
 	// stageSnapshotOnPort stamps the staged scan ahead of the edit, because a
-	// spec stages its snapshot before Execute persists the config and the gate
+	// spec stages its snapshot before Execute persists the config and the check
 	// requires a scan taken after that persist. stageSnapshotScannedAt takes the
 	// scan time explicitly, for specs about a scan that predates the edit.
 	stageSnapshotScannedAt := func(desiredTarget string, observedTarget string, pcState string, portState string, scannedPort uint16, scannedAt time.Time) {
@@ -225,7 +225,7 @@ var _ = Describe("EditProtocolConverter awaitRollout (rollout gate)", func() {
 	})
 
 	It("reports failure when the port was scanned but found closed", func() {
-		// The bug: the gate's only condition was port-number equality. Poll
+		// The bug: the check's only condition was port-number equality. Poll
 		// stamps the requested port onto a closed result too, so one poll after
 		// the edit the numbers match regardless of whether anything answered. A
 		// confirmed-closed port must not report a successful rollout.
@@ -260,7 +260,7 @@ var _ = Describe("EditProtocolConverter awaitRollout (rollout gate)", func() {
 	It("reports failure when the scanner is running but the port is not open", func() {
 		// IsRunning means different things per backend: the port accepted the
 		// connection on fsmv2, but only "the scanner process is up" on fsmv1.
-		// A gate keyed on it would pass on fsmv1 for a port that never answered,
+		// A check keyed on it would pass on fsmv1 for a port that never answered,
 		// and the other specs cannot catch that swap because they leave
 		// IsRunning false, so the healthy spec would be the only one to redden.
 		observed := &protocolconverter.ProtocolConverterObservedStateSnapshot{
@@ -316,7 +316,7 @@ var _ = Describe("EditProtocolConverter awaitRollout (rollout gate)", func() {
 
 	It("reports failure when the port was scanned but found filtered", func() {
 		// The connection FSM defines up as open and counts filtered (and all
-		// five non-open states) as down. Requiring open here makes the gate
+		// five non-open states) as down. Requiring open here makes the check
 		// agree with that definition rather than inventing a second one.
 		stageSnapshot("dest.example.com", "dest.example.com", protocolconverter.OperationalStateStartingFailedDFCMissing, string(nmapsvc.PortStateFiltered))
 
@@ -326,7 +326,7 @@ var _ = Describe("EditProtocolConverter awaitRollout (rollout gate)", func() {
 	})
 
 	It("reports failure when the only open port on record belongs to the previous host", func() {
-		// ENG-5586. The gate compared the port number and nothing else. So
+		// ENG-5586. The check compared the port number and nothing else. So
 		// repointing a bridge from one host to another on the same port was
 		// accepted by the OLD host's scan: the number matches, that port is
 		// open, and nothing has dialled the new host. If the new host refuses
@@ -350,7 +350,7 @@ var _ = Describe("EditProtocolConverter awaitRollout (rollout gate)", func() {
 		// get-protocolconverter therefore hands the Management Console the raw
 		// template string as the connection IP and a port of 0 (a template
 		// string does not parse as a number), and that is what returns in the
-		// edit payload. The gate must compare the scan against the rendered
+		// edit payload. The check must compare the scan against the rendered
 		// endpoint; comparing it against the payload can never match.
 		const (
 			timescaleHost = "timescale.example.com"
@@ -401,7 +401,7 @@ var _ = Describe("EditProtocolConverter awaitRollout (rollout gate)", func() {
 
 			elapsed, err := runAwaitRolloutOnPort("{{ .historian.timescale.host }}", 0)
 			Expect(err).NotTo(HaveOccurred(),
-				"the gate must compare the scan against the rendered endpoint, not the unresolved payload")
+				"the check must compare the scan against the rendered endpoint, not the unresolved payload")
 			Expect(elapsed).To(BeNumerically("<", 5*time.Second),
 				"a healthy edit of a templated connection must not wait out the rollout timeout")
 		})

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter_awaitrollout_test.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter_awaitrollout_test.go
@@ -36,7 +36,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/protocolconverter"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/models"
 	connsvc "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/connection"
-	nmapsvc "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/nmap"
+	nmapservice "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/nmap"
 	protocolconvertersvc "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/protocolconverter"
 )
 
@@ -79,11 +79,11 @@ var _ = Describe("EditProtocolConverter awaitRollout (connection check)", func()
 								Target: observedTarget,
 								Port:   scannedPort,
 							},
-							ServiceInfo: nmapsvc.ServiceInfo{
-								NmapStatus: nmapsvc.NmapServiceInfo{
-									LastScan: &nmapsvc.NmapScanResult{
+							ServiceInfo: nmapservice.ServiceInfo{
+								NmapStatus: nmapservice.NmapServiceInfo{
+									LastScan: &nmapservice.NmapScanResult{
 										Timestamp: scannedAt,
-										PortResult: nmapsvc.PortResult{
+										PortResult: nmapservice.PortResult{
 											State: portState,
 											Port:  scannedPort,
 										},
@@ -208,7 +208,7 @@ var _ = Describe("EditProtocolConverter awaitRollout (connection check)", func()
 		// first tick rather than wait out the timeout. This guards the opposite
 		// error: a check that never matches would fail every healthy edit after
 		// 30s, which is worse than the bug it replaces.
-		stageSnapshot("dest.example.com", "dest.example.com", protocolconverter.OperationalStateStartingFailedDFCMissing, string(nmapsvc.PortStateOpen))
+		stageSnapshot("dest.example.com", "dest.example.com", protocolconverter.OperationalStateStartingFailedDFCMissing, string(nmapservice.PortStateOpen))
 
 		elapsed, err := runAwaitRollout("dest.example.com")
 		Expect(err).NotTo(HaveOccurred(),
@@ -222,7 +222,7 @@ var _ = Describe("EditProtocolConverter awaitRollout (connection check)", func()
 		// stamps the requested port onto a closed result too, so one poll after
 		// the edit the numbers match regardless of whether anything answered. A
 		// confirmed-closed port must not report a successful rollout.
-		stageSnapshot("dest.example.com", "dest.example.com", protocolconverter.OperationalStateStartingFailedDFCMissing, string(nmapsvc.PortStateClosed))
+		stageSnapshot("dest.example.com", "dest.example.com", protocolconverter.OperationalStateStartingFailedDFCMissing, string(nmapservice.PortStateClosed))
 
 		_, err := runAwaitRollout("dest.example.com")
 		Expect(err).To(HaveOccurred(),
@@ -240,7 +240,7 @@ var _ = Describe("EditProtocolConverter awaitRollout (connection check)", func()
 			"dest.example.com",
 			"dest.example.com",
 			protocolconverter.OperationalStateStartingFailedDFCMissing,
-			string(nmapsvc.PortStateOpen),
+			string(nmapservice.PortStateOpen),
 			port,
 			time.Now().Add(-time.Hour),
 		)
@@ -271,12 +271,12 @@ var _ = Describe("EditProtocolConverter awaitRollout (connection check)", func()
 								Target: "dest.example.com",
 								Port:   port,
 							},
-							ServiceInfo: nmapsvc.ServiceInfo{
-								NmapStatus: nmapsvc.NmapServiceInfo{
+							ServiceInfo: nmapservice.ServiceInfo{
+								NmapStatus: nmapservice.NmapServiceInfo{
 									IsRunning: true,
-									LastScan: &nmapsvc.NmapScanResult{
-										PortResult: nmapsvc.PortResult{
-											State: string(nmapsvc.PortStateClosed),
+									LastScan: &nmapservice.NmapScanResult{
+										PortResult: nmapservice.PortResult{
+											State: string(nmapservice.PortStateClosed),
 											Port:  port,
 										},
 									},
@@ -311,7 +311,7 @@ var _ = Describe("EditProtocolConverter awaitRollout (connection check)", func()
 		// The connection FSM defines up as open and counts filtered (and all
 		// five non-open states) as down. Requiring open here makes the check
 		// agree with that definition rather than inventing a second one.
-		stageSnapshot("dest.example.com", "dest.example.com", protocolconverter.OperationalStateStartingFailedDFCMissing, string(nmapsvc.PortStateFiltered))
+		stageSnapshot("dest.example.com", "dest.example.com", protocolconverter.OperationalStateStartingFailedDFCMissing, string(nmapservice.PortStateFiltered))
 
 		_, err := runAwaitRollout("dest.example.com")
 		Expect(err).To(HaveOccurred(),
@@ -324,7 +324,7 @@ var _ = Describe("EditProtocolConverter awaitRollout (connection check)", func()
 		// accepted by the OLD host's scan: the number matches, that port is
 		// open, and nothing has dialled the new host. If the new host refuses
 		// the connection the edit still reported success.
-		stageSnapshot("dest.example.com", "src.example.com", protocolconverter.OperationalStateStartingFailedDFCMissing, string(nmapsvc.PortStateOpen))
+		stageSnapshot("dest.example.com", "src.example.com", protocolconverter.OperationalStateStartingFailedDFCMissing, string(nmapservice.PortStateOpen))
 
 		_, err := runAwaitRollout("dest.example.com")
 		Expect(err).To(HaveOccurred(),
@@ -390,7 +390,7 @@ var _ = Describe("EditProtocolConverter awaitRollout (connection check)", func()
 		})
 
 		It("reports a scanned-and-open resolved endpoint as a successful rollout, promptly", func() {
-			stageSnapshotOnPort(timescaleHost, timescaleHost, protocolconverter.OperationalStateStartingFailedDFCMissing, string(nmapsvc.PortStateOpen), timescalePort)
+			stageSnapshotOnPort(timescaleHost, timescaleHost, protocolconverter.OperationalStateStartingFailedDFCMissing, string(nmapservice.PortStateOpen), timescalePort)
 
 			elapsed, err := runAwaitRolloutOnPort("{{ .historian.timescale.host }}", 0)
 			Expect(err).NotTo(HaveOccurred(),

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter_awaitrollout_test.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter_awaitrollout_test.go
@@ -40,7 +40,7 @@ import (
 	protocolconvertersvc "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/protocolconverter"
 )
 
-var _ = Describe("EditProtocolConverter awaitRollout (config-as-truth gate)", func() {
+var _ = Describe("EditProtocolConverter awaitRollout (rollout gate)", func() {
 	const (
 		probeName    = "awaitrollout-bridge"
 		port         = uint16(445)
@@ -58,7 +58,7 @@ var _ = Describe("EditProtocolConverter awaitRollout (config-as-truth gate)", fu
 
 	// stageSnapshotOnPort writes a protocol-converter snapshot with an explicit
 	// desired connection config (the rendered config the bridge should be
-	// running, i.e. the "system of truth"), an explicit observed nmap config
+	// running), an explicit observed nmap config
 	// (what the scan has actually dialed), the port the scan ran against, the
 	// port state the last scan reported (open/closed/filtered), and the PC FSM
 	// state. Giving the desired and observed sides independently is what lets a
@@ -225,6 +225,63 @@ var _ = Describe("EditProtocolConverter awaitRollout (config-as-truth gate)", fu
 		_, err := runAwaitRollout("dest.example.com")
 		Expect(err).To(HaveOccurred(),
 			"a scanned-but-closed port must not be reported as a successful rollout")
+	})
+
+	It("reports failure when the scanner is running but the port is not open", func() {
+		// IsRunning means different things per backend: the port accepted the
+		// connection on fsmv2, but only "the scanner process is up" on fsmv1.
+		// A gate keyed on it would pass on fsmv1 for a port that never answered,
+		// and the other specs cannot catch that swap because they leave
+		// IsRunning false, so the healthy spec would be the only one to redden.
+		observed := &protocolconverter.ProtocolConverterObservedStateSnapshot{
+			ServiceInfo: protocolconvertersvc.ServiceInfo{
+				ConnectionObservedState: connfsm.ConnectionObservedState{
+					ObservedConnectionConfig: connectionserviceconfig.ConnectionServiceConfig{
+						NmapServiceConfig: nmapserviceconfig.NmapServiceConfig{
+							Target: "dest.example.com",
+							Port:   port,
+						},
+					},
+					ServiceInfo: connsvc.ServiceInfo{
+						NmapObservedState: nmapfsm.NmapObservedState{
+							ObservedNmapServiceConfig: nmapserviceconfig.NmapServiceConfig{
+								Target: "dest.example.com",
+								Port:   port,
+							},
+							ServiceInfo: nmapsvc.ServiceInfo{
+								NmapStatus: nmapsvc.NmapServiceInfo{
+									IsRunning: true,
+									LastScan: &nmapsvc.NmapScanResult{
+										PortResult: nmapsvc.PortResult{
+											State: string(nmapfsm.PortStateClosed),
+											Port:  port,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		snapMgr.UpdateSnapshot(&fsm.SystemSnapshot{
+			Managers: map[string]fsm.ManagerSnapshot{
+				constants.ProtocolConverterManagerName: &actions.MockManagerSnapshot{
+					Instances: map[string]*fsm.FSMInstanceSnapshot{
+						probeName: {
+							ID:                probeName,
+							CurrentState:      protocolconverter.OperationalStateStartingFailedDFCMissing,
+							DesiredState:      protocolconverter.OperationalStateActive,
+							LastObservedState: observed,
+						},
+					},
+				},
+			},
+		})
+
+		_, err := runAwaitRollout("dest.example.com")
+		Expect(err).To(HaveOccurred(),
+			"a running scanner reporting a closed port must not be reported as a successful rollout")
 	})
 
 	It("reports failure when the port was scanned but found filtered", func() {

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter_awaitrollout_test.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter_awaitrollout_test.go
@@ -56,9 +56,11 @@ var _ = Describe("EditProtocolConverter awaitRollout (connection check)", func()
 		mu        sync.Mutex
 	)
 
-	// Desired and observed sides are staged independently, so a spec can stage a
-	// connection edited to a target whose scan has not caught up yet.
-	stageSnapshotScannedAt := func(desiredTarget string, observedTarget string, pcState string, portState string, scannedPort uint16, scannedAt time.Time) {
+	// The desired side, the observed config and the last scan are staged
+	// independently, so a spec can stage a connection edited to a target whose
+	// scan has not caught up yet, and one where the observed config has caught
+	// up but the scan has not.
+	stageSnapshotScanned := func(desiredTarget string, observedTarget string, scannedTarget string, pcState string, portState string, scannedPort uint16, scannedAt time.Time) {
 		observed := &protocolconverter.ProtocolConverterObservedStateSnapshot{
 			ServiceInfo: protocolconvertersvc.ServiceInfo{
 				ConnectionObservedState: connfsm.ConnectionObservedState{
@@ -78,6 +80,7 @@ var _ = Describe("EditProtocolConverter awaitRollout (connection check)", func()
 								NmapStatus: nmapservice.NmapServiceInfo{
 									LastScan: &nmapservice.NmapScanResult{
 										Timestamp: scannedAt,
+										Target:    scannedTarget,
 										PortResult: nmapservice.PortResult{
 											State: portState,
 											Port:  scannedPort,
@@ -104,6 +107,11 @@ var _ = Describe("EditProtocolConverter awaitRollout (connection check)", func()
 				},
 			},
 		})
+	}
+
+	// The observed config and the scan agree unless a spec stages them apart.
+	stageSnapshotScannedAt := func(desiredTarget string, observedTarget string, pcState string, portState string, scannedPort uint16, scannedAt time.Time) {
+		stageSnapshotScanned(desiredTarget, observedTarget, observedTarget, pcState, portState, scannedPort, scannedAt)
 	}
 
 	stageSnapshotOnPort := func(desiredTarget string, observedTarget string, pcState string, portState string, scannedPort uint16) {
@@ -249,7 +257,12 @@ var _ = Describe("EditProtocolConverter awaitRollout (connection check)", func()
 							ServiceInfo: nmapservice.ServiceInfo{
 								NmapStatus: nmapservice.NmapServiceInfo{
 									IsRunning: true,
+									// Fresh and on the edited endpoint, so the
+									// spec reaches the port-state check instead
+									// of stopping at the staleness one.
 									LastScan: &nmapservice.NmapScanResult{
+										Timestamp: time.Now().Add(time.Minute),
+										Target:    "dest.example.com",
 										PortResult: nmapservice.PortResult{
 											State: string(nmapservice.PortStateClosed),
 											Port:  port,
@@ -307,8 +320,31 @@ var _ = Describe("EditProtocolConverter awaitRollout (connection check)", func()
 		// A bare HaveOccurred() would also be satisfied by a timeout for any other
 		// reason, so it cannot tell this spec passing from this spec passing by
 		// accident. The rollback message names what the last tick was waiting for.
-		Expect(err.Error()).To(ContainSubstring("waiting for nmap to scan dest.example.com"),
+		Expect(err.Error()).To(ContainSubstring("checking dest.example.com:445"),
 			"the rollout must have timed out on the host comparison, not on something else")
+	})
+
+	It("reports failure when the observed config names the new host but the fresh open scan does not", func() {
+		// ENG-5586. On fsmv1 the observed nmap config is parsed from the scan
+		// script on disk, so it names the new endpoint from the moment that
+		// script is rewritten. The old scanner keeps reporting the old endpoint
+		// as open until s6 restarts it, so comparing the observed config accepts
+		// a fresh open scan that never dialled the new host.
+		stageSnapshotScanned(
+			"dest.example.com",
+			"dest.example.com",
+			"src.example.com",
+			protocolconverter.OperationalStateStartingFailedDFCMissing,
+			string(nmapservice.PortStateOpen),
+			port,
+			time.Now().Add(time.Minute),
+		)
+
+		_, err := runAwaitRollout("dest.example.com")
+		Expect(err).To(HaveOccurred(),
+			"only the endpoint the scan recorded is evidence, not the one the scan script names")
+		Expect(err.Error()).To(ContainSubstring("checking dest.example.com:445"),
+			"the rollout must have timed out on the scanned endpoint, not on something else")
 	})
 
 	Describe("a bridge whose connection is templated", func() {

--- a/umh-core/pkg/fsm/nmap/models.go
+++ b/umh-core/pkg/fsm/nmap/models.go
@@ -19,7 +19,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/nmapserviceconfig"
 	publicfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/nmap"
+	nmapservice "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/nmap"
 )
 
 // These are the nmap-monitor operational states, in addition
@@ -35,7 +35,7 @@ const (
 	OperationalStateDegraded = "degraded"
 
 	// Running phase states
-	// See nmap-states here: https://nmap.org/book/man-port-scanning-basics.html
+	// See nmap-states here: https://nmapservice.org/book/man-port-scanning-basics.html
 	// active means nmap is running and it shows port filtered.
 	OperationalStateFiltered = "filtered"
 	// active means nmap is running and it shows port down.
@@ -118,7 +118,7 @@ type NmapObservedState struct {
 	// ObservedNmapServiceConfig contains the observed Nmap service config
 	ObservedNmapServiceConfig nmapserviceconfig.NmapServiceConfig
 	// We store the nmap data from nmap_monitor.GetStatus
-	ServiceInfo nmap.ServiceInfo
+	ServiceInfo nmapservice.ServiceInfo
 	// LastStateChange is the timestamp of the last observed state change
 	LastStateChange int64
 }
@@ -133,7 +133,7 @@ var _ publicfsm.FSMInstance = (*NmapInstance)(nil)
 type NmapInstance struct {
 
 	// The nmap service used to gather metrics
-	monitorService nmap.INmapService
+	monitorService nmapservice.INmapService
 
 	// This embeds the "BaseFSMInstance" which handles lifecycle states,
 	// desired state, removal, etc.
@@ -153,7 +153,7 @@ func (n *NmapInstance) GetLastObservedState() publicfsm.ObservedState {
 
 // SetService sets the Nmap service implementation
 // This is a testing-only utility to access the private field.
-func (n *NmapInstance) SetService(service nmap.INmapService) {
+func (n *NmapInstance) SetService(service nmapservice.INmapService) {
 	n.monitorService = service
 }
 

--- a/umh-core/pkg/fsm/nmap/models.go
+++ b/umh-core/pkg/fsm/nmap/models.go
@@ -146,17 +146,6 @@ type NmapInstance struct {
 	ObservedState NmapObservedState
 }
 
-type PortState string
-
-const (
-	PortStateOpen           PortState = "open"
-	PortStateFiltered       PortState = "filtered"
-	PortStateClosed         PortState = "closed"
-	PortStateUnfiltered     PortState = "unfiltered"
-	PortStateOpenFiltered   PortState = "open|filtered"
-	PortStateClosedFiltered PortState = "closed|filtered"
-)
-
 // GetLastObservedState returns the last known observed data.
 func (n *NmapInstance) GetLastObservedState() publicfsm.ObservedState {
 	return n.ObservedState

--- a/umh-core/pkg/fsm/nmap/models.go
+++ b/umh-core/pkg/fsm/nmap/models.go
@@ -35,7 +35,7 @@ const (
 	OperationalStateDegraded = "degraded"
 
 	// Running phase states
-	// See nmap-states here: https://nmapservice.org/book/man-port-scanning-basics.html
+	// See nmap-states here: https://nmap.org/book/man-port-scanning-basics.html
 	// active means nmap is running and it shows port filtered.
 	OperationalStateFiltered = "filtered"
 	// active means nmap is running and it shows port down.

--- a/umh-core/pkg/fsm/nmap/reconcile.go
+++ b/umh-core/pkg/fsm/nmap/reconcile.go
@@ -26,7 +26,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/metrics"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/nmap"
+	nmapservice "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/nmap"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/serviceregistry"
 	standarderrors "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/standarderrors"
 )
@@ -475,40 +475,40 @@ func (n *NmapInstance) checkPortState(currentState string) (bool, string) {
 		return false, ""
 	}
 
-	portState := nmap.PortState(strings.ToLower(n.ObservedState.ServiceInfo.NmapStatus.LastScan.PortResult.State))
+	portState := nmapservice.PortState(strings.ToLower(n.ObservedState.ServiceInfo.NmapStatus.LastScan.PortResult.State))
 
 	switch portState {
-	case nmap.PortStateOpen:
+	case nmapservice.PortStateOpen:
 		if currentState == OperationalStateOpen {
 			return false, ""
 		}
 
 		return true, EventPortOpen
-	case nmap.PortStateFiltered:
+	case nmapservice.PortStateFiltered:
 		if currentState == OperationalStateFiltered {
 			return false, ""
 		}
 
 		return true, EventPortFiltered
-	case nmap.PortStateClosed:
+	case nmapservice.PortStateClosed:
 		if currentState == OperationalStateClosed {
 			return false, ""
 		}
 
 		return true, EventPortClosed
-	case nmap.PortStateUnfiltered:
+	case nmapservice.PortStateUnfiltered:
 		if currentState == OperationalStateUnfiltered {
 			return false, ""
 		}
 
 		return true, EventPortUnfiltered
-	case nmap.PortStateOpenFiltered:
+	case nmapservice.PortStateOpenFiltered:
 		if currentState == OperationalStateOpenFiltered {
 			return false, ""
 		}
 
 		return true, EventPortOpenFiltered
-	case nmap.PortStateClosedFiltered:
+	case nmapservice.PortStateClosedFiltered:
 		if currentState == OperationalStateClosedFiltered {
 			return false, ""
 		}

--- a/umh-core/pkg/fsm/nmap/reconcile.go
+++ b/umh-core/pkg/fsm/nmap/reconcile.go
@@ -26,6 +26,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/metrics"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/nmap"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/serviceregistry"
 	standarderrors "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/standarderrors"
 )
@@ -474,40 +475,40 @@ func (n *NmapInstance) checkPortState(currentState string) (bool, string) {
 		return false, ""
 	}
 
-	portState := PortState(strings.ToLower(n.ObservedState.ServiceInfo.NmapStatus.LastScan.PortResult.State))
+	portState := nmap.PortState(strings.ToLower(n.ObservedState.ServiceInfo.NmapStatus.LastScan.PortResult.State))
 
 	switch portState {
-	case PortStateOpen:
+	case nmap.PortStateOpen:
 		if currentState == OperationalStateOpen {
 			return false, ""
 		}
 
 		return true, EventPortOpen
-	case PortStateFiltered:
+	case nmap.PortStateFiltered:
 		if currentState == OperationalStateFiltered {
 			return false, ""
 		}
 
 		return true, EventPortFiltered
-	case PortStateClosed:
+	case nmap.PortStateClosed:
 		if currentState == OperationalStateClosed {
 			return false, ""
 		}
 
 		return true, EventPortClosed
-	case PortStateUnfiltered:
+	case nmap.PortStateUnfiltered:
 		if currentState == OperationalStateUnfiltered {
 			return false, ""
 		}
 
 		return true, EventPortUnfiltered
-	case PortStateOpenFiltered:
+	case nmap.PortStateOpenFiltered:
 		if currentState == OperationalStateOpenFiltered {
 			return false, ""
 		}
 
 		return true, EventPortOpenFiltered
-	case PortStateClosedFiltered:
+	case nmap.PortStateClosedFiltered:
 		if currentState == OperationalStateClosedFiltered {
 			return false, ""
 		}

--- a/umh-core/pkg/fsmv2/nmap/manager.go
+++ b/umh-core/pkg/fsmv2/nmap/manager.go
@@ -94,9 +94,9 @@ func mapFresh(_ config.NmapConfig, s simple.Status[NmapStatus]) string {
 }
 
 // mapObserved builds a nmapfsm.NmapObservedState from the stored status. Both
-// Target and Port come from the status — what the scan actually dialled — with
+// Target and Port come from the status (what the scan actually dialed), with
 // no echo of the requested config. A requested edit that has not yet been
-// dialled therefore reads as unobserved, so a target-diffing consumer (the
+// dialed therefore reads as unobserved, so a target-diffing consumer (the
 // deploy gate) keeps waiting for a genuine scan. The ServiceInfo mirrors the
 // last scan (port state, port, latency, running).
 func mapObserved(_ config.NmapConfig, s simple.Status[NmapStatus]) publicfsm.ObservedState {

--- a/umh-core/pkg/fsmv2/nmap/manager.go
+++ b/umh-core/pkg/fsmv2/nmap/manager.go
@@ -21,6 +21,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/nmapserviceconfig"
 	publicfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
 	nmapfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/nmap"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/adapter"
@@ -92,12 +93,18 @@ func mapFresh(_ config.NmapConfig, s simple.Status[NmapStatus]) string {
 	}
 }
 
-// mapObserved builds a nmapfsm.NmapObservedState from the config and the stored
-// status: the observed service config comes from the config entry, and the
-// ServiceInfo mirrors the last scan (port state, port, latency, running).
-func mapObserved(cfg config.NmapConfig, s simple.Status[NmapStatus]) publicfsm.ObservedState {
+// mapObserved builds a nmapfsm.NmapObservedState from the stored status. Both
+// Target and Port come from the status — what the scan actually dialled — with
+// no echo of the requested config. A requested edit that has not yet been
+// dialled therefore reads as unobserved, so a target-diffing consumer (the
+// deploy gate) keeps waiting for a genuine scan. The ServiceInfo mirrors the
+// last scan (port state, port, latency, running).
+func mapObserved(_ config.NmapConfig, s simple.Status[NmapStatus]) publicfsm.ObservedState {
 	return nmapfsm.NmapObservedState{
-		ObservedNmapServiceConfig: cfg.NmapServiceConfig,
+		ObservedNmapServiceConfig: nmapserviceconfig.NmapServiceConfig{
+			Target: s.Result.Target,
+			Port:   s.Result.Port,
+		},
 		ServiceInfo: nmapservice.ServiceInfo{
 			NmapStatus: nmapservice.NmapServiceInfo{
 				IsRunning: s.Result.IsRunning,

--- a/umh-core/pkg/fsmv2/nmap/manager.go
+++ b/umh-core/pkg/fsmv2/nmap/manager.go
@@ -16,7 +16,6 @@ package fsmv2nmap
 
 import (
 	"fmt"
-	"time"
 
 	"gopkg.in/yaml.v3"
 
@@ -109,7 +108,7 @@ func mapObserved(_ config.NmapConfig, s simple.Status[NmapStatus]) publicfsm.Obs
 			NmapStatus: nmapservice.NmapServiceInfo{
 				IsRunning: s.Result.IsRunning,
 				LastScan: &nmapservice.NmapScanResult{
-					Timestamp: time.Now(),
+					Timestamp: s.Result.ScannedAt,
 					PortResult: nmapservice.PortResult{
 						State:     s.Result.PortState,
 						LatencyMs: s.Result.LatencyMs,

--- a/umh-core/pkg/fsmv2/nmap/manager.go
+++ b/umh-core/pkg/fsmv2/nmap/manager.go
@@ -96,9 +96,9 @@ func mapFresh(_ config.NmapConfig, s simple.Status[NmapStatus]) string {
 // and Port come from the status, so they name the endpoint the most recent poll
 // dialed rather than the one the config asked for. Until a poll of an edited
 // endpoint completes, the observed values are the previous endpoint's, which is
-// what lets awaitRollout in the edit action tell a converged edit from a pending
-// one. Timestamp is the scan's own start time, so an old poll cannot read as
-// fresh.
+// what lets a consumer tell a converged edit from a pending one. The scan
+// carries that endpoint and its own start time, so an old poll cannot read as
+// fresh or as evidence about a different endpoint.
 func mapObserved(_ config.NmapConfig, s simple.Status[NmapStatus]) publicfsm.ObservedState {
 	return nmapfsm.NmapObservedState{
 		ObservedNmapServiceConfig: nmapserviceconfig.NmapServiceConfig{
@@ -110,6 +110,7 @@ func mapObserved(_ config.NmapConfig, s simple.Status[NmapStatus]) publicfsm.Obs
 				IsRunning: s.Result.IsRunning,
 				LastScan: &nmapservice.NmapScanResult{
 					Timestamp: s.Result.ScannedAt,
+					Target:    s.Result.Target,
 					PortResult: nmapservice.PortResult{
 						State:     s.Result.PortState,
 						LatencyMs: s.Result.LatencyMs,

--- a/umh-core/pkg/fsmv2/nmap/manager.go
+++ b/umh-core/pkg/fsmv2/nmap/manager.go
@@ -75,17 +75,17 @@ func cfgFor(cfg config.NmapConfig) (map[string]any, error) {
 // the adapter, so this only classifies the healthy leaf.
 func mapFresh(_ config.NmapConfig, s simple.Status[NmapStatus]) string {
 	switch s.Result.PortState {
-	case string(nmapfsm.PortStateOpen):
+	case string(nmapservice.PortStateOpen):
 		return nmapfsm.OperationalStateOpen
-	case string(nmapfsm.PortStateClosed):
+	case string(nmapservice.PortStateClosed):
 		return nmapfsm.OperationalStateClosed
-	case string(nmapfsm.PortStateFiltered):
+	case string(nmapservice.PortStateFiltered):
 		return nmapfsm.OperationalStateFiltered
-	case string(nmapfsm.PortStateUnfiltered):
+	case string(nmapservice.PortStateUnfiltered):
 		return nmapfsm.OperationalStateUnfiltered
-	case string(nmapfsm.PortStateOpenFiltered):
+	case string(nmapservice.PortStateOpenFiltered):
 		return nmapfsm.OperationalStateOpenFiltered
-	case string(nmapfsm.PortStateClosedFiltered):
+	case string(nmapservice.PortStateClosedFiltered):
 		return nmapfsm.OperationalStateClosedFiltered
 	default:
 		return nmapfsm.OperationalStateStarting

--- a/umh-core/pkg/fsmv2/nmap/manager.go
+++ b/umh-core/pkg/fsmv2/nmap/manager.go
@@ -92,12 +92,13 @@ func mapFresh(_ config.NmapConfig, s simple.Status[NmapStatus]) string {
 	}
 }
 
-// mapObserved builds a nmapfsm.NmapObservedState from the stored status. Both
-// Target and Port come from the status (what the scan actually dialed), with
-// no echo of the requested config. A requested edit that has not yet been
-// dialed therefore reads as unobserved, so a target-diffing consumer (the
-// deploy gate) keeps waiting for a genuine scan. The ServiceInfo mirrors the
-// last scan (port state, port, latency, running).
+// mapObserved builds a nmapfsm.NmapObservedState from the stored status. Target
+// and Port come from the status, so they name the endpoint the most recent poll
+// dialed rather than the one the config asked for. Until a poll of an edited
+// endpoint completes, the observed values are the previous endpoint's, which is
+// what lets awaitRollout in the edit action tell a converged edit from a pending
+// one. Timestamp is the scan's own start time, so an old poll cannot read as
+// fresh.
 func mapObserved(_ config.NmapConfig, s simple.Status[NmapStatus]) publicfsm.ObservedState {
 	return nmapfsm.NmapObservedState{
 		ObservedNmapServiceConfig: nmapserviceconfig.NmapServiceConfig{

--- a/umh-core/pkg/fsmv2/nmap/manager_test.go
+++ b/umh-core/pkg/fsmv2/nmap/manager_test.go
@@ -146,7 +146,7 @@ var _ = Describe("NewFsmv2NmapManager", func() {
 	})
 
 	It("builds a NmapObservedState reflecting the status and config", func() {
-		stageClient(freshStatus(NmapStatus{PortState: "open", IsRunning: true, Port: port, LatencyMs: 7}), nil)
+		stageClient(freshStatus(NmapStatus{Target: target, PortState: "open", IsRunning: true, Port: port, LatencyMs: 7}), nil)
 
 		mgr := NewFsmv2NmapManager("test")
 
@@ -166,6 +166,38 @@ var _ = Describe("NewFsmv2NmapManager", func() {
 		Expect(nmapObserved.ServiceInfo.NmapStatus.LastScan).NotTo(BeNil())
 		Expect(nmapObserved.ServiceInfo.NmapStatus.LastScan.PortResult.State).To(Equal("open"))
 		Expect(nmapObserved.ServiceInfo.NmapStatus.LastScan.PortResult.Port).To(Equal(port))
+	})
+
+	It("reports the config the scan actually dialled, not the requested config", func() {
+		// Stage a scan reported at 10.0.0.1:502 while the snapshot asks for
+		// 10.0.0.2:445. mapObserved must reflect what the scan dialled, so a
+		// consumer (the deploy gate) can see that a requested edit has not yet
+		// taken effect.
+		stageClient(freshStatus(NmapStatus{
+			PortState: "open",
+			IsRunning: true,
+			Port:      502,
+			Target:    "10.0.0.1",
+			LatencyMs: 7,
+		}), nil)
+
+		mgr := NewFsmv2NmapManager("test")
+
+		requested := nmapConfig("running")
+		requested.NmapServiceConfig.Target = "10.0.0.2"
+		requested.NmapServiceConfig.Port = 445
+
+		err, _ := mgr.Reconcile(context.Background(), snapshotWith(requested), nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		observed, err := mgr.GetLastObservedState(name)
+		Expect(err).NotTo(HaveOccurred())
+
+		nmapObserved, ok := observed.(nmapfsm.NmapObservedState)
+		Expect(ok).To(BeTrue(), "expected a nmapfsm.NmapObservedState")
+
+		Expect(nmapObserved.ObservedNmapServiceConfig.Port).To(Equal(uint16(502)), "observed port must be the port the scan dialled, not the requested one")
+		Expect(nmapObserved.ObservedNmapServiceConfig.Target).To(Equal("10.0.0.1"), "observed target must be the target the scan dialled, not the requested one")
 	})
 
 	It("extracts configs from the snapshot and Upserts the enabled worker's ref", func() {

--- a/umh-core/pkg/fsmv2/nmap/manager_test.go
+++ b/umh-core/pkg/fsmv2/nmap/manager_test.go
@@ -168,9 +168,9 @@ var _ = Describe("NewFsmv2NmapManager", func() {
 		Expect(nmapObserved.ServiceInfo.NmapStatus.LastScan.PortResult.Port).To(Equal(port))
 	})
 
-	It("reports the config the scan actually dialled, not the requested config", func() {
+	It("reports the config the scan actually dialed, not the requested config", func() {
 		// Stage a scan reported at 10.0.0.1:502 while the snapshot asks for
-		// 10.0.0.2:445. mapObserved must reflect what the scan dialled, so a
+		// 10.0.0.2:445. mapObserved must reflect what the scan dialed, so a
 		// consumer (the deploy gate) can see that a requested edit has not yet
 		// taken effect.
 		stageClient(freshStatus(NmapStatus{
@@ -196,8 +196,8 @@ var _ = Describe("NewFsmv2NmapManager", func() {
 		nmapObserved, ok := observed.(nmapfsm.NmapObservedState)
 		Expect(ok).To(BeTrue(), "expected a nmapfsm.NmapObservedState")
 
-		Expect(nmapObserved.ObservedNmapServiceConfig.Port).To(Equal(uint16(502)), "observed port must be the port the scan dialled, not the requested one")
-		Expect(nmapObserved.ObservedNmapServiceConfig.Target).To(Equal("10.0.0.1"), "observed target must be the target the scan dialled, not the requested one")
+		Expect(nmapObserved.ObservedNmapServiceConfig.Port).To(Equal(uint16(502)), "observed port must be the port the scan dialed, not the requested one")
+		Expect(nmapObserved.ObservedNmapServiceConfig.Target).To(Equal("10.0.0.1"), "observed target must be the target the scan dialed, not the requested one")
 	})
 
 	It("extracts configs from the snapshot and Upserts the enabled worker's ref", func() {

--- a/umh-core/pkg/fsmv2/nmap/manager_test.go
+++ b/umh-core/pkg/fsmv2/nmap/manager_test.go
@@ -168,6 +168,50 @@ var _ = Describe("NewFsmv2NmapManager", func() {
 		Expect(nmapObserved.ServiceInfo.NmapStatus.LastScan.PortResult.Port).To(Equal(port))
 	})
 
+	It("reports the scan's own time, so a leftover scan cannot read as fresh", func() {
+		scannedAt := time.Now().Add(-42 * time.Minute)
+
+		stageClient(freshStatus(NmapStatus{
+			Target:    target,
+			PortState: "open",
+			IsRunning: true,
+			Port:      port,
+			ScannedAt: scannedAt,
+		}), nil)
+
+		mgr := NewFsmv2NmapManager("test")
+
+		err, _ := mgr.Reconcile(context.Background(), snapshotWith(nmapConfig("running")), nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		observed, err := mgr.GetLastObservedState(name)
+		Expect(err).NotTo(HaveOccurred())
+
+		nmapObserved, ok := observed.(nmapfsm.NmapObservedState)
+		Expect(ok).To(BeTrue(), "expected a nmapfsm.NmapObservedState")
+
+		Expect(nmapObserved.ServiceInfo.NmapStatus.LastScan.Timestamp).To(BeTemporally("==", scannedAt),
+			"the observed timestamp must come from the scan, not from the moment it was mapped")
+	})
+
+	It("reports a zero scan time for a worker that has never polled", func() {
+		stageClient(freshStatus(NmapStatus{}), nil)
+
+		mgr := NewFsmv2NmapManager("test")
+
+		err, _ := mgr.Reconcile(context.Background(), snapshotWith(nmapConfig("running")), nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		observed, err := mgr.GetLastObservedState(name)
+		Expect(err).NotTo(HaveOccurred())
+
+		nmapObserved, ok := observed.(nmapfsm.NmapObservedState)
+		Expect(ok).To(BeTrue(), "expected a nmapfsm.NmapObservedState")
+
+		Expect(nmapObserved.ServiceInfo.NmapStatus.LastScan.Timestamp).To(BeZero(),
+			"a never-polled worker must not report a usable scan time")
+	})
+
 	It("reports the config the scan actually dialed, not the requested config", func() {
 		// Stage a scan reported at 10.0.0.1:502 while the snapshot asks for
 		// 10.0.0.2:445. mapObserved must reflect what the scan dialed, so a

--- a/umh-core/pkg/fsmv2/nmap/manager_test.go
+++ b/umh-core/pkg/fsmv2/nmap/manager_test.go
@@ -164,6 +164,7 @@ var _ = Describe("NewFsmv2NmapManager", func() {
 
 		Expect(nmapObserved.ServiceInfo.NmapStatus.IsRunning).To(BeTrue())
 		Expect(nmapObserved.ServiceInfo.NmapStatus.LastScan).NotTo(BeNil())
+		Expect(nmapObserved.ServiceInfo.NmapStatus.LastScan.Target).To(Equal(target))
 		Expect(nmapObserved.ServiceInfo.NmapStatus.LastScan.PortResult.State).To(Equal("open"))
 		Expect(nmapObserved.ServiceInfo.NmapStatus.LastScan.PortResult.Port).To(Equal(port))
 	})

--- a/umh-core/pkg/fsmv2/nmap/manager_test.go
+++ b/umh-core/pkg/fsmv2/nmap/manager_test.go
@@ -145,7 +145,7 @@ var _ = Describe("NewFsmv2NmapManager", func() {
 		Expect(state).To(Equal(nmapfsm.OperationalStateDegraded))
 	})
 
-	It("builds a NmapObservedState reflecting the status and config", func() {
+	It("builds a NmapObservedState reflecting the scan, not the requested config", func() {
 		stageClient(freshStatus(NmapStatus{Target: target, PortState: "open", IsRunning: true, Port: port, LatencyMs: 7}), nil)
 
 		mgr := NewFsmv2NmapManager("test")
@@ -214,9 +214,8 @@ var _ = Describe("NewFsmv2NmapManager", func() {
 
 	It("reports the config the scan actually dialed, not the requested config", func() {
 		// Stage a scan reported at 10.0.0.1:502 while the snapshot asks for
-		// 10.0.0.2:445. mapObserved must reflect what the scan dialed, so a
-		// consumer (the deploy gate) can see that a requested edit has not yet
-		// taken effect.
+		// 10.0.0.2:445. mapObserved must reflect what the scan dialed, so
+		// awaitRollout can see that a requested edit has not yet taken effect.
 		stageClient(freshStatus(NmapStatus{
 			PortState: "open",
 			IsRunning: true,

--- a/umh-core/pkg/fsmv2/nmap/nmap.go
+++ b/umh-core/pkg/fsmv2/nmap/nmap.go
@@ -45,6 +45,8 @@ const (
 
 // NmapStatus is the result of one TCP-dial observation of the target port.
 type NmapStatus struct {
+	// Target is the hostname or IP address the scan dialled.
+	Target string `json:"target"`
 	// PortState is one of nmapfsm.PortStateOpen or nmapfsm.PortStateClosed.
 	PortState string `json:"port_state"`
 	// LatencyMs is the dial round-trip time in milliseconds. Zero unless the
@@ -77,10 +79,11 @@ func Poll(ctx context.Context, _ struct{}, cfg config.NmapConfig) (NmapStatus, e
 		// as shutdown reports cancelled, not closed. A deadline
 		// (ObservationTimeout) is not a shutdown: it falls through to closed.
 		if errors.Is(ctx.Err(), context.Canceled) {
-			return NmapStatus{Port: cfg.NmapServiceConfig.Port}, fmt.Errorf("scan cancelled: %w", ctx.Err())
+			return NmapStatus{Target: cfg.NmapServiceConfig.Target, Port: cfg.NmapServiceConfig.Port}, fmt.Errorf("scan cancelled: %w", ctx.Err())
 		}
 
 		return NmapStatus{
+			Target:    cfg.NmapServiceConfig.Target,
 			PortState: string(nmapfsm.PortStateClosed),
 			Port:      cfg.NmapServiceConfig.Port,
 		}, nil
@@ -90,6 +93,7 @@ func Poll(ctx context.Context, _ struct{}, cfg config.NmapConfig) (NmapStatus, e
 	_ = conn.Close()
 
 	return NmapStatus{
+		Target:    cfg.NmapServiceConfig.Target,
 		PortState: string(nmapfsm.PortStateOpen),
 		LatencyMs: elapsedMs,
 		Port:      cfg.NmapServiceConfig.Port,

--- a/umh-core/pkg/fsmv2/nmap/nmap.go
+++ b/umh-core/pkg/fsmv2/nmap/nmap.go
@@ -45,7 +45,7 @@ const (
 
 // NmapStatus is the result of one TCP-dial observation of the target port.
 type NmapStatus struct {
-	// Target is the hostname or IP address the scan dialled.
+	// Target is the hostname or IP address the scan dialed.
 	Target string `json:"target"`
 	// PortState is one of nmapfsm.PortStateOpen or nmapfsm.PortStateClosed.
 	PortState string `json:"port_state"`

--- a/umh-core/pkg/fsmv2/nmap/nmap.go
+++ b/umh-core/pkg/fsmv2/nmap/nmap.go
@@ -56,6 +56,10 @@ type NmapStatus struct {
 	Port uint16 `json:"port"`
 	// IsRunning is true when the target port accepted the connection.
 	IsRunning bool `json:"is_running"`
+	// ScannedAt is when the dial started. A consumer comparing it against the
+	// time a config edit was persisted can tell a scan of the new target from a
+	// leftover scan of the previous one, which no other field distinguishes.
+	ScannedAt time.Time `json:"scanned_at"`
 }
 
 // Poll dials the configured target once and reports the port state. A
@@ -79,13 +83,18 @@ func Poll(ctx context.Context, _ struct{}, cfg config.NmapConfig) (NmapStatus, e
 		// as shutdown reports cancelled, not closed. A deadline
 		// (ObservationTimeout) is not a shutdown: it falls through to closed.
 		if errors.Is(ctx.Err(), context.Canceled) {
-			return NmapStatus{Target: cfg.NmapServiceConfig.Target, Port: cfg.NmapServiceConfig.Port}, fmt.Errorf("scan cancelled: %w", ctx.Err())
+			return NmapStatus{
+				Target:    cfg.NmapServiceConfig.Target,
+				Port:      cfg.NmapServiceConfig.Port,
+				ScannedAt: start,
+			}, fmt.Errorf("scan cancelled: %w", ctx.Err())
 		}
 
 		return NmapStatus{
 			Target:    cfg.NmapServiceConfig.Target,
 			PortState: string(nmapfsm.PortStateClosed),
 			Port:      cfg.NmapServiceConfig.Port,
+			ScannedAt: start,
 		}, nil
 	}
 
@@ -98,6 +107,7 @@ func Poll(ctx context.Context, _ struct{}, cfg config.NmapConfig) (NmapStatus, e
 		LatencyMs: elapsedMs,
 		Port:      cfg.NmapServiceConfig.Port,
 		IsRunning: true,
+		ScannedAt: start,
 	}, nil
 }
 

--- a/umh-core/pkg/fsmv2/nmap/nmap.go
+++ b/umh-core/pkg/fsmv2/nmap/nmap.go
@@ -28,8 +28,8 @@ import (
 	"time"
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
-	nmapfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/nmap"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/simple"
+	nmapservice "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/nmap"
 )
 
 const (
@@ -47,7 +47,7 @@ const (
 type NmapStatus struct {
 	// Target is the hostname or IP address the scan dialed.
 	Target string `json:"target"`
-	// PortState is one of nmapfsm.PortStateOpen or nmapfsm.PortStateClosed.
+	// PortState is one of nmapservice.PortStateOpen or nmapservice.PortStateClosed.
 	PortState string `json:"port_state"`
 	// LatencyMs is the dial round-trip time in milliseconds. Zero unless the
 	// port is open.
@@ -92,7 +92,7 @@ func Poll(ctx context.Context, _ struct{}, cfg config.NmapConfig) (NmapStatus, e
 
 		return NmapStatus{
 			Target:    cfg.NmapServiceConfig.Target,
-			PortState: string(nmapfsm.PortStateClosed),
+			PortState: string(nmapservice.PortStateClosed),
 			Port:      cfg.NmapServiceConfig.Port,
 			ScannedAt: start,
 		}, nil
@@ -103,7 +103,7 @@ func Poll(ctx context.Context, _ struct{}, cfg config.NmapConfig) (NmapStatus, e
 
 	return NmapStatus{
 		Target:    cfg.NmapServiceConfig.Target,
-		PortState: string(nmapfsm.PortStateOpen),
+		PortState: string(nmapservice.PortStateOpen),
 		LatencyMs: elapsedMs,
 		Port:      cfg.NmapServiceConfig.Port,
 		IsRunning: true,

--- a/umh-core/pkg/fsmv2/nmap/nmap_test.go
+++ b/umh-core/pkg/fsmv2/nmap/nmap_test.go
@@ -71,7 +71,7 @@ var _ = Describe("Nmap Poll", func() {
 		Expect(status.LatencyMs).To(BeNumerically(">=", 0))
 	})
 
-	It("records the target and port it dialled", func() {
+	It("records the target and port it dialed", func() {
 		ln, err := net.Listen("tcp", "127.0.0.1:0")
 		Expect(err).NotTo(HaveOccurred())
 
@@ -86,8 +86,8 @@ var _ = Describe("Nmap Poll", func() {
 		st, err := fsmv2nmap.Poll(ctx, struct{}{}, cfg)
 		Expect(err).NotTo(HaveOccurred())
 
-		Expect(st.Target).To(Equal(host), "Poll must record the target it dialled")
-		Expect(st.Port).To(Equal(uint16(p)), "Poll must record the port it dialled") //nolint:unconvert // verbatim rung assertion: choose only uint16 to spell the port type
+		Expect(st.Target).To(Equal(host), "Poll must record the target it dialed")
+		Expect(st.Port).To(Equal(uint16(p)), "Poll must record the port it dialed") //nolint:unconvert // keep the explicit uint16 to match the scan's port type
 	})
 
 	It("reports a closed port without an error when the connection is refused", func() {

--- a/umh-core/pkg/fsmv2/nmap/nmap_test.go
+++ b/umh-core/pkg/fsmv2/nmap/nmap_test.go
@@ -71,6 +71,25 @@ var _ = Describe("Nmap Poll", func() {
 		Expect(status.LatencyMs).To(BeNumerically(">=", 0))
 	})
 
+	It("records the target and port it dialled", func() {
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		Expect(err).NotTo(HaveOccurred())
+
+		defer func() { _ = ln.Close() }()
+
+		host, p := hostPort(ln.Addr().String())
+		cfg := newNmapConfig(host, p)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		st, err := fsmv2nmap.Poll(ctx, struct{}{}, cfg)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(st.Target).To(Equal(host), "Poll must record the target it dialled")
+		Expect(st.Port).To(Equal(uint16(p)), "Poll must record the port it dialled") //nolint:unconvert // verbatim rung assertion: choose only uint16 to spell the port type
+	})
+
 	It("reports a closed port without an error when the connection is refused", func() {
 		// Bind a listener to grab a free loopback port, then close it so the
 		// kernel answers the dial with a TCP RST (connection refused). A refused

--- a/umh-core/pkg/fsmv2/nmap/nmap_test.go
+++ b/umh-core/pkg/fsmv2/nmap/nmap_test.go
@@ -90,6 +90,55 @@ var _ = Describe("Nmap Poll", func() {
 		Expect(st.Port).To(Equal(uint16(p)), "Poll must record the port it dialed") //nolint:unconvert // keep the explicit uint16 to match the scan's port type
 	})
 
+	It("records the scan start time and the target on the open, refused and cancelled paths", func() {
+		openListener, err := net.Listen("tcp", "127.0.0.1:0")
+		Expect(err).NotTo(HaveOccurred())
+
+		defer func() { _ = openListener.Close() }()
+
+		openHost, openPort := hostPort(openListener.Addr().String())
+
+		refusedListener, err := net.Listen("tcp", "127.0.0.1:0")
+		Expect(err).NotTo(HaveOccurred())
+
+		refusedHost, refusedPort := hostPort(refusedListener.Addr().String())
+		Expect(refusedListener.Close()).To(Succeed())
+
+		before := time.Now()
+
+		openCtx, cancelOpen := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancelOpen()
+
+		openStatus, err := fsmv2nmap.Poll(openCtx, struct{}{}, newNmapConfig(openHost, openPort))
+		Expect(err).NotTo(HaveOccurred())
+
+		refusedCtx, cancelRefused := context.WithTimeout(context.Background(), 500*time.Millisecond)
+		defer cancelRefused()
+
+		refusedStatus, err := fsmv2nmap.Poll(refusedCtx, struct{}{}, newNmapConfig(refusedHost, refusedPort))
+		Expect(err).NotTo(HaveOccurred())
+
+		cancelledCtx, cancelNow := context.WithCancel(context.Background())
+		cancelNow()
+
+		cancelledStatus, err := fsmv2nmap.Poll(cancelledCtx, struct{}{}, newNmapConfig(openHost, openPort))
+		Expect(err).To(HaveOccurred())
+
+		after := time.Now()
+
+		paths := map[string]fsmv2nmap.NmapStatus{
+			"open":      openStatus,
+			"refused":   refusedStatus,
+			"cancelled": cancelledStatus,
+		}
+
+		for path, status := range paths {
+			Expect(status.ScannedAt).To(BeTemporally(">=", before), "%s path must record when the dial started", path)
+			Expect(status.ScannedAt).To(BeTemporally("<=", after), "%s path must record when the dial started", path)
+			Expect(status.Target).NotTo(BeEmpty(), "%s path must record the target it dialed", path)
+		}
+	})
+
 	It("reports a closed port without an error when the connection is refused", func() {
 		// Bind a listener to grab a free loopback port, then close it so the
 		// kernel answers the dial with a TCP RST (connection refused). A refused

--- a/umh-core/pkg/fsmv2/nmap/nmap_test.go
+++ b/umh-core/pkg/fsmv2/nmap/nmap_test.go
@@ -87,7 +87,7 @@ var _ = Describe("Nmap Poll", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(st.Target).To(Equal(host), "Poll must record the target it dialed")
-		Expect(st.Port).To(Equal(uint16(p)), "Poll must record the port it dialed") //nolint:unconvert // keep the explicit uint16 to match the scan's port type
+		Expect(st.Port).To(Equal(p), "Poll must record the port it dialed")
 	})
 
 	It("records the scan start time and the target on the open, refused and cancelled paths", func() {

--- a/umh-core/pkg/service/connection/connection_test.go
+++ b/umh-core/pkg/service/connection/connection_test.go
@@ -527,42 +527,42 @@ func TransitionToNmapState(mockService *nmap.MockNmapService, serviceName string
 			IsS6Running: true,
 			IsRunning:   true,
 			S6FSMState:  s6fsm.OperationalStateRunning,
-			PortState:   string(nmapfsm.PortStateOpen),
+			PortState:   string(nmap.PortStateOpen),
 		})
 	case nmapfsm.OperationalStateOpenFiltered:
 		SetupNmapServiceState(mockService, serviceName, nmap.ServiceStateFlags{
 			IsS6Running: true,
 			IsRunning:   true,
 			S6FSMState:  s6fsm.OperationalStateRunning,
-			PortState:   string(nmapfsm.PortStateOpenFiltered),
+			PortState:   string(nmap.PortStateOpenFiltered),
 		})
 	case nmapfsm.OperationalStateFiltered:
 		SetupNmapServiceState(mockService, serviceName, nmap.ServiceStateFlags{
 			IsS6Running: true,
 			IsRunning:   true,
 			S6FSMState:  s6fsm.OperationalStateRunning,
-			PortState:   string(nmapfsm.PortStateFiltered),
+			PortState:   string(nmap.PortStateFiltered),
 		})
 	case nmapfsm.OperationalStateUnfiltered:
 		SetupNmapServiceState(mockService, serviceName, nmap.ServiceStateFlags{
 			IsS6Running: true,
 			IsRunning:   true,
 			S6FSMState:  s6fsm.OperationalStateRunning,
-			PortState:   string(nmapfsm.PortStateUnfiltered),
+			PortState:   string(nmap.PortStateUnfiltered),
 		})
 	case nmapfsm.OperationalStateClosed:
 		SetupNmapServiceState(mockService, serviceName, nmap.ServiceStateFlags{
 			IsS6Running: true,
 			IsRunning:   true,
 			S6FSMState:  s6fsm.OperationalStateRunning,
-			PortState:   string(nmapfsm.PortStateClosed),
+			PortState:   string(nmap.PortStateClosed),
 		})
 	case nmapfsm.OperationalStateClosedFiltered:
 		SetupNmapServiceState(mockService, serviceName, nmap.ServiceStateFlags{
 			IsS6Running: true,
 			IsRunning:   true,
 			S6FSMState:  s6fsm.OperationalStateRunning,
-			PortState:   string(nmapfsm.PortStateClosedFiltered),
+			PortState:   string(nmap.PortStateClosedFiltered),
 		})
 	case nmapfsm.OperationalStateStopping:
 		SetupNmapServiceState(mockService, serviceName, nmap.ServiceStateFlags{

--- a/umh-core/pkg/service/connection/connection_test.go
+++ b/umh-core/pkg/service/connection/connection_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
 	nmapfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/nmap"
 	s6fsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/s6"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/nmap"
+	nmapservice "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/nmap"
 	s6svc "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/s6"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/serviceregistry"
 )
@@ -41,7 +41,7 @@ const (
 var _ = Describe("ConnectionService", func() {
 	var (
 		service        *ConnectionService
-		mockNmap       *nmap.MockNmapService
+		mockNmap       *nmapservice.MockNmapService
 		ctx            context.Context
 		tick           uint64
 		connectionName string
@@ -55,7 +55,7 @@ var _ = Describe("ConnectionService", func() {
 		connectionName = "test-connection"
 
 		// Set up mock nmap service
-		mockNmap = nmap.NewMockNmapService()
+		mockNmap = nmapservice.NewMockNmapService()
 
 		// Set up a real service with mocked dependencies
 		service = NewDefaultConnectionService(connectionName,
@@ -130,7 +130,7 @@ var _ = Describe("ConnectionService", func() {
 		var (
 			cfg             *connectionserviceconfig.ConnectionServiceConfig
 			manager         *nmapfsm.NmapManager
-			mockNmapService *nmap.MockNmapService
+			mockNmapService *nmapservice.MockNmapService
 			statusService   *ConnectionService
 			nmapName        string
 		)
@@ -506,16 +506,16 @@ var _ = Describe("ConnectionService", func() {
 })
 
 // TransitionToNmapState is a helper to configure a service for a given high-level state.
-func TransitionToNmapState(mockService *nmap.MockNmapService, serviceName string, state string) {
+func TransitionToNmapState(mockService *nmapservice.MockNmapService, serviceName string, state string) {
 	switch state {
 	case nmapfsm.OperationalStateStopped,
 		nmapfsm.OperationalStateStarting:
-		SetupNmapServiceState(mockService, serviceName, nmap.ServiceStateFlags{
+		SetupNmapServiceState(mockService, serviceName, nmapservice.ServiceStateFlags{
 			IsS6Running: false,
 			S6FSMState:  s6fsm.OperationalStateStopped,
 		})
 	case nmapfsm.OperationalStateDegraded:
-		SetupNmapServiceState(mockService, serviceName, nmap.ServiceStateFlags{
+		SetupNmapServiceState(mockService, serviceName, nmapservice.ServiceStateFlags{
 			IsS6Running: true,
 			IsRunning:   false,
 			S6FSMState:  s6fsm.OperationalStateRunning,
@@ -523,49 +523,49 @@ func TransitionToNmapState(mockService *nmap.MockNmapService, serviceName string
 			PortState:   "",
 		})
 	case nmapfsm.OperationalStateOpen:
-		SetupNmapServiceState(mockService, serviceName, nmap.ServiceStateFlags{
+		SetupNmapServiceState(mockService, serviceName, nmapservice.ServiceStateFlags{
 			IsS6Running: true,
 			IsRunning:   true,
 			S6FSMState:  s6fsm.OperationalStateRunning,
-			PortState:   string(nmap.PortStateOpen),
+			PortState:   string(nmapservice.PortStateOpen),
 		})
 	case nmapfsm.OperationalStateOpenFiltered:
-		SetupNmapServiceState(mockService, serviceName, nmap.ServiceStateFlags{
+		SetupNmapServiceState(mockService, serviceName, nmapservice.ServiceStateFlags{
 			IsS6Running: true,
 			IsRunning:   true,
 			S6FSMState:  s6fsm.OperationalStateRunning,
-			PortState:   string(nmap.PortStateOpenFiltered),
+			PortState:   string(nmapservice.PortStateOpenFiltered),
 		})
 	case nmapfsm.OperationalStateFiltered:
-		SetupNmapServiceState(mockService, serviceName, nmap.ServiceStateFlags{
+		SetupNmapServiceState(mockService, serviceName, nmapservice.ServiceStateFlags{
 			IsS6Running: true,
 			IsRunning:   true,
 			S6FSMState:  s6fsm.OperationalStateRunning,
-			PortState:   string(nmap.PortStateFiltered),
+			PortState:   string(nmapservice.PortStateFiltered),
 		})
 	case nmapfsm.OperationalStateUnfiltered:
-		SetupNmapServiceState(mockService, serviceName, nmap.ServiceStateFlags{
+		SetupNmapServiceState(mockService, serviceName, nmapservice.ServiceStateFlags{
 			IsS6Running: true,
 			IsRunning:   true,
 			S6FSMState:  s6fsm.OperationalStateRunning,
-			PortState:   string(nmap.PortStateUnfiltered),
+			PortState:   string(nmapservice.PortStateUnfiltered),
 		})
 	case nmapfsm.OperationalStateClosed:
-		SetupNmapServiceState(mockService, serviceName, nmap.ServiceStateFlags{
+		SetupNmapServiceState(mockService, serviceName, nmapservice.ServiceStateFlags{
 			IsS6Running: true,
 			IsRunning:   true,
 			S6FSMState:  s6fsm.OperationalStateRunning,
-			PortState:   string(nmap.PortStateClosed),
+			PortState:   string(nmapservice.PortStateClosed),
 		})
 	case nmapfsm.OperationalStateClosedFiltered:
-		SetupNmapServiceState(mockService, serviceName, nmap.ServiceStateFlags{
+		SetupNmapServiceState(mockService, serviceName, nmapservice.ServiceStateFlags{
 			IsS6Running: true,
 			IsRunning:   true,
 			S6FSMState:  s6fsm.OperationalStateRunning,
-			PortState:   string(nmap.PortStateClosedFiltered),
+			PortState:   string(nmapservice.PortStateClosedFiltered),
 		})
 	case nmapfsm.OperationalStateStopping:
-		SetupNmapServiceState(mockService, serviceName, nmap.ServiceStateFlags{
+		SetupNmapServiceState(mockService, serviceName, nmapservice.ServiceStateFlags{
 			IsS6Running: false,
 			IsRunning:   false,
 			S6FSMState:  s6fsm.OperationalStateStopping,
@@ -575,16 +575,16 @@ func TransitionToNmapState(mockService *nmap.MockNmapService, serviceName string
 
 // SetupNmapServiceState configures the mock service state for Nmap instance tests.
 func SetupNmapServiceState(
-	mockService *nmap.MockNmapService,
+	mockService *nmapservice.MockNmapService,
 	serviceName string,
-	flags nmap.ServiceStateFlags,
+	flags nmapservice.ServiceStateFlags,
 ) {
 	// Ensure service exists in mock
 	mockService.ExistingServices[serviceName] = true
 
 	// Create service info if it doesn't exist
 	if mockService.ServiceStates[serviceName] == nil {
-		mockService.ServiceStates[serviceName] = &nmap.ServiceInfo{}
+		mockService.ServiceStates[serviceName] = &nmapservice.ServiceInfo{}
 	}
 
 	// Set S6 FSM state
@@ -613,8 +613,8 @@ func SetupNmapServiceState(
 	}
 
 	if flags.PortState != "" {
-		mockService.ServiceStates[serviceName].NmapStatus.LastScan = &nmap.NmapScanResult{
-			PortResult: nmap.PortResult{
+		mockService.ServiceStates[serviceName].NmapStatus.LastScan = &nmapservice.NmapScanResult{
+			PortResult: nmapservice.PortResult{
 				State: flags.PortState,
 			},
 		}
@@ -633,7 +633,7 @@ func SetupNmapServiceState(
 //   - serviceName: The name of the service to configure
 //   - targetState: The desired state to configure the service for
 func ConfigureNmapManagerForState(
-	mockService *nmap.MockNmapService,
+	mockService *nmapservice.MockNmapService,
 	serviceName string,
 	targetState string,
 ) {
@@ -646,11 +646,11 @@ func ConfigureNmapManagerForState(
 
 	// Make sure service state is initialized
 	if mockService.ServiceStates == nil {
-		mockService.ServiceStates = make(map[string]*nmap.ServiceInfo)
+		mockService.ServiceStates = make(map[string]*nmapservice.ServiceInfo)
 	}
 
 	if mockService.ServiceStates[serviceName] == nil {
-		mockService.ServiceStates[serviceName] = &nmap.ServiceInfo{}
+		mockService.ServiceStates[serviceName] = &nmapservice.ServiceInfo{}
 	}
 
 	// Configure the service for the target state

--- a/umh-core/pkg/service/nmap/nmap.go
+++ b/umh-core/pkg/service/nmap/nmap.go
@@ -168,8 +168,16 @@ func (s *NmapService) GetConfig(ctx context.Context, filesystemService filesyste
 	return result, nil
 }
 
+// scanCommandRegex reads the endpoint back out of the command a scan block
+// logged. GetConfig parses the run script on disk, which carries the new
+// endpoint from the moment it is rewritten, while the old scanner process keeps
+// producing scans of the old endpoint until s6 restarts it.
+var scanCommandRegex = regexp.MustCompile(`NMAP_COMMAND: nmap -n -Pn -p (\d+) ([^ ]+) -v`)
+
 // parseScanLogs parses the logs of an nmap service and extracts scan results.
-func (s *NmapService) parseScanLogs(logs []s6service.LogEntry, port uint16) *NmapScanResult {
+// configuredPort is used only when a scan block logs no command to read the
+// dialled port from.
+func (s *NmapService) parseScanLogs(logs []s6service.LogEntry, configuredPort uint16) *NmapScanResult {
 	if len(logs) == 0 {
 		return nil
 	}
@@ -209,11 +217,24 @@ func (s *NmapService) parseScanLogs(logs []s6service.LogEntry, port uint16) *Nma
 	latestScan := scanBlocks[len(scanBlocks)-1]
 	scanOutput := strings.Join(latestScan, "\n")
 
+	dialledTarget := ""
+	dialledPort := configuredPort
+
+	if matches := scanCommandRegex.FindStringSubmatch(scanOutput); len(matches) > 2 {
+		dialledTarget = matches[2]
+
+		parsedPort, parseErr := strconv.ParseUint(matches[1], 10, 16)
+		if parseErr == nil {
+			dialledPort = uint16(parsedPort)
+		}
+	}
+
 	// Create the scan result
 	result := &NmapScanResult{
+		Target:    dialledTarget,
 		RawOutput: scanOutput,
 		PortResult: PortResult{
-			Port: port,
+			Port: dialledPort,
 		},
 		Metrics: ScanMetrics{},
 	}
@@ -237,7 +258,7 @@ func (s *NmapService) parseScanLogs(logs []s6service.LogEntry, port uint16) *Nma
 	}
 
 	// Extract port state
-	portStateRegex := regexp.MustCompile(`(?i)` + strconv.Itoa(int(port)) + `/tcp\s+(open|closed|filtered|unfiltered|open\|filtered|closed\|filtered)`)
+	portStateRegex := regexp.MustCompile(`(?i)` + strconv.Itoa(int(dialledPort)) + `/tcp\s+(open|closed|filtered|unfiltered|open\|filtered|closed\|filtered)`)
 	if matches := portStateRegex.FindStringSubmatch(scanOutput); len(matches) > 1 {
 		result.PortResult.State = matches[1]
 	} else {

--- a/umh-core/pkg/service/nmap/nmap_test.go
+++ b/umh-core/pkg/service/nmap/nmap_test.go
@@ -341,6 +341,37 @@ done`
 				Expect(result.Timestamp.Format(time.RFC3339)).To(Equal("2025-05-27T09:29:59Z"))
 			})
 
+			It("should record the endpoint the scan dialled, not the configured one", func() {
+				// The configured endpoint comes from the run script on disk,
+				// which is rewritten before the running scanner picks it up. A
+				// consumer that has to tell one endpoint's scan from another's
+				// can only use what the scan block itself recorded.
+				rawLogs := `2025-05-27 09:29:59.576902049  NMAP_SCAN_START
+2025-05-27 09:29:59.577869966  NMAP_TIMESTAMP: 2025-05-27T09:29:59+00:00
+2025-05-27 09:29:59.578415299  NMAP_COMMAND: nmap -n -Pn -p 8080 localhost -v
+2025-05-27 09:29:59.619551216  8080/tcp open  http-proxy
+2025-05-27 09:29:59.623004091  NMAP_SCAN_END`
+
+				result := service.parseScanLogs(parseLogOutput(rawLogs), 445)
+				Expect(result).NotTo(BeNil())
+				Expect(result.Target).To(Equal("localhost"))
+				Expect(result.PortResult.Port).To(Equal(uint16(8080)))
+				Expect(result.PortResult.State).To(Equal("open"))
+			})
+
+			It("should leave the target empty when the scan recorded no command", func() {
+				rawLogs := `2025-05-27 09:29:59.576902049  NMAP_SCAN_START
+2025-05-27 09:29:59.577869966  NMAP_TIMESTAMP: 2025-05-27T09:29:59+00:00
+2025-05-27 09:29:59.619551216  8080/tcp open  http-proxy
+2025-05-27 09:29:59.623004091  NMAP_SCAN_END`
+
+				result := service.parseScanLogs(parseLogOutput(rawLogs), 8080)
+				Expect(result).NotTo(BeNil())
+				Expect(result.Target).To(BeEmpty())
+				Expect(result.PortResult.Port).To(Equal(uint16(8080)))
+				Expect(result.PortResult.State).To(Equal("open"))
+			})
+
 			It("should parse scan results correctly with multiple scans", func() {
 				rawLogs := `2025-05-27 11:34:24.541823586  Read data files from: /usr/bin/../share/nmap
 2025-05-27 11:34:24.541824086  Nmap done: 1 IP address (1 host up) scanned in 0.03 seconds

--- a/umh-core/pkg/service/nmap/types.go
+++ b/umh-core/pkg/service/nmap/types.go
@@ -82,6 +82,17 @@ type PortResult struct {
 	Port uint16 `json:"port"`
 }
 
+type PortState string
+
+const (
+	PortStateOpen           PortState = "open"
+	PortStateFiltered       PortState = "filtered"
+	PortStateClosed         PortState = "closed"
+	PortStateUnfiltered     PortState = "unfiltered"
+	PortStateOpenFiltered   PortState = "open|filtered"
+	PortStateClosedFiltered PortState = "closed|filtered"
+)
+
 // ScanMetrics contains overall metrics for the scan.
 type ScanMetrics struct {
 	// Total duration of scan in seconds

--- a/umh-core/pkg/service/nmap/types.go
+++ b/umh-core/pkg/service/nmap/types.go
@@ -62,6 +62,9 @@ type INmapService interface {
 type NmapScanResult struct {
 	// Timestamp of the scan
 	Timestamp time.Time `json:"timestamp"`
+	// Target the scan dialled, empty when the scan recorded no command to read
+	// it back from
+	Target string `json:"target"`
 	// Raw output from nmap
 	RawOutput string `json:"rawOutput"`
 	// Error message if scan failed
@@ -82,6 +85,7 @@ type PortResult struct {
 	Port uint16 `json:"port"`
 }
 
+// PortState is the state nmap reports for the scanned port.
 type PortState string
 
 const (

--- a/umh-core/pkg/service/protocolconverter/delegation_test.go
+++ b/umh-core/pkg/service/protocolconverter/delegation_test.go
@@ -19,7 +19,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/connection"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/dataflowcomponent"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/nmap"
+	nmapservice "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/nmap"
 )
 
 var _ = Describe("Delegation Approach", func() {
@@ -36,7 +36,7 @@ var _ = Describe("Delegation Approach", func() {
 				DfcFSMReadState:    dataflowcomponent.OperationalStateActive,
 				DfcFSMWriteState:   dataflowcomponent.OperationalStateActive,
 				ConnectionFSMState: connection.OperationalStateUp,
-				PortState:          nmap.PortStateOpen,
+				PortState:          nmapservice.PortStateOpen,
 			}
 
 			// Call SetConverterState

--- a/umh-core/pkg/service/protocolconverter/mock.go
+++ b/umh-core/pkg/service/protocolconverter/mock.go
@@ -26,13 +26,13 @@ import (
 	benthosfsmmanager "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/benthos"
 	connfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/connection"
 	dfcfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/dataflowcomponent"
-	nmapfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/nmap"
 	redpandafsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/redpanda"
 	benthosservice "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/benthos"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/benthos_monitor"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/connection"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/dataflowcomponent"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/filesystem"
+	nmapservice "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/nmap"
 	redpandasvc "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/redpanda"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/serviceregistry"
 )
@@ -127,7 +127,7 @@ type ConverterStateFlags struct {
 	DfcFSMWriteState   string
 	ConnectionFSMState string
 	RedpandaFSMState   string
-	PortState          nmapfsm.PortState
+	PortState          nmapservice.PortState
 	IsDFCRunning       bool
 	IsConnectionUp     bool
 	IsRedpandaRunning  bool

--- a/umh-core/test/fsm/nmap/nmap_test.go
+++ b/umh-core/test/fsm/nmap/nmap_test.go
@@ -250,7 +250,7 @@ var _ = Describe("NmapInstance FSM", func() {
 				IsS6Running: true,
 				IsRunning:   true,
 				S6FSMState:  s6fsm.OperationalStateRunning,
-				PortState:   string(nmap.PortStateOpen),
+				PortState:   string(nmapsvc.PortStateOpen),
 			})
 
 			tick, err = fsmtest.TestNmapStateTransition(
@@ -321,7 +321,7 @@ var _ = Describe("NmapInstance FSM", func() {
 				IsS6Running: true,
 				IsRunning:   true,
 				S6FSMState:  s6fsm.OperationalStateRunning,
-				PortState:   string(nmap.PortStateOpen),
+				PortState:   string(nmapsvc.PortStateOpen),
 			})
 			tick, err = fsmtest.TestNmapStateTransition(
 				ctx, instance, mockService, mockServices, serviceName,
@@ -408,7 +408,7 @@ var _ = Describe("NmapInstance FSM", func() {
 				IsS6Running: true,
 				IsRunning:   true,
 				S6FSMState:  s6fsm.OperationalStateRunning,
-				PortState:   string(nmap.PortStateOpen),
+				PortState:   string(nmapsvc.PortStateOpen),
 			})
 			tick, err = fsmtest.TestNmapStateTransition(
 				ctx, instance, mockService, mockServices, serviceName,
@@ -427,7 +427,7 @@ var _ = Describe("NmapInstance FSM", func() {
 			// Set timestamp to 15 seconds ago (NmapScanTimeout is 10 seconds)
 			oldTimestamp := time.Now().Add(-15 * time.Second)
 			mockService.ServiceStates[serviceName].NmapStatus.LastScan.Timestamp = oldTimestamp
-			mockService.ServiceStates[serviceName].NmapStatus.LastScan.PortResult.State = string(nmap.PortStateOpen)
+			mockService.ServiceStates[serviceName].NmapStatus.LastScan.PortResult.State = string(nmapsvc.PortStateOpen)
 
 			// The instance should transition from open => degraded due to timeout
 			tick, err = fsmtest.TestNmapStateTransition(
@@ -502,7 +502,7 @@ var _ = Describe("NmapInstance FSM", func() {
 				IsS6Running: true,
 				S6FSMState:  s6fsm.OperationalStateRunning,
 				IsRunning:   true,
-				PortState:   string(nmap.PortStateOpen),
+				PortState:   string(nmapsvc.PortStateOpen),
 			})
 			tick, err = fsmtest.TestNmapStateTransition(
 				ctx, instance, mockService, mockServices, serviceName,

--- a/umh-core/test/fsm/nmap/nmap_test.go
+++ b/umh-core/test/fsm/nmap/nmap_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/nmap"
 	s6fsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/s6"
-	nmapsvc "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/nmap"
+	nmapservice "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/nmap"
 	s6svc "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/s6"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/serviceregistry"
 )
@@ -39,7 +39,7 @@ import (
 var _ = Describe("NmapInstance FSM", func() {
 	var (
 		instance    *nmap.NmapInstance
-		mockService *nmapsvc.MockNmapService
+		mockService *nmapservice.MockNmapService
 		serviceName string
 		ctx         context.Context
 		tick        uint64
@@ -82,12 +82,12 @@ var _ = Describe("NmapInstance FSM", func() {
 			Expect(mockService.AddNmapToS6ManagerCalled).To(BeTrue())
 
 			// Next, mock the service creation success
-			mockService.ServiceStates[serviceName] = &nmapsvc.ServiceInfo{
+			mockService.ServiceStates[serviceName] = &nmapservice.ServiceInfo{
 				S6FSMState: s6fsm.OperationalStateStopped,
 				S6ObservedState: s6fsm.S6ObservedState{
 					ServiceInfo: s6svc.ServiceInfo{Status: s6svc.ServiceDown, Uptime: 5},
 				},
-				NmapStatus: nmapsvc.NmapServiceInfo{
+				NmapStatus: nmapservice.NmapServiceInfo{
 					IsRunning: true,
 				},
 			}
@@ -108,7 +108,7 @@ var _ = Describe("NmapInstance FSM", func() {
 			Expect(instance.GetDesiredFSMState()).To(Equal(nmap.OperationalStateOpen))
 
 			// Also set the mock flags for an initial start attempt
-			mockService.SetServiceState(serviceName, nmapsvc.ServiceStateFlags{
+			mockService.SetServiceState(serviceName, nmapservice.ServiceStateFlags{
 				IsS6Running: false,
 			})
 
@@ -142,7 +142,7 @@ var _ = Describe("NmapInstance FSM", func() {
 			)
 			Expect(err).NotTo(HaveOccurred())
 
-			mockService.ServiceStates[serviceName] = &nmapsvc.ServiceInfo{
+			mockService.ServiceStates[serviceName] = &nmapservice.ServiceInfo{
 				S6FSMState: s6fsm.OperationalStateStopped}
 			mockService.ExistingServices[serviceName] = true
 
@@ -169,7 +169,7 @@ var _ = Describe("NmapInstance FSM", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// from starting => degraded
-			mockService.SetServiceState(serviceName, nmapsvc.ServiceStateFlags{
+			mockService.SetServiceState(serviceName, nmapservice.ServiceStateFlags{
 				IsS6Running: true,
 				S6FSMState:  s6fsm.OperationalStateRunning,
 			})
@@ -203,7 +203,7 @@ var _ = Describe("NmapInstance FSM", func() {
 			)
 			Expect(err).NotTo(HaveOccurred())
 
-			mockService.ServiceStates[serviceName] = &nmapsvc.ServiceInfo{
+			mockService.ServiceStates[serviceName] = &nmapservice.ServiceInfo{
 				S6FSMState: s6fsm.OperationalStateStopped}
 			mockService.ExistingServices[serviceName] = true
 
@@ -230,7 +230,7 @@ var _ = Describe("NmapInstance FSM", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// from starting => degraded
-			mockService.SetServiceState(serviceName, nmapsvc.ServiceStateFlags{
+			mockService.SetServiceState(serviceName, nmapservice.ServiceStateFlags{
 				IsRunning:   true,
 				IsS6Running: true,
 				S6FSMState:  s6fsm.OperationalStateRunning,
@@ -246,11 +246,11 @@ var _ = Describe("NmapInstance FSM", func() {
 			Expect(instance.GetCurrentFSMState()).To(Equal(nmap.OperationalStateDegraded))
 
 			// Step 3: from Idle => Active when processing data
-			mockService.SetServiceState(serviceName, nmapsvc.ServiceStateFlags{
+			mockService.SetServiceState(serviceName, nmapservice.ServiceStateFlags{
 				IsS6Running: true,
 				IsRunning:   true,
 				S6FSMState:  s6fsm.OperationalStateRunning,
-				PortState:   string(nmapsvc.PortStateOpen),
+				PortState:   string(nmapservice.PortStateOpen),
 			})
 
 			tick, err = fsmtest.TestNmapStateTransition(
@@ -275,7 +275,7 @@ var _ = Describe("NmapInstance FSM", func() {
 			)
 			Expect(err).NotTo(HaveOccurred())
 
-			mockService.ServiceStates[serviceName] = &nmapsvc.ServiceInfo{
+			mockService.ServiceStates[serviceName] = &nmapservice.ServiceInfo{
 				S6FSMState: s6fsm.OperationalStateStopped}
 			mockService.ExistingServices[serviceName] = true
 
@@ -302,7 +302,7 @@ var _ = Describe("NmapInstance FSM", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// from starting => degraded
-			mockService.SetServiceState(serviceName, nmapsvc.ServiceStateFlags{
+			mockService.SetServiceState(serviceName, nmapservice.ServiceStateFlags{
 				IsS6Running: true,
 				S6FSMState:  s6fsm.OperationalStateRunning,
 				IsRunning:   true,
@@ -317,11 +317,11 @@ var _ = Describe("NmapInstance FSM", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// from idle => active
-			mockService.SetServiceState(serviceName, nmapsvc.ServiceStateFlags{
+			mockService.SetServiceState(serviceName, nmapservice.ServiceStateFlags{
 				IsS6Running: true,
 				IsRunning:   true,
 				S6FSMState:  s6fsm.OperationalStateRunning,
-				PortState:   string(nmapsvc.PortStateOpen),
+				PortState:   string(nmapservice.PortStateOpen),
 			})
 			tick, err = fsmtest.TestNmapStateTransition(
 				ctx, instance, mockService, mockServices, serviceName,
@@ -333,7 +333,7 @@ var _ = Describe("NmapInstance FSM", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Step 3: Then degrade => set flags => "degraded"
-			mockService.SetServiceState(serviceName, nmapsvc.ServiceStateFlags{
+			mockService.SetServiceState(serviceName, nmapservice.ServiceStateFlags{
 				IsS6Running: true,
 				IsRunning:   true,
 				S6FSMState:  s6fsm.OperationalStateRunning,
@@ -362,7 +362,7 @@ var _ = Describe("NmapInstance FSM", func() {
 			)
 			Expect(err).NotTo(HaveOccurred())
 
-			mockService.ServiceStates[serviceName] = &nmapsvc.ServiceInfo{
+			mockService.ServiceStates[serviceName] = &nmapservice.ServiceInfo{
 				S6FSMState: s6fsm.OperationalStateStopped}
 			mockService.ExistingServices[serviceName] = true
 
@@ -389,7 +389,7 @@ var _ = Describe("NmapInstance FSM", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// from starting => degraded
-			mockService.SetServiceState(serviceName, nmapsvc.ServiceStateFlags{
+			mockService.SetServiceState(serviceName, nmapservice.ServiceStateFlags{
 				IsS6Running: true,
 				S6FSMState:  s6fsm.OperationalStateRunning,
 				IsRunning:   true,
@@ -404,11 +404,11 @@ var _ = Describe("NmapInstance FSM", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// from degraded => open
-			mockService.SetServiceState(serviceName, nmapsvc.ServiceStateFlags{
+			mockService.SetServiceState(serviceName, nmapservice.ServiceStateFlags{
 				IsS6Running: true,
 				IsRunning:   true,
 				S6FSMState:  s6fsm.OperationalStateRunning,
-				PortState:   string(nmapsvc.PortStateOpen),
+				PortState:   string(nmapservice.PortStateOpen),
 			})
 			tick, err = fsmtest.TestNmapStateTransition(
 				ctx, instance, mockService, mockServices, serviceName,
@@ -422,12 +422,12 @@ var _ = Describe("NmapInstance FSM", func() {
 			// Step 3: Set an old timestamp that exceeds NmapScanTimeout
 			// First, ensure we have a LastScan with an old timestamp
 			if mockService.ServiceStates[serviceName].NmapStatus.LastScan == nil {
-				mockService.ServiceStates[serviceName].NmapStatus.LastScan = &nmapsvc.NmapScanResult{}
+				mockService.ServiceStates[serviceName].NmapStatus.LastScan = &nmapservice.NmapScanResult{}
 			}
 			// Set timestamp to 15 seconds ago (NmapScanTimeout is 10 seconds)
 			oldTimestamp := time.Now().Add(-15 * time.Second)
 			mockService.ServiceStates[serviceName].NmapStatus.LastScan.Timestamp = oldTimestamp
-			mockService.ServiceStates[serviceName].NmapStatus.LastScan.PortResult.State = string(nmapsvc.PortStateOpen)
+			mockService.ServiceStates[serviceName].NmapStatus.LastScan.PortResult.State = string(nmapservice.PortStateOpen)
 
 			// The instance should transition from open => degraded due to timeout
 			tick, err = fsmtest.TestNmapStateTransition(
@@ -457,7 +457,7 @@ var _ = Describe("NmapInstance FSM", func() {
 			)
 			Expect(err).NotTo(HaveOccurred())
 
-			mockService.ServiceStates[serviceName] = &nmapsvc.ServiceInfo{S6FSMState: s6fsm.OperationalStateStopped}
+			mockService.ServiceStates[serviceName] = &nmapservice.ServiceInfo{S6FSMState: s6fsm.OperationalStateStopped}
 			mockService.ExistingServices[serviceName] = true
 
 			tick, err = fsmtest.TestNmapStateTransition(
@@ -483,7 +483,7 @@ var _ = Describe("NmapInstance FSM", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// from starting => degraded
-			mockService.SetServiceState(serviceName, nmapsvc.ServiceStateFlags{
+			mockService.SetServiceState(serviceName, nmapservice.ServiceStateFlags{
 				IsS6Running: true,
 				S6FSMState:  s6fsm.OperationalStateRunning,
 				IsRunning:   true,
@@ -498,11 +498,11 @@ var _ = Describe("NmapInstance FSM", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// from startingConfigLoading => open
-			mockService.SetServiceState(serviceName, nmapsvc.ServiceStateFlags{
+			mockService.SetServiceState(serviceName, nmapservice.ServiceStateFlags{
 				IsS6Running: true,
 				S6FSMState:  s6fsm.OperationalStateRunning,
 				IsRunning:   true,
-				PortState:   string(nmapsvc.PortStateOpen),
+				PortState:   string(nmapservice.PortStateOpen),
 			})
 			tick, err = fsmtest.TestNmapStateTransition(
 				ctx, instance, mockService, mockServices, serviceName,
@@ -527,7 +527,7 @@ var _ = Describe("NmapInstance FSM", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// simulate S6 stopping
-			mockService.SetServiceState(serviceName, nmapsvc.ServiceStateFlags{
+			mockService.SetServiceState(serviceName, nmapservice.ServiceStateFlags{
 				IsS6Running: false,
 				S6FSMState:  s6fsm.OperationalStateStopped,
 			})
@@ -566,7 +566,7 @@ var _ = Describe("NmapInstance FSM", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Setup service in stopped state
-			mockService.ServiceStates[serviceName] = &nmapsvc.ServiceInfo{S6FSMState: s6fsm.OperationalStateStopped}
+			mockService.ServiceStates[serviceName] = &nmapservice.ServiceInfo{S6FSMState: s6fsm.OperationalStateStopped}
 			mockService.ExistingServices[serviceName] = true
 
 			// Progress to stopped state
@@ -623,7 +623,7 @@ var _ = Describe("NmapInstance port‑state transitions", func() {
 	var (
 		ctx          context.Context
 		instance     *nmap.NmapInstance
-		mockService  *nmapsvc.MockNmapService
+		mockService  *nmapservice.MockNmapService
 		mockServices *serviceregistry.Registry
 		serviceName  string
 		tick         uint64
@@ -646,7 +646,7 @@ var _ = Describe("NmapInstance port‑state transitions", func() {
 			5, tick,
 		)
 		// creating → stopped
-		mockService.ServiceStates[serviceName] = &nmapsvc.ServiceInfo{S6FSMState: s6fsm.OperationalStateStopped}
+		mockService.ServiceStates[serviceName] = &nmapservice.ServiceInfo{S6FSMState: s6fsm.OperationalStateStopped}
 		mockService.ExistingServices[serviceName] = true
 		tick, _ = fsmtest.TestNmapStateTransition(
 			ctx, instance, mockService, mockServices, serviceName,
@@ -665,7 +665,7 @@ var _ = Describe("NmapInstance port‑state transitions", func() {
 			5, tick,
 		)
 		// starting → degraded (service up, no port result yet)
-		mockService.SetServiceState(serviceName, nmapsvc.ServiceStateFlags{
+		mockService.SetServiceState(serviceName, nmapservice.ServiceStateFlags{
 			IsS6Running: true,
 			IsRunning:   true,
 			S6FSMState:  s6fsm.OperationalStateRunning,
@@ -681,7 +681,7 @@ var _ = Describe("NmapInstance port‑state transitions", func() {
 	AfterEach(func() {
 		Expect(instance.SetDesiredFSMState(nmap.OperationalStateStopped)).To(Succeed())
 
-		mockService.SetServiceState(serviceName, nmapsvc.ServiceStateFlags{
+		mockService.SetServiceState(serviceName, nmapservice.ServiceStateFlags{
 			IsS6Running: false,
 			S6FSMState:  s6fsm.OperationalStateStopped,
 		})
@@ -713,7 +713,7 @@ var _ = Describe("NmapInstance port‑state transitions", func() {
 
 	DescribeTable("follows the degraded → from → to matrix", func(fromState, toState, fromPort, toPort string, _ uint64) {
 		// Degraded → fromState
-		mockService.SetServiceState(serviceName, nmapsvc.ServiceStateFlags{
+		mockService.SetServiceState(serviceName, nmapservice.ServiceStateFlags{
 			IsS6Running: true,
 			IsRunning:   true,
 			S6FSMState:  s6fsm.OperationalStateRunning,
@@ -725,7 +725,7 @@ var _ = Describe("NmapInstance port‑state transitions", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		// fromState → toState
-		mockService.SetServiceState(serviceName, nmapsvc.ServiceStateFlags{
+		mockService.SetServiceState(serviceName, nmapservice.ServiceStateFlags{
 			IsS6Running: true,
 			IsRunning:   true,
 			S6FSMState:  s6fsm.OperationalStateRunning,

--- a/umh-core/test/fsm/protocolconverter/protocolconverter_test.go
+++ b/umh-core/test/fsm/protocolconverter/protocolconverter_test.go
@@ -30,9 +30,9 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
 	connectionfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/connection"
 	dataflowcomponentfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/dataflowcomponent"
-	nmapfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/nmap"
 	protocolconverterfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/protocolconverter"
 	redpandafsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/redpanda"
+	nmapservice "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/nmap"
 	protocolconvertersvc "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/protocolconverter"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/serviceregistry"
 )
@@ -1306,7 +1306,7 @@ var _ = Describe("ProtocolConverter FSM", func() {
 					DfcFSMReadState:    dataflowcomponentfsm.OperationalStateStopped,
 					ConnectionFSMState: connectionfsm.OperationalStateDown, // Connection is DOWN!
 					RedpandaFSMState:   redpandafsm.OperationalStateStopped,
-					PortState:          nmapfsm.PortStateClosed, // Port is CLOSED (unreachable)
+					PortState:          nmapservice.PortStateClosed, // Port is CLOSED (unreachable)
 				})
 
 			// The instance should stay stuck in starting_connection because connection is down


### PR DESCRIPTION
Bottom of the stack: **#2708** → #2716 → #2751. Umbrella: ENG-5853.

## Problem

Editing a bridge's connection to a target that does not answer reports a successful deploy. No config is corrupted, and the overview page shows the connection degraded a moment later. What gets lost is the rollback.

Three independent causes, each enough on its own:

1. nmap reported the config it was *asked* to scan as the config it observed. `awaitRollout` compares observed against requested, so it compared 445 with 445 and passed on the first tick, before anything had dialled the new port. FSMv2 only.
2. Only the port number was compared, never whether the port answered. `Poll` records the port it dialled even when the dial is refused, so a scanned-and-closed port passed too.
3. Only the port was compared, never the host. Repointing a bridge from one PLC to another on 502 was accepted by the old host's scan, with nothing having dialled the new host (ENG-5586).

Causes 2 and 3 are on the default backend as well, so those halves change deploy behaviour for every instance.

## What we are shipping

The check for connection-only edits, the branch a bridge with no flows takes.

- An edit to a target that does not answer now fails and rolls back. The check waits for the requested endpoint to be scanned and found **open**, and `NmapStatus` carries the target and port actually dialled.
- Both halves of the endpoint are compared, so a move to a different host on the same port no longer passes on the old host's scan.
- A port reporting filtered rather than open fails too. Affects fsmv1 as well.
- A scan taken before the edit is no longer evidence about the new endpoint. `NmapStatus` records when a scan started, on the open, refused and cancelled paths alike, and the check requires a scan started after the persist.
- A templated connection is compared against its resolved endpoint, re-resolved every tick. A historian bridge scans `{{ .historian.timescale.host }}`, which the old comparison could never match, so every such edit waited out the 30-second timeout and rolled back.
- `PortState` and its constants move from `pkg/fsm/nmap` to `pkg/service/nmap`, where the scan result already lives. No behaviour change.

The `IsRunning` divergence between backends has a test behind it rather than only a comment: a scanner reporting running with a closed port must fail the rollout. Mutating the check to trust `IsRunning` reddens that spec and nothing else.

## What we are NOT shipping

- The check still runs only for a bridge with no flows. A bridge with a read or write flow is accepted on its own pre-edit state; #2716 covers it.
- For a flowless bridge whose target is down, a location-only or state-only edit now fails where it used to succeed. ENG-5858 tracks whether the exemption #2716 adds can ever fire for a console edit.
- Deploying a new bridge still checks nothing. ENG-5599.
- Global variables still reach `BuildRuntimeConfig` as `nil` at three call sites. ENG-5855.

Fixes ENG-5579
Fixes ENG-5586

