### PR TITLE
fix(topicbrowser): stop sending topic metadata

### DIFF
--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Improvements
+
+- Topic browser payloads sent to the Management Console no longer carry the per-topic metadata map, which duplicated the Kafka headers already attached to every event
+
 ## [0.44.35]
 
 ### Improvements

--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Improvements
 
-- Topic browser payloads sent to the Management Console no longer carry the per-topic metadata map, which duplicated the Kafka headers already attached to every event
+- Topic Browser updates are around 60% smaller on instances with many topics, because per-topic metadata is no longer resent with every refresh. This helps most on slow or metered connections
 
 ## [0.44.35]
 

--- a/umh-core/pkg/communicator/topicbrowser/cache.go
+++ b/umh-core/pkg/communicator/topicbrowser/cache.go
@@ -247,8 +247,9 @@ func (c *Cache) processBuffer(buf *topicbrowserservice.BufferItem, log *zap.Suga
 
 	// upsert the uns map
 	for _, entry := range ub.GetUnsMap().GetEntries() {
-		// generate a hash from the entry by calling HashUNSTableEntry
 		hash := HashUNSTableEntry(entry)
+		// Metadata stays populated: Topic.metadata in graphql/schema.graphqls
+		// resolves from this map.
 		c.unsMap.Entries[hash] = entry
 	}
 

--- a/umh-core/pkg/communicator/topicbrowser/communicator.go
+++ b/umh-core/pkg/communicator/topicbrowser/communicator.go
@@ -337,9 +337,13 @@ func (tbc *TopicBrowserCommunicator) updateInternalCache(buf *topicbrowserservic
 		}
 	}
 
-	// Update topic map
+	// Update topic map, stripping metadata before storing to both the internal
+	// cache and (via getCacheBundle) the bootstrap wire.
 	for _, entry := range ub.GetUnsMap().GetEntries() {
+		// entry aliases freshly unmarshaled ub; mutating in place is safe and
+		// avoids a deep copy per buffer on the hot ingest loop.
 		hash := HashUNSTableEntry(entry)
+		entry.Metadata = nil
 		tbc.unsMap.Entries[hash] = entry
 	}
 

--- a/umh-core/pkg/communicator/topicbrowser/communicator.go
+++ b/umh-core/pkg/communicator/topicbrowser/communicator.go
@@ -350,15 +350,12 @@ func (tbc *TopicBrowserCommunicator) ingestBuffer(buf *topicbrowserservice.Buffe
 		}
 	}
 
-	// Metadata is cleared before the entry is stored, so nothing built from these
-	// entries carries it: not the internal cache, and not the bundle re-encoded
-	// below.
+	// Nothing built from this bundle carries metadata afterwards: not the
+	// internal cache below, and not the payload encoded from it.
+	removeMetadata(&ub)
+
 	for _, entry := range ub.GetUnsMap().GetEntries() {
-		// entry points into the ub unmarshaled just above, so nothing else holds
-		// it yet and clearing Metadata in place is safe.
-		hash := HashUNSTableEntry(entry)
-		entry.Metadata = nil
-		tbc.unsMap.Entries[hash] = entry
+		tbc.unsMap.Entries[HashUNSTableEntry(entry)] = entry
 	}
 
 	// Encoding on ingest costs one marshal per buffer, so the cost is
@@ -461,6 +458,18 @@ func (tbc *TopicBrowserCommunicator) cleanupOldPendingBuffers() {
 	tbc.pendingToSend = filtered
 
 	tbc.logger.Debugf("Cleaned up %d old pending buffers", dropped)
+}
+
+// removeMetadata clears the per-topic metadata map on every topic in the bundle.
+// The console reads none of it, and it is the bulk of what a topic costs to
+// send.
+//
+// The entries belong to a bundle the caller has just unmarshaled, so nothing
+// else holds them yet and clearing in place is safe.
+func removeMetadata(ub *tbproto.UnsBundle) {
+	for _, entry := range ub.GetUnsMap().GetEntries() {
+		entry.Metadata = nil
+	}
 }
 
 // unsentBundles returns the queued bundles a subscriber has not received yet, in

--- a/umh-core/pkg/communicator/topicbrowser/communicator.go
+++ b/umh-core/pkg/communicator/topicbrowser/communicator.go
@@ -69,15 +69,18 @@ type SubscriberData struct {
 	TopicCount      int            // Current number of topics in cache
 }
 
-// strippedBundle is one UnsBundle re-encoded by this package with the per-topic
-// metadata map removed.
+// queuedBundle is a bundle this package has encoded and is holding for
+// delivery; pendingToSend is a slice of these.
 //
-// It is deliberately not a topicbrowserservice.BufferItem. A ring-buffer item's
-// payload still carries the metadata, and its memory belongs to the ring buffer,
-// which keeps its own reference after handing out a snapshot. See the
-// Data & Ownership Flow section of the pkg/service/topicbrowser package doc.
-// Keeping the types apart means a ring-buffer item cannot reach pendingToSend.
-type strippedBundle struct {
+// It is deliberately not a topicbrowserservice.BufferItem. This package owns a
+// queuedBundle's bytes, while a ring-buffer item's belong to the ring buffer,
+// which keeps its own reference after handing out a snapshot. Keeping the types
+// apart means a ring-buffer item cannot reach pendingToSend. See the Data &
+// Ownership Flow section of the pkg/service/topicbrowser package doc.
+//
+// The per-topic metadata map is dropped on the way in, so the payload differs
+// from the ring-buffer item it came from.
+type queuedBundle struct {
 	Timestamp time.Time // ingest timestamp, copied from the ring-buffer item
 	Payload   []byte    // re-encoded UnsBundle, allocated here
 }
@@ -96,8 +99,8 @@ type TopicBrowserCommunicator struct {
 	logger    *zap.SugaredLogger // Component-specific logging
 
 	// 📡 COMMUNICATION STATE: Subscriber and delivery management
-	pendingToSend         []strippedBundle // Bundles not yet sent to subscribers
-	lastProcessedSequence uint64           // Last processed buffer sequence number
+	pendingToSend         []queuedBundle // Bundles not yet sent to subscribers
+	lastProcessedSequence uint64         // Last processed buffer sequence number
 
 	// 🔧 CONFIGURATION
 	maxPendingBuffers int // Cleanup threshold for old pending buffers
@@ -112,7 +115,7 @@ func NewTopicBrowserCommunicator(logger *zap.SugaredLogger) *TopicBrowserCommuni
 		eventMap:              make(map[string]*tbproto.EventTableEntry),
 		unsMap:                &tbproto.TopicMap{Entries: make(map[string]*tbproto.TopicInfo)},
 		lastProcessedSequence: 0, // Start from beginning
-		pendingToSend:         make([]strippedBundle, 0),
+		pendingToSend:         make([]queuedBundle, 0),
 		lastSentTimestamp:     time.Time{},
 		simulator:             nil,
 		simulatorEnabled:      false,
@@ -166,7 +169,7 @@ func (tbc *TopicBrowserCommunicator) ProcessSimulatedData() (*ProcessingResult, 
 // processNewBuffers handles the core buffer processing logic for both real and simulated data
 //
 // It reads BufferItems from obs.ServiceInfo.Status.BufferSnapshot.Items, updates
-// the internal cache from each, and queues a strippedBundle for delivery. The
+// the internal cache from each, and queues a queuedBundle for delivery. The
 // ring buffer's own items are not referenced after this returns.
 func (tbc *TopicBrowserCommunicator) processNewBuffers(obs *topicbrowserfsm.ObservedStateSnapshot, source ProcessingSource) (*ProcessingResult, error) {
 	tbc.mu.Lock()
@@ -324,7 +327,7 @@ func (tbc *TopicBrowserCommunicator) processIncrementalBuffers(buffers []*topicb
 
 // ingestBuffer updates the internal cache maps from one buffer, and returns that
 // buffer's bundle re-encoded without the metadata map.
-func (tbc *TopicBrowserCommunicator) ingestBuffer(buf *topicbrowserservice.BufferItem) (strippedBundle, error) {
+func (tbc *TopicBrowserCommunicator) ingestBuffer(buf *topicbrowserservice.BufferItem) (queuedBundle, error) {
 	// Unmarshal the protobuf data
 	var ub tbproto.UnsBundle
 	if err := proto.Unmarshal(buf.Payload, &ub); err != nil {
@@ -336,7 +339,7 @@ func (tbc *TopicBrowserCommunicator) ingestBuffer(buf *topicbrowserservice.Buffe
 		}
 		sentry.ReportIssueWithContext(err, sentry.IssueTypeError, tbc.logger, context)
 
-		return strippedBundle{}, fmt.Errorf("failed to unmarshal protobuf: %w", err)
+		return queuedBundle{}, fmt.Errorf("failed to unmarshal protobuf: %w", err)
 	}
 
 	// Update event map: keep only the latest event per topic
@@ -370,10 +373,10 @@ func (tbc *TopicBrowserCommunicator) ingestBuffer(buf *topicbrowserservice.Buffe
 		}
 		sentry.ReportIssueWithContext(err, sentry.IssueTypeError, tbc.logger, context)
 
-		return strippedBundle{}, fmt.Errorf("failed to marshal stripped protobuf: %w", err)
+		return queuedBundle{}, fmt.Errorf("failed to marshal stripped protobuf: %w", err)
 	}
 
-	return strippedBundle{
+	return queuedBundle{
 		Timestamp: buf.Timestamp,
 		Payload:   stripped,
 	}, nil
@@ -445,7 +448,7 @@ func (tbc *TopicBrowserCommunicator) cleanupOldPendingBuffers() {
 		return
 	}
 
-	filtered := make([]strippedBundle, 0, len(tbc.pendingToSend))
+	filtered := make([]queuedBundle, 0, len(tbc.pendingToSend))
 
 	for _, bundle := range tbc.pendingToSend {
 		if bundle.Timestamp.After(tbc.lastSentTimestamp) {
@@ -463,8 +466,8 @@ func (tbc *TopicBrowserCommunicator) cleanupOldPendingBuffers() {
 // unsentBundles returns the queued bundles a subscriber has not received yet, in
 // ingest order. It reads pendingToSend and lastSentTimestamp without locking;
 // GetSubscriberData holds the read lock, as it does for getCacheBundle.
-func (tbc *TopicBrowserCommunicator) unsentBundles() []strippedBundle {
-	unsent := make([]strippedBundle, 0, len(tbc.pendingToSend))
+func (tbc *TopicBrowserCommunicator) unsentBundles() []queuedBundle {
+	unsent := make([]queuedBundle, 0, len(tbc.pendingToSend))
 
 	for _, bundle := range tbc.pendingToSend {
 		if bundle.Timestamp.After(tbc.lastSentTimestamp) {

--- a/umh-core/pkg/communicator/topicbrowser/communicator.go
+++ b/umh-core/pkg/communicator/topicbrowser/communicator.go
@@ -63,10 +63,18 @@ func validateBufferSizeFromSnapshot(snapshot topicbrowserservice.RingBufferSnaps
 
 // SubscriberData contains data prepared for topic browser subscribers (UI clients).
 type SubscriberData struct {
-	LatestTimestamp time.Time      // Latest timestamp in this subscriber batch
-	UnsBundles      map[int][]byte // Ready-to-send data indexed by position (0=cache, 1+=incremental)
-	Summary         string         // Human-readable summary for debugging
-	TopicCount      int            // Current number of topics in cache
+	LatestTimestamp time.Time // Latest timestamp in this subscriber batch
+
+	// UnsBundles holds ready-to-send payloads indexed by position: 0 is the
+	// whole cache, 1 and up are queued bundles.
+	//
+	// A caller must not write to these bytes. Positions 1 and up are the same
+	// slices pendingToSend holds, so a write here would reach every later
+	// subscriber too.
+	UnsBundles map[int][]byte
+
+	Summary    string // Human-readable summary for debugging
+	TopicCount int    // Current number of topics in cache
 }
 
 // queuedBundle is a bundle this package has encoded and is holding for

--- a/umh-core/pkg/communicator/topicbrowser/communicator.go
+++ b/umh-core/pkg/communicator/topicbrowser/communicator.go
@@ -69,6 +69,19 @@ type SubscriberData struct {
 	TopicCount      int            // Current number of topics in cache
 }
 
+// strippedBundle is one UnsBundle re-encoded by this package with the per-topic
+// metadata map removed.
+//
+// It is deliberately not a topicbrowserservice.BufferItem. A ring-buffer item's
+// payload still carries the metadata, and its memory belongs to the ring buffer,
+// which keeps its own reference after handing out a snapshot. See the
+// Data & Ownership Flow section of the pkg/service/topicbrowser package doc.
+// Keeping the types apart means a ring-buffer item cannot reach pendingToSend.
+type strippedBundle struct {
+	Timestamp time.Time // ingest timestamp, copied from the ring-buffer item
+	Payload   []byte    // re-encoded UnsBundle, allocated here
+}
+
 // TopicBrowserCommunicator manages topic browser data flow from ring buffer to UI subscribers
 // It handles both the internal cache state and the communication/subscriber management.
 type TopicBrowserCommunicator struct {
@@ -83,8 +96,8 @@ type TopicBrowserCommunicator struct {
 	logger    *zap.SugaredLogger // Component-specific logging
 
 	// 📡 COMMUNICATION STATE: Subscriber and delivery management
-	pendingToSend         []*topicbrowserservice.BufferItem // Processed buffers not yet sent to subscribers
-	lastProcessedSequence uint64                            // Last processed buffer sequence number
+	pendingToSend         []strippedBundle // Bundles not yet sent to subscribers
+	lastProcessedSequence uint64           // Last processed buffer sequence number
 
 	// 🔧 CONFIGURATION
 	maxPendingBuffers int // Cleanup threshold for old pending buffers
@@ -99,7 +112,7 @@ func NewTopicBrowserCommunicator(logger *zap.SugaredLogger) *TopicBrowserCommuni
 		eventMap:              make(map[string]*tbproto.EventTableEntry),
 		unsMap:                &tbproto.TopicMap{Entries: make(map[string]*tbproto.TopicInfo)},
 		lastProcessedSequence: 0, // Start from beginning
-		pendingToSend:         make([]*topicbrowserservice.BufferItem, 0),
+		pendingToSend:         make([]strippedBundle, 0),
 		lastSentTimestamp:     time.Time{},
 		simulator:             nil,
 		simulatorEnabled:      false,
@@ -152,12 +165,9 @@ func (tbc *TopicBrowserCommunicator) ProcessSimulatedData() (*ProcessingResult, 
 
 // processNewBuffers handles the core buffer processing logic for both real and simulated data
 //
-// ## MEMORY MANAGEMENT
-// This function implements the consumer responsibility pattern for topicbrowser BufferItems:
-// - Gets BufferItems from obs.ServiceInfo.Status.BufferSnapshot.Items
-// - Processes the BufferItems for internal cache updates
-// - Returns BufferItems to pool immediately after processing since data is stored in internal cache
-// - Follows the documented ownership model from topicbrowser package.
+// It reads BufferItems from obs.ServiceInfo.Status.BufferSnapshot.Items, updates
+// the internal cache from each, and queues a strippedBundle for delivery. The
+// ring buffer's own items are not referenced after this returns.
 func (tbc *TopicBrowserCommunicator) processNewBuffers(obs *topicbrowserfsm.ObservedStateSnapshot, source ProcessingSource) (*ProcessingResult, error) {
 	tbc.mu.Lock()
 	defer tbc.mu.Unlock()
@@ -204,9 +214,6 @@ func (tbc *TopicBrowserCommunicator) processNewBuffers(obs *topicbrowserfsm.Obse
 	// Update the last processed sequence number
 	tbc.lastProcessedSequence = snapshot.LastSequenceNum
 
-	// NOTE: BufferItems are stored in pendingToSend and will be returned to pool
-	// after delivery to subscribers (handled by MarkDataAsSent/cleanupOldPendingBuffers)
-
 	return result, nil
 }
 
@@ -215,7 +222,8 @@ func (tbc *TopicBrowserCommunicator) processAllBuffers(buffers []*topicbrowserse
 	result := &ProcessingResult{}
 
 	for _, buf := range buffers {
-		if err := tbc.updateInternalCache(buf); err != nil {
+		bundle, err := tbc.ingestBuffer(buf)
+		if err != nil {
 			tbc.logger.Errorf("Failed to process buffer seq=%d: %v", buf.SequenceNum, err)
 
 			result.SkippedCount++
@@ -225,7 +233,7 @@ func (tbc *TopicBrowserCommunicator) processAllBuffers(buffers []*topicbrowserse
 
 		result.ProcessedCount++
 
-		tbc.pendingToSend = append(tbc.pendingToSend, buf)
+		tbc.pendingToSend = append(tbc.pendingToSend, bundle)
 
 		// Track latest timestamp
 		if buf.Timestamp.After(result.LatestTimestamp) {
@@ -259,7 +267,8 @@ func (tbc *TopicBrowserCommunicator) processIncrementalBuffers(buffers []*topicb
 	for i := startIndex; i < len(buffers); i++ {
 		buf := buffers[i]
 
-		if err := tbc.updateInternalCache(buf); err != nil {
+		bundle, err := tbc.ingestBuffer(buf)
+		if err != nil {
 			tbc.logger.Errorf("Failed to process buffer seq=%d: %v", buf.SequenceNum, err)
 
 			result.SkippedCount++
@@ -269,7 +278,7 @@ func (tbc *TopicBrowserCommunicator) processIncrementalBuffers(buffers []*topicb
 
 		result.ProcessedCount++
 
-		tbc.pendingToSend = append(tbc.pendingToSend, buf)
+		tbc.pendingToSend = append(tbc.pendingToSend, bundle)
 
 		// Track latest timestamp
 		if buf.Timestamp.After(result.LatestTimestamp) {
@@ -313,8 +322,9 @@ func (tbc *TopicBrowserCommunicator) processIncrementalBuffers(buffers []*topicb
 	return result, nil
 }
 
-// updateInternalCache processes a single buffer and updates the internal cache maps.
-func (tbc *TopicBrowserCommunicator) updateInternalCache(buf *topicbrowserservice.BufferItem) error {
+// ingestBuffer updates the internal cache maps from one buffer, and returns that
+// buffer's bundle re-encoded without the metadata map.
+func (tbc *TopicBrowserCommunicator) ingestBuffer(buf *topicbrowserservice.BufferItem) (strippedBundle, error) {
 	// Unmarshal the protobuf data
 	var ub tbproto.UnsBundle
 	if err := proto.Unmarshal(buf.Payload, &ub); err != nil {
@@ -326,7 +336,7 @@ func (tbc *TopicBrowserCommunicator) updateInternalCache(buf *topicbrowserservic
 		}
 		sentry.ReportIssueWithContext(err, sentry.IssueTypeError, tbc.logger, context)
 
-		return fmt.Errorf("failed to unmarshal protobuf: %w", err)
+		return strippedBundle{}, fmt.Errorf("failed to unmarshal protobuf: %w", err)
 	}
 
 	// Update event map: keep only the latest event per topic
@@ -337,17 +347,36 @@ func (tbc *TopicBrowserCommunicator) updateInternalCache(buf *topicbrowserservic
 		}
 	}
 
-	// Update topic map, stripping metadata before storing to both the internal
-	// cache and (via getCacheBundle) the bootstrap wire.
+	// Metadata is cleared before the entry is stored, so nothing built from these
+	// entries carries it: not the internal cache, and not the bundle re-encoded
+	// below.
 	for _, entry := range ub.GetUnsMap().GetEntries() {
-		// entry aliases freshly unmarshaled ub; mutating in place is safe and
-		// avoids a deep copy per buffer on the hot ingest loop.
+		// entry points into the ub unmarshaled just above, so nothing else holds
+		// it yet and clearing Metadata in place is safe.
 		hash := HashUNSTableEntry(entry)
 		entry.Metadata = nil
 		tbc.unsMap.Entries[hash] = entry
 	}
 
-	return nil
+	// Encoding on ingest costs one marshal per buffer, so the cost is
+	// independent of how many subscribers later read the bundle.
+	stripped, err := proto.Marshal(&ub)
+	if err != nil {
+		context := map[string]interface{}{
+			"operation":   "marshal_stripped_bundle",
+			"buffer_size": len(buf.Payload),
+			"timestamp":   buf.Timestamp,
+			"component":   "topic_browser_communicator",
+		}
+		sentry.ReportIssueWithContext(err, sentry.IssueTypeError, tbc.logger, context)
+
+		return strippedBundle{}, fmt.Errorf("failed to marshal stripped protobuf: %w", err)
+	}
+
+	return strippedBundle{
+		Timestamp: buf.Timestamp,
+		Payload:   stripped,
+	}, nil
 }
 
 // GetSubscriberData prepares topic browser data for UI subscribers
@@ -364,7 +393,9 @@ func (tbc *TopicBrowserCommunicator) GetSubscriberData(isBootstrapped bool) (*Su
 
 	index := 0
 
-	// New subscribers get the complete cache as bundle 0
+	// Bundles reach a subscriber from two sources. A subscriber that has just
+	// connected also gets bundle 0, the whole cache re-encoded by getCacheBundle.
+	// Every subscriber gets whatever unsentBundles has queued since its last send.
 	if !isBootstrapped {
 		cacheBundle := tbc.getCacheBundle()
 		if cacheBundle != nil {
@@ -375,22 +406,18 @@ func (tbc *TopicBrowserCommunicator) GetSubscriberData(isBootstrapped bool) (*Su
 		data.Summary = "Prepared cache bundle + "
 	}
 
-	// Add incremental buffers that haven't been sent yet
-	incrementalCount := 0
+	unsent := tbc.unsentBundles()
 
-	for _, buf := range tbc.pendingToSend {
-		if buf.Timestamp.After(tbc.lastSentTimestamp) {
-			data.UnsBundles[index] = buf.Payload
-			index++
-			incrementalCount++
+	for _, bundle := range unsent {
+		data.UnsBundles[index] = bundle.Payload
+		index++
 
-			if buf.Timestamp.After(data.LatestTimestamp) {
-				data.LatestTimestamp = buf.Timestamp
-			}
+		if bundle.Timestamp.After(data.LatestTimestamp) {
+			data.LatestTimestamp = bundle.Timestamp
 		}
 	}
 
-	data.Summary += fmt.Sprintf("%d incremental buffers", incrementalCount)
+	data.Summary += fmt.Sprintf("%d incremental buffers", len(unsent))
 	tbc.logger.Debugf("TopicBrowserCommunicator: %s", data.Summary)
 
 	return data, nil
@@ -412,32 +439,40 @@ func (tbc *TopicBrowserCommunicator) MarkDataAsSent(timestamp time.Time) {
 	tbc.cleanupOldPendingBuffers()
 }
 
-// cleanupOldPendingBuffers removes old buffers from the pending queue and returns them to pool.
+// cleanupOldPendingBuffers drops bundles that are no longer pending.
 func (tbc *TopicBrowserCommunicator) cleanupOldPendingBuffers() {
 	if len(tbc.pendingToSend) <= tbc.maxPendingBuffers {
 		return
 	}
 
-	// Separate buffers: keep newer ones, collect older ones for pool return
-	var buffersToReturn []*topicbrowserservice.BufferItem
+	filtered := make([]strippedBundle, 0, len(tbc.pendingToSend))
 
-	filtered := make([]*topicbrowserservice.BufferItem, 0, len(tbc.pendingToSend))
-
-	for _, buf := range tbc.pendingToSend {
-		if buf.Timestamp.After(tbc.lastSentTimestamp) {
-			filtered = append(filtered, buf)
-		} else {
-			buffersToReturn = append(buffersToReturn, buf)
+	for _, bundle := range tbc.pendingToSend {
+		if bundle.Timestamp.After(tbc.lastSentTimestamp) {
+			filtered = append(filtered, bundle)
 		}
 	}
 
+	dropped := len(tbc.pendingToSend) - len(filtered)
+
 	tbc.pendingToSend = filtered
 
-	// Return old buffers to pool
-	if len(buffersToReturn) > 0 {
-		topicbrowserservice.PutBufferItems(buffersToReturn)
-		tbc.logger.Debugf("Cleaned up %d old pending buffers and returned them to pool", len(buffersToReturn))
+	tbc.logger.Debugf("Cleaned up %d old pending buffers", dropped)
+}
+
+// unsentBundles returns the queued bundles a subscriber has not received yet, in
+// ingest order. It reads pendingToSend and lastSentTimestamp without locking;
+// GetSubscriberData holds the read lock, as it does for getCacheBundle.
+func (tbc *TopicBrowserCommunicator) unsentBundles() []strippedBundle {
+	unsent := make([]strippedBundle, 0, len(tbc.pendingToSend))
+
+	for _, bundle := range tbc.pendingToSend {
+		if bundle.Timestamp.After(tbc.lastSentTimestamp) {
+			unsent = append(unsent, bundle)
+		}
 	}
+
+	return unsent
 }
 
 // getCacheBundle returns the complete cache as a protobuf-encoded UnsBundle.

--- a/umh-core/pkg/communicator/topicbrowser/communicator.go
+++ b/umh-core/pkg/communicator/topicbrowser/communicator.go
@@ -67,10 +67,6 @@ type SubscriberData struct {
 
 	// UnsBundles holds ready-to-send payloads indexed by position: 0 is the
 	// whole cache, 1 and up are queued bundles.
-	//
-	// A caller must not write to these bytes. Positions 1 and up are the same
-	// slices pendingToSend holds, so a write here would reach every later
-	// subscriber too.
 	UnsBundles map[int][]byte
 
 	Summary    string // Human-readable summary for debugging
@@ -403,7 +399,8 @@ func (tbc *TopicBrowserCommunicator) GetSubscriberData(isBootstrapped bool) (*Su
 
 	// Bundles reach a subscriber from two sources. A subscriber that has just
 	// connected also gets bundle 0, the whole cache re-encoded by getCacheBundle.
-	// Every subscriber gets whatever unsentBundles has queued since its last send.
+	// Every subscriber gets whatever getUnsentBundles returns: the bundles
+	// queued since its last send.
 	if !isBootstrapped {
 		cacheBundle := tbc.getCacheBundle()
 		if cacheBundle != nil {
@@ -414,7 +411,7 @@ func (tbc *TopicBrowserCommunicator) GetSubscriberData(isBootstrapped bool) (*Su
 		data.Summary = "Prepared cache bundle + "
 	}
 
-	unsent := tbc.unsentBundles()
+	unsent := tbc.getUnsentBundles()
 
 	for _, bundle := range unsent {
 		data.UnsBundles[index] = bundle.Payload
@@ -480,10 +477,11 @@ func removeMetadata(ub *tbproto.UnsBundle) {
 	}
 }
 
-// unsentBundles returns the queued bundles a subscriber has not received yet, in
-// ingest order. It reads pendingToSend and lastSentTimestamp without locking;
-// GetSubscriberData holds the read lock, as it does for getCacheBundle.
-func (tbc *TopicBrowserCommunicator) unsentBundles() []queuedBundle {
+// getUnsentBundles returns the queued bundles a subscriber has not received
+// yet, in ingest order. It reads pendingToSend and lastSentTimestamp without
+// locking; GetSubscriberData holds the read lock, as it does for
+// getCacheBundle.
+func (tbc *TopicBrowserCommunicator) getUnsentBundles() []queuedBundle {
 	unsent := make([]queuedBundle, 0, len(tbc.pendingToSend))
 
 	for _, bundle := range tbc.pendingToSend {

--- a/umh-core/pkg/communicator/topicbrowser/communicator_metadata_strip_test.go
+++ b/umh-core/pkg/communicator/topicbrowser/communicator_metadata_strip_test.go
@@ -1,0 +1,103 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package topicbrowser_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/proto"
+
+	tbproto "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/communicator/models/topicbrowser/pb"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/communicator/topicbrowser"
+	topicbrowserservice "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/topicbrowser"
+)
+
+// bufferWithMetadata returns a BufferItem whose payload is a marshaled UnsBundle
+// carrying one TopicInfo entry whose Metadata map is populated.
+func bufferWithMetadata() *topicbrowserservice.BufferItem {
+	topicInfo := &tbproto.TopicInfo{
+		Level0:       "corpA",
+		Name:         "temperature",
+		DataContract: "_historian",
+		Metadata:     map[string]string{"unit": "degC", "serial_number": "1234"},
+	}
+	bundle := &tbproto.UnsBundle{
+		UnsMap: &tbproto.TopicMap{
+			Entries: map[string]*tbproto.TopicInfo{
+				topicbrowser.HashUNSTableEntry(topicInfo): topicInfo,
+			},
+		},
+	}
+	payload, err := proto.Marshal(bundle)
+	Expect(err).NotTo(HaveOccurred())
+
+	return &topicbrowserservice.BufferItem{
+		Payload:   payload,
+		Timestamp: time.Now(),
+	}
+}
+
+var _ = Describe("Topic metadata stripping on ingest", func() {
+	It("strips TopicInfo metadata from both the internal map and the bootstrap wire", func() {
+		comm := topicbrowser.NewTopicBrowserCommunicator(zap.NewNop().Sugar())
+
+		obs := createMockObservedStateSnapshot([]*topicbrowserservice.BufferItem{
+			bufferWithMetadata(),
+		})
+
+		_, err := comm.ProcessRealData(obs)
+		Expect(err).NotTo(HaveOccurred())
+
+		// (b) INTERNAL MAP (before any GetSubscriberData call): every entry is metadata-free.
+		unsMap := comm.GetUnsMap().GetEntries()
+		Expect(unsMap).ToNot(BeEmpty(), "internal topic map must not be empty")
+		for hash, entry := range unsMap {
+			Expect(entry.GetMetadata()).To(BeEmpty(), "internal map entry %s must be stripped of metadata", hash)
+		}
+
+		// (a) WIRE: the bootstrap bundle (index 0) carries no topic metadata.
+		data, err := comm.GetSubscriberData(false)
+		Expect(err).NotTo(HaveOccurred())
+
+		cacheBytes, ok := data.UnsBundles[0]
+		Expect(ok).To(BeTrue(), "bootstrap bundle (index 0) must be present")
+
+		var decoded tbproto.UnsBundle
+		Expect(proto.Unmarshal(cacheBytes, &decoded)).To(Succeed())
+
+		wiredEntries := decoded.GetUnsMap().GetEntries()
+		Expect(wiredEntries).ToNot(BeEmpty(), "bootstrap wire must not be empty")
+		for hash, entry := range wiredEntries {
+			Expect(entry.GetMetadata()).To(BeEmpty(), "wired topic %s must be stripped of metadata", hash)
+		}
+
+		// Stripping removes ONLY Metadata: the other TopicInfo fields that
+		// HashUNSTableEntry hashes (name, level0, data contract) must survive
+		// the ingest -> cache -> wire round trip, or over-stripping silently
+		// corrupts topic-map keys/reconstruction.
+		preserved := false
+		for _, entry := range wiredEntries {
+			if entry.GetName() == "temperature" && entry.GetLevel0() == "corpA" && entry.GetDataContract() == "_historian" {
+				preserved = true
+
+				break
+			}
+		}
+		Expect(preserved).To(BeTrue(), "non-metadata TopicInfo fields must survive the strip")
+	})
+})

--- a/umh-core/pkg/communicator/topicbrowser/communicator_metadata_strip_test.go
+++ b/umh-core/pkg/communicator/topicbrowser/communicator_metadata_strip_test.go
@@ -53,7 +53,7 @@ func bufferWithMetadata() *topicbrowserservice.BufferItem {
 }
 
 var _ = Describe("Topic metadata stripping on ingest", func() {
-	It("strips TopicInfo metadata from both the internal map and the bootstrap wire", func() {
+	It("strips TopicInfo metadata from both the internal map and the bootstrap bundle", func() {
 		comm := topicbrowser.NewTopicBrowserCommunicator(zap.NewNop().Sugar())
 
 		obs := createMockObservedStateSnapshot([]*topicbrowserservice.BufferItem{
@@ -63,14 +63,14 @@ var _ = Describe("Topic metadata stripping on ingest", func() {
 		_, err := comm.ProcessRealData(obs)
 		Expect(err).NotTo(HaveOccurred())
 
-		// (b) INTERNAL MAP (before any GetSubscriberData call): every entry is metadata-free.
+		// The internal map, before any GetSubscriberData call.
 		unsMap := comm.GetUnsMap().GetEntries()
 		Expect(unsMap).ToNot(BeEmpty(), "internal topic map must not be empty")
 		for hash, entry := range unsMap {
 			Expect(entry.GetMetadata()).To(BeEmpty(), "internal map entry %s must be stripped of metadata", hash)
 		}
 
-		// (a) WIRE: the bootstrap bundle (index 0) carries no topic metadata.
+		// The bundle a first-time subscriber receives.
 		data, err := comm.GetSubscriberData(false)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -81,15 +81,14 @@ var _ = Describe("Topic metadata stripping on ingest", func() {
 		Expect(proto.Unmarshal(cacheBytes, &decoded)).To(Succeed())
 
 		wiredEntries := decoded.GetUnsMap().GetEntries()
-		Expect(wiredEntries).ToNot(BeEmpty(), "bootstrap wire must not be empty")
+		Expect(wiredEntries).ToNot(BeEmpty(), "bootstrap bundle must carry its topic map")
 		for hash, entry := range wiredEntries {
 			Expect(entry.GetMetadata()).To(BeEmpty(), "wired topic %s must be stripped of metadata", hash)
 		}
 
-		// Stripping removes ONLY Metadata: the other TopicInfo fields that
-		// HashUNSTableEntry hashes (name, level0, data contract) must survive
-		// the ingest -> cache -> wire round trip, or over-stripping silently
-		// corrupts topic-map keys/reconstruction.
+		// Stripping removes only Metadata. Everything HashUNSTableEntry writes
+		// must survive the round trip, or the strip changes topic-map keys and
+		// the console cannot rebuild the topic map.
 		preserved := false
 		for _, entry := range wiredEntries {
 			if entry.GetName() == "temperature" && entry.GetLevel0() == "corpA" && entry.GetDataContract() == "_historian" {
@@ -99,5 +98,96 @@ var _ = Describe("Topic metadata stripping on ingest", func() {
 			}
 		}
 		Expect(preserved).To(BeTrue(), "non-metadata TopicInfo fields must survive the strip")
+	})
+})
+
+// bufferWithMetadataAndEvent returns a BufferItem whose payload is a marshaled
+// UnsBundle carrying one TopicInfo with a populated Metadata map and one event
+// under unsTreeID. The event lets a spec prove the payload a subscriber receives
+// is the ingested bundle and not an empty one.
+func bufferWithMetadataAndEvent(unsTreeID, topicName string) *topicbrowserservice.BufferItem {
+	topicInfo := &tbproto.TopicInfo{
+		Level0:       "corpB",
+		Name:         topicName,
+		DataContract: "_historian",
+		Metadata:     map[string]string{"unit": "bar", "serial_number": "5678"},
+	}
+	bundle := &tbproto.UnsBundle{
+		Events: &tbproto.EventTable{
+			Entries: []*tbproto.EventTableEntry{
+				{UnsTreeId: unsTreeID, ProducedAtMs: 1000},
+			},
+		},
+		UnsMap: &tbproto.TopicMap{
+			Entries: map[string]*tbproto.TopicInfo{
+				topicbrowser.HashUNSTableEntry(topicInfo): topicInfo,
+			},
+		},
+	}
+	payload, err := proto.Marshal(bundle)
+	Expect(err).NotTo(HaveOccurred())
+
+	return &topicbrowserservice.BufferItem{
+		Payload:   payload,
+		Timestamp: time.Now(),
+	}
+}
+
+var _ = Describe("Topic metadata stripping on incremental bundles", func() {
+	It("strips TopicInfo metadata from every bundle an already-bootstrapped subscriber receives", func() {
+		comm := topicbrowser.NewTopicBrowserCommunicator(zap.NewNop().Sugar())
+
+		// The first ingest takes the process-all path, the second the
+		// incremental path. Both append to pendingToSend, so both must strip.
+		first := bufferWithMetadataAndEvent("corpB.pressure.evt", "pressure")
+		_, err := comm.ProcessRealData(createMockObservedStateSnapshot(
+			[]*topicbrowserservice.BufferItem{first}))
+		Expect(err).NotTo(HaveOccurred())
+
+		second := bufferWithMetadataAndEvent("corpB.flow.evt", "flow")
+		_, err = comm.ProcessRealData(createMockObservedStateSnapshot(
+			[]*topicbrowserservice.BufferItem{second}))
+		Expect(err).NotTo(HaveOccurred())
+
+		// isBootstrapped=true: no cache bundle, only the pending incremental
+		// buffers. This is the path taken on every poll after the first.
+		data, err := comm.GetSubscriberData(true)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(data.UnsBundles).To(HaveLen(2), "an already-bootstrapped subscriber must receive both pending buffers")
+
+		seenEvents := []string{}
+
+		for _, staged := range []*topicbrowserservice.BufferItem{first, second} {
+			var input tbproto.UnsBundle
+			Expect(proto.Unmarshal(staged.Payload, &input)).To(Succeed())
+
+			for hash, entry := range input.GetUnsMap().GetEntries() {
+				Expect(entry.GetMetadata()).ToNot(BeEmpty(),
+					"fixture topic %s must still stage the metadata this spec strips: a fixture that never staged it, or an implementation that stripped the caller's payload in place, would satisfy the wire assertions vacuously", hash)
+			}
+		}
+
+		for index, encoded := range data.UnsBundles {
+			var decoded tbproto.UnsBundle
+			Expect(proto.Unmarshal(encoded, &decoded)).To(Succeed())
+
+			entries := decoded.GetUnsMap().GetEntries()
+
+			Expect(entries).ToNot(BeEmpty(),
+				"bundle %d must still carry its topic map: an implementation that drops uns_map satisfies the metadata assertion below by having no entries, and topic identity is keyed there (TopicMap in topic_browser_data.proto)", index)
+
+			for hash, entry := range entries {
+				Expect(entry.GetMetadata()).To(BeEmpty(), "bundle %d topic %s must be stripped of metadata", index, hash)
+				Expect(entry.GetLevel0()).To(Equal("corpB"), "bundle %d topic %s lost a non-metadata field to over-stripping", index, hash)
+				Expect(entry.GetDataContract()).To(Equal("_historian"), "bundle %d topic %s lost its data contract to over-stripping", index, hash)
+			}
+
+			for _, event := range decoded.GetEvents().GetEntries() {
+				seenEvents = append(seenEvents, event.GetUnsTreeId())
+			}
+		}
+
+		Expect(seenEvents).To(ConsistOf("corpB.pressure.evt", "corpB.flow.evt"),
+			"both ingested events must survive to the subscriber: an implementation returning empty or no bundles would satisfy the metadata assertions above")
 	})
 })


### PR DESCRIPTION
Ticket: [ENG-5679](https://linear.app/united-manufacturing-hub/issue/ENG-5679/umh-core-stop-sending-topicinfometadata).

## Problem

umh-core sends a map of Kafka headers on every topic, in every bundle, to every subscribed browser tab. On instances with many topics that map is most of the payload. The console does not read it: ManagementConsole#3456 removed the read and has merged.

A bundle reaches the console two ways, and both carried the map. See `GetSubscriberData` and `SubscriberData.UnsBundles`:

* A tab that has just connected gets bundle 0, rebuilt from umh-core's internal topic cache. Once per connection.
* Every poll after that gets bundles 1+, the payloads queued as they arrive from the ring buffer. This is almost all of the traffic.

Clearing the map at ingest cleans bundle 0, because the cache is built from the parsed entries. It does nothing for bundles 1+, which were forwarded as the original bytes. That is why there are two commits here.

Shrinking the payload is part of getting the Topic Browser to update once a second rather than once every ten seconds ([ENG-5525](https://linear.app/united-manufacturing-hub/issue/ENG-5525/umh-core-re-sends-the-full-topic-browser-cache-every-10s-and-never), console side [ENG-5652](https://linear.app/united-manufacturing-hub/issue/ENG-5652/topic-browser-stop-storing-topicinfometadata-on-every-topic-row)).

## What we're shipping

* Metadata is cleared at ingest, before an entry enters the internal cache. That covers bundle 0.
* The queued payload is re-encoded from the cleared entries. That covers bundles 1+. `updateInternalCache` returns that value now, and is renamed `ingestBuffer` because it no longer only updates the cache.
* The queued value has its own type, `strippedBundle`. A ring-buffer item cannot be queued by mistake: it does not compile there. Queueing one is the defect being fixed.
* `getUnsentBundles` gives the queued path a name. `GetSubscriberData` now shows both sources side by side, so a change to one is visibly not a change to the other.
* Re-encoding costs one marshal per buffer at ingest, so the cost does not grow with the number of subscribers.
* The queue no longer returns items to the ring buffer's pool. It no longer holds them, and returning a snapshot item was never safe, because the ring buffer keeps its own reference. This was the last production caller of `PutBufferItems`.

## What we're NOT shipping

* **Not touching the GraphQL path.** The cache behind GraphQL's `Topic.metadata` keeps the map, so this change does not affect that surface.
* **Not changing the ring buffer or its pool.** Only the communicator's queue stops holding pool-issued items.
* **Fixing the source.** benthos-umh still puts the map into every emission; umh-core now drops it on arrival. Stopping it there needs a plugin release and an upgrade on every instance ([ENG-5653](https://linear.app/united-manufacturing-hub/issue/ENG-5653/topic-browser-re-sends-every-topic-it-has-ever-seen-in-every-emitted)).

## Confidence

* Analysed against actual customer instances: around 60% reduction in size.
* The changes cause not much overhead. In a test, around 0.012% of a core more. GC gets cheaper rather than dearer, because less is retained.

