### PR TITLE
fix(topicbrowser): hand out buffer entries in the order they arrived

### DIFF
--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Topics no longer go missing from the Topic Browser when several updates arrive in quick succession
+
 ## [0.44.36]
 
 ### Improvements
@@ -11,7 +15,6 @@
 ### Fixes
 
 - Instances with large configurations no longer run out of time in the control loop, which previously caused "not enough time left to reconcile" error log messages.
-- Topics no longer go missing from the Topic Browser when several updates arrive in quick succession
 
 ## [0.44.35]
 

--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixes
 
 - Instances with large configurations no longer run out of time in the control loop, which previously caused "not enough time left to reconcile" error log messages.
+- Topics no longer go missing from the Topic Browser when several updates arrive in quick succession
 
 ## [0.44.35]
 

--- a/umh-core/pkg/communicator/topicbrowser/cache.go
+++ b/umh-core/pkg/communicator/topicbrowser/cache.go
@@ -145,8 +145,8 @@ func (c *Cache) ProcessIncrementalUpdates(obs *topicbrowserfsm.ObservedStateSnap
 		log.Warnf("Data loss detected: gap of %d sequences, lost %d buffers, processing all %d available",
 			newItemCount, lostCount, availableItems)
 	} else {
-		// Normal case: process first newItemCount items (they're newest-to-oldest)
-		itemsToProcess = buffers[:newItemCount]
+		// Normal case: process the last newItemCount items (they are oldest-to-newest)
+		itemsToProcess = buffers[len(buffers)-int(newItemCount):]
 	}
 
 	// Process the selected buffers

--- a/umh-core/pkg/communicator/topicbrowser/cache.go
+++ b/umh-core/pkg/communicator/topicbrowser/cache.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	tbproto "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/communicator/models/topicbrowser/pb"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants"
 	topicbrowserfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/topicbrowser"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/logger"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/sentry"
@@ -115,7 +114,6 @@ func (c *Cache) ProcessIncrementalUpdates(obs *topicbrowserfsm.ObservedStateSnap
 	}
 
 	snapshot := obs.ServiceInfo.Status.BufferSnapshot
-	buffers := snapshot.Items
 	lastSequenceNum := snapshot.LastSequenceNum
 
 	result := &ProcessingResult{}
@@ -131,22 +129,14 @@ func (c *Cache) ProcessIncrementalUpdates(obs *topicbrowserfsm.ObservedStateSnap
 
 	newItemCount := lastSequenceNum - c.lastProcessedSequenceNum
 
-	// Check for data loss (gap larger than buffer capacity)
-	dataLost := false
+	// NewestN clamps, so a gap larger than the ring returns everything it still
+	// holds. That is the data-loss case, reported below.
+	itemsToProcess := snapshot.NewestN(int(newItemCount))
 
-	var itemsToProcess []*topicbrowserservice.BufferItem
-
-	if newItemCount > uint64(constants.RingBufferCapacity) {
-		// Data loss: we can only process what's in the buffer
-		dataLost = true
-		availableItems := len(buffers)
-		itemsToProcess = buffers[:availableItems] // Process all available items
-		lostCount := newItemCount - uint64(availableItems)
+	dataLost := newItemCount > uint64(len(itemsToProcess))
+	if dataLost {
 		log.Warnf("Data loss detected: gap of %d sequences, lost %d buffers, processing all %d available",
-			newItemCount, lostCount, availableItems)
-	} else {
-		// Normal case: process the last newItemCount items (they are oldest-to-newest)
-		itemsToProcess = buffers[len(buffers)-int(newItemCount):]
+			newItemCount, newItemCount-uint64(len(itemsToProcess)), len(itemsToProcess))
 	}
 
 	// Process the selected buffers

--- a/umh-core/pkg/communicator/topicbrowser/cache_index_test.go
+++ b/umh-core/pkg/communicator/topicbrowser/cache_index_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Cache Sequence-Based Processing", func() {
 				ServiceInfo: topicbrowserservice.ServiceInfo{
 					Status: topicbrowserservice.Status{
 						BufferSnapshot: topicbrowserservice.RingBufferSnapshot{
-							Items:           []*topicbrowserservice.BufferItem{buffer3, buffer2, buffer1}, // Newest-to-oldest
+							Items:           []*topicbrowserservice.BufferItem{buffer1, buffer2, buffer3}, // Oldest-to-newest
 							LastSequenceNum: 3,
 						},
 					},
@@ -69,7 +69,7 @@ var _ = Describe("Cache Sequence-Based Processing", func() {
 				ServiceInfo: topicbrowserservice.ServiceInfo{
 					Status: topicbrowserservice.Status{
 						BufferSnapshot: topicbrowserservice.RingBufferSnapshot{
-							Items:           []*topicbrowserservice.BufferItem{buffer4, buffer3, buffer2, buffer1}, // Newest-to-oldest
+							Items:           []*topicbrowserservice.BufferItem{buffer1, buffer2, buffer3, buffer4}, // Oldest-to-newest
 							LastSequenceNum: 4,
 						},
 					},
@@ -98,7 +98,7 @@ var _ = Describe("Cache Sequence-Based Processing", func() {
 				ServiceInfo: topicbrowserservice.ServiceInfo{
 					Status: topicbrowserservice.Status{
 						BufferSnapshot: topicbrowserservice.RingBufferSnapshot{
-							Items:           []*topicbrowserservice.BufferItem{buffer3, buffer2, buffer1}, // Newest-to-oldest
+							Items:           []*topicbrowserservice.BufferItem{buffer1, buffer2, buffer3}, // Oldest-to-newest
 							LastSequenceNum: 3,
 						},
 					},
@@ -141,7 +141,7 @@ var _ = Describe("Cache Sequence-Based Processing", func() {
 				ServiceInfo: topicbrowserservice.ServiceInfo{
 					Status: topicbrowserservice.Status{
 						BufferSnapshot: topicbrowserservice.RingBufferSnapshot{
-							Items:           []*topicbrowserservice.BufferItem{buffer2, buffer1}, // Newest-to-oldest
+							Items:           []*topicbrowserservice.BufferItem{buffer1, buffer2}, // Oldest-to-newest
 							LastSequenceNum: 2,
 						},
 					},
@@ -170,7 +170,7 @@ var _ = Describe("Cache Sequence-Based Processing", func() {
 				ServiceInfo: topicbrowserservice.ServiceInfo{
 					Status: topicbrowserservice.Status{
 						BufferSnapshot: topicbrowserservice.RingBufferSnapshot{
-							Items: []*topicbrowserservice.BufferItem{buffer3, buffer2, buffer1}, // Newest-to-oldest
+							Items: []*topicbrowserservice.BufferItem{buffer1, buffer2, buffer3}, // Oldest-to-newest
 						},
 					},
 				},
@@ -182,8 +182,8 @@ var _ = Describe("Cache Sequence-Based Processing", func() {
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(pendingBuffers).To(HaveLen(2))        // buffer2 and buffer3
-			Expect(pendingBuffers[0]).To(Equal(buffer3)) // Newest first
-			Expect(pendingBuffers[1]).To(Equal(buffer2))
+			Expect(pendingBuffers[0]).To(Equal(buffer2)) // Filtering keeps the input order
+			Expect(pendingBuffers[1]).To(Equal(buffer3))
 		})
 	})
 })

--- a/umh-core/pkg/communicator/topicbrowser/communicator.go
+++ b/umh-core/pkg/communicator/topicbrowser/communicator.go
@@ -211,7 +211,7 @@ func (tbc *TopicBrowserCommunicator) processNewBuffers(obs *topicbrowserfsm.Obse
 	} else {
 		// Incremental processing: only process new buffers
 		newBufferCount := snapshot.LastSequenceNum - tbc.lastProcessedSequence
-		result, err = tbc.processIncrementalBuffers(snapshot.Items, newBufferCount, source)
+		result, err = tbc.processIncrementalBuffers(snapshot.NewestN(int(newBufferCount)), source)
 	}
 
 	if err != nil {
@@ -228,6 +228,9 @@ func (tbc *TopicBrowserCommunicator) processNewBuffers(obs *topicbrowserfsm.Obse
 func (tbc *TopicBrowserCommunicator) processAllBuffers(buffers []*topicbrowserservice.BufferItem, source ProcessingSource) (*ProcessingResult, error) {
 	result := &ProcessingResult{}
 
+	// buffers arrive oldest first, so the last one ingested is the newest.
+	var newestSeq uint64
+
 	for _, buf := range buffers {
 		bundle, err := tbc.ingestBuffer(buf)
 		if err != nil {
@@ -239,6 +242,7 @@ func (tbc *TopicBrowserCommunicator) processAllBuffers(buffers []*topicbrowserse
 		}
 
 		result.ProcessedCount++
+		newestSeq = buf.SequenceNum
 
 		tbc.pendingToSend = append(tbc.pendingToSend, bundle)
 
@@ -248,13 +252,8 @@ func (tbc *TopicBrowserCommunicator) processAllBuffers(buffers []*topicbrowserse
 		}
 	}
 
-	// Update sequence tracking to latest
-	if len(buffers) > 0 {
-		tbc.lastProcessedSequence = buffers[len(buffers)-1].SequenceNum // Newest buffer (last in slice)
-	}
-
 	result.DebugInfo = fmt.Sprintf("Processed ALL %d buffers from %s after overwrite (seq up to %d), %d errors",
-		result.ProcessedCount, source.String(), tbc.lastProcessedSequence, result.SkippedCount)
+		result.ProcessedCount, source.String(), newestSeq, result.SkippedCount)
 
 	tbc.logger.Debugf("TopicBrowserCommunicator DebugInfo: %s", result.DebugInfo)
 
@@ -262,18 +261,14 @@ func (tbc *TopicBrowserCommunicator) processAllBuffers(buffers []*topicbrowserse
 }
 
 // processIncrementalBuffers processes only new buffers since last processing.
-func (tbc *TopicBrowserCommunicator) processIncrementalBuffers(buffers []*topicbrowserservice.BufferItem, newBufferCount uint64, source ProcessingSource) (*ProcessingResult, error) {
+func (tbc *TopicBrowserCommunicator) processIncrementalBuffers(buffers []*topicbrowserservice.BufferItem, source ProcessingSource) (*ProcessingResult, error) {
 	result := &ProcessingResult{}
 
-	// Buffers are oldest-to-newest, so the newest ones are the last N items
-	startIndex := len(buffers) - int(newBufferCount)
-	if startIndex < 0 {
-		startIndex = 0
-	}
+	// buffers arrive oldest first, so the range reported below is the first and
+	// last entry actually ingested, skipped ones excluded.
+	var minSeq, maxSeq uint64
 
-	for i := startIndex; i < len(buffers); i++ {
-		buf := buffers[i]
-
+	for _, buf := range buffers {
 		bundle, err := tbc.ingestBuffer(buf)
 		if err != nil {
 			tbc.logger.Errorf("Failed to process buffer seq=%d: %v", buf.SequenceNum, err)
@@ -284,6 +279,11 @@ func (tbc *TopicBrowserCommunicator) processIncrementalBuffers(buffers []*topicb
 		}
 
 		result.ProcessedCount++
+		if result.ProcessedCount == 1 {
+			minSeq = buf.SequenceNum
+		}
+
+		maxSeq = buf.SequenceNum
 
 		tbc.pendingToSend = append(tbc.pendingToSend, bundle)
 
@@ -291,11 +291,6 @@ func (tbc *TopicBrowserCommunicator) processIncrementalBuffers(buffers []*topicb
 		if buf.Timestamp.After(result.LatestTimestamp) {
 			result.LatestTimestamp = buf.Timestamp
 		}
-	}
-
-	// Update sequence tracking to latest
-	if len(buffers) > 0 {
-		tbc.lastProcessedSequence = buffers[len(buffers)-1].SequenceNum // Newest buffer (last in slice)
 	}
 
 	// Validate topic count after processing
@@ -308,9 +303,6 @@ func (tbc *TopicBrowserCommunicator) processIncrementalBuffers(buffers []*topicb
 	var debugInfo string
 
 	if result.ProcessedCount > 0 {
-		minSeq := buffers[startIndex].SequenceNum // Oldest processed buffer
-
-		maxSeq := buffers[len(buffers)-1].SequenceNum // Newest processed buffer
 		if minSeq == maxSeq {
 			debugInfo = fmt.Sprintf("Processed %d incremental buffers from %s (seq %d), %d errors",
 				result.ProcessedCount, source.String(), minSeq, result.SkippedCount)

--- a/umh-core/pkg/communicator/topicbrowser/communicator.go
+++ b/umh-core/pkg/communicator/topicbrowser/communicator.go
@@ -250,7 +250,7 @@ func (tbc *TopicBrowserCommunicator) processAllBuffers(buffers []*topicbrowserse
 
 	// Update sequence tracking to latest
 	if len(buffers) > 0 {
-		tbc.lastProcessedSequence = buffers[0].SequenceNum // Newest buffer (first in slice)
+		tbc.lastProcessedSequence = buffers[len(buffers)-1].SequenceNum // Newest buffer (last in slice)
 	}
 
 	result.DebugInfo = fmt.Sprintf("Processed ALL %d buffers from %s after overwrite (seq up to %d), %d errors",
@@ -265,7 +265,7 @@ func (tbc *TopicBrowserCommunicator) processAllBuffers(buffers []*topicbrowserse
 func (tbc *TopicBrowserCommunicator) processIncrementalBuffers(buffers []*topicbrowserservice.BufferItem, newBufferCount uint64, source ProcessingSource) (*ProcessingResult, error) {
 	result := &ProcessingResult{}
 
-	// Buffers are newest-to-oldest, so we need the last N items
+	// Buffers are oldest-to-newest, so the newest ones are the last N items
 	startIndex := len(buffers) - int(newBufferCount)
 	if startIndex < 0 {
 		startIndex = 0
@@ -295,7 +295,7 @@ func (tbc *TopicBrowserCommunicator) processIncrementalBuffers(buffers []*topicb
 
 	// Update sequence tracking to latest
 	if len(buffers) > 0 {
-		tbc.lastProcessedSequence = buffers[0].SequenceNum // Newest buffer (first in slice)
+		tbc.lastProcessedSequence = buffers[len(buffers)-1].SequenceNum // Newest buffer (last in slice)
 	}
 
 	// Validate topic count after processing
@@ -308,9 +308,9 @@ func (tbc *TopicBrowserCommunicator) processIncrementalBuffers(buffers []*topicb
 	var debugInfo string
 
 	if result.ProcessedCount > 0 {
-		minSeq := buffers[len(buffers)-1].SequenceNum // Oldest processed buffer
+		minSeq := buffers[startIndex].SequenceNum // Oldest processed buffer
 
-		maxSeq := buffers[startIndex].SequenceNum // Newest processed buffer
+		maxSeq := buffers[len(buffers)-1].SequenceNum // Newest processed buffer
 		if minSeq == maxSeq {
 			debugInfo = fmt.Sprintf("Processed %d incremental buffers from %s (seq %d), %d errors",
 				result.ProcessedCount, source.String(), minSeq, result.SkippedCount)

--- a/umh-core/pkg/communicator/topicbrowser/incremental_newest_not_oldest_test.go
+++ b/umh-core/pkg/communicator/topicbrowser/incremental_newest_not_oldest_test.go
@@ -1,0 +1,95 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package topicbrowser_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/proto"
+
+	tbproto "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/communicator/models/topicbrowser/pb"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/communicator/topicbrowser"
+	topicbrowserservice "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/topicbrowser"
+)
+
+// incrementalBufferWithTopic returns a BufferItem whose payload is a marshaled
+// UnsBundle carrying a single TopicInfo whose Name is the given topic.
+func incrementalBufferWithTopic(seq uint64, topic string, ts time.Time) *topicbrowserservice.BufferItem {
+	topicInfo := &tbproto.TopicInfo{
+		Name: topic,
+	}
+
+	bundle := &tbproto.UnsBundle{
+		UnsMap: &tbproto.TopicMap{
+			Entries: map[string]*tbproto.TopicInfo{
+				topicbrowser.HashUNSTableEntry(topicInfo): topicInfo,
+			},
+		},
+	}
+
+	payload, err := proto.Marshal(bundle)
+	Expect(err).NotTo(HaveOccurred())
+
+	return &topicbrowserservice.BufferItem{
+		SequenceNum: seq,
+		Payload:     payload,
+		Timestamp:   ts,
+	}
+}
+
+var _ = Describe("Incremental buffer processing", func() {
+	It("ingests the newest buffer (Items[len-1]), not the oldest (Items[0])", func() {
+		comm := topicbrowser.NewTopicBrowserCommunicator(zap.NewNop().Sugar())
+
+		// First ProcessRealData establishes the baseline. Because
+		// lastProcessedSequence == 0, processAllBuffers runs and stores
+		// buffers[len-1].SequenceNum (10) as the last processed sequence.
+		baseline := incrementalBufferWithTopic(10, "baseline-topic", time.UnixMilli(1000))
+		_, err := comm.ProcessRealData(createMockObservedStateSnapshot([]*topicbrowserservice.BufferItem{baseline}))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(comm.GetLastProcessedSequence()).To(Equal(uint64(10)))
+
+		// Second snapshot: oldest-to-newest, with more slots than the
+		// 3-slot production ring so the newBufferCount=1 window is stable and
+		// unambiguous. LastSequenceNum = 11 while the last processed sequence
+		// is 10, so newBufferCount = 1: exactly one buffer is new.
+		second := []*topicbrowserservice.BufferItem{
+			incrementalBufferWithTopic(6, "oldest-topic", time.UnixMilli(1100)), // Items[0]
+			incrementalBufferWithTopic(7, "mid-7-topic", time.UnixMilli(1200)),
+			incrementalBufferWithTopic(8, "mid-8-topic", time.UnixMilli(1300)),
+			incrementalBufferWithTopic(9, "mid-9-topic", time.UnixMilli(1400)),
+			incrementalBufferWithTopic(10, "mid-10-topic", time.UnixMilli(1500)),
+			incrementalBufferWithTopic(11, "newest-topic", time.UnixMilli(2000)), // Items[len-1]
+		}
+
+		_, err = comm.ProcessRealData(createMockObservedStateSnapshot(second))
+		Expect(err).NotTo(HaveOccurred())
+
+		// Assert the OBSERVABLE OUTCOME on the ingested topic map, both ways:
+		// the newest payload's topic is present and the oldest payload's topic
+		// is absent. A test that only checked the newest arrived would falsely
+		// pass an implementation that ingests ALL buffers.
+		ingestedTopics := make(map[string]bool)
+		for _, entry := range comm.GetUnsMap().GetEntries() {
+			ingestedTopics[entry.GetName()] = true
+		}
+
+		Expect(ingestedTopics).To(HaveKey("newest-topic"), "the newest buffer (Items[len-1]) must be ingested")
+		Expect(ingestedTopics).ToNot(HaveKey("oldest-topic"), "the oldest buffer (Items[0]) must NOT be ingested")
+	})
+})

--- a/umh-core/pkg/communicator/topicbrowser/simulator.go
+++ b/umh-core/pkg/communicator/topicbrowser/simulator.go
@@ -126,7 +126,7 @@ func (s *Simulator) AddUnsBundleToSimObservedState(bundle []byte) {
 		SequenceNum: uint64(len(s.simObservedState.ServiceInfo.Status.BufferSnapshot.Items) + 1),
 	}
 
-	s.simObservedState.ServiceInfo.Status.BufferSnapshot.Items = append(s.simObservedState.ServiceInfo.Status.BufferSnapshot.Items, newItem)
+	s.simObservedState.ServiceInfo.Status.BufferSnapshot.AppendNewest(newItem)
 	s.simObservedState.ServiceInfo.Status.BufferSnapshot.LastSequenceNum = newItem.SequenceNum
 
 	// limit the buffer to 100 entries and delete the oldest entry if the buffer is full

--- a/umh-core/pkg/communicator/topicbrowser/simulator_ordering_test.go
+++ b/umh-core/pkg/communicator/topicbrowser/simulator_ordering_test.go
@@ -1,0 +1,96 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package topicbrowser_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/zap"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/communicator/topicbrowser"
+)
+
+// newestProducedAtMs returns the highest ProducedAtMs held in the communicator's
+// event map, which advances only when a bundle newer than everything already
+// ingested is processed.
+func newestProducedAtMs(comm *topicbrowser.TopicBrowserCommunicator) uint64 {
+	var newest uint64
+
+	for _, entry := range comm.GetEventMap() {
+		if produced := entry.GetProducedAtMs(); produced > newest {
+			newest = produced
+		}
+	}
+
+	return newest
+}
+
+var _ = Describe("Simulator buffer ordering", func() {
+	It("builds the simulated observed state oldest-to-newest, matching the RingBufferSnapshot.Items contract", func() {
+		simulator := topicbrowser.NewSimulator()
+		simulator.InitializeSimulator()
+
+		// Tick twice so there are at least two distinct bundles, then read the
+		// state the simulator hands to ProcessSimulatedData. The newest bundle
+		// must be last (the same contract the production ring and
+		// processIncrementalBuffers rely on); a newest-first arrangement would
+		// freeze demo mode reporting seq 1.
+		simulator.Tick()
+		simulator.Tick()
+		state := simulator.GetSimObservedState()
+
+		items := state.ServiceInfo.Status.BufferSnapshot.Items
+		Expect(items).NotTo(BeEmpty(), "simulated state must produce buffer items")
+
+		Expect(items[len(items)-1].SequenceNum).To(Equal(state.ServiceInfo.Status.BufferSnapshot.LastSequenceNum),
+			"the newest item is last, matching LastSequenceNum")
+	})
+
+	It("ingests the newest simulated bundle end to end, not one already seen", func() {
+		comm := topicbrowser.NewTopicBrowserCommunicatorWithSimulator(zap.NewNop().Sugar())
+
+		// The first call bootstraps: lastProcessedSequence is 0, so every buffer
+		// is ingested and the incremental path is not exercised yet.
+		_, err := comm.ProcessSimulatedData()
+		Expect(err).NotTo(HaveOccurred())
+
+		before := newestProducedAtMs(comm)
+		Expect(before).ToNot(BeZero(), "bootstrap must ingest at least one event")
+
+		// Every simulated bundle carries the SAME two hardcoded topics, so the
+		// topic map cannot tell two bundles apart and asserting on it would pass
+		// vacuously. The event payload is the only signal for which buffer was
+		// ingested.
+		//
+		// updateInternalCache replaces an event only when ProducedAtMs is
+		// STRICTLY greater, and ProducedAtMs has millisecond resolution, so two
+		// bundles generated inside one millisecond are indistinguishable even
+		// when selection is correct. The gap is required by that production
+		// semantic, not by the test.
+		time.Sleep(2 * time.Millisecond)
+
+		// The second call takes the incremental path with exactly one new buffer.
+		_, err = comm.ProcessSimulatedData()
+		Expect(err).NotTo(HaveOccurred())
+
+		// Assert the COMPOSITION of producer order and consumer selection: the
+		// newest event must advance. Selecting an already-ingested buffer leaves
+		// this unchanged, because its ProducedAtMs is not strictly greater.
+		Expect(newestProducedAtMs(comm)).To(BeNumerically(">", before),
+			"the incremental pass must ingest the newest simulated bundle, not one already seen")
+	})
+})

--- a/umh-core/pkg/service/topicbrowser/buffer.go
+++ b/umh-core/pkg/service/topicbrowser/buffer.go
@@ -30,12 +30,13 @@
 //    parseBufferPool, decodes the hex directly into a *BufferItem* obtained
 //    from bufferItemPool, then hands that BufferItem to the ring buffer.
 // 2. The ring buffer owns the BufferItem until it is overwritten.
-// 3. GetSnapshot exposes *read‑only* pointers; consumers must call
-//    PutBufferItems once they are finished so the structs can be reused.
+// 3. GetSnapshot exposes read-only pointers. The ring buffer keeps its own
+//    reference to every item, so a consumer must neither modify nor recycle
+//    them.
 //
 //  ▸ BufferItem is **immutable** after creation.
-//  ▸ Overwritten items are **not** returned automatically to the pool to
-//    avoid use‑after‑free while snapshots might still be in flight.
+//  ▸ Items are never returned to bufferItemPool. A snapshot may still be in
+//    flight, and nothing tracks when the last consumer is finished.
 //  ▸ parseBufferPool buffers are always returned immediately.
 //
 // Concurrency guarantees: Add and GetSnapshot are mutex‑protected and safe to
@@ -145,18 +146,6 @@ var bufferItemPool = sync.Pool{
 	New: func() any {
 		return &BufferItem{}
 	},
-}
-
-// PutBufferItems must be called by every consumer of GetSnapshot() when
-// finished. It zeroes the structs and returns them to bufferItemPool.
-func PutBufferItems(items []*BufferItem) {
-	for _, item := range items {
-		// Clear the item and return to pool
-		item.Payload = nil
-		item.Timestamp = time.Time{}
-		item.SequenceNum = 0
-		bufferItemPool.Put(item)
-	}
 }
 
 func (rb *Ringbuffer) Len() int {

--- a/umh-core/pkg/service/topicbrowser/buffer.go
+++ b/umh-core/pkg/service/topicbrowser/buffer.go
@@ -182,9 +182,7 @@ func (rb *Ringbuffer) GetSnapshot() RingBufferSnapshot {
 	// Go through the ring oldest to newest, adding each item to the snapshot.
 	for range rb.count {
 		// Only the pointer is copied; the item stays owned by the ring.
-		if b := rb.buf[idx]; b != nil {
-			snapshot.AppendNewest(b)
-		}
+		snapshot.AppendNewest(rb.buf[idx])
 
 		// Step forward, wrapping at the end of the array.
 		idx++

--- a/umh-core/pkg/service/topicbrowser/buffer.go
+++ b/umh-core/pkg/service/topicbrowser/buffer.go
@@ -162,17 +162,8 @@ func (rb *Ringbuffer) Cap() int {
 	return len(rb.buf)
 }
 
-// GetSnapshot returns the ring's items as a flat slice, oldest first, with the
-// newest sequence number assigned so far.
-//
-// The ring is a circular buffer behind a mutex, and its contents travel as part
-// of the FSM observed state. A caller needs one ordered value it can read after
-// the lock is released, without knowing about writePos.
-//
-// Only the pointers are copied. The items stay shared with the ring, which goes
-// on writing and may overwrite the slot an item came from, so a caller must
-// treat the payloads as read-only. Status.CopyBufferSnapshot depends on that
-// and skips a deep copy.
+// GetSnapshot returns the ring's items as a flat slice, oldest first, so a
+// caller can read them after the lock is released.
 func (rb *Ringbuffer) GetSnapshot() RingBufferSnapshot {
 	rb.mu.Lock()
 	defer rb.mu.Unlock()
@@ -182,17 +173,20 @@ func (rb *Ringbuffer) GetSnapshot() RingBufferSnapshot {
 		Items:           make([]*BufferItem, 0, rb.count),
 	}
 
-	// Start at the oldest live slot and step forward, wrapping at the end.
+	// The oldest live item sits count places behind the next write slot.
 	idx := rb.writePos - rb.count
 	if idx < 0 {
 		idx += len(rb.buf)
 	}
 
+	// Go through the ring oldest to newest, adding each item to the snapshot.
 	for range rb.count {
+		// Only the pointer is copied; the item stays owned by the ring.
 		if b := rb.buf[idx]; b != nil {
 			snapshot.AppendNewest(b)
 		}
 
+		// Step forward, wrapping at the end of the array.
 		idx++
 		if idx == len(rb.buf) {
 			idx = 0

--- a/umh-core/pkg/service/topicbrowser/buffer.go
+++ b/umh-core/pkg/service/topicbrowser/buffer.go
@@ -78,6 +78,29 @@ type RingBufferSnapshot struct {
 	LastSequenceNum uint64 // Latest sequence number
 }
 
+// NewestN returns up to n entries, the most recently added ones, in the order
+// they arrived. Fewer are returned when the snapshot holds fewer than n.
+//
+// Callers use this instead of slicing Items, so which end is newest is stated
+// once here rather than at each call site.
+func (s RingBufferSnapshot) NewestN(n int) []*BufferItem {
+	if n <= 0 {
+		return nil
+	}
+
+	if n >= len(s.Items) {
+		return s.Items
+	}
+
+	return s.Items[len(s.Items)-n:]
+}
+
+// AppendNewest adds item as the most recently arrived entry. Producers that
+// build a snapshot by hand use this so the call site never states an order.
+func (s *RingBufferSnapshot) AppendNewest(item *BufferItem) {
+	s.Items = append(s.Items, item)
+}
+
 // NewRingbufferWithDefaultCapacity creates a ring buffer with the standard production capacity.
 func NewRingbufferWithDefaultCapacity() *Ringbuffer {
 	return NewRingbuffer(constants.RingBufferCapacity)

--- a/umh-core/pkg/service/topicbrowser/buffer.go
+++ b/umh-core/pkg/service/topicbrowser/buffer.go
@@ -162,30 +162,42 @@ func (rb *Ringbuffer) Cap() int {
 	return len(rb.buf)
 }
 
-// GetSnapshot returns a consistent snapshot of the ring buffer state
-// This is the primary interface for consumers to get ring buffer data.
+// GetSnapshot returns the ring's items as a flat slice, oldest first, with the
+// newest sequence number assigned so far.
+//
+// The ring is a circular buffer behind a mutex, and its contents travel as part
+// of the FSM observed state. A caller needs one ordered value it can read after
+// the lock is released, without knowing about writePos.
+//
+// Only the pointers are copied. The items stay shared with the ring, which goes
+// on writing and may overwrite the slot an item came from, so a caller must
+// treat the payloads as read-only. Status.CopyBufferSnapshot depends on that
+// and skips a deep copy.
 func (rb *Ringbuffer) GetSnapshot() RingBufferSnapshot {
 	rb.mu.Lock()
 	defer rb.mu.Unlock()
 
-	return RingBufferSnapshot{
+	snapshot := RingBufferSnapshot{
 		LastSequenceNum: rb.sequenceNum,
-		Items:           rb.getBuffersInternal(),
+		Items:           make([]*BufferItem, 0, rb.count),
 	}
-}
 
-// getBuffersInternal returns shared references to buffer items, oldest first.
-// This is used internally by GetSnapshot and assumes mutex is already held.
-func (rb *Ringbuffer) getBuffersInternal() []*BufferItem {
-	result := make([]*BufferItem, 0, rb.count)
-	for i := range rb.count {
-		// writePos is the next slot to write, so the oldest live item sits
-		// count places behind it.
-		idx := (rb.writePos - rb.count + i + len(rb.buf)) % len(rb.buf)
+	// Start at the oldest live slot and step forward, wrapping at the end.
+	idx := rb.writePos - rb.count
+	if idx < 0 {
+		idx += len(rb.buf)
+	}
+
+	for range rb.count {
 		if b := rb.buf[idx]; b != nil {
-			result = append(result, b) // Share the reference, no copying
+			snapshot.AppendNewest(b)
+		}
+
+		idx++
+		if idx == len(rb.buf) {
+			idx = 0
 		}
 	}
 
-	return result
+	return snapshot
 }

--- a/umh-core/pkg/service/topicbrowser/buffer.go
+++ b/umh-core/pkg/service/topicbrowser/buffer.go
@@ -71,8 +71,11 @@ type Ringbuffer struct {
 
 // RingBufferSnapshot provides a consistent view of the ring buffer state.
 type RingBufferSnapshot struct {
-	Items           []*BufferItem // Current buffer contents, newest-to-oldest
-	LastSequenceNum uint64        // Latest sequence number
+	// Items holds the buffer contents oldest first, the order they were added.
+	// Whatever fills this field keeps that order, and a reader that wants the
+	// most recent N items takes them from the end.
+	Items           []*BufferItem
+	LastSequenceNum uint64 // Latest sequence number
 }
 
 // NewRingbufferWithDefaultCapacity creates a ring buffer with the standard production capacity.
@@ -159,12 +162,14 @@ func (rb *Ringbuffer) GetSnapshot() RingBufferSnapshot {
 	}
 }
 
-// getBuffersInternal returns shared references to buffer items (newest to oldest)
+// getBuffersInternal returns shared references to buffer items, oldest first.
 // This is used internally by GetSnapshot and assumes mutex is already held.
 func (rb *Ringbuffer) getBuffersInternal() []*BufferItem {
 	result := make([]*BufferItem, 0, rb.count)
 	for i := range rb.count {
-		idx := (rb.writePos - 1 - i + len(rb.buf)) % len(rb.buf)
+		// writePos is the next slot to write, so the oldest live item sits
+		// count places behind it.
+		idx := (rb.writePos - rb.count + i + len(rb.buf)) % len(rb.buf)
 		if b := rb.buf[idx]; b != nil {
 			result = append(result, b) // Share the reference, no copying
 		}

--- a/umh-core/pkg/service/topicbrowser/buffer_ordering_test.go
+++ b/umh-core/pkg/service/topicbrowser/buffer_ordering_test.go
@@ -1,0 +1,60 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package topicbrowser
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Ringbuffer snapshot ordering", func() {
+	sequences := func(items []*BufferItem) []uint64 {
+		seqs := make([]uint64, 0, len(items))
+		for _, item := range items {
+			seqs = append(seqs, item.SequenceNum)
+		}
+
+		return seqs
+	}
+
+	add := func(rb *Ringbuffer, count int) {
+		for i := range count {
+			rb.Add(&BufferItem{
+				Payload:   []byte{byte(i)},
+				Timestamp: time.Now().Add(time.Duration(i) * time.Second),
+			})
+		}
+	}
+
+	It("hands out items in the order they were added", func() {
+		rb := NewRingbuffer(3)
+		add(rb, 2)
+
+		Expect(sequences(rb.GetSnapshot().Items)).To(Equal([]uint64{1, 2}))
+	})
+
+	It("keeps the added order after the ring has wrapped, dropping only the oldest", func() {
+		// Five items into three slots, so writePos has wrapped and the oldest
+		// live item is no longer at index 0 of the underlying array. Reading
+		// backwards from writePos returns 5, 4, 3 and passes the spec above,
+		// which is why this case is separate.
+		rb := NewRingbuffer(3)
+		add(rb, 5)
+
+		Expect(sequences(rb.GetSnapshot().Items)).To(Equal([]uint64{3, 4, 5}))
+	})
+})

--- a/umh-core/pkg/service/topicbrowser/buffer_ordering_test.go
+++ b/umh-core/pkg/service/topicbrowser/buffer_ordering_test.go
@@ -58,3 +58,47 @@ var _ = Describe("Ringbuffer snapshot ordering", func() {
 		Expect(sequences(rb.GetSnapshot().Items)).To(Equal([]uint64{3, 4, 5}))
 	})
 })
+
+var _ = Describe("RingBufferSnapshot accessors", func() {
+	snapshotOf := func(seqs ...uint64) RingBufferSnapshot {
+		snapshot := RingBufferSnapshot{}
+		for _, seq := range seqs {
+			snapshot.AppendNewest(&BufferItem{SequenceNum: seq})
+		}
+
+		return snapshot
+	}
+
+	It("AppendNewest puts each entry after the ones already there", func() {
+		snapshot := snapshotOf(1, 2, 3)
+
+		Expect(snapshot.Items).To(HaveLen(3))
+		Expect(snapshot.Items[len(snapshot.Items)-1].SequenceNum).To(Equal(uint64(3)))
+	})
+
+	It("NewestN returns the most recent n, still in arrival order", func() {
+		snapshot := snapshotOf(1, 2, 3, 4, 5)
+
+		window := snapshot.NewestN(3)
+
+		Expect(window).To(HaveLen(3))
+		Expect(window[0].SequenceNum).To(Equal(uint64(3)))
+		Expect(window[len(window)-1].SequenceNum).To(Equal(uint64(5)))
+	})
+
+	It("NewestN returns everything it holds when n is larger", func() {
+		snapshot := snapshotOf(1, 2)
+
+		window := snapshot.NewestN(9)
+
+		Expect(window).To(HaveLen(2))
+		Expect(window[0].SequenceNum).To(Equal(uint64(1)))
+	})
+
+	It("NewestN returns nothing for a non-positive n", func() {
+		snapshot := snapshotOf(1, 2)
+
+		Expect(snapshot.NewestN(0)).To(BeEmpty())
+		Expect(snapshot.NewestN(-1)).To(BeEmpty())
+	})
+})

--- a/umh-core/pkg/service/topicbrowser/buffer_test.go
+++ b/umh-core/pkg/service/topicbrowser/buffer_test.go
@@ -103,7 +103,7 @@ var _ = Describe("Ringbuffer", func() {
 		})
 	})
 
-	Context("GetSnapshot / memory management", func() {
+	Context("GetSnapshot", func() {
 		It("provides immutable snapshot access", func() {
 			rb := NewRingbuffer(4)
 			rb.Add(helperBuf(42))
@@ -122,43 +122,6 @@ var _ = Describe("Ringbuffer", func() {
 			Expect(newSnapshot.Items[1].Payload[0]).To(Equal(byte(99))) // Newest last
 		})
 
-		It("demonstrates proper consumer memory management", func() {
-			rb := NewRingbuffer(4)
-			rb.Add(helperBuf(42))
-			rb.Add(helperBuf(43))
-
-			// Consumer pattern: get snapshot and always return items to pool
-			snapshot := rb.GetSnapshot()
-			defer PutBufferItems(snapshot.Items) // CRITICAL: Always return to pool when done
-
-			// Process the items
-			Expect(snapshot.Items).To(HaveLen(2))
-			for _, item := range snapshot.Items {
-				// Verify we can read the data
-				Expect(item.Payload).ToNot(BeNil())
-				Expect(item.Payload[0]).To(BeNumerically(">=", 42))
-			}
-
-			// At this point, defer will call PutBufferItems to return items to pool
-			// After that, snapshot.Items should not be used
-		})
-
-		It("shows that PutBufferItems clears the items", func() {
-			rb := NewRingbuffer(2)
-			rb.Add(helperBuf(100))
-
-			snapshot := rb.GetSnapshot()
-			Expect(snapshot.Items).To(HaveLen(1))
-			Expect(snapshot.Items[0].Payload[0]).To(Equal(byte(100)))
-
-			// Return to pool - this clears the items
-			PutBufferItems(snapshot.Items)
-
-			// Items are now cleared (should not use after PutBufferItems!)
-			Expect(snapshot.Items[0].Payload).To(BeNil())
-			Expect(snapshot.Items[0].Timestamp).To(Equal(time.Time{}))
-			Expect(snapshot.Items[0].SequenceNum).To(Equal(uint64(0)))
-		})
 	})
 
 	Context("Sequence number tracking", func() {

--- a/umh-core/pkg/service/topicbrowser/buffer_test.go
+++ b/umh-core/pkg/service/topicbrowser/buffer_test.go
@@ -40,16 +40,16 @@ var _ = Describe("Ringbuffer", func() {
 	})
 
 	Context("Add / Get basics", func() {
-		It("stores elements and returns them newest-first", func() {
+		It("stores elements and returns them oldest-first", func() {
 			rb.Add(newBuf(0))
 			rb.Add(newBuf(1))
 			Expect(rb.Len()).To(Equal(2))
 
 			snapshot := rb.GetSnapshot()
 			Expect(snapshot.Items).To(HaveLen(2))
-			// expect newest first (id 1, then id 0)
-			Expect(snapshot.Items[0].Payload[0]).To(Equal(byte(1)))
-			Expect(snapshot.Items[1].Payload[0]).To(Equal(byte(0)))
+			// expect oldest first (id 0, then id 1)
+			Expect(snapshot.Items[0].Payload[0]).To(Equal(byte(0)))
+			Expect(snapshot.Items[1].Payload[0]).To(Equal(byte(1)))
 		})
 	})
 
@@ -65,7 +65,7 @@ var _ = Describe("Ringbuffer", func() {
 			Expect(snapshot.Items).To(HaveLen(int(cap))) // still full capacity
 			ids := []byte{snapshot.Items[0].Payload[0], snapshot.Items[1].Payload[0], snapshot.Items[2].Payload[0]}
 			// oldest (0) must be gone, newest (3) present
-			Expect(ids).To(Equal([]byte{3, 2, 1}))
+			Expect(ids).To(Equal([]byte{1, 2, 3}))
 		})
 	})
 
@@ -119,7 +119,7 @@ var _ = Describe("Ringbuffer", func() {
 			// New snapshot reflects updates
 			newSnapshot := rb.GetSnapshot()
 			Expect(newSnapshot.Items).To(HaveLen(2))
-			Expect(newSnapshot.Items[0].Payload[0]).To(Equal(byte(99))) // Newest first
+			Expect(newSnapshot.Items[1].Payload[0]).To(Equal(byte(99))) // Newest last
 		})
 
 		It("demonstrates proper consumer memory management", func() {
@@ -200,8 +200,8 @@ var _ = Describe("Ringbuffer", func() {
 
 			// Only buf2 and buf3 should remain
 			Expect(snapshot.Items).To(HaveLen(2))
-			Expect(snapshot.Items[0].SequenceNum).To(Equal(uint64(3))) // Newest first
-			Expect(snapshot.Items[1].SequenceNum).To(Equal(uint64(2)))
+			Expect(snapshot.Items[0].SequenceNum).To(Equal(uint64(2)))
+			Expect(snapshot.Items[1].SequenceNum).To(Equal(uint64(3))) // Newest last
 		})
 	})
 
@@ -217,9 +217,9 @@ var _ = Describe("Ringbuffer", func() {
 			Expect(snapshot.LastSequenceNum).To(Equal(uint64(2)))
 			Expect(snapshot.Items).To(HaveLen(2))
 
-			// Items should be newest-to-oldest
-			Expect(snapshot.Items[0].Payload[0]).To(Equal(byte(20))) // Newest
-			Expect(snapshot.Items[1].Payload[0]).To(Equal(byte(10))) // Older
+			// Items should be oldest-to-newest
+			Expect(snapshot.Items[0].Payload[0]).To(Equal(byte(10))) // Oldest
+			Expect(snapshot.Items[1].Payload[0]).To(Equal(byte(20))) // Newest
 		})
 	})
 })


### PR DESCRIPTION
Part of the **ENG-5525** stack — see that ticket for the whole arc, and for what the other two PRs do.

## Problem

During the initial implementation there was confusion about where to add things to the buffer. It should have added newer entries to the end and sent out the entries from the front, so the buffer still absorbs bursts but we always send out the oldest entries first and keep the order intact.

`processIncrementalBuffers` was written for exactly that. It takes the last N entries and walks them front to back, so they leave in the order they arrived.

However, the ring buffer hands them out in the opposite order. `getBuffersInternal` walked backwards from the write position, so the newest entry came out first:

```go
idx := (rb.writePos - 1 - i + len(rb.buf)) % len(rb.buf)
```

Taking the last N therefore sends the oldest entries the ring still holds and skips the ones that just arrived.

## What we're shipping

- **Entries reach a browser in the order they arrived.** `GetSnapshot` hands them out oldest first, matching how they were added. `getBuffersInternal` is folded into it, so the walk reads as start at the oldest and step forward, wrapping at the end, instead of one modulo expression to decode.
- **The order is named in code rather than described in a comment.** `RingBufferSnapshot` gains `NewestN` and `AppendNewest`. Reads of a recent window and writes of a new entry go through them, so no call site restates which end is newest. Five sites used to.
- **Choosing which entries to process happens in one place.** `processIncrementalBuffers` is handed its window instead of slicing one, so it ingests what it is given.
- **`PutBufferItems` is removed.** Nothing called it once the PR below stopped returning ring-owned items to the pool, and its doc still told every consumer of `GetSnapshot` to call it. `bufferItemPool` stays: `parseBlock` still takes items from it.

The selection rule itself is unchanged: the newest N, in the order they arrived.

## What we're NOT shipping

- **NOT a change to how many entries the buffer holds.** That may well be too few; this PR does not make that call.
- **NOT the delivery filter.** Which entries get sent is still decided by timestamp. #2713 fixes that.
- **NOT reviving the GraphQL cache path.** `Cache.ProcessIncrementalUpdates` reads through `NewestN` like everything else, which also removes a slice that would have panicked on a gap larger than the entries held. It still has no writer, so nothing reads what it builds (ENG-3788).
- **NOT ordered delivery all the way to the browser.** umh-core sends oldest first, but the console decodes bundles concurrently, so it does not apply them in the order they arrive. Harmless today, because topics are deduplicated by content and events carry their own timestamps (ENG-5651).



