### PR TITLE
fix(topicbrowser): send the increments that were being dropped

### DIFF
--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Topics no longer go missing from the Topic Browser when several updates arrive in quick succession
+- The Topic Browser now updates as data arrives instead of in bursts roughly every 10 seconds. umh-core recorded the current time when it marked topic browser data as delivered, rather than the timestamp of the data it had actually sent. Because those timestamps are emission times that always trail the clock, every later update looked already-sent and was dropped, so no incremental update was ever delivered
 
 ## [0.44.36]
 

--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixes
 
 - Topics no longer go missing from the Topic Browser when several updates arrive in quick succession
-- The Topic Browser now updates as data arrives instead of in bursts roughly every 10 seconds. umh-core recorded the current time when it marked topic browser data as delivered, rather than the timestamp of the data it had actually sent. Because those timestamps are emission times that always trail the clock, every later update looked already-sent and was dropped, so no incremental update was ever delivered
+- The Topic Browser now updates as data arrives instead of in bursts roughly every 10 seconds
 
 ## [0.44.36]
 

--- a/umh-core/pkg/communicator/pkg/subscriber/subscribers.go
+++ b/umh-core/pkg/communicator/pkg/subscriber/subscribers.go
@@ -255,6 +255,6 @@ func (s *Handler) notify() {
 
 	// Mark data as sent for tracking purposes
 	if notified > 0 && s.topicBrowserCommunicator != nil {
-		s.topicBrowserCommunicator.MarkDataAsSent(time.Now())
+		s.topicBrowserCommunicator.MarkDataAsSent()
 	}
 }

--- a/umh-core/pkg/communicator/topicbrowser/communicator.go
+++ b/umh-core/pkg/communicator/topicbrowser/communicator.go
@@ -92,12 +92,15 @@ type queuedBundle struct {
 // TopicBrowserCommunicator manages topic browser data flow from ring buffer to UI subscribers
 // It handles both the internal cache state and the communication/subscriber management.
 type TopicBrowserCommunicator struct {
-	lastSentTimestamp time.Time // Last timestamp sent to subscribers
-	// Highest buffer timestamp handed to any subscriber but not yet acknowledged.
-	// Delivery is acknowledged against this rather than against a clock: buffer
-	// timestamps are emission times and always trail wall clock, so a clock-based
-	// acknowledgement also marks buffers that were never sent.
-	lastOfferedTimestamp time.Time
+	// sentWatermark is the position below which bundles are never sent again.
+	// MarkDataAsSent advances it, once per notify tick.
+	sentWatermark time.Time
+
+	// pendingWatermark is the highest bundle timestamp GetSubscriberData has put
+	// into a subscriber message. MarkDataAsSent promotes it to sentWatermark.
+	//
+	// Both are bundle emission times, never wall clock. See queuedBundle.Timestamp.
+	pendingWatermark time.Time
 
 	// 📊 INTERNAL CACHE STATE: The actual topic browser data storage
 	eventMap map[string]*tbproto.EventTableEntry // Latest event per topic (key = UnsTreeId)
@@ -125,7 +128,7 @@ func NewTopicBrowserCommunicator(logger *zap.SugaredLogger) *TopicBrowserCommuni
 		unsMap:                &tbproto.TopicMap{Entries: make(map[string]*tbproto.TopicInfo)},
 		lastProcessedSequence: 0, // Start from beginning
 		pendingToSend:         make([]queuedBundle, 0),
-		lastSentTimestamp:     time.Time{},
+		sentWatermark:     time.Time{},
 		simulator:             nil,
 		simulatorEnabled:      false,
 		maxPendingBuffers:     100, // Default cleanup threshold
@@ -421,8 +424,8 @@ func (tbc *TopicBrowserCommunicator) GetSubscriberData(isBootstrapped bool) (*Su
 		}
 	}
 
-	if data.LatestTimestamp.After(tbc.lastOfferedTimestamp) {
-		tbc.lastOfferedTimestamp = data.LatestTimestamp
+	if data.LatestTimestamp.After(tbc.pendingWatermark) {
+		tbc.pendingWatermark = data.LatestTimestamp
 	}
 
 	data.Summary += fmt.Sprintf("%d incremental buffers", len(unsent))
@@ -442,9 +445,9 @@ func (tbc *TopicBrowserCommunicator) MarkDataAsSent() {
 	tbc.mu.Lock()
 	defer tbc.mu.Unlock()
 
-	if tbc.lastOfferedTimestamp.After(tbc.lastSentTimestamp) {
-		tbc.lastSentTimestamp = tbc.lastOfferedTimestamp
-		tbc.logger.Debugf("Marked data as sent up to timestamp: %s", tbc.lastSentTimestamp.Format(time.RFC3339))
+	if tbc.pendingWatermark.After(tbc.sentWatermark) {
+		tbc.sentWatermark = tbc.pendingWatermark
+		tbc.logger.Debugf("Marked data as sent up to timestamp: %s", tbc.sentWatermark.Format(time.RFC3339))
 	}
 
 	// Cleanup old pending buffers to prevent memory growth
@@ -460,7 +463,7 @@ func (tbc *TopicBrowserCommunicator) cleanupOldPendingBuffers() {
 	filtered := make([]queuedBundle, 0, len(tbc.pendingToSend))
 
 	for _, bundle := range tbc.pendingToSend {
-		if bundle.Timestamp.After(tbc.lastSentTimestamp) {
+		if bundle.Timestamp.After(tbc.sentWatermark) {
 			filtered = append(filtered, bundle)
 		}
 	}
@@ -485,14 +488,14 @@ func removeMetadata(ub *tbproto.UnsBundle) {
 }
 
 // getUnsentBundles returns the queued bundles a subscriber has not received
-// yet, in ingest order. It reads pendingToSend and lastSentTimestamp without
+// yet, in ingest order. It reads pendingToSend and sentWatermark without
 // locking; GetSubscriberData holds the read lock, as it does for
 // getCacheBundle.
 func (tbc *TopicBrowserCommunicator) getUnsentBundles() []queuedBundle {
 	unsent := make([]queuedBundle, 0, len(tbc.pendingToSend))
 
 	for _, bundle := range tbc.pendingToSend {
-		if bundle.Timestamp.After(tbc.lastSentTimestamp) {
+		if bundle.Timestamp.After(tbc.sentWatermark) {
 			unsent = append(unsent, bundle)
 		}
 	}

--- a/umh-core/pkg/communicator/topicbrowser/communicator.go
+++ b/umh-core/pkg/communicator/topicbrowser/communicator.go
@@ -85,8 +85,11 @@ type SubscriberData struct {
 // The per-topic metadata map is dropped on the way in, so the payload differs
 // from the ring-buffer item it came from.
 type queuedBundle struct {
-	Timestamp time.Time // ingest timestamp, copied from the ring-buffer item
-	Payload   []byte    // re-encoded UnsBundle, allocated here
+	// Emission time parsed from the benthos log block, copied from
+	// topicbrowserservice.BufferItem.Timestamp. It trails wall clock by the
+	// pipeline lag, so a wall-clock value must never be compared against it.
+	Timestamp time.Time
+	Payload   []byte // re-encoded UnsBundle, allocated here
 }
 
 // TopicBrowserCommunicator manages topic browser data flow from ring buffer to UI subscribers
@@ -128,7 +131,7 @@ func NewTopicBrowserCommunicator(logger *zap.SugaredLogger) *TopicBrowserCommuni
 		unsMap:                &tbproto.TopicMap{Entries: make(map[string]*tbproto.TopicInfo)},
 		lastProcessedSequence: 0, // Start from beginning
 		pendingToSend:         make([]queuedBundle, 0),
-		sentWatermark:     time.Time{},
+		sentWatermark:         time.Time{},
 		simulator:             nil,
 		simulatorEnabled:      false,
 		maxPendingBuffers:     100, // Default cleanup threshold
@@ -387,8 +390,7 @@ func (tbc *TopicBrowserCommunicator) ingestBuffer(buf *topicbrowserservice.Buffe
 // For new subscribers (isBootstrapped=false): includes complete cache + incremental data
 // For existing subscribers (isBootstrapped=true): includes only incremental data.
 func (tbc *TopicBrowserCommunicator) GetSubscriberData(isBootstrapped bool) (*SubscriberData, error) {
-	// A write lock, not a read lock: this records what it handed out so the
-	// acknowledgement does not have to be told.
+	// Write lock: this advances pendingWatermark below.
 	tbc.mu.Lock()
 	defer tbc.mu.Unlock()
 
@@ -434,13 +436,13 @@ func (tbc *TopicBrowserCommunicator) GetSubscriberData(isBootstrapped bool) (*Su
 	return data, nil
 }
 
-// MarkDataAsSent marks everything handed to subscribers so far as delivered.
+// MarkDataAsSent promotes pendingWatermark, so every bundle GetSubscriberData
+// has put in a subscriber message stops being selected.
 //
-// It takes no timestamp on purpose. Only GetSubscriberData knows which buffers
-// went out, and the notify loop that acknowledges them builds its messages
-// through the status collector and never sees that answer. A caller-supplied
-// clock is therefore always wrong, and asking for one invited the bug this
-// replaced.
+// It takes no timestamp because no caller holds one. GetSubscriberData returns
+// the value in SubscriberData.LatestTimestamp, and the status collector drops
+// it when building models.TopicBrowser, so the notify loop that calls this has
+// no access to it.
 func (tbc *TopicBrowserCommunicator) MarkDataAsSent() {
 	tbc.mu.Lock()
 	defer tbc.mu.Unlock()
@@ -487,10 +489,8 @@ func removeMetadata(ub *tbproto.UnsBundle) {
 	}
 }
 
-// getUnsentBundles returns the queued bundles a subscriber has not received
-// yet, in ingest order. It reads pendingToSend and sentWatermark without
-// locking; GetSubscriberData holds the read lock, as it does for
-// getCacheBundle.
+// getUnsentBundles returns the queued bundles above sentWatermark, in ingest
+// order. Caller must hold tbc.mu.
 func (tbc *TopicBrowserCommunicator) getUnsentBundles() []queuedBundle {
 	unsent := make([]queuedBundle, 0, len(tbc.pendingToSend))
 

--- a/umh-core/pkg/communicator/topicbrowser/communicator.go
+++ b/umh-core/pkg/communicator/topicbrowser/communicator.go
@@ -433,11 +433,12 @@ func (tbc *TopicBrowserCommunicator) GetSubscriberData(isBootstrapped bool) (*Su
 
 // MarkDataAsSent marks everything handed to subscribers so far as delivered.
 //
-// The timestamp argument is ignored and is removed in the following commit. It
-// cannot be supplied correctly: the only caller is the notify loop, which builds
-// its messages through the status collector and never sees the SubscriberData
-// that knows which buffers went out.
-func (tbc *TopicBrowserCommunicator) MarkDataAsSent(_ time.Time) {
+// It takes no timestamp on purpose. Only GetSubscriberData knows which buffers
+// went out, and the notify loop that acknowledges them builds its messages
+// through the status collector and never sees that answer. A caller-supplied
+// clock is therefore always wrong, and asking for one invited the bug this
+// replaced.
+func (tbc *TopicBrowserCommunicator) MarkDataAsSent() {
 	tbc.mu.Lock()
 	defer tbc.mu.Unlock()
 

--- a/umh-core/pkg/communicator/topicbrowser/communicator.go
+++ b/umh-core/pkg/communicator/topicbrowser/communicator.go
@@ -93,6 +93,11 @@ type queuedBundle struct {
 // It handles both the internal cache state and the communication/subscriber management.
 type TopicBrowserCommunicator struct {
 	lastSentTimestamp time.Time // Last timestamp sent to subscribers
+	// Highest buffer timestamp handed to any subscriber but not yet acknowledged.
+	// Delivery is acknowledged against this rather than against a clock: buffer
+	// timestamps are emission times and always trail wall clock, so a clock-based
+	// acknowledgement also marks buffers that were never sent.
+	lastOfferedTimestamp time.Time
 
 	// 📊 INTERNAL CACHE STATE: The actual topic browser data storage
 	eventMap map[string]*tbproto.EventTableEntry // Latest event per topic (key = UnsTreeId)
@@ -379,8 +384,10 @@ func (tbc *TopicBrowserCommunicator) ingestBuffer(buf *topicbrowserservice.Buffe
 // For new subscribers (isBootstrapped=false): includes complete cache + incremental data
 // For existing subscribers (isBootstrapped=true): includes only incremental data.
 func (tbc *TopicBrowserCommunicator) GetSubscriberData(isBootstrapped bool) (*SubscriberData, error) {
-	tbc.mu.RLock()
-	defer tbc.mu.RUnlock()
+	// A write lock, not a read lock: this records what it handed out so the
+	// acknowledgement does not have to be told.
+	tbc.mu.Lock()
+	defer tbc.mu.Unlock()
 
 	data := &SubscriberData{
 		UnsBundles: make(map[int][]byte),
@@ -414,22 +421,29 @@ func (tbc *TopicBrowserCommunicator) GetSubscriberData(isBootstrapped bool) (*Su
 		}
 	}
 
+	if data.LatestTimestamp.After(tbc.lastOfferedTimestamp) {
+		tbc.lastOfferedTimestamp = data.LatestTimestamp
+	}
+
 	data.Summary += fmt.Sprintf("%d incremental buffers", len(unsent))
 	tbc.logger.Debugf("TopicBrowserCommunicator: %s", data.Summary)
 
 	return data, nil
 }
 
-// MarkDataAsSent marks data as delivered to subscribers and updates the last sent timestamp
-// This is used for tracking what data has been successfully delivered.
-func (tbc *TopicBrowserCommunicator) MarkDataAsSent(timestamp time.Time) {
+// MarkDataAsSent marks everything handed to subscribers so far as delivered.
+//
+// The timestamp argument is ignored and is removed in the following commit. It
+// cannot be supplied correctly: the only caller is the notify loop, which builds
+// its messages through the status collector and never sees the SubscriberData
+// that knows which buffers went out.
+func (tbc *TopicBrowserCommunicator) MarkDataAsSent(_ time.Time) {
 	tbc.mu.Lock()
 	defer tbc.mu.Unlock()
 
-	// Update the last sent timestamp for tracking purposes
-	if timestamp.After(tbc.lastSentTimestamp) {
-		tbc.lastSentTimestamp = timestamp
-		tbc.logger.Debugf("Marked data as sent up to timestamp: %s", timestamp.Format(time.RFC3339))
+	if tbc.lastOfferedTimestamp.After(tbc.lastSentTimestamp) {
+		tbc.lastSentTimestamp = tbc.lastOfferedTimestamp
+		tbc.logger.Debugf("Marked data as sent up to timestamp: %s", tbc.lastSentTimestamp.Format(time.RFC3339))
 	}
 
 	// Cleanup old pending buffers to prevent memory growth

--- a/umh-core/pkg/communicator/topicbrowser/delivered_watermark_test.go
+++ b/umh-core/pkg/communicator/topicbrowser/delivered_watermark_test.go
@@ -62,13 +62,12 @@ func deliveredTopics(data *topicbrowser.SubscriberData) []string {
 	return names
 }
 
-var _ = Describe("Delivery acknowledgement", func() {
+var _ = Describe("Delivery watermark", func() {
 	It("still delivers a buffer that arrived while a send was in flight, and does not deliver it twice", func() {
 		comm := topicbrowser.NewTopicBrowserCommunicator(zap.NewNop().Sugar())
 
-		// Buffer timestamps are EMISSION times parsed from the benthos log block,
-		// so they always trail wall clock by the pipeline lag. That gap is the
-		// defect: stamping these with time.Now() would not reproduce it.
+		// These must be in the past: the gap between a buffer's emission time and
+		// wall clock is what the defect turns on. See queuedBundle.Timestamp.
 		emittedFirst := time.Now().Add(-10 * time.Second)
 		emittedSecond := time.Now().Add(-5 * time.Second)
 
@@ -83,26 +82,24 @@ var _ = Describe("Delivery acknowledgement", func() {
 		sent, err := comm.GetSubscriberData(true)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(deliveredTopics(sent)).To(ConsistOf("topic-first"),
-			"the first tick must deliver the first buffer, or the rest of this spec is vacuous")
+			"the first tick must deliver the first buffer")
 
-		// The second buffer arrives BEFORE delivery of the first is acknowledged.
+		// The second buffer arrives before the first is marked sent.
 		// Items are oldest-first, so the new buffer is last.
 		_, err = comm.ProcessRealData(createMockObservedStateSnapshot(
 			[]*topicbrowserservice.BufferItem{first, second}))
 		Expect(err).NotTo(HaveOccurred())
 
-		// Acknowledge exactly the way notify() does. The call takes no timestamp,
-		// so this spec cannot accidentally hand it the right answer.
+		// Mark exactly the way notify() does.
 		comm.MarkDataAsSent()
 
 		// Tick 2 must deliver the buffer that arrived in between...
 		sent, err = comm.GetSubscriberData(true)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(deliveredTopics(sent)).To(ContainElement("topic-second"),
-			"a buffer that arrived before the acknowledgement must still be delivered")
+			"a buffer that arrived before the mark must still be delivered")
 
-		// ...and must not re-deliver what tick 1 already sent. Without this, an
-		// implementation that never advances the watermark would pass.
+		// ...and must not re-deliver what tick 1 already sent.
 		Expect(deliveredTopics(sent)).ToNot(ContainElement("topic-first"),
 			"an already-delivered buffer must not be delivered twice")
 	})

--- a/umh-core/pkg/communicator/topicbrowser/delivered_watermark_test.go
+++ b/umh-core/pkg/communicator/topicbrowser/delivered_watermark_test.go
@@ -91,10 +91,9 @@ var _ = Describe("Delivery acknowledgement", func() {
 			[]*topicbrowserservice.BufferItem{first, second}))
 		Expect(err).NotTo(HaveOccurred())
 
-		// Acknowledge exactly the way notify() does, with wall clock. The fix must
-		// make this harmless; passing the correct value here instead would let a
-		// broken implementation pass.
-		comm.MarkDataAsSent(time.Now())
+		// Acknowledge exactly the way notify() does. The call takes no timestamp,
+		// so this spec cannot accidentally hand it the right answer.
+		comm.MarkDataAsSent()
 
 		// Tick 2 must deliver the buffer that arrived in between...
 		sent, err = comm.GetSubscriberData(true)

--- a/umh-core/pkg/communicator/topicbrowser/delivered_watermark_test.go
+++ b/umh-core/pkg/communicator/topicbrowser/delivered_watermark_test.go
@@ -1,0 +1,110 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package topicbrowser_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/proto"
+
+	tbproto "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/communicator/models/topicbrowser/pb"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/communicator/topicbrowser"
+	topicbrowserservice "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/topicbrowser"
+)
+
+// bufferWithTopicAt builds a buffer carrying one identifiable topic. The sequence
+// number is set explicitly because createMockObservedStateSnapshot's fallback
+// counter is a package global shared with every other spec in this suite.
+func bufferWithTopicAt(seq uint64, topic string, ts time.Time) *topicbrowserservice.BufferItem {
+	topicInfo := &tbproto.TopicInfo{Name: topic, Level0: "corpA"}
+	bundle := &tbproto.UnsBundle{
+		UnsMap: &tbproto.TopicMap{
+			Entries: map[string]*tbproto.TopicInfo{
+				topicbrowser.HashUNSTableEntry(topicInfo): topicInfo,
+			},
+		},
+	}
+	payload, err := proto.Marshal(bundle)
+	Expect(err).NotTo(HaveOccurred())
+
+	return &topicbrowserservice.BufferItem{SequenceNum: seq, Payload: payload, Timestamp: ts}
+}
+
+// deliveredTopics decodes every bundle handed to a subscriber and returns the
+// topic names inside, which is how a spec tells one buffer's payload from another.
+func deliveredTopics(data *topicbrowser.SubscriberData) []string {
+	var names []string
+
+	for _, raw := range data.UnsBundles {
+		var decoded tbproto.UnsBundle
+		Expect(proto.Unmarshal(raw, &decoded)).To(Succeed())
+
+		for _, entry := range decoded.GetUnsMap().GetEntries() {
+			names = append(names, entry.GetName())
+		}
+	}
+
+	return names
+}
+
+var _ = Describe("Delivery acknowledgement", func() {
+	It("still delivers a buffer that arrived while a send was in flight, and does not deliver it twice", func() {
+		comm := topicbrowser.NewTopicBrowserCommunicator(zap.NewNop().Sugar())
+
+		// Buffer timestamps are EMISSION times parsed from the benthos log block,
+		// so they always trail wall clock by the pipeline lag. That gap is the
+		// defect: stamping these with time.Now() would not reproduce it.
+		emittedFirst := time.Now().Add(-10 * time.Second)
+		emittedSecond := time.Now().Add(-5 * time.Second)
+
+		first := bufferWithTopicAt(1, "topic-first", emittedFirst)
+		second := bufferWithTopicAt(2, "topic-second", emittedSecond)
+
+		// Tick 1: the first buffer is ingested and handed to a subscriber.
+		_, err := comm.ProcessRealData(createMockObservedStateSnapshot(
+			[]*topicbrowserservice.BufferItem{first}))
+		Expect(err).NotTo(HaveOccurred())
+
+		sent, err := comm.GetSubscriberData(true)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(deliveredTopics(sent)).To(ConsistOf("topic-first"),
+			"the first tick must deliver the first buffer, or the rest of this spec is vacuous")
+
+		// The second buffer arrives BEFORE delivery of the first is acknowledged.
+		// Items are oldest-first, so the new buffer is last.
+		_, err = comm.ProcessRealData(createMockObservedStateSnapshot(
+			[]*topicbrowserservice.BufferItem{first, second}))
+		Expect(err).NotTo(HaveOccurred())
+
+		// Acknowledge exactly the way notify() does, with wall clock. The fix must
+		// make this harmless; passing the correct value here instead would let a
+		// broken implementation pass.
+		comm.MarkDataAsSent(time.Now())
+
+		// Tick 2 must deliver the buffer that arrived in between...
+		sent, err = comm.GetSubscriberData(true)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(deliveredTopics(sent)).To(ContainElement("topic-second"),
+			"a buffer that arrived before the acknowledgement must still be delivered")
+
+		// ...and must not re-deliver what tick 1 already sent. Without this, an
+		// implementation that never advances the watermark would pass.
+		Expect(deliveredTopics(sent)).ToNot(ContainElement("topic-first"),
+			"an already-delivered buffer must not be delivered twice")
+	})
+})


### PR DESCRIPTION
## Problem

The topic browser never sends an increment, so data reaches the UI only once every 10 seconds instead
of as it arrives. After each send umh-core remembers the current time instead of the timestamp of the
data it sent, so everything arriving afterwards looks already-sent and is dropped.

## What we are shipping

* umh-core records the timestamp of the data it sent, so a buffer that arrives while a send is in
  flight is no longer mistaken for one already delivered.
* The topic browser updates as data arrives, instead of once every 10 seconds.
* `MarkDataAsSent` no longer takes a timestamp. No caller could supply a correct one, because the
  value is only known where the data is selected.

## What we are NOT shipping

* Turning off the 10-second full resend. It has a different cause: the browser refreshes its
  subscription every 10 seconds, that message fails to decode, and umh-core then treats the subscriber
  as new and re-sends the whole cache. 
* A limit on how much undelivered data umh-core holds. Today every send marks the whole pending
  queue as delivered, so the queue empties. After this change it keeps what was genuinely not
  delivered, which is the point of the fix, but nothing caps how large that can grow. [ENG-5651](https://linear.app/united-manufacturing-hub/issue/ENG-5651/topic-browser-deliver-every-pending-buffer-exactly-once-per-subscriber).
* Per-subscriber delivery tracking. One record still covers every subscriber, so a subscriber whose
  outbound channel is full is skipped while the record advances for everyone. Ticketed as [ENG-5651](https://linear.app/united-manufacturing-hub/issue/ENG-5651/topic-browser-deliver-every-pending-buffer-exactly-once-per-subscriber).

## Confidence

Measured on a local instance running two builds back to back: this branch, and its merge base with only
`communicator.go` and `subscribers.go` reverted. Same volume, same data source, same open console tab,
about eight minutes per build. The source was a simulator bridge emitting four topics at one message per
second each, so 60 events per minute per topic is the figure to compare against.

The counts were read in the browser from `recentTsEvents`, the 100-point buffer the topic browser chart
draws from. They are not read from umh-core's own logs, which cannot answer this: `logger.go` samples
repeated sub-warning messages to three per ten seconds, and the delivery counter is a constant string.

| | merge base | this branch |
| --- | --- | --- |
| events reaching the UI | 31.4 /min | 57.6 /min |
| coverage of the 60 /min produced | 52% | 96% |
| wall-clock time the 100-point chart spans | 189 s | 103 s |
| median gap between points | 1.02 s | 1.02 s |
| p95 gap | 2.96 s | 1.05 s |
| worst gap | 77.0 s | 2.96 s |
| gaps over 3 s | 4 to 5 per 100 points | 0 |
| topic browser errors | 0 | 0 |

Two results are worth separating. About half the events never reached the browser at all, so this is
lost data rather than late data. And the typical update was already prompt on both builds, since the
median gap is the same 1.02 s either way. What the fix removes is the tail, where the view could sit
still for over a minute while data kept flowing.

The chart gives no sign of this, which is why it was easy to miss. The buffer holds its last 100 points
whatever the arrival rate, so before the fix it looked like an ordinary chart while spanning three
minutes of history instead of one, with a 77-second hole inside it.

Caveat: one run per build, on a four-topic simulator in a two-CPU container. The figures show the size
of the effect, not a constant.
