### PR TITLE
fix(edit-pc): compare the deploy check against the scanned host, not only the port

### DIFF
--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Editing a bridge's connection to a port that does not answer now fails and restores the previous configuration, instead of reporting a successful deploy. The deploy waits for a scan that finds the new port open, so a port that is closed or filtered is no longer accepted
+- Repointing a bridge to a different host on the same port is now checked too. The deploy waits for a scan taken after the change, so the previous host's scan can no longer satisfy it
 
 ## [0.44.34]
 

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter.go
@@ -581,6 +581,11 @@ func (a *EditProtocolConverterAction) awaitRollout(previousConfig config.Protoco
 		// consecutive identical failures instead of burning the full timeout.
 		prevRenderErrMsg     string
 		identicalRenderFails int
+
+		// currentStateReason holds what the most recent tick was waiting for. The
+		// timeout branch reads it, so a rollback message names the half that never
+		// arrived instead of only saying the bridge did not become active.
+		currentStateReason string
 	)
 
 	const maxIdenticalRenderFails = 3
@@ -604,6 +609,10 @@ func (a *EditProtocolConverterAction) awaitRollout(previousConfig config.Protoco
 			}
 
 			stateMessage := fmt.Sprintf("Bridge '%s' edit timeout reached. It did not become %s in time. Rolled back to previous configuration", a.name, desiredPCState)
+			if currentStateReason != "" {
+				stateMessage += fmt.Sprintf(" (last check: %s)", currentStateReason)
+			}
+
 			if a.lastRenderErr != nil {
 				stateMessage += fmt.Sprintf(" (root cause: %v)", a.lastRenderErr)
 			}
@@ -660,7 +669,7 @@ func (a *EditProtocolConverterAction) awaitRollout(previousConfig config.Protoco
 				}
 
 				found = true
-				currentStateReason := "current state: " + instance.CurrentState
+				currentStateReason = "current state: " + instance.CurrentState
 
 				if a.dfcType == DFCTypeEmpty {
 					// Unreachable today: applyMutation forces the bridge to

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter.go
@@ -562,24 +562,12 @@ func (a *EditProtocolConverterAction) awaitRollout(previousConfig config.Protoco
 	// the two would never match, burn the whole timeout and roll back a healthy
 	// edit.
 	//
-	// A render failure falls back to the payload endpoint and is recorded in
-	// lastRenderErr so the timeout message names the real cause: the agent
-	// renders the same spec, so a spec that fails here cannot roll out either.
-	wantTarget := a.connectionIP
-	wantPort := a.connectionPort
-
-	if a.dfcType == DFCTypeEmpty && desiredPCState != protocolconverter.OperationalStateStopped {
-		resolved, renderErr := a.resolvedConnectionEndpoint(newSpec)
-		if renderErr != nil {
-			a.actionLogger.Warnf("Failed to resolve the connection endpoint for the rollout gate, falling back to the payload endpoint %s:%s: %v", a.connectionIP, a.connectionPort, renderErr)
-			a.lastRenderErr = renderErr
-		} else {
-			wantTarget = resolved.Target
-			wantPort = strconv.FormatUint(uint64(resolved.Port), 10)
-		}
-	}
-
-	wantEndpoint := wantTarget + ":" + wantPort
+	// The endpoint is resolved on every tick rather than once up front. Reading
+	// the config can fail transiently, and a single failure used to fall back to
+	// the payload endpoint — which for a templated bridge is an unresolved target
+	// on port 0, an endpoint no scan can ever match, so a healthy edit waited out
+	// the whole timeout and rolled back. Resolving per tick lets a transient
+	// failure heal; a deterministic one repeats and the timeout message names it.
 
 	var (
 		logs     []s6.LogEntry
@@ -686,6 +674,25 @@ func (a *EditProtocolConverterAction) awaitRollout(previousConfig config.Protoco
 					// because a stopped bridge stops its nmap service too and
 					// would never report the new port.
 					if desiredPCState != protocolconverter.OperationalStateStopped {
+						resolved, renderErr := a.resolvedConnectionEndpoint(newSpec)
+						if renderErr != nil {
+							a.lastRenderErr = renderErr
+							currentStateReason = "waiting to resolve the bridge's connection endpoint"
+							SendActionReply(
+								a.instanceUUID,
+								a.userEmail,
+								a.actionUUID,
+								models.ActionExecuting,
+								RemainingPrefixSec(remainingSeconds)+currentStateReason,
+								a.outboundChannel,
+								models.EditProtocolConverter,
+							)
+
+							continue
+						}
+
+						wantEndpoint := resolved.Target + ":" + strconv.FormatUint(uint64(resolved.Port), 10)
+
 						nmapObs := pcSnapshot.ServiceInfo.ConnectionObservedState.ServiceInfo.NmapObservedState
 						scannedEndpoint := nmapObs.ObservedNmapServiceConfig.Target + ":" +
 							strconv.FormatUint(uint64(nmapObs.ObservedNmapServiceConfig.Port), 10)

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter.go
@@ -46,6 +46,7 @@ import (
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/dataflowcomponentserviceconfig"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/nmapserviceconfig"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/protocolconverterserviceconfig"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
@@ -542,29 +543,34 @@ func (a *EditProtocolConverterAction) awaitRollout(previousConfig config.Protoco
 	startTime := time.Now()
 	timeoutDuration := timeoutInterval
 
-	// wantConnectionPort is the port the nmap gate below requires the scan to
-	// have dialed and found open. It is rendered from the spec this edit just
-	// persisted, not taken from the action payload: a bridge whose connection is
-	// templated resolves its endpoint only at render time. A historian bridge
-	// scans {{ .historian.timescale.host }}:{{ .historian.timescale.port }} and
-	// keeps no IP/PORT user variables, so its payload carries an unresolved
-	// target and port 0 while the scan dials the resolved port — comparing the
-	// two would never match, burn the whole timeout and roll back a healthy edit.
+	// wantTarget and wantPort are the host and port the nmap gate below requires
+	// the scan to have dialed and found open. They are rendered from the spec
+	// this edit just persisted, not taken from the action payload: a bridge whose
+	// connection is templated resolves its endpoint only at render time. A
+	// historian bridge scans {{ .historian.timescale.host }}:{{ .historian.timescale.port }}
+	// and keeps no IP/PORT user variables, so its payload carries an unresolved
+	// target and port 0 while the scan dials the resolved endpoint — comparing
+	// the two would never match, burn the whole timeout and roll back a healthy
+	// edit.
 	//
-	// A render failure falls back to the payload port and is recorded in
+	// A render failure falls back to the payload endpoint and is recorded in
 	// lastRenderErr so the timeout message names the real cause: the agent
 	// renders the same spec, so a spec that fails here cannot roll out either.
-	wantConnectionPort := a.connectionPort
+	wantTarget := a.connectionIP
+	wantPort := a.connectionPort
 
 	if a.dfcType == DFCTypeEmpty && desiredPCState != protocolconverter.OperationalStateStopped {
-		resolvedPort, renderErr := a.resolvedConnectionPort(newSpec)
+		resolved, renderErr := a.resolvedConnectionEndpoint(newSpec)
 		if renderErr != nil {
-			a.actionLogger.Warnf("Failed to resolve the connection endpoint for the rollout gate, falling back to the payload port %s: %v", a.connectionPort, renderErr)
+			a.actionLogger.Warnf("Failed to resolve the connection endpoint for the rollout gate, falling back to the payload endpoint %s:%s: %v", a.connectionIP, a.connectionPort, renderErr)
 			a.lastRenderErr = renderErr
 		} else {
-			wantConnectionPort = resolvedPort
+			wantTarget = resolved.Target
+			wantPort = strconv.FormatUint(uint64(resolved.Port), 10)
 		}
 	}
+
+	wantEndpoint := wantTarget + ":" + wantPort
 
 	var (
 		logs     []s6.LogEntry
@@ -663,10 +669,8 @@ func (a *EditProtocolConverterAction) awaitRollout(previousConfig config.Protoco
 					// would never report the new port.
 					if desiredPCState != protocolconverter.OperationalStateStopped {
 						nmapObs := pcSnapshot.ServiceInfo.ConnectionObservedState.ServiceInfo.NmapObservedState
-						nmapPort := strconv.FormatUint(
-							uint64(nmapObs.ObservedNmapServiceConfig.Port),
-							10,
-						)
+						scannedEndpoint := nmapObs.ObservedNmapServiceConfig.Target + ":" +
+							strconv.FormatUint(uint64(nmapObs.ObservedNmapServiceConfig.Port), 10)
 
 						// Port equality alone cannot tell a live port from a
 						// refused one, so require the scan to report open. Do not
@@ -676,8 +680,12 @@ func (a *EditProtocolConverterAction) awaitRollout(previousConfig config.Protoco
 						portIsOpen := nmapObs.ServiceInfo.NmapStatus.LastScan != nil &&
 							nmapObs.ServiceInfo.NmapStatus.LastScan.PortResult.State == string(nmapservice.PortStateOpen)
 
-						if nmapPort != wantConnectionPort {
-							currentStateReason = "waiting for nmap to connect to port " + wantConnectionPort
+						// Both halves must match. The port alone accepts a move
+						// to a different host on the same port: the number
+						// agrees, the old host's scan says that port is open,
+						// and nothing has dialed the new host (ENG-5586).
+						if scannedEndpoint != wantEndpoint {
+							currentStateReason = "waiting for nmap to scan " + wantEndpoint
 							SendActionReply(
 								a.instanceUUID,
 								a.userEmail,
@@ -697,7 +705,7 @@ func (a *EditProtocolConverterAction) awaitRollout(previousConfig config.Protoco
 								lastState = nmapObs.ServiceInfo.NmapStatus.LastScan.PortResult.State
 							}
 
-							currentStateReason = "waiting for nmap to report port " + wantConnectionPort + " open (last scan: " + lastState + ")"
+							currentStateReason = "waiting for nmap to report " + wantEndpoint + " open (last scan: " + lastState + ")"
 							SendActionReply(
 								a.instanceUUID,
 								a.userEmail,
@@ -1194,15 +1202,15 @@ func (a *EditProtocolConverterAction) mergeUserVariables(base map[string]any, in
 	return merged
 }
 
-// resolvedConnectionPort renders the connection template of the just-persisted
-// spec and returns the port the nmap scan is expected to dial, as the decimal
-// string the observed scan config is compared against.
+// resolvedConnectionEndpoint renders the connection template of the
+// just-persisted spec and returns the endpoint the nmap scan is expected to
+// dial, in the same type the observed scan config carries.
 //
 // It renders with the same inputs the agent uses — the persisted spec (which
 // already carries the edit's merged variables), the agent location and the
-// historian section read from the config manager — so the port returned here is
-// the port the control loop will make the scanner dial.
-func (a *EditProtocolConverterAction) resolvedConnectionPort(newSpec protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec) (string, error) {
+// historian section read from the config manager — so the endpoint returned
+// here is the endpoint the control loop will make the scanner dial.
+func (a *EditProtocolConverterAction) resolvedConnectionEndpoint(newSpec protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec) (nmapserviceconfig.NmapServiceConfig, error) {
 	systemSnapshot := a.systemSnapshotManager.GetDeepCopySnapshot()
 	agentLocation := convertIntMapToStringMap(systemSnapshot.CurrentConfig.Agent.Location)
 
@@ -1213,7 +1221,7 @@ func (a *EditProtocolConverterAction) resolvedConnectionPort(newSpec protocolcon
 
 	currentConfig, err := a.configManager.GetConfig(ctx, 0)
 	if err != nil {
-		return "", fmt.Errorf("failed to read current config for historian variables: %w", err)
+		return nmapserviceconfig.NmapServiceConfig{}, fmt.Errorf("failed to read current config for historian variables: %w", err)
 	}
 
 	runtimeConfig, err := runtime_config.BuildRuntimeConfig(
@@ -1225,13 +1233,10 @@ func (a *EditProtocolConverterAction) resolvedConnectionPort(newSpec protocolcon
 		a.name,
 	)
 	if err != nil {
-		return "", fmt.Errorf("failed to build runtime config: %w", err)
+		return nmapserviceconfig.NmapServiceConfig{}, fmt.Errorf("failed to build runtime config: %w", err)
 	}
 
-	return strconv.FormatUint(
-		uint64(runtimeConfig.ConnectionServiceConfig.NmapServiceConfig.Port),
-		10,
-	), nil
+	return runtimeConfig.ConnectionServiceConfig.NmapServiceConfig, nil
 }
 
 // renderDesiredDFCConfig renders the template variables in the desired DFC config

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter.go
@@ -167,6 +167,13 @@ type EditProtocolConverterAction struct {
 	// Atomic edit UUID used for configuration updates and rollbacks
 	atomicEditUUID uuid.UUID
 
+	// persistedAt is when the edit reached config.yaml. The rollout gate needs
+	// it because a scan is only evidence about the new endpoint if it started
+	// after the config changed: nmap's observed endpoint is re-read from the
+	// generated scan script, which is rewritten at persist time, so it names the
+	// new endpoint several ticks before anything dials it.
+	persistedAt time.Time
+
 	// rolloutSentryReported tells Execute to skip the generic rollout_failed
 	// Sentry event for this abort. Every awaitRollout abort path fires its own
 	// dedicated event; only the render-failure paths (added for ENG-5103) set
@@ -480,6 +487,8 @@ func (a *EditProtocolConverterAction) persistConfig(atomicEditUUID uuid.UUID, ne
 		return config.ProtocolConverterConfig{}, fmt.Errorf("failed to update protocol converter: %w", err)
 	}
 
+	a.persistedAt = time.Now()
+
 	// deep copy the old config therefore setup a full config
 	// this may seem hacky but like that we can reuse the Clone() function
 	// and we do not need to implement a custom Clone() function for the ProtocolConverterConfig
@@ -686,8 +695,10 @@ func (a *EditProtocolConverterAction) awaitRollout(previousConfig config.Protoco
 						// use IsRunning: it means the port accepted the connection
 						// on fsmv2 and "the scanner process is up" on fsmv1, so on
 						// fsmv1 it is true for a port that never answered.
-						portIsOpen := nmapObs.ServiceInfo.NmapStatus.LastScan != nil &&
-							nmapObs.ServiceInfo.NmapStatus.LastScan.PortResult.State == string(nmapservice.PortStateOpen)
+						lastScan := nmapObs.ServiceInfo.NmapStatus.LastScan
+						scanIsPostEdit := lastScan != nil && lastScan.Timestamp.After(a.persistedAt)
+						portIsOpen := lastScan != nil &&
+							lastScan.PortResult.State == string(nmapservice.PortStateOpen)
 
 						// Both halves must match. The port alone accepts a move
 						// to a different host on the same port: the number
@@ -695,6 +706,27 @@ func (a *EditProtocolConverterAction) awaitRollout(previousConfig config.Protoco
 						// and nothing has dialed the new host (ENG-5586).
 						if scannedEndpoint != wantEndpoint {
 							currentStateReason = "waiting for nmap to scan " + wantEndpoint
+							SendActionReply(
+								a.instanceUUID,
+								a.userEmail,
+								a.actionUUID,
+								models.ActionExecuting,
+								RemainingPrefixSec(remainingSeconds)+currentStateReason,
+								a.outboundChannel,
+								models.EditProtocolConverter,
+							)
+
+							continue
+						}
+
+						// The observed endpoint is re-read from the generated
+						// scan script, which is rewritten when the edit is
+						// persisted, so it names the new endpoint before the
+						// scanner has been rebuilt and dialed it. Requiring the
+						// scan to have started after the persist is what makes
+						// the endpoint match evidence rather than an echo.
+						if !scanIsPostEdit {
+							currentStateReason = "waiting for a scan of " + wantEndpoint + " taken after the edit"
 							SendActionReply(
 								a.instanceUUID,
 								a.userEmail,

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter_awaitrollout_test.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter_awaitrollout_test.go
@@ -295,6 +295,19 @@ var _ = Describe("EditProtocolConverter awaitRollout (rollout gate)", func() {
 			"a filtered port is down by the connection FSM's own definition and must not report success")
 	})
 
+	It("reports failure when the only open port on record belongs to the previous host", func() {
+		// ENG-5586. The gate compared the port number and nothing else. So
+		// repointing a bridge from one host to another on the same port was
+		// accepted by the OLD host's scan: the number matches, that port is
+		// open, and nothing has dialled the new host. If the new host refuses
+		// the connection the edit still reported success.
+		stageSnapshot("dest.example.com", "src.example.com", protocolconverter.OperationalStateStartingFailedDFCMissing, string(nmapsvc.PortStateOpen))
+
+		_, err := runAwaitRollout("dest.example.com")
+		Expect(err).To(HaveOccurred(),
+			"an open port on the previous host must not be reported as a successful rollout of the new one")
+	})
+
 	Describe("a bridge whose connection is templated", func() {
 		// A bridge that writes to the historian scans the shared
 		// historian.timescale endpoint, so its connection template carries no

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter_awaitrollout_test.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter_awaitrollout_test.go
@@ -68,7 +68,11 @@ var _ = Describe("EditProtocolConverter awaitRollout (rollout gate)", func() {
 	// awaitRollout must treat differently. Staging the scanned port separately
 	// from the payload port is what lets a test stage a templated connection,
 	// whose resolved port is not the one the payload carries.
-	stageSnapshotOnPort := func(desiredTarget string, observedTarget string, pcState string, portState string, scannedPort uint16) {
+	// stageSnapshotOnPort stamps the staged scan ahead of the edit, because a
+	// spec stages its snapshot before Execute persists the config and the gate
+	// requires a scan taken after that persist. stageSnapshotScannedAt takes the
+	// scan time explicitly, for specs about a scan that predates the edit.
+	stageSnapshotScannedAt := func(desiredTarget string, observedTarget string, pcState string, portState string, scannedPort uint16, scannedAt time.Time) {
 		observed := &protocolconverter.ProtocolConverterObservedStateSnapshot{
 			ServiceInfo: protocolconvertersvc.ServiceInfo{
 				ConnectionObservedState: connfsm.ConnectionObservedState{
@@ -87,6 +91,7 @@ var _ = Describe("EditProtocolConverter awaitRollout (rollout gate)", func() {
 							ServiceInfo: nmapsvc.ServiceInfo{
 								NmapStatus: nmapsvc.NmapServiceInfo{
 									LastScan: &nmapsvc.NmapScanResult{
+										Timestamp: scannedAt,
 										PortResult: nmapsvc.PortResult{
 											State: portState,
 											Port:  scannedPort,
@@ -113,6 +118,10 @@ var _ = Describe("EditProtocolConverter awaitRollout (rollout gate)", func() {
 				},
 			},
 		})
+	}
+
+	stageSnapshotOnPort := func(desiredTarget string, observedTarget string, pcState string, portState string, scannedPort uint16) {
+		stageSnapshotScannedAt(desiredTarget, observedTarget, pcState, portState, scannedPort, time.Now().Add(time.Minute))
 	}
 
 	// stageSnapshot stages a scan of the port the payload asks for, the case
@@ -225,6 +234,27 @@ var _ = Describe("EditProtocolConverter awaitRollout (rollout gate)", func() {
 		_, err := runAwaitRollout("dest.example.com")
 		Expect(err).To(HaveOccurred(),
 			"a scanned-but-closed port must not be reported as a successful rollout")
+	})
+
+	It("reports failure when the only open scan on record predates the edit", func() {
+		// nmap's observed endpoint is re-read from the generated scan script,
+		// which is rewritten when the edit is persisted, so it names the new
+		// endpoint before the scanner has been rebuilt and dialed it. Staging an
+		// open scan from before the edit reproduces that window: both halves of
+		// the endpoint match and the scan says open, yet nothing has dialed the
+		// new endpoint.
+		stageSnapshotScannedAt(
+			"dest.example.com",
+			"dest.example.com",
+			protocolconverter.OperationalStateStartingFailedDFCMissing,
+			string(nmapsvc.PortStateOpen),
+			port,
+			time.Now().Add(-time.Hour),
+		)
+
+		_, err := runAwaitRollout("dest.example.com")
+		Expect(err).To(HaveOccurred(),
+			"a scan taken before the edit is not evidence about the new endpoint")
 	})
 
 	It("reports failure when the scanner is running but the port is not open", func() {

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter_awaitrollout_test.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter_awaitrollout_test.go
@@ -306,6 +306,11 @@ var _ = Describe("EditProtocolConverter awaitRollout (rollout gate)", func() {
 		_, err := runAwaitRollout("dest.example.com")
 		Expect(err).To(HaveOccurred(),
 			"an open port on the previous host must not be reported as a successful rollout of the new one")
+		// A bare HaveOccurred() would also be satisfied by a timeout for any other
+		// reason, so it cannot tell this spec passing from this spec passing by
+		// accident. The rollback message names what the last tick was waiting for.
+		Expect(err.Error()).To(ContainSubstring("waiting for nmap to scan dest.example.com"),
+			"the rollout must have timed out on the host comparison, not on something else")
 	})
 
 	Describe("a bridge whose connection is templated", func() {


### PR DESCRIPTION
> **Superseded — these five commits now sit in #2708.** The stack was recut so the
> connection gate lands as one PR (observed truth, host and port comparison, post-edit
> scan) instead of two, because #2716's ENG-5580 spec cannot detect a target-only change
> without the host comparison added here. Nothing is dropped: `git log staging..eng-5579-nmap-observed-config`
> contains every commit that was on this branch. ENG-5586 is delivered by #2708.

## Problem

`awaitRollout` compares the scanned port against the requested port. It never reads the host.

So moving a bridge from `google.com:443` to `abc.com:443` is accepted immediately: the port matches, the old scan says that port is open, and nothing ever dials the new host. If `abc.com` is unreachable the deploy still reports success.

Comparing the host is necessary but not sufficient, and this is the part review turned up. nmap's observed endpoint is re-read from the generated scan script, and that script is rewritten when the edit is persisted — so the observed endpoint names the new host several ticks before the scanner has been rebuilt and dialled it. On a host-only change the port never moves, so both halves of the comparison match while the newest scan on record is still the previous host's. The gate could pass on tick 1, on entirely pre-edit state.

Not new, and not FSMv2-specific. The check has always been port-only. The previous PR in the stack makes it reachable in more cases, which is why it is worth closing now.

## What we are shipping

- The host is compared alongside the port, so a bridge repointed to a host that does not answer fails the deploy and rolls back.
- The scan must have started after the edit was persisted. The action records when the config was written and the gate requires `LastScan.Timestamp` to postdate it, which is what makes an endpoint match evidence rather than an echo of the rewritten script. fsmv1 already reports a real scan time, parsed from the scan's own output; ENG-5579 gives fsmv2 one.
- The connection endpoint is resolved on every tick instead of once up front. Reading the config can fail transiently, and a single failure used to fall back to the payload endpoint — an unresolved target on port 0 for a templated bridge, which no scan can match, so a healthy edit waited out the timeout and rolled back.
- A rollback on timeout names what the deploy was still waiting for.

Removing the post-edit requirement reddens exactly one spec, the one that stages an open scan from before the edit.

## What we are NOT shipping

- Config identity. A timestamp is a proxy for "does this observation belong to the current config"; the underlying gap is that observations carry no config identity at all, which is the framework work in ENG-5580's ticket.
- On the default backend the deeper cause is untouched: an `ErrServiceNotExist` tick leaves the previous observed state in the snapshot rather than clearing it (`pkg/fsm/nmap/actions.go`). The freshness requirement is what stops that stale state satisfying the gate; clearing it would flap every bridge to degraded on any legitimate service re-create, so it needs its own change.
- Still only bridges with no flows. A bridge with a read flow takes a different branch. ENG-5580.

Fixes ENG-5586

