### PR TITLE
fix(edit-pc): run the deploy connection check for every bridge, not only flowless ones

### DIFF
--- a/umh-core/pkg/communicator/actions/edit-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter.go
@@ -643,27 +643,32 @@ func (a *EditProtocolConverterAction) awaitRollout(
 				found = true
 				currentStateReason = "current state: " + instance.CurrentState
 
-				if a.dfcType == DFCTypeEmpty {
-					// Unreachable while applyMutation forces the bridge active.
-					// Kept because a stopped bridge stops its nmap service and
-					// would never report the new port.
-					if desiredPCState != protocolconverter.OperationalStateStopped {
-						if waitingFor := a.connectionCheckWait(rolloutConfig, pcSnapshot); waitingFor != "" {
-							currentStateReason = waitingFor
-							SendActionReply(
-								a.instanceUUID,
-								a.userEmail,
-								a.actionUUID,
-								models.ActionExecuting,
-								RemainingPrefixSec(remainingSeconds)+currentStateReason,
-								a.outboundChannel,
-								models.EditProtocolConverter,
-							)
+				// Runs before the DFC config comparison below, so a bridge whose target
+				// was never dialed is reported as a connection problem rather than a
+				// dataflow component one.
+				//
+				// An edit that carries no connection is exempt, so a bridge whose
+				// target is unreachable stays editable, including the edit that stops
+				// its flows. get-protocolconverter fills Connection.IP from the
+				// deployed spec, so a console edit may never hit that (ENG-5858).
+				if a.connectionIP != "" {
+					if waitingFor := a.connectionCheckWait(rolloutConfig, pcSnapshot); waitingFor != "" {
+						currentStateReason = waitingFor
+						SendActionReply(
+							a.instanceUUID,
+							a.userEmail,
+							a.actionUUID,
+							models.ActionExecuting,
+							RemainingPrefixSec(remainingSeconds)+currentStateReason,
+							a.outboundChannel,
+							models.EditProtocolConverter,
+						)
 
-							continue
-						}
+						continue
 					}
+				}
 
+				if a.dfcType == DFCTypeEmpty {
 					// Check if the protocol converter has reached the desired state
 					hasReachedDesiredState := false
 

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter_awaitrollout_test.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter_awaitrollout_test.go
@@ -582,10 +582,10 @@ var _ = Describe("EditProtocolConverter awaitRollout (connection check)", func()
 		// as open. Correct behaviour is to withhold acceptance until the requested
 		// target has actually been scanned.
 		//
-		// Today this FAILS: the read branch reads only CurrentState, so it accepts
-		// on the first tick against the pre-edit snapshot. That failure is the
-		// point — it is the deterministic form of a race the container harness
-		// reproduces only intermittently, and it depends on no log capture.
+		// Without the check above the DFC comparison, the read branch reads only
+		// CurrentState and accepts on the first tick against the pre-edit
+		// snapshot. This is the deterministic form of a race the container
+		// harness reproduces only intermittently, and it needs no log capture.
 		stageReadDFCSnapshot("dest.example.com", "src.example.com", protocolconverter.OperationalStateActive, string(nmapservice.PortStateOpen))
 
 		elapsed, err, replies := runAwaitRolloutRead("dest.example.com")
@@ -603,9 +603,9 @@ var _ = Describe("EditProtocolConverter awaitRollout (connection check)", func()
 		// PLACEMENT GUARD. The spec above cannot tell where the connection check
 		// sits: staged below the DFC config comparison it would still pass, because
 		// that comparison matches in that spec's case and the check then runs
-		// anyway. This spec stages the case that separates the two positions — the
+		// anyway. This spec stages the case that separates the two positions: the
 		// observed read DFC has not started (nil Input, which the comparison reads
-		// as "Benthos is still starting") AND the scan still shows the previous
+		// as "Benthos is still starting") and the scan still shows the previous
 		// target.
 		//
 		// With the connection check above the comparison, the operator is told the
@@ -627,7 +627,7 @@ var _ = Describe("EditProtocolConverter awaitRollout (connection check)", func()
 				},
 			},
 			ServiceInfo: protocolconvertersvc.ServiceInfo{
-				ConnectionObservedState:       observedConnection("dest.example.com", "src.example.com", string(nmapsvc.PortStateOpen), port, time.Now().Add(time.Minute)),
+				ConnectionObservedState:       observedConnection("dest.example.com", "src.example.com", "src.example.com", string(nmapservice.PortStateOpen), port, time.Now().Add(time.Minute)),
 				DataflowComponentReadFSMState: protocolconverter.OperationalStateActive,
 			},
 		})
@@ -635,7 +635,7 @@ var _ = Describe("EditProtocolConverter awaitRollout (connection check)", func()
 		_, err, replies := runAwaitRolloutRead("dest.example.com")
 
 		Expect(err).To(HaveOccurred(), "neither the scan nor the dataflow component has caught up")
-		Expect(replies).To(ContainElement(ContainSubstring("waiting for nmap to scan dest.example.com")),
+		Expect(replies).To(ContainElement(ContainSubstring("checking dest.example.com:445")),
 			"the connection check must run before the dataflow component comparison, or a bridge whose "+
 				"target was never dialed is reported as a dataflow component problem")
 	})
@@ -646,10 +646,10 @@ var _ = Describe("EditProtocolConverter awaitRollout (connection check)", func()
 		// the connection: otherwise a bridge whose target is unreachable can never
 		// be edited at all, including the edit that stops its flows.
 		//
-		// The scan here still shows the PREVIOUS target — the same staging the
-		// ENG-5580 spec above rejects. The only difference is that this payload
+		// The scan here still shows the previous target, the same staging the
+		// read-path spec above rejects. The only difference is that this payload
 		// carries no connection.
-		stageReadDFCSnapshot("dest.example.com", "src.example.com", protocolconverter.OperationalStateActive, string(nmapsvc.PortStateOpen))
+		stageReadDFCSnapshot("dest.example.com", "src.example.com", protocolconverter.OperationalStateActive, string(nmapservice.PortStateOpen))
 
 		elapsed, err, replies := runAwaitRolloutRead("")
 

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter_awaitrollout_test.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter_awaitrollout_test.go
@@ -520,6 +520,24 @@ var _ = Describe("EditProtocolConverter awaitRollout (connection check)", func()
 		_, _, err := a.Execute()
 		elapsed := time.Since(start)
 
+		// ConsumeOutboundMessages appends to msgs on its own goroutine, so a reply
+		// the action sent just before Execute returned may not have arrived yet.
+		// Wait until it stops appending before snapshotting. Without this a spec
+		// asserting a reply is PRESENT flakes under load, and, worse, a spec
+		// asserting a reply is ABSENT passes vacuously.
+		prev := -1
+
+		Eventually(func() bool {
+			mu.Lock()
+			n := len(msgs)
+			mu.Unlock()
+
+			settled := n == prev
+			prev = n
+
+			return settled
+		}, "3s", "50ms").Should(BeTrue(), "the reply consumer never stopped appending")
+
 		mu.Lock()
 		defer mu.Unlock()
 

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter_awaitrollout_test.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter_awaitrollout_test.go
@@ -541,7 +541,7 @@ var _ = Describe("EditProtocolConverter awaitRollout (connection check)", func()
 		mu.Lock()
 		defer mu.Unlock()
 
-		// The replies are the only record of WHETHER the gate accepted and on
+		// The replies are the only record of WHETHER the check accepted and on
 		// which tick, so they are decoded to text rather than counted.
 		out := make([]string, 0, len(msgs))
 
@@ -560,7 +560,7 @@ var _ = Describe("EditProtocolConverter awaitRollout (connection check)", func()
 	It("POSITIVE CONTROL: a read-DFC edit whose scan has caught up is accepted", func() {
 		// Establishes that this harness can reach the read path's acceptance at
 		// all. Without it the next spec's "was not accepted" could be satisfied by
-		// the DFC config comparison blocking the gate for an unrelated reason, and
+		// the DFC config comparison blocking the check for an unrelated reason, and
 		// would pass while proving nothing. The two specs differ in exactly one
 		// value: the observed nmap target.
 		stageReadDFCSnapshot("dest.example.com", "dest.example.com", protocolconverter.OperationalStateActive, string(nmapservice.PortStateOpen))
@@ -571,7 +571,7 @@ var _ = Describe("EditProtocolConverter awaitRollout (connection check)", func()
 		Expect(replies).To(ContainElement(ContainSubstring("read DFC configuration verified")),
 			"the read path's acceptance must be reachable in this harness, or the next spec proves nothing")
 		Expect(elapsed).To(BeNumerically("<", 4*time.Second),
-			"against a 6s budget: a gate that withholds acceptance from a healthy read-DFC edit is worse "+
+			"against a 6s budget: a check that withholds acceptance from a healthy read-DFC edit is worse "+
 				"than the bug it replaces, so this must not creep towards the timeout")
 	})
 

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter_awaitrollout_test.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter_awaitrollout_test.go
@@ -487,10 +487,6 @@ var _ = Describe("EditProtocolConverter awaitRollout (connection check)", func()
 		payload := map[string]interface{}{
 			"name": probeName,
 			"uuid": probeUUID.String(),
-			"connection": map[string]interface{}{
-				"ip":   ip,
-				"port": port,
-			},
 			"readDFC": map[string]interface{}{
 				"state": "active",
 				"inputs": map[string]interface{}{
@@ -509,6 +505,12 @@ var _ = Describe("EditProtocolConverter awaitRollout (connection check)", func()
 				},
 			},
 		}
+		// An empty ip stands for "the payload carried no connection block at all",
+		// which is what an edit that only changes a flow looks like.
+		if ip != "" {
+			payload["connection"] = map[string]interface{}{"ip": ip, "port": port}
+		}
+
 		Expect(a.Parse(payload)).To(Succeed())
 		Expect(a.Validate()).To(Succeed())
 		Expect(a.GetDFCType()).To(Equal("read"),
@@ -545,23 +547,17 @@ var _ = Describe("EditProtocolConverter awaitRollout (connection check)", func()
 		// value: the observed nmap target.
 		stageReadDFCSnapshot("dest.example.com", "dest.example.com", protocolconverter.OperationalStateActive, string(nmapservice.PortStateOpen))
 
-		_, err, replies := runAwaitRolloutRead("dest.example.com")
+		elapsed, err, replies := runAwaitRolloutRead("dest.example.com")
 
 		Expect(err).NotTo(HaveOccurred(), "a read-DFC edit whose scan agrees with the request must be accepted")
 		Expect(replies).To(ContainElement(ContainSubstring("read DFC configuration verified")),
 			"the read path's acceptance must be reachable in this harness, or the next spec proves nothing")
+		Expect(elapsed).To(BeNumerically("<", 4*time.Second),
+			"against a 6s budget: a gate that withholds acceptance from a healthy read-DFC edit is worse "+
+				"than the bug it replaces, so this must not creep towards the timeout")
 	})
 
-	// PENDING (XIt) because it reproduces ENG-5580 and therefore fails on today's
-	// code: it asserts the behaviour the fix must introduce, so it cannot be left
-	// enabled without a red suite. The fix that makes the read branch withhold
-	// acceptance until the requested target has been scanned must flip this back to
-	// It — a fix that leaves it pending has not been verified against the bug.
-	// Verified red before it was marked pending: the run reported the reply
-	// "bridge successfully activated with state 'active', read DFC configuration
-	// verified", i.e. it failed because the edit was ACCEPTED, not because of a
-	// timeout or a render failure.
-	XIt("does not accept a read-DFC edit while the scan still shows the previous target", func() {
+	It("does not accept a read-DFC edit while the scan still shows the previous target", func() {
 		// The reported bug (ENG-5580), in-process and deterministic. The bridge is
 		// edited to dest.example.com; the protocolconverter still carries its
 		// pre-edit CurrentState of active, and the scan still shows the OLD target
@@ -583,5 +579,65 @@ var _ = Describe("EditProtocolConverter awaitRollout (connection check)", func()
 			"an edit must not report success before the requested target has been scanned")
 		Expect(elapsed).To(BeNumerically(">", time.Second),
 			"acceptance on the first tick means the pre-edit snapshot was taken as evidence about the new config")
+	})
+
+	It("names the stale scan, not the dataflow component, when neither has caught up", func() {
+		// PLACEMENT GUARD. The spec above cannot tell where the connection check
+		// sits: staged below the DFC config comparison it would still pass, because
+		// that comparison matches in that spec's case and the check then runs
+		// anyway. This spec stages the case that separates the two positions — the
+		// observed read DFC has not started (nil Input, which the comparison reads
+		// as "Benthos is still starting") AND the scan still shows the previous
+		// target.
+		//
+		// With the connection check above the comparison, the operator is told the
+		// scan has not caught up. Below it, the comparison's own wait returns first
+		// and the scan is never mentioned, so the reply blames the dataflow
+		// component for a connection that was never dialed.
+		publish(protocolconverter.OperationalStateActive, &protocolconverter.ProtocolConverterObservedStateSnapshot{
+			ObservedProtocolConverterSpecConfig: protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec{
+				Config: protocolconverterserviceconfig.ProtocolConverterServiceConfigTemplate{
+					ConnectionServiceConfig: connectionserviceconfig.ConnectionServiceConfigTemplate{
+						NmapTemplate: &connectionserviceconfig.NmapConfigTemplate{
+							Target: "{{ .IP }}",
+							Port:   "{{ .PORT }}",
+						},
+					},
+				},
+				Variables: variables.VariableBundle{
+					User: map[string]interface{}{"IP": "src.example.com", "PORT": "443"},
+				},
+			},
+			ServiceInfo: protocolconvertersvc.ServiceInfo{
+				ConnectionObservedState:       observedConnection("dest.example.com", "src.example.com", string(nmapsvc.PortStateOpen), port, time.Now().Add(time.Minute)),
+				DataflowComponentReadFSMState: protocolconverter.OperationalStateActive,
+			},
+		})
+
+		_, err, replies := runAwaitRolloutRead("dest.example.com")
+
+		Expect(err).To(HaveOccurred(), "neither the scan nor the dataflow component has caught up")
+		Expect(replies).To(ContainElement(ContainSubstring("waiting for nmap to scan dest.example.com")),
+			"the connection check must run before the dataflow component comparison, or a bridge whose "+
+				"target was never dialed is reported as a dataflow component problem")
+	})
+
+	It("does not wait for a scan when the edit carries no connection", func() {
+		// The exemption that keeps a broken bridge editable. An edit that changes
+		// only a flow has no new endpoint to verify, so it must not be held up by
+		// the connection: otherwise a bridge whose target is unreachable can never
+		// be edited at all, including the edit that stops its flows.
+		//
+		// The scan here still shows the PREVIOUS target — the same staging the
+		// ENG-5580 spec above rejects. The only difference is that this payload
+		// carries no connection.
+		stageReadDFCSnapshot("dest.example.com", "src.example.com", protocolconverter.OperationalStateActive, string(nmapsvc.PortStateOpen))
+
+		elapsed, err, replies := runAwaitRolloutRead("")
+
+		Expect(err).NotTo(HaveOccurred(), "an edit that does not touch the connection must not be blocked by it")
+		Expect(replies).To(ContainElement(ContainSubstring("read DFC configuration verified")))
+		Expect(elapsed).To(BeNumerically("<", 4*time.Second),
+			"against a 6s budget: this edit has nothing to wait for")
 	})
 })

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter_awaitrollout_test.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter_awaitrollout_test.go
@@ -15,6 +15,7 @@
 package actions_test
 
 import (
+	"fmt"
 	"sync"
 	"time"
 
@@ -23,7 +24,9 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/communicator/actions"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/communicator/pkg/encoding"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/benthosserviceconfig"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/connectionserviceconfig"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/dataflowcomponentserviceconfig"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/nmapserviceconfig"
@@ -31,11 +34,14 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/variables"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
+	benthosfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/benthos"
 	connfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/connection"
+	dfcfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/dataflowcomponent"
 	nmapfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/nmap"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/protocolconverter"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/models"
 	connsvc "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/connection"
+	dfcsvc "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/dataflowcomponent"
 	nmapservice "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/nmap"
 	protocolconvertersvc "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/protocolconverter"
 )
@@ -60,32 +66,28 @@ var _ = Describe("EditProtocolConverter awaitRollout (connection check)", func()
 	// independently, so a spec can stage a connection edited to a target whose
 	// scan has not caught up yet, and one where the observed config has caught
 	// up but the scan has not.
-	stageSnapshotScanned := func(desiredTarget string, observedTarget string, scannedTarget string, pcState string, portState string, scannedPort uint16, scannedAt time.Time) {
-		observed := &protocolconverter.ProtocolConverterObservedStateSnapshot{
-			ServiceInfo: protocolconvertersvc.ServiceInfo{
-				ConnectionObservedState: connfsm.ConnectionObservedState{
-					ObservedConnectionConfig: connectionserviceconfig.ConnectionServiceConfig{
-						NmapServiceConfig: nmapserviceconfig.NmapServiceConfig{
-							Target: desiredTarget,
-							Port:   scannedPort,
-						},
+	observedConnection := func(desiredTarget string, observedTarget string, scannedTarget string, portState string, scannedPort uint16, scannedAt time.Time) connfsm.ConnectionObservedState {
+		return connfsm.ConnectionObservedState{
+			ObservedConnectionConfig: connectionserviceconfig.ConnectionServiceConfig{
+				NmapServiceConfig: nmapserviceconfig.NmapServiceConfig{
+					Target: desiredTarget,
+					Port:   scannedPort,
+				},
+			},
+			ServiceInfo: connsvc.ServiceInfo{
+				NmapObservedState: nmapfsm.NmapObservedState{
+					ObservedNmapServiceConfig: nmapserviceconfig.NmapServiceConfig{
+						Target: observedTarget,
+						Port:   scannedPort,
 					},
-					ServiceInfo: connsvc.ServiceInfo{
-						NmapObservedState: nmapfsm.NmapObservedState{
-							ObservedNmapServiceConfig: nmapserviceconfig.NmapServiceConfig{
-								Target: observedTarget,
-								Port:   scannedPort,
-							},
-							ServiceInfo: nmapservice.ServiceInfo{
-								NmapStatus: nmapservice.NmapServiceInfo{
-									LastScan: &nmapservice.NmapScanResult{
-										Timestamp: scannedAt,
-										Target:    scannedTarget,
-										PortResult: nmapservice.PortResult{
-											State: portState,
-											Port:  scannedPort,
-										},
-									},
+					ServiceInfo: nmapservice.ServiceInfo{
+						NmapStatus: nmapservice.NmapServiceInfo{
+							LastScan: &nmapservice.NmapScanResult{
+								Timestamp: scannedAt,
+								Target:    scannedTarget,
+								PortResult: nmapservice.PortResult{
+									State: portState,
+									Port:  scannedPort,
 								},
 							},
 						},
@@ -93,6 +95,11 @@ var _ = Describe("EditProtocolConverter awaitRollout (connection check)", func()
 				},
 			},
 		}
+	}
+
+	// publish installs observed as the bridge's LastObservedState with the given
+	// PC FSM state.
+	publish := func(pcState string, observed *protocolconverter.ProtocolConverterObservedStateSnapshot) {
 		snapMgr.UpdateSnapshot(&fsm.SystemSnapshot{
 			Managers: map[string]fsm.ManagerSnapshot{
 				constants.ProtocolConverterManagerName: &actions.MockManagerSnapshot{
@@ -105,6 +112,16 @@ var _ = Describe("EditProtocolConverter awaitRollout (connection check)", func()
 						},
 					},
 				},
+			},
+		})
+	}
+
+	// Only the connection half is observed, which is all the connection check
+	// reads.
+	stageSnapshotScanned := func(desiredTarget string, observedTarget string, scannedTarget string, pcState string, portState string, scannedPort uint16, scannedAt time.Time) {
+		publish(pcState, &protocolconverter.ProtocolConverterObservedStateSnapshot{
+			ServiceInfo: protocolconvertersvc.ServiceInfo{
+				ConnectionObservedState: observedConnection(desiredTarget, observedTarget, scannedTarget, portState, scannedPort, scannedAt),
 			},
 		})
 	}
@@ -238,57 +255,23 @@ var _ = Describe("EditProtocolConverter awaitRollout (connection check)", func()
 
 	It("reports failure when the scanner is running but the port is not open", func() {
 		// The other specs leave IsRunning false, so swapping the check to trust it
-		// would redden only the healthy spec. This one catches that swap.
+		// would redden only the healthy spec. This one catches that swap. Its scan
+		// is fresh and on the edited endpoint, so it reaches the port-state check
+		// instead of stopping at the staleness one.
 		observed := &protocolconverter.ProtocolConverterObservedStateSnapshot{
 			ServiceInfo: protocolconvertersvc.ServiceInfo{
-				ConnectionObservedState: connfsm.ConnectionObservedState{
-					ObservedConnectionConfig: connectionserviceconfig.ConnectionServiceConfig{
-						NmapServiceConfig: nmapserviceconfig.NmapServiceConfig{
-							Target: "dest.example.com",
-							Port:   port,
-						},
-					},
-					ServiceInfo: connsvc.ServiceInfo{
-						NmapObservedState: nmapfsm.NmapObservedState{
-							ObservedNmapServiceConfig: nmapserviceconfig.NmapServiceConfig{
-								Target: "dest.example.com",
-								Port:   port,
-							},
-							ServiceInfo: nmapservice.ServiceInfo{
-								NmapStatus: nmapservice.NmapServiceInfo{
-									IsRunning: true,
-									// Fresh and on the edited endpoint, so the
-									// spec reaches the port-state check instead
-									// of stopping at the staleness one.
-									LastScan: &nmapservice.NmapScanResult{
-										Timestamp: time.Now().Add(time.Minute),
-										Target:    "dest.example.com",
-										PortResult: nmapservice.PortResult{
-											State: string(nmapservice.PortStateClosed),
-											Port:  port,
-										},
-									},
-								},
-							},
-						},
-					},
-				},
+				ConnectionObservedState: observedConnection(
+					"dest.example.com",
+					"dest.example.com",
+					"dest.example.com",
+					string(nmapservice.PortStateClosed),
+					port,
+					time.Now().Add(time.Minute),
+				),
 			},
 		}
-		snapMgr.UpdateSnapshot(&fsm.SystemSnapshot{
-			Managers: map[string]fsm.ManagerSnapshot{
-				constants.ProtocolConverterManagerName: &actions.MockManagerSnapshot{
-					Instances: map[string]*fsm.FSMInstanceSnapshot{
-						probeName: {
-							ID:                probeName,
-							CurrentState:      protocolconverter.OperationalStateStartingFailedDFCMissing,
-							DesiredState:      protocolconverter.OperationalStateActive,
-							LastObservedState: observed,
-						},
-					},
-				},
-			},
-		})
+		observed.ServiceInfo.ConnectionObservedState.ServiceInfo.NmapObservedState.ServiceInfo.NmapStatus.IsRunning = true
+		publish(protocolconverter.OperationalStateStartingFailedDFCMissing, observed)
 
 		_, err := runAwaitRollout("dest.example.com")
 		Expect(err).To(HaveOccurred(),
@@ -409,5 +392,196 @@ var _ = Describe("EditProtocolConverter awaitRollout (connection check)", func()
 			Expect(elapsed).To(BeNumerically("<", 5*time.Second),
 				"a healthy edit of a templated connection must not wait out the rollout timeout")
 		})
+	})
+	// --- the read-DFC path -----------------------------------------------------
+	//
+	// Every spec above drives an edit with no dataflow component, which
+	// awaitRollout classifies as DFCTypeEmpty and gates on the nmap scan. An edit
+	// that carries a read DFC takes an entirely different branch: the nmap check
+	// lives inside `if a.dfcType == DFCTypeEmpty`, so on the read path it never
+	// runs, and acceptance is decided by the protocolconverter's CurrentState
+	// alone. These two specs pin that difference in-process.
+	//
+	// caughtUpReadDFCBenthos is the Benthos config a converged bridge observes for
+	// the read DFC in runAwaitRolloutRead's payload: the payload's own generate
+	// input and tag_processor, plus the downsampler that renderConfig appends to
+	// every timeseries pipeline. The values were read off renderDesiredDFCConfig
+	// for that exact payload, because compareSingleDFCConfig accepts only a
+	// comparator-equal match and the appended downsampler is invisible in the
+	// payload. Output is deliberately absent: the read comparison nils both sides'
+	// Output before comparing, since the read DFC's egress is forced to the UNS
+	// publisher at render time.
+	caughtUpReadDFCBenthos := benthosserviceconfig.BenthosServiceConfig{
+		Input: map[string]interface{}{
+			"generate": map[string]interface{}{
+				"count":    0,
+				"interval": "1s",
+				"mapping":  `root = "hello world"`,
+			},
+		},
+		Pipeline: map[string]interface{}{
+			"processors": []interface{}{
+				map[string]interface{}{
+					"tag_processor": map[string]interface{}{
+						"defaults": "msg.meta.location_path = \"probe\";\nmsg.meta.data_contract = \"_raw\";\nreturn msg;\n",
+					},
+				},
+				map[string]interface{}{"downsampler": map[string]interface{}{}},
+			},
+		},
+		Buffer: map[string]interface{}{"none": map[string]interface{}{}},
+	}
+
+	// stageReadDFCSnapshot stages a bridge that carries a read DFC. Beyond the
+	// connection half it stages the two things the read branch needs before it can
+	// reach its accepted-state check:
+	//
+	//   - ObservedProtocolConverterSpecConfig with a connection template.
+	//     renderDesiredDFCConfig renders the whole spec, and ConvertTemplateToRuntime
+	//     rejects an absent connection template outright ("connection template is nil
+	//     or empty"), so without it every tick fails to render rather than comparing.
+	//   - the observed read-DFC Benthos config. compareSingleDFCConfig treats a nil
+	//     observed Input as "Benthos is still starting" and returns false before it
+	//     ever renders, so a snapshot without it can never be accepted.
+	//
+	// The spec's variables hold the PRE-EDIT connection values on purpose: the
+	// observed spec lags the persisted edit by one or more control-loop cycles, and
+	// renderDesiredDFCConfig is expected to overlay the edit's own IP/PORT on top.
+	stageReadDFCSnapshot := func(desiredTarget string, scannedTarget string, pcState string, portState string) {
+		publish(pcState, &protocolconverter.ProtocolConverterObservedStateSnapshot{
+			ObservedProtocolConverterSpecConfig: protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec{
+				Config: protocolconverterserviceconfig.ProtocolConverterServiceConfigTemplate{
+					ConnectionServiceConfig: connectionserviceconfig.ConnectionServiceConfigTemplate{
+						NmapTemplate: &connectionserviceconfig.NmapConfigTemplate{
+							Target: "{{ .IP }}",
+							Port:   "{{ .PORT }}",
+						},
+					},
+				},
+				Variables: variables.VariableBundle{
+					User: map[string]interface{}{"IP": "src.example.com", "PORT": "443"},
+				},
+			},
+			ServiceInfo: protocolconvertersvc.ServiceInfo{
+				ConnectionObservedState:       observedConnection(desiredTarget, scannedTarget, scannedTarget, portState, port, time.Now().Add(time.Minute)),
+				DataflowComponentReadFSMState: protocolconverter.OperationalStateActive,
+				DataflowComponentReadObservedState: dfcfsm.DataflowComponentObservedState{
+					ServiceInfo: dfcsvc.ServiceInfo{
+						BenthosObservedState: benthosfsm.BenthosObservedState{
+							ObservedBenthosServiceConfig: caughtUpReadDFCBenthos,
+						},
+					},
+				},
+			},
+		})
+	}
+
+	// runAwaitRolloutRead is runAwaitRollout plus a read DFC in the payload, which
+	// is what flips deriveDFCType to "read".
+	runAwaitRolloutRead := func(ip string) (time.Duration, error, []string) {
+		a := actions.NewEditProtocolConverterAction(
+			"probe@example.com", uuid.New(), uuid.New(), outbound, mockCfg, snapMgr)
+		a.SetTickInterval(tickInterval)
+		a.SetAwaitTimeout(6 * time.Second)
+
+		payload := map[string]interface{}{
+			"name": probeName,
+			"uuid": probeUUID.String(),
+			"connection": map[string]interface{}{
+				"ip":   ip,
+				"port": port,
+			},
+			"readDFC": map[string]interface{}{
+				"state": "active",
+				"inputs": map[string]interface{}{
+					"type": "generate",
+					"data": "generate:\n  count: 0\n  interval: 1s\n  mapping: root = \"hello world\"\n",
+				},
+				// pipeline.processors is required by buildReadDFCServiceConfig; a
+				// read DFC without it is rejected before dfcType is ever derived.
+				"pipeline": map[string]interface{}{
+					"processors": map[string]interface{}{
+						"0": map[string]interface{}{
+							"type": "tag_processor",
+							"data": "tag_processor:\n  defaults: |\n    msg.meta.location_path = \"probe\";\n    msg.meta.data_contract = \"_raw\";\n    return msg;\n",
+						},
+					},
+				},
+			},
+		}
+		Expect(a.Parse(payload)).To(Succeed())
+		Expect(a.Validate()).To(Succeed())
+		Expect(a.GetDFCType()).To(Equal("read"),
+			"this spec is about the read-DFC branch; if the payload no longer yields a read DFC it is testing the wrong path")
+
+		start := time.Now()
+		_, _, err := a.Execute()
+		elapsed := time.Since(start)
+
+		mu.Lock()
+		defer mu.Unlock()
+
+		// The replies are the only record of WHETHER the gate accepted and on
+		// which tick, so they are decoded to text rather than counted.
+		out := make([]string, 0, len(msgs))
+
+		for _, m := range msgs {
+			dec, decErr := encoding.DecodeMessageFromUMHInstanceToUser(m.Content)
+			if decErr != nil {
+				continue
+			}
+
+			out = append(out, fmt.Sprintf("%v", dec.Payload))
+		}
+
+		return elapsed, err, out
+	}
+
+	It("POSITIVE CONTROL: a read-DFC edit whose scan has caught up is accepted", func() {
+		// Establishes that this harness can reach the read path's acceptance at
+		// all. Without it the next spec's "was not accepted" could be satisfied by
+		// the DFC config comparison blocking the gate for an unrelated reason, and
+		// would pass while proving nothing. The two specs differ in exactly one
+		// value: the observed nmap target.
+		stageReadDFCSnapshot("dest.example.com", "dest.example.com", protocolconverter.OperationalStateActive, string(nmapservice.PortStateOpen))
+
+		_, err, replies := runAwaitRolloutRead("dest.example.com")
+
+		Expect(err).NotTo(HaveOccurred(), "a read-DFC edit whose scan agrees with the request must be accepted")
+		Expect(replies).To(ContainElement(ContainSubstring("read DFC configuration verified")),
+			"the read path's acceptance must be reachable in this harness, or the next spec proves nothing")
+	})
+
+	// PENDING (XIt) because it reproduces ENG-5580 and therefore fails on today's
+	// code: it asserts the behaviour the fix must introduce, so it cannot be left
+	// enabled without a red suite. The fix that makes the read branch withhold
+	// acceptance until the requested target has been scanned must flip this back to
+	// It — a fix that leaves it pending has not been verified against the bug.
+	// Verified red before it was marked pending: the run reported the reply
+	// "bridge successfully activated with state 'active', read DFC configuration
+	// verified", i.e. it failed because the edit was ACCEPTED, not because of a
+	// timeout or a render failure.
+	XIt("does not accept a read-DFC edit while the scan still shows the previous target", func() {
+		// The reported bug (ENG-5580), in-process and deterministic. The bridge is
+		// edited to dest.example.com; the protocolconverter still carries its
+		// pre-edit CurrentState of active, and the scan still shows the OLD target
+		// as open. Correct behaviour is to withhold acceptance until the requested
+		// target has actually been scanned.
+		//
+		// Today this FAILS: the read branch reads only CurrentState, so it accepts
+		// on the first tick against the pre-edit snapshot. That failure is the
+		// point — it is the deterministic form of a race the container harness
+		// reproduces only intermittently, and it depends on no log capture.
+		stageReadDFCSnapshot("dest.example.com", "src.example.com", protocolconverter.OperationalStateActive, string(nmapservice.PortStateOpen))
+
+		elapsed, err, replies := runAwaitRolloutRead("dest.example.com")
+
+		Expect(replies).NotTo(ContainElement(ContainSubstring("read DFC configuration verified")),
+			"the edit was accepted while the only scan on record still described the PREVIOUS target: "+
+				"the read branch gates on the protocolconverter's CurrentState, which still held its pre-edit value")
+		Expect(err).To(HaveOccurred(),
+			"an edit must not report success before the requested target has been scanned")
+		Expect(elapsed).To(BeNumerically(">", time.Second),
+			"acceptance on the first tick means the pre-edit snapshot was taken as evidence about the new config")
 	})
 })


### PR DESCRIPTION
Middle of the stack: #2708 → **#2716** → #2751. Umbrella: ENG-5853.

## Problem

The connection check #2708 adds sits inside the empty-DFC branch. A bridge that already has a read or write flow never reaches it, so its edit is accepted on the bridge's own pre-edit state without the requested endpoint ever being dialled. That is the more common bridge.

## What we are shipping

- The check runs for every bridge, not only a flowless one. An edit to a bridge with a read flow now waits for the requested endpoint to be scanned and found open.
- It runs before the DFC config comparison, so a bridge whose target was never dialled is reported as a connection problem rather than a dataflow component one.
- An edit that carries no connection block is exempt, so a bridge whose target is unreachable stays editable, including the edit that stops its flows.

Five specs: a positive control that a healthy read-DFC edit is still accepted on the first tick, the read-path acceptance reproduced in-process (the deterministic form of a race the container suite reproduces intermittently), a placement guard that fails if the check moves back below the DFC comparison, the exemption, and the filtered-port spec moved along with the check.

## What we are NOT shipping

- Whether the exemption fires at all for a console edit. `get-protocolconverter` fills `Connection.IP` from the deployed spec and the wizard round-trips it, so a console payload normally carries a connection block and the exemption may be unreachable. ENG-5858.
- Any framework work. Nothing here touches `fsmv2client`, the adapter or the CSE store.

## Ticket

This branch is named for ENG-5580, but ENG-5580 is the FSMv2 config-identity/freshness ticket and lists "the consumer-side gate holes" under what it is *not* shipping. This PR is one of those gate holes, so it needs a ticket of its own, and merging it will not close ENG-5580.


