### PR TITLE
fsmv2: name the upstream cause when the transport degrades

### DIFF
--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- When the connection to the Management Console degrades after repeated failures, the log now names the upstream cause — the HTTP status and a snippet of the response — instead of only the error count. Previously the cause was recorded internally but never reached the log, so a connection that kept failing and recovering showed repeated degradation with no reason given
 - Renaming a bridge whose deployment then fails no longer leaves it impossible to edit or save. A failed deployment now undoes the rename along with the rest of the configuration, while Save Anyway keeps the new name as before
 
 ## [0.44.34]

--- a/umh-core/pkg/fsmv2/workers/transport/pull/degrade_reason_log_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/degrade_reason_log_test.go
@@ -1,0 +1,212 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pull_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/cse/storage"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
+	fsmconfig "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/config"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/supervisor"
+	transportpkg "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport"
+	httptransport "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/http"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/pull"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/pull/action"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/pull/snapshot"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/persistence/memory"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// nginx502Body is a real nginx 502 page, single-line, no control
+// characters, so sanitizeErrorDetail passes it through verbatim and the test
+// can read 'nginx/1.27.5' off the captured log line.
+const nginx502Body = "<html><head><title>502 Bad Gateway</title></head><body><center><h1>502 Bad Gateway</h1></center><hr><center>nginx/1.27.5</center></body></html>"
+
+var _ = Describe("ENG-5023: the upstream 502 reaches the logged Running->Degraded record", func() {
+	It("captures the upstream nginx body on the state_transition record, Execute returns nil, nothing at Warn+", func() {
+		// (1) A real upstream that answers every pull with a recognisable nginx 502 page.
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			_, _ = w.Write([]byte(nginx502Body))
+		}))
+		defer server.Close()
+
+		// Capturing logger WITHOUT the production samplers: NewUnsampledFSMLogger,
+		// not NewFSMLogger (1s/5/100) nor the zap-level sampler (10s/3/100), both of
+		// which can drop a record before an observer core sees it.
+		buf := new(bytes.Buffer)
+		logger := newUnsampledJSONLogger(buf)
+
+		transportpkg.SetChannelProvider(newTestChannelProvider())
+		defer transportpkg.ClearChannelProvider()
+
+		// (2) Real HTTPTransport against the live server, real PullDependencies.
+		realHTTP := httptransport.NewHTTPTransport(server.URL, 5*time.Second)
+		parentIdentity := deps.Identity{ID: "log-detail-parent", WorkerType: "transport"}
+		parentDeps := transportpkg.NewTransportDependencies(realHTTP, deps.NewBaseDependencies(logger, nil, parentIdentity))
+
+		pullIdentity := deps.Identity{ID: "log-detail-pull", WorkerType: "pull"}
+		pullDeps, err := pull.NewPullDependencies(parentDeps, deps.NewBaseDependencies(logger, nil, pullIdentity))
+		Expect(err).NotTo(HaveOccurred())
+
+		// (3) Drive the real action against the real 502 until the consecutive-error
+		// threshold (errorDegradedThreshold = 3) is crossed.
+		act := &action.PullAction{JWTToken: "log-detail-token"}
+		for range 3 {
+			err := act.Execute(context.Background(), pullDeps)
+			// (b) ENG-4450 invariant: a 502 is ErrorTypeServerError, IsTransient()==true,
+			// so Execute must return nil — this fix must not re-introduce the Sentry noise.
+			Expect(err).NotTo(HaveOccurred())
+		}
+		Expect(pullDeps.GetConsecutiveErrors()).To(BeNumerically(">=", 3))
+		Expect(pullDeps.GetLastStatusCode()).To(Equal(http.StatusBadGateway))
+		Expect(pullDeps.GetLastErrorDetail()).To(ContainSubstring("nginx/1.27.5"))
+
+		// (4) Run the supervisor far enough that Running -> Degraded is reconciled
+		// and the state_transition record is emitted. The fix's only observable
+		// effect lives on that logged reason; asserting a Next() return value would
+		// reproduce the exact failure #2626 slipped past.
+		store := storage.NewTriangularStore(memory.NewInMemoryStore(), logger)
+		sup := supervisor.NewSupervisor[fsmv2.Observation[snapshot.PullStatus], *fsmv2.WrappedDesiredState[snapshot.PullDesiredState]](supervisor.Config{
+			WorkerType: "pull",
+			Store:      store,
+			Logger:     logger,
+		})
+
+		sup.TestUpdateUserSpec(fsmconfig.UserSpec{Config: "authSession:\n  token: log-detail-token\n  expiry: 2030-01-01T00:00:00Z\n"})
+
+		worker, err := pull.NewPullWorker(pullIdentity, logger, nil, pullDeps)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(sup.AddWorker(pullIdentity, worker)).To(Succeed())
+
+		ctx := context.Background()
+
+		// Wait for the Running -> Degraded transition itself. The transition fires
+		// whether or not the cause is appended, so waiting on it (rather than on the
+		// '; last: ' marker) makes the RED failure land on the missing body below
+		// instead of timing out.
+		Eventually(func() bool {
+			_ = sup.TestTick(ctx)
+
+			return capturedDegradeTransitionReason(buf) != ""
+		}, "5s", "50ms").Should(BeTrue(),
+			"a state_transition record from Running to Degraded must be captured")
+
+		// (a) The whole feature: the logged edge carries the upstream response body
+		// AND the '; last: ' marker — read off captured log output, never a return value.
+		degradeReason := capturedDegradeTransitionReason(buf)
+		Expect(degradeReason).To(ContainSubstring("; last: "))
+		Expect(degradeReason).To(ContainSubstring("HTTP 502 (server_error)"))
+		Expect(degradeReason).To(ContainSubstring("nginx/1.27.5"))
+
+		// (c) Nothing from the state-transition path is at Warn or above. Scoped BY
+		// MESSAGE: RecordTypedError legitimately emits SentryWarn("persistent_pull_failure")
+		// once the failure-rate tracker crosses 90% over ~600 samples.
+		Expect(stateTransitionLevelsAtOrAboveWarn(buf)).To(BeEmpty())
+	})
+})
+
+// newUnsampledJSONLogger builds a JSON FSMLogger that captures every record
+// without the production message-based samplers (see spec Verification Strategy:
+// use deps.NewUnsampledFSMLogger, not NewFSMLogger/NewJSONFSMLogger).
+func newUnsampledJSONLogger(buf *bytes.Buffer) deps.FSMLogger {
+	encoderConfig := zapcore.EncoderConfig{
+		TimeKey:        "ts",
+		LevelKey:       "level",
+		MessageKey:     "msg",
+		EncodeLevel:    zapcore.LowercaseLevelEncoder,
+		EncodeTime:     zapcore.ISO8601TimeEncoder,
+		EncodeDuration: zapcore.StringDurationEncoder,
+	}
+
+	core := zapcore.NewCore(zapcore.NewJSONEncoder(encoderConfig), zapcore.AddSync(buf), zapcore.DebugLevel)
+
+	return deps.NewUnsampledFSMLogger(zap.New(core).Sugar())
+}
+
+// capturedLogRecords parses every JSON line written to buf into a map.
+func capturedLogRecords(buf *bytes.Buffer) []map[string]any {
+	var records []map[string]any
+
+	for _, line := range strings.Split(buf.String(), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		var m map[string]any
+		if err := json.Unmarshal([]byte(line), &m); err != nil {
+			continue
+		}
+
+		records = append(records, m)
+	}
+
+	return records
+}
+
+// capturedDegradeTransitionReason returns the "reason" field of the captured
+// 'state_transition' record that moves the worker from Running to Degraded, or
+// "" if no such record has been captured yet.
+func capturedDegradeTransitionReason(buf *bytes.Buffer) string {
+	for _, rec := range capturedLogRecords(buf) {
+		if msg, _ := rec["msg"].(string); msg != "state_transition" {
+			continue
+		}
+
+		from, _ := rec["from_state"].(string)
+		to, _ := rec["to_state"].(string)
+		if from != "Running" || to != "Degraded" {
+			continue
+		}
+
+		if reason, ok := rec["reason"].(string); ok {
+			return reason
+		}
+	}
+
+	return ""
+}
+
+// stateTransitionLevelsAtOrAboveWarn returns the level of every captured record
+// with message 'state_transition' that sits at or above zapcore.WarnLevel.
+func stateTransitionLevelsAtOrAboveWarn(buf *bytes.Buffer) []string {
+	var levels []string
+
+	for _, rec := range capturedLogRecords(buf) {
+		if msg, _ := rec["msg"].(string); msg != "state_transition" {
+			continue
+		}
+
+		level, _ := rec["level"].(string)
+		if level == "warn" || level == "error" || level == "dpanic" || level == "panic" || level == "fatal" {
+			levels = append(levels, level)
+		}
+	}
+
+	return levels
+}

--- a/umh-core/pkg/fsmv2/workers/transport/pull/degrade_reason_log_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/degrade_reason_log_test.go
@@ -48,23 +48,18 @@ const nginx502Body = "<html><head><title>502 Bad Gateway</title></head><body><ce
 
 var _ = Describe("ENG-5023: the upstream 502 reaches the logged Running->Degraded record", func() {
 	It("captures the upstream nginx body on the state_transition record, Execute returns nil, nothing at Warn+", func() {
-		// (1) A real upstream that answers every pull with a recognisable nginx 502 page.
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusBadGateway)
 			_, _ = w.Write([]byte(nginx502Body))
 		}))
 		defer server.Close()
 
-		// Capturing logger WITHOUT the production samplers: NewUnsampledFSMLogger,
-		// not NewFSMLogger (1s/5/100) nor the zap-level sampler (10s/3/100), both of
-		// which can drop a record before an observer core sees it.
 		buf := new(bytes.Buffer)
 		logger := newUnsampledJSONLogger(buf)
 
 		transportpkg.SetChannelProvider(newTestChannelProvider())
 		defer transportpkg.ClearChannelProvider()
 
-		// (2) Real HTTPTransport against the live server, real PullDependencies.
 		realHTTP := httptransport.NewHTTPTransport(server.URL, 5*time.Second)
 		parentIdentity := deps.Identity{ID: "log-detail-parent", WorkerType: "transport"}
 		parentDeps := transportpkg.NewTransportDependencies(realHTTP, deps.NewBaseDependencies(logger, nil, parentIdentity))
@@ -73,23 +68,15 @@ var _ = Describe("ENG-5023: the upstream 502 reaches the logged Running->Degrade
 		pullDeps, err := pull.NewPullDependencies(parentDeps, deps.NewBaseDependencies(logger, nil, pullIdentity))
 		Expect(err).NotTo(HaveOccurred())
 
-		// (3) Drive the real action against the real 502 until the consecutive-error
-		// threshold (errorDegradedThreshold = 3) is crossed.
 		act := &action.PullAction{JWTToken: "log-detail-token"}
 		for range 3 {
 			err := act.Execute(context.Background(), pullDeps)
-			// (b) ENG-4450 invariant: a 502 is ErrorTypeServerError, IsTransient()==true,
-			// so Execute must return nil — this fix must not re-introduce the Sentry noise.
 			Expect(err).NotTo(HaveOccurred())
 		}
 		Expect(pullDeps.GetConsecutiveErrors()).To(BeNumerically(">=", 3))
 		Expect(pullDeps.GetLastStatusCode()).To(Equal(http.StatusBadGateway))
 		Expect(pullDeps.GetLastErrorDetail()).To(ContainSubstring("nginx/1.27.5"))
 
-		// (4) Run the supervisor far enough that Running -> Degraded is reconciled
-		// and the state_transition record is emitted. The fix's only observable
-		// effect lives on that logged reason; asserting a Next() return value would
-		// reproduce the exact failure #2626 slipped past.
 		store := storage.NewTriangularStore(memory.NewInMemoryStore(), logger)
 		sup := supervisor.NewSupervisor[fsmv2.Observation[snapshot.PullStatus], *fsmv2.WrappedDesiredState[snapshot.PullDesiredState]](supervisor.Config{
 			WorkerType: "pull",
@@ -105,10 +92,6 @@ var _ = Describe("ENG-5023: the upstream 502 reaches the logged Running->Degrade
 
 		ctx := context.Background()
 
-		// Wait for the Running -> Degraded transition itself. The transition fires
-		// whether or not the cause is appended, so waiting on it (rather than on the
-		// '; last: ' marker) makes the RED failure land on the missing body below
-		// instead of timing out.
 		Eventually(func() bool {
 			_ = sup.TestTick(ctx)
 
@@ -116,23 +99,15 @@ var _ = Describe("ENG-5023: the upstream 502 reaches the logged Running->Degrade
 		}, "5s", "50ms").Should(BeTrue(),
 			"a state_transition record from Running to Degraded must be captured")
 
-		// (a) The whole feature: the logged edge carries the upstream response body
-		// AND the '; last: ' marker — read off captured log output, never a return value.
 		degradeReason := capturedDegradeTransitionReason(buf)
 		Expect(degradeReason).To(ContainSubstring("; last: "))
 		Expect(degradeReason).To(ContainSubstring("HTTP 502 (server_error)"))
 		Expect(degradeReason).To(ContainSubstring("nginx/1.27.5"))
 
-		// (c) Nothing from the state-transition path is at Warn or above. Scoped BY
-		// MESSAGE: RecordTypedError legitimately emits SentryWarn("persistent_pull_failure")
-		// once the failure-rate tracker crosses 90% over ~600 samples.
 		Expect(stateTransitionLevelsAtOrAboveWarn(buf)).To(BeEmpty())
 	})
 })
 
-// newUnsampledJSONLogger builds a JSON FSMLogger that captures every record
-// without the production message-based samplers (see spec Verification Strategy:
-// use deps.NewUnsampledFSMLogger, not NewFSMLogger/NewJSONFSMLogger).
 func newUnsampledJSONLogger(buf *bytes.Buffer) deps.FSMLogger {
 	encoderConfig := zapcore.EncoderConfig{
 		TimeKey:        "ts",
@@ -148,7 +123,6 @@ func newUnsampledJSONLogger(buf *bytes.Buffer) deps.FSMLogger {
 	return deps.NewUnsampledFSMLogger(zap.New(core).Sugar())
 }
 
-// capturedLogRecords parses every JSON line written to buf into a map.
 func capturedLogRecords(buf *bytes.Buffer) []map[string]any {
 	var records []map[string]any
 
@@ -169,9 +143,6 @@ func capturedLogRecords(buf *bytes.Buffer) []map[string]any {
 	return records
 }
 
-// capturedDegradeTransitionReason returns the "reason" field of the captured
-// 'state_transition' record that moves the worker from Running to Degraded, or
-// "" if no such record has been captured yet.
 func capturedDegradeTransitionReason(buf *bytes.Buffer) string {
 	for _, rec := range capturedLogRecords(buf) {
 		if msg, _ := rec["msg"].(string); msg != "state_transition" {
@@ -180,6 +151,7 @@ func capturedDegradeTransitionReason(buf *bytes.Buffer) string {
 
 		from, _ := rec["from_state"].(string)
 		to, _ := rec["to_state"].(string)
+
 		if from != "Running" || to != "Degraded" {
 			continue
 		}
@@ -192,8 +164,6 @@ func capturedDegradeTransitionReason(buf *bytes.Buffer) string {
 	return ""
 }
 
-// stateTransitionLevelsAtOrAboveWarn returns the level of every captured record
-// with message 'state_transition' that sits at or above zapcore.WarnLevel.
 func stateTransitionLevelsAtOrAboveWarn(buf *bytes.Buffer) []string {
 	var levels []string
 

--- a/umh-core/pkg/fsmv2/workers/transport/pull/state/state_running.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/state/state_running.go
@@ -47,8 +47,10 @@ func (s *RunningState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	}
 
 	if snap.Status.ConsecutiveErrors >= errorDegradedThreshold {
-		return fsmv2.Transition(&DegradedState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("degrading: %d consecutive errors (threshold=%d)", snap.Status.ConsecutiveErrors, errorDegradedThreshold), nil)
+		reason := fmt.Sprintf("degrading: %d consecutive errors (threshold=%d); last: %s",
+			snap.Status.ConsecutiveErrors, errorDegradedThreshold, snap.Status.LastErrorDetail)
+
+		return fsmv2.Transition(&DegradedState{}, fsmv2.SignalNone, nil, reason, nil)
 	}
 
 	if snap.Status.PendingMessageCount >= pendingDegradedThreshold {

--- a/umh-core/pkg/fsmv2/workers/transport/pull/state/state_running.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/state/state_running.go
@@ -47,8 +47,11 @@ func (s *RunningState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	}
 
 	if snap.Status.ConsecutiveErrors >= errorDegradedThreshold {
-		reason := fmt.Sprintf("degrading: %d consecutive errors (threshold=%d); last: %s",
-			snap.Status.ConsecutiveErrors, errorDegradedThreshold, snap.Status.LastErrorDetail)
+		reason := fmt.Sprintf("degrading: %d consecutive errors (threshold=%d)",
+			snap.Status.ConsecutiveErrors, errorDegradedThreshold)
+		if snap.Status.LastErrorDetail != "" {
+			reason += "; last: " + snap.Status.LastErrorDetail
+		}
 
 		return fsmv2.Transition(&DegradedState{}, fsmv2.SignalNone, nil, reason, nil)
 	}

--- a/umh-core/pkg/fsmv2/workers/transport/pull/state/state_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/state/state_test.go
@@ -260,6 +260,18 @@ var _ = Describe("RunningState", func() {
 		Expect(result.Reason).To(ContainSubstring("; last: " + detail))
 	})
 
+	It(`does not append "; last:" when the last error detail is empty`, func() {
+		snap := makeSnapshot(config.DesiredStateRunning, false, 3, true, true)
+		obs := snap.Observed.(fsmv2.Observation[snapshot.PullStatus])
+		obs.Status.LastErrorDetail = ""
+		snap.Observed = obs
+
+		result := s.Next(snap)
+
+		Expect(result.State).To(BeAssignableToTypeOf(&state.DegradedState{}))
+		Expect(result.Reason).To(Equal("degrading: 3 consecutive errors (threshold=3)"))
+	})
+
 	It("should stay Running and emit PullAction when less than 3 errors", func() {
 		snap := makeSnapshot(config.DesiredStateRunning, false, 2, true, true)
 		result := s.Next(snap)

--- a/umh-core/pkg/fsmv2/workers/transport/pull/state/state_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/state/state_test.go
@@ -245,6 +245,21 @@ var _ = Describe("RunningState", func() {
 		Expect(result.State).To(BeAssignableToTypeOf(&state.DegradedState{}))
 	})
 
+	It("appends the last error detail to the consecutive-error degrade reason", func() {
+		const detail = "HTTP 502 (server_error): <html>502 Bad Gateway nginx/1.27.5</html>"
+
+		snap := makeSnapshot(config.DesiredStateRunning, false, 3, true, true)
+		obs := snap.Observed.(fsmv2.Observation[snapshot.PullStatus])
+		obs.Status.LastErrorDetail = detail
+		snap.Observed = obs
+
+		result := s.Next(snap)
+
+		Expect(result.State).To(BeAssignableToTypeOf(&state.DegradedState{}))
+		Expect(result.Reason).To(ContainSubstring("degrading: 3 consecutive errors (threshold=3)"))
+		Expect(result.Reason).To(ContainSubstring("; last: " + detail))
+	})
+
 	It("should stay Running and emit PullAction when less than 3 errors", func() {
 		snap := makeSnapshot(config.DesiredStateRunning, false, 2, true, true)
 		result := s.Next(snap)

--- a/umh-core/pkg/fsmv2/workers/transport/push/state/state_running.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/state/state_running.go
@@ -46,6 +46,7 @@ func (s *RunningState) Next(snapAny any) fsmv2.NextResult[any, any] {
 		if snap.Status.LastErrorDetail != "" {
 			reason += "; last: " + snap.Status.LastErrorDetail
 		}
+
 		return fsmv2.Transition(&DegradedState{}, fsmv2.SignalNone, nil, reason, nil)
 	}
 

--- a/umh-core/pkg/fsmv2/workers/transport/push/state/state_running.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/state/state_running.go
@@ -42,8 +42,11 @@ func (s *RunningState) Next(snapAny any) fsmv2.NextResult[any, any] {
 	}
 
 	if snap.Status.ConsecutiveErrors >= errorDegradedThreshold {
-		return fsmv2.Transition(&DegradedState{}, fsmv2.SignalNone, nil,
-			fmt.Sprintf("degrading: %d consecutive errors", snap.Status.ConsecutiveErrors), nil)
+		reason := fmt.Sprintf("degrading: %d consecutive errors", snap.Status.ConsecutiveErrors)
+		if snap.Status.LastErrorDetail != "" {
+			reason += "; last: " + snap.Status.LastErrorDetail
+		}
+		return fsmv2.Transition(&DegradedState{}, fsmv2.SignalNone, nil, reason, nil)
 	}
 
 	if snap.Status.PendingMessageCount >= pendingDegradedThreshold {

--- a/umh-core/pkg/fsmv2/workers/transport/push/state/state_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/state/state_test.go
@@ -212,6 +212,33 @@ var _ = Describe("RunningState", func() {
 		Expect(result.State).To(BeAssignableToTypeOf(&state.DegradedState{}))
 	})
 
+	It("appends the last error detail to the consecutive-error degrade reason", func() {
+		const detail = "HTTP 502 (server_error): <html>502 Bad Gateway nginx/1.27.5</html>"
+
+		snap := makeSnapshot(config.DesiredStateRunning, false, 3, true, true)
+		obs := snap.Observed.(fsmv2.Observation[snapshot.PushStatus])
+		obs.Status.LastErrorDetail = detail
+		snap.Observed = obs
+
+		result := s.Next(snap)
+
+		Expect(result.State).To(BeAssignableToTypeOf(&state.DegradedState{}))
+		Expect(result.Reason).To(ContainSubstring("degrading: 3 consecutive errors"))
+		Expect(result.Reason).To(ContainSubstring("; last: " + detail))
+	})
+
+	It(`does not append "; last:" when the last error detail is empty`, func() {
+		snap := makeSnapshot(config.DesiredStateRunning, false, 3, true, true)
+		obs := snap.Observed.(fsmv2.Observation[snapshot.PushStatus])
+		obs.Status.LastErrorDetail = ""
+		snap.Observed = obs
+
+		result := s.Next(snap)
+
+		Expect(result.State).To(BeAssignableToTypeOf(&state.DegradedState{}))
+		Expect(result.Reason).To(Equal("degrading: 3 consecutive errors"))
+	})
+
 	It("should stay Running and emit PushAction when less than 3 errors", func() {
 		snap := makeSnapshot(config.DesiredStateRunning, false, 2, true, true)
 		result := s.Next(snap)


### PR DESCRIPTION
## Problem

When the communicator has transient errors, the full error message does not show up. ENG-5023 (#2626) addressed part of it — the detail is stored and reaches Sentry — but not the logs: it landed on the `Degraded` self-transition, and the supervisor logs a transition only when the state actually changes.

## What we are shipping

Transient errors land in the state reason of the puller and pusher — on the `Running → Degraded` transition the supervisor actually logs.

- Zero new log records: an existing INFO line gains a suffix, so no added volume and no Sentry exposure.

## What we are not shipping

- The auth path stays silent. `authenticate.go` discards the status code and message, so a 502 on `/v2/instance/login` still yields nothing.
