### PR TITLE
pkg/diagnosis: fix the vocabulary, and let a signal narrow its own answer

### DIFF
--- a/umh-core/pkg/diagnosis/declare.go
+++ b/umh-core/pkg/diagnosis/declare.go
@@ -89,6 +89,10 @@ func (m Measurement[S]) Read(s S) (value, against Reading) {
 type Signal[S any] struct {
 	Name        string
 	Instruments []Instrument[S]
+	// Refinements are signals asked only when this one fires, narrowing its
+	// answer: each is structurally a signal with the same instruments and
+	// marks, but it is never asked unless the parent fires.
+	Refinements []Signal[S]
 	// DemoteSpan is how long a signal may go unread before its window empties:
 	// stale detection, so an old number cannot stand forever.
 	DemoteSpan time.Duration

--- a/umh-core/pkg/diagnosis/declare.go
+++ b/umh-core/pkg/diagnosis/declare.go
@@ -45,20 +45,18 @@ func (e Environment) Has(c Capability) bool {
 	return e.caps[c]
 }
 
-// Instrument is one way of measuring a signal: what to read, over how long a
-// window, under which reduction, against which thresholds.
-type Instrument[S any] struct {
+// Measurement is one way of measuring a signal: what to read, over how long a
+// window, under which reduction.
+type Measurement[S any] struct {
+	Name string
 	// Extract reads the value from a snapshot, the numerator under DeltaRatio.
 	Extract func(S) Reading
 	// Against reads the DENOMINATOR of a ratio: DeltaRatio divides the delta of
 	// Extract's counter by the delta of this one. Nil for a single series.
 	Against   func(S) Reading
-	Name      string
-	Requires  []Capability
+	Span      time.Duration
 	Reduction Reduction
-	// Marks are the thresholds this instrument's number is judged against.
-	Marks Marks
-	Span  time.Duration
+	Requires  []Capability
 	// Boolean says the series is zero or one and nothing between.
 	Boolean bool
 	// Counter says both series are monotone counters, so a backwards step means
@@ -67,14 +65,22 @@ type Instrument[S any] struct {
 	Counter bool
 }
 
+// Instrument is one way of measuring a signal: a measurement plus the marks its
+// number is judged against.
+type Instrument[S any] struct {
+	Measurement[S]
+	// Marks are the thresholds this instrument's number is judged against.
+	Marks Marks
+}
+
 // Read applies both extractors to one snapshot, so both counters of a delta
 // ratio come off the same instant. With no Against it hands back an absence.
-func (i Instrument[S]) Read(s S) (value, against Reading) {
-	if i.Against == nil {
-		return i.Extract(s), Unknown()
+func (m Measurement[S]) Read(s S) (value, against Reading) {
+	if m.Against == nil {
+		return m.Extract(s), Unknown()
 	}
 
-	return i.Extract(s), i.Against(s)
+	return m.Extract(s), m.Against(s)
 }
 
 // Signal is a QUESTION about the resource, such as whether the CPU is saturated.

--- a/umh-core/pkg/diagnosis/declare.go
+++ b/umh-core/pkg/diagnosis/declare.go
@@ -45,8 +45,10 @@ func (e Environment) Has(c Capability) bool {
 	return e.caps[c]
 }
 
-// Measurement is one way of measuring a signal: what to read, over how long a
-// window, under which reduction.
+// Measurement is a number sampled over time: what to read, over how long a
+// window, under which reduction. It carries no thresholds, so nothing about a
+// measurement can answer a signal. Its number is judged only where an
+// Instrument pairs it with marks.
 type Measurement[S any] struct {
 	Name string
 	// Extract reads the value from a snapshot, the numerator under DeltaRatio.
@@ -65,7 +67,7 @@ type Measurement[S any] struct {
 	Counter bool
 }
 
-// Instrument is one way of measuring a signal: a measurement plus the marks its
+// Instrument is one way of answering a signal: a measurement plus the marks its
 // number is judged against.
 type Instrument[S any] struct {
 	Measurement[S]
@@ -89,12 +91,10 @@ type Signal[S any] struct {
 	// Instruments each answer the signal differently. The order is significant:
 	// the first instrument that can supply a number is the one used.
 	Instruments []Instrument[S]
-	// Refinements are signals that narrow this one's answer, with their own
-	// instruments and marks. A refinement is sampled AND judged every tick,
-	// whether or not this signal fired, so its window fills and its verdict is
-	// reached independently of when this signal fires. Only the report waits on
-	// this signal: a refinement appears in Fired.Refinements under a signal that
-	// fired, and never as a verdict of its own.
+	// Refinements are signals declared under this one, narrowing its answer with
+	// their own instruments and marks. A refinement appears in Fired.Refinements
+	// under a parent that fired, and never as a verdict of its own. The
+	// Refinements section of the package doc works through an example.
 	Refinements []Signal[S]
 	// DemoteSpan is how long a signal may go unread before its window empties:
 	// stale detection, so an old number cannot stand forever.

--- a/umh-core/pkg/diagnosis/declare.go
+++ b/umh-core/pkg/diagnosis/declare.go
@@ -84,14 +84,15 @@ func (m Measurement[S]) Read(s S) (value, against Reading) {
 }
 
 // Signal is a QUESTION about the resource, such as whether the CPU is saturated.
-// Each of its Instruments answers it differently. The order is significant: the
-// first instrument that can supply a number is the one used.
 type Signal[S any] struct {
-	Name        string
+	Name string
+	// Instruments each answer the signal differently. The order is significant:
+	// the first instrument that can supply a number is the one used.
 	Instruments []Instrument[S]
-	// Refinements are signals asked only when this one fires, narrowing its
-	// answer: each is structurally a signal with the same instruments and
-	// marks, but it is never asked unless the parent fires.
+	// Refinements are signals that narrow this one's answer, with their own
+	// instruments and marks. A refinement is sampled every tick, whether or not
+	// this signal fired, so its window fills independently of when this signal
+	// fires.
 	Refinements []Signal[S]
 	// DemoteSpan is how long a signal may go unread before its window empties:
 	// stale detection, so an old number cannot stand forever.
@@ -129,13 +130,16 @@ func (s Signal[S]) Capable(env Environment) []Instrument[S] {
 	return capable
 }
 
-// Table is the whole declaration for one resource: every signal, every
-// measurement, and the interval the caller ticks at. A measurement in
-// Table.Measurements is one no signal judges: reduced every tick like an
-// instrument but with no thresholds, so use it for a number the caller must
-// publish. The order of Signals is significant.
+// Table is the whole declaration for one resource: every signal and every
+// measurement.
 type Table[S any] struct {
-	Signals      []Signal[S]
+	// The order is significant: see Identity.Index.
+	Signals []Signal[S]
+	// Measurements are the numbers no signal judges: each has a window sampled
+	// every tick like an instrument's, but no thresholds, and it is reduced only
+	// when the caller reads it through Engine.Measurement. Use one for a number
+	// the caller must publish without a verdict.
 	Measurements []Measurement[S]
-	Interval     time.Duration
+	// Interval is how often the caller ticks.
+	Interval time.Duration
 }

--- a/umh-core/pkg/diagnosis/declare.go
+++ b/umh-core/pkg/diagnosis/declare.go
@@ -124,19 +124,13 @@ func (s Signal[S]) Capable(env Environment) []Instrument[S] {
 	return capable
 }
 
-// Track is a quantity measured but never judged: reduced every tick like an
-// instrument, with no thresholds. Use it for a number the caller must publish.
-type Track[S any] struct {
-	Extract   func(S) Reading
-	Name      string
-	Reduction Reduction
-	Span      time.Duration
-}
-
-// Table is the whole declaration for one resource: every signal, every track,
-// and the interval the caller ticks at. The order of Signals is significant.
+// Table is the whole declaration for one resource: every signal, every
+// measurement, and the interval the caller ticks at. A measurement in
+// Table.Measurements is one no signal judges: reduced every tick like an
+// instrument but with no thresholds, so use it for a number the caller must
+// publish. The order of Signals is significant.
 type Table[S any] struct {
-	Signals  []Signal[S]
-	Tracks   []Track[S]
-	Interval time.Duration
+	Signals      []Signal[S]
+	Measurements []Measurement[S]
+	Interval     time.Duration
 }

--- a/umh-core/pkg/diagnosis/declare.go
+++ b/umh-core/pkg/diagnosis/declare.go
@@ -92,9 +92,11 @@ type Signal[S any] struct {
 	// the first instrument that can supply a number is the one used.
 	Instruments []Instrument[S]
 	// Refinements are signals declared under this one, narrowing its answer with
-	// their own instruments and marks. A refinement appears in Fired.Refinements
-	// under a parent that fired, and never as a verdict of its own. The
-	// Refinements section of the package doc works through an example.
+	// their own instruments and marks. Each is sampled and judged on every tick,
+	// whether or not this signal fired, so its window is warm when this one fires
+	// and its Since is the tick IT crossed its mark. A refinement appears in
+	// Fired.Refinements under a parent that fired, and never as a verdict of its
+	// own. The Refinements section of the package doc works through an example.
 	Refinements []Signal[S]
 	// DemoteSpan is how long a signal may go unread before its window empties:
 	// stale detection, so an old number cannot stand forever.

--- a/umh-core/pkg/diagnosis/declare.go
+++ b/umh-core/pkg/diagnosis/declare.go
@@ -90,9 +90,11 @@ type Signal[S any] struct {
 	// the first instrument that can supply a number is the one used.
 	Instruments []Instrument[S]
 	// Refinements are signals that narrow this one's answer, with their own
-	// instruments and marks. A refinement is sampled every tick, whether or not
-	// this signal fired, so its window fills independently of when this signal
-	// fires.
+	// instruments and marks. A refinement is sampled AND judged every tick,
+	// whether or not this signal fired, so its window fills and its verdict is
+	// reached independently of when this signal fires. Only the report waits on
+	// this signal: a refinement appears in Fired.Refinements under a signal that
+	// fired, and never as a verdict of its own.
 	Refinements []Signal[S]
 	// DemoteSpan is how long a signal may go unread before its window empties:
 	// stale detection, so an old number cannot stand forever.

--- a/umh-core/pkg/diagnosis/declare.go
+++ b/umh-core/pkg/diagnosis/declare.go
@@ -95,6 +95,9 @@ type Signal[S any] struct {
 	// Tier is a rank class the caller assigns, lower meaning more urgent. The
 	// numbers themselves are the caller's vocabulary.
 	Tier int
+	// Attribution is who the caller blames, an opaque int. The numbers are the
+	// caller's vocabulary, and this package never interprets them.
+	Attribution int
 	// ReleaseOnAbsent stops reporting the signal the moment nothing can answer
 	// it at all, rather than waiting out DemoteSpan.
 	ReleaseOnAbsent bool

--- a/umh-core/pkg/diagnosis/declare.go
+++ b/umh-core/pkg/diagnosis/declare.go
@@ -92,11 +92,13 @@ type Signal[S any] struct {
 	// the first instrument that can supply a number is the one used.
 	Instruments []Instrument[S]
 	// Refinements are signals declared under this one, narrowing its answer with
-	// their own instruments and marks. Each is sampled and judged on every tick,
-	// whether or not this signal fired, so its window is warm when this one fires
-	// and its Since is the tick IT crossed its mark. A refinement appears in
-	// Fired.Refinements under a parent that fired, and never as a verdict of its
-	// own. The Refinements section of the package doc works through an example.
+	// their own instruments and marks. A refinement is itself a Signal, so it may
+	// declare refinements of its own, to any depth. Each is sampled and judged on
+	// every tick, whether or not this signal fired, so its window is warm when
+	// this one fires and its Since is the tick IT crossed its mark. A refinement
+	// appears in Fired.Refinements under a parent that fired, and never as a
+	// verdict of its own. The Refinements section of the package doc works
+	// through an example.
 	Refinements []Signal[S]
 	// DemoteSpan is how long a signal may go unread before its window empties:
 	// stale detection, so an old number cannot stand forever.
@@ -112,8 +114,9 @@ type Signal[S any] struct {
 	ReleaseOnAbsent bool
 }
 
-// Capable returns the instruments the environment satisfies, in declared order.
-func (s Signal[S]) Capable(env Environment) []Instrument[S] {
+// CapableInstruments returns the instruments the environment satisfies, in
+// declared order.
+func (s Signal[S]) CapableInstruments(env Environment) []Instrument[S] {
 	capable := make([]Instrument[S], 0, len(s.Instruments))
 	for _, inst := range s.Instruments {
 		satisfied := true

--- a/umh-core/pkg/diagnosis/declare.go
+++ b/umh-core/pkg/diagnosis/declare.go
@@ -50,15 +50,15 @@ func (e Environment) Has(c Capability) bool {
 // measurement can answer a signal. Its number is judged only where an
 // Instrument pairs it with marks.
 type Measurement[S any] struct {
-	Name string
 	// Extract reads the value from a snapshot, the numerator under DeltaRatio.
 	Extract func(S) Reading
 	// Against reads the DENOMINATOR of a ratio: DeltaRatio divides the delta of
 	// Extract's counter by the delta of this one. Nil for a single series.
 	Against   func(S) Reading
-	Span      time.Duration
-	Reduction Reduction
+	Name      string
 	Requires  []Capability
+	Reduction Reduction
+	Span      time.Duration
 	// Boolean says the series is zero or one and nothing between.
 	Boolean bool
 	// Counter says both series are monotone counters, so a backwards step means

--- a/umh-core/pkg/diagnosis/declare.go
+++ b/umh-core/pkg/diagnosis/declare.go
@@ -101,8 +101,6 @@ type Signal[S any] struct {
 	// ReleaseOnAbsent stops reporting the signal the moment nothing can answer
 	// it at all, rather than waiting out DemoteSpan.
 	ReleaseOnAbsent bool
-	// External marks a cause attributed outside this box rather than to it.
-	External bool
 }
 
 // Capable returns the instruments the environment satisfies, in declared order.

--- a/umh-core/pkg/diagnosis/doc.go
+++ b/umh-core/pkg/diagnosis/doc.go
@@ -30,4 +30,23 @@
 //
 // Observe returns two things: what fired, and one readiness row per signal, so
 // a caller can tell "measured, and fine" from "could not measure at all".
+//
+// # Refinements
+//
+// A signal answers one question, and the answer is often not helpful on its
+// own. One might add a rule that the CPU degrades above 70%. But that is not
+// helpful: the question is WHAT degraded it.
+//
+// So there can be smaller rules that fire underneath, called refinements. If
+// the main CPU signal is degraded, and only then, the engine reports whether
+// any signal in the level below it gives more information. For example, a
+// caller could measure the container's CPU. A refinement checks whether the
+// container CPU is over x% of the CPU currently used; if it fires, the
+// caller's message goes from "CPU degraded" to "CPU degraded, because the
+// container is taking a lot of CPU".
+//
+// There can be another refinement beside it that checks whether the host is
+// over x%, instead of the container's workload, and then it is "CPU degraded,
+// but nothing in our container and it is other software running on the host".
+// If the container metric is not available, both refinements are absent.
 package diagnosis

--- a/umh-core/pkg/diagnosis/doc.go
+++ b/umh-core/pkg/diagnosis/doc.go
@@ -34,19 +34,21 @@
 // # Refinements
 //
 // A signal answers one question, and the answer is often not helpful on its
-// own. One might add a rule that the CPU degrades above 70%. But that is not
+// own. One might add a signal that the CPU degrades above 70%. But that is not
 // helpful: the question is WHAT degraded it.
 //
-// So there can be smaller rules that fire underneath, called refinements. If
+// So there can be smaller signals that fire underneath, called refinements. If
 // the main CPU signal is degraded, and only then, the engine reports whether
 // any signal in the level below it gives more information. For example, a
 // caller could measure the container's CPU. A refinement checks whether the
-// container CPU is over x% of the CPU currently used; if it fires, the
+// container CPU is over 60% of the CPU currently used; if it fires, the
 // caller's message goes from "CPU degraded" to "CPU degraded, because the
 // container is taking a lot of CPU".
 //
-// There can be another refinement beside it that checks whether the host is
-// over x%, instead of the container's workload, and then it is "CPU degraded,
-// but nothing in our container and it is other software running on the host".
-// If the container metric is not available, both refinements are absent.
+// There can be another refinement beside it that checks whether everything
+// outside the container is over 60%, instead of the container's workload, and
+// then it is "CPU degraded, but nothing in our container and it is other
+// software running on the host". That one reads the CPU in use minus the
+// container's share, so it needs the container metric too: if that metric is
+// not available, both refinements are absent.
 package diagnosis

--- a/umh-core/pkg/diagnosis/engine.go
+++ b/umh-core/pkg/diagnosis/engine.go
@@ -92,19 +92,30 @@ type key struct{ Path, Instrument string }
 // because "one latch per signal" is now the type rather than two slices agreeing
 // about their length and their order.
 type signalState[S any] struct {
-	signal Signal[S]
-	// path is what this signal's windows are keyed under: its bare name at the
-	// top level, its parent's path plus its own name for a refinement.
-	path string
-	// latch is the single latch that judges this signal. Every node in the tree
-	// has its own, at every depth.
-	latch Latch
+	// instruments are this signal's own, deep-copied out of the caller's table.
+	instruments []Instrument[S]
 	// refinements is the same pairing one level down, one entry per refinement
 	// this signal declares, in declared order. A refinement is a signal in every
 	// respect the engine judges by: its own instruments, its own marks, its own
 	// latch, so judge and observeWindows recurse into it with no child branch.
 	// Observe's own loop does not recurse: it runs over the top level only.
 	refinements []signalState[S]
+	// path is what this signal's windows are keyed under: its bare name at the
+	// top level, its parent's path plus its own name for a refinement.
+	path string
+	// latch is the single latch that judges this signal. Every node in the tree
+	// has its own, at every depth.
+	latch Latch
+	// demoteSpan and releaseOnAbsent are Signal.DemoteSpan and
+	// Signal.ReleaseOnAbsent: what judge drives the latch with on a tick that
+	// reaches no capable window holding a trustworthy number.
+	demoteSpan      time.Duration
+	releaseOnAbsent bool
+}
+
+// capable applies Signal.Capable to the instruments this state holds.
+func (st *signalState[S]) capable(env Environment) []Instrument[S] {
+	return Signal[S]{Instruments: st.instruments}.Capable(env)
 }
 
 // measurementState is one measurement and the single window it reduces through,
@@ -180,37 +191,33 @@ func NewEngine[S any](t Table[S]) (*Engine[S], error) {
 // carries.
 func buildSignalState[S any](path string, s Signal[S], index int) signalState[S] {
 	// The caller keeps the table they passed, so the engine must own the
-	// instruments it stores: a copy of the Signal would still share the
-	// Instruments backing array, and a later edit to the caller's own table
-	// would rename the engine's instruments while the windows above stay
-	// keyed by the names as they were at construction. Deep-copy the
-	// instruments and, one level down, each instrument's capability list,
-	// which is a second slice header into the same table.
-	s.Instruments = append([]Instrument[S](nil), s.Instruments...)
-	for j := range s.Instruments {
-		s.Instruments[j].Requires = append([]Capability(nil), s.Instruments[j].Requires...)
+	// instruments it stores: the caller's slice header points into their own
+	// array, and a later edit there would rename the engine's instruments while
+	// the windows above stay keyed by the names as they were at construction.
+	// Deep-copy the instruments and, one level down, each instrument's
+	// capability list, which is a second slice header into the same table.
+	instruments := append([]Instrument[S](nil), s.Instruments...)
+	for j := range instruments {
+		instruments[j].Requires = append([]Capability(nil), instruments[j].Requires...)
 	}
 
 	st := signalState[S]{
-		signal: s,
-		path:   path,
+		instruments: instruments,
+		path:        path,
 		latch: Latch{identity: Identity{
 			Signal:      s.Name,
 			Tier:        s.Tier,
 			Attribution: s.Attribution,
 			Index:       index,
 		}},
-		refinements: make([]signalState[S], 0, len(s.Refinements)),
+		refinements:     make([]signalState[S], 0, len(s.Refinements)),
+		demoteSpan:      s.DemoteSpan,
+		releaseOnAbsent: s.ReleaseOnAbsent,
 	}
 
 	for i, r := range s.Refinements {
 		st.refinements = append(st.refinements, buildSignalState(path+"/"+r.Name, r, i))
 	}
-
-	// st.refinements is the engine's own copy of the tree, and one tree wants
-	// one owner. The stored Signal's own list of children would point into the
-	// caller's arrays, uncopied and so unowned.
-	st.signal.Refinements = nil
 
 	return st
 }
@@ -455,7 +462,7 @@ func validateMeasurement[S any](row string, spanNoun string, m Measurement[S], i
 // so a window reduced without a preceding Observe reports entries left over from
 // an earlier tick as trusted.
 func (e *Engine[S]) Select(s Signal[S], env Environment) (Instrument[S], Reduced, Coverage, Availability) {
-	return e.resolve(s.Name, s, s.Capable(env))
+	return e.resolve(s.Name, s.Capable(env))
 }
 
 // resolve applies the readiness gate to a signal's already-capable instruments:
@@ -466,7 +473,7 @@ func (e *Engine[S]) Select(s Signal[S], env Environment) (Instrument[S], Reduced
 //
 // path names the windows to read, so a refinement resolves against its own,
 // "A/X" rather than the "X" a top-level signal of that name holds.
-func (e *Engine[S]) resolve(path string, s Signal[S], capable []Instrument[S]) (Instrument[S], Reduced, Coverage, Availability) {
+func (e *Engine[S]) resolve(path string, capable []Instrument[S]) (Instrument[S], Reduced, Coverage, Availability) {
 	if len(capable) == 0 {
 		return Instrument[S]{}, Reduced{}, Coverage{}, NoInstrument
 	}
@@ -511,7 +518,7 @@ func (e *Engine[S]) resolve(path string, s Signal[S], capable []Instrument[S]) (
 // refinements is unconditional. Signal.Refinements states the contract that
 // follows for a caller.
 func observeWindows[S any](e *Engine[S], st *signalState[S], sample S, at time.Time) {
-	for _, inst := range st.signal.Instruments {
+	for _, inst := range st.instruments {
 		w := e.windows[key{Path: st.path, Instrument: inst.Name}]
 		if w == nil { // NewEngine builds a window for every pair; never nil here
 			continue
@@ -538,22 +545,20 @@ func observeWindows[S any](e *Engine[S], st *signalState[S], sample S, at time.T
 // refinements' as the recursion reaches them, so a parent's row comes
 // immediately before the rows of the subtree under it.
 func (e *Engine[S]) judge(st *signalState[S], env Environment, at time.Time, into []Readiness) []Readiness {
-	s := st.signal
-
-	inst, reduced, cov, avail := e.resolve(st.path, s, s.Capable(env))
+	inst, reduced, cov, avail := e.resolve(st.path, st.capable(env))
 	l := &st.latch
 
 	switch avail {
 	case Ready:
 		l.Update(inst.Name, reduced, cov, inst.Marks, at)
 	case AllAbsent:
-		if s.ReleaseOnAbsent {
+		if st.releaseOnAbsent {
 			l.Reset()
 		} else {
-			l.ReleaseAfter(s.DemoteSpan, at)
+			l.ReleaseAfter(st.demoteSpan, at)
 		}
 	default: // NoInstrument, NoneReady: hold, then release on the demote clock.
-		l.ReleaseAfter(s.DemoteSpan, at)
+		l.ReleaseAfter(st.demoteSpan, at)
 	}
 
 	into = append(into, Readiness{Signal: st.path, Availability: avail})

--- a/umh-core/pkg/diagnosis/engine.go
+++ b/umh-core/pkg/diagnosis/engine.go
@@ -45,8 +45,10 @@ import (
 type Availability int
 
 const (
-	// NoInstrument: this environment satisfies no instrument, so there is no
-	// capable window to take a maximum over. The latch runs its demote clock,
+	// NoInstrument: there is no capable window to take a maximum over, because
+	// this environment satisfies no instrument of the signal, or because no
+	// capable instrument has a window under the path read. The latch runs its
+	// demote clock,
 	// releasing once DemoteSpan has passed since the last trusted update.
 	NoInstrument Availability = iota
 	// AllAbsent: every capable window is empty. The latch resets at once if the
@@ -86,22 +88,17 @@ type Readiness struct {
 // refinement's path is its parent's path plus its own name, e.g. "A/X".
 type key struct{ Path, Instrument string }
 
-// signalState is one signal, the state the engine keeps for it, and the same
-// pairing for each of its refinements. 7e8301485 took these out of name-keyed
-// maps into slices held in the same order; pairing them finishes that move,
-// because "one latch per signal" is now the type rather than two slices agreeing
-// about their length and their order.
+// signalState is one signal narrowed to what the engine judges it by, the latch
+// that judges it, and the same pairing for each of its refinements. Pairing them
+// makes "one latch per signal" the type, rather than two slices agreeing about
+// their length and their order.
 type signalState[S any] struct {
 	// instruments are this signal's own, deep-copied out of the caller's table.
 	instruments []Instrument[S]
-	// refinements is the same pairing one level down, one entry per refinement
-	// this signal declares, in declared order. A refinement is a signal in every
-	// respect the engine judges by: its own instruments, its own marks, its own
-	// latch, so judge and observeWindows recurse into it with no child branch.
-	// Observe's own loop does not recurse: it runs over the top level only.
+	// refinements is the same pairing one level down, in declared order.
 	refinements []signalState[S]
-	// path is what this signal's windows are keyed under: its bare name at the
-	// top level, its parent's path plus its own name for a refinement.
+	// path is what this signal's windows are keyed under: its bare name for a
+	// top-level signal, its parent's path plus its own name for a refinement.
 	path string
 	// latch is the single latch that judges this signal. Every node in the tree
 	// has its own, at every depth.
@@ -119,8 +116,7 @@ func (st *signalState[S]) capable(env Environment) []Instrument[S] {
 }
 
 // measurementState is one measurement and the single window it reduces through,
-// paired for the same reason. Measurement no longer walks one slice while
-// indexing another.
+// paired for the same reason.
 type measurementState[S any] struct {
 	measurement Measurement[S]
 	window      SlidingWindow
@@ -131,16 +127,11 @@ type measurementState[S any] struct {
 // It is not synchronized: the goroutine that calls Observe owns it, and a reader
 // calling Select, Reduction or Measurement from another races on points and latches.
 type Engine[S any] struct {
-	// windows is keyed by path: "A/X" for a refinement X under A. Select looks
-	// up the bare name of the Signal handed to it, so a caller passing a
-	// refinement reads the key "X" rather than "A/X". That misses whenever no
-	// top-level signal is named X, which is what makes resolve's nil arm
-	// reachable. It does NOT miss when the table also declares a top-level X
-	// carrying an instrument the refinement names too: the lookup hits THAT
-	// signal's window, and the caller gets its number marked Ready. Select's
-	// doc carries the restriction this leaves on a caller. The two slices
-	// below are built by NewEngine and cannot miss, which is why they are
-	// pairs instead.
+	// windows is keyed by path: "A/X" for a refinement X under A. Select keys on
+	// a bare name instead, so a caller passing a refinement reads some other
+	// signal's window or none at all. That is what makes resolve's nil arm
+	// reachable, and Select's doc carries the restriction it leaves on a caller.
+	// The two slices below are built as pairs by NewEngine and cannot miss.
 	windows      map[key]*SlidingWindow
 	signals      []signalState[S]
 	measurements []measurementState[S]
@@ -169,13 +160,13 @@ func NewEngine[S any](t Table[S]) (*Engine[S], error) {
 		}
 	}
 
-	for _, tr := range t.Measurements {
-		w, err := NewSlidingWindow(tr.Span, tr.Span, tr.Reduction, false)
+	for _, m := range t.Measurements {
+		w, err := NewSlidingWindow(m.Span, m.Span, m.Reduction, false)
 		if err != nil {
 			return nil, err
 		}
 
-		e.measurements = append(e.measurements, measurementState[S]{measurement: tr, window: *w})
+		e.measurements = append(e.measurements, measurementState[S]{measurement: m, window: *w})
 	}
 
 	for i, s := range t.Signals {
@@ -318,8 +309,8 @@ func validate[S any](t Table[S]) error {
 }
 
 // validateSignal applies every rule a Signal is held to, then recurses into its
-// refinements under the child's path, so an error names where in the tree the
-// row lives rather than the bare child. Instrument and refinement names are
+// refinements under the refinement's own path, so an error names where in the
+// tree the row lives rather than the bare refinement. Instrument and refinement names are
 // unique among their siblings only.
 func validateSignal[S any](path string, s Signal[S], interval time.Duration) error {
 	// A refinement's path is its parent's path plus "/" plus its own name, and
@@ -411,8 +402,8 @@ func validateSignal[S any](path string, s Signal[S], interval time.Duration) err
 // Table.Measurements. row names the ownership for the error, e.g.
 // `signal "A" instrument "I1"`, and spanNoun is the word the loop uses for the
 // window's size, "window span" for an instrument as against "span" for a bare
-// table measurement. NewEngine's two specs for a zero span pin one wording
-// each, so the pair cannot collapse to a single noun unnoticed.
+// table measurement. NewEngine's two specs for a zero span each assert one of
+// the two wordings, so the pair cannot collapse to a single noun unnoticed.
 func validateMeasurement[S any](row string, spanNoun string, m Measurement[S], interval time.Duration) error {
 	if m.Extract == nil {
 		return fmt.Errorf("%s: nil extract", row)
@@ -537,7 +528,7 @@ func observeWindows[S any](e *Engine[S], st *signalState[S], sample S, at time.T
 // each of its refinements, whichever way this signal went. A refinement is
 // judged every tick for the same reason its window is filled every tick: a
 // verdict reached only while the parent happened to be firing would be decided
-// on however much history the child had at that instant. Only REPORTING a
+// on however much history the refinement had at that instant. Only REPORTING a
 // refinement waits on the parent, which firedTree does.
 //
 // It appends one Readiness row per signal it drives, carrying the Availability

--- a/umh-core/pkg/diagnosis/engine.go
+++ b/umh-core/pkg/diagnosis/engine.go
@@ -176,6 +176,11 @@ func NewEngine[S any](t Table[S]) (*Engine[S], error) {
 	return e, nil
 }
 
+// pathSeparator joins a refinement's name onto its parent's path.
+// validateSignal refuses it inside any name, so no two signals can compose
+// the same path and share a window.
+const pathSeparator = "/"
+
 // buildSignalState pairs one signal with the latch that judges it, then recurses
 // into its refinements under the same paths buildWindows keyed their windows
 // under. index is the signal's position among its siblings, which Identity.Index
@@ -207,7 +212,7 @@ func buildSignalState[S any](path string, s Signal[S], index int) signalState[S]
 	}
 
 	for i, r := range s.Refinements {
-		st.refinements = append(st.refinements, buildSignalState(path+"/"+r.Name, r, i))
+		st.refinements = append(st.refinements, buildSignalState(path+pathSeparator+r.Name, r, i))
 	}
 
 	return st
@@ -227,7 +232,7 @@ func buildWindows[S any](e *Engine[S], path string, s Signal[S]) error {
 	}
 
 	for _, r := range s.Refinements {
-		if err := buildWindows(e, path+"/"+r.Name, r); err != nil {
+		if err := buildWindows(e, path+pathSeparator+r.Name, r); err != nil {
 			return err
 		}
 	}
@@ -319,8 +324,8 @@ func validateSignal[S any](path string, s Signal[S], interval time.Duration) err
 	// "A/X" against the refinement X of a signal A, and the two would silently
 	// share one window. Refusing the separator in every segment makes that
 	// collision unreachable.
-	if strings.Contains(s.Name, "/") {
-		return fmt.Errorf("signal %q: a name may not contain %q", path, "/")
+	if strings.Contains(s.Name, pathSeparator) {
+		return fmt.Errorf("signal %q: a name may not contain %q", path, pathSeparator)
 	}
 
 	if len(s.Instruments) == 0 {
@@ -389,7 +394,7 @@ func validateSignal[S any](path string, s Signal[S], interval time.Duration) err
 
 		seen[r.Name] = true
 
-		if err := validateSignal(path+"/"+r.Name, r, interval); err != nil {
+		if err := validateSignal(path+pathSeparator+r.Name, r, interval); err != nil {
 			return err
 		}
 	}

--- a/umh-core/pkg/diagnosis/engine.go
+++ b/umh-core/pkg/diagnosis/engine.go
@@ -68,10 +68,15 @@ const (
 //	StateValue     (2)  -> Ready          (3)
 
 // Readiness is one signal's Availability, handed back by Observe beside the
-// fired set: one row per TOP-LEVEL signal, in table order, always. []Fired reports
-// only what fired, so this is the only route to "was this signal readable at all".
-// A refinement gets no row of its own, though it is judged every tick.
+// fired set: one row per signal at every depth, refinements included, always.
+// []Fired reports only what fired, so this is the only route to "was this signal
+// readable at all".
 type Readiness struct {
+	// Signal is the path, not the bare name: "A/X" for a refinement, its own
+	// name for a top-level signal. Two parents may each declare a refinement
+	// called X, and a bare name would not say which of them this row is about.
+	// It is the path Reduction takes, and NOT the bare name Identity.Signal
+	// carries on a Fired.
 	Signal       string
 	Availability Availability
 }
@@ -500,9 +505,11 @@ func observeWindows[S any](e *Engine[S], st *signalState[S], sample S, at time.T
 // on however much history the child had at that instant. Only REPORTING a
 // refinement waits on the parent, which firedTree does.
 //
-// It returns the Availability the latch was driven with, which is this signal's
-// Readiness row; a refinement's is not reported.
-func (e *Engine[S]) judge(st *signalState[S], env Environment, at time.Time) Availability {
+// It appends one Readiness row per signal it drives, carrying the Availability
+// that signal's latch was driven with: this signal's row first, then its
+// refinements' as the recursion reaches them, so a parent's row comes
+// immediately before the rows of the subtree under it.
+func (e *Engine[S]) judge(st *signalState[S], env Environment, at time.Time, into []Readiness) []Readiness {
 	s := st.signal
 
 	inst, reduced, cov, avail := e.resolve(st.path, s, s.Capable(env))
@@ -521,11 +528,13 @@ func (e *Engine[S]) judge(st *signalState[S], env Environment, at time.Time) Ava
 		l.ReleaseAfter(s.DemoteSpan, at)
 	}
 
+	into = append(into, Readiness{Signal: st.path, Availability: avail})
+
 	for i := range st.refinements {
-		e.judge(&st.refinements[i], env, at)
+		into = e.judge(&st.refinements[i], env, at, into)
 	}
 
-	return avail
+	return into
 }
 
 // firedTree reports one signal's verdict with the verdicts of the refinements
@@ -566,11 +575,14 @@ func firedTree[S any](st *signalState[S]) (Fired, bool) {
 }
 
 // Observe runs one tick against a snapshot and returns the fired set, unranked
-// (Rank puts it worst first), and one Readiness row per TOP-LEVEL signal, both
-// in table order. In order: append to every measurement's and every instrument's
-// window; then, per top-level signal, resolve its Availability over the
-// instruments Signal.Capable allows this tick, drive its single latch, collect
-// whatever fired, and emit a Readiness row whether or not it did.
+// (Rank puts it worst first), and one Readiness row per signal at every depth,
+// refinements included. The fired set holds top-level signals in table order;
+// the readiness rows are depth-first, each signal immediately before the subtree
+// under it, and each named by its path. In order: append to every measurement's
+// and every instrument's window; then walk the signals, resolving each one's
+// Availability over the instruments Signal.Capable allows it this tick, driving
+// its single latch and emitting its Readiness row whether or not it fired, and
+// collecting each top-level signal whose latch is fired.
 //
 // The append pass is unconditional, instruments this environment cannot satisfy
 // included, because Observe is the only call that ages a window: skip it once
@@ -579,9 +591,10 @@ func firedTree[S any](st *signalState[S]) (Fired, bool) {
 // Latch.Reset, and every other branch short of Ready runs the demote clock.
 //
 // A refinement is judged on the same terms every tick, whether or not the signal
-// it hangs under fired. What the parent decides is only whether the refinement is
-// REPORTED: a fired signal carries the refinements whose own latch is fired in
-// Fired.Refinements, and a refinement never appears in the returned slice itself.
+// it hangs under fired, and it has a Readiness row of its own either way. What
+// the parent decides is only whether the refinement's VERDICT is reported: a
+// fired signal carries the refinements whose own latch is fired in
+// Fired.Refinements, and a refinement never appears in the fired set itself.
 //
 // # One tick
 //
@@ -606,16 +619,16 @@ func (e *Engine[S]) Observe(sample S, env Environment, at time.Time) ([]Fired, [
 
 	var fired []Fired
 
+	// One row per signal at every depth, so len(e.signals) is a floor on the
+	// count rather than the count itself; judge grows the slice past it.
 	readiness := make([]Readiness, 0, len(e.signals))
 	for i := range e.signals {
 		st := &e.signals[i]
 
-		avail := e.judge(st, env, at)
+		readiness = e.judge(st, env, at, readiness)
 		if f, ok := firedTree(st); ok {
 			fired = append(fired, f)
 		}
-
-		readiness = append(readiness, Readiness{Signal: st.signal.Name, Availability: avail})
 	}
 
 	return fired, readiness

--- a/umh-core/pkg/diagnosis/engine.go
+++ b/umh-core/pkg/diagnosis/engine.go
@@ -199,62 +199,8 @@ func validate[S any](t Table[S]) error {
 
 		seenSignal[s.Name] = true
 
-		if len(s.Instruments) == 0 {
-			return fmt.Errorf("signal %q: no instruments", s.Name)
-		}
-
-		if s.DemoteSpan <= 0 {
-			return fmt.Errorf("signal %q: demote span %v is zero or negative", s.Name, s.DemoteSpan)
-		}
-
-		if t.Interval > 0 && s.DemoteSpan < t.Interval {
-			return fmt.Errorf("signal %q: demote span %v is below the table interval %v", s.Name, s.DemoteSpan, t.Interval)
-		}
-
-		seenInstrument := make(map[string]bool, len(s.Instruments))
-		for _, inst := range s.Instruments {
-			if err := validateMeasurement(fmt.Sprintf("signal %q instrument %q", s.Name, inst.Name), "window span", inst.Measurement, t.Interval); err != nil {
-				return err
-			}
-
-			if seenInstrument[inst.Name] {
-				return fmt.Errorf("signal %q: duplicate instrument name %q", s.Name, inst.Name)
-			}
-
-			seenInstrument[inst.Name] = true
-
-			if inst.Reduction.ordered && inst.Boolean {
-				return fmt.Errorf("signal %q instrument %q: ordered reduction %q on a boolean series", s.Name, inst.Name, inst.Reduction.Name)
-			}
-
-			if inst.Reduction.divides && inst.Against == nil {
-				return fmt.Errorf("signal %q instrument %q: reduction %q divides but the instrument declares no against extractor", s.Name, inst.Name, inst.Reduction.Name)
-			}
-
-			for _, mark := range []struct {
-				name  string
-				value float64
-			}{
-				{name: "fire mark", value: inst.Marks.Fire.At},
-				{name: "clear mark", value: inst.Marks.Clear.At},
-				{name: "worst value", value: inst.Marks.Worst},
-			} {
-				if math.IsNaN(mark.value) || math.IsInf(mark.value, 0) {
-					return fmt.Errorf("signal %q instrument %q: %s %v is not finite", s.Name, inst.Name, mark.name, mark.value)
-				}
-			}
-
-			if worse(inst.Marks.Clear.At, inst.Marks) >= worse(inst.Marks.Fire.At, inst.Marks) {
-				return fmt.Errorf("signal %q instrument %q: clear mark is not on the holding side of its fire mark under its polarity", s.Name, inst.Name)
-			}
-
-			if worse(inst.Marks.Worst, inst.Marks) <= worse(inst.Marks.Fire.At, inst.Marks) {
-				return fmt.Errorf("signal %q instrument %q: worst value %v is not strictly worse than fire mark %v under its polarity", s.Name, inst.Name, inst.Marks.Worst, inst.Marks.Fire.At)
-			}
-
-			if span := worse(inst.Marks.Worst, inst.Marks) - worse(inst.Marks.Fire.At, inst.Marks); math.IsInf(span, 0) {
-				return fmt.Errorf("signal %q instrument %q: the distance from fire mark %v to worst value %v overflows, so the severity denominator is not finite", s.Name, inst.Name, inst.Marks.Fire.At, inst.Marks.Worst)
-			}
+		if err := validateSignal(s.Name, s, t.Interval); err != nil {
+			return err
 		}
 	}
 
@@ -292,6 +238,85 @@ func validate[S any](t Table[S]) error {
 
 		if m.Reduction.divides {
 			return fmt.Errorf("measurement %q: reduction %q divides but a measurement declares no denominator series", m.Name, m.Reduction.Name)
+		}
+	}
+
+	return nil
+}
+
+// validateSignal applies every rule a Signal is held to, then recurses into its
+// refinements under the child's path, so an error names where in the tree the
+// row lives rather than the bare child. Instrument and refinement names are
+// unique among their siblings only.
+func validateSignal[S any](path string, s Signal[S], interval time.Duration) error {
+	if len(s.Instruments) == 0 {
+		return fmt.Errorf("signal %q: no instruments", path)
+	}
+
+	if s.DemoteSpan <= 0 {
+		return fmt.Errorf("signal %q: demote span %v is zero or negative", path, s.DemoteSpan)
+	}
+
+	if interval > 0 && s.DemoteSpan < interval {
+		return fmt.Errorf("signal %q: demote span %v is below the table interval %v", path, s.DemoteSpan, interval)
+	}
+
+	seenInstrument := make(map[string]bool, len(s.Instruments))
+	for _, inst := range s.Instruments {
+		if err := validateMeasurement(fmt.Sprintf("signal %q instrument %q", path, inst.Name), "window span", inst.Measurement, interval); err != nil {
+			return err
+		}
+
+		if seenInstrument[inst.Name] {
+			return fmt.Errorf("signal %q: duplicate instrument name %q", path, inst.Name)
+		}
+
+		seenInstrument[inst.Name] = true
+
+		if inst.Reduction.ordered && inst.Boolean {
+			return fmt.Errorf("signal %q instrument %q: ordered reduction %q on a boolean series", path, inst.Name, inst.Reduction.Name)
+		}
+
+		if inst.Reduction.divides && inst.Against == nil {
+			return fmt.Errorf("signal %q instrument %q: reduction %q divides but the instrument declares no against extractor", path, inst.Name, inst.Reduction.Name)
+		}
+
+		for _, mark := range []struct {
+			name  string
+			value float64
+		}{
+			{name: "fire mark", value: inst.Marks.Fire.At},
+			{name: "clear mark", value: inst.Marks.Clear.At},
+			{name: "worst value", value: inst.Marks.Worst},
+		} {
+			if math.IsNaN(mark.value) || math.IsInf(mark.value, 0) {
+				return fmt.Errorf("signal %q instrument %q: %s %v is not finite", path, inst.Name, mark.name, mark.value)
+			}
+		}
+
+		if worse(inst.Marks.Clear.At, inst.Marks) >= worse(inst.Marks.Fire.At, inst.Marks) {
+			return fmt.Errorf("signal %q instrument %q: clear mark is not on the holding side of its fire mark under its polarity", path, inst.Name)
+		}
+
+		if worse(inst.Marks.Worst, inst.Marks) <= worse(inst.Marks.Fire.At, inst.Marks) {
+			return fmt.Errorf("signal %q instrument %q: worst value %v is not strictly worse than fire mark %v under its polarity", path, inst.Name, inst.Marks.Worst, inst.Marks.Fire.At)
+		}
+
+		if span := worse(inst.Marks.Worst, inst.Marks) - worse(inst.Marks.Fire.At, inst.Marks); math.IsInf(span, 0) {
+			return fmt.Errorf("signal %q instrument %q: the distance from fire mark %v to worst value %v overflows, so the severity denominator is not finite", path, inst.Name, inst.Marks.Fire.At, inst.Marks.Worst)
+		}
+	}
+
+	seen := make(map[string]bool, len(s.Refinements))
+	for _, r := range s.Refinements {
+		if seen[r.Name] {
+			return fmt.Errorf("signal %q: duplicate refinement name %q", path, r.Name)
+		}
+
+		seen[r.Name] = true
+
+		if err := validateSignal(path+"/"+r.Name, r, interval); err != nil {
+			return err
 		}
 	}
 

--- a/umh-core/pkg/diagnosis/engine.go
+++ b/umh-core/pkg/diagnosis/engine.go
@@ -204,6 +204,11 @@ func buildSignalState[S any](path string, s Signal[S], index int) signalState[S]
 		st.refinements = append(st.refinements, buildSignalState(path+"/"+r.Name, r, i))
 	}
 
+	// st.refinements is the engine's own copy of the tree, and one tree wants
+	// one owner. The stored Signal's own list of children would point into the
+	// caller's arrays, uncopied and so unowned.
+	st.signal.Refinements = nil
+
 	return st
 }
 

--- a/umh-core/pkg/diagnosis/engine.go
+++ b/umh-core/pkg/diagnosis/engine.go
@@ -213,8 +213,8 @@ func validate[S any](t Table[S]) error {
 
 		seenInstrument := make(map[string]bool, len(s.Instruments))
 		for _, inst := range s.Instruments {
-			if inst.Extract == nil {
-				return fmt.Errorf("signal %q instrument %q: nil extract", s.Name, inst.Name)
+			if err := validateMeasurement(fmt.Sprintf("signal %q instrument %q", s.Name, inst.Name), "window span", inst.Measurement, t.Interval); err != nil {
+				return err
 			}
 
 			if seenInstrument[inst.Name] {
@@ -222,18 +222,6 @@ func validate[S any](t Table[S]) error {
 			}
 
 			seenInstrument[inst.Name] = true
-
-			if inst.Span <= 0 {
-				return fmt.Errorf("signal %q instrument %q: window span %v is zero or negative", s.Name, inst.Name, inst.Span)
-			}
-
-			if inst.Reduction.Min < 1 {
-				return fmt.Errorf("signal %q instrument %q: reduction %q minimum sample count %d is below one", s.Name, inst.Name, inst.Reduction.Name, inst.Reduction.Min)
-			}
-
-			if inst.Reduction.fold == nil {
-				return fmt.Errorf("signal %q instrument %q: reduction %q has no fold", s.Name, inst.Name, inst.Reduction.Name)
-			}
 
 			if inst.Reduction.ordered && inst.Boolean {
 				return fmt.Errorf("signal %q instrument %q: ordered reduction %q on a boolean series", s.Name, inst.Name, inst.Reduction.Name)
@@ -267,44 +255,55 @@ func validate[S any](t Table[S]) error {
 			if span := worse(inst.Marks.Worst, inst.Marks) - worse(inst.Marks.Fire.At, inst.Marks); math.IsInf(span, 0) {
 				return fmt.Errorf("signal %q instrument %q: the distance from fire mark %v to worst value %v overflows, so the severity denominator is not finite", s.Name, inst.Name, inst.Marks.Fire.At, inst.Marks.Worst)
 			}
-
-			if t.Interval > 0 && int(inst.Span/t.Interval)+1 < inst.Reduction.Min {
-				return fmt.Errorf("signal %q instrument %q: reduction %q minimum sample count %d exceeds what its window span %v can hold at table interval %v", s.Name, inst.Name, inst.Reduction.Name, inst.Reduction.Min, inst.Span, t.Interval)
-			}
 		}
 	}
 
 	seenMeasurement := make(map[string]bool, len(t.Measurements))
-	for _, tr := range t.Measurements {
-		if seenMeasurement[tr.Name] {
-			return fmt.Errorf("duplicate measurement name %q", tr.Name)
+	for _, m := range t.Measurements {
+		if seenMeasurement[m.Name] {
+			return fmt.Errorf("duplicate measurement name %q", m.Name)
 		}
 
-		seenMeasurement[tr.Name] = true
+		seenMeasurement[m.Name] = true
 
-		if tr.Extract == nil {
-			return fmt.Errorf("measurement %q: nil extract", tr.Name)
+		if err := validateMeasurement(fmt.Sprintf("measurement %q", m.Name), "span", m, t.Interval); err != nil {
+			return err
 		}
 
-		if tr.Span <= 0 {
-			return fmt.Errorf("measurement %q: span %v is zero or negative", tr.Name, tr.Span)
+		if m.Reduction.divides {
+			return fmt.Errorf("measurement %q: reduction %q divides but a measurement declares no denominator series", m.Name, m.Reduction.Name)
 		}
+	}
 
-		if tr.Reduction.Min < 1 {
-			return fmt.Errorf("measurement %q: reduction %q minimum sample count %d is below one", tr.Name, tr.Reduction.Name, tr.Reduction.Min)
-		}
+	return nil
+}
 
-		if tr.Reduction.fold == nil {
-			return fmt.Errorf("measurement %q: reduction %q has no fold", tr.Name, tr.Reduction.Name)
-		}
+// validateMeasurement applies the five rules every Measurement is held to,
+// whether it answers a signal (among a Signal's Instruments) or sits in
+// Table.Measurements. row names the ownership for the error, e.g.
+// `signal "A" instrument "I1"`, and spanNoun is the word the loop uses for the
+// window's size, "window span" for an instrument as against "span" for a bare
+// table measurement: each loop's wording is part of the message the tests
+// assert on, so the two stay exact.
+func validateMeasurement[S any](row string, spanNoun string, m Measurement[S], interval time.Duration) error {
+	if m.Extract == nil {
+		return fmt.Errorf("%s: nil extract", row)
+	}
 
-		if tr.Reduction.divides {
-			return fmt.Errorf("measurement %q: reduction %q divides but a measurement declares no denominator series", tr.Name, tr.Reduction.Name)
-		}
+	if m.Span <= 0 {
+		return fmt.Errorf("%s: %s %v is zero or negative", row, spanNoun, m.Span)
+	}
 
-		if t.Interval > 0 && int(tr.Span/t.Interval)+1 < tr.Reduction.Min {
-			return fmt.Errorf("measurement %q: reduction %q minimum sample count %d exceeds what its window span %v can hold at table interval %v", tr.Name, tr.Reduction.Name, tr.Reduction.Min, tr.Span, t.Interval)
-		}
+	if m.Reduction.Min < 1 {
+		return fmt.Errorf("%s: reduction %q minimum sample count %d is below one", row, m.Reduction.Name, m.Reduction.Min)
+	}
+
+	if m.Reduction.fold == nil {
+		return fmt.Errorf("%s: reduction %q has no fold", row, m.Reduction.Name)
+	}
+
+	if interval > 0 && int(m.Span/interval)+1 < m.Reduction.Min {
+		return fmt.Errorf("%s: reduction %q minimum sample count %d exceeds what its window span %v can hold at table interval %v", row, m.Reduction.Name, m.Reduction.Min, m.Span, interval)
 	}
 
 	return nil

--- a/umh-core/pkg/diagnosis/engine.go
+++ b/umh-core/pkg/diagnosis/engine.go
@@ -36,6 +36,7 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"strings"
 	"time"
 )
 
@@ -238,8 +239,9 @@ func buildWindows[S any](e *Engine[S], path string, s Signal[S]) error {
 // produce a verdict, could never hold a point, or names itself twice: a
 // reduction with no calculation to apply, a percentile over a boolean series, a
 // non-finite mark, a clear mark not on the holding side of its fire mark, a nil
-// extractor, a zero span, a duplicate name. The error names the row. Two rules
-// need more than an error string:
+// extractor, a zero span, a duplicate name, a name holding the separator paths
+// are composed with. The error names the row. Two rules need more than an error
+// string:
 //
 //   - Marks must be finite, Worst, the value where severity reaches 1, must be
 //     strictly worse than Fire under the pair's own polarity, and the span from
@@ -311,6 +313,16 @@ func validate[S any](t Table[S]) error {
 // row lives rather than the bare child. Instrument and refinement names are
 // unique among their siblings only.
 func validateSignal[S any](path string, s Signal[S], interval time.Duration) error {
+	// A refinement's path is its parent's path plus "/" plus its own name, and
+	// that path keys its windows. A name holding the separator could therefore
+	// compose a path equal to another signal's, e.g. a top-level signal named
+	// "A/X" against the refinement X of a signal A, and the two would silently
+	// share one window. Refusing the separator in every segment makes that
+	// collision unreachable.
+	if strings.Contains(s.Name, "/") {
+		return fmt.Errorf("signal %q: a name may not contain %q", path, "/")
+	}
+
 	if len(s.Instruments) == 0 {
 		return fmt.Errorf("signal %q: no instruments", path)
 	}

--- a/umh-core/pkg/diagnosis/engine.go
+++ b/umh-core/pkg/diagnosis/engine.go
@@ -35,6 +35,7 @@ package diagnosis
 import (
 	"fmt"
 	"math"
+	"sort"
 	"time"
 )
 
@@ -531,6 +532,10 @@ func (e *Engine[S]) judge(st *signalState[S], env Environment, at time.Time) Ava
 // under it nested inside, and nothing at all if this signal did not fire. Every
 // field of a nested entry comes off that refinement's own latch, so its Since is
 // the tick IT fired, not the tick its parent did.
+//
+// The nested entries come back lowest Tier first, then in the order the table
+// declared them. That ordering runs in every frame of the recursion, so a
+// refinement's own refinements are ordered among themselves the same way.
 func firedTree[S any](st *signalState[S]) (Fired, bool) {
 	f, ok := st.latch.Fired()
 	if !ok {
@@ -542,6 +547,20 @@ func firedTree[S any](st *signalState[S]) (Fired, bool) {
 			f.Refinements = append(f.Refinements, r)
 		}
 	}
+
+	// Index is the declaration position among these siblings and no two share
+	// one, so Tier and Index together are a total order that an unstable sort
+	// cannot disturb. Tier alone would not do: sort.Slice is explicitly not
+	// stable, and it leaves a short slice alone only because Go sorts twelve
+	// elements or fewer by insertion.
+	sort.Slice(f.Refinements, func(i, j int) bool {
+		a, b := f.Refinements[i], f.Refinements[j]
+		if a.Tier != b.Tier {
+			return a.Tier < b.Tier
+		}
+
+		return a.Index < b.Index
+	})
 
 	return f, true
 }

--- a/umh-core/pkg/diagnosis/engine.go
+++ b/umh-core/pkg/diagnosis/engine.go
@@ -14,9 +14,9 @@
 
 // This file is the engine. A caller declares a Table; NewEngine reads it once
 // and builds one SlidingWindow per (signal, instrument) pair, one SlidingWindow per measurement and
-// one Latch per signal, refusing a malformed table. Observe then appends the
-// snapshot to every window, resolves what each signal's windows can collectively
-// say, an Availability, and drives that signal's latch with it.
+// one Latch per signal, refinements included, refusing a malformed table. Observe
+// then appends the snapshot to every window, resolves what each signal's windows
+// can collectively say, an Availability, and drives that signal's latch with it.
 //
 // The environment is not checked while building: NewEngine takes no Environment
 // and builds a window for every instrument, capable or not. Signal.Capable runs
@@ -67,8 +67,9 @@ const (
 //	StateValue     (2)  -> Ready          (3)
 
 // Readiness is one signal's Availability, handed back by Observe beside the
-// fired set: one row per signal, in table order, always. []Fired reports only
-// what fired, so this is the only route to "was this signal readable at all".
+// fired set: one row per TOP-LEVEL signal, in table order, always. []Fired reports
+// only what fired, so this is the only route to "was this signal readable at all".
+// A refinement gets no row of its own, though it is judged every tick.
 type Readiness struct {
 	Signal       string
 	Availability Availability
@@ -78,13 +79,25 @@ type Readiness struct {
 // refinement's path is its parent's path plus its own name, e.g. "A/X".
 type key struct{ Path, Instrument string }
 
-// signalState is one signal and the single latch that judges it. 7e8301485 took
-// these out of name-keyed maps into slices held in the same order; pairing them
-// finishes that move, because "one latch per signal" is now the type rather than
-// two slices agreeing about their length and their order.
+// signalState is one signal, the state the engine keeps for it, and the same
+// pairing for each of its refinements. 7e8301485 took these out of name-keyed
+// maps into slices held in the same order; pairing them finishes that move,
+// because "one latch per signal" is now the type rather than two slices agreeing
+// about their length and their order.
 type signalState[S any] struct {
 	signal Signal[S]
-	latch  Latch
+	// path is what this signal's windows are keyed under: its bare name at the
+	// top level, its parent's path plus its own name for a refinement.
+	path string
+	// latch is the single latch that judges this signal. Every node in the tree
+	// has its own, at every depth.
+	latch Latch
+	// refinements is the same pairing one level down, one entry per refinement
+	// this signal declares, in declared order. A refinement is a signal in every
+	// respect the engine judges by: its own instruments, its own marks, its own
+	// latch, so judge and observeWindows recurse into it with no child branch.
+	// Observe's own loop does not recurse: it runs over the top level only.
+	refinements []signalState[S]
 }
 
 // measurementState is one measurement and the single window it reduces through,
@@ -95,22 +108,26 @@ type measurementState[S any] struct {
 	window      SlidingWindow
 }
 
-// Engine owns every window, every measurement and one latch per signal, for one table.
+// Engine owns every window, every measurement and one latch per signal, refinements
+// included, for one table.
 // It is not synchronized: the goroutine that calls Observe owns it, and a reader
 // calling Select, Reduction or Measurement from another races on points and latches.
 type Engine[S any] struct {
-	// windows is the last name-keyed map in here, and it stays one: Select
-	// resolves against the CALLER'S Signal, so a lookup can legitimately miss
-	// and resolve's nil arms are reachable. The two below are built by
-	// NewEngine and cannot miss, which is why they are pairs instead.
+	// windows is the last name-keyed map in here, and it stays one because
+	// Select resolves the CALLER'S Signal under its bare name: a caller holding
+	// a refinement looks under "X" while that refinement's windows are keyed
+	// "A/X", so every lookup misses and resolve's nil arms are reachable. The
+	// two below are built by NewEngine and cannot miss, which is why they are
+	// pairs instead.
 	windows      map[key]*SlidingWindow
 	signals      []signalState[S]
 	measurements []measurementState[S]
 }
 
 // NewEngine validates the table, then builds one window per (signal, instrument)
-// pair, one window per measurement, and one latch per signal, in signal order. It
-// is the single place a malformed table is refused; validate holds the list.
+// pair, one window per measurement, and one latch per signal and per refinement,
+// in declared order. It is the single place a malformed table is refused;
+// validate holds the list.
 //
 // A measurement's demote span is its own span, because a measurement belongs to
 // no signal and so has no hold for the demote clock to bound, and its counter
@@ -142,30 +159,46 @@ func NewEngine[S any](t Table[S]) (*Engine[S], error) {
 	}
 
 	for i, s := range t.Signals {
-		// The caller keeps the table they passed, so the engine must own the
-		// instruments it stores: a copy of the Signal would still share the
-		// Instruments backing array, and a later edit to the caller's own table
-		// would rename the engine's instruments while the windows above stay
-		// keyed by the names as they were at construction. Deep-copy the
-		// instruments and, one level down, each instrument's capability list,
-		// which is a second slice header into the same table.
-		s.Instruments = append([]Instrument[S](nil), s.Instruments...)
-		for j := range s.Instruments {
-			s.Instruments[j].Requires = append([]Capability(nil), s.Instruments[j].Requires...)
-		}
-
-		e.signals = append(e.signals, signalState[S]{
-			signal: s,
-			latch: Latch{identity: Identity{
-				Signal:      s.Name,
-				Tier:        s.Tier,
-				Attribution: s.Attribution,
-				Index:       i,
-			}},
-		})
+		e.signals = append(e.signals, buildSignalState(s.Name, s, i))
 	}
 
 	return e, nil
+}
+
+// buildSignalState pairs one signal with the latch that judges it, then recurses
+// into its refinements under the same paths buildWindows keyed their windows
+// under. index is the signal's position among its siblings, which Identity.Index
+// carries.
+func buildSignalState[S any](path string, s Signal[S], index int) signalState[S] {
+	// The caller keeps the table they passed, so the engine must own the
+	// instruments it stores: a copy of the Signal would still share the
+	// Instruments backing array, and a later edit to the caller's own table
+	// would rename the engine's instruments while the windows above stay
+	// keyed by the names as they were at construction. Deep-copy the
+	// instruments and, one level down, each instrument's capability list,
+	// which is a second slice header into the same table.
+	s.Instruments = append([]Instrument[S](nil), s.Instruments...)
+	for j := range s.Instruments {
+		s.Instruments[j].Requires = append([]Capability(nil), s.Instruments[j].Requires...)
+	}
+
+	st := signalState[S]{
+		signal: s,
+		path:   path,
+		latch: Latch{identity: Identity{
+			Signal:      s.Name,
+			Tier:        s.Tier,
+			Attribution: s.Attribution,
+			Index:       index,
+		}},
+		refinements: make([]signalState[S], 0, len(s.Refinements)),
+	}
+
+	for i, r := range s.Refinements {
+		st.refinements = append(st.refinements, buildSignalState(path+"/"+r.Name, r, i))
+	}
+
+	return st
 }
 
 // buildWindows opens one sliding window per (path, instrument) pair in a
@@ -388,7 +421,7 @@ func validateMeasurement[S any](row string, spanNoun string, m Measurement[S], i
 // so a window reduced without a preceding Observe reports entries left over from
 // an earlier tick as trusted.
 func (e *Engine[S]) Select(s Signal[S], env Environment) (Instrument[S], Reduced, Coverage, Availability) {
-	return e.resolve(s, s.Capable(env))
+	return e.resolve(s.Name, s, s.Capable(env))
 }
 
 // resolve applies the readiness gate to a signal's already-capable instruments:
@@ -396,7 +429,10 @@ func (e *Engine[S]) Select(s Signal[S], env Environment) (Instrument[S], Reduced
 // instrument, and whichever Availability the State table above names. That is
 // the maximum State over those windows, so StateValue returns at once, no later
 // window being able to beat it. Select and Observe both call it.
-func (e *Engine[S]) resolve(s Signal[S], capable []Instrument[S]) (Instrument[S], Reduced, Coverage, Availability) {
+//
+// path names the windows to read, so a refinement resolves against its own,
+// "A/X" rather than the "X" a top-level signal of that name holds.
+func (e *Engine[S]) resolve(path string, s Signal[S], capable []Instrument[S]) (Instrument[S], Reduced, Coverage, Availability) {
 	if len(capable) == 0 {
 		return Instrument[S]{}, Reduced{}, Coverage{}, NoInstrument
 	}
@@ -406,8 +442,8 @@ func (e *Engine[S]) resolve(s Signal[S], capable []Instrument[S]) (Instrument[S]
 	untrusted := false
 
 	for _, inst := range capable {
-		w := e.windows[key{Path: s.Name, Instrument: inst.Name}]
-		if w == nil { // NewEngine builds a window for every pair; never nil here
+		w := e.windows[key{Path: path, Instrument: inst.Name}]
+		if w == nil { // reachable through Select; Engine.windows names the route
 			continue
 		}
 
@@ -440,9 +476,9 @@ func (e *Engine[S]) resolve(s Signal[S], capable []Instrument[S]) (Instrument[S]
 // refinements included, keyed by path. It reads no latch, so the recursion into
 // refinements is unconditional. Signal.Refinements states the contract that
 // follows for a caller.
-func observeWindows[S any](e *Engine[S], path string, s Signal[S], sample S, at time.Time) {
-	for _, inst := range s.Instruments {
-		w := e.windows[key{Path: path, Instrument: inst.Name}]
+func observeWindows[S any](e *Engine[S], st *signalState[S], sample S, at time.Time) {
+	for _, inst := range st.signal.Instruments {
+		w := e.windows[key{Path: st.path, Instrument: inst.Name}]
 		if w == nil { // NewEngine builds a window for every pair; never nil here
 			continue
 		}
@@ -451,23 +487,82 @@ func observeWindows[S any](e *Engine[S], path string, s Signal[S], sample S, at 
 		w.Observe(value, against, at)
 	}
 
-	for _, r := range s.Refinements {
-		observeWindows(e, path+"/"+r.Name, r, sample, at)
+	for i := range st.refinements {
+		observeWindows(e, &st.refinements[i], sample, at)
 	}
 }
 
+// judge drives one signal's latch from its own windows, then does the same for
+// each of its refinements, whichever way this signal went. A refinement is
+// judged every tick for the same reason its window is filled every tick: a
+// verdict reached only while the parent happened to be firing would be decided
+// on however much history the child had at that instant. Only REPORTING a
+// refinement waits on the parent, which firedTree does.
+//
+// It returns the Availability the latch was driven with, which is this signal's
+// Readiness row; a refinement's is not reported.
+func (e *Engine[S]) judge(st *signalState[S], env Environment, at time.Time) Availability {
+	s := st.signal
+
+	inst, reduced, cov, avail := e.resolve(st.path, s, s.Capable(env))
+	l := &st.latch
+
+	switch avail {
+	case Ready:
+		l.Update(inst.Name, reduced, cov, inst.Marks, at)
+	case AllAbsent:
+		if s.ReleaseOnAbsent {
+			l.Reset()
+		} else {
+			l.ReleaseAfter(s.DemoteSpan, at)
+		}
+	default: // NoInstrument, NoneReady: hold, then release on the demote clock.
+		l.ReleaseAfter(s.DemoteSpan, at)
+	}
+
+	for i := range st.refinements {
+		e.judge(&st.refinements[i], env, at)
+	}
+
+	return avail
+}
+
+// firedTree reports one signal's verdict with the verdicts of the refinements
+// under it nested inside, and nothing at all if this signal did not fire. Every
+// field of a nested entry comes off that refinement's own latch, so its Since is
+// the tick IT fired, not the tick its parent did.
+func firedTree[S any](st *signalState[S]) (Fired, bool) {
+	f, ok := st.latch.Fired()
+	if !ok {
+		return Fired{}, false
+	}
+
+	for i := range st.refinements {
+		if r, ok := firedTree(&st.refinements[i]); ok {
+			f.Refinements = append(f.Refinements, r)
+		}
+	}
+
+	return f, true
+}
+
 // Observe runs one tick against a snapshot and returns the fired set, unranked
-// (Rank puts it worst first), and every signal's Readiness, both in table
-// order. In order: append to every measurement's and every instrument's window;
-// then, per signal, resolve its Availability over the instruments Signal.Capable
-// allows this tick, drive its single latch, collect whatever fired, and emit a
-// Readiness row whether or not it did.
+// (Rank puts it worst first), and one Readiness row per TOP-LEVEL signal, both
+// in table order. In order: append to every measurement's and every instrument's
+// window; then, per top-level signal, resolve its Availability over the
+// instruments Signal.Capable allows this tick, drive its single latch, collect
+// whatever fired, and emit a Readiness row whether or not it did.
 //
 // The append pass is unconditional, instruments this environment cannot satisfy
 // included, because Observe is the only call that ages a window: skip it once
 // and its stale entries count as current when it is next selected. No held latch
 // is left unbounded: AllAbsent on a signal setting ReleaseOnAbsent calls
 // Latch.Reset, and every other branch short of Ready runs the demote clock.
+//
+// A refinement is judged on the same terms every tick, whether or not the signal
+// it hangs under fired. What the parent decides is only whether the refinement is
+// REPORTED: a fired signal carries the refinements whose own latch is fired in
+// Fired.Refinements, and a refinement never appears in the returned slice itself.
 //
 // # One tick
 //
@@ -486,8 +581,8 @@ func (e *Engine[S]) Observe(sample S, env Environment, at time.Time) ([]Fired, [
 		ts.window.Observe(ts.measurement.Extract(sample), Unknown(), at) // same clock as every window below
 	}
 
-	for _, st := range e.signals {
-		observeWindows(e, st.signal.Name, st.signal, sample, at)
+	for i := range e.signals {
+		observeWindows(e, &e.signals[i], sample, at)
 	}
 
 	var fired []Fired
@@ -495,28 +590,13 @@ func (e *Engine[S]) Observe(sample S, env Environment, at time.Time) ([]Fired, [
 	readiness := make([]Readiness, 0, len(e.signals))
 	for i := range e.signals {
 		st := &e.signals[i]
-		s := st.signal
-		inst, reduced, cov, avail := e.resolve(s, s.Capable(env))
-		l := &st.latch
 
-		switch avail {
-		case Ready:
-			l.Update(inst.Name, reduced, cov, inst.Marks, at)
-		case AllAbsent:
-			if s.ReleaseOnAbsent {
-				l.Reset()
-			} else {
-				l.ReleaseAfter(s.DemoteSpan, at)
-			}
-		default: // NoInstrument, NoneReady: hold, then release on the demote clock.
-			l.ReleaseAfter(s.DemoteSpan, at)
-		}
-
-		if f, ok := l.Fired(); ok {
+		avail := e.judge(st, env, at)
+		if f, ok := firedTree(st); ok {
 			fired = append(fired, f)
 		}
 
-		readiness = append(readiness, Readiness{Signal: s.Name, Availability: avail})
+		readiness = append(readiness, Readiness{Signal: st.signal.Name, Availability: avail})
 	}
 
 	return fired, readiness

--- a/umh-core/pkg/diagnosis/engine.go
+++ b/umh-core/pkg/diagnosis/engine.go
@@ -74,8 +74,9 @@ type Readiness struct {
 	Availability Availability
 }
 
-// key indexes the engine's window map by (signal, instrument) pair.
-type key struct{ Signal, Instrument string }
+// key indexes the engine's window map by (path, instrument) pair, where a
+// refinement's path is its parent's path plus its own name, e.g. "A/X".
+type key struct{ Path, Instrument string }
 
 // signalState is one signal and the single latch that judges it. 7e8301485 took
 // these out of name-keyed maps into slices held in the same order; pairing them
@@ -126,13 +127,8 @@ func NewEngine[S any](t Table[S]) (*Engine[S], error) {
 		measurements: make([]measurementState[S], 0, len(t.Measurements)),
 	}
 	for _, s := range t.Signals {
-		for _, inst := range s.Instruments {
-			w, err := NewSlidingWindow(inst.Span, s.DemoteSpan, inst.Reduction, inst.Counter)
-			if err != nil {
-				return nil, err
-			}
-
-			e.windows[key{Signal: s.Name, Instrument: inst.Name}] = w
+		if err := buildWindows(e, s.Name, s); err != nil {
+			return nil, err
 		}
 	}
 
@@ -170,6 +166,28 @@ func NewEngine[S any](t Table[S]) (*Engine[S], error) {
 	}
 
 	return e, nil
+}
+
+// buildWindows opens one sliding window per (path, instrument) pair in a
+// signal's tree, recursing into refinements under their own paths, so A/X and
+// B/X keep separate windows even though both are named X.
+func buildWindows[S any](e *Engine[S], path string, s Signal[S]) error {
+	for _, inst := range s.Instruments {
+		w, err := NewSlidingWindow(inst.Span, s.DemoteSpan, inst.Reduction, inst.Counter)
+		if err != nil {
+			return err
+		}
+
+		e.windows[key{Path: path, Instrument: inst.Name}] = w
+	}
+
+	for _, r := range s.Refinements {
+		if err := buildWindows(e, path+"/"+r.Name, r); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // validate walks a table once and stops at the first row that could never
@@ -388,7 +406,7 @@ func (e *Engine[S]) resolve(s Signal[S], capable []Instrument[S]) (Instrument[S]
 	untrusted := false
 
 	for _, inst := range capable {
-		w := e.windows[key{Signal: s.Name, Instrument: inst.Name}]
+		w := e.windows[key{Path: s.Name, Instrument: inst.Name}]
 		if w == nil { // NewEngine builds a window for every pair; never nil here
 			continue
 		}
@@ -416,6 +434,26 @@ func (e *Engine[S]) resolve(s Signal[S], capable []Instrument[S]) (Instrument[S]
 	}
 
 	return Instrument[S]{}, Reduced{}, Coverage{}, NoInstrument
+}
+
+// observeWindows appends the snapshot to every window in a signal's tree,
+// refinements included, keyed by path. It is unconditional: a refinement is
+// sampled every tick whether or not its parent fired, so its window fills like
+// any other.
+func observeWindows[S any](e *Engine[S], path string, s Signal[S], sample S, at time.Time) {
+	for _, inst := range s.Instruments {
+		w := e.windows[key{Path: path, Instrument: inst.Name}]
+		if w == nil { // NewEngine builds a window for every pair; never nil here
+			continue
+		}
+
+		value, against := inst.Read(sample)
+		w.Observe(value, against, at)
+	}
+
+	for _, r := range s.Refinements {
+		observeWindows(e, path+"/"+r.Name, r, sample, at)
+	}
 }
 
 // Observe runs one tick against a snapshot and returns the fired set, unranked
@@ -449,15 +487,7 @@ func (e *Engine[S]) Observe(sample S, env Environment, at time.Time) ([]Fired, [
 	}
 
 	for _, st := range e.signals {
-		for _, inst := range st.signal.Instruments {
-			w := e.windows[key{Signal: st.signal.Name, Instrument: inst.Name}]
-			if w == nil { // NewEngine builds a window for every pair; never nil here
-				continue
-			}
-
-			value, against := inst.Read(sample)
-			w.Observe(value, against, at)
-		}
+		observeWindows(e, st.signal.Name, st.signal, sample, at)
 	}
 
 	var fired []Fired
@@ -494,12 +524,14 @@ func (e *Engine[S]) Observe(sample S, env Environment, at time.Time) ([]Fired, [
 
 // Reduction returns one named instrument's window reduced as it stands, the only
 // route to a number the caller must publish whether or not the latch fired. Like
-// Select it reduces without ageing, so it too must follow an Observe. An unnamed
-// pair returns the zero Reduced, StateAbsent, indistinguishable from a window
-// that exists and is empty: name windows through the SAME constants the table
-// declares them with, since a typo in a literal reads as a permanent absence.
-func (e *Engine[S]) Reduction(signal, instrument string) Reduced {
-	w := e.windows[key{Signal: signal, Instrument: instrument}]
+// Select it reduces without ageing, so it too must follow an Observe. path names
+// the signal: a refinement's path such as "A/X", or a top-level signal's bare
+// name. An unnamed pair returns the zero Reduced, StateAbsent, indistinguishable
+// from a window that exists and is empty: name windows through the SAME
+// constants the table declares them with, since a typo reads as a permanent
+// absence.
+func (e *Engine[S]) Reduction(path, instrument string) Reduced {
+	w := e.windows[key{Path: path, Instrument: instrument}]
 	if w == nil {
 		return Reduced{}
 	}

--- a/umh-core/pkg/diagnosis/engine.go
+++ b/umh-core/pkg/diagnosis/engine.go
@@ -18,10 +18,10 @@
 // collectively say, an Availability, and drive that signal's latch with it.
 //
 // The environment is not checked while building: NewEngine takes no Environment
-// and builds a window for every instrument, capable or not. Signal.Capable runs
-// inside Observe, every tick, so one table runs unchanged on boxes with
-// different capabilities and a capability that appears or disappears takes
-// effect on the next tick.
+// and builds a window for every instrument, capable or not.
+// Signal.CapableInstruments runs inside Observe, every tick, so one table runs
+// unchanged on boxes with different capabilities and a capability that appears
+// or disappears takes effect on the next tick.
 //
 // Using it:
 //
@@ -110,9 +110,10 @@ type signalState[S any] struct {
 	releaseOnAbsent bool
 }
 
-// capable applies Signal.Capable to the instruments this state holds.
-func (st *signalState[S]) capable(env Environment) []Instrument[S] {
-	return Signal[S]{Instruments: st.instruments}.Capable(env)
+// capableInstruments applies Signal.CapableInstruments to the instruments this
+// state holds.
+func (st *signalState[S]) capableInstruments(env Environment) []Instrument[S] {
+	return Signal[S]{Instruments: st.instruments}.CapableInstruments(env)
 }
 
 // measurementState is one measurement and the single window it reduces through,
@@ -181,6 +182,14 @@ func NewEngine[S any](t Table[S]) (*Engine[S], error) {
 // the same path and share a window.
 const pathSeparator = "/"
 
+// childPath is the path a refinement's windows and latch are keyed under: its
+// parent's path, then pathSeparator, then its own name. Every caller that walks
+// into a refinement composes the path through here, so the three walks cannot
+// disagree about what a nested signal is called.
+func childPath(parent, name string) string {
+	return parent + pathSeparator + name
+}
+
 // buildSignalState pairs one signal with the latch that judges it, then recurses
 // into its refinements under the same paths buildWindows keyed their windows
 // under. index is the signal's position among its siblings, which Identity.Index
@@ -212,7 +221,7 @@ func buildSignalState[S any](path string, s Signal[S], index int) signalState[S]
 	}
 
 	for i, r := range s.Refinements {
-		st.refinements = append(st.refinements, buildSignalState(path+pathSeparator+r.Name, r, i))
+		st.refinements = append(st.refinements, buildSignalState(childPath(path, r.Name), r, i))
 	}
 
 	return st
@@ -232,7 +241,7 @@ func buildWindows[S any](e *Engine[S], path string, s Signal[S]) error {
 	}
 
 	for _, r := range s.Refinements {
-		if err := buildWindows(e, path+pathSeparator+r.Name, r); err != nil {
+		if err := buildWindows(e, childPath(path, r.Name), r); err != nil {
 			return err
 		}
 	}
@@ -392,7 +401,7 @@ func validateSignal[S any](path string, s Signal[S], interval time.Duration) err
 
 		seen[r.Name] = true
 
-		if err := validateSignal(path+pathSeparator+r.Name, r, interval); err != nil {
+		if err := validateSignal(childPath(path, r.Name), r, interval); err != nil {
 			return err
 		}
 	}
@@ -436,12 +445,13 @@ func validateMeasurement[S any](row string, spanNoun string, m Measurement[S], i
 // extent and the Availability that justifies them. It is caller-facing API:
 // nothing in the package calls it, and Observe applies the same two gates itself.
 //
-// Gate one is CAPABILITY, Signal.Capable, re-evaluated every tick against the
-// Environment handed in. Gate two is READINESS: can this instrument's window
-// supply a trustworthy value right now. They stay separate because a percentile
-// instrument and the cheap fallback behind it usually declare the SAME
-// capability: a capability-only selector would return the percentile forever,
-// leave it untrusted below twenty samples, and never reach the fallback.
+// Gate one is CAPABILITY, Signal.CapableInstruments, re-evaluated every tick
+// against the Environment handed in. Gate two is READINESS: can this
+// instrument's window supply a trustworthy value right now. They stay separate
+// because a percentile instrument and the cheap fallback behind it usually
+// declare the SAME capability: a capability-only selector would return the
+// percentile forever, leave it untrusted below twenty samples, and never reach
+// the fallback.
 //
 // Select takes a top-level signal of the table. Passing a refinement is not
 // supported: windows are keyed by path and Select keys on the bare name, so a
@@ -456,7 +466,7 @@ func validateMeasurement[S any](row string, spanNoun string, m Measurement[S], i
 // so a window reduced without a preceding Observe reports entries left over from
 // an earlier tick as trusted.
 func (e *Engine[S]) Select(s Signal[S], env Environment) (Instrument[S], Reduced, Coverage, Availability) {
-	return e.resolve(s.Name, s.Capable(env))
+	return e.resolve(s.Name, s.CapableInstruments(env))
 }
 
 // resolve applies the readiness gate to a signal's already-capable instruments:
@@ -537,7 +547,7 @@ func observeWindows[S any](e *Engine[S], st *signalState[S], sample S, at time.T
 // refinements' as the recursion reaches them, so a parent's row comes
 // immediately before the rows of the subtree under it.
 func (e *Engine[S]) judge(st *signalState[S], env Environment, at time.Time, into []Readiness) []Readiness {
-	inst, reduced, cov, avail := e.resolve(st.path, st.capable(env))
+	inst, reduced, cov, avail := e.resolve(st.path, st.capableInstruments(env))
 	l := &st.latch
 
 	switch avail {
@@ -604,9 +614,9 @@ func firedTree[S any](st *signalState[S]) (Fired, bool) {
 // the readiness rows are depth-first, each signal immediately before the subtree
 // under it, and each named by its path. In order: append to every measurement's
 // and every instrument's window; then walk the signals, resolving each one's
-// Availability over the instruments Signal.Capable allows it this tick, driving
-// its single latch and emitting its Readiness row whether or not it fired, and
-// collecting each top-level signal whose latch is fired.
+// Availability over the instruments Signal.CapableInstruments allows it this
+// tick, driving its single latch and emitting its Readiness row whether or not
+// it fired, and collecting each top-level signal whose latch is fired.
 //
 // The append pass is unconditional, instruments this environment cannot satisfy
 // included, because Observe is the only call that ages a window: skip it once

--- a/umh-core/pkg/diagnosis/engine.go
+++ b/umh-core/pkg/diagnosis/engine.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // This file is the engine. A caller declares a Table; NewEngine reads it once
-// and builds one SlidingWindow per (signal, instrument) pair, one SlidingWindow per track and
+// and builds one SlidingWindow per (signal, instrument) pair, one SlidingWindow per measurement and
 // one Latch per signal, refusing a malformed table. Observe then appends the
 // snapshot to every window, resolves what each signal's windows can collectively
 // say, an Availability, and drives that signal's latch with it.
@@ -86,42 +86,44 @@ type signalState[S any] struct {
 	latch  Latch
 }
 
-// trackState is one track and the single window it reduces through, paired for
-// the same reason. Track no longer walks one slice while indexing another.
-type trackState[S any] struct {
-	track  Track[S]
-	window SlidingWindow
+// measurementState is one measurement and the single window it reduces through,
+// paired for the same reason. Measurement no longer walks one slice while
+// indexing another.
+type measurementState[S any] struct {
+	measurement Measurement[S]
+	window      SlidingWindow
 }
 
-// Engine owns every window, every track and one latch per signal, for one table.
+// Engine owns every window, every measurement and one latch per signal, for one table.
 // It is not synchronized: the goroutine that calls Observe owns it, and a reader
-// calling Select, Reduction or Track from another races on points and latches.
+// calling Select, Reduction or Measurement from another races on points and latches.
 type Engine[S any] struct {
 	// windows is the last name-keyed map in here, and it stays one: Select
 	// resolves against the CALLER'S Signal, so a lookup can legitimately miss
 	// and resolve's nil arms are reachable. The two below are built by
 	// NewEngine and cannot miss, which is why they are pairs instead.
-	windows map[key]*SlidingWindow
-	signals []signalState[S]
-	tracks  []trackState[S]
+	windows      map[key]*SlidingWindow
+	signals      []signalState[S]
+	measurements []measurementState[S]
 }
 
 // NewEngine validates the table, then builds one window per (signal, instrument)
-// pair, one window per track, and one latch per signal, in signal order. It
+// pair, one window per measurement, and one latch per signal, in signal order. It
 // is the single place a malformed table is refused; validate holds the list.
 //
-// A track's demote span is its own span, because a track belongs to no signal
-// and so has no hold for the demote clock to bound, and its counter flag is
-// false, because a counter track would need the restart rule declared.
+// A measurement's demote span is its own span, because a measurement belongs to
+// no signal and so has no hold for the demote clock to bound, and its counter
+// flag is
+// false, because a counter measurement would need the restart rule declared.
 func NewEngine[S any](t Table[S]) (*Engine[S], error) {
 	if err := validate(t); err != nil {
 		return nil, err
 	}
 
 	e := &Engine[S]{
-		windows: make(map[key]*SlidingWindow),
-		signals: make([]signalState[S], 0, len(t.Signals)),
-		tracks:  make([]trackState[S], 0, len(t.Tracks)),
+		windows:      make(map[key]*SlidingWindow),
+		signals:      make([]signalState[S], 0, len(t.Signals)),
+		measurements: make([]measurementState[S], 0, len(t.Measurements)),
 	}
 	for _, s := range t.Signals {
 		for _, inst := range s.Instruments {
@@ -134,13 +136,13 @@ func NewEngine[S any](t Table[S]) (*Engine[S], error) {
 		}
 	}
 
-	for _, tr := range t.Tracks {
+	for _, tr := range t.Measurements {
 		w, err := NewSlidingWindow(tr.Span, tr.Span, tr.Reduction, false)
 		if err != nil {
 			return nil, err
 		}
 
-		e.tracks = append(e.tracks, trackState[S]{track: tr, window: *w})
+		e.measurements = append(e.measurements, measurementState[S]{measurement: tr, window: *w})
 	}
 
 	for i, s := range t.Signals {
@@ -272,36 +274,36 @@ func validate[S any](t Table[S]) error {
 		}
 	}
 
-	seenTrack := make(map[string]bool, len(t.Tracks))
-	for _, tr := range t.Tracks {
-		if seenTrack[tr.Name] {
-			return fmt.Errorf("duplicate track name %q", tr.Name)
+	seenMeasurement := make(map[string]bool, len(t.Measurements))
+	for _, tr := range t.Measurements {
+		if seenMeasurement[tr.Name] {
+			return fmt.Errorf("duplicate measurement name %q", tr.Name)
 		}
 
-		seenTrack[tr.Name] = true
+		seenMeasurement[tr.Name] = true
 
 		if tr.Extract == nil {
-			return fmt.Errorf("track %q: nil extract", tr.Name)
+			return fmt.Errorf("measurement %q: nil extract", tr.Name)
 		}
 
 		if tr.Span <= 0 {
-			return fmt.Errorf("track %q: span %v is zero or negative", tr.Name, tr.Span)
+			return fmt.Errorf("measurement %q: span %v is zero or negative", tr.Name, tr.Span)
 		}
 
 		if tr.Reduction.Min < 1 {
-			return fmt.Errorf("track %q: reduction %q minimum sample count %d is below one", tr.Name, tr.Reduction.Name, tr.Reduction.Min)
+			return fmt.Errorf("measurement %q: reduction %q minimum sample count %d is below one", tr.Name, tr.Reduction.Name, tr.Reduction.Min)
 		}
 
 		if tr.Reduction.fold == nil {
-			return fmt.Errorf("track %q: reduction %q has no fold", tr.Name, tr.Reduction.Name)
+			return fmt.Errorf("measurement %q: reduction %q has no fold", tr.Name, tr.Reduction.Name)
 		}
 
 		if tr.Reduction.divides {
-			return fmt.Errorf("track %q: reduction %q divides but a track declares no denominator series", tr.Name, tr.Reduction.Name)
+			return fmt.Errorf("measurement %q: reduction %q divides but a measurement declares no denominator series", tr.Name, tr.Reduction.Name)
 		}
 
 		if t.Interval > 0 && int(tr.Span/t.Interval)+1 < tr.Reduction.Min {
-			return fmt.Errorf("track %q: reduction %q minimum sample count %d exceeds what its window span %v can hold at table interval %v", tr.Name, tr.Reduction.Name, tr.Reduction.Min, tr.Span, t.Interval)
+			return fmt.Errorf("measurement %q: reduction %q minimum sample count %d exceeds what its window span %v can hold at table interval %v", tr.Name, tr.Reduction.Name, tr.Reduction.Min, tr.Span, t.Interval)
 		}
 	}
 
@@ -374,8 +376,8 @@ func (e *Engine[S]) resolve(s Signal[S], capable []Instrument[S]) (Instrument[S]
 
 // Observe runs one tick against a snapshot and returns the fired set, unranked
 // (Rank puts it worst first), and every signal's Readiness, both in table
-// order. In order: append to every track's and every instrument's window; then,
-// per signal, resolve its Availability over the instruments Signal.Capable
+// order. In order: append to every measurement's and every instrument's window;
+// then, per signal, resolve its Availability over the instruments Signal.Capable
 // allows this tick, drive its single latch, collect whatever fired, and emit a
 // Readiness row whether or not it did.
 //
@@ -397,9 +399,9 @@ func (e *Engine[S]) resolve(s Signal[S], capable []Instrument[S]) (Instrument[S]
 //	  the engine          resolves  Availability  what one signal can say now
 //	  Latch.Update        judges    Fired         a signal that crossed its mark
 func (e *Engine[S]) Observe(sample S, env Environment, at time.Time) ([]Fired, []Readiness) {
-	for i := range e.tracks { // reduced, never judged
-		ts := &e.tracks[i]
-		ts.window.Observe(ts.track.Extract(sample), Unknown(), at) // same clock as every window below
+	for i := range e.measurements { // reduced, never judged
+		ts := &e.measurements[i]
+		ts.window.Observe(ts.measurement.Extract(sample), Unknown(), at) // same clock as every window below
 	}
 
 	for _, st := range e.signals {
@@ -461,13 +463,14 @@ func (e *Engine[S]) Reduction(signal, instrument string) Reduced {
 	return w.Reduce()
 }
 
-// Track returns one named track's window reduced as it stands; an unnamed track
-// returns the zero Reduced, StateAbsent. Same contract as Reduction, on the
-// windows that belong to no signal: it must follow an Observe on the same tick.
-func (e *Engine[S]) Track(name string) Reduced {
-	for i := range e.tracks {
-		if e.tracks[i].track.Name == name {
-			return e.tracks[i].window.Reduce()
+// Measurement returns one named measurement's window reduced as it stands; an
+// unnamed measurement returns the zero Reduced, StateAbsent. Same contract as
+// Reduction, on the windows that belong to no signal: it must follow an Observe
+// on the same tick.
+func (e *Engine[S]) Measurement(name string) Reduced {
+	for i := range e.measurements {
+		if e.measurements[i].measurement.Name == name {
+			return e.measurements[i].window.Reduce()
 		}
 	}
 

--- a/umh-core/pkg/diagnosis/engine.go
+++ b/umh-core/pkg/diagnosis/engine.go
@@ -437,9 +437,9 @@ func (e *Engine[S]) resolve(s Signal[S], capable []Instrument[S]) (Instrument[S]
 }
 
 // observeWindows appends the snapshot to every window in a signal's tree,
-// refinements included, keyed by path. It is unconditional: a refinement is
-// sampled every tick whether or not its parent fired, so its window fills like
-// any other.
+// refinements included, keyed by path. It reads no latch, so the recursion into
+// refinements is unconditional. Signal.Refinements states the contract that
+// follows for a caller.
 func observeWindows[S any](e *Engine[S], path string, s Signal[S], sample S, at time.Time) {
 	for _, inst := range s.Instruments {
 		w := e.windows[key{Path: path, Instrument: inst.Name}]

--- a/umh-core/pkg/diagnosis/engine.go
+++ b/umh-core/pkg/diagnosis/engine.go
@@ -120,11 +120,15 @@ type measurementState[S any] struct {
 // It is not synchronized: the goroutine that calls Observe owns it, and a reader
 // calling Select, Reduction or Measurement from another races on points and latches.
 type Engine[S any] struct {
-	// windows is the last name-keyed map in here, and it stays one because
-	// Select resolves the CALLER'S Signal under its bare name: a caller holding
-	// a refinement looks under "X" while that refinement's windows are keyed
-	// "A/X", so every lookup misses and resolve's nil arms are reachable. The
-	// two below are built by NewEngine and cannot miss, which is why they are
+	// windows is keyed by path: "A/X" for a refinement X under A. Select looks
+	// up the bare name of the Signal handed to it, so a caller passing a
+	// refinement reads the key "X" rather than "A/X". That misses whenever no
+	// top-level signal is named X, which is what makes resolve's nil arm
+	// reachable. It does NOT miss when the table also declares a top-level X
+	// carrying an instrument the refinement names too: the lookup hits THAT
+	// signal's window, and the caller gets its number marked Ready. Select's
+	// doc carries the restriction this leaves on a caller. The two slices
+	// below are built by NewEngine and cannot miss, which is why they are
 	// pairs instead.
 	windows      map[key]*SlidingWindow
 	signals      []signalState[S]
@@ -137,9 +141,7 @@ type Engine[S any] struct {
 // validate holds the list.
 //
 // A measurement's demote span is its own span, because a measurement belongs to
-// no signal and so has no hold for the demote clock to bound, and its counter
-// flag is
-// false, because a counter measurement would need the restart rule declared.
+// no signal and so has no hold for the demote clock to bound.
 func NewEngine[S any](t Table[S]) (*Engine[S], error) {
 	if err := validate(t); err != nil {
 		return nil, err
@@ -402,8 +404,8 @@ func validateSignal[S any](path string, s Signal[S], interval time.Duration) err
 // Table.Measurements. row names the ownership for the error, e.g.
 // `signal "A" instrument "I1"`, and spanNoun is the word the loop uses for the
 // window's size, "window span" for an instrument as against "span" for a bare
-// table measurement: each loop's wording is part of the message the tests
-// assert on, so the two stay exact.
+// table measurement. NewEngine's two specs for a zero span pin one wording
+// each, so the pair cannot collapse to a single noun unnoticed.
 func validateMeasurement[S any](row string, spanNoun string, m Measurement[S], interval time.Duration) error {
 	if m.Extract == nil {
 		return fmt.Errorf("%s: nil extract", row)
@@ -439,6 +441,15 @@ func validateMeasurement[S any](row string, spanNoun string, m Measurement[S], i
 // instrument and the cheap fallback behind it usually declare the SAME
 // capability: a capability-only selector would return the percentile forever,
 // leave it untrusted below twenty samples, and never reach the fallback.
+//
+// Select takes a top-level signal of the table. Passing a refinement is not
+// supported: windows are keyed by path and Select keys on the bare name, so a
+// refinement named X under A reads the key a top-level X would hold. If the
+// table declares no top-level X the result is the zero instrument and
+// NoInstrument. If it declares one, and that X carries an instrument the
+// refinement names too, Select returns THAT signal's instrument and number,
+// marked Ready, with nothing to tell the caller it is the wrong signal's. Read
+// a refinement through Reduction, which takes the path.
 //
 // Select must follow an Observe on the same tick. Only Observe ages the windows,
 // so a window reduced without a preceding Observe reports entries left over from

--- a/umh-core/pkg/diagnosis/engine.go
+++ b/umh-core/pkg/diagnosis/engine.go
@@ -161,10 +161,11 @@ func NewEngine[S any](t Table[S]) (*Engine[S], error) {
 		e.signals = append(e.signals, signalState[S]{
 			signal: s,
 			latch: Latch{identity: Identity{
-				Signal:   s.Name,
-				Tier:     s.Tier,
-				External: s.External,
-				Index:    i,
+				Signal:      s.Name,
+				Tier:        s.Tier,
+				Attribution: s.Attribution,
+				External:    s.External,
+				Index:       i,
 			}},
 		})
 	}

--- a/umh-core/pkg/diagnosis/engine.go
+++ b/umh-core/pkg/diagnosis/engine.go
@@ -12,11 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This file is the engine. A caller declares a Table; NewEngine reads it once
-// and builds one SlidingWindow per (signal, instrument) pair, one SlidingWindow per measurement and
-// one Latch per signal, refinements included, refusing a malformed table. Observe
-// then appends the snapshot to every window, resolves what each signal's windows
-// can collectively say, an Availability, and drives that signal's latch with it.
+// This file is the engine. A caller declares a Table; NewEngine builds the
+// windows and latches it declares, and Observe runs one tick against them:
+// append the snapshot to every window, resolve what each signal's windows can
+// collectively say, an Availability, and drive that signal's latch with it.
 //
 // The environment is not checked while building: NewEngine takes no Environment
 // and builds a window for every instrument, capable or not. Signal.Capable runs
@@ -84,8 +83,10 @@ type Readiness struct {
 	Availability Availability
 }
 
-// key indexes the engine's window map by (path, instrument) pair, where a
-// refinement's path is its parent's path plus its own name, e.g. "A/X".
+// key indexes the engine's window map by (path, instrument) pair. A top-level
+// signal's path is its bare name; a refinement's is its parent's path, the
+// pathSeparator, and its own name, e.g. "A/X". This is where that rule is
+// stated; the sites that compose or consume a path point here.
 type key struct{ Path, Instrument string }
 
 // signalState is one signal narrowed to what the engine judges it by, the latch
@@ -97,8 +98,7 @@ type signalState[S any] struct {
 	instruments []Instrument[S]
 	// refinements is the same pairing one level down, in declared order.
 	refinements []signalState[S]
-	// path is what this signal's windows are keyed under: its bare name for a
-	// top-level signal, its parent's path plus its own name for a refinement.
+	// path is what this signal's windows are keyed under; see key.
 	path string
 	// latch is the single latch that judges this signal. Every node in the tree
 	// has its own, at every depth.
@@ -127,7 +127,7 @@ type measurementState[S any] struct {
 // It is not synchronized: the goroutine that calls Observe owns it, and a reader
 // calling Select, Reduction or Measurement from another races on points and latches.
 type Engine[S any] struct {
-	// windows is keyed by path: "A/X" for a refinement X under A. Select keys on
+	// windows is keyed by key. Select keys on
 	// a bare name instead, so a caller passing a refinement reads some other
 	// signal's window or none at all. That is what makes resolve's nil arm
 	// reachable, and Select's doc carries the restriction it leaves on a caller.
@@ -318,12 +318,10 @@ func validate[S any](t Table[S]) error {
 // tree the row lives rather than the bare refinement. Instrument and refinement names are
 // unique among their siblings only.
 func validateSignal[S any](path string, s Signal[S], interval time.Duration) error {
-	// A refinement's path is its parent's path plus "/" plus its own name, and
-	// that path keys its windows. A name holding the separator could therefore
-	// compose a path equal to another signal's, e.g. a top-level signal named
-	// "A/X" against the refinement X of a signal A, and the two would silently
-	// share one window. Refusing the separator in every segment makes that
-	// collision unreachable.
+	// A name holding the separator could compose a path equal to another
+	// signal's, e.g. a top-level signal named "A/X" against the refinement X of
+	// a signal A, and the two would silently share one window. Refusing it in
+	// every segment makes that collision unreachable.
 	if strings.Contains(s.Name, pathSeparator) {
 		return fmt.Errorf("signal %q: a name may not contain %q", path, pathSeparator)
 	}
@@ -511,8 +509,8 @@ func (e *Engine[S]) resolve(path string, capable []Instrument[S]) (Instrument[S]
 
 // observeWindows appends the snapshot to every window in a signal's tree,
 // refinements included, keyed by path. It reads no latch, so the recursion into
-// refinements is unconditional. Signal.Refinements states the contract that
-// follows for a caller.
+// refinements is unconditional; Signal.Refinements states what that gives a
+// caller.
 func observeWindows[S any](e *Engine[S], st *signalState[S], sample S, at time.Time) {
 	for _, inst := range st.instruments {
 		w := e.windows[key{Path: st.path, Instrument: inst.Name}]
@@ -530,11 +528,9 @@ func observeWindows[S any](e *Engine[S], st *signalState[S], sample S, at time.T
 }
 
 // judge drives one signal's latch from its own windows, then does the same for
-// each of its refinements, whichever way this signal went. A refinement is
-// judged every tick for the same reason its window is filled every tick: a
-// verdict reached only while the parent happened to be firing would be decided
-// on however much history the refinement had at that instant. Only REPORTING a
-// refinement waits on the parent, which firedTree does.
+// each of its refinements, whichever way this signal went; Signal.Refinements
+// states why. Only REPORTING a refinement waits on the parent, which firedTree
+// does.
 //
 // It appends one Readiness row per signal it drives, carrying the Availability
 // that signal's latch was driven with: this signal's row first, then its
@@ -571,9 +567,8 @@ func (e *Engine[S]) judge(st *signalState[S], env Environment, at time.Time, int
 // field of a nested entry comes off that refinement's own latch, so its Since is
 // the tick IT fired, not the tick its parent did.
 //
-// The nested entries come back lowest Tier first, then in the order the table
-// declared them. That ordering runs in every frame of the recursion, so a
-// refinement's own refinements are ordered among themselves the same way.
+// It sorts the nested entries into the order Fired.Refinements states, in every
+// frame of the recursion.
 func firedTree[S any](st *signalState[S]) (Fired, bool) {
 	f, ok := st.latch.Fired()
 	if !ok {
@@ -618,12 +613,6 @@ func firedTree[S any](st *signalState[S]) (Fired, bool) {
 // and its stale entries count as current when it is next selected. No held latch
 // is left unbounded: AllAbsent on a signal setting ReleaseOnAbsent calls
 // Latch.Reset, and every other branch short of Ready runs the demote clock.
-//
-// A refinement is judged on the same terms every tick, whether or not the signal
-// it hangs under fired, and it has a Readiness row of its own either way. What
-// the parent decides is only whether the refinement's VERDICT is reported: a
-// fired signal carries the refinements whose own latch is fired in
-// Fired.Refinements, and a refinement never appears in the fired set itself.
 //
 // # One tick
 //

--- a/umh-core/pkg/diagnosis/engine.go
+++ b/umh-core/pkg/diagnosis/engine.go
@@ -164,7 +164,6 @@ func NewEngine[S any](t Table[S]) (*Engine[S], error) {
 				Signal:      s.Name,
 				Tier:        s.Tier,
 				Attribution: s.Attribution,
-				External:    s.External,
 				Index:       i,
 			}},
 		})

--- a/umh-core/pkg/diagnosis/engine.go
+++ b/umh-core/pkg/diagnosis/engine.go
@@ -266,6 +266,26 @@ func validate[S any](t Table[S]) error {
 
 		seenMeasurement[m.Name] = true
 
+		// Against, Requires, Boolean and Counter are judging-only: an instrument
+		// uses them under the marks a signal judges by, but no signal judges a
+		// table-level measurement, so declaring one would build and then be
+		// silently ignored (the window is still created with Counter false).
+		if m.Against != nil {
+			return fmt.Errorf("measurement %q: Against is only meaningful inside a signal", m.Name)
+		}
+
+		if len(m.Requires) > 0 {
+			return fmt.Errorf("measurement %q: Requires is only meaningful inside a signal", m.Name)
+		}
+
+		if m.Boolean {
+			return fmt.Errorf("measurement %q: Boolean is only meaningful inside a signal", m.Name)
+		}
+
+		if m.Counter {
+			return fmt.Errorf("measurement %q: Counter is only meaningful inside a signal", m.Name)
+		}
+
 		if err := validateMeasurement(fmt.Sprintf("measurement %q", m.Name), "span", m, t.Interval); err != nil {
 			return err
 		}

--- a/umh-core/pkg/diagnosis/engine_episode_test.go
+++ b/umh-core/pkg/diagnosis/engine_episode_test.go
@@ -1,0 +1,300 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package diagnosis
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// Every other spec in this package drives one property in isolation. This one
+// drives a single engine through one episode — healthy, degraded, healthy again
+// — on one clock, and checks that the properties hold together and in sequence.
+// The interaction is the point: a refinement's window warming before its parent
+// fires is what makes the report at the firing tick worth anything, and neither
+// half shows that on its own.
+//
+// The whole episode is one spec on one engine. Splitting it into several specs
+// over a shared fixture would give each one a fresh engine and lose exactly the
+// thing being checked, which is what the engine carries from one tick to the
+// next.
+var _ = Describe("Engine.Observe over one degradation episode", func() {
+
+	// snap is the caller's snapshot type: one field per signal, so a phase can
+	// move one signal's own number without touching any other's.
+	type snap struct{ p, q, c, g float64 }
+
+	// instrument is the one instrument name every signal here declares. The
+	// engine keys a window by (signal path, instrument name), so the hysteresis
+	// phase reads C's number back through this same constant rather than a
+	// typed-out copy of it.
+	const instrument = "I"
+
+	// C's marks, named because the hysteresis phase asserts that C's number sits
+	// between them. The other three signals' marks are written inline.
+	const cFire, cClear = 0.60, 0.30
+
+	base := time.Unix(1_000_000, 0)
+
+	// at names a tick by its index. The table interval is one second, so tick i
+	// is i seconds into the episode, and every instant asserted below is stated
+	// as the tick it belongs to.
+	at := func(i int) time.Time { return base.Add(time.Duration(i) * time.Second) }
+
+	// names lists one level of a fired set by signal name, so a phase can state
+	// the shape of that level in one line.
+	names := func(fired []Fired) []string {
+		out := make([]string, len(fired))
+		for i, f := range fired {
+			out[i] = f.Identity.Signal
+		}
+
+		return out
+	}
+
+	// G narrows C, the third level of the tree. It reduces through Last, so it
+	// fires on the tick its own value crosses 0.70 and releases on the tick that
+	// value falls below 0.40. Tier 3 is the least urgent in the table.
+	signalG := Signal[snap]{
+		Name:       "G",
+		Tier:       3,
+		DemoteSpan: time.Minute,
+		Instruments: []Instrument[snap]{{
+			Measurement: Measurement[snap]{
+				Name:      instrument,
+				Extract:   func(s snap) Reading { return Known(s.g) },
+				Reduction: Last,
+				Span:      10 * time.Second,
+			},
+			Marks: Marks{Unit: "ratio", Fire: Mark{At: 0.70}, Clear: Mark{At: 0.40}, Worst: 1.0, Polarity: HigherIsWorse},
+		}},
+	}
+
+	// C narrows P. It reduces a three-second window through Mean, which at a
+	// one-second interval holds four samples and needs two before it can answer
+	// at all. That is what makes the degrading phase mean something: C cannot
+	// answer off the single sample it has on the tick its value first goes bad.
+	//
+	// Tier 0 makes C the most urgent signal in the table, more urgent than either
+	// top-level signal. A refinement that leaked into the ranked set would
+	// therefore sort first, where it cannot be missed.
+	signalC := Signal[snap]{
+		Name:        "C",
+		Tier:        0,
+		DemoteSpan:  time.Minute,
+		Refinements: []Signal[snap]{signalG},
+		Instruments: []Instrument[snap]{{
+			Measurement: Measurement[snap]{
+				Name:      instrument,
+				Extract:   func(s snap) Reading { return Known(s.c) },
+				Reduction: Mean,
+				Span:      3 * time.Second,
+			},
+			Marks: Marks{Unit: "ratio", Fire: Mark{At: cFire}, Clear: Mark{At: cClear}, Worst: 1.0, Polarity: HigherIsWorse},
+		}},
+	}
+
+	// P is the top-level signal the episode degrades and recovers. Last again, so
+	// P fires on the tick its own value crosses 0.80 and releases on the tick that
+	// value falls below 0.50.
+	signalP := Signal[snap]{
+		Name:        "P",
+		Tier:        1,
+		DemoteSpan:  time.Minute,
+		Refinements: []Signal[snap]{signalC},
+		Instruments: []Instrument[snap]{{
+			Measurement: Measurement[snap]{
+				Name:      instrument,
+				Extract:   func(s snap) Reading { return Known(s.p) },
+				Reduction: Last,
+				Span:      10 * time.Second,
+			},
+			Marks: Marks{Unit: "ratio", Fire: Mark{At: 0.80}, Clear: Mark{At: 0.50}, Worst: 1.0, Polarity: HigherIsWorse},
+		}},
+	}
+
+	// Q is a second top-level signal with no refinements, so ranking has two
+	// entries to order and readiness has two roots to list.
+	signalQ := Signal[snap]{
+		Name:       "Q",
+		Tier:       2,
+		DemoteSpan: time.Minute,
+		Instruments: []Instrument[snap]{{
+			Measurement: Measurement[snap]{
+				Name:      instrument,
+				Extract:   func(s snap) Reading { return Known(s.q) },
+				Reduction: Last,
+				Span:      10 * time.Second,
+			},
+			Marks: Marks{Unit: "ratio", Fire: Mark{At: 0.80}, Clear: Mark{At: 0.50}, Worst: 1.0, Polarity: HigherIsWorse},
+		}},
+	}
+
+	// Q is declared FIRST. Observe returns the fired set in table order, so the
+	// set comes back Q then P while Rank must put P first on tier. Declaring P
+	// first would leave the set already in ranked order, and the ranking
+	// assertion would hold on an engine that never sorted anything.
+	table := Table[snap]{Signals: []Signal[snap]{signalQ, signalP}, Interval: time.Second}
+
+	// Readiness carries one row per signal at every depth, named by path, in
+	// depth-first order over the table: Q, then P and the subtree under it. Every
+	// tick of this episode is readable for every signal, so this is what
+	// readiness must look like at every point in it.
+	allReady := []Readiness{
+		{Signal: "Q", Availability: Ready},
+		{Signal: "P", Availability: Ready},
+		{Signal: "P/C", Availability: Ready},
+		{Signal: "P/C/G", Availability: Ready},
+	}
+
+	It("warms, nests, ranks, holds through the hysteresis band, and empties from the inside out", func() {
+		e, err := NewEngine(table)
+		Expect(err).ToNot(HaveOccurred())
+
+		// drive runs ticks from..to inclusive on one snapshot and hands back what
+		// the last of those ticks returned. Each phase below states its own tick
+		// range, so which tick an assertion reads is on the line above it.
+		drive := func(from, to int, s snap) ([]Fired, []Readiness) {
+			var (
+				fired     []Fired
+				readiness []Readiness
+			)
+
+			for i := from; i <= to; i++ {
+				fired, readiness = e.Observe(s, NewEnvironment(), at(i))
+			}
+
+			return fired, readiness
+		}
+
+		// Phase 1, healthy, ticks 0 to 4. Every value sits far below every fire
+		// mark, so nothing may fire — and every signal must still be reported as
+		// readable, since "measured, and fine" is not the same answer as "could
+		// not measure".
+		//
+		// Read at tick 4 rather than tick 0 because C's mean needs two samples:
+		// at tick 0 C is NoneReady, which is a warm-up state rather than a
+		// healthy one.
+		fired, readiness := drive(0, 4, snap{p: 0.10, q: 0.10, c: 0.10, g: 0.10})
+
+		Expect(fired).To(BeEmpty(), "nothing crossed a fire mark, at any depth")
+		Expect(readiness).To(Equal(allReady),
+			"readiness reports every signal at every depth, refinements included, whether or not anything fired")
+
+		// Phase 2, degrading, ticks 5 to 11. C's and G's own values go bad while
+		// P stays far below its own mark. Their windows fill and their latches
+		// fire during these ticks, and none of it is reported: a refinement is
+		// reported only under a parent that fired, and P has not fired.
+		//
+		// This emptiness and the Since values read in phase 3 are one assertion in
+		// two halves. Emptiness alone would also hold on a build that never
+		// judged a refinement until its parent fired.
+		fired, readiness = drive(5, 11, snap{p: 0.10, q: 0.10, c: 1.0, g: 1.0})
+
+		Expect(fired).To(BeEmpty(), "C and G have fired by now, and a silent parent reports neither")
+		Expect(readiness).To(Equal(allReady), "a refinement has a readiness row whichever way its parent went")
+
+		// Phase 3, degraded, tick 12. P's own value crosses its fire mark, and the
+		// verdicts latched during phase 2 are reported, nested under it.
+		fired, _ = drive(12, 12, snap{p: 0.90, q: 0.10, c: 1.0, g: 1.0})
+
+		Expect(names(fired)).To(Equal([]string{"P"}),
+			"P is the only top-level entry: a refinement is never a verdict of its own")
+		Expect(fired[0].Since).To(Equal(at(12)))
+
+		Expect(names(fired[0].Refinements)).To(Equal([]string{"C"}), "C nests under the parent it narrows")
+
+		nested := fired[0].Refinements[0]
+
+		// C's mean over ticks 4 to 7 is 0.775, the first window in which the three
+		// bad samples outweigh the healthy one still in it. So C answered off a
+		// full four-sample window five ticks before P fired, and did it while P
+		// was silent. A build that started C's window when P fired would stamp C
+		// at tick 12 with the same value, which is why the tick is asserted and
+		// not only the value.
+		Expect(nested.Since).To(Equal(at(7)), "C fired on tick 7, off a window warmed while P was below its mark")
+		Expect(nested.Since).To(BeTemporally("<", fired[0].Since), "C's episode began before P's")
+		Expect(nested.Value).To(Equal(0.775), "the mean C latched at tick 7 is what phase 5 must not disturb")
+
+		Expect(names(nested.Refinements)).To(Equal([]string{"G"}), "the second level of nesting: G under C, not under P")
+		Expect(nested.Refinements[0].Since).To(Equal(at(5)),
+			"G reads its newest sample, so it fired on the first bad tick, before both C and P")
+
+		// Phase 4, ranked, tick 13. Q's own value crosses its fire mark too, so
+		// there are two top-level signals to order.
+		fired, _ = drive(13, 13, snap{p: 0.90, q: 0.90, c: 1.0, g: 1.0})
+
+		Expect(names(fired)).To(Equal([]string{"Q", "P"}), "the fired set comes back in table order")
+		Expect(names(Rank(fired))).To(Equal([]string{"P", "Q"}),
+			"Rank orders the top level on tier, P at 1 ahead of Q at 2, and has no refinement to sort: C at tier 0 would come first")
+
+		// Phase 5, hysteresis, ticks 14 to 21. C's own value moves to 0.45, which
+		// is past neither of C's marks — below the 0.60 it fires at, above the
+		// 0.30 it clears at. Nothing else moves.
+		//
+		// Ticks 14 to 16 flush the 1.0 samples out of C's three-second window. By
+		// tick 17 the window holds four samples of 0.45 and nothing else, so the
+		// mean sits in the band for the rest of the phase.
+		drive(14, 16, snap{p: 0.90, q: 0.90, c: 0.45, g: 1.0})
+
+		// Five ticks in the band. C must stay reported on every one of them, with
+		// the Since it was stamped with on tick 7. This is the whole point of a
+		// latch: a build that re-decided from the window each tick would drop C
+		// here, and one that re-stamped on every tick it was still bad would move
+		// its Since.
+		for i := 17; i <= 21; i++ {
+			fired, _ = e.Observe(snap{p: 0.90, q: 0.90, c: 0.45, g: 1.0}, NewEnvironment(), at(i))
+
+			value, state := e.Reduction("P/C", instrument).Get()
+			Expect(state).To(Equal(StateValue), "C's window is answering, so the hold is not an artefact of an unreadable tick")
+			Expect(value).To(BeNumerically(">", cClear), "C's number has not reached its clear mark")
+			Expect(value).To(BeNumerically("<", cFire), "C's number would not fire the latch if it were unfired")
+
+			Expect(names(fired)).To(Equal([]string{"Q", "P"}))
+			Expect(names(fired[1].Refinements)).To(Equal([]string{"C"}), "C is still reported at tick %d", i)
+			Expect(fired[1].Refinements[0].Since).To(Equal(at(7)), "Since is stamped once, on the firing tick, and never refreshed")
+			Expect(fired[1].Refinements[0].Value).To(Equal(0.775), "the latched value does not follow the signal either")
+		}
+
+		// Phase 6, recovering, ticks 22 to 24. The values return past the clear
+		// marks and the report empties from the inside out.
+		//
+		// Tick 22: G reads its newest sample, 0.10, past its 0.40 clear mark, so G
+		// releases. C's mean over ticks 19 to 22 is 0.3625, short of C's 0.30
+		// clear mark, so C holds — and holds with nothing under it.
+		fired, _ = drive(22, 22, snap{p: 0.90, q: 0.90, c: 0.10, g: 0.10})
+
+		Expect(names(fired)).To(Equal([]string{"Q", "P"}))
+		Expect(names(fired[1].Refinements)).To(Equal([]string{"C"}))
+		Expect(fired[1].Refinements[0].Refinements).To(BeEmpty(), "G released, so C reports nothing under it")
+
+		// Tick 23: C's mean over ticks 20 to 23 is 0.275, past its clear mark, so
+		// C releases. P's own value has not moved, so P holds, now alone.
+		fired, _ = drive(23, 23, snap{p: 0.90, q: 0.90, c: 0.10, g: 0.10})
+
+		Expect(names(fired)).To(Equal([]string{"Q", "P"}))
+		Expect(fired[1].Refinements).To(BeEmpty(), "C released, so P reports nothing under it")
+
+		// Tick 24: P's and Q's own values return past their clear marks, and the
+		// episode is over.
+		fired, readiness = drive(24, 24, snap{p: 0.10, q: 0.10, c: 0.10, g: 0.10})
+
+		Expect(fired).To(BeEmpty(), "nothing is fired at any depth")
+		Expect(readiness).To(Equal(allReady),
+			"readiness lists every signal at every depth after the episode exactly as it did before it")
+	})
+})

--- a/umh-core/pkg/diagnosis/engine_episode_test.go
+++ b/umh-core/pkg/diagnosis/engine_episode_test.go
@@ -240,7 +240,7 @@ var _ = Describe("Engine.Observe over one degradation episode", func() {
 
 		Expect(names(fired)).To(Equal([]string{"Q", "P"}), "the fired set comes back in table order")
 		Expect(names(Rank(fired))).To(Equal([]string{"P", "Q"}),
-			"Rank orders the top level on tier, P at 1 ahead of Q at 2, and has no refinement to sort: C at tier 0 would come first")
+			"Rank orders the top-level set on tier, P at 1 ahead of Q at 2, and has no refinement to sort: C at tier 0 would come first")
 
 		// Phase 5, hysteresis, ticks 14 to 21. C's own value moves to 0.45, which
 		// is past neither of C's marks — below the 0.60 it fires at, above the

--- a/umh-core/pkg/diagnosis/engine_episode_test.go
+++ b/umh-core/pkg/diagnosis/engine_episode_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Engine.Observe over one degradation episode", func() {
 	names := func(fired []Fired) []string {
 		out := make([]string, len(fired))
 		for i, f := range fired {
-			out[i] = f.Identity.Signal
+			out[i] = f.Signal
 		}
 
 		return out

--- a/umh-core/pkg/diagnosis/engine_newengine_test.go
+++ b/umh-core/pkg/diagnosis/engine_newengine_test.go
@@ -436,9 +436,6 @@ var _ = Describe("NewEngine", func() {
 	// accepts the endpoints are exact, whatever the unit or direction. Rising
 	// ratio: (4.0 - 2.0) / (4.0 - 2.0) = 1. Falling headroom, worse() negating
 	// every term: (1.0 - 0.0) / (1.0 - 0.0) = 1 at the value -1.0 against fire 0.0.
-	// Under the earlier design the falling denominator was fire - (-worst), which
-	// put severity 1 at a value the quantity could not reach and scored a signal
-	// at its worst near zero.
 	It("scores exactly 0.0 at the fire mark and exactly 1.0 at the worst value, under both polarities", func() {
 		rising := Marks{Unit: "ratio", Fire: Mark{At: 2.0, Inclusive: true}, Clear: Mark{At: 1.0, Inclusive: true}, Polarity: HigherIsWorse, Worst: 4.0}
 		falling := Marks{Unit: "cores", Fire: Mark{At: 0.0, Inclusive: true}, Clear: Mark{At: 0.5, Inclusive: true}, Polarity: LowerIsWorse, Worst: -1.0}

--- a/umh-core/pkg/diagnosis/engine_newengine_test.go
+++ b/umh-core/pkg/diagnosis/engine_newengine_test.go
@@ -138,9 +138,7 @@ var _ = Describe("NewEngine", func() {
 		tbl := validTable([]Signal[snap]{validSignal("A")})
 		tbl.Measurements = []Measurement[snap]{{Name: "M-against", Extract: extract, Span: 60 * time.Second, Reduction: Last, Against: against}}
 		_, err := NewEngine(tbl)
-		if err == nil {
-			Fail("expected NewEngine to reject a table-level measurement that sets Against")
-		}
+		Expect(err).To(HaveOccurred(), "NewEngine must reject a table-level measurement that sets Against")
 		Expect(err.Error()).To(ContainSubstring("M-against"))
 		Expect(err.Error()).To(ContainSubstring("only meaningful inside a signal"))
 	})
@@ -149,9 +147,7 @@ var _ = Describe("NewEngine", func() {
 		tbl := validTable([]Signal[snap]{validSignal("A")})
 		tbl.Measurements = []Measurement[snap]{{Name: "M-requires", Extract: extract, Span: 60 * time.Second, Reduction: Last, Requires: []Capability{"psi"}}}
 		_, err := NewEngine(tbl)
-		if err == nil {
-			Fail("expected NewEngine to reject a table-level measurement that sets Requires")
-		}
+		Expect(err).To(HaveOccurred(), "NewEngine must reject a table-level measurement that sets Requires")
 		Expect(err.Error()).To(ContainSubstring("M-requires"))
 		Expect(err.Error()).To(ContainSubstring("only meaningful inside a signal"))
 	})
@@ -160,9 +156,7 @@ var _ = Describe("NewEngine", func() {
 		tbl := validTable([]Signal[snap]{validSignal("A")})
 		tbl.Measurements = []Measurement[snap]{{Name: "M-boolean", Extract: extract, Span: 60 * time.Second, Reduction: Last, Boolean: true}}
 		_, err := NewEngine(tbl)
-		if err == nil {
-			Fail("expected NewEngine to reject a table-level measurement that sets Boolean")
-		}
+		Expect(err).To(HaveOccurred(), "NewEngine must reject a table-level measurement that sets Boolean")
 		Expect(err.Error()).To(ContainSubstring("M-boolean"))
 		Expect(err.Error()).To(ContainSubstring("only meaningful inside a signal"))
 	})
@@ -171,9 +165,7 @@ var _ = Describe("NewEngine", func() {
 		tbl := validTable([]Signal[snap]{validSignal("A")})
 		tbl.Measurements = []Measurement[snap]{{Name: "M-counter", Extract: extract, Span: 60 * time.Second, Reduction: Last, Counter: true}}
 		_, err := NewEngine(tbl)
-		if err == nil {
-			Fail("expected NewEngine to reject a table-level measurement that sets Counter")
-		}
+		Expect(err).To(HaveOccurred(), "NewEngine must reject a table-level measurement that sets Counter")
 		Expect(err.Error()).To(ContainSubstring("M-counter"))
 		Expect(err.Error()).To(ContainSubstring("only meaningful inside a signal"))
 	})
@@ -469,9 +461,7 @@ var _ = Describe("NewEngine", func() {
 		parent := validSignal("A")
 		parent.Refinements = []Signal[snap]{ref}
 		_, err := NewEngine(validTable([]Signal[snap]{parent}))
-		if err == nil {
-			Fail("expected NewEngine to reject a refinement whose demote span is zero")
-		}
+		Expect(err).To(HaveOccurred(), "NewEngine must reject a refinement whose demote span is zero")
 		Expect(err.Error()).To(ContainSubstring("A/A1"),
 			"the error names the parent and the child, not the bare child")
 	})
@@ -480,9 +470,7 @@ var _ = Describe("NewEngine", func() {
 		parent := validSignal("A")
 		parent.Refinements = []Signal[snap]{validSignal("A1"), validSignal("A1")}
 		_, err := NewEngine(validTable([]Signal[snap]{parent}))
-		if err == nil {
-			Fail("expected NewEngine to reject duplicate sibling refinement names")
-		}
+		Expect(err).To(HaveOccurred(), "NewEngine must reject duplicate sibling refinement names")
 		Expect(err.Error()).To(ContainSubstring("A"))
 		Expect(err.Error()).To(ContainSubstring("A1"))
 	})
@@ -506,9 +494,7 @@ var _ = Describe("NewEngine", func() {
 	// name.
 	It("refuses a top-level signal whose name holds the path separator", func() {
 		_, err := NewEngine(validTable([]Signal[snap]{validSignal("A/X")}))
-		if err == nil {
-			Fail("expected NewEngine to reject a top-level signal named A/X")
-		}
+		Expect(err).To(HaveOccurred(), "NewEngine must reject a top-level signal named A/X")
 		Expect(err.Error()).To(ContainSubstring("A/X"))
 		Expect(err.Error()).To(ContainSubstring(`may not contain "/"`))
 	})
@@ -517,9 +503,7 @@ var _ = Describe("NewEngine", func() {
 		parent := validSignal("A")
 		parent.Refinements = []Signal[snap]{validSignal("B/C")}
 		_, err := NewEngine(validTable([]Signal[snap]{parent}))
-		if err == nil {
-			Fail("expected NewEngine to reject a refinement named B/C")
-		}
+		Expect(err).To(HaveOccurred(), "NewEngine must reject a refinement named B/C")
 		Expect(err.Error()).To(ContainSubstring("B/C"))
 		Expect(err.Error()).To(ContainSubstring(`may not contain "/"`))
 	})

--- a/umh-core/pkg/diagnosis/engine_newengine_test.go
+++ b/umh-core/pkg/diagnosis/engine_newengine_test.go
@@ -77,6 +77,8 @@ var _ = Describe("NewEngine", func() {
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("A"))
 		Expect(err.Error()).To(ContainSubstring("I1"))
+		Expect(err.Error()).To(ContainSubstring("window span"),
+			"an instrument sizes a window, and the measurement spec below reads the other wording; the pair is why validateMeasurement takes the noun as a parameter")
 	})
 
 	It("refuses a HigherIsWorse mark pair whose clear mark is not below its fire mark", func() {
@@ -261,6 +263,9 @@ var _ = Describe("NewEngine", func() {
 		_, err := NewEngine(tbl)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("T"))
+		Expect(err.Error()).To(ContainSubstring("span"))
+		Expect(err.Error()).ToNot(ContainSubstring("window span"),
+			"a table measurement hangs under no signal, so there is no signal's window to name and the error says the shorter word")
 	})
 
 	It("refuses a measurement whose reduction minimum sample count is below one", func() {

--- a/umh-core/pkg/diagnosis/engine_newengine_test.go
+++ b/umh-core/pkg/diagnosis/engine_newengine_test.go
@@ -491,4 +491,65 @@ var _ = Describe("NewEngine", func() {
 		Expect(err).ToNot(HaveOccurred(),
 			"a refinement name is unique among its parent's refinements, not across the tree")
 	})
+
+	// A refinement's windows are keyed under its parent's path plus its own
+	// name, joined with "/", so a top-level signal named "A/X" is keyed under
+	// the same "A/X" as the refinement X of a signal A. The second one built
+	// overwrites the first, and from then on both signals judge whichever window
+	// survived. Refusing "/" inside any name makes that collision unreachable:
+	// no segment can hold the separator, so no composed path can equal a bare
+	// name.
+	It("refuses a top-level signal whose name holds the path separator", func() {
+		_, err := NewEngine(validTable([]Signal[snap]{validSignal("A/X")}))
+		if err == nil {
+			Fail("expected NewEngine to reject a top-level signal named A/X")
+		}
+		Expect(err.Error()).To(ContainSubstring("A/X"))
+		Expect(err.Error()).To(ContainSubstring(`may not contain "/"`))
+	})
+
+	It("refuses a refinement whose name holds the path separator, so the rule reaches below the top level", func() {
+		parent := validSignal("A")
+		parent.Refinements = []Signal[snap]{validSignal("B/C")}
+		_, err := NewEngine(validTable([]Signal[snap]{parent}))
+		if err == nil {
+			Fail("expected NewEngine to reject a refinement named B/C")
+		}
+		Expect(err.Error()).To(ContainSubstring("B/C"))
+		Expect(err.Error()).To(ContainSubstring(`may not contain "/"`))
+	})
+
+	// Two parents each declaring a refinement called X is the case paths exist
+	// for, and the refusal above must not reach it. Reading both reduced values
+	// is what pins that down: a rule that rejected this table, or one that let
+	// the two share a window, would leave the two refusals above green while the
+	// feature was broken. Each X reads the snapshot through its own extractor,
+	// so one shared window could not report both numbers.
+	It("keeps the windows of a refinement named X under A and one named X under B separate", func() {
+		refinementReading := func(read func(snap) float64) Signal[snap] {
+			r := validSignal("X")
+			r.Instruments[0].Extract = func(s snap) Reading { return Known(read(s)) }
+
+			return r
+		}
+
+		a := validSignal("A")
+		a.Refinements = []Signal[snap]{refinementReading(func(s snap) float64 { return s.v })}
+		b := validSignal("B")
+		b.Refinements = []Signal[snap]{refinementReading(func(s snap) float64 { return s.v * 3 })}
+
+		e, err := NewEngine(validTable([]Signal[snap]{a, b}))
+		Expect(err).ToNot(HaveOccurred(),
+			"two parents may each declare a refinement called X: the paths A/X and B/X keep them apart")
+
+		e.Observe(snap{v: 2}, NewEnvironment("source-1"), time.Unix(1_000_000, 0))
+
+		underA, stateA := e.Reduction("A/X", "I1").Get()
+		Expect(stateA).To(Equal(StateValue))
+		Expect(underA).To(Equal(2.0))
+
+		underB, stateB := e.Reduction("B/X", "I1").Get()
+		Expect(stateB).To(Equal(StateValue))
+		Expect(underB).To(Equal(6.0), "B/X reads three times what A/X does, so one shared window could not report both")
+	})
 })

--- a/umh-core/pkg/diagnosis/engine_newengine_test.go
+++ b/umh-core/pkg/diagnosis/engine_newengine_test.go
@@ -44,10 +44,15 @@ var _ = Describe("NewEngine", func() {
 			DemoteSpan: 60 * time.Second,
 			Instruments: []Instrument[snap]{
 				{
-					Name: "I1", Requires: []Capability{"source-1"}, Extract: extract, Reduction: Last, Span: 60 * time.Second, Marks: validMarks(),
+					Measurement: Measurement[snap]{
+						Name: "I1", Requires: []Capability{"source-1"}, Extract: extract, Reduction: Last, Span: 60 * time.Second,
+					},
+					Marks: validMarks(),
 				},
 				{
-					Name: "I2", Requires: []Capability{"source-1"}, Extract: extract, Reduction: Mean, Span: 3 * time.Second,
+					Measurement: Measurement[snap]{
+						Name: "I2", Requires: []Capability{"source-1"}, Extract: extract, Reduction: Mean, Span: 3 * time.Second,
+					},
 					Marks: Marks{Unit: "cores", Fire: Mark{At: 8, Inclusive: true}, Clear: Mark{At: 4, Inclusive: true}, Polarity: HigherIsWorse, Worst: 16},
 				},
 			},

--- a/umh-core/pkg/diagnosis/engine_newengine_test.go
+++ b/umh-core/pkg/diagnosis/engine_newengine_test.go
@@ -192,15 +192,15 @@ var _ = Describe("NewEngine", func() {
 
 			sig := validSignal("A")
 			sig.Instruments[0].Reduction = reduction // I1 spans 60s
-			byTrack := validTable([]Signal[snap]{validSignal("A")})
-			byTrack.Measurements = []Measurement[snap]{{Name: "T", Extract: extract, Span: 60 * time.Second, Reduction: reduction}}
+			byMeasurement := validTable([]Signal[snap]{validSignal("A")})
+			byMeasurement.Measurements = []Measurement[snap]{{Name: "T", Extract: extract, Span: 60 * time.Second, Reduction: reduction}}
 
 			for _, row := range []struct {
 				name string
 				tbl  Table[snap]
 			}{
 				{name: "instrument", tbl: validTable([]Signal[snap]{sig})},
-				{name: "measurement", tbl: byTrack},
+				{name: "measurement", tbl: byMeasurement},
 			} {
 				_, err := NewEngine(row.tbl)
 				if count <= 61 {
@@ -455,7 +455,7 @@ var _ = Describe("NewEngine", func() {
 		}
 	})
 
-	It("rejects a refinement under its parent's path, so the error names A/A1 not the bare child", func() {
+	It("rejects a refinement under its parent's path, so the error names A/A1 and not the bare A1", func() {
 		ref := validSignal("A1")
 		ref.DemoteSpan = 0
 		parent := validSignal("A")
@@ -463,7 +463,7 @@ var _ = Describe("NewEngine", func() {
 		_, err := NewEngine(validTable([]Signal[snap]{parent}))
 		Expect(err).To(HaveOccurred(), "NewEngine must reject a refinement whose demote span is zero")
 		Expect(err.Error()).To(ContainSubstring("A/A1"),
-			"the error names the parent and the child, not the bare child")
+			"the error names the parent and the refinement, not the refinement alone")
 	})
 
 	It("refuses two sibling refinements with the same name under one parent", func() {
@@ -499,7 +499,7 @@ var _ = Describe("NewEngine", func() {
 		Expect(err.Error()).To(ContainSubstring(`may not contain "/"`))
 	})
 
-	It("refuses a refinement whose name holds the path separator, so the rule reaches below the top level", func() {
+	It("refuses a refinement whose name holds the path separator, so the rule reaches every depth and not just top-level signals", func() {
 		parent := validSignal("A")
 		parent.Refinements = []Signal[snap]{validSignal("B/C")}
 		_, err := NewEngine(validTable([]Signal[snap]{parent}))

--- a/umh-core/pkg/diagnosis/engine_newengine_test.go
+++ b/umh-core/pkg/diagnosis/engine_newengine_test.go
@@ -124,9 +124,9 @@ var _ = Describe("NewEngine", func() {
 		Expect(err.Error()).To(ContainSubstring("I1"))
 	})
 
-	It("refuses a track whose reduction has nil fold, which a caller can leave nil by writing a Reduction literal", func() {
+	It("refuses a measurement whose reduction has nil fold, which a caller can leave nil by writing a Reduction literal", func() {
 		tbl := validTable([]Signal[snap]{validSignal("A")})
-		tbl.Tracks = []Track[snap]{{Name: "T", Extract: extract, Span: 60 * time.Second, Reduction: Reduction{Name: "x", Min: 2}}}
+		tbl.Measurements = []Measurement[snap]{{Name: "T", Extract: extract, Span: 60 * time.Second, Reduction: Reduction{Name: "x", Min: 2}}}
 		_, err := NewEngine(tbl)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("T"))
@@ -147,7 +147,7 @@ var _ = Describe("NewEngine", func() {
 	// refusals with minimums far from the capacity, which leaves where each rule
 	// cuts unpinned. Capacity counts both edges, span/interval + 1: a 60s span at
 	// 1s holds the entries at 0s and at 60s and the 59 between them, so 61.
-	It("cuts the capacity rule at exactly the entries a span holds, 61 over a 60s span at a 1s interval and not 60, for an instrument and a track alike", func() {
+	It("cuts the capacity rule at exactly the entries a span holds, 61 over a 60s span at a 1s interval and not 60, for an instrument and a measurement alike", func() {
 		for _, count := range []int{61, 62} {
 			reduction, rerr := NewReduction("boundary", count, func([]Point) float64 { return 0 })
 			Expect(rerr).ToNot(HaveOccurred())
@@ -155,14 +155,14 @@ var _ = Describe("NewEngine", func() {
 			sig := validSignal("A")
 			sig.Instruments[0].Reduction = reduction // I1 spans 60s
 			byTrack := validTable([]Signal[snap]{validSignal("A")})
-			byTrack.Tracks = []Track[snap]{{Name: "T", Extract: extract, Span: 60 * time.Second, Reduction: reduction}}
+			byTrack.Measurements = []Measurement[snap]{{Name: "T", Extract: extract, Span: 60 * time.Second, Reduction: reduction}}
 
 			for _, row := range []struct {
 				name string
 				tbl  Table[snap]
 			}{
 				{name: "instrument", tbl: validTable([]Signal[snap]{sig})},
-				{name: "track", tbl: byTrack},
+				{name: "measurement", tbl: byTrack},
 			} {
 				_, err := NewEngine(row.tbl)
 				if count <= 61 {
@@ -211,33 +211,33 @@ var _ = Describe("NewEngine", func() {
 		Expect(err.Error()).To(ContainSubstring("I1"))
 	})
 
-	It("refuses a track whose span is zero or negative", func() {
+	It("refuses a measurement whose span is zero or negative", func() {
 		tbl := validTable([]Signal[snap]{validSignal("A")})
-		tbl.Tracks = []Track[snap]{{Name: "T", Extract: extract, Span: 0, Reduction: Mean}}
+		tbl.Measurements = []Measurement[snap]{{Name: "T", Extract: extract, Span: 0, Reduction: Mean}}
 		_, err := NewEngine(tbl)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("T"))
 	})
 
-	It("refuses a track whose reduction minimum sample count is below one", func() {
+	It("refuses a measurement whose reduction minimum sample count is below one", func() {
 		tbl := validTable([]Signal[snap]{validSignal("A")})
-		tbl.Tracks = []Track[snap]{{Name: "T", Extract: extract, Span: 60 * time.Second, Reduction: Reduction{Name: "low", Min: 0, fold: func([]Point) float64 { return 0 }}}}
+		tbl.Measurements = []Measurement[snap]{{Name: "T", Extract: extract, Span: 60 * time.Second, Reduction: Reduction{Name: "low", Min: 0, fold: func([]Point) float64 { return 0 }}}}
 		_, err := NewEngine(tbl)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("T"))
 	})
 
-	It("refuses a track that names a dividing reduction, because a track declares no denominator series", func() {
+	It("refuses a measurement that names a dividing reduction, because a measurement declares no denominator series", func() {
 		tbl := validTable([]Signal[snap]{validSignal("A")})
-		tbl.Tracks = []Track[snap]{{Name: "T", Extract: extract, Span: 60 * time.Second, Reduction: DeltaRatio}}
+		tbl.Measurements = []Measurement[snap]{{Name: "T", Extract: extract, Span: 60 * time.Second, Reduction: DeltaRatio}}
 		_, err := NewEngine(tbl)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("T"))
 	})
 
-	It("refuses a track whose Extract is nil, which would panic in the observe loop", func() {
+	It("refuses a measurement whose Extract is nil, which would panic in the observe loop", func() {
 		tbl := validTable([]Signal[snap]{validSignal("A")})
-		tbl.Tracks = []Track[snap]{{Name: "T", Span: 60 * time.Second, Reduction: Mean}}
+		tbl.Measurements = []Measurement[snap]{{Name: "T", Span: 60 * time.Second, Reduction: Mean}}
 		_, err := NewEngine(tbl)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("T"))
@@ -250,9 +250,9 @@ var _ = Describe("NewEngine", func() {
 		Expect(err).ToNot(HaveOccurred(), "a non-nil against under a non-dividing reduction is a redundant declaration, not a refusal")
 	})
 
-	It("refuses duplicate track names, which would leave Track returning whichever one it reached first", func() {
+	It("refuses duplicate measurement names, which would leave Measurement returning whichever one it reached first", func() {
 		tbl := validTable([]Signal[snap]{validSignal("A")})
-		tbl.Tracks = []Track[snap]{
+		tbl.Measurements = []Measurement[snap]{
 			{Name: "T", Extract: extract, Span: 60 * time.Second, Reduction: Mean},
 			{Name: "T", Extract: extract, Span: 60 * time.Second, Reduction: Mean},
 		}

--- a/umh-core/pkg/diagnosis/engine_newengine_test.go
+++ b/umh-core/pkg/diagnosis/engine_newengine_test.go
@@ -132,6 +132,50 @@ var _ = Describe("NewEngine", func() {
 		Expect(err.Error()).To(ContainSubstring("T"))
 	})
 
+	It("refuses a table-level measurement that sets Against, which is only meaningful for an instrument", func() {
+		tbl := validTable([]Signal[snap]{validSignal("A")})
+		tbl.Measurements = []Measurement[snap]{{Name: "M-against", Extract: extract, Span: 60 * time.Second, Reduction: Last, Against: against}}
+		_, err := NewEngine(tbl)
+		if err == nil {
+			Fail("expected NewEngine to reject a table-level measurement that sets Against")
+		}
+		Expect(err.Error()).To(ContainSubstring("M-against"))
+		Expect(err.Error()).To(ContainSubstring("only meaningful inside a signal"))
+	})
+
+	It("refuses a table-level measurement that sets Requires, which is only meaningful for an instrument", func() {
+		tbl := validTable([]Signal[snap]{validSignal("A")})
+		tbl.Measurements = []Measurement[snap]{{Name: "M-requires", Extract: extract, Span: 60 * time.Second, Reduction: Last, Requires: []Capability{"psi"}}}
+		_, err := NewEngine(tbl)
+		if err == nil {
+			Fail("expected NewEngine to reject a table-level measurement that sets Requires")
+		}
+		Expect(err.Error()).To(ContainSubstring("M-requires"))
+		Expect(err.Error()).To(ContainSubstring("only meaningful inside a signal"))
+	})
+
+	It("refuses a table-level measurement that sets Boolean, which is only meaningful for an instrument", func() {
+		tbl := validTable([]Signal[snap]{validSignal("A")})
+		tbl.Measurements = []Measurement[snap]{{Name: "M-boolean", Extract: extract, Span: 60 * time.Second, Reduction: Last, Boolean: true}}
+		_, err := NewEngine(tbl)
+		if err == nil {
+			Fail("expected NewEngine to reject a table-level measurement that sets Boolean")
+		}
+		Expect(err.Error()).To(ContainSubstring("M-boolean"))
+		Expect(err.Error()).To(ContainSubstring("only meaningful inside a signal"))
+	})
+
+	It("refuses a table-level measurement that sets Counter, which is only meaningful for an instrument", func() {
+		tbl := validTable([]Signal[snap]{validSignal("A")})
+		tbl.Measurements = []Measurement[snap]{{Name: "M-counter", Extract: extract, Span: 60 * time.Second, Reduction: Last, Counter: true}}
+		_, err := NewEngine(tbl)
+		if err == nil {
+			Fail("expected NewEngine to reject a table-level measurement that sets Counter")
+		}
+		Expect(err.Error()).To(ContainSubstring("M-counter"))
+		Expect(err.Error()).To(ContainSubstring("only meaningful inside a signal"))
+	})
+
 	It("refuses an instrument whose reduction minimum sample count is below one", func() {
 		sig := validSignal("A")
 		sig.Instruments[0].Reduction = Reduction{Name: "low", Min: 0, fold: func([]Point) float64 { return 0 }}

--- a/umh-core/pkg/diagnosis/engine_newengine_test.go
+++ b/umh-core/pkg/diagnosis/engine_newengine_test.go
@@ -457,4 +457,38 @@ var _ = Describe("NewEngine", func() {
 			Expect(Fired{Marks: m, Value: m.Fire.At}.Severity()).To(Equal(0.0), m.Unit)
 		}
 	})
+
+	It("rejects a refinement under its parent's path, so the error names A/A1 not the bare child", func() {
+		ref := validSignal("A1")
+		ref.DemoteSpan = 0
+		parent := validSignal("A")
+		parent.Refinements = []Signal[snap]{ref}
+		_, err := NewEngine(validTable([]Signal[snap]{parent}))
+		if err == nil {
+			Fail("expected NewEngine to reject a refinement whose demote span is zero")
+		}
+		Expect(err.Error()).To(ContainSubstring("A/A1"),
+			"the error names the parent and the child, not the bare child")
+	})
+
+	It("refuses two sibling refinements with the same name under one parent", func() {
+		parent := validSignal("A")
+		parent.Refinements = []Signal[snap]{validSignal("A1"), validSignal("A1")}
+		_, err := NewEngine(validTable([]Signal[snap]{parent}))
+		if err == nil {
+			Fail("expected NewEngine to reject duplicate sibling refinement names")
+		}
+		Expect(err.Error()).To(ContainSubstring("A"))
+		Expect(err.Error()).To(ContainSubstring("A1"))
+	})
+
+	It("accepts the same refinement name under different parents, because uniqueness is among siblings only", func() {
+		a := validSignal("A")
+		a.Refinements = []Signal[snap]{validSignal("X")}
+		b := validSignal("B")
+		b.Refinements = []Signal[snap]{validSignal("X")}
+		_, err := NewEngine(validTable([]Signal[snap]{a, b}))
+		Expect(err).ToNot(HaveOccurred(),
+			"a refinement name is unique among its parent's refinements, not across the tree")
+	})
 })

--- a/umh-core/pkg/diagnosis/engine_refinements_test.go
+++ b/umh-core/pkg/diagnosis/engine_refinements_test.go
@@ -24,9 +24,10 @@ import (
 // A refinement is a signal that narrows the answer of the signal it hangs
 // under. It is sampled every tick and judged every tick, whichever way its
 // parent went; only whether the parent REPORTS it turns on the parent having
-// fired. These specs read the reporting side on a tick where the parent HAS
+// fired. Most specs here read the reporting side on a tick where the parent HAS
 // fired: which refinements nest under it, and that a refinement is nested
-// rather than returned beside its parent.
+// rather than returned beside its parent. The last one reads the other side,
+// where the parent is silent and its fired refinement is reported nowhere.
 var _ = Describe("Engine.Observe on a signal's refinements", func() {
 
 	type snap struct {
@@ -176,5 +177,45 @@ var _ = Describe("Engine.Observe on a signal's refinements", func() {
 		Expect(first[0].Refinements[0].Since).To(Equal(base), "Since is the tick the refinement fired")
 		Expect(second[0].Refinements[0].Since).To(Equal(first[0].Refinements[0].Since),
 			"the second tick holds the same Since: a refinement's verdict is latched, not re-decided each tick")
+	})
+
+	// The three specs above all read a tick where the parent fired, so none of
+	// them can tell a build that suppresses a fired refinement from one that
+	// emits it beside its parent. This one drives the parent below its fire mark
+	// throughout and reads the whole returned slice.
+	It("reports nothing at all while the parent is silent, though its refinement has fired and stays warm", func() {
+		e := engineOver(parentOver(refinement("C", Mean, func(s snap) float64 { return s.first })))
+
+		// Tick 0 leaves the child below Mean's minimum of two. Tick 1 reaches it
+		// at a mean of 1.0, past the child's 0.6 fire mark, so the child fires
+		// here and this is the Since the later ticks must still carry.
+		e.Observe(snap{parent: 0.0, first: 1.0}, NewEnvironment(), base)
+		e.Observe(snap{parent: 0.0, first: 1.0}, NewEnvironment(), base.Add(time.Second))
+
+		// The tick after the child fired. The parent is still at 0.0, below its
+		// own 0.5 fire mark.
+		silent, _ := e.Observe(snap{parent: 0.0, first: 1.0}, NewEnvironment(), base.Add(2*time.Second))
+
+		Expect(silent).To(BeEmpty(),
+			"a fired refinement under a silent parent is reported nowhere: not nested, and not as a top-level entry of its own")
+
+		// Suppression is about reporting only, so the child's window keeps taking
+		// samples across the silent ticks and stays trustworthy.
+		value, state := e.Reduction("P/C", "I").Get()
+		Expect(state).To(Equal(StateValue), "the refinement's window is still warm while the parent is silent")
+		Expect(value).To(Equal(1.0), "and still reduces to the mean it fired on")
+
+		// Nothing about the child changes on this tick; only the parent crosses
+		// its mark. The child appearing now, with the Since it stamped on tick 1,
+		// is what shows its latch held across the two silent ticks rather than
+		// firing fresh here.
+		fired, _ := e.Observe(snap{parent: 1.0, first: 1.0}, NewEnvironment(), base.Add(3*time.Second))
+
+		Expect(fired).To(HaveLen(1))
+		Expect(fired[0].Identity.Signal).To(Equal("P"))
+		Expect(fired[0].Refinements).To(HaveLen(1))
+		Expect(fired[0].Refinements[0].Identity.Signal).To(Equal("C"))
+		Expect(fired[0].Refinements[0].Since).To(Equal(base.Add(time.Second)),
+			"the child fired on tick 1 and held: the empty slice above was suppression, not a child that had not fired")
 	})
 })

--- a/umh-core/pkg/diagnosis/engine_refinements_test.go
+++ b/umh-core/pkg/diagnosis/engine_refinements_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Engine.Observe on a signal's refinements", func() {
 	names := func(fired []Fired) []string {
 		out := make([]string, len(fired))
 		for i, f := range fired {
-			out[i] = f.Identity.Signal
+			out[i] = f.Signal
 		}
 
 		return out

--- a/umh-core/pkg/diagnosis/engine_refinements_test.go
+++ b/umh-core/pkg/diagnosis/engine_refinements_test.go
@@ -29,9 +29,11 @@ import (
 // nested rather than returned beside its parent. One reads the other side, where
 // the parent is silent and its fired refinement is reported nowhere. One hands
 // the returned set to Rank, which orders top-level signals only. Three read the
-// order the refinements under one signal come back in. The last reads Observe's
+// order the refinements under one signal come back in. One reads Observe's
 // other return value, the readiness rows, which every signal gets at every depth
-// whichever way it or its parent went.
+// whichever way it or its parent went. Two read how a refinement LEAVES a
+// parent's report once it is in: on its own clear mark, and on its own demote
+// clock.
 var _ = Describe("Engine.Observe on a signal's refinements", func() {
 
 	type snap struct {
@@ -257,7 +259,9 @@ var _ = Describe("Engine.Observe on a signal's refinements", func() {
 		// Tier 0 is more urgent than either top-level signal, and Index 0 (its
 		// position among its siblings) is the value that wins the last tie-break,
 		// so no single field carries the fixture. Attribution differs from the
-		// parents' too, though Rank never reads it.
+		// parents' too: Rank never reads it, but the caller it routes blame to
+		// does, and the last assertion in this spec is the only one holding it to
+		// reaching a nested Fired.
 		child := refinement("C", 0, Last, func(s snap) float64 { return s.first })
 		child.Attribution = 7
 
@@ -292,6 +296,8 @@ var _ = Describe("Engine.Observe on a signal's refinements", func() {
 			"the nested entry keeps the urgent tier it was declared with; it is unranked, not demoted")
 		Expect(ranked[1].Refinements[0].Index).To(Equal(0),
 			"and the index that wins the last tie-break, so the absence above is not the refinement sorting last")
+		Expect(ranked[1].Refinements[0].Attribution).To(Equal(7),
+			"and the Attribution it was declared with, the field the consumer routes blame on, carried down to the nested verdict rather than the parent's")
 	})
 
 	// Rank orders the top-level set. The three specs below are about the order
@@ -435,11 +441,12 @@ var _ = Describe("Engine.Observe on a signal's refinements", func() {
 		Expect(readiness[3].Availability).To(Equal(Ready), "Q reads its sample")
 	})
 
-	// The two specs above read the fire mark, which decides whether a refinement
-	// ENTERS a parent's report. The two below read the other end, the two ways a
-	// refinement LEAVES it: its own clear mark, and its own demote clock. Both
-	// keep the parent firing throughout, so the parent's report is the only thing
-	// the child can be missing from.
+	// A refinement ENTERS a parent's report on its own fire mark, which the spec
+	// "reports only the refinement past its own fire mark, naming it" reads. It
+	// LEAVES on one of two others: its own clear mark, and its own demote clock.
+	// The two specs named for those follow. Both keep the parent firing
+	// throughout, so the parent's report is the only thing the child can be
+	// missing from.
 
 	// The clear arm needs Coverage.Full(), which on the ten-second window this
 	// fixture builds takes eleven ticks at the table's one-second interval: t0

--- a/umh-core/pkg/diagnosis/engine_refinements_test.go
+++ b/umh-core/pkg/diagnosis/engine_refinements_test.go
@@ -56,7 +56,7 @@ var _ = Describe("Engine.Observe on a signal's refinements", func() {
 
 	// A top-level signal reads its newest sample, so it fires on the tick its own
 	// value crosses 0.5 and needs no warm-up: every spec below can put the firing
-	// tick wherever it wants the child observed. Name, tier and the field it
+	// tick wherever it wants the refinement observed. Name, tier and the field it
 	// reads are the caller's, so two of them can sit in one table and rank
 	// against each other.
 	topLevel := func(name string, tier int, read func(snap) float64, refinements ...Signal[snap]) Signal[snap] {
@@ -112,16 +112,17 @@ var _ = Describe("Engine.Observe on a signal's refinements", func() {
 		return e
 	}
 
-	// The child's window is filled on each of the parent's ten silent ticks, a
-	// 1.0 every time, so the child reaches Mean's minimum of two samples and
-	// fires on tick 1 — nine ticks before its parent fires at all. Since is what
-	// proves that: a child sampled or judged only while its parent fires would
-	// hold the single 0.0 of tick 10, sit below Mean's minimum, and never fire.
+	// The refinement's window is filled on each of the parent's ten silent
+	// ticks, a 1.0 every time, so the refinement reaches Mean's minimum of two
+	// samples and fires on tick 1 — nine ticks before its parent fires at all.
+	// Since is what proves that: a refinement sampled or judged only while its
+	// parent fires would hold the single 0.0 of tick 10, sit below Mean's
+	// minimum, and never fire.
 	//
 	// Two choices in the fixture are load-bearing. Mean over a minimum of two is
 	// what makes a cold window unable to answer; Last would answer off one
 	// sample. And the 0.0 at tick 10 is what a build reducing the window at
-	// REPORT time would report, 10/11 rather than the 1.0 the child latched.
+	// REPORT time would report, 10/11 rather than the 1.0 the refinement latched.
 	It("reports a fired parent's refinement nested under it, warm over ten ticks, not as a top-level entry beside it", func() {
 		e := engineOver(parentOver(refinement("C", 0, Mean, func(s snap) float64 { return s.first })))
 
@@ -129,20 +130,20 @@ var _ = Describe("Engine.Observe on a signal's refinements", func() {
 			e.Observe(snap{parent: 0.0, first: 1.0}, NewEnvironment(), base.Add(time.Duration(i)*time.Second))
 		}
 
-		// The parent crosses its fire mark (0.0 -> 1.0) while the child's newest
-		// sample drops below the child's own (1.0 -> 0.0). The child's mean over
-		// the warm window, 10/11, stays past its 0.4 clear mark, so the child is
-		// still held.
+		// The parent crosses its fire mark (0.0 -> 1.0) while the refinement's
+		// newest sample drops below the refinement's own (1.0 -> 0.0). Its mean
+		// over the warm window, 10/11, stays past its 0.4 clear mark, so the
+		// refinement is still held.
 		fired, _ := e.Observe(snap{parent: 1.0, first: 0.0}, NewEnvironment(), base.Add(10*time.Second))
 
-		Expect(fired).To(HaveLen(1), "only the fired parent appears at the top level; the refinement nests under it")
+		Expect(fired).To(HaveLen(1), "only the fired parent is a top-level entry; the refinement nests under it")
 		Expect(fired[0].Identity.Signal).To(Equal("P"))
 		Expect(fired[0].Refinements).To(HaveLen(1), "the fired parent reports the refinement its own latch holds")
 		Expect(fired[0].Refinements[0].Identity.Signal).To(Equal("C"), "the nested entry names the refinement")
 		Expect(fired[0].Refinements[0].Since).To(Equal(base.Add(time.Second)),
-			"the child fired on tick 1, off a window warmed while the parent was silent")
+			"the refinement fired on tick 1, off a window warmed while the parent was silent")
 		Expect(fired[0].Refinements[0].Value).To(Equal(1.0),
-			"the value is the mean the child fired on, not the window's 10/11 at report time")
+			"the value is the mean the refinement fired on, not the window's 10/11 at report time")
 	})
 
 	It("reports only the refinement past its own fire mark, naming it", func() {
@@ -152,7 +153,7 @@ var _ = Describe("Engine.Observe on a signal's refinements", func() {
 		))
 
 		// One tick is enough: Last needs a single sample, so the parent and both
-		// children reduce to a trustworthy value on the first tick. The parent
+		// refinements reduce to a trustworthy value on the first tick. The parent
 		// and C1 cross their marks; C2 sits below its own.
 		fired, _ := e.Observe(snap{parent: 1.0, first: 1.0, second: 0.0}, NewEnvironment(), base)
 
@@ -180,10 +181,10 @@ var _ = Describe("Engine.Observe on a signal's refinements", func() {
 		Expect(reported[0].Refinements).To(HaveLen(1), "two samples are enough for the refinement to be judged")
 		Expect(reported[0].Refinements[0].Identity.Signal).To(Equal("C"))
 
-		// One sample is below Mean's minimum of two, so the child's window holds
-		// nothing trustworthy to judge. That sample sits past the child's fire
-		// mark, so a build that reported the window without asking whether it was
-		// ready would report the child here too.
+		// One sample is below Mean's minimum of two, so the refinement's window
+		// holds nothing trustworthy to judge. That sample sits past the
+		// refinement's fire mark, so a build that reported the window without
+		// asking whether it was ready would report the refinement here too.
 		cold := engineOver(declaration())
 		fired, _ := cold.Observe(snap{parent: 1.0, first: 1.0}, NewEnvironment(), base)
 
@@ -215,29 +216,30 @@ var _ = Describe("Engine.Observe on a signal's refinements", func() {
 	It("reports nothing at all while the parent is silent, though its refinement has fired and stays warm", func() {
 		e := engineOver(parentOver(refinement("C", 0, Mean, func(s snap) float64 { return s.first })))
 
-		// Tick 0 leaves the child below Mean's minimum of two. Tick 1 reaches it
-		// at a mean of 1.0, past the child's 0.6 fire mark, so the child fires
-		// here and this is the Since the later ticks must still carry.
+		// Tick 0 leaves the refinement below Mean's minimum of two. Tick 1
+		// reaches it at a mean of 1.0, past the refinement's 0.6 fire mark, so
+		// the refinement fires here and this is the Since the later ticks must
+		// still carry.
 		e.Observe(snap{parent: 0.0, first: 1.0}, NewEnvironment(), base)
 		e.Observe(snap{parent: 0.0, first: 1.0}, NewEnvironment(), base.Add(time.Second))
 
-		// The tick after the child fired. The parent is still at 0.0, below its
-		// own 0.5 fire mark.
+		// The tick after the refinement fired. The parent is still at 0.0, below
+		// its own 0.5 fire mark.
 		silent, _ := e.Observe(snap{parent: 0.0, first: 1.0}, NewEnvironment(), base.Add(2*time.Second))
 
 		Expect(silent).To(BeEmpty(),
 			"a fired refinement under a silent parent is reported nowhere: not nested, and not as a top-level entry of its own")
 
-		// Suppression is about reporting only, so the child's window keeps taking
-		// samples across the silent ticks and stays trustworthy.
+		// Suppression is about reporting only, so the refinement's window keeps
+		// taking samples across the silent ticks and stays trustworthy.
 		value, state := e.Reduction("P/C", "I").Get()
 		Expect(state).To(Equal(StateValue), "the refinement's window is still warm while the parent is silent")
 		Expect(value).To(Equal(1.0), "and still reduces to the mean it fired on")
 
-		// Nothing about the child changes on this tick; only the parent crosses
-		// its mark. The child appearing now, with the Since it stamped on tick 1,
-		// is what shows its latch held across the two silent ticks rather than
-		// firing fresh here.
+		// Nothing about the refinement changes on this tick; only the parent
+		// crosses its mark. The refinement appearing now, with the Since it
+		// stamped on tick 1, is what shows its latch held across the two silent
+		// ticks rather than firing fresh here.
 		fired, _ := e.Observe(snap{parent: 1.0, first: 1.0}, NewEnvironment(), base.Add(3*time.Second))
 
 		Expect(fired).To(HaveLen(1))
@@ -245,7 +247,7 @@ var _ = Describe("Engine.Observe on a signal's refinements", func() {
 		Expect(fired[0].Refinements).To(HaveLen(1))
 		Expect(fired[0].Refinements[0].Identity.Signal).To(Equal("C"))
 		Expect(fired[0].Refinements[0].Since).To(Equal(base.Add(time.Second)),
-			"the child fired on tick 1 and held: the empty slice above was suppression, not a child that had not fired")
+			"the refinement fired on tick 1 and held: the empty slice above was suppression, not a refinement that had not fired")
 	})
 	// Rank is asked a question about the top-level set: which of the signals the
 	// caller can act on comes first. A refinement's urgency is meaningful under
@@ -262,8 +264,8 @@ var _ = Describe("Engine.Observe on a signal's refinements", func() {
 		// parents' too: Rank never reads it, but the caller it routes blame to
 		// does, and the last assertion in this spec is the only one holding it to
 		// reaching a nested Fired.
-		child := refinement("C", 0, Last, func(s snap) float64 { return s.first })
-		child.Attribution = 7
+		ref := refinement("C", 0, Last, func(s snap) float64 { return s.first })
+		ref.Attribution = 7
 
 		// Both fire on their first sample, both at tier 1, so only severity
 		// separates them: Severe reads 1.0 against a fire mark of 0.5 and a worst
@@ -271,7 +273,7 @@ var _ = Describe("Engine.Observe on a signal's refinements", func() {
 		// under Mild, the one that must stay second, so a comparator reaching into
 		// a nested tier to break the tier tie would hoist Mild and be caught.
 		severe := topLevel("Severe", 1, func(s snap) float64 { return s.parent })
-		mild := topLevel("Mild", 1, func(s snap) float64 { return s.second }, child)
+		mild := topLevel("Mild", 1, func(s snap) float64 { return s.second }, ref)
 
 		e, err := NewEngine(Table[snap]{Signals: []Signal[snap]{severe, mild}, Interval: time.Second})
 		Expect(err).ToNot(HaveOccurred())
@@ -378,17 +380,17 @@ var _ = Describe("Engine.Observe on a signal's refinements", func() {
 	})
 
 	It("orders the refinements of a refinement by the same rule, so every level is ordered and not just the first", func() {
-		child := refinement("C", 0, Last, func(s snap) float64 { return s.first },
+		ref := refinement("C", 0, Last, func(s snap) float64 { return s.first },
 			refinement("LessUrgent", 2, Last, func(s snap) float64 { return s.second }),
 			refinement("MoreUrgent", 1, Last, func(s snap) float64 { return s.third }),
 		)
 
-		e := engineOver(parentOver(child))
+		e := engineOver(parentOver(ref))
 
 		fired, _ := e.Observe(snap{parent: 1.0, first: 0.7, second: 0.7, third: 0.7}, NewEnvironment(), base)
 
 		Expect(fired).To(HaveLen(1))
-		Expect(fired[0].Refinements).To(HaveLen(1), "the child fired and nests under the parent")
+		Expect(fired[0].Refinements).To(HaveLen(1), "the refinement fired and nests under the parent")
 		Expect(fired[0].Refinements[0].Refinements).To(HaveLen(2), "both of its own refinements fired too")
 		Expect(names(fired[0].Refinements[0].Refinements)).To(Equal([]string{"MoreUrgent", "LessUrgent"}),
 			"two levels down the tiers still decide, though these were also declared less urgent first")
@@ -400,25 +402,25 @@ var _ = Describe("Engine.Observe on a signal's refinements", func() {
 	// judged every tick, so it has an availability of its own, and a row of its
 	// own is the only way a caller sees it.
 	It("returns one readiness row per signal at every depth, depth-first, named by path and carrying that signal's own availability", func() {
-		// The grandchild's instrument requires nothing, so it is capable in the
-		// same empty environment that leaves its parent with no instrument at
-		// all. That is what separates a row resolved per signal from a row
-		// handed down the tree.
-		grandchild := refinement("G", 1, Last, func(s snap) float64 { return s.third })
+		// G's instrument requires nothing, so it is capable in the same empty
+		// environment that leaves C above it with no instrument at all. That is
+		// what separates a row resolved per signal from a row handed down the
+		// tree.
+		nested := refinement("G", 1, Last, func(s snap) float64 { return s.third })
 
 		// C is the one signal here this environment cannot satisfy: its
 		// instrument requires a capability the empty environment does not have,
 		// so C resolves to NoInstrument while P above it and G below it both
 		// read their sample.
-		child := refinement("C", 1, Last, func(s snap) float64 { return s.first }, grandchild)
-		child.Instruments[0].Requires = []Capability{"psi"}
+		ref := refinement("C", 1, Last, func(s snap) float64 { return s.first }, nested)
+		ref.Instruments[0].Requires = []Capability{"psi"}
 
 		// A second top-level signal, declared after P, is what makes the
 		// depth-first claim testable: it must come after P's whole subtree and
 		// not between P and the subtree, which is where a breadth-first walk
 		// would put it.
 		e, err := NewEngine(Table[snap]{
-			Signals:  []Signal[snap]{parentOver(child), topLevel("Q", 1, func(s snap) float64 { return s.second })},
+			Signals:  []Signal[snap]{parentOver(ref), topLevel("Q", 1, func(s snap) float64 { return s.second })},
 			Interval: time.Second,
 		})
 		Expect(err).ToNot(HaveOccurred())
@@ -431,7 +433,7 @@ var _ = Describe("Engine.Observe on a signal's refinements", func() {
 		}
 
 		Expect(rows).To(Equal([]string{"P", "P/C", "P/C/G", "Q"}),
-			"depth-first, a parent immediately before its own children, each row named by its path: two parents may each declare a refinement named X, so a bare name would not say which one this is")
+			"depth-first, a parent immediately before its own refinements, each row named by its path: two parents may each declare a refinement named X, so a bare name would not say which one this is")
 
 		Expect(readiness[0].Availability).To(Equal(Ready), "P reads its sample")
 		Expect(readiness[1].Availability).To(Equal(NoInstrument),
@@ -445,16 +447,17 @@ var _ = Describe("Engine.Observe on a signal's refinements", func() {
 	// "reports only the refinement past its own fire mark, naming it" reads. It
 	// LEAVES on one of two others: its own clear mark, and its own demote clock.
 	// The two specs named for those follow. Both keep the parent firing
-	// throughout, so the parent's report is the only thing the child can be
+	// throughout, so the parent's report is the only thing the refinement can be
 	// missing from.
 
 	// The clear arm needs Coverage.Full(), which on the ten-second window this
 	// fixture builds takes eleven ticks at the table's one-second interval: t0
-	// through t10 span exactly ten seconds. Dropping the child earlier would be a
-	// release granted on a window that had not filled, which is a different rule.
+	// through t10 span exactly ten seconds. Dropping the refinement earlier
+	// would be a release granted on a window that had not filled, which is a
+	// different rule.
 	It("drops a refinement, and the refinement under it, on the tick the refinement crosses its own clear mark", func() {
-		grandchild := refinement("G", 1, Last, func(s snap) float64 { return s.second })
-		e := engineOver(parentOver(refinement("C", 1, Last, func(s snap) float64 { return s.first }, grandchild)))
+		nested := refinement("G", 1, Last, func(s snap) float64 { return s.second })
+		e := engineOver(parentOver(refinement("C", 1, Last, func(s snap) float64 { return s.first }, nested)))
 
 		var warm []Fired
 		for i := 0; i <= 10; i++ {
@@ -462,24 +465,24 @@ var _ = Describe("Engine.Observe on a signal's refinements", func() {
 		}
 
 		Expect(names(warm)).To(Equal([]string{"P"}))
-		Expect(names(warm[0].Refinements)).To(Equal([]string{"C"}), "the child fired on its first sample and is held")
-		Expect(names(warm[0].Refinements[0].Refinements)).To(Equal([]string{"G"}), "and so is the grandchild under it")
+		Expect(names(warm[0].Refinements)).To(Equal([]string{"C"}), "C fired on its first sample and is held")
+		Expect(names(warm[0].Refinements[0].Refinements)).To(Equal([]string{"G"}), "and so is G, the refinement nested under C")
 
-		// 0.3 is past the child's own 0.4 clear mark. Nothing else moves: the
-		// parent still reads 1.0, and the grandchild still reads the 0.7 that is
-		// past its own fire mark and nowhere near its own clear mark.
+		// 0.3 is past C's own 0.4 clear mark. Nothing else moves: the parent
+		// still reads 1.0, and G still reads the 0.7 that is past its own fire
+		// mark and nowhere near its own clear mark.
 		released, _ := e.Observe(snap{parent: 1.0, first: 0.3, second: 0.7}, NewEnvironment(), base.Add(11*time.Second))
 
 		Expect(names(released)).To(Equal([]string{"P"}),
 			"the parent is untouched: its own value never left its own marks")
 		Expect(released[0].Refinements).To(BeEmpty(),
-			"the child released on its own clear mark, and the grandchild leaves with it: a refinement of an unreported refinement is reported nowhere")
+			"C released on its own clear mark, and G leaves with it: a refinement of an unreported refinement is reported nowhere")
 
-		// What the grandchild lost was its route to the report, not its verdict.
-		// Latch re-arms one Coverage span after a release, so the child cannot
-		// fire again before t21 however far past its fire mark it reads. When it
-		// does, the grandchild reappears under it carrying the Since it stamped on
-		// the first tick of all, which a grandchild that had released could not.
+		// What G lost was its route to the report, not its verdict. Latch re-arms
+		// one Coverage span after a release, so C cannot fire again before t21
+		// however far past its fire mark it reads. When it does, G reappears
+		// under it carrying the Since it stamped on the first tick of all, which
+		// it could not do had it released too.
 		var refired []Fired
 		for i := 12; i <= 21; i++ {
 			refired, _ = e.Observe(snap{parent: 1.0, first: 0.7, second: 0.7}, NewEnvironment(), base.Add(time.Duration(i)*time.Second))
@@ -487,31 +490,31 @@ var _ = Describe("Engine.Observe on a signal's refinements", func() {
 
 		Expect(refired[0].Refinements).To(HaveLen(1))
 		Expect(refired[0].Refinements[0].Since).To(Equal(base.Add(21*time.Second)),
-			"the child fired fresh, one window span after the release above")
+			"C fired fresh, one window span after the release above")
 		Expect(refired[0].Refinements[0].Refinements).To(HaveLen(1))
 		Expect(refired[0].Refinements[0].Refinements[0].Since).To(Equal(base),
-			"the grandchild held the verdict it stamped on tick 0 through the ten ticks it was reported nowhere")
+			"G held the verdict it stamped on tick 0 through the ten ticks it was reported nowhere")
 	})
 
 	// A refinement holds a verdict on stale evidence for its OWN DemoteSpan. The
-	// child here declares five seconds against the parent's sixty, so a build
-	// reading the parent's span would still be reporting the child on every tick
+	// refinement here declares five seconds against the parent's sixty, so a
+	// build reading the parent's span would still be reporting it on every tick
 	// this spec looks at.
 	//
 	// The tick numbers come from the span and the table interval and nothing
 	// else. Latch.ReleaseAfter releases once now is no longer before the last
 	// trusted update plus the span, so five seconds at a one-second interval
-	// releases on tick 5: the child fires and is last trusted on tick 0, holds
-	// through ticks 1 to 4, and is gone on tick 5.
+	// releases on tick 5: the refinement fires and is last trusted on tick 0,
+	// holds through ticks 1 to 4, and is gone on tick 5.
 	It("releases a refinement on its own demote span, not its parent's, when its instrument goes absent", func() {
-		child := refinement("C", 1, Last, func(s snap) float64 { return s.first })
-		child.DemoteSpan = 5 * time.Second
+		ref := refinement("C", 1, Last, func(s snap) float64 { return s.first })
+		ref.DemoteSpan = 5 * time.Second
 
 		// The instrument stops reading rather than reading a low value, so what
-		// removes the child below is the demote clock and not the clear mark the
-		// spec above covers.
+		// removes the refinement below is the demote clock and not the clear mark
+		// the spec above covers.
 		absent := false
-		child.Instruments[0].Extract = func(s snap) Reading {
+		ref.Instruments[0].Extract = func(s snap) Reading {
 			if absent {
 				return Unknown()
 			}
@@ -519,32 +522,32 @@ var _ = Describe("Engine.Observe on a signal's refinements", func() {
 			return Known(s.first)
 		}
 
-		e := engineOver(parentOver(child))
+		e := engineOver(parentOver(ref))
 
 		fired, _ := e.Observe(snap{parent: 1.0, first: 0.7}, NewEnvironment(), base)
 
 		Expect(names(fired)).To(Equal([]string{"P"}))
-		Expect(names(fired[0].Refinements)).To(Equal([]string{"C"}), "tick 0 is the child's last trusted update")
+		Expect(names(fired[0].Refinements)).To(Equal([]string{"C"}), "tick 0 is the refinement's last trusted update")
 
 		absent = true
 
 		// Ticks 1 to 4. The window keeps the point it stored on tick 0 but stores
-		// nothing on these, so it reduces untrusted and no tick moves the child's
-		// clock forward.
+		// nothing on these, so it reduces untrusted and no tick moves the
+		// refinement's clock forward.
 		var held []Fired
 		for i := 1; i <= 4; i++ {
 			held, _ = e.Observe(snap{parent: 1.0}, NewEnvironment(), base.Add(time.Duration(i)*time.Second))
 		}
 
 		Expect(names(held[0].Refinements)).To(Equal([]string{"C"}),
-			"one tick short of its own five-second span the child still reports what it latched")
+			"one tick short of its own five-second span the refinement still reports what it latched")
 
 		gone, _ := e.Observe(snap{parent: 1.0}, NewEnvironment(), base.Add(5*time.Second))
 
 		Expect(names(gone)).To(Equal([]string{"P"}),
-			"the parent is sixty seconds from its own release and still firing, so the child's departure is the child's own clock")
+			"the parent is sixty seconds from its own release and still firing, so the refinement leaves on a clock of its own")
 		Expect(gone[0].Refinements).To(BeEmpty(),
-			"five seconds after its last trusted update the child releases")
+			"five seconds after its last trusted update the refinement releases")
 	})
 
 })

--- a/umh-core/pkg/diagnosis/engine_refinements_test.go
+++ b/umh-core/pkg/diagnosis/engine_refinements_test.go
@@ -26,8 +26,9 @@ import (
 // parent went; only whether the parent REPORTS it turns on the parent having
 // fired. Most specs here read the reporting side on a tick where the parent HAS
 // fired: which refinements nest under it, and that a refinement is nested
-// rather than returned beside its parent. The last one reads the other side,
-// where the parent is silent and its fired refinement is reported nowhere.
+// rather than returned beside its parent. One reads the other side, where the
+// parent is silent and its fired refinement is reported nowhere. The last one
+// hands the returned set to Rank, which orders top-level signals only.
 var _ = Describe("Engine.Observe on a signal's refinements", func() {
 
 	type snap struct {
@@ -38,24 +39,33 @@ var _ = Describe("Engine.Observe on a signal's refinements", func() {
 
 	base := time.Unix(1_000_000, 0)
 
-	// The parent reads its newest sample, so it fires on the tick its own value
-	// crosses 0.5 and needs no warm-up: every spec below can put the parent's
-	// firing tick wherever it wants the child observed.
-	parentOver := func(refinements ...Signal[snap]) Signal[snap] {
+	// A top-level signal reads its newest sample, so it fires on the tick its own
+	// value crosses 0.5 and needs no warm-up: every spec below can put the firing
+	// tick wherever it wants the child observed. Name, tier and the field it
+	// reads are the caller's, so two of them can sit in one table and rank
+	// against each other.
+	topLevel := func(name string, tier int, read func(snap) float64, refinements ...Signal[snap]) Signal[snap] {
 		return Signal[snap]{
-			Name:        "P",
+			Name:        name,
+			Tier:        tier,
 			DemoteSpan:  60 * time.Second,
 			Refinements: refinements,
 			Instruments: []Instrument[snap]{{
 				Measurement: Measurement[snap]{
 					Name:      "I",
-					Extract:   func(s snap) Reading { return Known(s.parent) },
+					Extract:   func(s snap) Reading { return Known(read(s)) },
 					Reduction: Last,
 					Span:      10 * time.Second,
 				},
 				Marks: Marks{Unit: "ratio", Fire: Mark{At: 0.5}, Clear: Mark{At: 0.4}, Worst: 1.0, Polarity: HigherIsWorse},
 			}},
 		}
+	}
+
+	// The parent the reporting specs hang their refinements under: named "P", at
+	// tier 0, reading the snapshot's parent field.
+	parentOver := func(refinements ...Signal[snap]) Signal[snap] {
+		return topLevel("P", 0, func(s snap) float64 { return s.parent }, refinements...)
 	}
 
 	// A refinement fires past 0.6 on whichever field of the snapshot it is told
@@ -218,4 +228,63 @@ var _ = Describe("Engine.Observe on a signal's refinements", func() {
 		Expect(fired[0].Refinements[0].Since).To(Equal(base.Add(time.Second)),
 			"the child fired on tick 1 and held: the empty slice above was suppression, not a child that had not fired")
 	})
+	// Rank is asked a question about the top-level set: which of the signals the
+	// caller can act on comes first. A refinement's urgency is meaningful under
+	// its parent, not against its parent's peers, so it must not enter that
+	// comparison at any position. The fixture makes the refinement the entry
+	// that would win every key it could be ranked on -- the lowest tier in the
+	// table, and the index that wins the last tie-break -- so a build that
+	// ranked it would put it first and fail loudly, rather than hiding at the
+	// end of the slice where a sorted-last refinement would pass either way.
+	It("ranks the top-level signals only, leaving a refinement more urgent than any of them nested and out of the ranked set", func() {
+		names := func(fired []Fired) []string {
+			out := make([]string, len(fired))
+			for i, f := range fired {
+				out[i] = f.Identity.Signal
+			}
+
+			return out
+		}
+
+		// Tier 0 is more urgent than either top-level signal, and Index 0 (its
+		// position among its siblings) is the value that wins the last tie-break,
+		// so no single field carries the fixture. Attribution differs from the
+		// parents' too, though Rank never reads it.
+		child := refinement("C", Last, func(s snap) float64 { return s.first })
+		child.Tier = 0
+		child.Attribution = 7
+
+		// Both fire on their first sample, both at tier 1, so only severity
+		// separates them: Severe reads 1.0 against a fire mark of 0.5 and a worst
+		// of 1.0, scoring 1.0; Mild reads 0.6 and scores 0.2. The refinement hangs
+		// under Mild, the one that must stay second, so a comparator reaching into
+		// a nested tier to break the tier tie would hoist Mild and be caught.
+		severe := topLevel("Severe", 1, func(s snap) float64 { return s.parent })
+		mild := topLevel("Mild", 1, func(s snap) float64 { return s.second }, child)
+
+		e, err := NewEngine(Table[snap]{Signals: []Signal[snap]{severe, mild}, Interval: time.Second})
+		Expect(err).ToNot(HaveOccurred())
+
+		fired, _ := e.Observe(snap{parent: 1.0, second: 0.6, first: 1.0}, NewEnvironment(), base)
+
+		Expect(names(fired)).To(Equal([]string{"Severe", "Mild"}),
+			"Observe returns the two top-level signals that fired, in table order, and the refinement is not one of them")
+
+		ranked := Rank(fired)
+
+		Expect(names(ranked)).To(Equal([]string{"Severe", "Mild"}),
+			"the higher-severity top-level signal ranks first; the tier-0 refinement is not ranked at all")
+		Expect(names(ranked)).ToNot(ContainElement("C"),
+			"a refinement never competes with a top-level signal for rank, however urgent it is")
+
+		// Without this the spec would also pass on a build that simply dropped the
+		// refinement, which is a different defect, not the absence being asserted.
+		Expect(ranked[1].Refinements).To(HaveLen(1), "the refinement is still reported, nested under the parent it narrows")
+		Expect(ranked[1].Refinements[0].Identity.Signal).To(Equal("C"))
+		Expect(ranked[1].Refinements[0].Tier).To(Equal(0),
+			"the nested entry keeps the urgent tier it was declared with; it is unranked, not demoted")
+		Expect(ranked[1].Refinements[0].Index).To(Equal(0),
+			"and the index that wins the last tie-break, so the absence above is not the refinement sorting last")
+	})
+
 })

--- a/umh-core/pkg/diagnosis/engine_refinements_test.go
+++ b/umh-core/pkg/diagnosis/engine_refinements_test.go
@@ -27,17 +27,28 @@ import (
 // fired. Most specs here read the reporting side on a tick where the parent HAS
 // fired: which refinements nest under it, and that a refinement is nested
 // rather than returned beside its parent. One reads the other side, where the
-// parent is silent and its fired refinement is reported nowhere. The last one
-// hands the returned set to Rank, which orders top-level signals only.
+// parent is silent and its fired refinement is reported nowhere. One hands the
+// returned set to Rank, which orders top-level signals only. The last three
+// read the order the refinements under one signal come back in.
 var _ = Describe("Engine.Observe on a signal's refinements", func() {
 
 	type snap struct {
 		parent float64
 		first  float64
 		second float64
+		third  float64
 	}
 
 	base := time.Unix(1_000_000, 0)
+
+	names := func(fired []Fired) []string {
+		out := make([]string, len(fired))
+		for i, f := range fired {
+			out[i] = f.Identity.Signal
+		}
+
+		return out
+	}
 
 	// A top-level signal reads its newest sample, so it fires on the tick its own
 	// value crosses 0.5 and needs no warm-up: every spec below can put the firing
@@ -69,11 +80,15 @@ var _ = Describe("Engine.Observe on a signal's refinements", func() {
 	}
 
 	// A refinement fires past 0.6 on whichever field of the snapshot it is told
-	// to read, under whichever reduction the spec needs.
-	refinement := func(name string, reduction Reduction, read func(snap) float64) Signal[snap] {
+	// to read, under whichever reduction the spec needs. Tier is the caller's, as
+	// it is on topLevel, so two refinements under one parent can differ in
+	// urgency; refinements of its own let a spec hang a third level under it.
+	refinement := func(name string, tier int, reduction Reduction, read func(snap) float64, refinements ...Signal[snap]) Signal[snap] {
 		return Signal[snap]{
-			Name:       name,
-			DemoteSpan: 60 * time.Second,
+			Name:        name,
+			Tier:        tier,
+			DemoteSpan:  60 * time.Second,
+			Refinements: refinements,
 			Instruments: []Instrument[snap]{{
 				Measurement: Measurement[snap]{
 					Name:      "I",
@@ -104,7 +119,7 @@ var _ = Describe("Engine.Observe on a signal's refinements", func() {
 	// sample. And the 0.0 at tick 10 is what a build reducing the window at
 	// REPORT time would report, 10/11 rather than the 1.0 the child latched.
 	It("reports a fired parent's refinement nested under it, warm over ten ticks, not as a top-level entry beside it", func() {
-		e := engineOver(parentOver(refinement("C", Mean, func(s snap) float64 { return s.first })))
+		e := engineOver(parentOver(refinement("C", 0, Mean, func(s snap) float64 { return s.first })))
 
 		for i := 0; i < 10; i++ {
 			e.Observe(snap{parent: 0.0, first: 1.0}, NewEnvironment(), base.Add(time.Duration(i)*time.Second))
@@ -128,8 +143,8 @@ var _ = Describe("Engine.Observe on a signal's refinements", func() {
 
 	It("reports only the refinement past its own fire mark, naming it", func() {
 		e := engineOver(parentOver(
-			refinement("C1", Last, func(s snap) float64 { return s.first }),
-			refinement("C2", Last, func(s snap) float64 { return s.second }),
+			refinement("C1", 0, Last, func(s snap) float64 { return s.first }),
+			refinement("C2", 0, Last, func(s snap) float64 { return s.second }),
 		))
 
 		// One tick is enough: Last needs a single sample, so the parent and both
@@ -147,7 +162,7 @@ var _ = Describe("Engine.Observe on a signal's refinements", func() {
 
 	It("leaves out a refinement whose window cannot yet reduce", func() {
 		declaration := func() Signal[snap] {
-			return parentOver(refinement("C", Mean, func(s snap) float64 { return s.first }))
+			return parentOver(refinement("C", 0, Mean, func(s snap) float64 { return s.first }))
 		}
 
 		// The control: two samples reach Mean's minimum, so the same refinement
@@ -175,7 +190,7 @@ var _ = Describe("Engine.Observe on a signal's refinements", func() {
 	})
 
 	It("stamps a held refinement's Since once, on the tick it fired", func() {
-		e := engineOver(parentOver(refinement("C", Last, func(s snap) float64 { return s.first })))
+		e := engineOver(parentOver(refinement("C", 0, Last, func(s snap) float64 { return s.first })))
 
 		first, _ := e.Observe(snap{parent: 1.0, first: 1.0}, NewEnvironment(), base)
 		second, _ := e.Observe(snap{parent: 1.0, first: 1.0}, NewEnvironment(), base.Add(time.Second))
@@ -194,7 +209,7 @@ var _ = Describe("Engine.Observe on a signal's refinements", func() {
 	// emits it beside its parent. This one drives the parent below its fire mark
 	// throughout and reads the whole returned slice.
 	It("reports nothing at all while the parent is silent, though its refinement has fired and stays warm", func() {
-		e := engineOver(parentOver(refinement("C", Mean, func(s snap) float64 { return s.first })))
+		e := engineOver(parentOver(refinement("C", 0, Mean, func(s snap) float64 { return s.first })))
 
 		// Tick 0 leaves the child below Mean's minimum of two. Tick 1 reaches it
 		// at a mean of 1.0, past the child's 0.6 fire mark, so the child fires
@@ -237,21 +252,11 @@ var _ = Describe("Engine.Observe on a signal's refinements", func() {
 	// ranked it would put it first and fail loudly, rather than hiding at the
 	// end of the slice where a sorted-last refinement would pass either way.
 	It("ranks the top-level signals only, leaving a refinement more urgent than any of them nested and out of the ranked set", func() {
-		names := func(fired []Fired) []string {
-			out := make([]string, len(fired))
-			for i, f := range fired {
-				out[i] = f.Identity.Signal
-			}
-
-			return out
-		}
-
 		// Tier 0 is more urgent than either top-level signal, and Index 0 (its
 		// position among its siblings) is the value that wins the last tie-break,
 		// so no single field carries the fixture. Attribution differs from the
 		// parents' too, though Rank never reads it.
-		child := refinement("C", Last, func(s snap) float64 { return s.first })
-		child.Tier = 0
+		child := refinement("C", 0, Last, func(s snap) float64 { return s.first })
 		child.Attribution = 7
 
 		// Both fire on their first sample, both at tier 1, so only severity
@@ -285,6 +290,100 @@ var _ = Describe("Engine.Observe on a signal's refinements", func() {
 			"the nested entry keeps the urgent tier it was declared with; it is unranked, not demoted")
 		Expect(ranked[1].Refinements[0].Index).To(Equal(0),
 			"and the index that wins the last tie-break, so the absence above is not the refinement sorting last")
+	})
+
+	// Rank orders the top-level set. The three specs below are about the order
+	// INSIDE one signal's Refinements, which Rank never touches: lower tier
+	// first, so the caller can read the first nested entry as the most urgent
+	// narrowing without sorting anything itself.
+
+	// The two refinements are declared in the order a build that ignored Tier
+	// would return them, less urgent first. Declaring them already in the
+	// reported order would pass whether or not anything ordered them.
+	It("reports a parent's refinements lowest tier first, against the order they were declared in", func() {
+		e := engineOver(parentOver(
+			refinement("LessUrgent", 2, Last, func(s snap) float64 { return s.first }),
+			refinement("MoreUrgent", 1, Last, func(s snap) float64 { return s.second }),
+		))
+
+		// Last reduces off a single sample, so the parent and both refinements
+		// are judged on the first tick and all three cross their marks. The
+		// refinements read 0.7, just past their own 0.6, so it is that mark
+		// admitting them; a 1.0 would sit past whatever mark they carried.
+		fired, _ := e.Observe(snap{parent: 1.0, first: 0.7, second: 0.7}, NewEnvironment(), base)
+
+		Expect(fired).To(HaveLen(1))
+		Expect(fired[0].Refinements).To(HaveLen(2), "both refinements crossed their own fire mark")
+		Expect(names(fired[0].Refinements)).To(Equal([]string{"MoreUrgent", "LessUrgent"}),
+			"tier 1 is reported before tier 2 though it was declared second")
+	})
+
+	It("keeps refinements of one tier in the order they were declared", func() {
+		reported := func(refinements ...Signal[snap]) []string {
+			e := engineOver(parentOver(refinements...))
+			fired, _ := e.Observe(snap{parent: 1.0, first: 0.7, second: 0.7}, NewEnvironment(), base)
+
+			Expect(fired).To(HaveLen(1))
+			Expect(fired[0].Refinements).To(HaveLen(len(refinements)), "every refinement crossed its own fire mark")
+
+			return names(fired[0].Refinements)
+		}
+
+		// A pair, both directions, because either direction alone also holds on a
+		// build that emits whatever order it was handed.
+		a := refinement("A", 1, Last, func(s snap) float64 { return s.first })
+		b := refinement("B", 1, Last, func(s snap) float64 { return s.second })
+
+		Expect(reported(a, b)).To(Equal([]string{"A", "B"}))
+		Expect(reported(b, a)).To(Equal([]string{"B", "A"}))
+
+		// The pair above cannot tell a declared tie-break from a sort that
+		// happens to leave it alone: Go sorts twelve elements or fewer by
+		// insertion, which never moves two entries their comparator calls equal.
+		// Thirteen across two tiers is the smallest table where a sort comparing
+		// tier alone visibly scrambles each tier's declaration order.
+		const wide = 13
+
+		spread := make([]Signal[snap], 0, wide)
+		lower := make([]string, 0, wide)
+		upper := make([]string, 0, wide)
+
+		for i := range wide {
+			name := string(rune('A' + i))
+			tier := 1 + i%2
+
+			spread = append(spread, refinement(name, tier, Last, func(s snap) float64 { return s.first }))
+
+			if tier == 1 {
+				lower = append(lower, name)
+			} else {
+				upper = append(upper, name)
+			}
+		}
+
+		expected := make([]string, 0, wide)
+		expected = append(expected, lower...)
+		expected = append(expected, upper...)
+
+		Expect(reported(spread...)).To(Equal(expected),
+			"each tier comes back in declaration order, the lower tier first")
+	})
+
+	It("orders the refinements of a refinement by the same rule, so every level is ordered and not just the first", func() {
+		child := refinement("C", 0, Last, func(s snap) float64 { return s.first },
+			refinement("LessUrgent", 2, Last, func(s snap) float64 { return s.second }),
+			refinement("MoreUrgent", 1, Last, func(s snap) float64 { return s.third }),
+		)
+
+		e := engineOver(parentOver(child))
+
+		fired, _ := e.Observe(snap{parent: 1.0, first: 0.7, second: 0.7, third: 0.7}, NewEnvironment(), base)
+
+		Expect(fired).To(HaveLen(1))
+		Expect(fired[0].Refinements).To(HaveLen(1), "the child fired and nests under the parent")
+		Expect(fired[0].Refinements[0].Refinements).To(HaveLen(2), "both of its own refinements fired too")
+		Expect(names(fired[0].Refinements[0].Refinements)).To(Equal([]string{"MoreUrgent", "LessUrgent"}),
+			"two levels down the tiers still decide, though these were also declared less urgent first")
 	})
 
 })

--- a/umh-core/pkg/diagnosis/engine_refinements_test.go
+++ b/umh-core/pkg/diagnosis/engine_refinements_test.go
@@ -126,7 +126,7 @@ var _ = Describe("Engine.Observe on a signal's refinements", func() {
 	It("reports a fired parent's refinement nested under it, warm over ten ticks, not as a top-level entry beside it", func() {
 		e := engineOver(parentOver(refinement("C", 0, Mean, func(s snap) float64 { return s.first })))
 
-		for i := 0; i < 10; i++ {
+		for i := range 10 {
 			e.Observe(snap{parent: 0.0, first: 1.0}, NewEnvironment(), base.Add(time.Duration(i)*time.Second))
 		}
 
@@ -460,7 +460,7 @@ var _ = Describe("Engine.Observe on a signal's refinements", func() {
 		e := engineOver(parentOver(refinement("C", 1, Last, func(s snap) float64 { return s.first }, nested)))
 
 		var warm []Fired
-		for i := 0; i <= 10; i++ {
+		for i := range 11 {
 			warm, _ = e.Observe(snap{parent: 1.0, first: 0.7, second: 0.7}, NewEnvironment(), base.Add(time.Duration(i)*time.Second))
 		}
 

--- a/umh-core/pkg/diagnosis/engine_refinements_test.go
+++ b/umh-core/pkg/diagnosis/engine_refinements_test.go
@@ -23,13 +23,15 @@ import (
 
 // A refinement is a signal that narrows the answer of the signal it hangs
 // under. It is sampled every tick and judged every tick, whichever way its
-// parent went; only whether the parent REPORTS it turns on the parent having
-// fired. Most specs here read the reporting side on a tick where the parent HAS
-// fired: which refinements nest under it, and that a refinement is nested
-// rather than returned beside its parent. One reads the other side, where the
-// parent is silent and its fired refinement is reported nowhere. One hands the
-// returned set to Rank, which orders top-level signals only. The last three
-// read the order the refinements under one signal come back in.
+// parent went; only whether the parent reports its VERDICT turns on the parent
+// having fired. Most specs here read the reporting side on a tick where the
+// parent HAS fired: which refinements nest under it, and that a refinement is
+// nested rather than returned beside its parent. One reads the other side, where
+// the parent is silent and its fired refinement is reported nowhere. One hands
+// the returned set to Rank, which orders top-level signals only. Three read the
+// order the refinements under one signal come back in. The last reads Observe's
+// other return value, the readiness rows, which every signal gets at every depth
+// whichever way it or its parent went.
 var _ = Describe("Engine.Observe on a signal's refinements", func() {
 
 	type snap struct {
@@ -384,6 +386,53 @@ var _ = Describe("Engine.Observe on a signal's refinements", func() {
 		Expect(fired[0].Refinements[0].Refinements).To(HaveLen(2), "both of its own refinements fired too")
 		Expect(names(fired[0].Refinements[0].Refinements)).To(Equal([]string{"MoreUrgent", "LessUrgent"}),
 			"two levels down the tiers still decide, though these were also declared less urgent first")
+	})
+
+	// Every spec above reads the fired set. This one reads the other return
+	// value, the readiness rows, which say what each signal's own instruments
+	// could tell the engine this tick whether or not it fired. A refinement is
+	// judged every tick, so it has an availability of its own, and a row of its
+	// own is the only way a caller sees it.
+	It("returns one readiness row per signal at every depth, depth-first, named by path and carrying that signal's own availability", func() {
+		// The grandchild's instrument requires nothing, so it is capable in the
+		// same empty environment that leaves its parent with no instrument at
+		// all. That is what separates a row resolved per signal from a row
+		// handed down the tree.
+		grandchild := refinement("G", 1, Last, func(s snap) float64 { return s.third })
+
+		// C is the one signal here this environment cannot satisfy: its
+		// instrument requires a capability the empty environment does not have,
+		// so C resolves to NoInstrument while P above it and G below it both
+		// read their sample.
+		child := refinement("C", 1, Last, func(s snap) float64 { return s.first }, grandchild)
+		child.Instruments[0].Requires = []Capability{"psi"}
+
+		// A second top-level signal, declared after P, is what makes the
+		// depth-first claim testable: it must come after P's whole subtree and
+		// not between P and the subtree, which is where a breadth-first walk
+		// would put it.
+		e, err := NewEngine(Table[snap]{
+			Signals:  []Signal[snap]{parentOver(child), topLevel("Q", 1, func(s snap) float64 { return s.second })},
+			Interval: time.Second,
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		_, readiness := e.Observe(snap{parent: 1.0, first: 1.0, second: 1.0, third: 1.0}, NewEnvironment(), base)
+
+		rows := make([]string, len(readiness))
+		for i, r := range readiness {
+			rows[i] = r.Signal
+		}
+
+		Expect(rows).To(Equal([]string{"P", "P/C", "P/C/G", "Q"}),
+			"depth-first, a parent immediately before its own children, each row named by its path: two parents may each declare a refinement named X, so a bare name would not say which one this is")
+
+		Expect(readiness[0].Availability).To(Equal(Ready), "P reads its sample")
+		Expect(readiness[1].Availability).To(Equal(NoInstrument),
+			"C's own instrument is unsatisfied here, so its row says so rather than repeating the Ready of the parent it hangs under")
+		Expect(readiness[2].Availability).To(Equal(Ready),
+			"G reads its sample through an instrument of its own, so an unreadable parent does not make it unreadable")
+		Expect(readiness[3].Availability).To(Equal(Ready), "Q reads its sample")
 	})
 
 })

--- a/umh-core/pkg/diagnosis/engine_refinements_test.go
+++ b/umh-core/pkg/diagnosis/engine_refinements_test.go
@@ -1,0 +1,180 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package diagnosis
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// A refinement is a signal that narrows the answer of the signal it hangs
+// under. It is sampled every tick and judged every tick, whichever way its
+// parent went; only whether the parent REPORTS it turns on the parent having
+// fired. These specs read the reporting side on a tick where the parent HAS
+// fired: which refinements nest under it, and that a refinement is nested
+// rather than returned beside its parent.
+var _ = Describe("Engine.Observe on a signal's refinements", func() {
+
+	type snap struct {
+		parent float64
+		first  float64
+		second float64
+	}
+
+	base := time.Unix(1_000_000, 0)
+
+	// The parent reads its newest sample, so it fires on the tick its own value
+	// crosses 0.5 and needs no warm-up: every spec below can put the parent's
+	// firing tick wherever it wants the child observed.
+	parentOver := func(refinements ...Signal[snap]) Signal[snap] {
+		return Signal[snap]{
+			Name:        "P",
+			DemoteSpan:  60 * time.Second,
+			Refinements: refinements,
+			Instruments: []Instrument[snap]{{
+				Measurement: Measurement[snap]{
+					Name:      "I",
+					Extract:   func(s snap) Reading { return Known(s.parent) },
+					Reduction: Last,
+					Span:      10 * time.Second,
+				},
+				Marks: Marks{Unit: "ratio", Fire: Mark{At: 0.5}, Clear: Mark{At: 0.4}, Worst: 1.0, Polarity: HigherIsWorse},
+			}},
+		}
+	}
+
+	// A refinement fires past 0.6 on whichever field of the snapshot it is told
+	// to read, under whichever reduction the spec needs.
+	refinement := func(name string, reduction Reduction, read func(snap) float64) Signal[snap] {
+		return Signal[snap]{
+			Name:       name,
+			DemoteSpan: 60 * time.Second,
+			Instruments: []Instrument[snap]{{
+				Measurement: Measurement[snap]{
+					Name:      "I",
+					Extract:   func(s snap) Reading { return Known(read(s)) },
+					Reduction: reduction,
+					Span:      10 * time.Second,
+				},
+				Marks: Marks{Unit: "ratio", Fire: Mark{At: 0.6}, Clear: Mark{At: 0.4}, Worst: 1.0, Polarity: HigherIsWorse},
+			}},
+		}
+	}
+
+	engineOver := func(s Signal[snap]) *Engine[snap] {
+		e, err := NewEngine(Table[snap]{Signals: []Signal[snap]{s}, Interval: time.Second})
+		Expect(err).ToNot(HaveOccurred())
+
+		return e
+	}
+
+	// The child's window is filled on each of the parent's ten silent ticks, a
+	// 1.0 every time, so the child reaches Mean's minimum of two samples and
+	// fires on tick 1 — nine ticks before its parent fires at all. Since is what
+	// proves that: a child sampled or judged only while its parent fires would
+	// hold the single 0.0 of tick 10, sit below Mean's minimum, and never fire.
+	//
+	// Two choices in the fixture are load-bearing. Mean over a minimum of two is
+	// what makes a cold window unable to answer; Last would answer off one
+	// sample. And the 0.0 at tick 10 is what a build reducing the window at
+	// REPORT time would report, 10/11 rather than the 1.0 the child latched.
+	It("reports a fired parent's refinement nested under it, warm over ten ticks, not as a top-level entry beside it", func() {
+		e := engineOver(parentOver(refinement("C", Mean, func(s snap) float64 { return s.first })))
+
+		for i := 0; i < 10; i++ {
+			e.Observe(snap{parent: 0.0, first: 1.0}, NewEnvironment(), base.Add(time.Duration(i)*time.Second))
+		}
+
+		// The parent crosses its fire mark (0.0 -> 1.0) while the child's newest
+		// sample drops below the child's own (1.0 -> 0.0). The child's mean over
+		// the warm window, 10/11, stays past its 0.4 clear mark, so the child is
+		// still held.
+		fired, _ := e.Observe(snap{parent: 1.0, first: 0.0}, NewEnvironment(), base.Add(10*time.Second))
+
+		Expect(fired).To(HaveLen(1), "only the fired parent appears at the top level; the refinement nests under it")
+		Expect(fired[0].Identity.Signal).To(Equal("P"))
+		Expect(fired[0].Refinements).To(HaveLen(1), "the fired parent reports the refinement its own latch holds")
+		Expect(fired[0].Refinements[0].Identity.Signal).To(Equal("C"), "the nested entry names the refinement")
+		Expect(fired[0].Refinements[0].Since).To(Equal(base.Add(time.Second)),
+			"the child fired on tick 1, off a window warmed while the parent was silent")
+		Expect(fired[0].Refinements[0].Value).To(Equal(1.0),
+			"the value is the mean the child fired on, not the window's 10/11 at report time")
+	})
+
+	It("reports only the refinement past its own fire mark, naming it", func() {
+		e := engineOver(parentOver(
+			refinement("C1", Last, func(s snap) float64 { return s.first }),
+			refinement("C2", Last, func(s snap) float64 { return s.second }),
+		))
+
+		// One tick is enough: Last needs a single sample, so the parent and both
+		// children reduce to a trustworthy value on the first tick. The parent
+		// and C1 cross their marks; C2 sits below its own.
+		fired, _ := e.Observe(snap{parent: 1.0, first: 1.0, second: 0.0}, NewEnvironment(), base)
+
+		Expect(fired).To(HaveLen(1), "the parent is the only top-level entry; a fired refinement nests under it")
+		Expect(fired[0].Identity.Signal).To(Equal("P"))
+		Expect(fired[0].Refinements).To(HaveLen(1))
+		Expect(fired[0].Refinements[0].Identity.Signal).To(Equal("C1"),
+			"the refinement past its mark is the one reported, not whichever came first")
+		Expect(fired[0].Refinements[0].Value).To(Equal(1.0))
+	})
+
+	It("leaves out a refinement whose window cannot yet reduce", func() {
+		declaration := func() Signal[snap] {
+			return parentOver(refinement("C", Mean, func(s snap) float64 { return s.first }))
+		}
+
+		// The control: two samples reach Mean's minimum, so the same refinement
+		// on the same declaration IS reported. Without it the absence below would
+		// also hold on a build that reports no refinement ever.
+		warmed := engineOver(declaration())
+		warmed.Observe(snap{parent: 1.0, first: 1.0}, NewEnvironment(), base)
+		reported, _ := warmed.Observe(snap{parent: 1.0, first: 1.0}, NewEnvironment(), base.Add(time.Second))
+
+		Expect(reported).To(HaveLen(1))
+		Expect(reported[0].Refinements).To(HaveLen(1), "two samples are enough for the refinement to be judged")
+		Expect(reported[0].Refinements[0].Identity.Signal).To(Equal("C"))
+
+		// One sample is below Mean's minimum of two, so the child's window holds
+		// nothing trustworthy to judge. That sample sits past the child's fire
+		// mark, so a build that reported the window without asking whether it was
+		// ready would report the child here too.
+		cold := engineOver(declaration())
+		fired, _ := cold.Observe(snap{parent: 1.0, first: 1.0}, NewEnvironment(), base)
+
+		Expect(fired).To(HaveLen(1), "the parent fires on its own single sample")
+		Expect(fired[0].Identity.Signal).To(Equal("P"))
+		Expect(fired[0].Refinements).To(BeEmpty(),
+			"an unready refinement is absent, not present at Value 0 with no marks and no instrument")
+	})
+
+	It("stamps a held refinement's Since once, on the tick it fired", func() {
+		e := engineOver(parentOver(refinement("C", Last, func(s snap) float64 { return s.first })))
+
+		first, _ := e.Observe(snap{parent: 1.0, first: 1.0}, NewEnvironment(), base)
+		second, _ := e.Observe(snap{parent: 1.0, first: 1.0}, NewEnvironment(), base.Add(time.Second))
+
+		Expect(first).To(HaveLen(1), "the parent is the only top-level entry on this tick")
+		Expect(second).To(HaveLen(1))
+		Expect(first[0].Refinements).To(HaveLen(1))
+		Expect(second[0].Refinements).To(HaveLen(1))
+		Expect(first[0].Refinements[0].Since).To(Equal(base), "Since is the tick the refinement fired")
+		Expect(second[0].Refinements[0].Since).To(Equal(first[0].Refinements[0].Since),
+			"the second tick holds the same Since: a refinement's verdict is latched, not re-decided each tick")
+	})
+})

--- a/umh-core/pkg/diagnosis/engine_refinements_test.go
+++ b/umh-core/pkg/diagnosis/engine_refinements_test.go
@@ -435,4 +435,109 @@ var _ = Describe("Engine.Observe on a signal's refinements", func() {
 		Expect(readiness[3].Availability).To(Equal(Ready), "Q reads its sample")
 	})
 
+	// The two specs above read the fire mark, which decides whether a refinement
+	// ENTERS a parent's report. The two below read the other end, the two ways a
+	// refinement LEAVES it: its own clear mark, and its own demote clock. Both
+	// keep the parent firing throughout, so the parent's report is the only thing
+	// the child can be missing from.
+
+	// The clear arm needs Coverage.Full(), which on the ten-second window this
+	// fixture builds takes eleven ticks at the table's one-second interval: t0
+	// through t10 span exactly ten seconds. Dropping the child earlier would be a
+	// release granted on a window that had not filled, which is a different rule.
+	It("drops a refinement, and the refinement under it, on the tick the refinement crosses its own clear mark", func() {
+		grandchild := refinement("G", 1, Last, func(s snap) float64 { return s.second })
+		e := engineOver(parentOver(refinement("C", 1, Last, func(s snap) float64 { return s.first }, grandchild)))
+
+		var warm []Fired
+		for i := 0; i <= 10; i++ {
+			warm, _ = e.Observe(snap{parent: 1.0, first: 0.7, second: 0.7}, NewEnvironment(), base.Add(time.Duration(i)*time.Second))
+		}
+
+		Expect(names(warm)).To(Equal([]string{"P"}))
+		Expect(names(warm[0].Refinements)).To(Equal([]string{"C"}), "the child fired on its first sample and is held")
+		Expect(names(warm[0].Refinements[0].Refinements)).To(Equal([]string{"G"}), "and so is the grandchild under it")
+
+		// 0.3 is past the child's own 0.4 clear mark. Nothing else moves: the
+		// parent still reads 1.0, and the grandchild still reads the 0.7 that is
+		// past its own fire mark and nowhere near its own clear mark.
+		released, _ := e.Observe(snap{parent: 1.0, first: 0.3, second: 0.7}, NewEnvironment(), base.Add(11*time.Second))
+
+		Expect(names(released)).To(Equal([]string{"P"}),
+			"the parent is untouched: its own value never left its own marks")
+		Expect(released[0].Refinements).To(BeEmpty(),
+			"the child released on its own clear mark, and the grandchild leaves with it: a refinement of an unreported refinement is reported nowhere")
+
+		// What the grandchild lost was its route to the report, not its verdict.
+		// Latch re-arms one Coverage span after a release, so the child cannot
+		// fire again before t21 however far past its fire mark it reads. When it
+		// does, the grandchild reappears under it carrying the Since it stamped on
+		// the first tick of all, which a grandchild that had released could not.
+		var refired []Fired
+		for i := 12; i <= 21; i++ {
+			refired, _ = e.Observe(snap{parent: 1.0, first: 0.7, second: 0.7}, NewEnvironment(), base.Add(time.Duration(i)*time.Second))
+		}
+
+		Expect(refired[0].Refinements).To(HaveLen(1))
+		Expect(refired[0].Refinements[0].Since).To(Equal(base.Add(21*time.Second)),
+			"the child fired fresh, one window span after the release above")
+		Expect(refired[0].Refinements[0].Refinements).To(HaveLen(1))
+		Expect(refired[0].Refinements[0].Refinements[0].Since).To(Equal(base),
+			"the grandchild held the verdict it stamped on tick 0 through the ten ticks it was reported nowhere")
+	})
+
+	// A refinement holds a verdict on stale evidence for its OWN DemoteSpan. The
+	// child here declares five seconds against the parent's sixty, so a build
+	// reading the parent's span would still be reporting the child on every tick
+	// this spec looks at.
+	//
+	// The tick numbers come from the span and the table interval and nothing
+	// else. Latch.ReleaseAfter releases once now is no longer before the last
+	// trusted update plus the span, so five seconds at a one-second interval
+	// releases on tick 5: the child fires and is last trusted on tick 0, holds
+	// through ticks 1 to 4, and is gone on tick 5.
+	It("releases a refinement on its own demote span, not its parent's, when its instrument goes absent", func() {
+		child := refinement("C", 1, Last, func(s snap) float64 { return s.first })
+		child.DemoteSpan = 5 * time.Second
+
+		// The instrument stops reading rather than reading a low value, so what
+		// removes the child below is the demote clock and not the clear mark the
+		// spec above covers.
+		absent := false
+		child.Instruments[0].Extract = func(s snap) Reading {
+			if absent {
+				return Unknown()
+			}
+
+			return Known(s.first)
+		}
+
+		e := engineOver(parentOver(child))
+
+		fired, _ := e.Observe(snap{parent: 1.0, first: 0.7}, NewEnvironment(), base)
+
+		Expect(names(fired)).To(Equal([]string{"P"}))
+		Expect(names(fired[0].Refinements)).To(Equal([]string{"C"}), "tick 0 is the child's last trusted update")
+
+		absent = true
+
+		// Ticks 1 to 4. The window keeps the point it stored on tick 0 but stores
+		// nothing on these, so it reduces untrusted and no tick moves the child's
+		// clock forward.
+		var held []Fired
+		for i := 1; i <= 4; i++ {
+			held, _ = e.Observe(snap{parent: 1.0}, NewEnvironment(), base.Add(time.Duration(i)*time.Second))
+		}
+
+		Expect(names(held[0].Refinements)).To(Equal([]string{"C"}),
+			"one tick short of its own five-second span the child still reports what it latched")
+
+		gone, _ := e.Observe(snap{parent: 1.0}, NewEnvironment(), base.Add(5*time.Second))
+
+		Expect(names(gone)).To(Equal([]string{"P"}),
+			"the parent is sixty seconds from its own release and still firing, so the child's departure is the child's own clock")
+		Expect(gone[0].Refinements).To(BeEmpty(),
+			"five seconds after its last trusted update the child releases")
+	})
+
 })

--- a/umh-core/pkg/diagnosis/engine_select_foreign_test.go
+++ b/umh-core/pkg/diagnosis/engine_select_foreign_test.go
@@ -52,11 +52,13 @@ var _ = Describe("Engine.Select on a signal the engine was not built from", func
 			Name:       "declared",
 			DemoteSpan: 60 * time.Second,
 			Instruments: []Instrument[outSnap]{{
-				Name:      "mean",
-				Extract:   extract,
-				Reduction: Mean,
-				Span:      3 * time.Second,
-				Marks:     marks,
+				Measurement: Measurement[outSnap]{
+					Name:      "mean",
+					Extract:   extract,
+					Reduction: Mean,
+					Span:      3 * time.Second,
+				},
+				Marks: marks,
 			}},
 		}
 
@@ -95,11 +97,13 @@ var _ = Describe("Engine.Select on a signal the engine was not built from", func
 			Name:       "never-declared",
 			DemoteSpan: 60 * time.Second,
 			Instruments: []Instrument[outSnap]{{
-				Name:      "mean",
-				Extract:   extract,
-				Reduction: Mean,
-				Span:      3 * time.Second,
-				Marks:     marks,
+				Measurement: Measurement[outSnap]{
+					Name:      "mean",
+					Extract:   extract,
+					Reduction: Mean,
+					Span:      3 * time.Second,
+				},
+				Marks: marks,
 			}},
 		}
 		Expect(foreign.Capable(env)).To(HaveLen(1),
@@ -127,9 +131,9 @@ var _ = Describe("Engine.Select on a signal the engine was not built from", func
 			Name:       "never-declared",
 			DemoteSpan: 60 * time.Second,
 			Instruments: []Instrument[outSnap]{
-				{Name: "a", Extract: extract, Reduction: Mean, Span: 3 * time.Second, Marks: marks},
-				{Name: "b", Extract: extract, Reduction: Mean, Span: 3 * time.Second, Marks: marks},
-				{Name: "c", Extract: extract, Reduction: Mean, Span: 3 * time.Second, Marks: marks},
+				{Measurement: Measurement[outSnap]{Name: "a", Extract: extract, Reduction: Mean, Span: 3 * time.Second}, Marks: marks},
+				{Measurement: Measurement[outSnap]{Name: "b", Extract: extract, Reduction: Mean, Span: 3 * time.Second}, Marks: marks},
+				{Measurement: Measurement[outSnap]{Name: "c", Extract: extract, Reduction: Mean, Span: 3 * time.Second}, Marks: marks},
 			},
 		}
 		Expect(foreign.Capable(env)).To(HaveLen(3),

--- a/umh-core/pkg/diagnosis/engine_select_foreign_test.go
+++ b/umh-core/pkg/diagnosis/engine_select_foreign_test.go
@@ -86,7 +86,7 @@ var _ = Describe("Engine.Select on a signal the engine was not built from", func
 		Expect(declaredAvail).To(Equal(Ready),
 			"control: the declared signal resolves Ready at two samples, so the engine is answering")
 
-		// The foreign signal's instrument declares no Requires, so Capable
+		// The foreign signal's instrument declares no Requires, so CapableInstruments
 		// returns it and resolve enters its instrument loop. Without that,
 		// resolve's empty-capable early return would produce the same
 		// NoInstrument without ever reaching the nil-window arms, and this spec
@@ -106,7 +106,7 @@ var _ = Describe("Engine.Select on a signal the engine was not built from", func
 				Marks: marks,
 			}},
 		}
-		Expect(foreign.Capable(env)).To(HaveLen(1),
+		Expect(foreign.CapableInstruments(env)).To(HaveLen(1),
 			"resolve must enter its instrument loop; an empty capable set short-circuits before the missing-window arms and makes this spec vacuous")
 
 		inst, reduced, cov, avail := e.Select(foreign, env)
@@ -136,7 +136,7 @@ var _ = Describe("Engine.Select on a signal the engine was not built from", func
 				{Measurement: Measurement[outSnap]{Name: "c", Extract: extract, Reduction: Mean, Span: 3 * time.Second}, Marks: marks},
 			},
 		}
-		Expect(foreign.Capable(env)).To(HaveLen(3),
+		Expect(foreign.CapableInstruments(env)).To(HaveLen(3),
 			"all three arms must pass the capability gate, or the loop does not run three times")
 
 		_, _, _, avail := e.Select(foreign, env)

--- a/umh-core/pkg/diagnosis/engine_test.go
+++ b/umh-core/pkg/diagnosis/engine_test.go
@@ -40,11 +40,13 @@ var _ = Describe("Engine", func() {
 			DemoteSpan: 60 * time.Second,
 			Instruments: []Instrument[engSnap]{
 				{
-					Name:      "A-p95",
-					Requires:  []Capability{"source-1"},
-					Extract:   extract,
-					Reduction: P95,
-					Span:      60 * time.Second,
+					Measurement: Measurement[engSnap]{
+						Name:      "A-p95",
+						Requires:  []Capability{"source-1"},
+						Extract:   extract,
+						Reduction: P95,
+						Span:      60 * time.Second,
+					},
 					Marks: Marks{
 						Unit:     "ratio",
 						Fire:     Mark{At: 2.0, Inclusive: true},
@@ -54,11 +56,13 @@ var _ = Describe("Engine", func() {
 					},
 				},
 				{
-					Name:      "A-mean",
-					Requires:  []Capability{"source-1"},
-					Extract:   extract,
-					Reduction: Mean,
-					Span:      3 * time.Second,
+					Measurement: Measurement[engSnap]{
+						Name:      "A-mean",
+						Requires:  []Capability{"source-1"},
+						Extract:   extract,
+						Reduction: Mean,
+						Span:      3 * time.Second,
+					},
 					Marks: Marks{
 						Unit:     "ratio",
 						Fire:     Mark{At: 2.0, Inclusive: true},
@@ -103,11 +107,13 @@ var _ = Describe("Engine", func() {
 			DemoteSpan: 60 * time.Second,
 			Instruments: []Instrument[cpuSnap]{
 				{
-					Name:      "pressure",
-					Requires:  []Capability{"psi"},
-					Extract:   func(s cpuSnap) Reading { return Known(s.stall) },
-					Reduction: Last,
-					Span:      60 * time.Second,
+					Measurement: Measurement[cpuSnap]{
+						Name:      "pressure",
+						Requires:  []Capability{"psi"},
+						Extract:   func(s cpuSnap) Reading { return Known(s.stall) },
+						Reduction: Last,
+						Span:      60 * time.Second,
+					},
 					Marks: Marks{
 						Unit:     "ratio",
 						Fire:     Mark{At: 0.10},
@@ -117,10 +123,12 @@ var _ = Describe("Engine", func() {
 					},
 				},
 				{
-					Name:      "headroom",
-					Extract:   func(s cpuSnap) Reading { return Known(s.headroom) },
-					Reduction: Last,
-					Span:      60 * time.Second,
+					Measurement: Measurement[cpuSnap]{
+						Name:      "headroom",
+						Extract:   func(s cpuSnap) Reading { return Known(s.headroom) },
+						Reduction: Last,
+						Span:      60 * time.Second,
+					},
 					Marks: Marks{
 						Unit:     "cores",
 						Fire:     Mark{At: 0},
@@ -157,11 +165,13 @@ var _ = Describe("Engine", func() {
 			DemoteSpan: 60 * time.Second,
 			Instruments: []Instrument[snap]{
 				{
-					Name:      "I",
-					Requires:  []Capability{"rise"},
-					Extract:   func(s snap) Reading { return Known(s.v) },
-					Reduction: Last,
-					Span:      60 * time.Second,
+					Measurement: Measurement[snap]{
+						Name:      "I",
+						Requires:  []Capability{"rise"},
+						Extract:   func(s snap) Reading { return Known(s.v) },
+						Reduction: Last,
+						Span:      60 * time.Second,
+					},
 					Marks: Marks{
 						Unit:     "u",
 						Fire:     Mark{At: 2, Inclusive: true},
@@ -196,11 +206,13 @@ var _ = Describe("Engine", func() {
 			DemoteSpan: 60 * time.Second,
 			Instruments: []Instrument[snap]{
 				{
-					Name:      "I",
-					Requires:  []Capability{"rise"},
-					Extract:   func(s snap) Reading { return Known(s.v) },
-					Reduction: Last,
-					Span:      60 * time.Second,
+					Measurement: Measurement[snap]{
+						Name:      "I",
+						Requires:  []Capability{"rise"},
+						Extract:   func(s snap) Reading { return Known(s.v) },
+						Reduction: Last,
+						Span:      60 * time.Second,
+					},
 					Marks: Marks{
 						Unit:     "u",
 						Fire:     Mark{At: 2, Inclusive: true},
@@ -236,11 +248,13 @@ var _ = Describe("Engine", func() {
 			Name:       "S",
 			DemoteSpan: 60 * time.Second,
 			Instruments: []Instrument[tsnap]{{
-				Name:      "I",
-				Requires:  []Capability{"c"},
-				Extract:   func(s tsnap) Reading { return Known(s.v) },
-				Reduction: Last,
-				Span:      60 * time.Second,
+				Measurement: Measurement[tsnap]{
+					Name:      "I",
+					Requires:  []Capability{"c"},
+					Extract:   func(s tsnap) Reading { return Known(s.v) },
+					Reduction: Last,
+					Span:      60 * time.Second,
+				},
 				Marks: Marks{
 					Unit:     "u",
 					Fire:     Mark{At: 100, Inclusive: true},
@@ -285,7 +299,9 @@ var _ = Describe("Engine", func() {
 		sig := Signal[usnap]{
 			Name: "S", DemoteSpan: 60 * time.Second,
 			Instruments: []Instrument[usnap]{{
-				Name: "I", Extract: func(s usnap) Reading { return Known(s.v) }, Reduction: Last, Span: 60 * time.Second,
+				Measurement: Measurement[usnap]{
+					Name: "I", Extract: func(s usnap) Reading { return Known(s.v) }, Reduction: Last, Span: 60 * time.Second,
+				},
 				Marks: Marks{Unit: "u", Fire: Mark{At: 100, Inclusive: true}, Worst: 200, Clear: Mark{At: 0, Inclusive: false}, Polarity: HigherIsWorse},
 			}},
 		}
@@ -313,21 +329,27 @@ var _ = Describe("Engine", func() {
 		fire := Signal[s9]{
 			Name: "F", DemoteSpan: 60 * time.Second,
 			Instruments: []Instrument[s9]{{
-				Name: "I", Requires: []Capability{"c"}, Extract: ext, Reduction: Last, Span: 60 * time.Second,
+				Measurement: Measurement[s9]{
+					Name: "I", Requires: []Capability{"c"}, Extract: ext, Reduction: Last, Span: 60 * time.Second,
+				},
 				Marks: Marks{Unit: "u", Fire: Mark{At: 2, Inclusive: true}, Worst: 4, Clear: Mark{At: 0, Inclusive: false}, Polarity: HigherIsWorse},
 			}},
 		}
 		quiet := Signal[s9]{
 			Name: "Q", DemoteSpan: 60 * time.Second,
 			Instruments: []Instrument[s9]{{
-				Name: "I", Requires: []Capability{"c"}, Extract: ext, Reduction: Last, Span: 60 * time.Second,
+				Measurement: Measurement[s9]{
+					Name: "I", Requires: []Capability{"c"}, Extract: ext, Reduction: Last, Span: 60 * time.Second,
+				},
 				Marks: Marks{Unit: "u", Fire: Mark{At: 100, Inclusive: true}, Worst: 200, Clear: Mark{At: 0, Inclusive: false}, Polarity: HigherIsWorse},
 			}},
 		}
 		incapable := Signal[s9]{
 			Name: "N", DemoteSpan: 60 * time.Second,
 			Instruments: []Instrument[s9]{{
-				Name: "I", Requires: []Capability{"missing"}, Extract: ext, Reduction: Last, Span: 60 * time.Second,
+				Measurement: Measurement[s9]{
+					Name: "I", Requires: []Capability{"missing"}, Extract: ext, Reduction: Last, Span: 60 * time.Second,
+				},
 				Marks: Marks{Unit: "u", Fire: Mark{At: 2, Inclusive: true}, Worst: 4, Clear: Mark{At: 1, Inclusive: true}, Polarity: HigherIsWorse},
 			}},
 		}
@@ -363,15 +385,17 @@ var _ = Describe("Engine", func() {
 			return Signal[s6]{
 				Name: name, DemoteSpan: 60 * time.Second, ReleaseOnAbsent: release,
 				Instruments: []Instrument[s6]{{
-					Name: "I", Requires: []Capability{"c"},
-					Extract: func(s s6) Reading {
-						if !*on {
-							return Unknown()
-						}
+					Measurement: Measurement[s6]{
+						Name: "I", Requires: []Capability{"c"},
+						Extract: func(s s6) Reading {
+							if !*on {
+								return Unknown()
+							}
 
-						return Known(5.0)
+							return Known(5.0)
+						},
+						Reduction: Last, Span: 60 * time.Second,
 					},
-					Reduction: Last, Span: 60 * time.Second,
 					Marks: Marks{Unit: "u", Fire: Mark{At: 2, Inclusive: true}, Worst: 4, Clear: Mark{At: 0, Inclusive: false}, Polarity: HigherIsWorse},
 				}},
 			}
@@ -424,9 +448,11 @@ var _ = Describe("Engine", func() {
 		sig := Signal[nsnap]{
 			Name: "N", DemoteSpan: 60 * time.Second,
 			Instruments: []Instrument[nsnap]{{
-				Name: "I", Requires: []Capability{"c"},
-				Extract:   func(s nsnap) Reading { return Known(s.v) },
-				Reduction: Last, Span: 60 * time.Second,
+				Measurement: Measurement[nsnap]{
+					Name: "I", Requires: []Capability{"c"},
+					Extract:   func(s nsnap) Reading { return Known(s.v) },
+					Reduction: Last, Span: 60 * time.Second,
+				},
 				Marks: Marks{Unit: "u", Fire: Mark{At: 2, Inclusive: true}, Worst: 4, Clear: Mark{At: 0, Inclusive: false}, Polarity: HigherIsWorse},
 			}},
 		}
@@ -453,9 +479,11 @@ var _ = Describe("Engine", func() {
 		sig := Signal[rsnap]{
 			Name: "R", DemoteSpan: 60 * time.Second, ReleaseOnAbsent: true,
 			Instruments: []Instrument[rsnap]{{
-				Name: "I", Requires: []Capability{"c"},
-				Extract:   func(s rsnap) Reading { return Known(s.v) },
-				Reduction: Last, Span: 60 * time.Second,
+				Measurement: Measurement[rsnap]{
+					Name: "I", Requires: []Capability{"c"},
+					Extract:   func(s rsnap) Reading { return Known(s.v) },
+					Reduction: Last, Span: 60 * time.Second,
+				},
 				Marks: Marks{Unit: "u", Fire: Mark{At: 2, Inclusive: true}, Worst: 4, Clear: Mark{At: 0, Inclusive: false}, Polarity: HigherIsWorse},
 			}},
 		}
@@ -487,12 +515,18 @@ var _ = Describe("Engine", func() {
 			Name: "S", DemoteSpan: 60 * time.Second, ReleaseOnAbsent: true,
 			Instruments: []Instrument[qsnap]{
 				{
-					Name: "A", Requires: []Capability{"psi"}, Reduction: Last, Span: 60 * time.Second, Marks: marks,
-					Extract: func(s qsnap) Reading { return Known(s.v) },
+					Measurement: Measurement[qsnap]{
+						Name: "A", Requires: []Capability{"psi"}, Reduction: Last, Span: 60 * time.Second,
+						Extract: func(s qsnap) Reading { return Known(s.v) },
+					},
+					Marks: marks,
 				},
 				{
-					Name: "B", Reduction: Last, Span: 60 * time.Second, Marks: marks,
-					Extract: func(qsnap) Reading { return Unknown() },
+					Measurement: Measurement[qsnap]{
+						Name: "B", Reduction: Last, Span: 60 * time.Second,
+						Extract: func(qsnap) Reading { return Unknown() },
+					},
+					Marks: marks,
 				},
 			},
 		}
@@ -535,18 +569,24 @@ var _ = Describe("Engine", func() {
 			Name: "S", DemoteSpan: 60 * time.Second,
 			Instruments: []Instrument[fsnap]{
 				{
-					Name: "A", Requires: []Capability{"psi"}, Reduction: Last, Span: 60 * time.Second, Marks: marks,
-					Extract: func(fsnap) Reading {
-						if !firing {
-							return Unknown()
-						}
+					Measurement: Measurement[fsnap]{
+						Name: "A", Requires: []Capability{"psi"}, Reduction: Last, Span: 60 * time.Second,
+						Extract: func(fsnap) Reading {
+							if !firing {
+								return Unknown()
+							}
 
-						return Known(3.0)
+							return Known(3.0)
+						},
 					},
+					Marks: marks,
 				},
 				{
-					Name: "B", Reduction: Last, Span: 60 * time.Second, Marks: marks,
-					Extract: func(fsnap) Reading { return Unknown() },
+					Measurement: Measurement[fsnap]{
+						Name: "B", Reduction: Last, Span: 60 * time.Second,
+						Extract: func(fsnap) Reading { return Unknown() },
+					},
+					Marks: marks,
 				},
 			},
 		}
@@ -614,10 +654,12 @@ var _ = Describe("Engine", func() {
 				Name:       "s",
 				DemoteSpan: 60 * time.Second,
 				Instruments: []Instrument[snap]{{
-					Name:      "i",
-					Extract:   func(s snap) Reading { return Known(s.v) },
-					Reduction: Mean,
-					Span:      3 * time.Second,
+					Measurement: Measurement[snap]{
+						Name:      "i",
+						Extract:   func(s snap) Reading { return Known(s.v) },
+						Reduction: Mean,
+						Span:      3 * time.Second,
+					},
 					Marks: Marks{
 						Unit:     "u",
 						Fire:     Mark{At: 100, Inclusive: true},
@@ -678,8 +720,8 @@ var _ = Describe("Engine", func() {
 			Name:       "S",
 			DemoteSpan: 60 * time.Second,
 			Instruments: []Instrument[armSnap]{
-				{Name: "p95", Extract: extract, Reduction: P95, Span: 60 * time.Second, Marks: marks},
-				{Name: "mean", Extract: extract, Reduction: Mean, Span: 60 * time.Second, Marks: marks},
+				{Measurement: Measurement[armSnap]{Name: "p95", Extract: extract, Reduction: P95, Span: 60 * time.Second}, Marks: marks},
+				{Measurement: Measurement[armSnap]{Name: "mean", Extract: extract, Reduction: Mean, Span: 60 * time.Second}, Marks: marks},
 			},
 		}
 		tbl := Table[armSnap]{Signals: []Signal[armSnap]{sig}, Interval: time.Second}

--- a/umh-core/pkg/diagnosis/engine_test.go
+++ b/umh-core/pkg/diagnosis/engine_test.go
@@ -819,6 +819,133 @@ var _ = Describe("Engine", func() {
 			"a caller's later edit to their own table must not detach a REFINEMENT from its window either")
 		Expect(value).To(Equal(7.0), "the refinement reduces the sample this tick observed")
 	})
+	// Owning the Instruments slice is not enough: copying the structs leaves
+	// every instrument's Requires header pointing into the caller's own array,
+	// so a later edit there rewrites what the engine's instrument asks the
+	// environment for. Capable drops an instrument whose capability the
+	// environment lacks, which is the whole signal here, so the edit would show
+	// up as NoInstrument. The positive control runs the same table unedited in
+	// the same environment, which shows the instrument is reachable at all.
+	It("keeps an instrument capable when the caller edits their own Requires after NewEngine returns", func() {
+		type snap struct{ v float64 }
+
+		mk := func() Table[snap] {
+			sig := Signal[snap]{
+				Name:       "s",
+				DemoteSpan: 60 * time.Second,
+				Instruments: []Instrument[snap]{{
+					Measurement: Measurement[snap]{
+						Name:      "i",
+						Requires:  []Capability{"declared"},
+						Extract:   func(s snap) Reading { return Known(s.v) },
+						Reduction: Last,
+						Span:      60 * time.Second,
+					},
+					Marks: Marks{
+						Unit:     "u",
+						Fire:     Mark{At: 100, Inclusive: true},
+						Worst:    200,
+						Clear:    Mark{At: 0, Inclusive: false},
+						Polarity: HigherIsWorse,
+					},
+				}},
+			}
+
+			return Table[snap]{Signals: []Signal[snap]{sig}, Interval: time.Second}
+		}
+
+		// The environment holds the capability the table declares and nothing
+		// else, so an instrument asking for any other one is dropped.
+		env := NewEnvironment("declared")
+
+		control, err := NewEngine(mk())
+		Expect(err).ToNot(HaveOccurred())
+		_, controlReadiness := control.Observe(snap{v: 7.0}, env, time.Unix(10_000_000, 0))
+		Expect(controlReadiness[0].Availability).To(Equal(Ready),
+			"unedited, the environment satisfies the instrument and its window reduces this tick's sample")
+
+		tbl := mk()
+		e, err := NewEngine(tbl)
+		Expect(err).ToNot(HaveOccurred())
+		tbl.Signals[0].Instruments[0].Requires[0] = "undeclared"
+		_, readiness := e.Observe(snap{v: 7.0}, env, time.Unix(10_000_001, 0))
+		Expect(readiness[0].Availability).To(Equal(Ready),
+			"a caller's later edit to their own capability list must not make the engine's instrument incapable")
+	})
+
+	// The capability list has to be copied at every depth, for the same reason
+	// the Instruments slice does: buildSignalState recurses into refinements, so
+	// a refinement's instrument holds its own header into the caller's array.
+	// The positive control runs the same table unedited, which shows the
+	// refinement's instrument is capable at all. Only then does the failing half
+	// rewrite the REFINEMENT's capability through the caller's own table.
+	It("keeps a refinement's instrument capable when the caller edits their own Requires after NewEngine returns", func() {
+		type snap struct{ v float64 }
+
+		arm := func(name string) Instrument[snap] {
+			return Instrument[snap]{
+				Measurement: Measurement[snap]{
+					Name:      name,
+					Requires:  []Capability{"declared"},
+					Extract:   func(s snap) Reading { return Known(s.v) },
+					Reduction: Last,
+					Span:      60 * time.Second,
+				},
+				Marks: Marks{
+					Unit:     "u",
+					Fire:     Mark{At: 100, Inclusive: true},
+					Worst:    200,
+					Clear:    Mark{At: 0, Inclusive: false},
+					Polarity: HigherIsWorse,
+				},
+			}
+		}
+
+		mk := func() Table[snap] {
+			parent := Signal[snap]{
+				Name:        "P",
+				DemoteSpan:  60 * time.Second,
+				Instruments: []Instrument[snap]{arm("pi")},
+			}
+			parent.Refinements = []Signal[snap]{{
+				Name:        "C",
+				DemoteSpan:  60 * time.Second,
+				Instruments: []Instrument[snap]{arm("ci")},
+			}}
+
+			return Table[snap]{Signals: []Signal[snap]{parent}, Interval: time.Second}
+		}
+
+		// Readiness carries one row per signal at every depth, keyed by path, so
+		// the refinement is read as "P/C" rather than by position.
+		availabilityOf := func(rows []Readiness, path string) Availability {
+			for _, r := range rows {
+				if r.Signal == path {
+					return r.Availability
+				}
+			}
+
+			Fail("readiness carries no row for " + path)
+
+			return NoInstrument
+		}
+
+		env := NewEnvironment("declared")
+
+		control, err := NewEngine(mk())
+		Expect(err).ToNot(HaveOccurred())
+		_, controlReadiness := control.Observe(snap{v: 7.0}, env, time.Unix(10_000_000, 0))
+		Expect(availabilityOf(controlReadiness, "P/C")).To(Equal(Ready),
+			"unedited, the environment satisfies the refinement's instrument and its window reduces this tick's sample")
+
+		tbl := mk()
+		e, err := NewEngine(tbl)
+		Expect(err).ToNot(HaveOccurred())
+		tbl.Signals[0].Refinements[0].Instruments[0].Requires[0] = "undeclared"
+		_, readiness := e.Observe(snap{v: 7.0}, env, time.Unix(10_000_001, 0))
+		Expect(availabilityOf(readiness, "P/C")).To(Equal(Ready),
+			"a caller's later edit must not make a REFINEMENT's instrument incapable either")
+	})
 
 	// Fired must remember WHICH instrument crossed the fire mark, not which
 	// instrument is the live winner on any later tick: the latch stamps Marks and

--- a/umh-core/pkg/diagnosis/engine_test.go
+++ b/umh-core/pkg/diagnosis/engine_test.go
@@ -273,6 +273,34 @@ var _ = Describe("Engine", func() {
 		Expect(v).To(Equal(4.0), "under a last-value reduction the newest entry is the answer")
 	})
 
+	It("keys refinement windows by path, so two parents each carrying an X keep their own reduction", func() {
+		type snap struct{ a, b float64 }
+		arm := func(name string, read func(s snap) float64) Instrument[snap] {
+			return Instrument[snap]{
+				Measurement: Measurement[snap]{Name: name, Extract: func(s snap) Reading { return Known(read(s)) }, Reduction: Last, Span: 60 * time.Second},
+				Marks:       Marks{Unit: "u", Fire: Mark{At: 2, Inclusive: true}, Worst: 4, Clear: Mark{At: 1, Inclusive: true}, Polarity: HigherIsWorse},
+			}
+		}
+		sig := func(name string, arms ...Instrument[snap]) Signal[snap] {
+			return Signal[snap]{Name: name, DemoteSpan: 60 * time.Second, Instruments: arms}
+		}
+
+		a := sig("A", arm("I", func(s snap) float64 { return s.a }))
+		a.Refinements = []Signal[snap]{sig("X", arm("I", func(s snap) float64 { return s.a }))}
+		b := sig("B", arm("I", func(s snap) float64 { return s.b }))
+		b.Refinements = []Signal[snap]{sig("X", arm("I", func(s snap) float64 { return s.b }))}
+
+		e, err := NewEngine(Table[snap]{Signals: []Signal[snap]{a, b}, Interval: time.Second})
+		Expect(err).ToNot(HaveOccurred())
+
+		e.Observe(snap{a: 1.0, b: 5.0}, NewEnvironment(), time.Now())
+
+		va, _ := e.Reduction("A/X", "I").Get()
+		Expect(va).To(Equal(1.0), "A/X reduces its own 1.0 from the shared snapshot")
+		vb, _ := e.Reduction("B/X", "I").Get()
+		Expect(vb).To(Equal(5.0), "B/X keeps a separate window and reduces its own 5.0")
+	})
+
 	It("should fold every declared measurement on every tick and reduce it back by name, without selecting, judging or firing anything", func() {
 		type tsnap struct{ v float64 }
 		// The signal is quiet (fire mark far above any value), so the fired set is

--- a/umh-core/pkg/diagnosis/engine_test.go
+++ b/umh-core/pkg/diagnosis/engine_test.go
@@ -239,11 +239,11 @@ var _ = Describe("Engine", func() {
 		Expect(v).To(Equal(4.0), "under a last-value reduction the newest entry is the answer")
 	})
 
-	It("should fold every declared track on every tick and reduce it back by name, without selecting, judging or firing anything", func() {
+	It("should fold every declared measurement on every tick and reduce it back by name, without selecting, judging or firing anything", func() {
 		type tsnap struct{ v float64 }
 		// The signal is quiet (fire mark far above any value), so the fired set is
-		// empty and any fired/readiness contribution from the TRACK is plainly
-		// absent.
+		// empty and any fired/readiness contribution from the MEASUREMENT is
+		// plainly absent.
 		sig := Signal[tsnap]{
 			Name:       "S",
 			DemoteSpan: 60 * time.Second,
@@ -264,9 +264,9 @@ var _ = Describe("Engine", func() {
 				},
 			}},
 		}
-		track := Track[tsnap]{Name: "T", Extract: func(s tsnap) Reading { return Known(s.v) }, Span: 60 * time.Second, Reduction: Mean}
+		measurement := Measurement[tsnap]{Name: "T", Extract: func(s tsnap) Reading { return Known(s.v) }, Span: 60 * time.Second, Reduction: Mean}
 
-		tbl := Table[tsnap]{Signals: []Signal[tsnap]{sig}, Tracks: []Track[tsnap]{track}, Interval: time.Second}
+		tbl := Table[tsnap]{Signals: []Signal[tsnap]{sig}, Measurements: []Measurement[tsnap]{measurement}, Interval: time.Second}
 		env := NewEnvironment("c")
 		e, err := NewEngine(tbl)
 		Expect(err).ToNot(HaveOccurred())
@@ -275,26 +275,26 @@ var _ = Describe("Engine", func() {
 		e.Observe(tsnap{v: 1.0}, env, base)
 		_, readiness := e.Observe(tsnap{v: 3.0}, env, base.Add(time.Second))
 
-		v, st := e.Track("T").Get()
-		Expect(st).To(Equal(StateValue), "a track that has met its floor is trustworthy")
-		Expect(v).To(Equal(2.0), "the track folds the mean of its two ticks (1,3)")
+		v, st := e.Measurement("T").Get()
+		Expect(st).To(Equal(StateValue), "a measurement that has met its floor is trustworthy")
+		Expect(v).To(Equal(2.0), "the measurement folds the mean of its two ticks (1,3)")
 
-		// A track is neither selected, judged nor fired: exactly one readiness row
+		// A measurement is neither selected, judged nor fired: exactly one readiness row
 		// (the signal), and the signal stays quiet (below its fire mark).
-		Expect(readiness).To(HaveLen(1), "a track adds no readiness row of its own")
+		Expect(readiness).To(HaveLen(1), "a measurement adds no readiness row of its own")
 		Expect(readiness[0].Signal).To(Equal("S"))
 
-		_, absent := e.Track("nope").Get()
-		Expect(absent).To(Equal(StateAbsent), "an unnamed track reduces to absence")
+		_, absent := e.Measurement("nope").Get()
+		Expect(absent).To(Equal(StateAbsent), "an unnamed measurement reduces to absence")
 	})
 
-	It("should reduce a track whose extractor never reads to an absence, not to a zero the caller would publish as a measurement", func() {
+	It("should reduce a measurement whose extractor never reads to an absence, not to a zero the caller would publish as a measurement", func() {
 		type usnap struct{ v float64 }
-		// Two tracks over the same ticks: one reads, one never does. The reading
+		// Two measurements over the same ticks: one reads, one never does. The reading
 		// one is the positive control, so an absence on the silent one is a fact
-		// about its extractor and not about a track that was never folded.
-		reads := Track[usnap]{Name: "reads", Extract: func(s usnap) Reading { return Known(s.v) }, Span: 60 * time.Second, Reduction: Mean}
-		silent := Track[usnap]{Name: "silent", Extract: func(usnap) Reading { return Unknown() }, Span: 60 * time.Second, Reduction: Mean}
+		// about its extractor and not about a measurement that was never folded.
+		reads := Measurement[usnap]{Name: "reads", Extract: func(s usnap) Reading { return Known(s.v) }, Span: 60 * time.Second, Reduction: Mean}
+		silent := Measurement[usnap]{Name: "silent", Extract: func(usnap) Reading { return Unknown() }, Span: 60 * time.Second, Reduction: Mean}
 
 		sig := Signal[usnap]{
 			Name: "S", DemoteSpan: 60 * time.Second,
@@ -305,7 +305,7 @@ var _ = Describe("Engine", func() {
 				Marks: Marks{Unit: "u", Fire: Mark{At: 100, Inclusive: true}, Worst: 200, Clear: Mark{At: 0, Inclusive: false}, Polarity: HigherIsWorse},
 			}},
 		}
-		e, err := NewEngine(Table[usnap]{Signals: []Signal[usnap]{sig}, Tracks: []Track[usnap]{reads, silent}, Interval: time.Second})
+		e, err := NewEngine(Table[usnap]{Signals: []Signal[usnap]{sig}, Measurements: []Measurement[usnap]{reads, silent}, Interval: time.Second})
 		Expect(err).ToNot(HaveOccurred())
 
 		base := time.Unix(4_000_000, 0)
@@ -313,12 +313,12 @@ var _ = Describe("Engine", func() {
 		e.Observe(usnap{v: 2.0}, env, base)
 		e.Observe(usnap{v: 4.0}, env, base.Add(time.Second))
 
-		v, st := e.Track("reads").Get()
-		Expect(st).To(Equal(StateValue), "the reading track met its floor of two samples over these two ticks")
-		Expect(v).To(Equal(3.0), "the reading track folds the mean of its two ticks (2,4)")
+		v, st := e.Measurement("reads").Get()
+		Expect(st).To(Equal(StateValue), "the reading measurement met its floor of two samples over these two ticks")
+		Expect(v).To(Equal(3.0), "the reading measurement folds the mean of its two ticks (2,4)")
 
-		sv, sst := e.Track("silent").Get()
-		Expect(sst).To(Equal(StateAbsent), "a track whose extractor answered Unknown on every tick stored nothing, so it has no number to reduce")
+		sv, sst := e.Measurement("silent").Get()
+		Expect(sst).To(Equal(StateAbsent), "a measurement whose extractor answered Unknown on every tick stored nothing, so it has no number to reduce")
 		Expect(sv).To(Equal(0.0), "the absence carries the zero value, which Get hands back only alongside StateAbsent")
 	})
 

--- a/umh-core/pkg/diagnosis/engine_test.go
+++ b/umh-core/pkg/diagnosis/engine_test.go
@@ -822,7 +822,7 @@ var _ = Describe("Engine", func() {
 	// Owning the Instruments slice is not enough: copying the structs leaves
 	// every instrument's Requires header pointing into the caller's own array,
 	// so a later edit there rewrites what the engine's instrument asks the
-	// environment for. Capable drops an instrument whose capability the
+	// environment for. CapableInstruments drops an instrument whose capability the
 	// environment lacks, which is the whole signal here, so the edit would show
 	// up as NoInstrument. The positive control runs the same table unedited in
 	// the same environment, which shows the instrument is reachable at all.

--- a/umh-core/pkg/diagnosis/engine_test.go
+++ b/umh-core/pkg/diagnosis/engine_test.go
@@ -759,6 +759,67 @@ var _ = Describe("Engine", func() {
 			"a caller's later edit to their own table must not detach the engine from its windows")
 	})
 
+	// The engine must own the instruments it stores at every depth, not only at
+	// the top: buildSignalState recurses into refinements, so the copy has to
+	// happen there too. The positive control runs the same table unedited,
+	// which shows the refinement's window reads its sample back at all. Only
+	// then does the failing half rename the REFINEMENT's instrument through the
+	// caller's own table.
+	It("keeps a refinement's window reachable when the caller edits their own table after NewEngine returns", func() {
+		type snap struct{ v float64 }
+
+		arm := func(name string) Instrument[snap] {
+			return Instrument[snap]{
+				Measurement: Measurement[snap]{
+					Name:      name,
+					Extract:   func(s snap) Reading { return Known(s.v) },
+					Reduction: Last,
+					Span:      60 * time.Second,
+				},
+				Marks: Marks{
+					Unit:     "u",
+					Fire:     Mark{At: 100, Inclusive: true},
+					Worst:    200,
+					Clear:    Mark{At: 0, Inclusive: false},
+					Polarity: HigherIsWorse,
+				},
+			}
+		}
+
+		mk := func() Table[snap] {
+			parent := Signal[snap]{
+				Name:        "P",
+				DemoteSpan:  60 * time.Second,
+				Instruments: []Instrument[snap]{arm("pi")},
+			}
+			parent.Refinements = []Signal[snap]{{
+				Name:        "C",
+				DemoteSpan:  60 * time.Second,
+				Instruments: []Instrument[snap]{arm("ci")},
+			}}
+
+			return Table[snap]{Signals: []Signal[snap]{parent}, Interval: time.Second}
+		}
+
+		control, err := NewEngine(mk())
+		Expect(err).ToNot(HaveOccurred())
+		control.Observe(snap{v: 7.0}, NewEnvironment(), time.Unix(10_000_000, 0))
+		controlValue, controlState := control.Reduction("P/C", "ci").Get()
+		Expect(controlState).To(Equal(StateValue), "unedited, the refinement's window holds the tick's sample")
+		Expect(controlValue).To(Equal(7.0))
+
+		tbl := mk()
+		e, err := NewEngine(tbl)
+		Expect(err).ToNot(HaveOccurred())
+		tbl.Signals[0].Refinements[0].Instruments[0].Name = "renamed"
+		e.Observe(snap{v: 7.0}, NewEnvironment(), time.Unix(10_000_001, 0))
+
+		value, state := e.Reduction("P/C", "ci").Get()
+		Expect(state).To(Equal(StateValue),
+			"a caller's later edit to their own table must not detach a REFINEMENT from its window either")
+		Expect(value).To(Equal(7.0), "the refinement reduces the sample this tick observed")
+	})
+
 	// Fired must remember WHICH instrument crossed the fire mark, not which
 	// instrument is the live winner on any later tick: the latch stamps Marks and
 	// Value at the fire transition and never refreshes them, and Instrument must be

--- a/umh-core/pkg/diagnosis/engine_test.go
+++ b/umh-core/pkg/diagnosis/engine_test.go
@@ -385,43 +385,43 @@ var _ = Describe("Engine", func() {
 	})
 
 	It("should return one readiness row per signal beside the fired set, carrying the same availability the latch arm acted on, for signals that fired and signals that could not be read alike", func() {
-		type s9 struct{ v float64 }
-		ext := func(s s9) Reading { return Known(s.v) }
+		type snap struct{ v float64 }
+		ext := func(s snap) Reading { return Known(s.v) }
 
-		fire := Signal[s9]{
+		fire := Signal[snap]{
 			Name: "F", DemoteSpan: 60 * time.Second,
-			Instruments: []Instrument[s9]{{
-				Measurement: Measurement[s9]{
+			Instruments: []Instrument[snap]{{
+				Measurement: Measurement[snap]{
 					Name: "I", Requires: []Capability{"c"}, Extract: ext, Reduction: Last, Span: 60 * time.Second,
 				},
 				Marks: Marks{Unit: "u", Fire: Mark{At: 2, Inclusive: true}, Worst: 4, Clear: Mark{At: 0, Inclusive: false}, Polarity: HigherIsWorse},
 			}},
 		}
-		quiet := Signal[s9]{
+		quiet := Signal[snap]{
 			Name: "Q", DemoteSpan: 60 * time.Second,
-			Instruments: []Instrument[s9]{{
-				Measurement: Measurement[s9]{
+			Instruments: []Instrument[snap]{{
+				Measurement: Measurement[snap]{
 					Name: "I", Requires: []Capability{"c"}, Extract: ext, Reduction: Last, Span: 60 * time.Second,
 				},
 				Marks: Marks{Unit: "u", Fire: Mark{At: 100, Inclusive: true}, Worst: 200, Clear: Mark{At: 0, Inclusive: false}, Polarity: HigherIsWorse},
 			}},
 		}
-		incapable := Signal[s9]{
+		incapable := Signal[snap]{
 			Name: "N", DemoteSpan: 60 * time.Second,
-			Instruments: []Instrument[s9]{{
-				Measurement: Measurement[s9]{
+			Instruments: []Instrument[snap]{{
+				Measurement: Measurement[snap]{
 					Name: "I", Requires: []Capability{"missing"}, Extract: ext, Reduction: Last, Span: 60 * time.Second,
 				},
 				Marks: Marks{Unit: "u", Fire: Mark{At: 2, Inclusive: true}, Worst: 4, Clear: Mark{At: 1, Inclusive: true}, Polarity: HigherIsWorse},
 			}},
 		}
 
-		tbl := Table[s9]{Signals: []Signal[s9]{fire, quiet, incapable}, Interval: time.Second}
+		tbl := Table[snap]{Signals: []Signal[snap]{fire, quiet, incapable}, Interval: time.Second}
 		env := NewEnvironment("c")
 		e, err := NewEngine(tbl)
 		Expect(err).ToNot(HaveOccurred())
 
-		fired, readiness := e.Observe(s9{v: 3.0}, env, time.Unix(6_000_000, 0))
+		fired, readiness := e.Observe(snap{v: 3.0}, env, time.Unix(6_000_000, 0))
 
 		Expect(readiness).To(HaveLen(3), "one readiness row per signal, in table order")
 		Expect(readiness[0].Signal).To(Equal("F"))
@@ -437,19 +437,19 @@ var _ = Describe("Engine", func() {
 
 	It("should reset a fired latch the moment its window is AllAbsent when the signal declares release-on-absent, while a non-release signal holds until its own demote clock elapses", func() {
 		// Carries nothing: this spec switches readability through the closures
-		// below, not through the snapshot, so every Observe passes s6{}.
-		type s6 struct{}
+		// below, not through the snapshot, so every Observe passes snap{}.
+		type snap struct{}
 
 		// Readability-switched extractors: when a signal's switch is on, its
 		// window stores an over-fire value; when off, an absence on every tick.
 		onT, onF := true, true
-		mkElem := func(name string, on *bool, release bool) Signal[s6] {
-			return Signal[s6]{
+		mkElem := func(name string, on *bool, release bool) Signal[snap] {
+			return Signal[snap]{
 				Name: name, DemoteSpan: 60 * time.Second, ReleaseOnAbsent: release,
-				Instruments: []Instrument[s6]{{
-					Measurement: Measurement[s6]{
+				Instruments: []Instrument[snap]{{
+					Measurement: Measurement[snap]{
 						Name: "I", Requires: []Capability{"c"},
-						Extract: func(s s6) Reading {
+						Extract: func(s snap) Reading {
 							if !*on {
 								return Unknown()
 							}
@@ -463,13 +463,13 @@ var _ = Describe("Engine", func() {
 			}
 		}
 
-		tbl := Table[s6]{Signals: []Signal[s6]{mkElem("T", &onT, true), mkElem("F", &onF, false)}, Interval: time.Second}
+		tbl := Table[snap]{Signals: []Signal[snap]{mkElem("T", &onT, true), mkElem("F", &onF, false)}, Interval: time.Second}
 		env := NewEnvironment("c")
 		e, err := NewEngine(tbl)
 		Expect(err).ToNot(HaveOccurred())
 
 		base := time.Unix(7_000_000, 0)
-		e.Observe(s6{}, env, base) // both readable: both fire
+		e.Observe(snap{}, env, base) // both readable: both fire
 
 		// Give F one more trusted (Ready) tick just inside its demote boundary so
 		// its latch clock restarts from a recent update. The Reset arm and the
@@ -479,7 +479,7 @@ var _ = Describe("Engine", func() {
 		// make the arms observable, F's clock must still be running on the AllAbsent
 		// tick, which means F's window must not yet be empty.
 		onT = false
-		e.Observe(s6{}, env, base.Add(55*time.Second)) // F still readable -> Ready; T freezes, holds
+		e.Observe(snap{}, env, base.Add(55*time.Second)) // F still readable -> Ready; T freezes, holds
 
 		// Silence both and advance past T's demote boundary. T's window (fired at
 		// base, never re-updated) demotes -> AllAbsent -> Reset: released
@@ -488,7 +488,7 @@ var _ = Describe("Engine", func() {
 		// update, has NOT elapsed: F stays fired. T's Reset is what distinguishes
 		// the two on this tick.
 		onF = false
-		fired, readiness := e.Observe(s6{}, env, base.Add(61*time.Second))
+		fired, readiness := e.Observe(snap{}, env, base.Add(61*time.Second))
 
 		byName := make(map[string]bool, len(fired))
 		for _, f := range fired {
@@ -501,7 +501,7 @@ var _ = Describe("Engine", func() {
 		// Once F's own demote boundary passes (base+55s + 60s) F, too, releases on
 		// the clock, so the two converge with the clock alone.
 		onT, onF = false, false
-		firedAfter, _ := e.Observe(s6{}, env, base.Add(116*time.Second))
+		firedAfter, _ := e.Observe(snap{}, env, base.Add(116*time.Second))
 		Expect(firedAfter).To(BeEmpty(), "F releases once its own demote boundary passes")
 	})
 

--- a/umh-core/pkg/diagnosis/engine_test.go
+++ b/umh-core/pkg/diagnosis/engine_test.go
@@ -199,6 +199,40 @@ var _ = Describe("Engine", func() {
 		Expect(readiness[0].Availability).To(Equal(Ready))
 	})
 
+	It("stamps the signal's Attribution, who the caller blames, onto the fired verdict", func() {
+		type snap struct{ v float64 }
+		sig := Signal[snap]{
+			Name:        "P",
+			DemoteSpan:  60 * time.Second,
+			Attribution: 7,
+			Instruments: []Instrument[snap]{
+				{
+					Measurement: Measurement[snap]{
+						Name:      "I",
+						Requires:  []Capability{"rise"},
+						Extract:   func(s snap) Reading { return Known(s.v) },
+						Reduction: Last,
+						Span:      60 * time.Second,
+					},
+					Marks: Marks{
+						Unit:     "u",
+						Fire:     Mark{At: 2, Inclusive: true},
+						Worst:    4,
+						Clear:    Mark{At: 1, Inclusive: true},
+						Polarity: HigherIsWorse,
+					},
+				},
+			},
+		}
+
+		e, err := NewEngine(Table[snap]{Signals: []Signal[snap]{sig}, Interval: time.Second})
+		Expect(err).ToNot(HaveOccurred())
+
+		fired, _ := e.Observe(snap{v: 3.0}, NewEnvironment("rise"), time.Now())
+		Expect(fired).To(HaveLen(1), "a value above the fire mark arms the signal")
+		Expect(fired[0].Identity.Attribution).To(Equal(7), "the verdict stamps who the caller said to blame")
+	})
+
 	It("reads back a populated window's reduction rather than reporting a permanent absence", func() {
 		type snap struct{ v float64 }
 		sig := Signal[snap]{

--- a/umh-core/pkg/diagnosis/example_test.go
+++ b/umh-core/pkg/diagnosis/example_test.go
@@ -41,11 +41,13 @@ func Example() {
 			Name:       name,
 			DemoteSpan: time.Minute,
 			Instruments: []diagnosis.Instrument[mounts]{{
-				Name:      "spare",
-				Reduction: diagnosis.Last,
-				Span:      10 * time.Second,
-				Marks:     spare,
-				Extract:   func(m mounts) diagnosis.Reading { return diagnosis.Known(read(m)) },
+				Measurement: diagnosis.Measurement[mounts]{
+					Name:      "spare",
+					Reduction: diagnosis.Last,
+					Span:      10 * time.Second,
+					Extract:   func(m mounts) diagnosis.Reading { return diagnosis.Known(read(m)) },
+				},
+				Marks: spare,
 			}},
 		}
 	}

--- a/umh-core/pkg/diagnosis/example_test.go
+++ b/umh-core/pkg/diagnosis/example_test.go
@@ -26,6 +26,9 @@ import (
 // 0, where the reserve is first touched, and severity reaches 1 at -10, where the
 // whole reserve is gone. Worst is NEGATIVE because it must lie on the worse side
 // of Fire, which for a falling quantity is below it.
+//
+// The two signals are named "root" and "var-log" rather than by their mount
+// points, because NewEngine refuses a "/" in any signal name.
 func Example() {
 	type mounts struct{ root, varLog float64 } // GB free above the reserve
 
@@ -55,8 +58,8 @@ func Example() {
 	engine, err := diagnosis.NewEngine(diagnosis.Table[mounts]{
 		Interval: time.Second,
 		Signals: []diagnosis.Signal[mounts]{
-			watch("/", func(m mounts) float64 { return m.root }),
-			watch("/var", func(m mounts) float64 { return m.varLog }),
+			watch("root", func(m mounts) float64 { return m.root }),
+			watch("var-log", func(m mounts) float64 { return m.varLog }),
 		},
 	})
 	if err != nil {
@@ -65,11 +68,11 @@ func Example() {
 
 	fired, _ := engine.Observe(mounts{root: -3, varLog: -10}, diagnosis.NewEnvironment(), time.Unix(0, 0))
 	for _, cause := range diagnosis.Rank(fired) {
-		fmt.Printf("%-4s %+5.1f %s  severity %.2f\n",
+		fmt.Printf("%-7s %+5.1f %s  severity %.2f\n",
 			cause.Signal, cause.Value, cause.Marks.Unit, cause.Severity())
 	}
 
 	// Output:
-	// /var -10.0 GB  severity 1.00
-	// /     -3.0 GB  severity 0.30
+	// var-log -10.0 GB  severity 1.00
+	// root     -3.0 GB  severity 0.30
 }

--- a/umh-core/pkg/diagnosis/instrument_test.go
+++ b/umh-core/pkg/diagnosis/instrument_test.go
@@ -19,10 +19,10 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-// Instrument is one way of measuring a signal, and Signal.Capable is the
-// capability gate and nothing more: it returns every instrument whose required
-// capabilities are present, in table order, and does not pick a winner. The
-// gate filters on startup facts, so tests use bare capability names and unit
+// Instrument is one way of measuring a signal, and Signal.CapableInstruments is
+// the capability gate and nothing more: it returns every instrument whose
+// required capabilities are present, in table order, and does not pick a winner.
+// The gate filters on startup facts, so tests use bare capability names and unit
 // strings, which are the caller's vocabulary.
 var _ = Describe("Instrument", func() {
 	// snap is a generic caller snapshot type holding both counters of a pair.
@@ -103,7 +103,7 @@ var _ = Describe("Instrument", func() {
 			},
 		}
 
-		got := signal.Capable(NewEnvironment("source-1"))
+		got := signal.CapableInstruments(NewEnvironment("source-1"))
 		Expect(got).To(HaveLen(2), "the environment satisfies the free instrument and the source-1 instrument only")
 		Expect(got[0].Name).To(Equal("A-free"), "a zero-Requires instrument is satisfied by any environment")
 		Expect(got[1].Name).To(Equal("A-1"), "the satisfied instruments come back in table order")
@@ -118,7 +118,7 @@ var _ = Describe("Instrument", func() {
 			},
 		}
 
-		got := signal.Capable(NewEnvironment())
+		got := signal.CapableInstruments(NewEnvironment())
 		Expect(got).To(HaveLen(1), "an empty environment satisfies only the zero-Requires instrument")
 		Expect(got[0].Name).To(Equal("A-free"))
 	})
@@ -132,7 +132,7 @@ var _ = Describe("Instrument", func() {
 			},
 		}
 
-		got := signal.Capable(NewEnvironment("source-1"))
+		got := signal.CapableInstruments(NewEnvironment("source-1"))
 		Expect(got).To(HaveLen(2), "both instruments declaring the same capability survive the gate")
 		Expect(got[0].Name).To(Equal("A-p95"), "the first match keeps its place in table order")
 		Expect(got[1].Name).To(Equal("A-mean"), "the second match is not discarded by a gate that picks a winner")

--- a/umh-core/pkg/diagnosis/instrument_test.go
+++ b/umh-core/pkg/diagnosis/instrument_test.go
@@ -32,8 +32,10 @@ var _ = Describe("Instrument", func() {
 
 	It("should read both counters of a delta ratio off one snapshot by construction", func() {
 		withAgainst := Instrument[snap]{
-			Extract: func(s snap) Reading { return Known(s.value) },
-			Against: func(s snap) Reading { return Known(s.against) },
+			Measurement: Measurement[snap]{
+				Extract: func(s snap) Reading { return Known(s.value) },
+				Against: func(s snap) Reading { return Known(s.against) },
+			},
 		}
 
 		value, against := withAgainst.Read(snap{value: 3, against: 40})
@@ -48,7 +50,9 @@ var _ = Describe("Instrument", func() {
 
 	It("should read an absence denominator when the instrument has no Against", func() {
 		noAgainst := Instrument[snap]{
-			Extract: func(s snap) Reading { return Known(s.value) },
+			Measurement: Measurement[snap]{
+				Extract: func(s snap) Reading { return Known(s.value) },
+			},
 		}
 
 		value, against := noAgainst.Read(snap{value: 5})
@@ -61,7 +65,9 @@ var _ = Describe("Instrument", func() {
 
 	It("should carry its own fire and clear marks, so one signal can hold several mark pairs in different units", func() {
 		ratio := Instrument[snap]{
-			Name: "B-ratio",
+			Measurement: Measurement[snap]{
+				Name: "B-ratio",
+			},
 			Marks: Marks{
 				Unit:     "ratio",
 				Fire:     Mark{At: 0.9, Inclusive: true},
@@ -70,7 +76,9 @@ var _ = Describe("Instrument", func() {
 			},
 		}
 		cores := Instrument[snap]{
-			Name: "B-cores",
+			Measurement: Measurement[snap]{
+				Name: "B-cores",
+			},
 			Marks: Marks{
 				Unit:     "cores",
 				Fire:     Mark{At: 2, Inclusive: true},
@@ -89,9 +97,9 @@ var _ = Describe("Instrument", func() {
 		signal := Signal[snap]{
 			Name: "A",
 			Instruments: []Instrument[snap]{
-				{Name: "A-free", Extract: func(s snap) Reading { return Known(s.value) }},
-				{Name: "A-1", Requires: []Capability{"source-1"}, Extract: func(s snap) Reading { return Known(s.value) }},
-				{Name: "A-2", Requires: []Capability{"source-2"}, Extract: func(s snap) Reading { return Known(s.value) }},
+				{Measurement: Measurement[snap]{Name: "A-free", Extract: func(s snap) Reading { return Known(s.value) }}},
+				{Measurement: Measurement[snap]{Name: "A-1", Requires: []Capability{"source-1"}, Extract: func(s snap) Reading { return Known(s.value) }}},
+				{Measurement: Measurement[snap]{Name: "A-2", Requires: []Capability{"source-2"}, Extract: func(s snap) Reading { return Known(s.value) }}},
 			},
 		}
 
@@ -105,8 +113,8 @@ var _ = Describe("Instrument", func() {
 		signal := Signal[snap]{
 			Name: "A",
 			Instruments: []Instrument[snap]{
-				{Name: "A-1", Requires: []Capability{"source-1"}, Extract: func(s snap) Reading { return Known(s.value) }},
-				{Name: "A-free", Extract: func(s snap) Reading { return Known(s.value) }},
+				{Measurement: Measurement[snap]{Name: "A-1", Requires: []Capability{"source-1"}, Extract: func(s snap) Reading { return Known(s.value) }}},
+				{Measurement: Measurement[snap]{Name: "A-free", Extract: func(s snap) Reading { return Known(s.value) }}},
 			},
 		}
 
@@ -119,8 +127,8 @@ var _ = Describe("Instrument", func() {
 		signal := Signal[snap]{
 			Name: "A",
 			Instruments: []Instrument[snap]{
-				{Name: "A-p95", Requires: []Capability{"source-1"}, Extract: func(s snap) Reading { return Known(s.value) }},
-				{Name: "A-mean", Requires: []Capability{"source-1"}, Extract: func(s snap) Reading { return Known(s.value) }},
+				{Measurement: Measurement[snap]{Name: "A-p95", Requires: []Capability{"source-1"}, Extract: func(s snap) Reading { return Known(s.value) }}},
+				{Measurement: Measurement[snap]{Name: "A-mean", Requires: []Capability{"source-1"}, Extract: func(s snap) Reading { return Known(s.value) }}},
 			},
 		}
 

--- a/umh-core/pkg/diagnosis/judge.go
+++ b/umh-core/pkg/diagnosis/judge.go
@@ -61,6 +61,9 @@ type Marks struct {
 // every Fired so ranking and consumers never read the table. Rank sorts on
 // Tier, severity and Index.
 type Identity struct {
+	// Signal is the bare name the table declared, "X" for a refinement declared
+	// as X, and NOT the "A/X" path a Readiness row is named by: a Fired sits
+	// under the parent it narrows, which already says whose refinement it is.
 	Signal string
 	// Tier is the rank class the caller gave the signal, lower meaning more
 	// urgent.

--- a/umh-core/pkg/diagnosis/judge.go
+++ b/umh-core/pkg/diagnosis/judge.go
@@ -91,6 +91,11 @@ type Fired struct {
 	// themselves, each judged against its own marks. A refinement is judged
 	// every tick, whether or not this signal fired, but it is reported only
 	// here, under a signal that did fire.
+	//
+	// They come lowest Tier first, ties going to the one the table declared
+	// first, at this and every deeper level: the entry at index 0 is the most
+	// urgent narrowing of this signal, with no sorting left to the caller. Rank
+	// does not reach in here; it orders the top-level set only.
 	Refinements []Fired
 }
 

--- a/umh-core/pkg/diagnosis/judge.go
+++ b/umh-core/pkg/diagnosis/judge.go
@@ -82,17 +82,17 @@ type Fired struct {
 	// Instrument is the instrument that fired, stamped on the fire transition and
 	// never refreshed; a later live winner does not overwrite it.
 	Instrument string
+	// Refinements are the signals hanging under this one that have fired, each
+	// judged against its own marks and ordered lowest Tier first, ties going to
+	// declaration order, at every depth. Index 0 is the most urgent narrowing of
+	// this signal.
+	Refinements []Fired
 	Identity
 	// Marks is the pair Value fired against, stamped with it: Severity scores the
 	// one against the other, so a later instrument's pair would not measure it.
 	Marks Marks
 	// Value is the number that fired, untransformed by polarity.
 	Value float64
-	// Refinements are the signals hanging under this one that have fired, each
-	// judged against its own marks and ordered lowest Tier first, ties going to
-	// declaration order, at every depth. Index 0 is the most urgent narrowing of
-	// this signal.
-	Refinements []Fired
 }
 
 // Latch holds one signal's fired-or-not verdict, one per signal and never one per

--- a/umh-core/pkg/diagnosis/judge.go
+++ b/umh-core/pkg/diagnosis/judge.go
@@ -58,15 +58,18 @@ type Marks struct {
 }
 
 // Identity is what a consumer needs to know about a fired signal, copied onto
-// every Fired so ranking and consumers never read the table: which Signal, its
-// Tier, who the caller blames (Attribution), and its table Index. Rank sorts
-// on Tier, severity and Index; Attribution is payload it never reads, the
-// caller's vocabulary.
+// every Fired so ranking and consumers never read the table. Rank sorts on
+// Tier, severity and Index.
 type Identity struct {
-	Signal      string
-	Tier        int
+	Signal string
+	// Tier is the rank class the caller gave the signal, lower meaning more
+	// urgent.
+	Tier int
+	// Attribution is who the caller blames, an opaque number in the caller's
+	// vocabulary. It is payload for the consumer; Rank never reads it.
 	Attribution int
-	Index       int
+	// Index is the signal's position in Table.Signals.
+	Index int
 }
 
 // Fired is one signal's verdict once it has fired: value, marks, and since when.

--- a/umh-core/pkg/diagnosis/judge.go
+++ b/umh-core/pkg/diagnosis/judge.go
@@ -173,16 +173,58 @@ func crossedClear(v float64, m Marks) bool {
 // Fired names the instrument that fired, not whichever one a later tick selected.
 // It is attribution only; the clear arm does not read it.
 //
-// Arms measuring genuinely different quantities are the remaining gap: while a
-// foreign pair keeps answering Ready, no tick can release the episode and every
-// tick refreshes lastUpdate, so the Signal.DemoteSpan fallback in Engine.Observe
-// never runs either. Such an episode holds until its own arm answers again.
+// An arm measuring a genuinely different quantity can act on an episode it did
+// not fire, but only when its own number is decisive. The block inside Update
+// says which readings release, which hold, and which move the blame.
 func (l *Latch) Update(instrument string, r Reduced, c Coverage, m Marks, now time.Time) {
 	if r.state != StateValue {
 		return
 	}
 
 	l.lastUpdate = now
+
+	// A signal can be answered by more than one measurement, and they are not
+	// always comparable: spare cores on the host is a different number from our
+	// own usage, on a different scale. So only the measurement that made us
+	// degraded is allowed to clear it.
+	//
+	// The edge case is a measurement that fires and then goes absent. Without this
+	// block we would keep waiting for a number nobody can read, and the signal
+	// would stay degraded forever. Instead we switch to a measurement we can still
+	// read, and judge against its marks from here on.
+	//
+	// Say we went degraded because the host had 0.2 cores spare, and host stats
+	// stop being readable. Our own usage is then judged on its own marks:
+	//
+	//	40%   below the 60% clear mark    healthy: nothing we can read says otherwise
+	//	65%   inside the 60 to 70% band   stay degraded: the band is where we hold
+	//	85%   past the 70% fire mark      stay degraded, and the reason becomes usage
+	//
+	// since is not re-stamped, because the condition never stopped. Only what we
+	// can measure changed.
+	//
+	// A one-tick gap in the old measurement does reach this block, because a window
+	// goes untrusted on the first reading it misses rather than when it drains.
+	// The middle row is what makes that harmless: a live number that says neither
+	// degraded nor healthy leaves the episode exactly as it was, marks and blame
+	// included. So a gap can only change the verdict when the number we can still
+	// read is itself decisive. And once released, crossedFire below will not fire
+	// again until a span has passed.
+	if l.fired && m != l.marks {
+		if crossedClear(r.v, m) && c.Full() {
+			l.release(now)
+
+			return
+		}
+
+		if crossedFire(r.v, m) {
+			l.marks = m
+			l.value = r.v
+			l.instrument = instrument
+		}
+
+		return
+	}
 
 	if l.fired && m == l.marks && crossedClear(r.v, l.marks) && c.Full() {
 		l.release(now)

--- a/umh-core/pkg/diagnosis/judge.go
+++ b/umh-core/pkg/diagnosis/judge.go
@@ -65,11 +65,9 @@ type Identity struct {
 	// as X, and NOT the "A/X" path a Readiness row is named by: a Fired sits
 	// under the parent it narrows, which already says whose refinement it is.
 	Signal string
-	// Tier is the rank class the caller gave the signal, lower meaning more
-	// urgent.
+	// Tier is Signal.Tier as declared.
 	Tier int
-	// Attribution is who the caller blames, an opaque number in the caller's
-	// vocabulary. It is payload for the consumer; Rank never reads it.
+	// Attribution is Signal.Attribution as declared. Rank never reads it.
 	Attribution int
 	// Index is the signal's position among its siblings: in Table.Signals for a
 	// top-level signal, in the parent's Refinements for a refinement.
@@ -91,15 +89,18 @@ type Fired struct {
 	// Value is the number that fired, untransformed by polarity.
 	Value float64
 	// Refinements are the signals hanging under this one that have fired, each
-	// judged against its own marks. firedTree sorts them lowest Tier first, ties
-	// going to the order the table declared them in, at this and every deeper
-	// level, so index 0 is the most urgent narrowing of this signal.
+	// judged against its own marks and ordered lowest Tier first, ties going to
+	// declaration order, at every depth. Index 0 is the most urgent narrowing of
+	// this signal.
 	Refinements []Fired
 }
 
 // Latch holds one signal's fired-or-not verdict, one per signal and never one per
 // instrument: only the instrument picked for this tick reaches Update. It is not
 // synchronized, so only the loop driving Update may call Fired.
+//
+// An episode is one fired span: from the tick the signal crosses its fire mark
+// to the tick it releases.
 type Latch struct {
 	since       time.Time
 	lastUpdate  time.Time
@@ -155,21 +156,21 @@ func crossedClear(v float64, m Marks) bool {
 // answered in spare cores and in a usage fraction cannot have the cores episode
 // released by a fraction that happens to sit past a cores threshold.
 //
-// The gate is the pair, not the instrument, because arms that share a pair are by
-// construction answering one question in one unit and differ only in how they
-// reduce it — a p95 and the mean fallback behind it. Selection moves between
+// The gate is the pair, not the instrument, because instruments that share a pair
+// are by construction answering one question in one unit and differ only in how
+// they reduce it — a p95 and the mean fallback behind it. Selection moves between
 // those on the tick the p95 reaches its minimum sample count, on every start, and
 // their values are interchangeable for judging recovery. Gating on the instrument
-// name instead strands such an episode fired: the arm that fired it is never
-// selected again, so nothing can ever release it.
+// name instead strands such an episode fired: the instrument that fired it is
+// never selected again, so nothing can ever release it.
 //
 // instrument names the instrument the reduction came from. It is stamped beside
 // the marks and value when the latch fires, and never refreshed afterwards, so a
 // Fired names the instrument that fired, not whichever one a later tick selected.
 // It is attribution only; the clear arm does not read it.
 //
-// An arm measuring a genuinely different quantity can act on an episode it did
-// not fire, but only when its own number is decisive. The block inside Update
+// An instrument measuring a genuinely different quantity can act on an episode it
+// did not fire, but only when its own number is decisive. The block inside Update
 // says which readings release, which hold, and which move the blame.
 func (l *Latch) Update(instrument string, r Reduced, c Coverage, m Marks, now time.Time) {
 	if r.state != StateValue {
@@ -178,33 +179,15 @@ func (l *Latch) Update(instrument string, r Reduced, c Coverage, m Marks, now ti
 
 	l.lastUpdate = now
 
-	// A signal can be answered by more than one measurement, and they are not
-	// always comparable: spare cores on the host is a different number from our
-	// own usage, on a different scale. So only the measurement that made us
-	// degraded is allowed to clear it.
+	// The instrument that fired has stopped answering, so judge on the marks of
+	// one that still does. since is not re-stamped: the condition never stopped,
+	// only what can measure it changed. latch_measurement_switch_test.go works
+	// the three cases through.
 	//
-	// The edge case is a measurement that fires and then goes absent. Without this
-	// block we would keep waiting for a number nobody can read, and the signal
-	// would stay degraded forever. Instead we switch to a measurement we can still
-	// read, and judge against its marks from here on.
-	//
-	// Say we went degraded because the host had 0.2 cores spare, and host stats
-	// stop being readable. Our own usage is then judged on its own marks:
-	//
-	//	40%   below the 60% clear mark    healthy: nothing we can read says otherwise
-	//	65%   inside the 60 to 70% band   stay degraded: the band is where we hold
-	//	85%   past the 70% fire mark      stay degraded, and the reason becomes usage
-	//
-	// since is not re-stamped, because the condition never stopped. Only what we
-	// can measure changed.
-	//
-	// A one-tick gap in the old measurement does reach this block, because a window
-	// goes untrusted on the first reading it misses rather than when it drains.
-	// The middle row is what makes that harmless: a live number that says neither
-	// degraded nor healthy leaves the episode exactly as it was, marks and blame
-	// included. So a gap can only change the verdict when the number we can still
-	// read is itself decisive. And once released, crossedFire below will not fire
-	// again until a span has passed.
+	// A one-tick gap reaches this block too, because a window goes untrusted on
+	// the first reading it misses rather than when it drains. That is harmless
+	// because a live number reading neither past its clear nor past its fire
+	// leaves the episode exactly as it was, marks and blame included.
 	if l.fired && m != l.marks {
 		if crossedClear(r.v, m) && c.Full() {
 			l.release(now)
@@ -314,8 +297,8 @@ func (f Fired) Severity() float64 {
 	return clamp01((worse(f.Value, m) - fire) / (worse(m.Worst, m) - fire))
 }
 
-// Rank orders the signals that fired. It never reorders a signal's refinements.
-// Those arrive already sorted, from firedTree.
+// Rank orders the signals that fired, and only the top level: a signal's
+// refinements arrive in Fired.Refinements already ordered.
 //
 // The order is tier ascending (a lower tier outranks a higher one), then
 // severity descending, then the signal's table index, so the caller can show

--- a/umh-core/pkg/diagnosis/judge.go
+++ b/umh-core/pkg/diagnosis/judge.go
@@ -68,7 +68,8 @@ type Identity struct {
 	// Attribution is who the caller blames, an opaque number in the caller's
 	// vocabulary. It is payload for the consumer; Rank never reads it.
 	Attribution int
-	// Index is the signal's position in Table.Signals.
+	// Index is the signal's position among its siblings: in Table.Signals for a
+	// top-level signal, in the parent's Refinements for a refinement.
 	Index int
 }
 
@@ -86,6 +87,11 @@ type Fired struct {
 	Marks Marks
 	// Value is the number that fired, untransformed by polarity.
 	Value float64
+	// Refinements are the signals hanging under this one that have fired
+	// themselves, each judged against its own marks. A refinement is judged
+	// every tick, whether or not this signal fired, but it is reported only
+	// here, under a signal that did fire.
+	Refinements []Fired
 }
 
 // Latch holds one signal's fired-or-not verdict, one per signal and never one per

--- a/umh-core/pkg/diagnosis/judge.go
+++ b/umh-core/pkg/diagnosis/judge.go
@@ -59,14 +59,13 @@ type Marks struct {
 
 // Identity is what a consumer needs to know about a fired signal, copied onto
 // every Fired so ranking and consumers never read the table: which Signal, its
-// Tier, who the caller blames (Attribution), whether the cause is External to
-// this box, and its table Index. Rank sorts on Tier, External and Index;
-// Attribution is payload it never reads, the caller's vocabulary.
+// Tier, who the caller blames (Attribution), and its table Index. Rank sorts
+// on Tier, severity and Index; Attribution is payload it never reads, the
+// caller's vocabulary.
 type Identity struct {
 	Signal      string
 	Tier        int
 	Attribution int
-	External    bool
 	Index       int
 }
 
@@ -263,8 +262,8 @@ func (f Fired) Severity() float64 {
 
 // Rank orders the signals that fired so the caller can show the main reason
 // first: tier ascending (a lower tier outranks a higher one), then severity
-// descending, then external attribution first, then the signal's table index.
-// It sorts in place and returns the same slice.
+// descending, then the signal's table index. It sorts in place and returns the
+// same slice.
 func Rank(fired []Fired) []Fired {
 	sort.Slice(fired, func(i, j int) bool {
 		a, b := fired[i], fired[j]
@@ -274,10 +273,6 @@ func Rank(fired []Fired) []Fired {
 
 		if sa, sb := a.Severity(), b.Severity(); sa != sb {
 			return sa > sb
-		}
-
-		if a.External != b.External {
-			return a.External
 		}
 
 		return a.Index < b.Index

--- a/umh-core/pkg/diagnosis/judge.go
+++ b/umh-core/pkg/diagnosis/judge.go
@@ -90,15 +90,10 @@ type Fired struct {
 	Marks Marks
 	// Value is the number that fired, untransformed by polarity.
 	Value float64
-	// Refinements are the signals hanging under this one that have fired
-	// themselves, each judged against its own marks. A refinement is judged
-	// every tick, whether or not this signal fired, but it is reported only
-	// here, under a signal that did fire.
-	//
-	// They come lowest Tier first, ties going to the one the table declared
-	// first, at this and every deeper level: the entry at index 0 is the most
-	// urgent narrowing of this signal, with no sorting left to the caller. Rank
-	// does not reach in here; it orders the top-level set only.
+	// Refinements are the signals hanging under this one that have fired, each
+	// judged against its own marks. firedTree sorts them lowest Tier first, ties
+	// going to the order the table declared them in, at this and every deeper
+	// level, so index 0 is the most urgent narrowing of this signal.
 	Refinements []Fired
 }
 
@@ -319,10 +314,12 @@ func (f Fired) Severity() float64 {
 	return clamp01((worse(f.Value, m) - fire) / (worse(m.Worst, m) - fire))
 }
 
-// Rank orders the signals that fired so the caller can show the main reason
-// first: tier ascending (a lower tier outranks a higher one), then severity
-// descending, then the signal's table index. It sorts in place and returns the
-// same slice.
+// Rank orders the signals that fired. It never reorders a signal's refinements.
+// Those arrive already sorted, from firedTree.
+//
+// The order is tier ascending (a lower tier outranks a higher one), then
+// severity descending, then the signal's table index, so the caller can show
+// the main reason first. It sorts in place and returns the same slice.
 func Rank(fired []Fired) []Fired {
 	sort.Slice(fired, func(i, j int) bool {
 		a, b := fired[i], fired[j]

--- a/umh-core/pkg/diagnosis/judge.go
+++ b/umh-core/pkg/diagnosis/judge.go
@@ -57,14 +57,17 @@ type Marks struct {
 	Worst float64
 }
 
-// Identity is the four sort keys Rank needs, copied onto every Fired so ranking
-// never reads the table: which Signal, its Tier (rank class, sorted ascending),
-// whether the cause is External to this box, and its table Index.
+// Identity is what a consumer needs to know about a fired signal, copied onto
+// every Fired so ranking and consumers never read the table: which Signal, its
+// Tier, who the caller blames (Attribution), whether the cause is External to
+// this box, and its table Index. Rank sorts on Tier, External and Index;
+// Attribution is payload it never reads, the caller's vocabulary.
 type Identity struct {
-	Signal   string
-	Tier     int
-	External bool
-	Index    int
+	Signal      string
+	Tier        int
+	Attribution int
+	External    bool
+	Index       int
 }
 
 // Fired is one signal's verdict once it has fired: value, marks, and since when.

--- a/umh-core/pkg/diagnosis/latch_foreign_release_test.go
+++ b/umh-core/pkg/diagnosis/latch_foreign_release_test.go
@@ -13,16 +13,18 @@
 // limitations under the License.
 
 // These specs pin the SCALE a fired episode is released on. A latch fires against
-// one mark pair; the clear arm must only release it on a reduction measured
-// against that same pair.
+// one mark pair; a reduction measured against a DIFFERENT pair may act on that
+// episode only when its own number is decisive, past its own clear or past its
+// own fire. A foreign number with no verdict of its own leaves the episode
+// alone, even when it would read as a release on the pair that fired.
 //
 // The two shapes below are both real, and a fix that satisfies one while breaking
 // the other is the trap here:
 //
 //   - Different pairs. A signal answers one question two ways, in different units
 //     and opposite polarities (spare cores falling is bad; usage fraction rising
-//     is bad). The foreign arm's number must not release an episode it never
-//     measured.
+//     is bad). A foreign arm sitting in its own hold band must not release an
+//     episode it never measured.
 //   - One shared pair. A p95 and the mean fallback behind it share their pair and
 //     differ only in minimum sample count, so selection moves to the p95 the tick
 //     it reaches that minimum, on every start. Recovery must still release. Gating
@@ -73,11 +75,12 @@ var _ = Describe("Latch release is judged on the pair the episode fired under", 
 		Expect(f.Instrument).To(Equal("host-headroom"))
 
 		// The headroom arm is gone; a different instrument now measures a fraction.
-		// 0.55 sits inside the fraction arm's own HOLD band (between its clear 0.60
-		// and fire 0.70), so on its own marks it holds — but under the cores arm the
-		// same 0.55 is on the releasing side of a 0.5 clear. The episode was fired
+		// 0.65 sits inside the fraction arm's own HOLD band, between its clear of
+		// 0.60 and its fire of 0.70, so that arm has no verdict of its own to
+		// offer. Read against the CORES clear of 0.5 the same 0.65 looks like a
+		// release, and that is the mistake this spec catches: the episode was fired
 		// by the cores arm, so a fraction cannot be what declares its recovery.
-		l.Update("usage-fraction", Reduced{v: 0.55, state: StateValue}, full, usage, t0.Add(time.Second))
+		l.Update("usage-fraction", Reduced{v: 0.65, state: StateValue}, full, usage, t0.Add(time.Second))
 		f, fired = l.Fired()
 		Expect(fired).To(BeTrue(), "a different instrument's value inside its own hold band does not release the fired episode")
 		Expect(f.Instrument).To(Equal("host-headroom"), "the held episode keeps the instrument that fired it")
@@ -145,6 +148,24 @@ var _ = Describe("Latch release is judged on the pair the episode fired under", 
 			"the p95 must hold selection at the end, or this spec never leaves the arm that fired and proves nothing")
 		Expect(last).To(BeEmpty(),
 			"a quiet signal must release even though the arm that fired it is no longer selected")
+	})
+
+	It("should release the episode when a different instrument crosses its OWN clear", func() {
+		t0 := time.Unix(1_000_000, 0)
+		l := NewLatch(Identity{Signal: "s"})
+
+		l.Update("host-headroom", Reduced{v: -0.2, state: StateValue}, full, headroom, t0)
+		_, fired := l.Fired()
+		Expect(fired).To(BeTrue(), "a value below the cores fire mark fires the latch")
+
+		// The half of the rule the hold above does not cover. 0.40 is past the
+		// fraction arm's own clear of 0.60, so unlike 0.65 that arm HAS a verdict,
+		// and it says healthy. Holding on regardless is the stuck-degraded bug: the
+		// cores arm cannot contradict it, because a foreign arm is only selected
+		// when the arm that fired has stopped answering.
+		l.Update("usage-fraction", Reduced{v: 0.40, state: StateValue}, full, usage, t0.Add(time.Second))
+		_, fired = l.Fired()
+		Expect(fired).To(BeFalse(), "an arm past its own clear ends an episode nothing else can still measure")
 	})
 
 	It("should still release on the instrument that fired the episode when its own clear is crossed", func() {
@@ -218,11 +239,11 @@ var _ = Describe("Latch release is judged on the pair the episode fired under", 
 		Expect(fired[0].Instrument).To(Equal("host-headroom"))
 
 		// The headroom arm's read fails this tick, so it reduces to untrusted and
-		// resolve hands over to the usage arm, whose 0.55 sits inside its own hold
-		// band. Full coverage is live; under the buggy release the fraction's 0.55
+		// resolve hands over to the usage arm, whose 0.65 sits inside its own hold
+		// band. Full coverage is live; under the buggy release the fraction's 0.65
 		// is read against the cores clear and releases the cores-fired episode.
 		headroomReadable = false
-		fired, readiness := e.Observe(cpuSnap{usage: 0.55}, env, base.Add(5*time.Second))
+		fired, readiness := e.Observe(cpuSnap{usage: 0.65}, env, base.Add(5*time.Second))
 		Expect(readiness).To(HaveLen(1))
 		Expect(readiness[0].Availability).To(Equal(Ready), "the usage arm now answers the question")
 		Expect(fired).To(HaveLen(1), "a change of winning instrument does not release the episode it fired")

--- a/umh-core/pkg/diagnosis/latch_foreign_release_test.go
+++ b/umh-core/pkg/diagnosis/latch_foreign_release_test.go
@@ -109,8 +109,8 @@ var _ = Describe("Latch release is judged on the pair the episode fired under", 
 			Name:       "steal",
 			DemoteSpan: 60 * time.Second,
 			Instruments: []Instrument[stealSnap]{
-				{Name: "steal-p95", Extract: read, Reduction: P95, Span: 60 * time.Second, Marks: shared},
-				{Name: "steal-mean", Extract: read, Reduction: Mean, Span: 60 * time.Second, Marks: shared},
+				{Measurement: Measurement[stealSnap]{Name: "steal-p95", Extract: read, Reduction: P95, Span: 60 * time.Second}, Marks: shared},
+				{Measurement: Measurement[stealSnap]{Name: "steal-mean", Extract: read, Reduction: Mean, Span: 60 * time.Second}, Marks: shared},
 			},
 		}
 		e, err := NewEngine(Table[stealSnap]{Signals: []Signal[stealSnap]{sig}, Interval: time.Second})
@@ -172,24 +172,28 @@ var _ = Describe("Latch release is judged on the pair the episode fired under", 
 
 		headroomReadable := true
 		headroomArm := Instrument[cpuSnap]{
-			Name: "host-headroom",
-			Extract: func(s cpuSnap) Reading {
-				if !headroomReadable {
-					return Unknown()
-				}
+			Measurement: Measurement[cpuSnap]{
+				Name: "host-headroom",
+				Extract: func(s cpuSnap) Reading {
+					if !headroomReadable {
+						return Unknown()
+					}
 
-				return Known(s.headroom)
+					return Known(s.headroom)
+				},
+				Reduction: Last,
+				Span:      3 * time.Second,
 			},
-			Reduction: Last,
-			Span:      3 * time.Second,
-			Marks:     headroom,
+			Marks: headroom,
 		}
 		usageArm := Instrument[cpuSnap]{
-			Name:      "usage-fraction",
-			Extract:   func(s cpuSnap) Reading { return Known(s.usage) },
-			Reduction: Last,
-			Span:      3 * time.Second,
-			Marks:     usage,
+			Measurement: Measurement[cpuSnap]{
+				Name:      "usage-fraction",
+				Extract:   func(s cpuSnap) Reading { return Known(s.usage) },
+				Reduction: Last,
+				Span:      3 * time.Second,
+			},
+			Marks: usage,
 		}
 		sig := Signal[cpuSnap]{
 			Name:        "saturation",

--- a/umh-core/pkg/diagnosis/latch_measurement_switch_test.go
+++ b/umh-core/pkg/diagnosis/latch_measurement_switch_test.go
@@ -1,0 +1,171 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// These specs pin what happens to a fired signal when the measurement that
+// fired it stops being readable while a second measurement keeps answering.
+//
+// The clear arm of Latch.Update releases only on the mark pair the episode
+// fired under, which is right: spare cores on the host and our own usage
+// fraction are different numbers on different scales, and one cannot declare
+// the other recovered. But a measurement can also go away for good. Then the
+// pair that fired can never be read again, nothing can reach the clear arm, and
+// the engine's staleness fallback never runs either, because a second
+// measurement keeps the signal Ready.
+//
+// So the latch moves the episode onto the marks it can still read, and judges
+// against those from there on. These specs drive a real Engine, because the
+// hold-forever only appears through the engine's availability handling.
+
+package diagnosis
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("A fired signal is judged on a measurement it can still read", func() {
+	const (
+		tick       = time.Second
+		armSpan    = 10 * time.Second
+		demoteSpan = 30 * time.Second
+	)
+
+	type cpuSnap struct {
+		headroom float64
+		usage    float64
+	}
+
+	// Two answers to one question that are not comparable: spare cores on the
+	// host falling is bad, our own usage fraction rising is bad.
+	headroomMarks := Marks{
+		Unit:     "cores",
+		Fire:     Mark{At: 0},
+		Clear:    Mark{At: 0.5},
+		Polarity: LowerIsWorse,
+		Worst:    -1,
+	}
+	usageMarks := Marks{
+		Unit:     "fraction",
+		Fire:     Mark{At: 0.70},
+		Clear:    Mark{At: 0.60},
+		Polarity: HigherIsWorse,
+		Worst:    1.0,
+	}
+
+	// drive fires the signal on the headroom measurement, then takes that
+	// measurement away for long enough that its window empties, while the usage
+	// measurement reports usageAfter on every one of those ticks. It returns the
+	// fired set and the readiness rows of the last tick.
+	drive := func(usageAfter float64) ([]Fired, []Readiness) {
+		headroomReadable := true
+
+		sig := Signal[cpuSnap]{
+			Name:       "saturation",
+			DemoteSpan: demoteSpan,
+			Instruments: []Instrument[cpuSnap]{
+				{
+					Measurement: Measurement[cpuSnap]{
+						Name: "host-headroom",
+						Extract: func(s cpuSnap) Reading {
+							if !headroomReadable {
+								return Unknown()
+							}
+
+							return Known(s.headroom)
+						},
+						Reduction: Last,
+						Span:      armSpan,
+					},
+					Marks: headroomMarks,
+				},
+				{
+					Measurement: Measurement[cpuSnap]{
+						Name:      "usage-fraction",
+						Extract:   func(s cpuSnap) Reading { return Known(s.usage) },
+						Reduction: Last,
+						Span:      armSpan,
+					},
+					Marks: usageMarks,
+				},
+			},
+		}
+
+		e, err := NewEngine(Table[cpuSnap]{Signals: []Signal[cpuSnap]{sig}, Interval: tick})
+		Expect(err).ToNot(HaveOccurred())
+
+		env := NewEnvironment()
+		base := time.Unix(9_000_000, 0)
+		at := func(i int) time.Time { return base.Add(time.Duration(i) * tick) }
+
+		// Fifteen ticks at 0.2 cores short of the fire mark. The headroom
+		// measurement is declared first and answers every tick, so it is the one
+		// that fires, and its window covers its whole span by the end.
+		var fired []Fired
+		for i := range 15 {
+			fired, _ = e.Observe(cpuSnap{headroom: -0.2, usage: 0.10}, env, at(i))
+		}
+
+		Expect(fired).To(HaveLen(1), "the headroom measurement fires the signal")
+		Expect(fired[0].Instrument).To(Equal("host-headroom"))
+		Expect(fired[0].Marks.Unit).To(Equal("cores"))
+
+		// Now host stats stop being readable. Sixty ticks is twice the demote
+		// span, so the headroom window is not merely stale, it is empty: that
+		// measurement can never answer this signal again. Usage answers every one
+		// of those ticks, so the signal stays Ready and the engine's staleness
+		// fallback is never reached.
+		headroomReadable = false
+
+		var readiness []Readiness
+		for i := 15; i < 75; i++ {
+			fired, readiness = e.Observe(cpuSnap{usage: usageAfter}, env, at(i))
+		}
+
+		return fired, readiness
+	}
+
+	It("releases a signal whose live measurement reads healthy on its own marks", func() {
+		fired, readiness := drive(0.40)
+
+		Expect(readiness).To(HaveLen(1))
+		Expect(readiness[0].Availability).To(Equal(Ready),
+			"usage keeps answering, so the engine never reaches its staleness fallback")
+		Expect(fired).To(BeEmpty(),
+			"0.40 usage is past the 0.60 clear mark, and nothing else can be read, so the signal must release")
+	})
+
+	It("holds a signal whose live measurement reads inside its own hysteresis band", func() {
+		fired, readiness := drive(0.65)
+
+		Expect(readiness).To(HaveLen(1))
+		Expect(readiness[0].Availability).To(Equal(Ready))
+		Expect(fired).To(HaveLen(1),
+			"0.65 usage is between the 0.60 clear and the 0.70 fire mark, which is where the signal holds")
+	})
+
+	It("holds a signal whose live measurement reads past its own fire mark, and blames that measurement", func() {
+		fired, readiness := drive(0.85)
+
+		Expect(readiness).To(HaveLen(1))
+		Expect(readiness[0].Availability).To(Equal(Ready))
+		Expect(fired).To(HaveLen(1), "0.85 usage is past the 0.70 fire mark, so the signal stays fired")
+		Expect(fired[0].Instrument).To(Equal("usage-fraction"),
+			"the reason a caller is shown must be a number the caller can still read")
+		Expect(fired[0].Marks.Unit).To(Equal("fraction"),
+			"a value in fractions scored against marks in cores is not a severity")
+		Expect(fired[0].Value).To(Equal(0.85))
+	})
+})

--- a/umh-core/pkg/diagnosis/latch_signature_test.go
+++ b/umh-core/pkg/diagnosis/latch_signature_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Latch signature", func() {
 		// the fields carry no fact about whether THIS tick's read succeeded.
 		ct := reflect.TypeOf(Coverage{})
 		Expect(ct.NumField()).To(Equal(2),
-			"Coverage must carry exactly two durations — a readability field smuggled in here is F1 rebuilt")
+			"Coverage must carry exactly two durations: a third field is a route by which a readability fact could reach the latch")
 		for i := range ct.NumField() {
 			Expect(ct.Field(i).Type).To(Equal(reflect.TypeOf(time.Duration(0))),
 				"every Coverage field must be a time.Duration, never a bool or a Reading")

--- a/umh-core/pkg/diagnosis/latch_test.go
+++ b/umh-core/pkg/diagnosis/latch_test.go
@@ -100,7 +100,7 @@ var _ = Describe("Latch", func() {
 
 	It("should carry the identity the engine stamped at construction into the Fired it reports", func() {
 		t0 := time.Unix(1_000_000, 0)
-		id := Identity{Signal: "sig", Tier: 2, External: true, Index: 7}
+		id := Identity{Signal: "sig", Tier: 2, Index: 7}
 		l := NewLatch(id)
 
 		l.Update("march", Reduced{v: 0.20, state: StateValue}, full(), march(), t0)

--- a/umh-core/pkg/diagnosis/latch_test.go
+++ b/umh-core/pkg/diagnosis/latch_test.go
@@ -27,7 +27,8 @@ import (
 // derive everything from those two and must never see a readability fact.
 // Their unexported fields are reachable from inside the package;
 // reduced_access_test.go proves they are not from outside, and
-// latch_spec6_test.go pins the shape of Reduced, Coverage and Update.
+// latch_signature_test.go checks the two signatures that keep a readability
+// fact out: the fields of Coverage, and the parameters of Update.
 var _ = Describe("Latch", func() {
 	const latchSpan = 60 * time.Second
 

--- a/umh-core/pkg/diagnosis/ranking_test.go
+++ b/umh-core/pkg/diagnosis/ranking_test.go
@@ -120,7 +120,7 @@ var _ = Describe("Ranking", func() {
 		// cannot change any outcome, because Index already totally orders two
 		// distinct entries. So this covers every position where Attribution
 		// could matter: blame stays payload the caller reads off the fired set,
-		// uninterpreted by the machine pass.
+		// uninterpreted by this package.
 		early := rises(1, 0, 0.5, 0.5, 1.0) // severity 0, Index 0
 		late := rises(1, 1, 0.5, 0.5, 1.0)  // severity 0, Index 1
 		early.Attribution = 7

--- a/umh-core/pkg/diagnosis/ranking_test.go
+++ b/umh-core/pkg/diagnosis/ranking_test.go
@@ -117,6 +117,25 @@ var _ = Describe("Ranking", func() {
 		Expect(indexes(sorted)).To(Equal([]int{0, 3}))
 	})
 
+	It("should not rank by Attribution, leaving it payload rather than a fifth sort key", func() {
+		// Two verdicts identical in every sort key (Tier, severity, External,
+		// Index), differing only in who the caller blames. If Rank read
+		// Attribution, the attribution ordering would force one outcome no
+		// matter the append order. Preserving BOTH declaration orders proves
+		// Attribution is not consulted: a consumer reads blame off the fired
+		// set, the caller's vocabulary uninterpreted by the machine pass. The
+		// two runs agree with their own input order, so they differ from each
+		// other, which is exactly what a fifth sort key would forbid.
+		low := rises(1, 0, 0.5, 0.5, 1.0)  // severity 0
+		high := rises(1, 0, 0.5, 0.5, 1.0) // severity 0, identical to low except Attribution
+		low.Attribution = 2
+		high.Attribution = 7
+		Expect(Rank([]Fired{low, high})).To(Equal([]Fired{low, high}),
+			"with Attribution not a key, the first declaration order is preserved")
+		Expect(Rank([]Fired{high, low})).To(Equal([]Fired{high, low}),
+			"with Attribution not a key, the reversed declaration order is also preserved")
+	})
+
 	It("should return a total order, so ranking the same set twice in different append orders gives the same sequence", func() {
 		// A set deliberately chosen to cluster on tier, severity and externality
 		// so that only the total order (all four keys) settles it.

--- a/umh-core/pkg/diagnosis/ranking_test.go
+++ b/umh-core/pkg/diagnosis/ranking_test.go
@@ -109,23 +109,26 @@ var _ = Describe("Ranking", func() {
 		Expect(indexes(sorted)).To(Equal([]int{0, 3}))
 	})
 
-	It("should not rank by Attribution, leaving it payload rather than a fifth sort key", func() {
-		// Two verdicts identical in every sort key (Tier, severity, Index),
-		// differing only in who the caller blames. If Rank read Attribution,
-		// the attribution ordering would force one outcome no matter the append
-		// order. Preserving BOTH declaration orders proves Attribution is not
-		// consulted: a consumer reads blame off the fired set, the caller's
-		// vocabulary uninterpreted by the machine pass. The two runs agree with
-		// their own input order, so they differ from each other, which is
-		// exactly what a fifth sort key would forbid.
-		low := rises(1, 0, 0.5, 0.5, 1.0)  // severity 0
-		high := rises(1, 0, 0.5, 0.5, 1.0) // severity 0, identical to low except Attribution
-		low.Attribution = 2
-		high.Attribution = 7
-		Expect(Rank([]Fired{low, high})).To(Equal([]Fired{low, high}),
-			"with Attribution not a key, the first declaration order is preserved")
-		Expect(Rank([]Fired{high, low})).To(Equal([]Fired{high, low}),
-			"with Attribution not a key, the reversed declaration order is also preserved")
+	It("should not consult Attribution at or before Index, leaving it payload rather than a sort key", func() {
+		// Two verdicts equal in Tier and severity, so the comparator falls
+		// through to Index, its last key. Attribution runs opposite to Index:
+		// the entry with the lower Index carries the higher Attribution. Index
+		// is unique per signal, so the Index comparison answers strictly and
+		// the expected sequence does not depend on what sort.Slice does with
+		// entries it treats as equal. A comparator reading Attribution at or
+		// before Index returns the pair the other way round. A read after Index
+		// cannot change any outcome, because Index already totally orders two
+		// distinct entries. So this covers every position where Attribution
+		// could matter: blame stays payload the caller reads off the fired set,
+		// uninterpreted by the machine pass.
+		early := rises(1, 0, 0.5, 0.5, 1.0) // severity 0, Index 0
+		late := rises(1, 1, 0.5, 0.5, 1.0)  // severity 0, Index 1
+		early.Attribution = 7
+		late.Attribution = 2
+		Expect(indexes(Rank([]Fired{early, late}))).To(Equal([]int{0, 1}),
+			"Index decides the order, not the higher Attribution sitting on the lower Index")
+		Expect(indexes(Rank([]Fired{late, early}))).To(Equal([]int{0, 1}),
+			"the reversed input order gives the same sequence, still decided by Index")
 	})
 
 	It("should return a total order, so ranking the same set twice in different append orders gives the same sequence", func() {

--- a/umh-core/pkg/diagnosis/ranking_test.go
+++ b/umh-core/pkg/diagnosis/ranking_test.go
@@ -58,9 +58,9 @@ var _ = Describe("Ranking", func() {
 	// falls builds a LowerIsWorse headroom cause whose severity is
 	// (fire-value)/(fire-worst), clamped to [0,1]. Worst is below fire, so it is
 	// the more negative number.
-	falls := func(tier, index int, value, fire, worst float64, external bool) Fired {
+	falls := func(tier, index int, value, fire, worst float64) Fired {
 		return Fired{
-			Identity: Identity{Signal: "f", Tier: tier, Index: index, External: external},
+			Identity: Identity{Signal: "f", Tier: tier, Index: index},
 			Value:    value,
 			Marks: Marks{
 				Fire:     Mark{At: fire},
@@ -92,7 +92,7 @@ var _ = Describe("Ranking", func() {
 
 	It("should give a falling mark the same severity scale as a rising one, so an absolute quantity and a ratio compare", func() {
 		// Headroom firing at 0 and exhausted at -4 cores: half of that is -2.
-		falling := falls(1, 0, -2, 0, -4, false) // (0-(-2))/(0-(-4)) = 0.5
+		falling := falls(1, 0, -2, 0, -4) // (0-(-2))/(0-(-4)) = 0.5
 		Expect(falling.Severity()).To(Equal(0.5),
 			"halfway between the fire mark and the worst value scores half")
 
@@ -102,30 +102,22 @@ var _ = Describe("Ranking", func() {
 			"an absolute quantity and a ratio with the same normalised severity share a scale")
 	})
 
-	It("should break a remaining tie in favour of the externally-attributed cause", func() {
-		internal := rises(1, 0, 0.5, 0.5, 1.0) // severity 0
-		external := rises(1, 1, 0.5, 0.5, 1.0) // severity 0
-		external.External = true
-		sorted := Rank([]Fired{internal, external})
-		Expect(indexes(sorted)).To(Equal([]int{1, 0}))
-	})
-
 	It("should break a last tie by the signal's declared position in the table", func() {
-		a := rises(1, 0, 0.5, 0.5, 1.0) // severity 0, not external
-		b := rises(1, 3, 0.5, 0.5, 1.0) // severity 0, not external, lower index wins
+		a := rises(1, 0, 0.5, 0.5, 1.0) // severity 0
+		b := rises(1, 3, 0.5, 0.5, 1.0) // severity 0, lower index wins
 		sorted := Rank([]Fired{b, a})
 		Expect(indexes(sorted)).To(Equal([]int{0, 3}))
 	})
 
 	It("should not rank by Attribution, leaving it payload rather than a fifth sort key", func() {
-		// Two verdicts identical in every sort key (Tier, severity, External,
-		// Index), differing only in who the caller blames. If Rank read
-		// Attribution, the attribution ordering would force one outcome no
-		// matter the append order. Preserving BOTH declaration orders proves
-		// Attribution is not consulted: a consumer reads blame off the fired
-		// set, the caller's vocabulary uninterpreted by the machine pass. The
-		// two runs agree with their own input order, so they differ from each
-		// other, which is exactly what a fifth sort key would forbid.
+		// Two verdicts identical in every sort key (Tier, severity, Index),
+		// differing only in who the caller blames. If Rank read Attribution,
+		// the attribution ordering would force one outcome no matter the append
+		// order. Preserving BOTH declaration orders proves Attribution is not
+		// consulted: a consumer reads blame off the fired set, the caller's
+		// vocabulary uninterpreted by the machine pass. The two runs agree with
+		// their own input order, so they differ from each other, which is
+		// exactly what a fifth sort key would forbid.
 		low := rises(1, 0, 0.5, 0.5, 1.0)  // severity 0
 		high := rises(1, 0, 0.5, 0.5, 1.0) // severity 0, identical to low except Attribution
 		low.Attribution = 2
@@ -137,14 +129,14 @@ var _ = Describe("Ranking", func() {
 	})
 
 	It("should return a total order, so ranking the same set twice in different append orders gives the same sequence", func() {
-		// A set deliberately chosen to cluster on tier, severity and externality
-		// so that only the total order (all four keys) settles it.
+		// A set deliberately chosen to cluster on tier and severity so that only
+		// the total order (tier, then severity, then index) settles it.
 		set := []Fired{
 			rises(2, 0, 0.7, 0.5, 1.0), // tier 2, severity 0.4
 			rises(0, 1, 0.5, 0.5, 1.0), // tier 0, severity 0
-			falls(1, 2, -2, 0, -4, false),
-			falls(1, 3, -2, 0, -4, true), // same tier+severity, external
-			rises(1, 4, 0.5, 0.5, 1.0),   // same tier, severity 0, not external
+			falls(1, 2, -2, 0, -4),
+			falls(1, 3, -2, 0, -4),     // same tier+severity, so only index distinguishes
+			rises(1, 4, 0.5, 0.5, 1.0), // same tier, severity 0
 		}
 		want := indexes(Rank(append([]Fired{}, set...)))
 		shuffled := []Fired{set[4], set[1], set[3], set[0], set[2]}
@@ -175,8 +167,8 @@ var _ = Describe("Ranking", func() {
 		// scale; a value sitting exactly on the fire mark gives 0/0 = NaN, which
 		// must fall back to the bottom. Same handling as the rising arm, on the
 		// other polarity. Rank stays a total order.
-		below := falls(1, 0, 4, 8, 8, false) // (8-4)/(8-8) = 4/0 = +Inf
-		at := falls(1, 1, 8, 8, 8, false)    // (8-8)/(8-8) = 0/0 = NaN
+		below := falls(1, 0, 4, 8, 8) // (8-4)/(8-8) = 4/0 = +Inf
+		at := falls(1, 1, 8, 8, 8)    // (8-8)/(8-8) = 0/0 = NaN
 		for _, f := range []Fired{below, at} {
 			s := f.Severity()
 			Expect(math.IsNaN(s)).To(BeFalse(), "a degenerate falling mark must not leak NaN into the comparator")
@@ -187,7 +179,7 @@ var _ = Describe("Ranking", func() {
 		Expect(below.Severity()).To(Equal(1.0), "the overshooting arm clamps to the top of the severity scale")
 		Expect(at.Severity()).To(Equal(0.0), "the 0/0 arm falls back to the bottom of the severity scale")
 
-		set := []Fired{below, falls(1, 2, -2, 0, -4, false)}
+		set := []Fired{below, falls(1, 2, -2, 0, -4)}
 		want := indexes(Rank(append([]Fired{}, set...)))
 		Expect(indexes(Rank([]Fired{set[1], set[0]}))).To(Equal(want),
 			"the degenerate falling cause is still ranked deterministically")
@@ -207,8 +199,8 @@ var _ = Describe("Ranking", func() {
 		// carries the HIGHER Index. A comparator that stopped discriminating on
 		// severity would fall through to the Index tie-break and order these the
 		// other way round.
-		worse := falls(1, 1, 2, 5, -4, false) // (5-2)/(5-(-4)) = 3/9 -> 0.333, Index 1
-		less := falls(1, 0, 4, 5, -4, false)  // (5-4)/(5-(-4)) = 1/9 -> 0.111, Index 0
+		worse := falls(1, 1, 2, 5, -4) // (5-2)/(5-(-4)) = 3/9 -> 0.333, Index 1
+		less := falls(1, 0, 4, 5, -4)  // (5-4)/(5-(-4)) = 1/9 -> 0.111, Index 0
 		sorted := Rank([]Fired{less, worse})
 		Expect(indexes(sorted)).To(Equal([]int{1, 0}),
 			"the higher-severity falling cause ranks first within the tier")

--- a/umh-core/pkg/diagnosis/suite.go
+++ b/umh-core/pkg/diagnosis/suite.go
@@ -49,7 +49,7 @@ type Scenario struct {
 	Case   Case
 }
 
-// Suite generates one Scenario per (signal, case) over t.Signals, never t.Tracks.
+// Suite generates one Scenario per (signal, case) over t.Signals, never t.Measurements.
 func Suite[S any](t Table[S]) []Scenario {
 	cases := []Case{CaseLive, CaseBriefOutage, CaseLongOutage, CaseUnsupported, CasePostOutageDip, CaseBelowFloor}
 

--- a/umh-core/pkg/diagnosis/suite.go
+++ b/umh-core/pkg/diagnosis/suite.go
@@ -198,7 +198,9 @@ func drive[S any](e *Engine[S], interval time.Duration, env Environment, seq []b
 		}
 
 		_, readiness := e.Observe(sample, env, at)
-		// One row, because runScenario builds this engine over a single signal.
+		// Row 0, because the rows come depth-first and runScenario builds this
+		// engine over one signal: that signal's own row is first, and the rows
+		// of any refinements under it follow.
 		availability = readiness[0].Availability
 		at = at.Add(interval)
 	}

--- a/umh-core/pkg/diagnosis/suite.go
+++ b/umh-core/pkg/diagnosis/suite.go
@@ -212,7 +212,7 @@ func drive[S any](e *Engine[S], interval time.Duration, env Environment, seq []b
 // instruments, falling back to the smallest on the signal, then to one.
 func minCapableMin[S any](s Signal[S], env Environment) int {
 	m := 0
-	for _, inst := range s.Capable(env) {
+	for _, inst := range s.CapableInstruments(env) {
 		if m == 0 || inst.Reduction.Min < m {
 			m = inst.Reduction.Min
 		}

--- a/umh-core/pkg/diagnosis/suite_test.go
+++ b/umh-core/pkg/diagnosis/suite_test.go
@@ -53,7 +53,7 @@ var _ = Describe("Suite", func() {
 	}
 
 	instrument := func(reduction Reduction) Instrument[snap] {
-		return Instrument[snap]{Name: "I", Requires: []Capability{"source-1"}, Extract: extract, Reduction: reduction, Span: 60 * time.Second, Marks: marks()}
+		return Instrument[snap]{Measurement: Measurement[snap]{Name: "I", Requires: []Capability{"source-1"}, Extract: extract, Reduction: reduction, Span: 60 * time.Second}, Marks: marks()}
 	}
 
 	// Signal A reduces by Last (m == 1), signal B by Mean (m == 2). Both require
@@ -135,7 +135,7 @@ var _ = Describe("Suite", func() {
 
 	It("refuses a table whose instrument cannot reach its reduction's minimum within its span at the interval", func() {
 		sig := Signal[snap]{Name: "A", DemoteSpan: 60 * time.Second, Instruments: []Instrument[snap]{
-			{Name: "I", Requires: []Capability{"source-1"}, Extract: extract, Reduction: P99, Span: 60 * time.Second, Marks: marks()},
+			{Measurement: Measurement[snap]{Name: "I", Requires: []Capability{"source-1"}, Extract: extract, Reduction: P99, Span: 60 * time.Second}, Marks: marks()},
 		}}
 		tbl := Table[snap]{Signals: []Signal[snap]{sig}, Interval: time.Second}
 		_, err := NewEngine(tbl)
@@ -145,7 +145,7 @@ var _ = Describe("Suite", func() {
 
 	It("does not refuse an instrument whose span can hold its reduction's minimum at the interval", func() {
 		sig := Signal[snap]{Name: "A", DemoteSpan: 60 * time.Second, Instruments: []Instrument[snap]{
-			{Name: "I", Requires: []Capability{"source-1"}, Extract: extract, Reduction: P95, Span: 60 * time.Second, Marks: marks()},
+			{Measurement: Measurement[snap]{Name: "I", Requires: []Capability{"source-1"}, Extract: extract, Reduction: P95, Span: 60 * time.Second}, Marks: marks()},
 		}}
 		tbl := Table[snap]{Signals: []Signal[snap]{sig}, Interval: time.Second}
 		_, err := NewEngine(tbl)
@@ -243,7 +243,7 @@ var _ = Describe("Suite", func() {
 		tbl := Table[snap]{
 			Signals: []Signal[snap]{
 				{Name: "N", DemoteSpan: 60 * time.Second, Instruments: []Instrument[snap]{
-					{Name: "I", Requires: []Capability{}, Extract: extract, Reduction: Last, Span: 60 * time.Second, Marks: marks()},
+					{Measurement: Measurement[snap]{Name: "I", Requires: []Capability{}, Extract: extract, Reduction: Last, Span: 60 * time.Second}, Marks: marks()},
 				}},
 			},
 			Interval: time.Second,

--- a/umh-core/pkg/diagnosis/suite_test.go
+++ b/umh-core/pkg/diagnosis/suite_test.go
@@ -105,7 +105,7 @@ var _ = Describe("Suite", func() {
 		return NoInstrument
 	}
 
-	It("generates one scenario per (signal, case): 6 x len(signals), never over tracks", func() {
+	It("generates one scenario per (signal, case): 6 x len(signals), never over measurements", func() {
 		cases := []Case{CaseLive, CaseBriefOutage, CaseLongOutage, CaseUnsupported, CasePostOutageDip, CaseBelowFloor}
 
 		tbl := table()
@@ -124,13 +124,13 @@ var _ = Describe("Suite", func() {
 			}
 		}
 
-		// A table that also declares tracks still emits 6 x len(signals): a
-		// track has no availability to assert, so no scenario may name one.
-		tbl.Tracks = []Track[snap]{{Name: "T", Extract: extract, Reduction: Mean, Span: 60 * time.Second}}
+		// A table that also declares measurements still emits 6 x len(signals): a
+		// measurement has no availability to assert, so no scenario may name one.
+		tbl.Measurements = []Measurement[snap]{{Name: "T", Extract: extract, Reduction: Mean, Span: 60 * time.Second}}
 		Expect(Suite(tbl)).To(HaveLen(6 * len(tbl.Signals)))
 
-		// A table with only tracks emits zero scenarios.
-		Expect(Suite(Table[snap]{Tracks: tbl.Tracks, Interval: time.Second})).To(BeEmpty())
+		// A table with only measurements emits zero scenarios.
+		Expect(Suite(Table[snap]{Measurements: tbl.Measurements, Interval: time.Second})).To(BeEmpty())
 	})
 
 	It("refuses a table whose instrument cannot reach its reduction's minimum within its span at the interval", func() {
@@ -152,10 +152,10 @@ var _ = Describe("Suite", func() {
 		Expect(err).ToNot(HaveOccurred(), "a p95 over 60s at 1s holds 61 entries against a minimum of 20")
 	})
 
-	It("refuses a track whose span cannot hold its reduction's minimum at the interval", func() {
+	It("refuses a measurement whose span cannot hold its reduction's minimum at the interval", func() {
 		tbl := Table[snap]{
-			Tracks:   []Track[snap]{{Name: "T", Extract: extract, Reduction: P99, Span: 60 * time.Second}},
-			Interval: time.Second,
+			Measurements: []Measurement[snap]{{Name: "T", Extract: extract, Reduction: P99, Span: 60 * time.Second}},
+			Interval:     time.Second,
 		}
 		_, err := NewEngine(tbl)
 		Expect(err).To(HaveOccurred())


### PR DESCRIPTION
Ticket: [ENG-5128](https://linear.app/united-manufacturing-hub/issue/ENG-5128/expose-p95p99-cpu-metrics-and-persist-degraded-state)

## Problem

While reviewing the CPU health PR I could not follow a code comment. I went digging and found a bad abstraction under it.

`Track` is a weird word. Nothing says how a track differs from an instrument. Tracks exist only for attribution in the cpuhealth implementation.

But attribution belongs in the signal instead, and it should be a tree. If overall CPU is fine, everything is good. If it fires, we are degraded and do not yet know who to blame. Only then is it worth looking one level down, where a firing sub-signal turns "CPU degraded" into "CPU degraded, because the container is taking a lot of CPU".

## What we are shipping

* An "instrument" is now a "measurement" plus the "marks" that judge it. A number with no marks is just a "measurement".
* "track" is removed. If you want to just record data without alerting on it, then just use a "measurement"
* A signal declares its own "attribution" instead of being something done at the end
* A signal can declare sub-signals, called "refinements". If the parent signal fires, the engine will check all the refinements for additional information of where this is coming from.
* If the "measurement" that made a signal fire can no longer be read, the signal now switches to one it can still read and judges on that one's marks. Without this it stays degraded until the original measurement comes back, which can be forever.

## What we are NOT shipping

* **No CPU vocabulary.**
* **No consumer changes.**
