### PR TITLE
Load scenario for the fsmv2 transport worker

### DIFF
--- a/umh-core/pkg/fsmv2/cmd/runner/main.go
+++ b/umh-core/pkg/fsmv2/cmd/runner/main.go
@@ -42,6 +42,15 @@ func main() {
 		listFlag     = flag.Bool("list", false, "list available scenarios and exit")
 		traceFlag    = flag.Bool("trace", false, "enable trace logging")
 		dumpStore    = flag.Bool("dump-store", false, "dump store deltas and final state after scenario")
+
+		// transport-load scenario flags. Zero means the scenario picks its own
+		// documented default; see TransportLoadConfig in examples/transport_load_scenario.go.
+		subscribers  = flag.Int("subscribers", 0, "transport-load: number of independent message streams, 0 means the scenario default (1)")
+		topicCount   = flag.Int("topic-count", 0, "transport-load: topic count that derives the payload size, 0 means payload-bytes is used instead")
+		payloadBytes = flag.Int("payload-bytes", 0, "transport-load: payload size in bytes per message when topic-count is 0, 0 means the scenario default (1024)")
+		bandwidth    = flag.Int("bandwidth", 0, "transport-load: uplink bandwidth limit in bytes per second, 0 means unthrottled")
+		burstBytes   = flag.Int("burst-bytes", 0, "transport-load: size in bytes of an oversized message sent on top of the streams, 0 means no burst")
+		burstEvery   = flag.Duration("burst-every", 0, "transport-load: interval between bursts, 0 means send the burst once")
 	)
 
 	flag.Parse()
@@ -190,6 +199,14 @@ func main() {
 		Store:              store,
 		EnableTraceLogging: *traceFlag,
 		DumpStore:          *dumpStore,
+		TransportLoad: examples.TransportLoadConfig{
+			Subscribers:             *subscribers,
+			TopicCount:              *topicCount,
+			PayloadBytes:            *payloadBytes,
+			BandwidthBytesPerSecond: *bandwidth,
+			BurstBytes:              *burstBytes,
+			BurstEvery:              *burstEvery,
+		},
 	})
 	if err != nil {
 		if isCleanInterruptExit(err, ctx.Err()) {

--- a/umh-core/pkg/fsmv2/examples/scenario.go
+++ b/umh-core/pkg/fsmv2/examples/scenario.go
@@ -177,18 +177,19 @@ type Scenario struct {
 // Registry contains all available scenarios.
 // Add new scenarios here to make them available in both tests and CLI.
 var Registry = map[string]Scenario{
-	"helloworld":   HelloworldScenario,
-	"simple":       SimpleScenario,
-	"failing":      FailingScenario,
-	"panic":        PanicScenario,
-	"slow":         SlowScenario,
-	"cascade":      CascadeScenario,
-	"timeout":      TimeoutScenario,
-	"configerror":  ConfigErrorScenario,
-	"inheritance":  InheritanceScenario,
-	"communicator": CommunicatorScenarioEntry,
-	"concurrent":   ConcurrentScenario,
-	"persistence":  PersistenceScenarioEntry,
+	"helloworld":     HelloworldScenario,
+	"simple":         SimpleScenario,
+	"failing":        FailingScenario,
+	"panic":          PanicScenario,
+	"slow":           SlowScenario,
+	"cascade":        CascadeScenario,
+	"timeout":        TimeoutScenario,
+	"configerror":    ConfigErrorScenario,
+	"inheritance":    InheritanceScenario,
+	"communicator":   CommunicatorScenarioEntry,
+	"concurrent":     ConcurrentScenario,
+	"persistence":    PersistenceScenarioEntry,
+	"transport-load": TransportLoadScenarioEntry,
 }
 
 // CommunicatorScenarioEntry registers the communicator scenario for CLI access.
@@ -302,12 +303,16 @@ var PersistenceScenarioEntry = Scenario{
 
 // RunConfig configures how a scenario is executed.
 type RunConfig struct {
-	Store        storage.TriangularStoreInterface
-	Logger       deps.FSMLogger
-	Scenario     Scenario
-	ScenarioV2   ScenarioV2    // When Driver is set, Run takes the v2 kernel-only path
-	Duration     time.Duration // 0 means run forever (until context cancelled)
-	TickInterval time.Duration
+	Store      storage.TriangularStoreInterface
+	Logger     deps.FSMLogger
+	Scenario   Scenario
+	ScenarioV2 ScenarioV2 // When Driver is set, Run takes the v2 kernel-only path
+	// TransportLoad configures the offered load and the uplink rate for the
+	// transport-load scenario. Other scenarios ignore it. The zero value is a
+	// valid load; see TransportLoadConfig for what each field defaults to.
+	TransportLoad TransportLoadConfig
+	Duration      time.Duration // 0 means run forever (until context cancelled)
+	TickInterval  time.Duration
 	// GracefulShutdownTimeout is the per-level drain base propagated to the
 	// supervisor subtree. Zero falls back to the supervisor default (5s). A
 	// tiny value forces a degraded drain, which is how tests exercise the

--- a/umh-core/pkg/fsmv2/examples/transport_load_scenario.go
+++ b/umh-core/pkg/fsmv2/examples/transport_load_scenario.go
@@ -162,7 +162,10 @@ func RunTransportLoadScenario(ctx context.Context, cfg TransportRunConfig, load 
 		}()
 	}
 
-	go stopLoad(result, cancelLoad, &streams, cleanup)
+	loadStopped := make(chan struct{})
+	result.LoadStopped = loadStopped
+
+	go stopLoad(result, cancelLoad, &streams, cleanup, loadStopped)
 
 	return result
 }
@@ -172,16 +175,24 @@ func RunTransportLoadScenario(ctx context.Context, cfg TransportRunConfig, load 
 // After the run ends nothing reads the outbound channel any more, so a stream
 // parked on a full queue would never return. Draining the channel until every
 // stream has stopped releases them, which is what leaves no goroutine behind.
-func stopLoad(result *TransportRunResult, cancelLoad context.CancelFunc, streams *sync.WaitGroup, cleanup func()) {
+func stopLoad(
+	result *TransportRunResult,
+	cancelLoad context.CancelFunc,
+	streams *sync.WaitGroup,
+	cleanup func(),
+	stopped chan<- struct{},
+) {
+	defer close(stopped)
+
 	<-result.Done
 
 	cancelLoad()
 
-	stopped := make(chan struct{})
+	drained := make(chan struct{})
 
 	go func() {
 		streams.Wait()
-		close(stopped)
+		close(drained)
 	}()
 
 	_, outbound := result.ChannelProvider.GetChannels("")
@@ -189,7 +200,7 @@ func stopLoad(result *TransportRunResult, cancelLoad context.CancelFunc, streams
 	for {
 		select {
 		case <-outbound:
-		case <-stopped:
+		case <-drained:
 			cleanup()
 
 			return

--- a/umh-core/pkg/fsmv2/examples/transport_load_scenario.go
+++ b/umh-core/pkg/fsmv2/examples/transport_load_scenario.go
@@ -1,0 +1,222 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package examples
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/communicator/testutil"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/types"
+)
+
+// Payload size of a status message carrying N topics: statusEnvelopeBytes for
+// everything that is not a topic, plus statusBytesPerTopic per topic. Both are
+// measured from real status messages and are orders of magnitude - about ten
+// kilobytes of envelope, a couple of hundred bytes per topic - not limits.
+const (
+	statusEnvelopeBytes = 8900
+	statusBytesPerTopic = 190
+)
+
+// defaultPayloadBytes applies when the caller sets neither TopicCount nor PayloadBytes.
+const defaultPayloadBytes = 1024
+
+// TransportLoadConfig describes the load offered to the transport worker and
+// the uplink it runs against.
+type TransportLoadConfig struct {
+	Subscribers             int           // independent streams, each offering one message per second
+	TopicCount              int           // when non-zero, derives the payload size
+	PayloadBytes            int           // payload size when TopicCount is zero
+	BurstBytes              int           // one oversized message on top of the streams
+	BurstEvery              time.Duration // 0 means send the burst once
+	BandwidthBytesPerSecond int           // 0 means unthrottled
+}
+
+// TransportLoadScenarioEntry registers the transport-load scenario for CLI access.
+//
+// The worker runs the configuration it ships with; only the offered load and the
+// uplink rate vary. Set RunConfig.TransportLoad to choose them. A CLI run gets the
+// zero value: one stream of 1 KiB messages against an unthrottled server.
+var TransportLoadScenarioEntry = Scenario{
+	Name:        "transport-load",
+	Description: "Tests FSMv2 transport worker under offered load against a bandwidth-limited mock server",
+	CustomRunner: func(ctx context.Context, cfg RunConfig) (*RunResult, error) {
+		result := RunTransportLoadScenario(ctx, TransportRunConfig{
+			Duration:     cfg.Duration,
+			TickInterval: cfg.TickInterval,
+			Logger:       cfg.Logger,
+		}, cfg.TransportLoad)
+
+		if result.Error != nil {
+			return nil, result.Error
+		}
+
+		done := make(chan struct{})
+		wrapped := &RunResult{Done: done, Shutdown: result.Shutdown}
+
+		go func() {
+			<-result.Done
+			wrapped.ShutdownClean = result.ShutdownClean
+			close(done)
+		}()
+
+		return wrapped, nil
+	},
+}
+
+// RunTransportLoadScenario runs the FSMv2 transport worker under offered load.
+//
+// Messages are queued onto the live outbound channel while the run is in progress,
+// never seeded before it starts, so the worker keeps the outbound capacity it ships
+// with and the streams keep the queue near that capacity.
+//
+// A caller that supplies cfg.MockServer owns it and its uplink is left untouched,
+// so BandwidthBytesPerSecond then has no effect.
+func RunTransportLoadScenario(ctx context.Context, cfg TransportRunConfig, load TransportLoadConfig) *TransportRunResult {
+	subscribers := load.Subscribers
+	if subscribers == 0 {
+		subscribers = 1
+	}
+
+	payloadBytes := load.PayloadBytes
+
+	switch {
+	case load.TopicCount > 0:
+		payloadBytes = statusEnvelopeBytes + load.TopicCount*statusBytesPerTopic
+	case payloadBytes == 0:
+		payloadBytes = defaultPayloadBytes
+	}
+
+	cleanup := func() {}
+
+	if cfg.MockServer == nil {
+		server := testutil.NewMockRelayServer()
+		server.SimulateBandwidthLimitation(load.BandwidthBytesPerSecond)
+		cfg.MockServer = server
+		cleanup = server.Close
+	}
+
+	logger := cfg.Logger
+	if logger == nil {
+		logger = deps.NewNopFSMLogger()
+	}
+
+	logger.Info("transport_load_params",
+		deps.Int("subscribers", subscribers),
+		deps.Int("payload_bytes", payloadBytes),
+		deps.Int("topic_count", load.TopicCount),
+		deps.Int("burst_bytes", load.BurstBytes),
+		deps.Duration("burst_every", load.BurstEvery),
+		deps.Int("bandwidth_bytes_per_second", load.BandwidthBytesPerSecond),
+	)
+
+	result := RunTransportScenario(ctx, cfg)
+
+	if result.Error != nil {
+		cleanup()
+
+		return result
+	}
+
+	loadCtx, cancelLoad := context.WithCancel(ctx)
+
+	var streams sync.WaitGroup
+
+	for range subscribers {
+		streams.Add(1)
+
+		go func() {
+			defer streams.Done()
+
+			offerStream(loadCtx, result.ChannelProvider, time.Second, payloadBytes)
+		}()
+	}
+
+	if load.BurstBytes > 0 {
+		streams.Add(1)
+
+		go func() {
+			defer streams.Done()
+
+			if load.BurstEvery == 0 {
+				offerMessage(result.ChannelProvider, load.BurstBytes)
+			} else {
+				offerStream(loadCtx, result.ChannelProvider, load.BurstEvery, load.BurstBytes)
+			}
+		}()
+	}
+
+	go stopLoad(result, cancelLoad, &streams, cleanup)
+
+	return result
+}
+
+// stopLoad ends the offered load once the run completes.
+//
+// After the run ends nothing reads the outbound channel any more, so a stream
+// parked on a full queue would never return. Draining the channel until every
+// stream has stopped releases them, which is what leaves no goroutine behind.
+func stopLoad(result *TransportRunResult, cancelLoad context.CancelFunc, streams *sync.WaitGroup, cleanup func()) {
+	<-result.Done
+
+	cancelLoad()
+
+	stopped := make(chan struct{})
+
+	go func() {
+		streams.Wait()
+		close(stopped)
+	}()
+
+	_, outbound := result.ChannelProvider.GetChannels("")
+
+	for {
+		select {
+		case <-outbound:
+		case <-stopped:
+			cleanup()
+
+			return
+		}
+	}
+}
+
+// offerMessage queues one message of the given payload size. It blocks while the
+// outbound queue is full, which is the backpressure under test.
+func offerMessage(provider *TransportTestChannelProvider, payloadBytes int) {
+	provider.QueueOutbound(&types.UMHMessage{
+		InstanceUUID: "test-instance-uuid",
+		Content:      strings.Repeat("x", payloadBytes),
+	})
+}
+
+// offerStream queues one message of the given payload size every interval, until ctx ends.
+func offerStream(ctx context.Context, provider *TransportTestChannelProvider, interval time.Duration, payloadBytes int) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			offerMessage(provider, payloadBytes)
+		}
+	}
+}

--- a/umh-core/pkg/fsmv2/examples/transport_load_scenario_test.go
+++ b/umh-core/pkg/fsmv2/examples/transport_load_scenario_test.go
@@ -1,0 +1,72 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package examples_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/examples"
+	transportWorker "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport"
+)
+
+// The transport-load scenario has no pass condition yet. What load the product
+// must sustain is not decided, so this spec asserts only that the scenario
+// completes and shuts down cleanly. Rows pinning an envelope belong here later,
+// as a DescribeTable.
+//
+// The load is chosen so that shutdown is the hard case rather than the easy one.
+// Several streams against an uplink far too slow for them leave the outbound
+// channel full at the moment the run ends, and nothing reads that channel after
+// the worker stops. A stream still parked on a send would then never return, so
+// a regression in the scenario's own teardown appears here as Done never
+// closing.
+var _ = Describe("Transport Load Scenario", func() {
+	var ctx context.Context
+	var cancel context.CancelFunc
+
+	BeforeEach(func() {
+		ctx, cancel = context.WithTimeout(context.Background(), 35*time.Second)
+	})
+
+	AfterEach(func() {
+		cancel()
+		// SetChannelProvider is process-global, so leaving it set pollutes every
+		// later spec in this package.
+		transportWorker.ClearChannelProvider()
+	})
+
+	It("completes and drains its own streams when the uplink cannot keep up", func() {
+		result := examples.RunTransportLoadScenario(ctx,
+			examples.TransportRunConfig{Duration: 3 * time.Second},
+			examples.TransportLoadConfig{
+				Subscribers:             4,
+				PayloadBytes:            32 * 1024,
+				BandwidthBytesPerSecond: 4096,
+			})
+
+		Expect(result.Error).NotTo(HaveOccurred())
+		Eventually(result.Done, GracefulShutdownCascadingTimeout).Should(BeClosed())
+		Expect(result.ShutdownClean).To(BeTrue())
+
+		// Teardown outlives the run, so Done alone proves nothing about it.
+		// Deleting the channel drain in stopLoad leaves the streams parked on a
+		// full queue for ever, and this is the assertion that then fails.
+		Eventually(result.LoadStopped, GracefulShutdownCascadingTimeout).Should(BeClosed())
+	})
+})

--- a/umh-core/pkg/fsmv2/examples/transport_scenario.go
+++ b/umh-core/pkg/fsmv2/examples/transport_scenario.go
@@ -105,6 +105,7 @@ type TransportRunResult struct {
 	PushedMessages    []*types.UMHMessage           // Messages pushed to HTTP
 	ConsecutiveErrors int                           // Final consecutive error count from mock server
 	AuthCallCount     int                           // Auth endpoint calls (>1 indicates re-auth)
+	ShutdownClean     bool                          // Whether the supervisor drained cleanly; read after Done closes
 }
 
 // RunTransportScenario runs the FSMv2 transport worker via ApplicationSupervisor with a mock relay server.
@@ -264,6 +265,7 @@ children:
 
 		result.PushedMessages = mockServer.GetPushedMessages()
 		result.AuthCallCount = mockServer.AuthCallCount()
+		result.ShutdownClean = runResult.ShutdownClean
 
 		if channelProvider != nil {
 			transportWorker.ClearChannelProvider()

--- a/umh-core/pkg/fsmv2/examples/transport_scenario.go
+++ b/umh-core/pkg/fsmv2/examples/transport_scenario.go
@@ -86,24 +86,25 @@ drainLoop:
 
 // TransportRunConfig configures a transport scenario run with a mock relay server.
 type TransportRunConfig struct {
-	Logger                  deps.FSMLogger             // If nil, creates a no-op logger
+	Logger                  deps.FSMLogger            // If nil, creates a no-op logger
 	MockServer              *testutil.MockRelayServer // If nil, creates and manages internally; caller closes if provided
 	AuthToken               string                    // Defaults to "test-auth-token"
-	InitialPullMessages     []*types.UMHMessage   // Messages queued for transport to pull
-	InitialOutboundMessages []*types.UMHMessage   // Messages queued for worker to push
+	InitialPullMessages     []*types.UMHMessage       // Messages queued for transport to pull
+	InitialOutboundMessages []*types.UMHMessage       // Messages queued for worker to push
 	Duration                time.Duration             // 0 = run until context cancelled; negative = error
 	TickInterval            time.Duration             // Defaults to 100ms
 }
 
 // TransportRunResult contains observable results after scenario completion (populated after Done closes).
 type TransportRunResult struct {
-	Error             error                   // Non-nil if scenario setup failed
-	Done              <-chan struct{}         // Closes when scenario completes
-	Shutdown          func()                  // Triggers graceful shutdown
-	ReceivedMessages  []*types.UMHMessage // Messages pulled from HTTP (nil for HTTP-only tests)
-	PushedMessages    []*types.UMHMessage // Messages pushed to HTTP
-	ConsecutiveErrors int                     // Final consecutive error count from mock server
-	AuthCallCount     int                     // Auth endpoint calls (>1 indicates re-auth)
+	Error             error                         // Non-nil if scenario setup failed
+	Done              <-chan struct{}               // Closes when scenario completes
+	Shutdown          func()                        // Triggers graceful shutdown
+	ChannelProvider   *TransportTestChannelProvider // Queues onto the worker's outbound channel; unlike the fields below, valid immediately
+	ReceivedMessages  []*types.UMHMessage           // Messages pulled from HTTP (nil for HTTP-only tests)
+	PushedMessages    []*types.UMHMessage           // Messages pushed to HTTP
+	ConsecutiveErrors int                           // Final consecutive error count from mock server
+	AuthCallCount     int                           // Auth endpoint calls (>1 indicates re-auth)
 }
 
 // RunTransportScenario runs the FSMv2 transport worker via ApplicationSupervisor with a mock relay server.
@@ -186,7 +187,6 @@ children:
         relayURL: "%s"
         instanceUUID: "test-instance-uuid"
         authToken: "%s"
-        timeout: "5s"
 `, serverURL, authToken)
 
 	testScenario := Scenario{
@@ -233,9 +233,10 @@ children:
 	}
 
 	result := &TransportRunResult{
-		Done:     done,
-		Shutdown: runResult.Shutdown,
-		Error:    nil,
+		Done:            done,
+		Shutdown:        runResult.Shutdown,
+		Error:           nil,
+		ChannelProvider: channelProvider,
 	}
 
 	go func() {

--- a/umh-core/pkg/fsmv2/examples/transport_scenario.go
+++ b/umh-core/pkg/fsmv2/examples/transport_scenario.go
@@ -106,6 +106,11 @@ type TransportRunResult struct {
 	ConsecutiveErrors int                           // Final consecutive error count from mock server
 	AuthCallCount     int                           // Auth endpoint calls (>1 indicates re-auth)
 	ShutdownClean     bool                          // Whether the supervisor drained cleanly; read after Done closes
+	// LoadStopped closes once a scenario that offers its own load has stopped
+	// offering it and released what it created. Nil for scenarios that offer no
+	// load, which is every scenario that does not set it. Done closing is not
+	// enough to wait on: teardown outlives the run.
+	LoadStopped <-chan struct{}
 }
 
 // RunTransportScenario runs the FSMv2 transport worker via ApplicationSupervisor with a mock relay server.

--- a/umh-core/pkg/fsmv2/workers/communicator/testutil/mockserver.go
+++ b/umh-core/pkg/fsmv2/workers/communicator/testutil/mockserver.go
@@ -39,7 +39,11 @@ type MockRelayServer struct {
 	authCalls         int
 	nextError         int
 	slowDelay         time.Duration
-	mu                sync.Mutex
+	// bandwidthBytesPerSecond stays in effect until changed, where nextError and
+	// slowDelay above clear themselves after one request. Set by
+	// SimulateBandwidthLimitation, which describes what it does.
+	bandwidthBytesPerSecond int
+	mu                      sync.Mutex
 }
 
 // NewMockRelayServer creates and starts a new mock relay server.
@@ -74,6 +78,27 @@ func (m *MockRelayServer) handler(w http.ResponseWriter, r *http.Request) {
 	m.mu.Lock()
 	m.connectionHeaders = append(m.connectionHeaders, r.Header.Get("Connection"))
 	m.mu.Unlock()
+
+	// Hold requests whose body has a declared length, to simulate a bandwidth-limited
+	// uplink rather than a slow server: a bigger body waits longer. This has no path
+	// exemption, unlike the error/slow-response faults below. It does not need one:
+	// keying the hold on body size already confines its effect to push, since push is
+	// the only endpoint whose request declares a length. login has no body and pull is
+	// a GET with a nil body, so both report zero bytes, and zero bytes at any rate is
+	// no delay.
+	m.mu.Lock()
+	bytesPerSecond := m.bandwidthBytesPerSecond
+	m.mu.Unlock()
+
+	if bytesPerSecond > 0 && r.ContentLength > 0 {
+		holdDuration := time.Duration(r.ContentLength) * time.Second / time.Duration(bytesPerSecond)
+
+		select {
+		case <-time.After(holdDuration):
+		case <-r.Context().Done():
+			return
+		}
+	}
 
 	// Check for injected errors (except for login endpoint)
 	if r.URL.Path != "/v2/instance/login" {
@@ -278,6 +303,18 @@ func (m *MockRelayServer) SimulateSlowResponse(delay time.Duration) {
 	defer m.mu.Unlock()
 
 	m.slowDelay = delay
+}
+
+// SimulateBandwidthLimitation models a slow uplink rather than a slow server: every
+// request whose body has a declared length is held for ContentLength/maxBytesPerSecond
+// before it is answered, so a bigger request takes proportionally longer. Unlike
+// SimulateServerError and SimulateSlowResponse, it is not one-time — it stays in effect
+// for every request until changed. Pass 0 to disable it.
+func (m *MockRelayServer) SimulateBandwidthLimitation(maxBytesPerSecond int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.bandwidthBytesPerSecond = maxBytesPerSecond
 }
 
 // GetReceivedConnectionHeaders returns all Connection headers received from requests.

--- a/umh-core/pkg/fsmv2/workers/communicator/testutil/mockserver.go
+++ b/umh-core/pkg/fsmv2/workers/communicator/testutil/mockserver.go
@@ -44,6 +44,12 @@ type MockRelayServer struct {
 	// SimulateBandwidthLimitation, which describes what it does.
 	bandwidthBytesPerSecond int
 	mu                      sync.Mutex
+	// closing is closed once, at the start of Close, to release any request
+	// parked in the bandwidth hold below. Without it, Close waits out the
+	// full hold of every in-flight request, since nothing else cancels their
+	// contexts.
+	closing     chan struct{}
+	closingOnce sync.Once
 }
 
 // NewMockRelayServer creates and starts a new mock relay server.
@@ -56,6 +62,7 @@ func NewMockRelayServer() *MockRelayServer {
 		// Bug #6 fix: Default backend UUID - different from any placeholder UUID
 		backendUUID: "backend-real-uuid-12345678",
 		backendName: "Mock Instance Name",
+		closing:     make(chan struct{}),
 	}
 
 	m.server = httptest.NewServer(http.HandlerFunc(m.handler))
@@ -96,6 +103,8 @@ func (m *MockRelayServer) handler(w http.ResponseWriter, r *http.Request) {
 		select {
 		case <-time.After(holdDuration):
 		case <-r.Context().Done():
+			return
+		case <-m.closing:
 			return
 		}
 	}
@@ -240,8 +249,13 @@ func (m *MockRelayServer) URL() string {
 	return m.server.URL
 }
 
-// Close shuts down the mock server.
+// Close shuts down the mock server. Safe to call more than once: it releases
+// any request parked in the bandwidth hold before waiting for handlers to
+// return, so a closing server never blocks on its own held requests.
 func (m *MockRelayServer) Close() {
+	m.closingOnce.Do(func() {
+		close(m.closing)
+	})
 	m.server.Close()
 }
 

--- a/umh-core/pkg/fsmv2/workers/communicator/testutil/mockserver_test.go
+++ b/umh-core/pkg/fsmv2/workers/communicator/testutil/mockserver_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -314,6 +315,48 @@ var _ = Describe("MockRelayServer", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			_ = resp.Body.Close()
+		})
+	})
+
+	Describe("Bandwidth Limitation", func() {
+		It("holds a larger push body measurably longer than a smaller one at the same rate", func() {
+			server.SimulateBandwidthLimitation(1_000_000) // 1 MB/s
+
+			push := func(contentSize int) time.Duration {
+				msg := &types.UMHMessage{
+					InstanceUUID: "test-instance-123",
+					Content:      strings.Repeat("x", contentSize),
+					Email:        "test@example.com",
+				}
+				payload := struct {
+					UMHMessages []*types.UMHMessage `json:"UMHMessages"`
+				}{
+					UMHMessages: []*types.UMHMessage{msg},
+				}
+				body, err := json.Marshal(payload)
+				Expect(err).NotTo(HaveOccurred())
+
+				req, err := http.NewRequest(http.MethodPost, server.URL()+"/v2/instance/push", bytes.NewReader(body))
+				Expect(err).NotTo(HaveOccurred())
+				req.Header.Set("Content-Type", "application/json")
+				req.AddCookie(&http.Cookie{Name: "token", Value: "test-jwt-token"})
+
+				client := &http.Client{}
+
+				start := time.Now()
+				resp, err := client.Do(req)
+				elapsed := time.Since(start)
+				Expect(err).NotTo(HaveOccurred())
+				defer func() { _ = resp.Body.Close() }()
+				Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+				return elapsed
+			}
+
+			smallElapsed := push(10)
+			largeElapsed := push(300_000)
+
+			Expect(largeElapsed - smallElapsed).To(BeNumerically(">", 200*time.Millisecond))
 		})
 	})
 


### PR DESCRIPTION
## Problem

Nobody can say what load a umh-core instance supports. When an instance reports its outbound message channel full, the only evidence available is an agent log after the fact, and there is no way to reproduce the behaviour, show it to anyone, or state the supported envelope.

There is also no way to measure whether the cost of a push grows with the number of bytes or the number of messages, because the fake relay server used in tests could only delay a request by a fixed amount. A delay that does not scale with the variable under test can only ever report "no effect".

## Shipping

A `transport-load` scenario for the fsmv2 CLI runner. It drives the real transport worker, under a real supervisor, against the fake relay server, at a load and an uplink rate you choose:

```
go run ./pkg/fsmv2/cmd/runner --scenario transport-load --duration 60s \
  --subscribers 5 --topic-count 4000 --bandwidth 200000 --burst-bytes 50000 --burst-every 30s
```

- **Load**: `--subscribers` streams offering one message per second each, at `--payload-bytes`, or at a size derived from `--topic-count` as `8900 + topics*190`. Both constants are measured and give an order of magnitude; neither is a limit.
- **Bursts**: `--burst-bytes` with `--burst-every` models the two real events that deliver a large payload at once — a Console session opening, and a log tab fetching every line since a start time.
- **Uplink**: `SimulateBandwidthLimitation` on the fake server holds each request for `ContentLength/rate`, so a bigger request is genuinely slower. It needs no path exemption: pull is a GET with a nil body and login has none, so a size-derived hold reaches only the push endpoint.
- **Output**: the worker's own log lines, plus exactly one line echoing the resolved parameters. No counters and no derived rates, so a scenario log and an agent log from the field contain the same strings.

The scenario sets load and uplink rate only. It configures no timeout, no queue capacity and no retry policy, so the worker runs the configuration that ships — this PR also deletes a `timeout: "5s"` the harness had been injecting, which matched nothing in production.

## NOT shipping

- **No production code change and no fix.** Every change is to test scenarios, the fake server, and the runner CLI.
- **No pass condition.** What load the product must sustain is undecided. The one spec asserts only that the scenario completes and stops the streams it started. Rows pinning an envelope belong in that file later, as a table.
- **The action-reply path is not covered.** A status message and an action reply are both `types.UMHMessage` on the outbound channel and the transport worker cannot tell them apart; the reply-specific defects live outside this worker tree.
- **Payload growth is not reproduced.** Payload size here is a parameter, not an emergent property.

## Notes for review

Two of the seven commits exist because the smoke spec was broken on purpose to see whether it could fail, and it could not:

- Teardown runs in a goroutine that outlives the run, so `Done` closing said nothing about it. Deleting the channel drain left every stream parked on a full queue and no assertion noticed. `TransportRunResult.LoadStopped` now closes when teardown finishes, and the spec waits on that.
- With that fixed, the spec failed for a real reason. The bandwidth hold could only be released by cancelling the request, and nothing cancels those requests when a scenario closes the server it created, while `httptest.Server.Close` blocks until every handler returns. The fake server now releases parked requests when it closes.

Four findings outside this branch's scope were recorded during the work and need tickets: below-Warn log records are sampled, so counting INFO log lines is unsound in any investigation; a sustained uplink stall leaves the push worker reporting `Running` with no degrade; `TotalMessagesPushed`/`TotalMessagesPulled` are always zero; and `--trace`/`--dump-store` are silently ignored for every `CustomRunner` scenario.

Test-only change with no user-visible behaviour, so this needs the `skip-changelog-guard` label rather than a changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
