### PR TITLE
fix(router): read the resubscribed flag from the decoded subscribe payload

### DIFF
--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- An instance now rebuilds its full topic-browser cache for a console session once, when that session first subscribes, instead of every ten seconds for as long as it stays open. The console says whether a subscribe is a refresh, and that flag was never read, so every refresh was treated as a first-time subscriber. On an instance with many topics the rebuild is large enough to miss its one-second budget, and a session that misses it receives no status message at all and shows the instance as offline
+
 ## [0.44.35]
 
 ### Improvements

--- a/umh-core/pkg/communicator/router/handle_sub_test.go
+++ b/umh-core/pkg/communicator/router/handle_sub_test.go
@@ -1,0 +1,65 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package router
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/models"
+)
+
+var _ = Describe("resubscribedFromPayload", func() {
+	It("reads resubscribed from a decoded JSON payload", func() {
+		resubscribed, err := resubscribedFromPayload(map[string]interface{}{"resubscribed": true})
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resubscribed).To(BeTrue())
+	})
+
+	It("reports a new subscriber when the payload says so", func() {
+		resubscribed, err := resubscribedFromPayload(map[string]interface{}{"resubscribed": false})
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resubscribed).To(BeFalse())
+	})
+
+	It("reports a new subscriber for a payload without the field", func() {
+		resubscribed, err := resubscribedFromPayload(map[string]interface{}{})
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resubscribed).To(BeFalse())
+	})
+
+	It("reports a new subscriber for an absent payload", func() {
+		resubscribed, err := resubscribedFromPayload(nil)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resubscribed).To(BeFalse())
+	})
+
+	It("errors on a payload that is not a decoded object", func() {
+		_, err := resubscribedFromPayload("resubscribed")
+
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("still reads an already-typed payload", func() {
+		resubscribed, err := resubscribedFromPayload(models.SubscribeMessagePayload{Resubscribed: true})
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resubscribed).To(BeTrue())
+	})
+})

--- a/umh-core/pkg/communicator/router/router.go
+++ b/umh-core/pkg/communicator/router/router.go
@@ -15,6 +15,7 @@
 package router
 
 import (
+	"fmt"
 	"sync"
 	"time"
 
@@ -159,15 +160,41 @@ func (r *Router) handleSub(message *models.UMHMessage, messageContent models.UMH
 		return
 	}
 
-	var subscribePayload models.SubscribeMessagePayload
-	if messageContent.Payload != nil {
-		// Try direct type assertion first
-		if payload, ok := messageContent.Payload.(models.SubscribeMessagePayload); ok {
-			subscribePayload = payload
-		}
+	resubscribed, err := resubscribedFromPayload(messageContent.Payload)
+	if err != nil {
+		r.routerLogger.Warnf("Treating subscriber %s as new: %v", message.Email, err)
 	}
 
-	r.subHandler.AddOrRefreshSubscriber(message.Email, subscribePayload.Resubscribed)
+	r.subHandler.AddOrRefreshSubscriber(message.Email, resubscribed)
+}
+
+// resubscribedFromPayload reads the resubscribed flag from a subscribe payload.
+//
+// The payload arrives JSON-decoded, so it is a map and not the struct. Asserting it
+// straight to the struct always fails, and the zero value it leaves behind reports
+// every refresh as a new subscriber, which costs a full topic-cache bundle each time.
+// A false return is the safe error case: an unnecessary bundle is wasteful, while a
+// wrong true leaves a genuinely new subscriber with no cache at all.
+func resubscribedFromPayload(payload any) (bool, error) {
+	if payload == nil {
+		return false, nil
+	}
+
+	if typed, ok := payload.(models.SubscribeMessagePayload); ok {
+		return typed.Resubscribed, nil
+	}
+
+	payloadMap, ok := payload.(map[string]interface{})
+	if !ok {
+		return false, fmt.Errorf("subscribe payload is %T, not a decoded object", payload)
+	}
+
+	var subscribePayload models.SubscribeMessagePayload
+	if err := maptostruct.MapToStruct(payloadMap, &subscribePayload); err != nil {
+		return false, fmt.Errorf("failed to convert payload into SubscribeMessagePayload: %w", err)
+	}
+
+	return subscribePayload.Resubscribed, nil
 }
 
 func (r *Router) handleAction(messageContent models.UMHMessageContent, message *models.UMHMessage, watcherUUID uuid.UUID) {

--- a/umh-core/pkg/communicator/router/router_suite_test.go
+++ b/umh-core/pkg/communicator/router/router_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package router
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestRouter(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Router Suite")
+}


### PR DESCRIPTION
## Problem

`handleSub` asserts `messageContent.Payload` straight to `models.SubscribeMessagePayload`. The payload arrives JSON-decoded, so it is a `map[string]interface{}` and that assertion never succeeds — `Resubscribed` is always the zero value, and every subscribe looks like a new subscriber.

The console re-subscribes each instance every ten seconds and sets that flag correctly. Because it is never read, the registry clears `Bootstrapped` on every refresh, and each clear makes `notify()` rebuild the entire topic-browser cache for that subscriber: every event, every topic, a fresh `proto.Marshal`. The comment above `handleSub` already warns this is what the flag exists to avoid.

On an instance with many topics that rebuild can miss the one-second budget the notify loop shares across subscribers. A subscriber that misses it gets no status message, so the console shows the instance as offline — and the retry costs the same, because pending buffers are only trimmed after a delivery succeeds.

## What we are shipping

- The subscribe payload is decoded the way `handleAction` in the same file already decodes its own, so a refresh is recognised as a refresh.
- Specs covering the decode, including the JSON-map shape that regressed. A build with only the direct assertion now fails.

The direct assertion stays as the first branch, so an already-typed payload still works and the comment describing that branch is accurate again.

## What we are NOT shipping

- **The one-second budget and the trimming**, both in `pkg/communicator/pkg/subscriber/subscribers.go`. The budget is shared across every subscriber, so one slow bootstrap starves the rest, and `MarkDataAsSent` runs only when a delivery succeeded, so a failed send also blocks the cleanup that would make the retry cheaper. Both change delivery timing and want their own PR.
- **A confirmed diagnosis of ENG-5703.** This is the amplifier that turns a short subscription gap into a long one, and it has been live since `7f35cbe85` (2025-07-18) — so it cannot be what made the symptom appear this month. The trigger is on the console side and is in ManagementConsole#3471. Confirming this half means finding `context deadline exceeded` from `subscribers.go:174`, or the outbound-channel-full warning at `:205`, in the reporter's window.
- **Any change to `AddOrRefresh` clearing `Bootstrapped`.** I had planned it and dropped it: once the flag is read, clearing on an explicit `resubscribed: false` is the correct signal — that is how a console that lost its cache asks for a fresh one.

Refs ENG-5703
