### PR TITLE
feat: topic validation enforcement for write flows

### DIFF
--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Improvements
+
+- A write flow can now only subscribe to topics beneath the location of its own bridge, so a bridge at `enterprise.site.line` no longer reads data from elsewhere in the hierarchy. Existing write flows that subscribe outside their location stop writing after the upgrade and name the offending topics in the bridge's status, and the bridge's read flow keeps running while the topics are corrected
+
 ## [0.44.35]
 
 ### Improvements

--- a/umh-core/internal/fsmtest/protocolconverter.go
+++ b/umh-core/internal/fsmtest/protocolconverter.go
@@ -54,7 +54,20 @@ var (
 
 	goodDataflowComponentWriteConfig = dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
 		Source: dataflowcomponentserviceconfig.WriteConfigSource{
-			Topics: "umh.v1.test.*",
+			// Beneath the agent location the harness sets ("test-location"), as the
+			// topic hierarchy check requires.
+			Topics: "umh.v1.test-location.*",
+		},
+		Destination: dataflowcomponentserviceconfig.WriteConfigDestination{
+			Protocol: "stdout",
+		},
+	}
+
+	// outsideLocationDataflowComponentWriteConfig subscribes above the bridge location the
+	// harness sets, which the topic hierarchy check rejects.
+	outsideLocationDataflowComponentWriteConfig = dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
+		Source: dataflowcomponentserviceconfig.WriteConfigSource{
+			Topics: "umh.v1.some-other-location.*",
 		},
 		Destination: dataflowcomponentserviceconfig.WriteConfigDestination{
 			Protocol: "stdout",
@@ -96,6 +109,22 @@ func CreateProtocolConverterTestConfig(name string, desiredState string) config.
 			},
 		},
 	}
+}
+
+// SetupProtocolConverterInstanceWithOutsideLocationWriteTopics creates and configures a
+// ProtocolConverter instance whose write flow topics lie outside the bridge location, which
+// the topic hierarchy check rejects. Returns the instance, the mock service, and the config.
+func SetupProtocolConverterInstanceWithOutsideLocationWriteTopics(serviceName string, desiredState string) (*protocolconverterfsm.ProtocolConverterInstance, *protocolconvertersvc.MockProtocolConverterService, config.ProtocolConverterConfig) {
+	cfg := CreateProtocolConverterTestConfig(serviceName, desiredState)
+	cfg.ProtocolConverterServiceConfig.Config.DataflowComponentWriteServiceConfig = outsideLocationDataflowComponentWriteConfig
+
+	mockService := protocolconvertersvc.NewMockProtocolConverterService()
+	mockService.ExistingComponents = map[string]bool{serviceName: true}
+	ConfigureProtocolConverterServiceConfig(mockService)
+
+	instance := setUpMockProtocolConverterInstance(cfg, mockService, serviceregistry.NewMockRegistry())
+
+	return instance, mockService, cfg
 }
 
 // CreateProtocolConverterTestConfigWithMissingDfc creates a standard ProtocolConverter config for testing

--- a/umh-core/pkg/communicator/actions/deploy-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/deploy-protocolconverter.go
@@ -178,6 +178,14 @@ func (a *DeployProtocolConverterAction) Execute() (interface{}, map[string]inter
 	// currently, we canot reuse templates, so we need to create a new one
 	pcConfig.ProtocolConverterServiceConfig.TemplateRef = pcConfig.Name
 
+	if err := validateWriteTopicHierarchy(pcConfig, a.systemSnapshotManager); err != nil {
+		errorMsg := fmt.Sprintf("Invalid write flow configuration: %v", err)
+		SendActionReply(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedWithFailure,
+			errorMsg, a.outboundChannel, models.DeployProtocolConverter)
+
+		return nil, nil, fmt.Errorf("%s", errorMsg)
+	}
+
 	// Add to configuration
 	ctx, cancel := context.WithTimeout(context.Background(), constants.ActionTimeout)
 	defer cancel()

--- a/umh-core/pkg/communicator/actions/deploy-protocolconverter_test.go
+++ b/umh-core/pkg/communicator/actions/deploy-protocolconverter_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/communicator/actions"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/dataflowcomponentserviceconfig"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/models"
 )
 
@@ -247,6 +248,51 @@ var _ = Describe("DeployProtocolConverter", func() {
 	})
 
 	Describe("Execute", func() {
+		// deployWithWriteTopics deploys a bridge at pcLocation whose write flow subscribes
+		// to the given topics, and returns the Execute error.
+		deployWithWriteTopics := func(topics string) error {
+			topicAction := actions.NewDeployProtocolConverterAction(
+				userEmail, actionUUID, instanceUUID, outboundChannel, mockConfig, fsm.NewSnapshotManager())
+
+			payload := map[string]interface{}{
+				"name": pcName,
+				"connection": map[string]interface{}{
+					"ip":   pcIP,
+					"port": pcPort,
+				},
+				"location": pcLocation,
+				"writeDFC": map[string]interface{}{
+					"ignoreErrors": true,
+					"destination": map[string]interface{}{
+						"protocol": "stdout",
+					},
+					"source": map[string]interface{}{
+						"topics": topics,
+					},
+				},
+			}
+
+			Expect(topicAction.Parse(payload)).To(Succeed())
+			Expect(topicAction.Validate()).To(Succeed())
+
+			_, _, err := topicAction.Execute()
+
+			return err
+		}
+
+		It("should reject a write flow whose topics are outside the bridge location", func() {
+			err := deployWithWriteTopics("umh.v1.TestEnterprise.OtherSite.foo")
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("must be beneath the bridge location"))
+			Expect(err.Error()).To(ContainSubstring("umh.v1.TestEnterprise.OtherSite.foo"))
+			Expect(mockConfig.AtomicAddProtocolConverterCalled).To(BeFalse())
+		})
+
+		It("should accept a write flow whose topics resolve beneath the bridge location", func() {
+			Expect(deployWithWriteTopics("umh.v1.{{ .location_path }}.foo")).To(Succeed())
+		})
+
 		It("should deploy protocol converter successfully", func() {
 			// Setup - parse valid payload first
 			payload := map[string]interface{}{

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter.go
@@ -334,6 +334,16 @@ func (a *EditProtocolConverterAction) Execute() (interface{}, map[string]interfa
 		return nil, nil, fmt.Errorf("%s", errorMsg)
 	}
 
+	// Only an edit that supplies a write config is held to the topic hierarchy: a read-only
+	// edit must not be blocked by a violation it did not introduce.
+	if err := a.validateSuppliedWriteTopics(newSpec); err != nil {
+		errorMsg := fmt.Sprintf("Invalid write flow configuration: %v", err)
+		SendActionReply(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedWithFailure,
+			errorMsg, a.outboundChannel, models.EditProtocolConverter)
+
+		return nil, nil, fmt.Errorf("%s", errorMsg)
+	}
+
 	oldConfig, err := a.persistConfig(atomicEditUUID, newSpec)
 	if err != nil {
 		errorMsg := fmt.Sprintf("Failed to persist configuration changes: %v", err)
@@ -377,6 +387,16 @@ func (a *EditProtocolConverterAction) Execute() (interface{}, map[string]interfa
 	}
 
 	return response, nil, nil
+}
+
+// validateSuppliedWriteTopics enforces the topic hierarchy only when this edit supplies a
+// write config. See validateWriteTopicHierarchy for the rule itself.
+func (a *EditProtocolConverterAction) validateSuppliedWriteTopics(newSpec config.ProtocolConverterConfig) error {
+	if a.writeDFCInput == nil {
+		return nil
+	}
+
+	return validateWriteTopicHierarchy(newSpec, a.systemSnapshotManager)
 }
 
 // applyMutation analyzes the current configuration and applies the necessary mutations
@@ -1207,6 +1227,13 @@ func (a *EditProtocolConverterAction) renderDesiredDFCConfig(pcSnapshot *protoco
 		runtime_config.BridgedByPlaceholder,
 		pcName,
 	)
+	// A failure confined to the write flow still yields a usable read flow, so a read-side
+	// verification must not fail because of it.
+	var writeFlowErr *runtime_config.WriteFlowConfigError
+	if errors.As(err, &writeFlowErr) && dfcTypeToReturn == DFCTypeRead {
+		err = nil
+	}
+
 	if err != nil {
 		return dataflowcomponentserviceconfig.DataflowComponentServiceConfig{}, fmt.Errorf("failed to build runtime config: %w", err)
 	}

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter_test.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter_test.go
@@ -983,6 +983,106 @@ var _ = Describe("EditProtocolConverter", func() {
 			})
 		})
 
+		Context("when the write flow subscribes to topics outside the bridge location", func() {
+			// editWithWriteTopics edits the bridge so that it sits at
+			// test-enterprise.test-site and its write flow subscribes to the given topics.
+			editWithWriteTopics := func(topics string) error {
+				topicAction := actions.NewEditProtocolConverterAction(
+					userEmail, actionUUID, instanceUUID, outboundChannel, mockConfig, fsm.NewSnapshotManager())
+
+				payload := map[string]interface{}{
+					"name": pcName,
+					"uuid": pcUUID.String(),
+					"connection": map[string]interface{}{
+						"ip":   "wttr.in",
+						"port": 80,
+					},
+					"location": map[string]interface{}{
+						"0": "test-enterprise",
+						"1": "test-site",
+					},
+					"writeDFC": map[string]interface{}{
+						"ignoreErrors": true,
+						"destination": map[string]interface{}{
+							"protocol": "stdout",
+						},
+						"source": map[string]interface{}{
+							"topics": topics,
+						},
+					},
+				}
+
+				Expect(topicAction.Parse(payload)).To(Succeed())
+				Expect(topicAction.Validate()).To(Succeed())
+
+				_, _, err := topicAction.Execute()
+
+				return err
+			}
+
+			It("rejects the edit without persisting it", func() {
+				err := editWithWriteTopics("umh.v1.test-enterprise.other-site.foo")
+
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("must be beneath the bridge location"))
+				Expect(err.Error()).To(ContainSubstring("umh.v1.test-enterprise.other-site.foo"))
+				Expect(mockConfig.AtomicEditProtocolConverterCalled).To(BeFalse())
+			})
+
+			It("accepts topics that resolve beneath the bridge location", func() {
+				Expect(editWithWriteTopics("umh.v1.{{ .location_path }}.foo")).To(Succeed())
+			})
+
+			It("does not block a read-only edit on a bridge whose write flow already violates the rule", func() {
+				// The bridge already carries an offending write flow, active. Editing only the
+				// read flow must go through; the render degrades the write flow on its own.
+				spec := &mockConfig.Config.ProtocolConverter[0].ProtocolConverterServiceConfig
+				spec.Config.DataflowComponentWriteServiceConfig = dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
+					Source:      dataflowcomponentserviceconfig.WriteConfigSource{Topics: "umh.v1.test-enterprise.other-site.foo"},
+					Destination: dataflowcomponentserviceconfig.WriteConfigDestination{Protocol: "stdout"},
+				}
+				spec.WriteDFCDesiredState = "active"
+
+				readOnlyAction := actions.NewEditProtocolConverterAction(
+					userEmail, actionUUID, instanceUUID, outboundChannel, mockConfig, fsm.NewSnapshotManager())
+
+				payload := map[string]interface{}{
+					"name": pcName,
+					"uuid": pcUUID.String(),
+					"connection": map[string]interface{}{
+						"ip":   "wttr.in",
+						"port": 80,
+					},
+					"location": map[string]interface{}{
+						"0": "test-enterprise",
+						"1": "test-site",
+					},
+					"readDFC": map[string]interface{}{
+						"ignoreErrors": true,
+						"inputs": map[string]interface{}{
+							"data": "input:\n  http_client:\n    url: http://example.com",
+							"type": "http_client",
+						},
+						"pipeline": map[string]interface{}{
+							"processors": map[string]interface{}{
+								"0": map[string]interface{}{
+									"type": "bloblang",
+									"data": "bloblang: |-\n  root = content()",
+								},
+							},
+						},
+					},
+				}
+
+				Expect(readOnlyAction.Parse(payload)).To(Succeed())
+				Expect(readOnlyAction.Validate()).To(Succeed())
+
+				_, _, err := readOnlyAction.Execute()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(mockConfig.AtomicEditProtocolConverterCalled).To(BeTrue())
+			})
+		})
+
 		It("should handle protocol converter not found error", func() {
 			// Use a non-existent UUID
 			nonExistentUUID := uuid.New()

--- a/umh-core/pkg/communicator/actions/protocolconverter_helpers.go
+++ b/umh-core/pkg/communicator/actions/protocolconverter_helpers.go
@@ -19,10 +19,13 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/benthosserviceconfig"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/connectionserviceconfig"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/dataflowcomponentserviceconfig"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/models"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/protocolconverter/runtime_config"
 )
 
 // buildUserScope constructs the template rendering scope from a ProtocolConverter's
@@ -50,6 +53,38 @@ func validateWriteDFCConfig(cfg *dataflowcomponentserviceconfig.DataflowComponen
 		if err := ValidateDataFlowComponentState(state); err != nil {
 			return fmt.Errorf("invalid write DFC state: %w", err)
 		}
+	}
+
+	return nil
+}
+
+// validateWriteTopicHierarchy rejects a bridge whose write flow subscribes to topics
+// outside the bridge's own location, so the violation is reported to the user instead of
+// only degrading the bridge later. The rule itself lives in BuildRuntimeConfig, which
+// reports it as a WriteFlowConfigError; every other render failure is left to the
+// reconciliation loop, which reports it on the bridge.
+//
+// The agent location is read from the system snapshot; with no snapshot manager that half
+// of the bridge location is unknown, so the check is skipped.
+func validateWriteTopicHierarchy(pcConfig config.ProtocolConverterConfig, snapshotManager *fsm.SnapshotManager) error {
+	if snapshotManager == nil {
+		return nil
+	}
+
+	snapshot := snapshotManager.GetDeepCopySnapshot()
+
+	_, err := runtime_config.BuildRuntimeConfig(
+		pcConfig.ProtocolConverterServiceConfig,
+		convertIntMapToStringMap(snapshot.CurrentConfig.Agent.Location),
+		nil, // TODO: add global vars
+		nil, // historian: a write flow referencing it fails the render, which is not this check's concern
+		runtime_config.BridgedByPlaceholder,
+		pcConfig.Name,
+	)
+
+	var writeFlowErr *runtime_config.WriteFlowConfigError
+	if errors.As(err, &writeFlowErr) {
+		return writeFlowErr.Err
 	}
 
 	return nil

--- a/umh-core/pkg/config/dataflowcomponentserviceconfig/write_config.go
+++ b/umh-core/pkg/config/dataflowcomponentserviceconfig/write_config.go
@@ -15,6 +15,7 @@
 package dataflowcomponentserviceconfig
 
 import (
+	"fmt"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -23,6 +24,10 @@ import (
 // HistorianDestinationProtocol is the destination protocol of the built-in historian output
 // plugin. A write DFC targeting it renders against the shared historian: render scope.
 const HistorianDestinationProtocol = "historian"
+
+// UNSTopicPrefix is the fixed prefix of every UNS topic. The segments after it are the
+// location path, followed by the data contract and any virtual path.
+const UNSTopicPrefix = "umh.v1."
 
 // PlaceholderUMHTopicUnset is used when no input topics were configured for a write DFC.
 // It makes the misconfiguration visible in Benthos logs rather than silently subscribing to nothing.
@@ -183,6 +188,49 @@ func splitTopics(s string) []string {
 	}
 
 	return out
+}
+
+// topicUnderLocation reports whether topic addresses a node strictly beneath locationPath.
+// The `umh.v1.` prefix is optional on topic. An empty locationPath places no restriction
+// beyond the topic naming at least one segment.
+func topicUnderLocation(topic, locationPath string) bool {
+	relative := strings.TrimPrefix(strings.TrimSpace(topic), UNSTopicPrefix)
+
+	if locationPath == "" {
+		return relative != ""
+	}
+
+	// The trailing dot rules out a topic that merely shares a prefix with a longer
+	// sibling level (`site.cologne2` is not beneath `site.cologne`), and the length
+	// check rules out the bridge location itself, which is not beneath itself.
+	return strings.HasPrefix(relative, locationPath+".") && len(relative) > len(locationPath)+1
+}
+
+// ValidateTopicsUnderLocation reports the topics that do not lie beneath locationPath.
+//
+// A write flow may only consume data from its own branch of the UNS tree: a bridge at
+// `enterprise.cologne.sublevel` must not subscribe to `enterprise.cologne.foo`. Topics
+// must already be rendered; an unrendered `{{ }}` action is compared verbatim and reported.
+func (c DataflowComponentWriteConfig) ValidateTopicsUnderLocation(locationPath string) error {
+	var offending []string
+
+	for _, topic := range c.Topics {
+		if topic == PlaceholderUMHTopicUnset {
+			continue
+		}
+
+		if !topicUnderLocation(topic, locationPath) {
+			offending = append(offending, topic)
+		}
+	}
+
+	if len(offending) == 0 {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"write flow topics must be beneath the bridge location %q: %s",
+		UNSTopicPrefix+locationPath, strings.Join(offending, ", "))
 }
 
 // HasOutput reports whether a write output is configured.

--- a/umh-core/pkg/config/dataflowcomponentserviceconfig/write_config_test.go
+++ b/umh-core/pkg/config/dataflowcomponentserviceconfig/write_config_test.go
@@ -160,4 +160,46 @@ var _ = Describe("write_config", func() {
 			Expect(svc.BenthosConfig.Buffer).To(HaveKey("memory"))
 		})
 	})
+
+	Describe("topic hierarchy", func() {
+		DescribeTable("reports whether a topic lies beneath the bridge location",
+			func(topic, locationPath string, expected bool) {
+				input := dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
+					Source: dataflowcomponentserviceconfig.WriteConfigSource{Topics: topic},
+				}
+				accepted := input.ToWriteConfig().ValidateTopicsUnderLocation(locationPath) == nil
+
+				Expect(accepted).To(Equal(expected))
+			},
+			Entry("direct child", "umh.v1.UMHDEVTEST.cologne.foo", "UMHDEVTEST.cologne", true),
+			Entry("deep child", "umh.v1.UMHDEVTEST.cologne.a.b.c", "UMHDEVTEST.cologne", true),
+			Entry("topic without umh.v1. prefix", "UMHDEVTEST.cologne.foo", "UMHDEVTEST.cologne", true),
+			Entry("sibling branch", "umh.v1.UMHDEVTEST.cologne.foo", "UMHDEVTEST.cologne.sublevel", false),
+			Entry("parent level", "umh.v1.UMHDEVTEST.foo", "UMHDEVTEST.cologne", false),
+			Entry("shared prefix but different level", "umh.v1.UMHDEVTEST.cologne2.foo", "UMHDEVTEST.cologne", false),
+			Entry("bridge location itself", "umh.v1.UMHDEVTEST.cologne", "UMHDEVTEST.cologne", false),
+			Entry("empty location accepts any topic", "umh.v1.anything.foo", "", true),
+		)
+	})
+
+	Describe("ValidateTopicsUnderLocation", func() {
+		validate := func(topics, locationPath string) error {
+			input := dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
+				Source: dataflowcomponentserviceconfig.WriteConfigSource{Topics: topics},
+			}
+
+			return input.ToWriteConfig().ValidateTopicsUnderLocation(locationPath)
+		}
+
+		It("reports every offending topic", func() {
+			err := validate("umh.v1.UMHDEVTEST.cologne.foo\numh.v1.UMHDEVTEST.cologne.bar", "UMHDEVTEST.cologne.sublevel")
+			Expect(err).To(MatchError(ContainSubstring("umh.v1.UMHDEVTEST.cologne.foo")))
+			Expect(err).To(MatchError(ContainSubstring("umh.v1.UMHDEVTEST.cologne.bar")))
+			Expect(err).To(MatchError(ContainSubstring("umh.v1.UMHDEVTEST.cologne.sublevel")))
+		})
+
+		It("accepts the placeholder used when no topic was configured", func() {
+			Expect(validate(dataflowcomponentserviceconfig.PlaceholderUMHTopicUnset, "UMHDEVTEST.cologne")).To(Succeed())
+		})
+	})
 })

--- a/umh-core/pkg/fsm/protocolconverter/actions.go
+++ b/umh-core/pkg/fsm/protocolconverter/actions.go
@@ -338,8 +338,20 @@ func (p *ProtocolConverterInstance) UpdateObservedStateOfInstance(ctx context.Co
 		runtime_config.BridgedByPlaceholder,
 		p.baseFSMInstance.GetID(),
 	)
-	if err != nil {
-		p.baseFSMInstance.GetLogger().Errorf("failed to build runtime config: %v", err)
+	// A failure confined to the write flow leaves connection and read flow rendered, so the
+	// bridge keeps serving them. Any other failure means no usable config at all.
+	var writeFlowErr *runtime_config.WriteFlowConfigError
+
+	p.writeFlowConfigErr = nil
+
+	switch {
+	case errors.As(err, &writeFlowErr):
+		// Repeats every tick until the config is fixed, so dedup by format string.
+		p.baseFSMInstance.Logger.LogErrorDedup("write flow config error: %v", writeFlowErr)
+		p.writeFlowConfigErr = writeFlowErr.Err
+		p.ObservedState.ServiceInfo.StatusReason = p.writeFlowConfigReason()
+	case err != nil:
+		p.baseFSMInstance.Logger.LogErrorDedup("failed to build runtime config: %v", err)
 		// Capture the configuration error in StatusReason for troubleshooting
 		p.ObservedState.ServiceInfo.StatusReason = "config error: " + err.Error()
 
@@ -461,6 +473,16 @@ func (p *ProtocolConverterInstance) IsRedpandaHealthy() (bool, string) {
 	return false, statusReason
 }
 
+// writeFlowConfigReason renders the write flow's config failure for StatusReason, or
+// returns an empty string when the write flow config is fine.
+func (p *ProtocolConverterInstance) writeFlowConfigReason() string {
+	if p.writeFlowConfigErr == nil {
+		return ""
+	}
+
+	return "write flow config error: " + p.writeFlowConfigErr.Error()
+}
+
 // IsDFCHealthy checks whether the underlying DFCs are healthy.
 // A DFC is considered healthy when it is active/idle, intentionally stopped
 // (ReadDFCDesiredState/WriteDFCDesiredState == "stopped"), or has no configuration
@@ -487,6 +509,12 @@ func (p *ProtocolConverterInstance) IsDFCHealthy() (bool, string) {
 	readHealthy := readRunning || readIntentionallyStopped || !readHasConfig
 	writeHealthy := writeRunning || writeIntentionallyStopped || !writeHasConfig
 
+	// A rejected write flow is kept out of the runtime, so it reads as stopped rather than
+	// failed. Without this the bridge would recover to idle and degrade again every tick.
+	if p.writeFlowConfigErr != nil && !writeIntentionallyStopped {
+		writeHealthy = false
+	}
+
 	if readHealthy && writeHealthy {
 		return true, ""
 	}
@@ -498,6 +526,10 @@ func (p *ProtocolConverterInstance) IsDFCHealthy() (bool, string) {
 		}
 
 		return false, statusReason
+	}
+
+	if p.writeFlowConfigErr != nil {
+		return false, p.writeFlowConfigReason()
 	}
 
 	statusReason := p.ObservedState.ServiceInfo.DataflowComponentWriteObservedState.ServiceInfo.StatusReason

--- a/umh-core/pkg/fsm/protocolconverter/machine.go
+++ b/umh-core/pkg/fsm/protocolconverter/machine.go
@@ -62,6 +62,10 @@ func NewProtocolConverterInstance(
 
 	var startingAndRunningStates = append(startingStatesWithFailed, runningStates...)
 
+	// A flow rejected by config validation never becomes healthy, so the bridge reports it
+	// as degraded instead of waiting in starting_dfc forever.
+	var dfcDegradedStates = append([]string{OperationalStateStartingDFC}, runningStates...)
+
 	cfg := internal_fsm.BaseFSMInstanceConfig{
 		ID:                           config.Name,
 		DesiredFSMState:              OperationalStateStopped,
@@ -91,7 +95,7 @@ func NewProtocolConverterInstance(
 			//	active/idle -> degraded
 			{Name: EventConnectionUnhealthy, Src: runningStates, Dst: OperationalStateDegradedConnection},
 			{Name: EventRedpandaDegraded, Src: runningStates, Dst: OperationalStateDegradedRedpanda},
-			{Name: EventDFCDegraded, Src: runningStates, Dst: OperationalStateDegradedDFC},
+			{Name: EventDFCDegraded, Src: dfcDegradedStates, Dst: OperationalStateDegradedDFC},
 			{Name: EventDegradedOther, Src: runningStates, Dst: OperationalStateDegradedOther},
 
 			// active -> idle

--- a/umh-core/pkg/fsm/protocolconverter/models.go
+++ b/umh-core/pkg/fsm/protocolconverter/models.go
@@ -202,6 +202,11 @@ type ProtocolConverterInstance struct {
 	// determine the next state
 	ObservedState ProtocolConverterObservedState
 
+	// writeFlowConfigErr is the last write-flow-only render failure, or nil. Such a write
+	// flow (e.g. topics outside the bridge location) is kept out of the runtime and never
+	// starts, so the bridge reports degraded_dfc with this as the reason.
+	writeFlowConfigErr error
+
 	// debugLevel controls whether debug logging is enabled for the underlying Benthos processes
 	debugLevel bool
 }

--- a/umh-core/pkg/fsm/protocolconverter/reconcile.go
+++ b/umh-core/pkg/fsm/protocolconverter/reconcile.go
@@ -410,6 +410,15 @@ func (p *ProtocolConverterInstance) reconcileStartingStates(ctx context.Context,
 			return err, false
 		}
 
+		// A rejected write flow config never becomes healthy, so waiting here would hold the
+		// bridge in starting forever and leave the read flow looking stopped. Degrade
+		// instead: the read flow keeps running and the cause is visible.
+		if p.writeFlowConfigErr != nil {
+			p.ObservedState.ServiceInfo.StatusReason = "flow degraded: " + p.writeFlowConfigReason()
+
+			return p.baseFSMInstance.SendEvent(ctx, EventDFCDegraded), true
+		}
+
 		// Now check whether the flow is healthy
 		running, reason = p.IsDFCHealthy()
 		if !running {

--- a/umh-core/pkg/service/protocolconverter/runtime_config/runtime_config.go
+++ b/umh-core/pkg/service/protocolconverter/runtime_config/runtime_config.go
@@ -34,6 +34,10 @@ import (
 // name is identical across both callers — update both if this ever changes.
 const BridgedByPlaceholder = "unimplemented"
 
+// dfcDesiredStateStopped repeats the DFC FSM's "stopped" literal, because the FSM packages
+// depend on this one.
+const dfcDesiredStateStopped = "stopped"
+
 // BuildRuntimeConfig merges all variables (user + agent + global + internal),
 // performs the location merge, derives the `bridged_by` header, and finally
 // renders the three sub-templates.
@@ -72,6 +76,9 @@ const BridgedByPlaceholder = "unimplemented"
 //   - The function is pure: it performs no side-effects and never mutates *Spec*.
 //   - Passing a nil *Spec* results in an explicit error; an empty runtime
 //     struct is **never** returned.
+//   - A *WriteFlowConfigError* is returned together with a runtime whose connection and
+//     read flow are usable and whose write flow is blank. Callers that need only the read
+//     side can ignore it; the bridge stays up either way.
 //   - After rendering, **no** `{{ … }}` directives remain.
 //   - The returned object is ready for diffing or to be handed straight to the
 //     Protocol-Converter FSM.
@@ -230,13 +237,30 @@ func BuildRuntimeConfig(
 	//----------------------------------------------------------------------
 	scope := vb.Flatten()
 
-	runtime, err := renderConfig(spec, scope, secrets) // unexported helper that enforces UNS
+	runtime, err := renderConfig(spec, scope, locationPath, secrets) // unexported helper that enforces UNS
 	if err != nil && !historianUsable && referencesMissingHistorian(err) {
 		return runtime, fmt.Errorf(
 			"this bridge references {{ .historian.* }} but no valid historian: section is configured in config.yaml; add or fix it: %w", err)
 	}
 
 	return runtime, err
+}
+
+// WriteFlowConfigError marks a configuration failure confined to the write flow of a
+// bridge. BuildRuntimeConfig returns it alongside a runtime whose connection and read
+// flow are rendered and whose write flow is blank, so the read flow keeps running.
+type WriteFlowConfigError struct {
+	Err error
+}
+
+// Error implements the error interface.
+func (e *WriteFlowConfigError) Error() string {
+	return "write flow: " + e.Err.Error()
+}
+
+// Unwrap exposes the underlying cause to errors.Is and errors.As.
+func (e *WriteFlowConfigError) Unwrap() error {
+	return e.Err
 }
 
 // referencesMissingHistorian reports whether err is the text/template
@@ -308,6 +332,7 @@ func referencesMissingHistorian(err error) bool {
 func renderConfig(
 	spec protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec,
 	scope map[string]any,
+	locationPath string,
 	secrets []string,
 ) (
 	protocolconverterserviceconfig.ProtocolConverterServiceConfigRuntime,
@@ -353,6 +378,21 @@ func renderConfig(
 		return protocolconverterserviceconfig.ProtocolConverterServiceConfigRuntime{}, err
 	}
 
+	// Enforce the UNS hierarchy: a write flow may only consume topics beneath the location
+	// of the bridge it belongs to. Checked after rendering, so topics written as
+	// `umh.v1.{{ .location_path }}.…` are checked in their resolved form. A violation blanks
+	// the write flow instead of failing the render, leaving connection and read flow up.
+	// A write flow with no destination, or a stopped one, subscribes to nothing.
+	var writeFlowErr error
+
+	writeStopped := spec.WriteDFCDesiredState == dfcDesiredStateStopped
+	if renderedWriteConfig.HasOutput() && !writeStopped {
+		if err := renderedWriteConfig.ToWriteConfig().ValidateTopicsUnderLocation(locationPath); err != nil {
+			writeFlowErr = &WriteFlowConfigError{Err: err}
+			renderedWriteConfig = dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{}
+		}
+	}
+
 	// Extract the resolved bridged_by value from the scope to wire up the UNS consumer group.
 	// A blank value is acceptable only for structural comparisons (no live Benthos wire).
 	// When a write output is configured, bridgedBy must be non-empty — a blank value means
@@ -375,7 +415,7 @@ func renderConfig(
 		ConnectionServiceConfig:             connRuntime,
 		DataflowComponentReadServiceConfig:  read,
 		DataflowComponentWriteServiceConfig: write,
-	}, nil
+	}, writeFlowErr
 }
 
 // appendDownsampler appends a downsampler as the last processor if one doesn't already exist.

--- a/umh-core/pkg/service/protocolconverter/runtime_config/runtime_config_test.go
+++ b/umh-core/pkg/service/protocolconverter/runtime_config/runtime_config_test.go
@@ -16,6 +16,7 @@ package runtime_config_test
 
 import (
 	"context"
+	"errors"
 	"os"
 	"strconv"
 
@@ -317,7 +318,7 @@ var _ = Describe("BuildRuntimeConfig", func() {
 				Config: protocolconverterserviceconfig.ProtocolConverterServiceConfigTemplate{
 					ConnectionServiceConfig: createConnectionConfig(),
 					DataflowComponentWriteServiceConfig: dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
-						Source:      dataflowcomponentserviceconfig.WriteConfigSource{Topics: "umh.v1.factory.line-1.*\numh.v1.factory.line-2.*"},
+						Source:      dataflowcomponentserviceconfig.WriteConfigSource{Topics: "umh.v1.plant-A.line-4.press.*\numh.v1.plant-A.line-4.oven.*"},
 						Destination: dataflowcomponentserviceconfig.WriteConfigDestination{Protocol: "stdout"},
 					},
 				},
@@ -330,7 +331,70 @@ var _ = Describe("BuildRuntimeConfig", func() {
 			Expect(writeInput).To(HaveKey("uns"))
 			unsInput, ok := writeInput["uns"].(map[string]any)
 			Expect(ok).To(BeTrue())
-			Expect(unsInput["umh_topics"]).To(Equal([]string{"umh.v1.factory.line-1.*", "umh.v1.factory.line-2.*"}))
+			Expect(unsInput["umh_topics"]).To(Equal([]string{"umh.v1.plant-A.line-4.press.*", "umh.v1.plant-A.line-4.oven.*"}))
+		})
+
+		It("should reject topics outside the bridge location and keep the read flow rendered", func() {
+			testSpec := protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec{
+				Config: protocolconverterserviceconfig.ProtocolConverterServiceConfigTemplate{
+					ConnectionServiceConfig: createConnectionConfig(),
+					DataflowComponentReadServiceConfig: dataflowcomponentserviceconfig.DataflowComponentServiceConfig{
+						BenthosConfig: dataflowcomponentserviceconfig.BenthosConfig{
+							Input: map[string]any{"generate": map[string]any{"mapping": "root = {}"}},
+						},
+					},
+					DataflowComponentWriteServiceConfig: dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
+						Source:      dataflowcomponentserviceconfig.WriteConfigSource{Topics: "umh.v1.plant-A.line-4.press.*\numh.v1.plant-A.line-9.oven.*"},
+						Destination: dataflowcomponentserviceconfig.WriteConfigDestination{Protocol: "stdout"},
+					},
+				},
+			}
+
+			result, err := runtime_config.BuildRuntimeConfig(testSpec, agentLocation, globalVars, nil, nodeName, pcName)
+			Expect(err).To(MatchError(ContainSubstring("umh.v1.plant-A.line-9.oven.*")))
+			Expect(err).To(MatchError(ContainSubstring("must be beneath the bridge location")))
+			Expect(errors.As(err, new(*runtime_config.WriteFlowConfigError))).To(BeTrue())
+
+			// The violation is confined to the write flow: the connection and read flow
+			// stay usable so the bridge comes up and the write flow can be debugged.
+			Expect(result.DataflowComponentWriteServiceConfig).To(Equal(dataflowcomponentserviceconfig.DataflowComponentServiceConfig{}))
+			Expect(result.ConnectionServiceConfig.NmapServiceConfig.Target).To(Equal("127.0.0.1"))
+			Expect(result.DataflowComponentReadServiceConfig.BenthosConfig.Input).To(HaveKey("generate"))
+		})
+
+		It("should not validate the topics of a write flow whose desired state is stopped", func() {
+			testSpec := protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec{
+				Config: protocolconverterserviceconfig.ProtocolConverterServiceConfigTemplate{
+					ConnectionServiceConfig: createConnectionConfig(),
+					DataflowComponentWriteServiceConfig: dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
+						Source:      dataflowcomponentserviceconfig.WriteConfigSource{Topics: "umh.v1.somewhere.else.*"},
+						Destination: dataflowcomponentserviceconfig.WriteConfigDestination{Protocol: "stdout"},
+					},
+				},
+				WriteDFCDesiredState: "stopped",
+			}
+
+			_, err := runtime_config.BuildRuntimeConfig(testSpec, agentLocation, globalVars, nil, nodeName, pcName)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should accept topics that resolve beneath the bridge location via location_path", func() {
+			testSpec := protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec{
+				Config: protocolconverterserviceconfig.ProtocolConverterServiceConfigTemplate{
+					ConnectionServiceConfig: createConnectionConfig(),
+					DataflowComponentWriteServiceConfig: dataflowcomponentserviceconfig.DataflowComponentWriteConfigInput{
+						Source:      dataflowcomponentserviceconfig.WriteConfigSource{Topics: "umh.v1.{{ .location_path }}.press.*"},
+						Destination: dataflowcomponentserviceconfig.WriteConfigDestination{Protocol: "stdout"},
+					},
+				},
+			}
+
+			result, err := runtime_config.BuildRuntimeConfig(testSpec, agentLocation, globalVars, nil, nodeName, pcName)
+			Expect(err).NotTo(HaveOccurred())
+
+			unsInput, ok := result.DataflowComponentWriteServiceConfig.BenthosConfig.Input["uns"].(map[string]any)
+			Expect(ok).To(BeTrue())
+			Expect(unsInput["umh_topics"]).To(Equal([]string{"umh.v1.plant-A.line-4.press.*"}))
 		})
 
 		It("should not require UMHTopics when write DFC has no output", func() {

--- a/umh-core/test/fsm/protocolconverter/protocolconverter_test.go
+++ b/umh-core/test/fsm/protocolconverter/protocolconverter_test.go
@@ -236,6 +236,70 @@ var _ = Describe("ProtocolConverter FSM", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
+		It("should go to DegradedDFC instead of waiting in StartingDFC when the write flow topics lie outside the bridge location", func() {
+			var err error
+
+			// A write flow rejected by the topic hierarchy check is kept out of the runtime
+			// and never becomes healthy. The bridge must not wait for it in starting_dfc:
+			// it reports degraded_dfc so the read flow stays usable and the cause is visible.
+			instance, mockService, _ = fsmtest.SetupProtocolConverterInstanceWithOutsideLocationWriteTopics(
+				componentName, protocolconverterfsm.OperationalStateStopped)
+
+			tick, err = fsmtest.TestProtocolConverterStateTransition(
+				ctx, instance, mockService, mockRegistry, componentName,
+				internalfsm.LifecycleStateToBeCreated,
+				internalfsm.LifecycleStateCreating, 5, tick, startTime)
+			Expect(err).NotTo(HaveOccurred())
+
+			mockService.ExistingComponents[componentName] = true
+			fsmtest.TransitionToProtocolConverterState(mockService, componentName, protocolconverterfsm.OperationalStateStopped)
+
+			tick, err = fsmtest.TestProtocolConverterStateTransition(
+				ctx, instance, mockService, mockRegistry, componentName,
+				internalfsm.LifecycleStateCreating,
+				protocolconverterfsm.OperationalStateStopped, 5, tick, startTime)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(instance.SetDesiredFSMState(protocolconverterfsm.OperationalStateActive)).To(Succeed())
+
+			tick, err = fsmtest.TestProtocolConverterStateTransition(
+				ctx, instance, mockService, mockRegistry, componentName,
+				protocolconverterfsm.OperationalStateStopped,
+				protocolconverterfsm.OperationalStateStartingConnection, 5, tick, startTime)
+			Expect(err).NotTo(HaveOccurred())
+
+			fsmtest.TransitionToProtocolConverterState(mockService, componentName, protocolconverterfsm.OperationalStateStartingRedpanda)
+
+			tick, err = fsmtest.TestProtocolConverterStateTransition(
+				ctx, instance, mockService, mockRegistry, componentName,
+				protocolconverterfsm.OperationalStateStartingConnection,
+				protocolconverterfsm.OperationalStateStartingRedpanda, 5, tick, startTime)
+			Expect(err).NotTo(HaveOccurred())
+
+			fsmtest.TransitionToProtocolConverterState(mockService, componentName, protocolconverterfsm.OperationalStateStartingDFC)
+
+			tick, err = fsmtest.TestProtocolConverterStateTransition(
+				ctx, instance, mockService, mockRegistry, componentName,
+				protocolconverterfsm.OperationalStateStartingRedpanda,
+				protocolconverterfsm.OperationalStateStartingDFC, 5, tick, startTime)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Even with every underlying service reporting idle, the bridge lands in
+			// degraded_dfc rather than idle, and names the offending topics.
+			fsmtest.TransitionToProtocolConverterState(mockService, componentName, protocolconverterfsm.OperationalStateIdle)
+
+			tick, err = fsmtest.TestProtocolConverterStateTransition(
+				ctx, instance, mockService, mockRegistry, componentName,
+				protocolconverterfsm.OperationalStateStartingDFC,
+				protocolconverterfsm.OperationalStateDegradedDFC, 5, tick, startTime)
+			Expect(err).NotTo(HaveOccurred())
+
+			observed, ok := instance.GetLastObservedState().(protocolconverterfsm.ProtocolConverterObservedState)
+			Expect(ok).To(BeTrue())
+			Expect(observed.ServiceInfo.StatusReason).To(ContainSubstring("write flow config error"))
+			Expect(observed.ServiceInfo.StatusReason).To(ContainSubstring("umh.v1.some-other-location.*"))
+		})
+
 		It("should transition from Idle to Active when processing data", func() {
 			var err error
 


### PR DESCRIPTION
- Input topics of a write flow must now be located BELOW the bridge that uses it

## Problem

See ticket ENG-5694

## What we are shipping

See ticket ENG-5694

## What we are NOT shipping

- No data contract validation in this ticket. Will be done in ENG-5696

Fixes ENG-5694
