### PR TITLE
Fix/ci improvements

### DIFF
--- a/.github/workflows/build-umh-core.yml
+++ b/.github/workflows/build-umh-core.yml
@@ -50,6 +50,11 @@ jobs:
       digest: ${{ steps.digest.outputs.digest }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          filter: blob:none
+          sparse-checkout: |
+            umh-core
+            .github
 
       - name: Compute short SHA
         id: short-sha

--- a/.github/workflows/go-analysis.yml
+++ b/.github/workflows/go-analysis.yml
@@ -28,6 +28,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          filter: blob:none
+          sparse-checkout: |
+            umh-core
+            .github
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
@@ -46,6 +51,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          filter: blob:none
+          sparse-checkout: |
+            umh-core
+            .github
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7

--- a/.github/workflows/go-analysis.yml
+++ b/.github/workflows/go-analysis.yml
@@ -38,13 +38,14 @@ jobs:
         with:
           go-version-file: umh-core/go.mod
           cache: true
+          cache-dependency-path: umh-core/go.sum
 
       - name: Run go vet
         run: make vet
 
   nilaway:
     name: Nilaway Analysis
-    runs-on: depot-ubuntu-24.04
+    runs-on: depot-ubuntu-24.04-4
     defaults:
       run:
         working-directory: ./umh-core
@@ -62,6 +63,7 @@ jobs:
         with:
           go-version-file: umh-core/go.mod
           cache: true
+          cache-dependency-path: umh-core/go.sum
 
       - name: Get Nilaway version from Makefile
         id: nilaway_version

--- a/.github/workflows/linear-release.yml
+++ b/.github/workflows/linear-release.yml
@@ -82,6 +82,7 @@ jobs:
       # always the revision the running workflow came from, which does.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          filter: blob:none
           ref: ${{ github.workflow_sha }}
           path: .ci-tooling
           sparse-checkout: .github/scripts

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -32,6 +32,10 @@ jobs:
       changelog: ${{ steps.filter.outputs.changelog }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          filter: blob:none
+          # paths-filter only reads .github/path-filters.yml; it diffs git trees, not the worktree
+          sparse-checkout: .github
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
@@ -74,6 +78,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          filter: blob:none
+          sparse-checkout: |
+            umh-core
+            .github
       - name: FOSSA Analyze
         uses: fossas/fossa-action@29693cc50323968e039056be419b32989fc5880c # v2
         with:
@@ -109,6 +118,10 @@ jobs:
       packages: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          filter: blob:none
+          # Scans a published image, not the source tree; checkout is only for git revision metadata
+          sparse-checkout: .github
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
@@ -144,6 +157,9 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          filter: blob:none
+          sparse-checkout: .fossa-vendored
 
       - name: FOSSA Analyze (vendored binaries)
         uses: fossas/fossa-action@29693cc50323968e039056be419b32989fc5880c # v2
@@ -224,6 +240,10 @@ jobs:
       # the changelog guard for tag lookup and merge-base computation)
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          filter: blob:none
+          sparse-checkout: |
+            umh-core/CHANGELOG.md
+            .github
           fetch-depth: 0
       # Generate token for cross-repo access
       - name: Generate GitHub App token

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -241,9 +241,10 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           filter: blob:none
+          sparse-checkout-cone-mode: false
           sparse-checkout: |
             umh-core/CHANGELOG.md
-            .github
+            .github/
           fetch-depth: 0
       # Generate token for cross-repo access
       - name: Generate GitHub App token

--- a/.github/workflows/sync-changelog.yml
+++ b/.github/workflows/sync-changelog.yml
@@ -87,9 +87,10 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           filter: blob:none
+          sparse-checkout-cone-mode: false
           sparse-checkout: |
             umh-core/CHANGELOG.md
-            umh-core/changelog-images
+            umh-core/changelog-images/
           path: umh-core
 
       - name: Generate GitHub App token

--- a/.github/workflows/sync-changelog.yml
+++ b/.github/workflows/sync-changelog.yml
@@ -86,6 +86,10 @@ jobs:
       - name: Checkout umh-core
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          filter: blob:none
+          sparse-checkout: |
+            umh-core/CHANGELOG.md
+            umh-core/changelog-images
           path: umh-core
 
       - name: Generate GitHub App token

--- a/.github/workflows/test-umh-core.yml
+++ b/.github/workflows/test-umh-core.yml
@@ -41,6 +41,11 @@ jobs:
         working-directory: ./umh-core
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          filter: blob:none
+          sparse-checkout: |
+            umh-core
+            .github
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
@@ -92,6 +97,11 @@ jobs:
         working-directory: ./umh-core
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          filter: blob:none
+          sparse-checkout: |
+            umh-core
+            .github
 
       - name: Login to Docker Hub
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4

--- a/.github/workflows/update-github-release.yml
+++ b/.github/workflows/update-github-release.yml
@@ -39,6 +39,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           filter: blob:none
+          sparse-checkout-cone-mode: false
           sparse-checkout: umh-core/CHANGELOG.md
           ref: ${{ inputs.version || github.event.release.tag_name }}
 

--- a/.github/workflows/update-github-release.yml
+++ b/.github/workflows/update-github-release.yml
@@ -38,6 +38,8 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          filter: blob:none
+          sparse-checkout: umh-core/CHANGELOG.md
           ref: ${{ inputs.version || github.event.release.tag_name }}
 
       - name: Extract changelog section

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,9 +122,8 @@ The United Manufacturing Hub (UMH) is an Industrial IoT platform for manufacturi
 1. **Comments**: Do NOT add inline comments unless explicitly requested. DO add godoc comments on exported functions/types and comments on non-obvious constants, following [Google Developer Documentation Style Guide](https://developers.google.com/style) (active voice, present tense, concise)
 2. **Prefer editing existing files over creating new ones**
 3. **Follow existing patterns in the codebase**
-4. **Struct field alignment**: Run `make betteralign-fix` (automated tool orders fields by decreasing size)
-5. **Error handling**: Return errors up the stack, handle in reconciliation loop
-6. **No direct FSM state changes**: Always go through reconciliation
+4. **Error handling**: Return errors up the stack, handle in reconciliation loop
+5. **No direct FSM state changes**: Always go through reconciliation
 
 ## Documentation Maintenance
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -48,12 +48,6 @@ pre-push:
           exit 1
         fi
 
-    - name: field-alignment
-      glob: "**/*.go"
-      root: "umh-core"
-      run: |
-        make betteralign
-
 pre-commit:
   parallel: true
   jobs:

--- a/umh-core/Makefile
+++ b/umh-core/Makefile
@@ -403,7 +403,7 @@ benchmark-encoding:
 	cd pkg/communicator/pkg/encoding && go test -bench=. -benchmem -benchtime=10s -count=1
 
 # Meta target to setup the environment for the tests
-pre-test: build-protobuf stop-all-pods vet-nilaway-lint
+pre-test: build-protobuf stop-all-pods
 
 # - Injects VERSION via ldflags into AppVersion for proper error identification in Sentry
 # - CI test failures SHOULD be reported to Sentry (unlike local dev failures)

--- a/umh-core/Makefile
+++ b/umh-core/Makefile
@@ -61,7 +61,6 @@ GINKGO_VERSION = v2.23.4
 NILAWAY_VERSION = v0.0.0-20260213150243-937701de96c7
 LEFTHOOK_VERSION = v1.13.2
 GOLANGCI_LINT_VERSION = v2.5.0
-BETTERALIGN_VERSION = v0.7.1
 GOTESTSUM_VERSION = v1.13.0
 DLV_VERSION = v1.25.1
 
@@ -91,7 +90,6 @@ install:
 	go install github.com/onsi/ginkgo/v2/ginkgo@$(GINKGO_VERSION)
 	go install github.com/evilmartians/lefthook@$(LEFTHOOK_VERSION)
 	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
-	go install github.com/dkorunic/betteralign/cmd/betteralign@$(BETTERALIGN_VERSION)
 	go install gotest.tools/gotestsum@$(GOTESTSUM_VERSION)
 
 download-docker-binaries:
@@ -340,22 +338,10 @@ nilaway:
 		-exclude-errors-in-files="integration/" \
 		./...
 
-betteralign:
-	betteralign -test=false ./... || (echo "Consider running 'make betteralign-fix' to fix the issues" && exit 1)
-betteralign-fix:
-	betteralign -test=false -apply ./...
+# Meta target for vet, nilaway and lint
+vet-nilaway-lint: vet nilaway lint
 
-betteralign-fix-all:
-	@echo "Running betteralign-fix in loop until exit code is not 3..."
-	@while betteralign -test=false -apply ./...; [ $$? -eq 3 ]; do \
-		echo "betteralign-fix returned exit code 3, running again..."; \
-	done
-	@echo "betteralign-fix-all completed"
-
-# Meta target for vet, nilaway, lint, staticcheck and betteralign
-vet-nilaway-lint-betteralign: vet nilaway lint betteralign
-
-test: vet-nilaway-lint-betteralign
+test: vet-nilaway-lint
 	go test -race -v -tags=test ./...
 
 unit-test:
@@ -379,7 +365,7 @@ else
 endif
 
 # Sequential fallback using ginkgo directly (no fail-fast, full failure report, covers ./...)
-unit-test-fail-slow: vet-nilaway-lint-betteralign
+unit-test-fail-slow: vet-nilaway-lint
 	go run github.com/onsi/ginkgo/v2/ginkgo -r --tags=test --race --label-filter='$(UNIT_LABEL_FILTER)' ./...
 
 benchmark:
@@ -417,7 +403,7 @@ benchmark-encoding:
 	cd pkg/communicator/pkg/encoding && go test -bench=. -benchmem -benchtime=10s -count=1
 
 # Meta target to setup the environment for the tests
-pre-test: build-protobuf stop-all-pods vet-nilaway-lint-betteralign
+pre-test: build-protobuf stop-all-pods vet-nilaway-lint
 
 # - Injects VERSION via ldflags into AppVersion for proper error identification in Sentry
 # - CI test failures SHOULD be reported to Sentry (unlike local dev failures)


### PR DESCRIPTION
## Problem

CI grew slow and messy: `betteralign` added noise without value, and `vet-nilaway-lint` duplicated work in pre-test since we don't act on lint fixes there anyway.

## What we are shipping

- Removed `betteralign` entirely
- Removed redundant `vet-nilaway-lint` from pre-test steps
- Faster CI with better caching overall using filter and sparse checkouts

## What we are NOT shipping

Nothing deferred here — this is cleanup only.

Fixes ENG-5750