### PR TITLE
fix: add changelog images in validation step in CI

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -244,6 +244,7 @@ jobs:
           sparse-checkout-cone-mode: false
           sparse-checkout: |
             umh-core/CHANGELOG.md
+            umh-core/changelog-images/
             .github/
           fetch-depth: 0
       # Generate token for cross-repo access

--- a/.github/workflows/update-github-release.yml
+++ b/.github/workflows/update-github-release.yml
@@ -40,7 +40,9 @@ jobs:
         with:
           filter: blob:none
           sparse-checkout-cone-mode: false
-          sparse-checkout: umh-core/CHANGELOG.md
+          sparse-checkout: |
+            umh-core/CHANGELOG.md
+            umh-core/changelog-images/
           ref: ${{ inputs.version || github.event.release.tag_name }}
 
       - name: Extract changelog section


### PR DESCRIPTION

## Problem

Cleaned up / improved CI yesterday, but "cleaned up too much" :D 
This PR now re-adds the missing "changelog-images" directory in CI, so it does not fail.

## What we are shipping

- changelog-images dir in CI

## What we are NOT shipping

- Nothing
