### PR TITLE
Add four CPU scenarios over a mocked filesystem, and one that runs against a real machine

### DIFF
--- a/umh-core/pkg/cpuhealth/fakebox/fakebox.go
+++ b/umh-core/pkg/cpuhealth/fakebox/fakebox.go
@@ -174,9 +174,8 @@ type Condition struct {
 // the clock the sampler stamps its samples from.
 type Box struct {
 	// clk is the mock the sampler stamps from. It is set once at construction
-	// and only advanced after that: a clock that moved backwards produces a
-	// negative elapsed time in the admission window downstream, and that window
-	// then never opens.
+	// and only advanced after that; shieldedClock says what a backwards step
+	// costs.
 	clk *clock.Mock
 
 	base string
@@ -246,11 +245,13 @@ func (b *Box) FS() filesystem.Service {
 // shieldedClock hides the mock behind a plain clock.Clock. Returning the
 // interface is not on its own enough to hide anything: the dynamic type travels
 // with it, so box.Clock().(*clock.Mock) succeeds and hands the caller Set,
-// which moves the clock BACKWARDS. That is not a style point. The admission
-// window in pkg/fsmv2/cpu subtracts two instants with no lower guard, so one
-// backwards step leaves it refusing for the rest of the process. Embedding the
-// interface in an unexported struct promotes every read method and leaves no
-// way back to the mock.
+// which moves the clock BACKWARDS. cpuhealth publishes a rate only while the
+// gap between two Timestamps is positive: advanceUsageRate in cgroup_source.go
+// and advanceHostRates in host_source.go both guard on it. So a backwards step
+// costs the tick it lands on, which serves no rate at all. The baseline still
+// moves to the backwards instant, so ticking forward restores the rates on the
+// next tick. Embedding the interface in an unexported struct promotes every
+// read method and leaves no way back to the mock.
 type shieldedClock struct{ clock.Clock }
 
 // Clock returns the clock to hand to cpuhealth.NewLinuxSamplerWithClock. Tick
@@ -287,8 +288,11 @@ func (b *Box) Set(c Condition) {
 // delta by the gap between two Sample Timestamps: advancing one without the
 // other would serve a rate nobody asked for.
 //
-// It panics on a non-positive d, because a clock that moves backwards produces
-// a negative elapsed time downstream that no later tick recovers from.
+// It panics on a non-positive d rather than serving it. A zero d accrues
+// nothing and moves nothing, so the next read finds no elapsed time to divide
+// by. A negative d subtracts from counters that only rise, which cpuhealth
+// reads as a cgroup reset. Either way the tick serves no rate, so the condition
+// the caller stated goes missing instead of failing.
 func (b *Box) Tick(d time.Duration) {
 	if d <= 0 {
 		panic(fmt.Sprintf("fakebox: Tick(%s) must advance time; a clock that moves backwards is not recoverable downstream", d))
@@ -303,10 +307,12 @@ func (b *Box) Tick(d time.Duration) {
 	// that increments nr_periods only for a quota'd cgroup, so an unquota'd one
 	// reports nr_periods 0 for its whole life however busy it gets.
 	//
-	// Holding them still here is not only fidelity. A denominator that always
-	// advances cannot express a denominator that never does, and that is a real
-	// suspected defect in this package: a throttle ratio taken over a stalled
-	// nr_periods. A Box with no quota states that machine directly.
+	// Holding them still is also the only way to hand the sampler a denominator
+	// that never advances, and two guards downstream exist for that machine: the
+	// throttling signal requires HasLimit (signal_throttling.go), and
+	// SlidingWindow.Reduce marks a dividing reduction untrusted when the
+	// denominator delta is not positive. A Box with no quota states that machine
+	// directly, so a spec can reach both.
 	if b.cond.QuotaCores > 0 {
 		// Both counters are integers, so a tick producing a fractional count of
 		// either cannot be served: rounding nr_throttled changes the throttle
@@ -385,6 +391,7 @@ func (b *Box) ServablePaths() []string {
 	for path := range b.servers {
 		paths = append(paths, path)
 	}
+
 	sort.Strings(paths)
 
 	return paths
@@ -473,7 +480,7 @@ func (b *Box) procStat() string {
 
 	fmt.Fprintf(&sb, "cpu  %d 0 0 %d 0 0 0 %d 0 0\n", b.jiffiesUser, b.jiffiesIdle, b.jiffiesSteal)
 
-	for i := 0; i < b.cond.Cores; i++ {
+	for i := range b.cond.Cores {
 		fmt.Fprintf(&sb, "cpu%d 0 0 0 0 0 0 0 0 0 0\n", i)
 	}
 

--- a/umh-core/pkg/cpuhealth/fakebox/fakebox.go
+++ b/umh-core/pkg/cpuhealth/fakebox/fakebox.go
@@ -1,0 +1,611 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package fakebox turns a machine condition stated in operator units into the
+// cgroup and /proc files the cpuhealth sampler reads. A test states "four CPUs,
+// 60% busy, throttled in 8% of periods" and drives the real sampler over it,
+// instead of hand-writing kernel file text whose field positions it has to get
+// right, or hand-building a Sample that skips the parsing entirely.
+//
+// Two rules make the numbers come back out unchanged.
+//
+// First, the counters and the clock move together. Every rate the sampler
+// publishes is a counter delta divided by the gap between two Sample
+// Timestamps, so a Box that advanced one without the other would report a
+// condition nobody stated. Tick does both, and there is no way to do either
+// alone.
+//
+// Second, the kernel writes these counters as integers, so a stated condition
+// that does not land on the integer grid cannot be served. Such a condition
+// panics naming the value rather than rounding to the nearest one it can write:
+// rounding nr_throttled at a 100 ms period turns a stated 8% throttle into a
+// served 10%, which is on the far side of the 5% fire mark, so the signal fires
+// with the wrong number while the test still looks like it passed.
+//
+// The dependency runs one way. This package imports neither cpuhealth nor
+// anything that does, and cpuhealth must not import it. Nothing in the compiler
+// stops it — the two build either way — so this is a rule here rather than
+// something the build enforces. What it buys is that every number a Box writes
+// is stated independently of the one the sampler reads it back with, so a wrong
+// constant on either side shows up as a wrong reading instead of cancelling out
+// against itself.
+//
+// One route through the sampler is deliberately not modelled: the ARM64 DMI
+// fallback, where /sys/class/dmi/id/sys_vendor carries the hypervisor identity
+// that an ARM64 product_name never names. A Box always writes an x86
+// /proc/cpuinfo with a flags line, so the sampler settles virtualisation before
+// it gets there. That route is covered separately and is not this fixture's
+// job.
+//
+// It ships as non-test code, like the filesystem package's MockFileSystem, so
+// tests in other packages can use it.
+//
+// A Box is not safe for concurrent use.
+package fakebox
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/benbjohnson/clock"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/filesystem"
+)
+
+// userHz is the jiffy rate /proc/stat counts in. The host source divides by a
+// constant of the same name and the same value, stated over there separately on
+// purpose — see the one-way dependency in the package comment.
+const userHz = 100
+
+// psiScale is the 0..100 figure the kernel writes cpu.pressure averages as,
+// which the PSI reader divides back out into a 0..1 fraction.
+const psiScale = 100
+
+// cfsPeriodsUs are the CFS periods a Box may write, largest first. All three
+// are legal cpu.max periods; the shorter ones exist so a Throttle that cannot
+// be written as a whole number of throttled periods at 100 ms still can at a
+// finer grid.
+var cfsPeriodsUs = []int64{100_000, 10_000, 1_000}
+
+// referenceTick is the tick length NewBox assumes when it picks the CFS period.
+// The period has to be fixed before the first Tick, because cpu.max publishes
+// it and nr_periods accrues against it, but NewBox is not told how long the
+// caller's ticks will be. One second is the sampler's own cadence. A caller who
+// ticks at some other length is not silently mis-served: Tick re-checks the
+// actual tick against the chosen period and panics if it does not divide.
+const referenceTick = time.Second
+
+// fixtureEpoch is where a Box's clock starts. It is a fixed instant far from
+// any plausible wall clock, so a Timestamp that came from time.Now() instead of
+// this clock cannot coincidentally look right.
+var fixtureEpoch = time.Date(2020, time.March, 14, 15, 9, 26, 0, time.UTC)
+
+// errUnreadable is what a file a Box does not serve reads as. The sampler
+// branches on the read failing at all and never on which error it was, so the
+// only thing that matters here is that it is non-nil.
+var errUnreadable = errors.New("no such file or directory")
+
+// unreadable is the error for one path, wrapping errUnreadable so a caller can
+// still match it with errors.Is.
+func unreadable(path string) error {
+	return fmt.Errorf("fakebox: %s: %w", path, errUnreadable)
+}
+
+// Condition is one tick's steady state of a machine, in the units an operator
+// would say out loud. It says what the machine IS doing, not what any file
+// contains; a Box turns it into the files.
+type Condition struct {
+	// Cores is the machine's CPU count, the number of per-CPU lines /proc/stat
+	// carries.
+	Cores int
+
+	// QuotaCores is the cgroup's CPU limit in cores, the figure docker run
+	// --cpus or a Kubernetes CPU limit sets. Zero or less writes cpu.max as
+	// "max", an explicit no-limit.
+	QuotaCores float64
+
+	// UsageCores is this cgroup's own CPU usage over the tick, in cores.
+	UsageCores float64
+
+	// HostBusy is how busy the whole machine is, as a fraction from 0 to 1. It
+	// is a fraction here and reads back in CORES, because that is the unit the
+	// sampler publishes: 0.60 on a four-CPU machine reads back as 2.4.
+	HostBusy float64
+
+	// Steal is the fraction of machine jiffies lost to steal, 0 to 1. HostBusy
+	// and Steal are fractions of the same total and cannot exceed 1 together.
+	Steal float64
+
+	// Throttle is the fraction of CFS periods in which the cgroup was
+	// throttled, 0 to 1.
+	Throttle float64
+
+	// Pressure is PSI "some" avg60 as a fraction from 0 to 1. It is a LEVEL the
+	// kernel reports directly, not a counter, so a Box writes it rather than
+	// accruing it: two ticks at the same Pressure serve the same figure.
+	Pressure float64
+
+	// PsiPresent false makes cpu.pressure unreadable, which is how a kernel
+	// built without PSI, or a cgroup that does not expose it, behaves. Pressure
+	// is then unreachable whatever it says.
+	PsiPresent bool
+
+	// Virtualized true makes /proc/cpuinfo carry the hypervisor flag.
+	Virtualized bool
+
+	// Affinity is how many CPUs the cgroup may run on, the size of
+	// cpuset.cpus.effective. Zero means all of Cores, the unpinned case; any
+	// smaller number is a pinned container and reads back as affinity scope.
+	Affinity int
+
+	// Unreadable lists absolute paths this machine cannot read, whatever the
+	// rest of the condition says — an unreadable /proc/stat, a cgroup whose
+	// cpu.stat the process may not open. Each entry is matched whole, against
+	// the same path the sampler asks for, so a cgroup file needs the base:
+	// "/sys/fs/cgroup/cpu.stat", not "cpu.stat". An entry that is relative, or
+	// that names no file this box serves, panics rather than being ignored —
+	// silently ignoring it would leave a spec asserting against the readable
+	// machine it was written to rule out.
+	//
+	// This is a list rather than a bool per file on purpose. Four bools would
+	// all mean the same thing and each would carry the PsiPresent inversion,
+	// where false is the interesting value and the zero value reads as the
+	// healthy one.
+	Unreadable []string
+}
+
+// Box serves one machine's cgroup and /proc files from a Condition, and owns
+// the clock the sampler stamps its samples from.
+type Box struct {
+	// clk is the mock the sampler stamps from. It is set once at construction
+	// and only advanced after that: a clock that moved backwards produces a
+	// negative elapsed time in the admission window downstream, and that window
+	// then never opens.
+	clk *clock.Mock
+
+	base string
+	cond Condition
+
+	// servers is the path-to-renderer table, built once in NewBox because it
+	// closes over base. See newServers.
+	servers map[string]func() string
+
+	// periodUs is the CFS period, chosen once in NewBox. It is fixed for the
+	// box's lifetime because cpu.max has already published it and nr_periods
+	// has been accruing against it, so changing it mid-run would make the
+	// counter's own history inconsistent.
+	periodUs int64
+
+	// The cumulative counters, in the units their files carry. They start at
+	// zero and only rise. Tick adds one tick's worth, except that the two
+	// throttle counters stand still without a quota — see Tick.
+	usageUsec    int64
+	nrPeriods    int64
+	nrThrottled  int64
+	psiTotalUsec int64
+
+	// The /proc/stat jiffy totals. Everything not busy and not stolen lands in
+	// idle, which is what keeps the total the sampler divides steal by equal to
+	// the whole machine's jiffies for the interval.
+	jiffiesUser  int64
+	jiffiesIdle  int64
+	jiffiesSteal int64
+}
+
+// NewBox returns a Box serving the cgroup files under base, in the state
+// initial describes. Its counters start at zero and its clock at fixtureEpoch.
+// It panics on a condition no machine could be in, and on a Throttle no CFS
+// period can express — see chooseCfsPeriodUs.
+func NewBox(base string, initial Condition) *Box {
+	validate(initial)
+
+	clk := clock.NewMock()
+	clk.Set(fixtureEpoch)
+
+	b := &Box{
+		clk:      clk,
+		base:     base,
+		cond:     initial,
+		periodUs: chooseCfsPeriodUs(initial.Throttle),
+	}
+	b.servers = b.newServers()
+	b.checkUnreadable(initial)
+
+	return b
+}
+
+// FS returns a filesystem service serving this box's files. It reads the box's
+// state at each call rather than a snapshot, so one service stays correct
+// across later Set and Tick calls. Every path the box does not serve reads as
+// an error, which is what the sampler sees on a machine lacking that file.
+func (b *Box) FS() filesystem.Service {
+	fs := filesystem.NewMockFileSystem()
+	fs.ReadFileFunc = func(ctx context.Context, path string) ([]byte, error) {
+		return b.readFile(path)
+	}
+
+	return fs
+}
+
+// shieldedClock hides the mock behind a plain clock.Clock. Returning the
+// interface is not on its own enough to hide anything: the dynamic type travels
+// with it, so box.Clock().(*clock.Mock) succeeds and hands the caller Set,
+// which moves the clock BACKWARDS. That is not a style point. The admission
+// window in pkg/fsmv2/cpu subtracts two instants with no lower guard, so one
+// backwards step leaves it refusing for the rest of the process. Embedding the
+// interface in an unexported struct promotes every read method and leaves no
+// way back to the mock.
+type shieldedClock struct{ clock.Clock }
+
+// Clock returns the clock to hand to cpuhealth.NewLinuxSamplerWithClock. Tick
+// is the only thing that moves it, and Tick only ever moves it forwards.
+func (b *Box) Clock() clock.Clock { return shieldedClock{b.clk} }
+
+// Set changes the condition later ticks accrue at. It does not accrue anything
+// itself, so a Set between two reads changes the next tick's rates and not the
+// counters already served.
+//
+// Set cannot check the new Throttle against the CFS period this box fixed at
+// NewBox, because whether a Throttle is servable depends on the tick length and
+// Set is not told it. Tick applies that check against the tick it is actually
+// given, and panics there.
+func (b *Box) Set(c Condition) {
+	validate(c)
+	b.checkUnreadable(c)
+
+	// A machine does not lose CPUs and keep its counters. Dropping Cores would
+	// cut HostCpus at once while the jiffy totals kept rising from the
+	// wider-machine era, and the tick that straddled the change would report
+	// more busy cores than the machine now has.
+	if c.Cores != b.cond.Cores {
+		panic(fmt.Sprintf(
+			"fakebox: Set Cores %d on a %d-CPU box: a machine does not gain or lose CPUs mid-run while its /proc/stat counters keep rising; construct a new Box instead",
+			c.Cores, b.cond.Cores))
+	}
+
+	b.cond = c
+}
+
+// Tick accrues d worth of every counter at the current condition AND advances
+// the clock by d. The two happen together because the sampler divides a counter
+// delta by the gap between two Sample Timestamps: advancing one without the
+// other would serve a rate nobody asked for.
+//
+// It panics on a non-positive d, because a clock that moves backwards produces
+// a negative elapsed time downstream that no later tick recovers from.
+func (b *Box) Tick(d time.Duration) {
+	if d <= 0 {
+		panic(fmt.Sprintf("fakebox: Tick(%s) must advance time; a clock that moves backwards is not recoverable downstream", d))
+	}
+
+	seconds := d.Seconds()
+
+	b.usageUsec += whole("usage_usec over the tick", b.cond.UsageCores*1e6*seconds)
+
+	// The throttle counters only move while CFS bandwidth control is on, which
+	// is what a positive quota turns on. The kernel starts the period timer
+	// that increments nr_periods only for a quota'd cgroup, so an unquota'd one
+	// reports nr_periods 0 for its whole life however busy it gets.
+	//
+	// Holding them still here is not only fidelity. A denominator that always
+	// advances cannot express a denominator that never does, and that is a real
+	// suspected defect in this package: a throttle ratio taken over a stalled
+	// nr_periods. A Box with no quota states that machine directly.
+	if b.cond.QuotaCores > 0 {
+		// Both counters are integers, so a tick producing a fractional count of
+		// either cannot be served: rounding nr_throttled changes the throttle
+		// RATIO the instrument reads, which is the whole point of the counter.
+		periods := whole("nr_periods over the tick", float64(d.Microseconds())/float64(b.periodUs))
+		throttled := whole("nr_throttled over the tick", b.cond.Throttle*float64(periods))
+		b.nrPeriods += periods
+		b.nrThrottled += throttled
+	}
+
+	// The machine's jiffies for the interval. Busy and steal are fractions of
+	// this total and idle takes the rest, so the denominator the sampler
+	// computes off the served line is exactly this total.
+	total := whole("/proc/stat jiffies over the tick", float64(b.cond.Cores)*userHz*seconds)
+	busy := whole("/proc/stat busy jiffies over the tick", b.cond.HostBusy*float64(total))
+	steal := whole("/proc/stat steal jiffies over the tick", b.cond.Steal*float64(total))
+	b.jiffiesUser += busy
+	b.jiffiesSteal += steal
+	b.jiffiesIdle += total - busy - steal
+
+	// cpu.pressure's total is the one counter nothing in cpuhealth reads — only
+	// avg60 is parsed — so it is rounded rather than held to the integer grid.
+	// Holding it there would reject a Pressure the reader would have served
+	// exactly.
+	b.psiTotalUsec += int64(math.Round(b.cond.Pressure * 1e6 * seconds))
+
+	b.clk.Add(d)
+}
+
+// readFile serves one path, or reports the error the sampler would see for a
+// file this machine does not have.
+func (b *Box) readFile(path string) ([]byte, error) {
+	// Checked before anything else, so a path the box would otherwise serve
+	// still fails when the condition says this machine cannot read it.
+	for _, p := range b.cond.Unreadable {
+		if p == path {
+			return nil, unreadable(path)
+		}
+	}
+
+	// A kernel without PSI has no cpu.pressure to open at all, which is a
+	// different fact from the file being listed unreadable and reads the same
+	// way to the sampler.
+	if path == b.base+"/cpu.pressure" && !b.cond.PsiPresent {
+		return nil, unreadable(path)
+	}
+
+	render, served := b.servers[path]
+	if !served {
+		return nil, fmt.Errorf("fakebox: %q is not one of the files this box serves: %w", path, errUnreadable)
+	}
+
+	return []byte(render()), nil
+}
+
+// newServers builds the table of every file this box serves, mapped to what
+// renders it. It is the single source of truth for "servable": readFile
+// dispatches on it and checkUnreadable rejects against it, so a path cannot be
+// servable to one and unknown to the other.
+func (b *Box) newServers() map[string]func() string {
+	return map[string]func() string{
+		b.base + "/cpu.stat":              b.cpuStat,
+		b.base + "/cpu.max":               b.cpuMax,
+		b.base + "/cpu.pressure":          b.cpuPressure,
+		b.base + "/cpuset.cpus.effective": b.cpusetEffective,
+		"/proc/stat":                      b.procStat,
+		"/proc/cpuinfo":                   b.procCpuinfo,
+		"/sys/class/dmi/id/product_name":  b.dmiProductName,
+	}
+}
+
+// ServablePaths returns every path this box serves, sorted. Exported so a test
+// can walk the whole set rather than repeating it and drifting from it.
+func (b *Box) ServablePaths() []string {
+	paths := make([]string, 0, len(b.servers))
+	for path := range b.servers {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+
+	return paths
+}
+
+// checkUnreadable rejects an Unreadable entry that names no file this box could
+// ever serve. Without this the entry is silently ignored, so a spec written to
+// prove behaviour under an unreadable cpu.stat would run against a perfectly
+// readable one and assert nothing — the failure this whole package exists to
+// prevent, reached through its own newest field.
+func (b *Box) checkUnreadable(c Condition) {
+	for _, path := range c.Unreadable {
+		if !strings.HasPrefix(path, "/") {
+			panic(fmt.Sprintf(
+				"fakebox: Unreadable %q is not an absolute path; entries are matched whole against the path the sampler asks for, so a cgroup file needs the base — %q, not %q",
+				path, b.base+"/"+path, path))
+		}
+
+		if _, served := b.servers[path]; !served {
+			panic(fmt.Sprintf(
+				"fakebox: Unreadable %q names no file this box serves, so listing it would change nothing; this box serves %v",
+				path, b.ServablePaths()))
+		}
+	}
+}
+
+// cpuStat writes the cgroup's CPU accounting. Only usage_usec, nr_periods and
+// nr_throttled are read by cpuhealth; the rest are here because a real cpu.stat
+// carries them and a fixture missing them would not be one.
+func (b *Box) cpuStat() string {
+	return fmt.Sprintf(
+		"usage_usec %d\nuser_usec %d\nsystem_usec 0\nnr_periods %d\nnr_throttled %d\nthrottled_usec %d\n",
+		b.usageUsec, b.usageUsec, b.nrPeriods, b.nrThrottled, b.nrThrottled*b.periodUs)
+}
+
+// cpuMax writes the cgroup's CPU limit as the kernel's quota-and-period pair.
+// The quota scales with whichever period this box picked, so the cores the
+// sampler divides back out are the stated ones at any period.
+func (b *Box) cpuMax() string {
+	if b.cond.QuotaCores <= 0 {
+		return fmt.Sprintf("max %d\n", b.periodUs)
+	}
+
+	quota := whole("cpu.max quota", b.cond.QuotaCores*float64(b.periodUs))
+
+	return fmt.Sprintf("%d %d\n", quota, b.periodUs)
+}
+
+// cpuPressure writes the PSI averages at the two decimals the kernel writes,
+// matching the hand-written fixture in read_psi_test.go. Writing more decimals
+// would let a test state a pressure no real box could report, and a test that
+// passes has to describe a machine that could exist. validate rejects a
+// Pressure this precision cannot carry, so nothing is rounded away here.
+func (b *Box) cpuPressure() string {
+	avg := b.cond.Pressure * psiScale
+
+	return fmt.Sprintf(
+		"some avg10=%.2f avg60=%.2f avg300=%.2f total=%d\nfull avg10=%.2f avg60=%.2f avg300=%.2f total=%d\n",
+		avg, avg, avg, b.psiTotalUsec, avg, avg, avg, b.psiTotalUsec)
+}
+
+// cpusetEffective writes the CPUs the cgroup may run on, as the contiguous
+// range starting at 0 that the kernel writes for a run of CPUs.
+func (b *Box) cpusetEffective() string {
+	allowed := b.cond.Affinity
+	if allowed == 0 {
+		allowed = b.cond.Cores
+	}
+
+	if allowed == 1 {
+		return "0\n"
+	}
+
+	return fmt.Sprintf("0-%d\n", allowed-1)
+}
+
+// procStat writes the machine's CPU time. The aggregate "cpu " line carries the
+// jiffy totals, in the kernel's field order: user, nice, system, idle, iowait,
+// irq, softirq, steal, guest, guest_nice. Everything a Condition does not name
+// stays zero, so the busy total the sampler sums is exactly the user field.
+//
+// The per-CPU lines below it are all zeros: nothing parses them, and their
+// COUNT is the machine's CPU count.
+func (b *Box) procStat() string {
+	var sb strings.Builder
+
+	fmt.Fprintf(&sb, "cpu  %d 0 0 %d 0 0 0 %d 0 0\n", b.jiffiesUser, b.jiffiesIdle, b.jiffiesSteal)
+
+	for i := 0; i < b.cond.Cores; i++ {
+		fmt.Fprintf(&sb, "cpu%d 0 0 0 0 0 0 0 0 0 0\n", i)
+	}
+
+	return sb.String()
+}
+
+// procCpuinfo writes an x86 cpuinfo. The flags line is what makes this machine
+// answerable either way: "hypervisor" among the flags proves a guest, and the
+// line's mere presence is what lets a bare-metal verdict be cached instead of
+// re-read every tick.
+func (b *Box) procCpuinfo() string {
+	flags := "fpu vme de pse tsc msr pae mce cx8 apic lm"
+	if b.cond.Virtualized {
+		flags += " hypervisor"
+	}
+
+	return "processor\t: 0\nvendor_id\t: GenuineIntel\nflags\t\t: " + flags + "\n"
+}
+
+// dmiProductName writes the SMBIOS product name, and always a bare-metal one.
+// There is no hypervisor branch because nothing could reach it: a virtualized
+// Box writes the hypervisor flag into /proc/cpuinfo, and the sampler settles
+// the fact there and never opens DMI.
+//
+// A bare-metal box has to serve this file. With no readable DMI source the
+// sampler leaves virtualisation unresolved and re-reads it every tick, so a Box
+// that errored here would never let the fact settle.
+func (b *Box) dmiProductName() string { return "PowerEdge R640\n" }
+
+// chooseCfsPeriodUs picks the largest CFS period at which Throttle is a whole
+// number of throttled periods over referenceTick.
+//
+// The period matters because nr_throttled is an integer. At a 100 ms period a
+// one-second tick has ten periods, so a Throttle of 0.08 accrues 0.8 of a
+// period: served as an integer that is 1, a ratio of 0.10, which is on the far
+// side of the 5% fire mark. The signal then fires with a number nobody stated.
+// A 10 ms period gives that same tick a hundred periods and 0.08 accrues
+// exactly 8.
+//
+// A Throttle no period can express panics rather than being served
+// approximately, because there is no way to tell a wrong-by-rounding ratio
+// apart from a stated one once it is in the file.
+func chooseCfsPeriodUs(throttle float64) int64 {
+	for _, periodUs := range cfsPeriodsUs {
+		periods := float64(referenceTick.Microseconds()) / float64(periodUs)
+		if isWhole(throttle * periods) {
+			return periodUs
+		}
+	}
+
+	panic(fmt.Sprintf(
+		"fakebox: Throttle %v is not a whole number of throttled periods at any CFS period (100ms, 10ms, 1ms) over a %s tick; state a Throttle that is, such as a multiple of 0.001",
+		throttle, referenceTick))
+}
+
+// validate rejects a Condition no machine could be in. Each of these would
+// otherwise be served as some other condition — a Steal above 1 as a negative
+// idle, an Affinity above Cores as a cpuset the machine does not have — and the
+// test would then be asserting against a machine it did not describe.
+func validate(c Condition) {
+	if c.Cores < 1 {
+		panic(fmt.Sprintf("fakebox: Cores %d: a machine has at least one CPU", c.Cores))
+	}
+
+	if c.UsageCores < 0 {
+		panic(fmt.Sprintf("fakebox: UsageCores %v: usage cannot be negative", c.UsageCores))
+	}
+
+	unitFraction("HostBusy", c.HostBusy)
+	unitFraction("Steal", c.Steal)
+	unitFraction("Throttle", c.Throttle)
+	unitFraction("Pressure", c.Pressure)
+
+	// Busy and stolen time are both fractions of the machine's jiffies, and
+	// what is left over is idle. Together above 1 there is no idle left to take
+	// it from.
+	if c.HostBusy+c.Steal > 1 {
+		panic(fmt.Sprintf(
+			"fakebox: HostBusy %v + Steal %v is %v: they are fractions of the same machine and cannot exceed 1 together",
+			c.HostBusy, c.Steal, c.HostBusy+c.Steal))
+	}
+
+	// cpu.pressure carries two decimals of a percentage. A finer Pressure
+	// cannot be written, and this package states what it cannot serve rather
+	// than rounding it into something the caller did not ask for.
+	if !isWhole(c.Pressure * psiScale * 100) {
+		panic(fmt.Sprintf(
+			"fakebox: Pressure %v is finer than the two decimals of a percentage cpu.pressure carries; state a multiple of 0.0001",
+			c.Pressure))
+	}
+
+	// Only a quota'd cgroup can be throttled, because the quota is what turns
+	// CFS bandwidth control on. Serving a throttle without one would mean
+	// writing nr_throttled against an nr_periods that never moves.
+	if c.Throttle > 0 && c.QuotaCores <= 0 {
+		panic(fmt.Sprintf(
+			"fakebox: Throttle %v with QuotaCores %v: a cgroup with no quota has no CFS bandwidth control and is never throttled",
+			c.Throttle, c.QuotaCores))
+	}
+
+	if c.Affinity < 0 || c.Affinity > c.Cores {
+		panic(fmt.Sprintf(
+			"fakebox: Affinity %d on a %d-CPU machine: a cgroup runs on some of the machine's CPUs, and 0 means all of them",
+			c.Affinity, c.Cores))
+	}
+}
+
+// unitFraction panics unless v is a fraction from 0 to 1.
+func unitFraction(name string, v float64) {
+	if v < 0 || v > 1 {
+		panic(fmt.Sprintf("fakebox: %s %v: expected a fraction from 0 to 1", name, v))
+	}
+}
+
+// wholeTolerance is the slack whole allows for float64 representation. The
+// products it checks are computed from decimal fractions, whose error at these
+// magnitudes is many orders below this, while the smallest fractional part it
+// has to reject is 0.5.
+const wholeTolerance = 1e-6
+
+// isWhole reports whether v is an integer up to float64 representation.
+func isWhole(v float64) bool { return math.Abs(v-math.Round(v)) <= wholeTolerance }
+
+// whole rounds v to the integer the file will carry, and panics naming what
+// could not be written when v is not one. Serving the rounded value instead
+// would change the condition rather than fail to express it.
+func whole(what string, v float64) int64 {
+	if !isWhole(v) {
+		panic(fmt.Sprintf(
+			"fakebox: %s is %v, which is not a whole number; the kernel writes this counter as an integer, so this condition cannot be served exactly",
+			what, v))
+	}
+
+	return int64(math.Round(v))
+}

--- a/umh-core/pkg/cpuhealth/fakebox/fakebox_suite_test.go
+++ b/umh-core/pkg/cpuhealth/fakebox/fakebox_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fakebox_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestFakebox(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Fakebox Suite")
+}

--- a/umh-core/pkg/cpuhealth/fakebox/fakebox_test.go
+++ b/umh-core/pkg/cpuhealth/fakebox/fakebox_test.go
@@ -1,0 +1,502 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// What a Box promises: a Condition stated in operator units comes back out of
+// the real sampler as the same numbers. The specs below drive
+// cpuhealth.NewLinuxSamplerWithClock over a Box rather than checking the file
+// text, because file text that parses is not the same fact as a Sample that
+// reads correctly — a wrong field position produces both.
+//
+// Every assertion is on the SECOND read. The first read only fixes the rate
+// baselines the sampler subtracts from, so it publishes no rate at all.
+package fakebox_test
+
+import (
+	"context"
+	"time"
+
+	"github.com/benbjohnson/clock"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/cpuhealth"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/cpuhealth/fakebox"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/diagnosis"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/filesystem"
+)
+
+// dmiProductName is the SMBIOS identity file the bare-metal path resolves
+// against.
+const dmiProductName = "/sys/class/dmi/id/product_name"
+
+// countingFS counts reads per path on the way through to the box. Some facts
+// the sampler settles once are invisible in the Sample — a resolved
+// virtualisation fact and an unresolved one both read Virtualized false — and
+// the read count is the only thing that separates them.
+type countingFS struct {
+	filesystem.Service
+
+	reads map[string]int
+}
+
+func newCountingFS(inner filesystem.Service) *countingFS {
+	return &countingFS{Service: inner, reads: map[string]int{}}
+}
+
+func (c *countingFS) ReadFile(ctx context.Context, path string) ([]byte, error) {
+	c.reads[path]++
+
+	return c.Service.ReadFile(ctx, path)
+}
+
+var _ = Describe("a machine condition served as cgroup and proc files", func() {
+	const base = "/sys/fs/cgroup"
+
+	// tol is tight on purpose. The numbers below are exact on the integer grid
+	// the kernel files are written on, so the only slack any of them needs is
+	// float64 representation. A loose tolerance here would accept a fixture
+	// that rounds a counter and reports a neighbouring value instead.
+	const tol = 1e-9
+
+	// known returns a Reading's value and fails the spec when it is absent, so
+	// a missing reading reports as itself rather than as a zero value.
+	known := func(r diagnosis.Reading, what string) float64 {
+		v, ok := r.Get()
+		ExpectWithOffset(1, ok).To(BeTrue(), what+" must be a present reading")
+
+		return v
+	}
+
+	// readTwice drives the real sampler across one tick of the box and returns
+	// both samples: the baseline read, then the read after the tick.
+	readTwice := func(box *fakebox.Box, d time.Duration) (cpuhealth.Sample, cpuhealth.Sample) {
+		ctx := context.Background()
+		sampler := cpuhealth.NewLinuxSamplerWithClock(box.FS(), base, box.Clock())
+
+		s1, err := sampler.Read(ctx)
+		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "the baseline read must succeed")
+
+		box.Tick(d)
+
+		s2, err := sampler.Read(ctx)
+		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "the read after the tick must succeed")
+
+		return s1, s2
+	}
+
+	It("reads back every number of a busy, throttled, virtualized machine", func() {
+		// A four-CPU VM capped at two cores, using 1.2 of them, on a machine
+		// that is 60% busy and losing 5% to steal, throttled in 8% of its CFS
+		// periods, with PSI reporting a quarter of the time stalled.
+		box := fakebox.NewBox(base, fakebox.Condition{
+			Cores:       4,
+			QuotaCores:  2,
+			UsageCores:  1.2,
+			HostBusy:    0.60,
+			Steal:       0.05,
+			Throttle:    0.08,
+			Pressure:    0.25,
+			PsiPresent:  true,
+			Virtualized: true,
+		})
+
+		s1, s2 := readTwice(box, time.Second)
+
+		// Tick must move the counters and the clock by the same amount. Every
+		// rate below is a counter delta divided by this elapsed time, so a
+		// clock that moved differently would scale all of them together and
+		// none of the assertions could tell.
+		Expect(s2.Timestamp.Sub(s1.Timestamp)).To(Equal(time.Second),
+			"one Tick(1s) must advance the sample's Timestamp by exactly one second")
+
+		Expect(known(s2.UsageCores, "UsageCores")).To(BeNumerically("~", 1.2, tol),
+			"a cgroup using 1.2 cores must read back as 1.2 cores")
+
+		// HostBusy is in CORES, not a fraction: 60% of a four-CPU machine.
+		Expect(known(s2.HostBusy, "HostBusy")).To(BeNumerically("~", 2.4, tol),
+			"a machine 60 percent busy across 4 CPUs must read back as 2.4 busy cores")
+
+		Expect(known(s2.Steal, "Steal")).To(BeNumerically("~", 0.05, tol),
+			"5 percent steal must read back as the fraction 0.05")
+
+		// The throttle ratio is the two counters' deltas across the window,
+		// which is what the throttling instrument's DeltaRatio reduction takes.
+		// Asserting the ratio rather than either counter is what catches a
+		// fixture that rounds nr_throttled to a neighbouring integer.
+		dPeriods := known(s2.NrPeriods, "NrPeriods") - known(s1.NrPeriods, "NrPeriods")
+		dThrottled := known(s2.NrThrottled, "NrThrottled") - known(s1.NrThrottled, "NrThrottled")
+		Expect(dPeriods).To(BeNumerically(">", 0), "the tick must advance nr_periods")
+		Expect(dThrottled/dPeriods).To(BeNumerically("~", 0.08, tol),
+			"throttling in 8 percent of CFS periods must read back as the ratio 0.08")
+
+		Expect(known(s2.Pressure, "Pressure")).To(BeNumerically("~", 0.25, tol),
+			"PSI some avg60 of a quarter must read back as 0.25")
+		Expect(s2.PsiAvailable).To(BeTrue(), "a readable cpu.pressure must set PsiAvailable")
+
+		Expect(known(s2.HostCpus, "HostCpus")).To(BeNumerically("~", 4, tol),
+			"a four-CPU machine must read back four machine CPUs")
+		Expect(known(s2.LogicalCpus, "LogicalCpus")).To(BeNumerically("~", 4, tol),
+			"an unpinned container on a four-CPU machine may use all four")
+		Expect(s2.CpuScope).To(Equal(cpuhealth.ScopeHost),
+			"a cpuset covering every machine CPU is host scope, not affinity scope")
+
+		Expect(s2.Virtualized).To(BeTrue(),
+			"a guest must read back virtualized")
+
+		Expect(known(s2.Quota, "Quota")).To(BeNumerically("~", 2, tol),
+			"a two-core cap must read back as a quota of 2 cores")
+	})
+
+	It("reads back a bare-metal machine with no PSI, pinned to a subset of its CPUs", func() {
+		// The same four-CPU machine, but the kernel publishes no PSI, the host
+		// is bare metal, and the container is pinned to two of the four CPUs.
+		box := fakebox.NewBox(base, fakebox.Condition{
+			Cores:       4,
+			QuotaCores:  2,
+			UsageCores:  1.2,
+			HostBusy:    0.60,
+			Steal:       0.05,
+			Throttle:    0.08,
+			Pressure:    0.25,
+			PsiPresent:  false,
+			Virtualized: false,
+			Affinity:    2,
+		})
+
+		_, s2 := readTwice(box, time.Second)
+
+		// Pressure is stated but unreachable: PsiPresent false makes
+		// cpu.pressure unreadable, so the stated level must not surface.
+		_, ok := s2.Pressure.Get()
+		Expect(ok).To(BeFalse(),
+			"an unreadable cpu.pressure must leave Pressure absent, never a confident zero")
+		Expect(s2.PsiAvailable).To(BeFalse(),
+			"a kernel that never published PSI must leave PsiAvailable false")
+
+		Expect(known(s2.LogicalCpus, "LogicalCpus")).To(BeNumerically("~", 2, tol),
+			"a container pinned to two CPUs must read back two logical CPUs")
+		Expect(known(s2.HostCpus, "HostCpus")).To(BeNumerically("~", 4, tol),
+			"pinning does not change the machine's CPU count")
+		Expect(s2.CpuScope).To(Equal(cpuhealth.ScopeAffinity),
+			"a cpuset smaller than the machine is affinity scope")
+
+		Expect(s2.Virtualized).To(BeFalse(),
+			"a bare-metal host must read back not virtualized")
+	})
+
+	It("derives the same rates from any servable tick length", func() {
+		// The headline property: Tick moves the counters and the clock
+		// together. A Box that advanced the clock by d but accrued counters for
+		// a hard-coded one second would agree with the 1s case above and be
+		// wrong by 2x either side of it.
+		//
+		// Not every length is servable — this box picks the 10ms CFS period for
+		// Throttle 0.08, and 100ms of that is 8/10ths of a throttled period,
+		// which panics. The last case of the panic spec below pins that.
+		//
+		// 250ms and 1.5s are here because 500ms, 1s and 2s are all whole
+		// multiples of 100ms and cannot tell a box that quietly rounded ticks
+		// to a tenth of a second from one that did not.
+		cond := fakebox.Condition{
+			Cores:       4,
+			QuotaCores:  2,
+			UsageCores:  1.2,
+			HostBusy:    0.60,
+			Steal:       0.05,
+			Throttle:    0.08,
+			Pressure:    0.25,
+			PsiPresent:  true,
+			Virtualized: true,
+		}
+
+		for _, d := range []time.Duration{250 * time.Millisecond, 500 * time.Millisecond, time.Second, 1500 * time.Millisecond, 2 * time.Second} {
+			at := " at a tick of " + d.String()
+
+			s1, s2 := readTwice(fakebox.NewBox(base, cond), d)
+
+			Expect(s2.Timestamp.Sub(s1.Timestamp)).To(Equal(d),
+				"the stamp must move by exactly the tick"+at)
+			Expect(known(s2.UsageCores, "UsageCores")).To(BeNumerically("~", 1.2, tol),
+				"the same condition must read back 1.2 usage cores"+at)
+			Expect(known(s2.HostBusy, "HostBusy")).To(BeNumerically("~", 2.4, tol),
+				"the same condition must read back 2.4 busy cores"+at)
+			Expect(known(s2.Steal, "Steal")).To(BeNumerically("~", 0.05, tol),
+				"the same condition must read back 0.05 steal"+at)
+
+			dPeriods := known(s2.NrPeriods, "NrPeriods") - known(s1.NrPeriods, "NrPeriods")
+			dThrottled := known(s2.NrThrottled, "NrThrottled") - known(s1.NrThrottled, "NrThrottled")
+			Expect(dPeriods).To(BeNumerically(">", 0), "the tick must advance nr_periods"+at)
+			Expect(dThrottled/dPeriods).To(BeNumerically("~", 0.08, tol),
+				"the same condition must read back a throttle ratio of 0.08"+at)
+		}
+	})
+
+	It("holds the throttle counters still on a cgroup with no quota", func() {
+		// The kernel only runs the CFS period timer for a quota'd cgroup, so an
+		// unquota'd one reports nr_periods 0 for its whole life however busy it
+		// gets. A fixture that advanced the denominator anyway could not state
+		// this machine at all.
+		box := fakebox.NewBox(base, fakebox.Condition{
+			Cores:      4,
+			QuotaCores: 0,
+			UsageCores: 1.2,
+			HostBusy:   0.60,
+			Steal:      0.05,
+			Pressure:   0.25,
+			PsiPresent: true,
+		})
+
+		s1, s2 := readTwice(box, time.Second)
+
+		Expect(known(s1.NrPeriods, "NrPeriods")).To(Equal(0.0),
+			"an unquota'd cgroup starts with nr_periods 0")
+		Expect(known(s2.NrPeriods, "NrPeriods")).To(Equal(0.0),
+			"nr_periods must not advance without a quota, however long the box ticks")
+		Expect(known(s2.NrThrottled, "NrThrottled")).To(Equal(0.0),
+			"a cgroup with no bandwidth control is never throttled")
+
+		// Everything not gated on the quota still moves.
+		Expect(known(s2.Quota, "Quota")).To(Equal(0.0),
+			"cpu.max \"max\" is a present no-limit, not an absent reading")
+		Expect(known(s2.UsageCores, "UsageCores")).To(BeNumerically("~", 1.2, tol),
+			"usage accrues whether or not the cgroup has a quota")
+	})
+
+	It("resolves the bare-metal identity from a readable product_name, once", func() {
+		bareMetal := fakebox.Condition{
+			Cores:      4,
+			QuotaCores: 2,
+			UsageCores: 1.2,
+			HostBusy:   0.60,
+			Steal:      0.05,
+			Throttle:   0.08,
+			Pressure:   0.25,
+			PsiPresent: true,
+		}
+		ctx := context.Background()
+
+		box := fakebox.NewBox(base, bareMetal)
+		counted := newCountingFS(box.FS())
+		sampler := cpuhealth.NewLinuxSamplerWithClock(counted, base, box.Clock())
+
+		s1, err := sampler.Read(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(s1.Virtualized).To(BeFalse())
+		Expect(counted.reads[dmiProductName]).To(Equal(1),
+			"the bare-metal path must find product_name READABLE; a Sample cannot say so on its own, since an unreadable one also reads Virtualized false")
+
+		// A settled fact is not re-read. This is the property the fixture's
+		// comment claims and the reason a bare-metal box has to serve DMI.
+		settled := counted.reads[dmiProductName] + counted.reads["/proc/cpuinfo"]
+		box.Tick(time.Second)
+		_, err = sampler.Read(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(counted.reads[dmiProductName]+counted.reads["/proc/cpuinfo"]).To(Equal(settled),
+			"a resolved virtualisation fact must not be read again on the next tick")
+
+		// The control. With product_name unreadable the fact cannot settle, so
+		// the sampler retries every tick. Virtualized reads false either way,
+		// which is exactly why the count is what has to be measured.
+		unresolvable := bareMetal
+		unresolvable.Unreadable = []string{dmiProductName}
+
+		box2 := fakebox.NewBox(base, unresolvable)
+		counted2 := newCountingFS(box2.FS())
+		sampler2 := cpuhealth.NewLinuxSamplerWithClock(counted2, base, box2.Clock())
+
+		_, err = sampler2.Read(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		box2.Tick(time.Second)
+		s, err := sampler2.Read(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(s.Virtualized).To(BeFalse(),
+			"an unresolvable identity still reads not virtualized, same as the resolved one")
+		Expect(counted2.reads["/proc/cpuinfo"]).To(Equal(2),
+			"an unresolved fact must be retried every tick, which is what makes the settled case above a real assertion")
+	})
+
+	It("makes a listed path unreadable", func() {
+		ctx := context.Background()
+		readable := fakebox.Condition{
+			Cores:      4,
+			QuotaCores: 2,
+			UsageCores: 1.2,
+			HostBusy:   0.60,
+			Steal:      0.05,
+			Throttle:   0.08,
+			Pressure:   0.25,
+			PsiPresent: true,
+		}
+
+		// cpu.stat is the primary file: unreadable, the whole sample fails.
+		noStat := readable
+		noStat.Unreadable = []string{base + "/cpu.stat"}
+		box := fakebox.NewBox(base, noStat)
+
+		_, err := cpuhealth.NewLinuxSamplerWithClock(box.FS(), base, box.Clock()).Read(ctx)
+		Expect(err).To(HaveOccurred(),
+			"an unreadable cpu.stat must fail the whole sample, not drop a field")
+
+		// /proc/stat is not primary. The sample still succeeds and loses the
+		// machine's CPU count, and with it the scope that needs it.
+		noProcStat := readable
+		noProcStat.Unreadable = []string{"/proc/stat"}
+		box2 := fakebox.NewBox(base, noProcStat)
+
+		s, err := cpuhealth.NewLinuxSamplerWithClock(box2.FS(), base, box2.Clock()).Read(ctx)
+		Expect(err).NotTo(HaveOccurred(),
+			"an unreadable /proc/stat must not fail the sample; only cpu.stat is primary")
+		_, ok := s.HostCpus.Get()
+		Expect(ok).To(BeFalse(),
+			"an unreadable /proc/stat must leave the machine CPU count absent")
+		Expect(s.CpuScope).To(Equal(cpuhealth.ScopeUnknown),
+			"no machine count means no scope, never a silent host scope")
+	})
+
+	It("carries both decimals of the pressure it was given", func() {
+		// 0.0625 is 6.25 percent — a pressure that needs both of
+		// cpu.pressure's decimals. Case A's 0.25 is 25.00 percent and would
+		// survive being written with none, so it cannot tell this precision
+		// from a coarser one.
+		box := fakebox.NewBox(base, fakebox.Condition{
+			Cores:      4,
+			QuotaCores: 2,
+			Pressure:   0.0625,
+			PsiPresent: true,
+		})
+
+		_, s2 := readTwice(box, time.Second)
+
+		Expect(known(s2.Pressure, "Pressure")).To(BeNumerically("~", 0.0625, tol),
+			"a pressure of 6.25 percent must survive the file at full precision, not be rounded to 6.2 or 6")
+	})
+
+	It("refuses an Unreadable path it would never be asked for", func() {
+		// A silently ignored entry is the worst outcome available here: a spec
+		// written to prove behaviour under an unreadable cpu.stat would run
+		// against a readable one and assert nothing.
+		base10 := fakebox.Condition{Cores: 4, QuotaCores: 2, PsiPresent: true}
+
+		with := func(paths ...string) fakebox.Condition {
+			c := base10
+			c.Unreadable = paths
+
+			return c
+		}
+
+		Expect(func() { fakebox.NewBox(base, with("cpu.stat")) }).
+			To(PanicWith(ContainSubstring("is not an absolute path")),
+				"a cgroup path missing its base is the likely typo, and it must not be ignored")
+
+		Expect(func() { fakebox.NewBox(base, with("/proc/meminfo")) }).
+			To(PanicWith(ContainSubstring("names no file this box serves")),
+				"listing a file the box never serves would change nothing, so it is a mistake, not a no-op")
+
+		Expect(func() { fakebox.NewBox(base, base10).Set(with("cpu.stat")) }).
+			To(PanicWith(ContainSubstring("is not an absolute path")),
+				"Set must reject what NewBox rejects")
+
+		// Every path the box claims to serve must actually read, or the table
+		// the rejection above is checked against is itself wrong.
+		box := fakebox.NewBox(base, base10)
+		Expect(box.ServablePaths()).To(HaveLen(7))
+
+		for _, path := range box.ServablePaths() {
+			data, err := box.FS().ReadFile(context.Background(), path)
+			Expect(err).NotTo(HaveOccurred(), "the box claims to serve "+path+", so it must read")
+			Expect(data).NotTo(BeEmpty(), path+" must not read as empty")
+
+			// And each one must then be accepted as an Unreadable entry.
+			Expect(func() { fakebox.NewBox(base, with(path)) }).NotTo(Panic(),
+				"every servable path must be listable as unreadable: "+path)
+		}
+	})
+
+	It("hands out a clock the caller cannot move backwards", func() {
+		// Returning a clock.Clock is not on its own enough to hide the mock:
+		// the dynamic type travels with the interface, so an unwrapped mock
+		// would come straight back out of a type assertion, bringing Set with
+		// it. A backwards clock makes the admission window in pkg/fsmv2/cpu
+		// subtract to a negative elapsed, and it then refuses for good.
+		box := fakebox.NewBox(base, fakebox.Condition{Cores: 4, QuotaCores: 2, PsiPresent: true})
+
+		_, recovered := box.Clock().(*clock.Mock)
+		Expect(recovered).To(BeFalse(),
+			"the mock must not be recoverable from the clock a Box hands out, or the caller can move time backwards")
+
+		// The clock still has to work as a clock, and still has to move under
+		// Tick — hiding the mock must not have hidden the time.
+		before := box.Clock().Now()
+		box.Tick(time.Second)
+		Expect(box.Clock().Now().Sub(before)).To(Equal(time.Second),
+			"the shielded clock must still advance by exactly the tick")
+	})
+
+	It("panics on a machine it cannot serve, naming what it could not serve", func() {
+		// Every guard below is otherwise unexercised, which means any of them
+		// could be deleted without a spec going red.
+		ok := fakebox.Condition{Cores: 4, QuotaCores: 2, UsageCores: 1.2, PsiPresent: true}
+
+		with := func(f func(c *fakebox.Condition)) fakebox.Condition {
+			c := ok
+			f(&c)
+
+			return c
+		}
+
+		Expect(func() {
+			fakebox.NewBox(base, with(func(c *fakebox.Condition) { c.HostBusy, c.Steal = 0.8, 0.5 }))
+		}).To(PanicWith(ContainSubstring("cannot exceed 1 together")),
+			"busy and stolen time are fractions of the same machine")
+
+		Expect(func() {
+			fakebox.NewBox(base, with(func(c *fakebox.Condition) { c.Affinity = 8 }))
+		}).To(PanicWith(ContainSubstring("Affinity 8 on a 4-CPU machine")),
+			"a cgroup cannot be pinned to CPUs the machine does not have")
+
+		Expect(func() {
+			fakebox.NewBox(base, with(func(c *fakebox.Condition) { c.Pressure = 0.000005 }))
+		}).To(PanicWith(ContainSubstring("two decimals of a percentage")),
+			"a pressure finer than cpu.pressure can carry must be refused, not rounded")
+
+		Expect(func() {
+			fakebox.NewBox(base, with(func(c *fakebox.Condition) { c.Throttle, c.QuotaCores = 0.08, 0 }))
+		}).To(PanicWith(ContainSubstring("no CFS bandwidth control")),
+			"a cgroup with no quota is never throttled")
+
+		Expect(func() {
+			fakebox.NewBox(base, with(func(c *fakebox.Condition) { c.Throttle = 0.0001 }))
+		}).To(PanicWith(ContainSubstring("not a whole number of throttled periods at any CFS period")),
+			"a throttle no CFS period can express must name itself rather than be rounded")
+
+		Expect(func() {
+			fakebox.NewBox(base, ok).Set(with(func(c *fakebox.Condition) { c.Cores = 2 }))
+		}).To(PanicWith(ContainSubstring("does not gain or lose CPUs mid-run")),
+			"dropping Cores mid-run would cut HostCpus while the jiffy totals kept rising")
+
+		Expect(func() {
+			fakebox.NewBox(base, ok).Tick(0)
+		}).To(PanicWith(ContainSubstring("must advance time")),
+			"a clock that does not move forwards is not recoverable downstream")
+
+		// The tick length the CFS period cannot divide. This is the case Set
+		// cannot check, because whether a Throttle is servable depends on a
+		// tick Set is never told: 0.08 needs the 10ms period, and 100ms of it
+		// is 8/10ths of a throttled period.
+		Expect(func() {
+			fakebox.NewBox(base, with(func(c *fakebox.Condition) { c.Throttle = 0.08 })).Tick(100 * time.Millisecond)
+		}).To(PanicWith(ContainSubstring("nr_throttled over the tick")),
+			"a tick that would need a fractional nr_throttled must panic rather than round it")
+	})
+})

--- a/umh-core/pkg/cpuhealth/fakebox/fakebox_test.go
+++ b/umh-core/pkg/cpuhealth/fakebox/fakebox_test.go
@@ -366,9 +366,9 @@ var _ = Describe("a machine condition served as cgroup and proc files", func() {
 
 	It("carries both decimals of the pressure it was given", func() {
 		// 0.0625 is 6.25 percent — a pressure that needs both of
-		// cpu.pressure's decimals. Case A's 0.25 is 25.00 percent and would
-		// survive being written with none, so it cannot tell this precision
-		// from a coarser one.
+		// cpu.pressure's decimals. The 0.25 the other specs state is 25.00
+		// percent and would survive being written with none, so none of them
+		// can tell this precision from a coarser one.
 		box := fakebox.NewBox(base, fakebox.Condition{
 			Cores:      4,
 			QuotaCores: 2,
@@ -427,8 +427,7 @@ var _ = Describe("a machine condition served as cgroup and proc files", func() {
 		// Returning a clock.Clock is not on its own enough to hide the mock:
 		// the dynamic type travels with the interface, so an unwrapped mock
 		// would come straight back out of a type assertion, bringing Set with
-		// it. A backwards clock makes the admission window in pkg/fsmv2/cpu
-		// subtract to a negative elapsed, and it then refuses for good.
+		// it. fakebox.go's shieldedClock says what a backwards step costs.
 		box := fakebox.NewBox(base, fakebox.Condition{Cores: 4, QuotaCores: 2, PsiPresent: true})
 
 		_, recovered := box.Clock().(*clock.Mock)

--- a/umh-core/pkg/cpuhealth/read.go
+++ b/umh-core/pkg/cpuhealth/read.go
@@ -22,7 +22,8 @@ package cpuhealth
 import (
 	"context"
 	"fmt"
-	"time"
+
+	"github.com/benbjohnson/clock"
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/diagnosis"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/filesystem"
@@ -52,9 +53,16 @@ const (
 
 // NewLinuxSampler returns a Sampler reading via fs from base.
 func NewLinuxSampler(fs filesystem.Service, base string) Sampler {
+	return NewLinuxSamplerWithClock(fs, base, clock.New())
+}
+
+// NewLinuxSamplerWithClock returns a Sampler reading via fs from base that
+// stamps every Sample from clk.
+func NewLinuxSamplerWithClock(fs filesystem.Service, base string, clk clock.Clock) Sampler {
 	return &linuxSampler{
 		cgroup: newCgroupSource(fs, base),
 		host:   newHostSource(fs),
+		clock:  clk,
 	}
 }
 
@@ -64,6 +72,7 @@ func NewLinuxSampler(fs filesystem.Service, base string) Sampler {
 // exists only to stamp the tick's single Timestamp and derive CPU scope, the
 // one fact that needs both sources' reads to compute.
 type linuxSampler struct {
+	clock  clock.Clock
 	cgroup *cgroupSource
 	host   *hostSource
 }
@@ -77,10 +86,10 @@ type linuxSampler struct {
 func (s *linuxSampler) Read(ctx context.Context) (Sample, error) {
 	var smp Sample
 	// Stamped once, here, and passed to both sources: neither cgroup nor host
-	// calls time.Now() itself, so both rate derivations divide by the same
+	// reads a clock itself, so both rate derivations divide by the same
 	// elapsed time and Decide never compares a machine-wide mean against a
 	// cgroup mean taken from a different instant.
-	ts := time.Now()
+	ts := s.clock.Now()
 	smp.Timestamp = ts
 
 	// cpu.pressure: PSI presence is sticky once seen; this tick's read success

--- a/umh-core/pkg/cpuhealth/read_clock_test.go
+++ b/umh-core/pkg/cpuhealth/read_clock_test.go
@@ -1,0 +1,82 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The clock seam. NewLinuxSamplerWithClock builds a sampler that stamps every
+// Sample from the clock it was handed, so a caller that moves the clock moves
+// every stamp with it. A sampler still calling time.Now() stamps wall time,
+// which cannot equal an instant pinned to 2020-03-14T15:09:26Z — the first
+// assertion below can only pass by reading the injected clock.
+package cpuhealth_test
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/benbjohnson/clock"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/cpuhealth"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/filesystem"
+)
+
+var _ = Describe("sampler-injected clock", func() {
+	const base = "/sys/fs/cgroup"
+
+	// Read tolerates the errors unserved paths return, so the sample succeeds
+	// and the assertions land on the timestamp rather than an error path.
+	readableFS := func() filesystem.Service {
+		fs := filesystem.NewMockFileSystem()
+		fs.ReadFileFunc = func(ctx context.Context, path string) ([]byte, error) {
+			switch path {
+			case base + "/cpu.stat":
+				return []byte("usage_usec 5000000\nuser_usec 4000000\nsystem_usec 1000000\nnr_periods 10\nnr_throttled 2\n"), nil
+			case base + "/cpu.max":
+				return []byte("200000 100000"), nil
+			case base + "/cpu.pressure":
+				return []byte("some avg10=1.00 avg60=2.00 avg300=3.00 total=0\n"), nil
+			case base + "/cpuset.cpus.effective":
+				return []byte("0-1"), nil
+			case "/proc/stat":
+				return []byte("cpu  100 0 300 5000 0 0 10 0 0 0\ncpu0 50 0 150 2500 0 0 5 0 0 0\ncpu1 50 0 150 2500 0 0 5 0 0 0\n"), nil
+			default:
+				return nil, errors.New("unreadable")
+			}
+		}
+		return fs
+	}
+
+	It("stamps every Sample from the clock it was built with", func() {
+		ctx := context.Background()
+		clk := clock.NewMock()
+		start := time.Date(2020, time.March, 14, 15, 9, 26, 0, time.UTC)
+		clk.Set(start)
+
+		s := cpuhealth.NewLinuxSamplerWithClock(readableFS(), base, clk)
+
+		first, err := s.Read(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(first.Timestamp).To(Equal(start),
+			"the first Sample must carry the mock's instant, not wall time")
+
+		const d = 7 * time.Second
+		clk.Add(d)
+
+		second, err := s.Read(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(second.Timestamp.Sub(first.Timestamp)).To(Equal(d),
+			"the second Sample must land exactly d after the first on the injected clock")
+	})
+})

--- a/umh-core/pkg/fsmv2/cpu/cpu.go
+++ b/umh-core/pkg/fsmv2/cpu/cpu.go
@@ -136,9 +136,18 @@ func Poll(ctx context.Context, d *CPUDeps, _ CPUConfig) (CPUStatus, error) {
 	env := cpuhealth.DeriveEnvironment(sample)
 	verdict, details := cpuhealth.Decide(d.engine, sample, env)
 
+	message := cpuhealth.ComposeMessage(verdict, details)
+
+	// Same fixed-event-name rule as the SentryWarn above: dynamic values ride
+	// in the structured fields, never in the message.
+	d.GetLogger().Debug("cpu_reading",
+		deps.String("verdict", string(verdict.State)),
+		deps.String("message", message),
+	)
+
 	return CPUStatus{
 		Verdict: string(verdict.State),
-		Message: cpuhealth.ComposeMessage(verdict, details),
+		Message: message,
 		Details: details,
 	}, nil
 }

--- a/umh-core/pkg/fsmv2/cpu/cpu.go
+++ b/umh-core/pkg/fsmv2/cpu/cpu.go
@@ -21,6 +21,8 @@ import (
 	"context"
 	"time"
 
+	"github.com/benbjohnson/clock"
+
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/cpuhealth"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/diagnosis"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
@@ -47,6 +49,14 @@ const (
 	// alone, so two payloads cannot share one key. Same convention as
 	// configworker.ConfigManagerDepsKey.
 	FilesystemDepsKey = WorkerType + ".filesystem"
+
+	// ClockDepsKey is the register.SetDeps key under which a caller publishes
+	// the clock.Clock the sampler stamps every Sample from. NewDeps looks it up
+	// per instance at spawn time — the instance then samples on that clock for
+	// the rest of its life, so a publish after the spawn reaches nothing — and
+	// falls back to the real clock when nothing is published. Same key
+	// convention as FilesystemDepsKey.
+	ClockDepsKey = WorkerType + ".clock"
 
 	// cgroupBase is the cgroup v2 mount point whose CPU controller files the
 	// sampler reads (cpu.stat, cpu.max, cpu.pressure, cpuset.cpus.effective).
@@ -140,13 +150,22 @@ func Poll(ctx context.Context, d *CPUDeps, _ CPUConfig) (CPUStatus, error) {
 // A failed startup read yields cores=0, quota=0, which drops the two capacity
 // signals from this instance's table for its whole lifetime; a later
 // successful read does not restore them (ENG-5752).
+//
+// The sampler reads through the filesystem.Service published under
+// FilesystemDepsKey and stamps from the clock.Clock published under
+// ClockDepsKey; each key's doc states the lookup timing and the fallback.
 func NewDeps(_ deps.Identity, bd *deps.BaseDependencies) *CPUDeps {
 	fs := register.GetDeps[filesystem.Service](FilesystemDepsKey)
 	if fs == nil {
 		fs = filesystem.NewDefaultService()
 	}
 
-	sampler := cpuhealth.NewLinuxSampler(fs, cgroupBase)
+	clk := register.GetDeps[clock.Clock](ClockDepsKey)
+	if clk == nil {
+		clk = clock.New()
+	}
+
+	sampler := cpuhealth.NewLinuxSamplerWithClock(fs, cgroupBase, clk)
 
 	d := &CPUDeps{
 		BaseDependencies: bd,

--- a/umh-core/pkg/fsmv2/cpu/cpu_clock_injection_test.go
+++ b/umh-core/pkg/fsmv2/cpu/cpu_clock_injection_test.go
@@ -1,0 +1,153 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Specs for the clock seam at the worker boundary; ClockDepsKey's doc is the
+// contract. The consequence these specs exploit: a mock pinned to
+// 2020-03-14T15:09:26Z can only appear in a Sample by reading the published
+// clock, since a sampler still stamping from time.Now() cannot produce that
+// instant.
+package fsmv2cpu
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/benbjohnson/clock"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/register"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/filesystem"
+)
+
+var _ = Describe("the clock the CPU worker samples on", func() {
+	// readableFS serves every cgroup file the sampler reads, from the same
+	// cgroupBase the sampler is constructed with, so a read succeeds and the
+	// assertions land on the timestamp rather than an error path. Unserved
+	// paths — /proc/cpuinfo and the two DMI identity files — answer with an
+	// error the sampler tolerates, so the virtualisation fact stays unresolved.
+	readableFS := func() filesystem.Service {
+		fs := filesystem.NewMockFileSystem()
+		fs.ReadFileFunc = func(ctx context.Context, path string) ([]byte, error) {
+			switch path {
+			case cgroupBase + "/cpu.stat":
+				return []byte("usage_usec 5000000\nuser_usec 4000000\nsystem_usec 1000000\nnr_periods 10\nnr_throttled 2\n"), nil
+			case cgroupBase + "/cpu.max":
+				return []byte("200000 100000"), nil
+			case cgroupBase + "/cpu.pressure":
+				return []byte("some avg10=1.00 avg60=2.00 avg300=3.00 total=0\n"), nil
+			case cgroupBase + "/cpuset.cpus.effective":
+				return []byte("0-1"), nil
+			case "/proc/stat":
+				return []byte("cpu  100 0 300 5000 0 0 10 0 0 0\ncpu0 50 0 150 2500 0 0 5 0 0 0\ncpu1 50 0 150 2500 0 0 5 0 0 0\n"), nil
+			default:
+				return nil, errors.New("unreadable")
+			}
+		}
+		return fs
+	}
+
+	newBaseDeps := func() (deps.Identity, *deps.BaseDependencies) {
+		id := deps.Identity{ID: "cpu-clock-injection", WorkerType: WorkerType}
+
+		return id, deps.NewBaseDependencies(deps.NewNopFSMLogger(), nil, id)
+	}
+
+	It("samples on a published clock rather than the real one", func() {
+		pinned := time.Date(2020, time.March, 14, 15, 9, 26, 0, time.UTC)
+		clk := clock.NewMock()
+		clk.Set(pinned)
+
+		// The registry is process-global and outlives this spec, so both keys
+		// are cleared afterwards: no later spec may inherit this clock or this
+		// filesystem.
+		register.SetDeps[filesystem.Service](FilesystemDepsKey, readableFS())
+		DeferCleanup(register.ClearDeps, FilesystemDepsKey)
+		register.SetDeps[clock.Clock](ClockDepsKey, clk)
+		DeferCleanup(register.ClearDeps, ClockDepsKey)
+
+		id, bd := newBaseDeps()
+		d := NewDeps(id, bd)
+
+		sample, err := d.sampler.Read(context.Background())
+		Expect(err).NotTo(HaveOccurred(),
+			"the published filesystem serves every cgroup file, so the read must succeed")
+		Expect(sample.Timestamp).To(Equal(pinned),
+			"a sampler still stamping from time.Now() cannot produce 2020-03-14T15:09:26Z")
+	})
+
+	It("falls back to the real clock when nothing was published", func() {
+		Expect(register.GetDeps[clock.Clock](ClockDepsKey)).To(BeNil(),
+			"precondition: no earlier spec may have left a clock in the registry")
+
+		register.SetDeps[filesystem.Service](FilesystemDepsKey, readableFS())
+		DeferCleanup(register.ClearDeps, FilesystemDepsKey)
+
+		id, bd := newBaseDeps()
+		d := NewDeps(id, bd)
+
+		Expect(d.sampler).NotTo(BeNil(), "an unpublished clock still yields a sampler")
+		Expect(d.engineErr).NotTo(HaveOccurred(), "the table builds either way")
+
+		// A wall-clock window rather than a non-zero check: clock.New().Now()
+		// is time.Now(), so a real-clock stamp necessarily lands in [before,
+		// after], while a clock pinned to any fixed instant — including a
+		// fresh clock.NewMock(), which starts at the epoch — falls outside it.
+		// A wrong clock that happens to return a current wall instant still
+		// passes; that one is indistinguishable from the real clock. A nil
+		// clock handed through would have panicked at the Read below.
+		before := time.Now()
+		sample, err := d.sampler.Read(context.Background())
+		after := time.Now()
+		Expect(err).NotTo(HaveOccurred(),
+			"the published filesystem serves every cgroup file, so the read must succeed")
+		Expect(sample.Timestamp).To(BeTemporally(">=", before),
+			"the real clock stamps an instant at or after the read started")
+		Expect(sample.Timestamp).To(BeTemporally("<=", after),
+			"the real clock stamps an instant at or before the read finished")
+	})
+
+	It("binds the clock at spawn, so a publish after the spawn cannot re-stamp the sampler", func() {
+		Expect(register.GetDeps[clock.Clock](ClockDepsKey)).To(BeNil(),
+			"precondition: no earlier spec may have left a clock in the registry")
+
+		register.SetDeps[filesystem.Service](FilesystemDepsKey, readableFS())
+		DeferCleanup(register.ClearDeps, FilesystemDepsKey)
+
+		id, bd := newBaseDeps()
+		d := NewDeps(id, bd)
+
+		// Only after the spawn does the clock appear. A sampler that re-read
+		// the registry on every Read would now stamp from this mock.
+		pinned := time.Date(2020, time.March, 14, 15, 9, 26, 0, time.UTC)
+		clk := clock.NewMock()
+		clk.Set(pinned)
+		register.SetDeps[clock.Clock](ClockDepsKey, clk)
+		DeferCleanup(register.ClearDeps, ClockDepsKey)
+
+		before := time.Now()
+		sample, err := d.sampler.Read(context.Background())
+		after := time.Now()
+		Expect(err).NotTo(HaveOccurred(),
+			"the published filesystem serves every cgroup file, so the read must succeed")
+		Expect(sample.Timestamp).To(BeTemporally(">=", before),
+			"the sampler keeps the clock it was built with, so a publish after the spawn cannot re-stamp it")
+		Expect(sample.Timestamp).To(BeTemporally("<=", after),
+			"the sampler keeps the clock it was built with, so a publish after the spawn cannot re-stamp it")
+		Expect(sample.Timestamp).NotTo(Equal(pinned),
+			"a pinned instant means the sampler looked the clock up per read instead of at spawn")
+	})
+})

--- a/umh-core/pkg/fsmv2/cpu/cpu_reading_log_test.go
+++ b/umh-core/pkg/fsmv2/cpu/cpu_reading_log_test.go
@@ -1,0 +1,137 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fsmv2cpu
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/cpuhealth"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/diagnosis"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
+)
+
+// debugRecord captures one actual Debug invocation: its message name and its
+// structured fields.
+type debugRecord struct {
+	msg    string
+	fields map[string]any
+}
+
+// debugSpyLogger wraps NopFSMLogger and records every actual Debug invocation —
+// its message and structured fields — so a test can assert on real call counts
+// rather than a field. With returns the spy itself because
+// deps.NewBaseDependencies enriches the logger it is given through With, and a
+// pass-through to the wrapped Nop would hide every later Debug from the spy.
+// Test-local: only this test observes the per-tick reading entry.
+type debugSpyLogger struct {
+	deps.FSMLogger
+	debugs []debugRecord
+}
+
+func (l *debugSpyLogger) Debug(msg string, fields ...deps.Field) {
+	rec := debugRecord{msg: msg, fields: make(map[string]any, len(fields))}
+	for _, f := range fields {
+		rec.fields[f.Key] = f.Value
+	}
+
+	l.debugs = append(l.debugs, rec)
+}
+
+func (l *debugSpyLogger) With(_ ...deps.Field) deps.FSMLogger { return l }
+
+// cpuReadings returns the Debug entries the spy captured under the fixed name
+// cpu_reading, whatever else the tick logged.
+func cpuReadings(l *debugSpyLogger) []debugRecord {
+	var readings []debugRecord
+	for _, rec := range l.debugs {
+		if rec.msg == "cpu_reading" {
+			readings = append(readings, rec)
+		}
+	}
+
+	return readings
+}
+
+// newDepsWithLogger is newDeps with an explicit logger, so a spec can observe
+// what Poll writes. It lives here rather than beside newDeps because its
+// previous home, cpu_admission_deadline_warning_test.go, was deleted with the
+// admission window, and this spec is its only remaining caller.
+func newDepsWithLogger(log deps.FSMLogger, s cpuhealth.Sampler, cores, quota float64) *CPUDeps {
+	engine, err := diagnosis.NewEngine(cpuhealth.Table(cores, quota))
+	Expect(err).NotTo(HaveOccurred(), "the test table must be buildable")
+
+	return &CPUDeps{
+		BaseDependencies: deps.NewBaseDependencies(log, nil, deps.Identity{ID: "cpu-test", WorkerType: WorkerType}),
+		sampler:          s,
+		engine:           engine,
+	}
+}
+
+var _ = Describe("a completed CPU poll's reading log", func() {
+	It("records the verdict it reached and the message it composed, once per completed poll and never for a failed read", func() {
+		// Presence: a quiet, fully present sample on a 4-cores/2-quota box —
+		// the same setup as "reports a verdict from Decide rather than a raw
+		// measurement" — judges healthy, and that judgement must be on the log.
+		spy := &debugSpyLogger{FSMLogger: deps.NewNopFSMLogger()}
+		d := newDepsWithLogger(spy, stubSampler{read: func(context.Context) (cpuhealth.Sample, error) {
+			return cpuhealth.Sample{
+				Timestamp: time.Now(),
+				Quota:     diagnosis.Known(2),
+				// All signals present and quiet: nothing fires.
+				NrPeriods:   diagnosis.Known(1),
+				NrThrottled: diagnosis.Known(0),
+				UsageUsec:   diagnosis.Known(5000000),
+				Pressure:    diagnosis.Known(0),
+				Steal:       diagnosis.Known(0),
+				HostBusy:    diagnosis.Known(0.5),
+				Virtualized: false,
+			}, nil
+		}}, 4, 2)
+
+		status, err := Poll(context.Background(), d, CPUConfig{})
+		Expect(err).NotTo(HaveOccurred())
+		// The recorded fields must carry what this tick actually produced, so
+		// pin that the tick produced something before reading it back.
+		Expect(status.Verdict).NotTo(BeEmpty(), "a completed tick must reach a verdict for one to be recorded")
+		Expect(status.Message).NotTo(BeEmpty(), "a completed tick must compose a message for one to be recorded")
+
+		readings := cpuReadings(spy)
+		Expect(readings).To(HaveLen(1), "a completed poll emits exactly one cpu_reading Debug entry")
+		// Both field VALUES are asserted — never just the entry's presence —
+		// so an entry emitted with empty fields fails here.
+		Expect(readings[0].fields["verdict"]).To(Equal(status.Verdict),
+			"the entry's verdict field is the verdict the poll reached")
+		Expect(readings[0].fields["message"]).To(Equal(status.Message),
+			"the entry's message field is the message the poll composed")
+
+		// Absence: a read that fails never completes a poll, so nothing may be
+		// recorded for it.
+		readErr := errors.New("cgroup read failed")
+		spyFailed := &debugSpyLogger{FSMLogger: deps.NewNopFSMLogger()}
+		dFailed := newDepsWithLogger(spyFailed, stubSampler{read: func(context.Context) (cpuhealth.Sample, error) {
+			return cpuhealth.Sample{}, readErr
+		}}, 4, 2)
+
+		_, err = Poll(context.Background(), dFailed, CPUConfig{})
+		Expect(err).To(MatchError(readErr), "the failure path ran: Poll surfaces the read error")
+		Expect(cpuReadings(spyFailed)).To(BeEmpty(),
+			"a poll whose read failed records no cpu_reading entry")
+	})
+})

--- a/umh-core/pkg/fsmv2/examples/cpu_blind_scenario.go
+++ b/umh-core/pkg/fsmv2/examples/cpu_blind_scenario.go
@@ -30,7 +30,7 @@ const (
 	// cpuPressureBase carries the full note on why nothing checks that.
 	cpuBlindBase = "/sys/fs/cgroup"
 
-	// The two files this scenario takes away, in the order it takes them.
+	// The files this scenario takes away, in the order it takes them.
 	//
 	// /proc/stat is the machine's own CPU accounting, a HOST file outside the
 	// cgroup. cpu.stat is the cgroup's, and the sampler treats it as primary:
@@ -73,8 +73,10 @@ const (
 // door. That is a KNOWN DEFECT and not the intended answer. The message is
 // wrong twice over: it blames a cgroup read for a HOST file, and it announces
 // its own default rather than refusing to answer. This scenario pins what the
-// code does today so the behaviour is visible instead of inferred; the fix is
-// in pkg/cpuhealth, out of this package's scope, and already recorded there.
+// code does today so the behaviour is visible instead of inferred. The fix is in
+// pkg/cpuhealth, out of this package's scope, where healthy-on-unavailable is
+// currently the documented contract rather than a recorded defect.
+// TODO(ENG-XXXX): file the cpuhealth fix.
 //
 // Losing cpu.stat is the other shape. The read fails, the poll returns an
 // error, and the framework marks the worker degraded with the error as its
@@ -82,11 +84,12 @@ const (
 //
 // # CLI Usage
 //
-//	go run pkg/fsmv2/cmd/runner/main.go --scenario=cpu-blind --duration=200ms --log-level=debug --dump-store
+//	go run pkg/fsmv2/cmd/runner/main.go --scenario=cpu-blind --duration=200ms --log-level=debug
 //
-// The verdict shows up on the collector's observed_changed line, which is a
-// debug line — the CPU worker declares no Health function, so its verdict never
-// moves the worker's FSM state and nothing about the verdict is logged at info.
+// On every completed poll the cpu_reading debug line carries the verdict and the
+// composed message; a failed poll never reaches it. When the worker's state
+// changes, the message also appears at info in the state_transition line's
+// reason field.
 var CPUBlindScenarioV2 = ScenarioV2{
 	Name:        "cpu-blind",
 	Description: "Takes away the two files the CPU monitor reads, and shows that one fails open and the other does not (v2)",

--- a/umh-core/pkg/fsmv2/examples/cpu_blind_scenario.go
+++ b/umh-core/pkg/fsmv2/examples/cpu_blind_scenario.go
@@ -1,0 +1,195 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package examples
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/cpuhealth/fakebox"
+	fsmv2cpu "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/cpu"
+)
+
+const (
+	// cpuBlindBase is where this scenario's fake machine serves its cgroup
+	// files, and has to equal the unexported cgroupBase in pkg/fsmv2/cpu.
+	// cpuPressureBase carries the full note on why nothing checks that.
+	cpuBlindBase = "/sys/fs/cgroup"
+
+	// The two files this scenario takes away, in the order it takes them.
+	//
+	// /proc/stat is the machine's own CPU accounting, a HOST file outside the
+	// cgroup. cpu.stat is the cgroup's, and the sampler treats it as primary:
+	// a cgroup that cannot be read at all is not a machine to reason about.
+	cpuBlindHostStat   = "/proc/stat"
+	cpuBlindCgroupStat = cpuBlindBase + "/cpu.stat"
+
+	// The machine this scenario runs on, while it can still be read. It is a
+	// quiet four-core box with no CPU limit: nothing here is near any mark, so
+	// every verdict in this story comes from what could and could not be read
+	// rather than from a number crossing a threshold.
+	cpuBlindCores      = 4
+	cpuBlindHostBusy   = 0.30
+	cpuBlindUsageCores = 0.5
+	cpuBlindPressure   = 0.02
+
+	// How much machine time each condition is held for. This is machine time,
+	// not wall time: see holdMachine.
+	//
+	// Nothing here waits on a window, because nothing here is a rate crossing a
+	// mark: the sampler either reads a file or does not, and the verdict moves
+	// on the next reading. The holds are long enough that a reader sees the
+	// machine sit in each condition, and no longer. In particular none of them
+	// reaches the 60 readings at which a window with nothing new to store
+	// empties, so the readings this story shows are the ones the outage itself
+	// produces rather than the ones its aftermath does.
+	cpuBlindHold = 15 * time.Second
+)
+
+// CPUBlindScenarioV2 drives the real CPU monitor over a fake machine and then
+// takes away, one at a time, the two files it reads its numbers from.
+//
+// The story is that the two failures do not behave alike, and the difference
+// matters more than either on its own.
+//
+// Losing /proc/stat is a fail-open. The poll SUCCEEDS, the worker reports
+// healthy, and the message says CPU monitoring is unavailable — so a machine
+// nothing can measure is published as a healthy one, and everything downstream
+// that gates on the verdict, admission of new bridges included, sees an open
+// door. That is a KNOWN DEFECT and not the intended answer. The message is
+// wrong twice over: it blames a cgroup read for a HOST file, and it announces
+// its own default rather than refusing to answer. This scenario pins what the
+// code does today so the behaviour is visible instead of inferred; the fix is
+// in pkg/cpuhealth, out of this package's scope, and already recorded there.
+//
+// Losing cpu.stat is the other shape. The read fails, the poll returns an
+// error, and the framework marks the worker degraded with the error as its
+// reason. Nothing is defaulted and nothing is guessed.
+//
+// # CLI Usage
+//
+//	go run pkg/fsmv2/cmd/runner/main.go --scenario=cpu-blind --duration=200ms --log-level=debug --dump-store
+//
+// The verdict shows up on the collector's observed_changed line, which is a
+// debug line — the CPU worker declares no Health function, so its verdict never
+// moves the worker's FSM state and nothing about the verdict is logged at info.
+var CPUBlindScenarioV2 = ScenarioV2{
+	Name:        "cpu-blind",
+	Description: "Takes away the two files the CPU monitor reads, and shows that one fails open and the other does not (v2)",
+	Driver:      driveCPUBlind,
+}
+
+// driveCPUBlind publishes a fake machine, spawns the CPU monitor onto it
+// through the migration-API client, then makes /proc/stat unreadable and then
+// cpu.stat as well.
+//
+// The second outage keeps the first, because a machine losing sight of itself
+// does not usually get one file back as it loses another, and because a story
+// that restored /proc/stat would be testing recovery rather than the two
+// failures. cpu.stat failing is what decides that condition either way: the
+// sampler gives up on it before it reaches anything /proc/stat would answer.
+//
+// It judges nothing. What the worker made of each condition is read back after
+// the run, out of the store's own delta history, by the spec beside this file.
+func driveCPUBlind(ctx context.Context, env Env) error {
+	readable := cpuBlindMachine()
+	machine := newTickingBox(cpuBlindBase, readable)
+
+	// Published before the Upsert below, because cpu.NewDeps reads both keys
+	// once, at the moment the supervisor spawns the worker; anything published
+	// after that spawn reaches nothing. The poll cadence has the same deadline:
+	// the collector reads it when the worker spawns.
+	clearDeps := machine.Deps()
+	defer clearDeps()
+
+	restorePoll := useFastCPUPoll()
+	defer restorePoll()
+
+	// The box advances on the sampler's read of cpu.pressure, which this
+	// scenario never takes away, so machine time keeps moving through both
+	// outages — including the last one, where the read fails before it reaches
+	// most of the files.
+	machine.StartPerRead(cpuMachineSecond)
+	defer machine.Stop()
+
+	announceBlindMachine(readable)
+
+	// Nil config: CPUConfig is an empty struct, and this is the same call the
+	// config worker makes in production.
+	if err := env.Client.Upsert(fsmv2cpu.Ref, nil); err != nil {
+		return fmt.Errorf("upsert cpu monitor: %w", err)
+	}
+
+	if err := awaitFirstCPUReading(ctx, env.Client); err != nil {
+		return fmt.Errorf("wait for the cpu monitor's first reading: %w", err)
+	}
+
+	if err := holdMachine(ctx, machine, cpuBlindHold); err != nil {
+		return err
+	}
+
+	for _, gone := range [][]string{
+		{cpuBlindHostStat},
+		{cpuBlindHostStat, cpuBlindCgroupStat},
+	} {
+		condition := cpuBlindMachine(gone...)
+		machine.Set(condition)
+		announceBlindMachine(condition)
+
+		if err := holdMachine(ctx, machine, cpuBlindHold); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// cpuBlindMachine is this scenario's machine with the named files unreadable.
+// Everything else is the same in all three conditions, so the three calls
+// differ by exactly what the machine can no longer see.
+//
+// fakebox rejects a path it does not serve rather than ignoring it, so a
+// mistyped name here fails the run instead of leaving the spec asserting
+// against the readable machine it was written to rule out.
+func cpuBlindMachine(unreadable ...string) fakebox.Condition {
+	return fakebox.Condition{
+		Cores:      cpuBlindCores,
+		HostBusy:   cpuBlindHostBusy,
+		UsageCores: cpuBlindUsageCores,
+		Pressure:   cpuBlindPressure,
+		PsiPresent: true,
+		Unreadable: unreadable,
+	}
+}
+
+// announceBlindMachine prints the fake machine's condition, and is the only
+// thing this scenario prints. One line goes out each time the mock changes, the
+// opening condition included, and nothing else at all: every other line on the
+// page is the supervisor's own output, so a reader can tell a stimulus from a
+// response without being told which is which.
+//
+// It names what cannot be read, which announceMachine does not, because that is
+// the only thing this scenario changes.
+func announceBlindMachine(c fakebox.Condition) {
+	unreadable := "nothing"
+	if len(c.Unreadable) > 0 {
+		unreadable = strings.Join(c.Unreadable, ", ")
+	}
+
+	fmt.Printf("fake machine: %d cores, host %.0f%% busy, this instance %g cores, pressure %.0f%%, unreadable: %s\n",
+		c.Cores, c.HostBusy*100, c.UsageCores, c.Pressure*100, unreadable)
+}

--- a/umh-core/pkg/fsmv2/examples/cpu_blind_scenario_test.go
+++ b/umh-core/pkg/fsmv2/examples/cpu_blind_scenario_test.go
@@ -24,49 +24,26 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/config"
 	fsmv2cpu "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/cpu"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/examples"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/register"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/simple"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/configworker"
 )
 
 var _ = Describe("CPU blind ScenarioV2", func() {
-	// The configworker deps key is process-global; a run that fails midway
-	// would otherwise leak it into every later spec in this process.
-	BeforeEach(func() {
-		DeferCleanup(func() {
-			register.ClearDeps(configworker.WorkerTypeName)
-		})
-	})
+	clearConfigWorkerDepsEachSpec()
 
 	It("registers cpu-blind in the merged listing the CLI reads", func() {
 		Expect(examples.ListScenarios()).To(HaveKey("cpu-blind"))
 	})
 
 	It("reports a machine it cannot measure as healthy, and a cgroup it cannot read as a poll error", func() {
-		scenario, ok := examples.RegistryV2["cpu-blind"]
-		Expect(ok).To(BeTrue())
-
-		logger := deps.NewNopFSMLogger()
-		store := examples.SetupStore(logger)
-
-		// Machine time advances one second per reading, so the wall cost is
-		// the collector's cadence and a healthy run is about two seconds. On a
-		// machine the worker cannot read at all, machine time never advances,
-		// the holds never finish, and this ctx is what ends the run.
-		ctx, cancel := context.WithTimeout(context.Background(), 300*time.Second)
-		defer cancel()
-
-		result, err := examples.Run(ctx, examples.RunConfig{
-			ScenarioV2:   scenario,
-			Duration:     200 * time.Millisecond,
-			TickInterval: 100 * time.Millisecond,
-			Logger:       logger,
-			Store:        store,
+		// On a machine the worker can read, this story costs about two seconds
+		// of wall time; the ctx budget is many times that.
+		store := runCPUScenario(cpuScenarioRun{
+			Name:       "cpu-blind",
+			CtxBudget:  300 * time.Second,
+			Settle:     200 * time.Millisecond,
+			DoneWithin: 300 * time.Second,
 		})
-		Expect(err).NotTo(HaveOccurred())
-		Eventually(result.Done, "300s").Should(BeClosed())
 
 		history := cpuObservationHistory(store)
 

--- a/umh-core/pkg/fsmv2/examples/cpu_blind_scenario_test.go
+++ b/umh-core/pkg/fsmv2/examples/cpu_blind_scenario_test.go
@@ -1,0 +1,122 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package examples_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/config"
+	fsmv2cpu "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/cpu"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/examples"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/register"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/simple"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/configworker"
+)
+
+var _ = Describe("CPU blind ScenarioV2", func() {
+	// The configworker deps key is process-global; a run that fails midway
+	// would otherwise leak it into every later spec in this process.
+	BeforeEach(func() {
+		DeferCleanup(func() {
+			register.ClearDeps(configworker.WorkerTypeName)
+		})
+	})
+
+	It("registers cpu-blind in the merged listing the CLI reads", func() {
+		Expect(examples.ListScenarios()).To(HaveKey("cpu-blind"))
+	})
+
+	It("reports a machine it cannot measure as healthy, and a cgroup it cannot read as a poll error", func() {
+		scenario, ok := examples.RegistryV2["cpu-blind"]
+		Expect(ok).To(BeTrue())
+
+		logger := deps.NewNopFSMLogger()
+		store := examples.SetupStore(logger)
+
+		// Machine time advances one second per reading, so the wall cost is
+		// the collector's cadence and a healthy run is about two seconds. On a
+		// machine the worker cannot read at all, machine time never advances,
+		// the holds never finish, and this ctx is what ends the run.
+		ctx, cancel := context.WithTimeout(context.Background(), 300*time.Second)
+		defer cancel()
+
+		result, err := examples.Run(ctx, examples.RunConfig{
+			ScenarioV2:   scenario,
+			Duration:     200 * time.Millisecond,
+			TickInterval: 100 * time.Millisecond,
+			Logger:       logger,
+			Store:        store,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Eventually(result.Done, "300s").Should(BeClosed())
+
+		history := cpuObservationHistory(store)
+
+		// The machine while it can still be read. The core count and the busy
+		// figure are this driver's, and they are what tie the two outages below
+		// to the published machine rather than to whatever the real host was
+		// doing: a host that happened to say the same thing would have to be a
+		// four-core box running at 1.2 cores.
+		readable := messageAfter(history, -1, "The machine is using 1.2 of 4 cores")
+		Expect(readable).To(BeNumerically(">=", 0),
+			"the readable machine never reached the store; readings seen: %d", len(history))
+		Expect(history[readable].Verdict).To(Equal("healthy"))
+
+		// /proc/stat gone. The poll SUCCEEDS and the machine is published
+		// healthy with an admission-open verdict, which is the fail-open this
+		// scenario exists to make visible rather than the intended answer. The
+		// message is wrong twice: it blames a cgroup read when the file that
+		// went is a host file, and it announces its own default rather than
+		// refusing to answer. Pinned as it stands today; the fix belongs in
+		// pkg/cpuhealth.
+		blind := messageAfter(history, readable,
+			"CPU monitoring unavailable: cgroup read failed. Defaulting to healthy.")
+		Expect(blind).To(BeNumerically(">", readable),
+			"losing the host's CPU accounting changed no message; readings seen: %d", len(history))
+		Expect(history[blind].Verdict).To(Equal("healthy"))
+		Expect(history[blind].Degraded).To(BeFalse())
+
+		// cpu.stat gone as well. The sampler treats the cgroup's own accounting
+		// as primary, so the read fails, the poll returns an error, and the
+		// framework marks the worker degraded with that error as its reason.
+		// Nothing is defaulted. The path is the one this driver staged.
+		failed := reasonAfter(history, blind,
+			"poll error: read /sys/fs/cgroup/cpu.stat")
+		Expect(failed).To(BeNumerically(">", blind),
+			"losing the cgroup's own accounting did not fail the poll; readings seen: %d", len(history))
+		Expect(history[failed].Degraded).To(BeTrue())
+
+		// A failed poll publishes the zero status, so the verdict is not
+		// "healthy" and not "degraded" but ABSENT. The worker's degraded state
+		// lives in the framework's own fields, and a consumer reading only the
+		// verdict sees neither a judgement nor a failure.
+		Expect(history[failed].Verdict).To(BeEmpty())
+
+		// The same, settled, in the worker's current observation.
+		var observed fsmv2.Observation[simple.Status[fsmv2cpu.CPUStatus]]
+		Expect(store.LoadObservedTyped(context.Background(),
+			fsmv2cpu.WorkerType, config.ChildID(fsmv2cpu.InstanceName), &observed)).To(Succeed())
+
+		Expect(observed.Status.Degraded).To(BeTrue())
+		Expect(observed.Status.Reason).To(ContainSubstring("poll error: read /sys/fs/cgroup/cpu.stat"))
+		Expect(observed.Status.Result.Verdict).To(BeEmpty())
+	})
+})

--- a/umh-core/pkg/fsmv2/examples/cpu_filling_scenario.go
+++ b/umh-core/pkg/fsmv2/examples/cpu_filling_scenario.go
@@ -1,0 +1,294 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package examples
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/cpuhealth/fakebox"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
+	fsmv2cpu "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/cpu"
+)
+
+const (
+	// cpuFillingBase is where this scenario's fake machine serves its cgroup
+	// files, and has to equal the unexported cgroupBase in pkg/fsmv2/cpu.
+	// cpuPressureBase carries the full note on why nothing checks that.
+	cpuFillingBase = "/sys/fs/cgroup"
+
+	// cpuFillingCores is the machine's CPU count and cpuFillingQuotaCores this
+	// instance's own CPU limit, the figure docker run --cpus sets.
+	//
+	// The quota is load-bearing, not decoration. The attribution paragraphs
+	// this scenario exists to show are gated on Details.LimitApplies in
+	// message.go, so on a machine with no limit BOTH of the last two conditions
+	// render the same sentence and the story demonstrates nothing.
+	//
+	// Three cores against four is also chosen so the container's own limit
+	// stays clear throughout — see the condition table below.
+	cpuFillingCores      = 4
+	cpuFillingQuotaCores = 3
+
+	// How much machine time each condition is held for. This is machine time,
+	// not wall time, and the difference matters: see holdMachine.
+	//
+	// The lengths are not cosmetic here, the way cpuPressureHold is. Every
+	// number this story turns on is a 60-second sliding MEAN, so a condition
+	// has to be held long enough for the mean to cross its mark, and the quiet
+	// opening has to be held short enough that its readings age out of the
+	// window rather than holding the mean back.
+	//
+	// Measured against those means, in readings after the condition BEFORE the
+	// one that carries them:
+	//
+	//	55 readings after the quiet condition ends, the machine reads full — the
+	//	quiet readings have aged far enough out of the headroom window for its
+	//	mean to go under zero
+	//	31 readings after the filled-from-outside condition ends, the blame moves
+	//	to us — the share window's mean crosses both refinement marks, and the
+	//	60-second bar on re-firing a released signal has passed
+	//
+	// Both are offsets rather than fixed readings, because the quiet condition
+	// runs longer than the hold below asks for: the driver's readiness wait looks
+	// at the store every cpuPressureReadyPoll, and machine seconds pass while it
+	// does. Measured here, the quiet condition ran to reading 21 and the two
+	// verdicts landed on readings 76 and 132 of a run that ends at 161 — the same
+	// three numbers on every run, which is what the read-driven clock buys.
+	//
+	// Each hold runs well past the second it has to reach, so a reader of the
+	// store sees each verdict for a stretch rather than for one reading.
+	cpuFillingQuietHold = 10 * time.Second
+	cpuFillingHostHold  = 80 * time.Second
+	cpuFillingOursHold  = 60 * time.Second
+)
+
+// CPUFillingScenarioV2 drives the real CPU monitor over a fake machine that
+// fills up, and then over the same machine filled by this instance's own load
+// instead of somebody else's.
+//
+// The story is that "the machine is full" is not the whole answer a customer
+// needs, because the remedy depends on whose load filled it. The middle
+// condition is a machine filled from outside, and the advice is to reduce the
+// other software on it. The last condition is the same machine, equally full,
+// filled by this instance — and telling that customer to go after somebody
+// else's load would send them after nothing.
+//
+// Nothing else moves across those two conditions: the machine is 80% busy in
+// both, its pressure is the same, and its CPU limit is reached in neither. The
+// one difference is how much of the busy time is ours.
+//
+// # CLI Usage
+//
+//	go run pkg/fsmv2/cmd/runner/main.go --scenario=cpu-filling --duration=200ms --log-level=debug --dump-store
+//
+// The verdict shows up on the collector's observed_changed line, which is a
+// debug line — the CPU worker declares no Health function, so its verdict never
+// moves the worker's FSM state and nothing about the verdict is logged at info.
+// --dump-store prints the closing message whole.
+var CPUFillingScenarioV2 = ScenarioV2{
+	Name:        "cpu-filling",
+	Description: "Fills a fake machine from outside, then from this instance, and shows the remedy change (v2)",
+	Driver:      driveCPUFilling,
+}
+
+// driveCPUFilling publishes a fake machine, spawns the CPU monitor onto it
+// through the migration-API client, and walks the machine through three
+// conditions: quiet, filled from outside, filled by us.
+//
+// It judges nothing. What the worker made of each condition is read back after
+// the run, out of the store's own delta history, by the spec beside this file.
+func driveCPUFilling(ctx context.Context, env Env) error {
+	quiet := cpuFillingQuiet()
+	machine := newTickingBox(cpuFillingBase, quiet)
+
+	// Published before the Upsert below, because cpu.NewDeps reads both keys
+	// once, at the moment the supervisor spawns the worker; anything published
+	// after that spawn reaches nothing. The poll cadence has the same deadline:
+	// the collector reads it when the worker spawns.
+	clearDeps := machine.Deps()
+	defer clearDeps()
+
+	restorePoll := useFastCPUPoll()
+	defer restorePoll()
+
+	machine.StartPerRead(cpuMachineSecond)
+	defer machine.Stop()
+
+	announceFillingMachine(quiet)
+
+	// Nil config: CPUConfig is an empty struct, and this is the same call the
+	// config worker makes in production.
+	if err := env.Client.Upsert(fsmv2cpu.Ref, nil); err != nil {
+		return fmt.Errorf("upsert cpu monitor: %w", err)
+	}
+
+	if err := awaitFirstCPUReading(ctx, env.Client); err != nil {
+		return fmt.Errorf("wait for the cpu monitor's first reading: %w", err)
+	}
+
+	if err := holdMachine(ctx, machine, cpuFillingQuietHold); err != nil {
+		return err
+	}
+
+	hostFilled := cpuFillingHostFilled()
+	machine.Set(hostFilled)
+	announceFillingMachine(hostFilled)
+
+	if err := holdMachine(ctx, machine, cpuFillingHostHold); err != nil {
+		return err
+	}
+
+	oursFilled := cpuFillingOursFilled()
+	machine.Set(oursFilled)
+	announceFillingMachine(oursFilled)
+
+	return holdMachine(ctx, machine, cpuFillingOursHold)
+}
+
+// The three conditions, in the order the driver walks them. Each is written as
+// its own function so the call sites read as the story rather than as three
+// triples of floats, and so the numbers sit under the table that explains them.
+//
+// What each condition produces, in the units the signals are denominated in.
+// Host busy is the fraction times the four cores. Host headroom is cores less
+// host busy less the one-core reserve, and the machine is called full below
+// zero. Limit headroom is the quota less our usage less a tenth of the quota,
+// and our own limit is reached below zero. Our share is our usage over the
+// machine's busy time, and the two refinements under "the machine is full"
+// blame the host below 0.49 and blame us above 0.51.
+//
+//	condition     host busy   host headroom   limit headroom   our share
+//	quiet             0.8            2.2            2.20         0.625
+//	filled by them    3.2           -0.2            2.06         0.20
+//	filled by us      3.2           -0.2            0.14         0.80
+//
+// Limit headroom stays positive in all three, which is why the usage figures
+// are 0.64 and 2.56 rather than rounder numbers: this instance never reaches
+// its own limit, so the message layer renders the pure attribution paragraph
+// rather than the blended sentence it writes for a container at BOTH ceilings.
+//
+// Pressure moves with the load, because a filling machine would show it, and
+// stays well under the 0.20 mark at which it would fire and take the headline
+// away from capacity.
+func cpuFillingQuiet() fakebox.Condition { return cpuFillingMachine(0.20, 0.5, 0.02) }
+
+func cpuFillingHostFilled() fakebox.Condition { return cpuFillingMachine(0.80, 0.64, 0.05) }
+
+func cpuFillingOursFilled() fakebox.Condition { return cpuFillingMachine(0.80, 2.56, 0.05) }
+
+// cpuFillingMachine is this scenario's machine at one condition. Everything the
+// three conditions share is written here once, so the three calls above differ
+// by exactly the three numbers the story turns on.
+func cpuFillingMachine(hostBusy, usageCores, pressure float64) fakebox.Condition {
+	return fakebox.Condition{
+		Cores:      cpuFillingCores,
+		QuotaCores: cpuFillingQuotaCores,
+		HostBusy:   hostBusy,
+		UsageCores: usageCores,
+		Pressure:   pressure,
+		PsiPresent: true,
+	}
+}
+
+// announceFillingMachine prints the fake machine's condition, and is the only
+// thing this scenario prints. One line goes out each time the mock changes, the
+// opening condition included, and nothing else at all: every other line on the
+// page is the supervisor's own output, so a reader can tell a stimulus from a
+// response without being told which is which.
+//
+// It names the CPU limit, which announceMachine does not, because this
+// scenario's message changes only on a machine that has one.
+func announceFillingMachine(c fakebox.Condition) {
+	fmt.Printf("fake machine: %d cores, limit %g cores, host %.0f%% busy, this instance %g cores, pressure %.0f%%\n",
+		c.Cores, c.QuotaCores, c.HostBusy*100, c.UsageCores, c.Pressure*100)
+}
+
+const (
+	// The machine clock the CPU scenarios measured in machine time run on, and
+	// the collector cadence that carries it.
+	//
+	// The box advances one machine SECOND per sampler read (StartPerRead), so
+	// readings land one second apart on an exact grid — the cadence the CPU
+	// worker runs at in production, and the one thing that makes a release
+	// reachable rather than a coincidence. Machine time then advances only when
+	// the worker reads, so the collector's cadence is what a machine second
+	// costs in wall time, and cpuFastPollWall is what makes these stories
+	// affordable: they are two and a half minutes of machine time, because the
+	// 60-second windows have to fill and one release rule waits a further 60,
+	// and that is under a wall second here.
+	cpuMachineSecond = time.Second
+	cpuFastPollWall  = 5 * time.Millisecond
+
+	// cpuMachineHoldPoll is how often holdMachine looks at the box's clock, and
+	// is under the wall time one machine second costs, so a hold overshoots by
+	// less than one reading.
+	cpuMachineHoldPoll = time.Millisecond
+)
+
+// useFastCPUPoll speeds the collector's poll of the CPU worker up to
+// cpuFastPollWall, and returns the function that puts the previous cadence
+// back. Why the cadence has to outrun the box's ticker is under cpuFastPollWall.
+//
+// The registry behind it is process-global, exactly as the deps keys are, so a
+// driver that left it set would hand the next scenario in this process a CPU
+// worker polling twenty times a second. It is a plain function rather than
+// anything the supervisor owns, so it can be called before the worker spawns,
+// which is when the collector reads the cadence.
+//
+// The restore is conditional because nothing can un-register a worker type. In
+// this process it always fires: simple.Register publishes every monitor's
+// Interval from its own init, so the CPU worker always has a cadence to go back
+// to.
+func useFastCPUPoll() (restore func()) {
+	previous, registered := fsmv2.ObservationIntervalFor(fsmv2cpu.WorkerType)
+	fsmv2.RegisterObservationInterval(fsmv2cpu.WorkerType, cpuFastPollWall)
+
+	return func() {
+		if registered {
+			fsmv2.RegisterObservationInterval(fsmv2cpu.WorkerType, previous)
+		}
+	}
+}
+
+// holdMachine waits until the box has advanced d of MACHINE time, or until ctx
+// is cancelled.
+//
+// Machine time is the right unit for any hold whose length has to mean
+// something to the engine, because every window span, every coverage rule and
+// every re-fire bar downstream is denominated in the sample clock. Wall time is
+// not a stand-in for it. The box advances by however many ticks its ticker
+// actually delivered, and a run under debug logging delivers materially fewer
+// than the same run with a discarding logger — measured here as a story that
+// reached its second verdict on one and never reached it on the other, from the
+// same holds. Holding on this clock pays that difference in wall seconds and
+// leaves the story identical.
+func holdMachine(ctx context.Context, machine *tickingBox, d time.Duration) error {
+	deadline := machine.MachineNow().Add(d)
+
+	ticker := time.NewTicker(cpuMachineHoldPoll)
+	defer ticker.Stop()
+
+	for machine.MachineNow().Before(deadline) {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+
+	return nil
+}

--- a/umh-core/pkg/fsmv2/examples/cpu_filling_scenario.go
+++ b/umh-core/pkg/fsmv2/examples/cpu_filling_scenario.go
@@ -93,12 +93,12 @@ const (
 //
 // # CLI Usage
 //
-//	go run pkg/fsmv2/cmd/runner/main.go --scenario=cpu-filling --duration=200ms --log-level=debug --dump-store
+//	go run pkg/fsmv2/cmd/runner/main.go --scenario=cpu-filling --duration=200ms --log-level=debug
 //
-// The verdict shows up on the collector's observed_changed line, which is a
-// debug line — the CPU worker declares no Health function, so its verdict never
-// moves the worker's FSM state and nothing about the verdict is logged at info.
-// --dump-store prints the closing message whole.
+// On every completed poll the cpu_reading debug line carries the verdict and the
+// composed message; a failed poll never reaches it. When the worker's state
+// changes, the message also appears at info in the state_transition line's
+// reason field.
 var CPUFillingScenarioV2 = ScenarioV2{
 	Name:        "cpu-filling",
 	Description: "Fills a fake machine from outside, then from this instance, and shows the remedy change (v2)",
@@ -245,7 +245,7 @@ const (
 //
 // The registry behind it is process-global, exactly as the deps keys are, so a
 // driver that left it set would hand the next scenario in this process a CPU
-// worker polling twenty times a second. It is a plain function rather than
+// worker still polling at cpuFastPollWall. It is a plain function rather than
 // anything the supervisor owns, so it can be called before the worker spawns,
 // which is when the collector reads the cadence.
 //

--- a/umh-core/pkg/fsmv2/examples/cpu_filling_scenario_test.go
+++ b/umh-core/pkg/fsmv2/examples/cpu_filling_scenario_test.go
@@ -1,0 +1,118 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package examples_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/config"
+	fsmv2cpu "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/cpu"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/examples"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/register"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/configworker"
+)
+
+var _ = Describe("CPU filling ScenarioV2", func() {
+	// The configworker deps key is process-global; a run that fails midway
+	// would otherwise leak it into every later spec in this process.
+	BeforeEach(func() {
+		DeferCleanup(func() {
+			register.ClearDeps(configworker.WorkerTypeName)
+		})
+	})
+
+	It("registers cpu-filling in the merged listing the CLI reads", func() {
+		Expect(examples.ListScenarios()).To(HaveKey("cpu-filling"))
+	})
+
+	It("moves the remedy from the other software on the machine to this instance's own load", func() {
+		scenario, ok := examples.RegistryV2["cpu-filling"]
+		Expect(ok).To(BeTrue())
+
+		logger := deps.NewNopFSMLogger()
+		store := examples.SetupStore(logger)
+
+		// The ctx bounds the driver, which waits for the worker's first
+		// reading and then holds three conditions for 150 seconds of machine
+		// time between them. Machine time advances one second per reading, so
+		// the wall cost is the collector's cadence and a healthy run is a
+		// couple of seconds; the budget is many times that. On a machine the
+		// worker cannot read, machine time never advances, the holds never
+		// finish, and this ctx is what ends the run.
+		ctx, cancel := context.WithTimeout(context.Background(), 300*time.Second)
+		defer cancel()
+
+		// Duration is the settle window after the driver returns, not the
+		// length of the run. The box is frozen through it, so it buys readings
+		// taken after the story ended rather than more of the story.
+		result, err := examples.Run(ctx, examples.RunConfig{
+			ScenarioV2:   scenario,
+			Duration:     200 * time.Millisecond,
+			TickInterval: 100 * time.Millisecond,
+			Logger:       logger,
+			Store:        store,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Eventually(result.Done, "300s").Should(BeClosed())
+
+		// The three readings this scenario turns on do not coexist: each
+		// replaces the one before it, so only the last survives in the
+		// worker's current observation. cpuObservationHistory replays the
+		// store's own delta history, and searching it forward is what makes
+		// the ORDER part of the claim — a run that produced the last sentence
+		// first would fail here.
+		history := cpuObservationHistory(store)
+
+		// The quiet opening, which names the CPU limit this driver staged and
+		// this instance's usage against it. Nothing else in the run says "of 3
+		// cores", and a host the suite happened to run on would have to be
+		// under a three-core limit at half a core of usage to say it, so this
+		// is the reading that ties the story to the published machine rather
+		// than to whatever the real host was doing.
+		quiet := messageAfter(history, -1,
+			"This instance is using 0.5 of 3 cores (17% of its limit)")
+		Expect(quiet).To(BeNumerically(">=", 0),
+			"the quiet condition never reached the store; readings seen: %d", len(history))
+
+		// The machine fills from outside. "Other software" is the remedy only
+		// a machine filled by somebody else earns.
+		host := messageAfter(history, quiet, "reduce other software running on it")
+		Expect(host).To(BeNumerically(">", quiet),
+			"the machine never read full with the blame outside this instance; readings seen: %d", len(history))
+
+		// The same machine, equally full, filled by this instance. The remedy
+		// has to change: sending this customer after somebody else's load
+		// would send them after nothing.
+		ours := messageAfter(history, host, "this instance is using most of it")
+		Expect(ours).To(BeNumerically(">", host),
+			"the blame never moved to this instance; readings seen: %d", len(history))
+
+		// The box freezes when the driver returns, and a frozen box withholds
+		// every rate rather than reporting zero, so the settled verdict is the
+		// one the last condition earned.
+		var observed fsmv2.Observation[fsmv2cpu.CPUStatus]
+		Expect(store.LoadObservedTyped(context.Background(),
+			fsmv2cpu.WorkerType, config.ChildID(fsmv2cpu.InstanceName), &observed)).To(Succeed())
+
+		Expect(observed.Status.Verdict).To(Equal("degraded"))
+		Expect(observed.Status.Message).To(ContainSubstring("this instance is using most of it"))
+	})
+})

--- a/umh-core/pkg/fsmv2/examples/cpu_filling_scenario_test.go
+++ b/umh-core/pkg/fsmv2/examples/cpu_filling_scenario_test.go
@@ -24,54 +24,28 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/config"
 	fsmv2cpu "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/cpu"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/examples"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/register"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/configworker"
 )
 
 var _ = Describe("CPU filling ScenarioV2", func() {
-	// The configworker deps key is process-global; a run that fails midway
-	// would otherwise leak it into every later spec in this process.
-	BeforeEach(func() {
-		DeferCleanup(func() {
-			register.ClearDeps(configworker.WorkerTypeName)
-		})
-	})
+	clearConfigWorkerDepsEachSpec()
 
 	It("registers cpu-filling in the merged listing the CLI reads", func() {
 		Expect(examples.ListScenarios()).To(HaveKey("cpu-filling"))
 	})
 
 	It("moves the remedy from the other software on the machine to this instance's own load", func() {
-		scenario, ok := examples.RegistryV2["cpu-filling"]
-		Expect(ok).To(BeTrue())
-
-		logger := deps.NewNopFSMLogger()
-		store := examples.SetupStore(logger)
-
-		// The ctx bounds the driver, which waits for the worker's first
-		// reading and then holds three conditions for 150 seconds of machine
-		// time between them. Machine time advances one second per reading, so
-		// the wall cost is the collector's cadence and a healthy run is a
-		// couple of seconds; the budget is many times that. On a machine the
-		// worker cannot read, machine time never advances, the holds never
-		// finish, and this ctx is what ends the run.
-		ctx, cancel := context.WithTimeout(context.Background(), 300*time.Second)
-		defer cancel()
-
-		// Duration is the settle window after the driver returns, not the
-		// length of the run. The box is frozen through it, so it buys readings
-		// taken after the story ended rather than more of the story.
-		result, err := examples.Run(ctx, examples.RunConfig{
-			ScenarioV2:   scenario,
-			Duration:     200 * time.Millisecond,
-			TickInterval: 100 * time.Millisecond,
-			Logger:       logger,
-			Store:        store,
+		// This story holds three conditions for 150 seconds of machine time
+		// between them, which on a machine the worker can read costs a couple of
+		// seconds of wall time; the ctx budget is many times that. The box is
+		// frozen through the settle window, so that window buys readings taken
+		// after the story ended.
+		store := runCPUScenario(cpuScenarioRun{
+			Name:       "cpu-filling",
+			CtxBudget:  300 * time.Second,
+			Settle:     200 * time.Millisecond,
+			DoneWithin: 300 * time.Second,
 		})
-		Expect(err).NotTo(HaveOccurred())
-		Eventually(result.Done, "300s").Should(BeClosed())
 
 		// The three readings this scenario turns on do not coexist: each
 		// replaces the one before it, so only the last survives in the

--- a/umh-core/pkg/fsmv2/examples/cpu_host_scenario.go
+++ b/umh-core/pkg/fsmv2/examples/cpu_host_scenario.go
@@ -34,9 +34,10 @@ import (
 //
 //	go run pkg/fsmv2/cmd/runner/main.go --scenario=cpu-host --duration=60s --log-level=debug
 //
-// Debug is the level to watch at: the CPU worker's verdict never moves its
-// FSM state, so the collector's observed_changed line, which is a debug
-// line, is where each reading shows up.
+// On every completed poll the cpu_reading debug line carries the verdict and the
+// composed message; a failed poll never reaches it. When the worker's state
+// changes, the message also appears at info in the state_transition line's
+// reason field.
 //
 // On a machine with no cgroup v2 CPU files, such as every developer Mac, no
 // reading can ever land, and the driver refuses rather than spend its whole

--- a/umh-core/pkg/fsmv2/examples/cpu_host_scenario.go
+++ b/umh-core/pkg/fsmv2/examples/cpu_host_scenario.go
@@ -38,7 +38,7 @@ import (
 // FSM state, so the collector's observed_changed line, which is a debug
 // line, is where each reading shows up.
 //
-// On a machine with no cgroup v2 CPU files — every developer Mac — no
+// On a machine with no cgroup v2 CPU files, such as every developer Mac, no
 // reading can ever land, and the driver refuses rather than spend its whole
 // duration on a machine it cannot read. The refusal names tools/cpu-host,
 // the wrapper that runs this scenario in a Linux container where those
@@ -58,6 +58,7 @@ var CPUHostScenarioV2 = ScenarioV2{
 		if err := env.Client.Upsert(fsmv2cpu.Ref, nil); err != nil {
 			return fmt.Errorf("upsert cpu monitor: %w", err)
 		}
+
 		return awaitFirstCPUReading(ctx, env.Client)
 	},
 }

--- a/umh-core/pkg/fsmv2/examples/cpu_host_scenario.go
+++ b/umh-core/pkg/fsmv2/examples/cpu_host_scenario.go
@@ -1,0 +1,63 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package examples
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	fsmv2cpu "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/cpu"
+)
+
+// CPUHostScenarioV2 runs the CPU monitor against the machine it is running
+// on, unmodified. Every other CPU scenario publishes a fake machine before
+// the upsert; this one publishes nothing, so the CPU worker reads the host's
+// own cgroup v2 and /proc/stat files, and whatever the log says about the
+// machine is what the real machine deserves. It is for watching the monitor
+// work, not for judging it: nothing in the suite asserts its output, and its
+// result changes with the machine it runs on.
+//
+// # CLI Usage
+//
+//	go run pkg/fsmv2/cmd/runner/main.go --scenario=cpu-host --duration=60s --log-level=debug
+//
+// Debug is the level to watch at: the CPU worker's verdict never moves its
+// FSM state, so the collector's observed_changed line, which is a debug
+// line, is where each reading shows up.
+//
+// On a machine with no cgroup v2 CPU files — every developer Mac — no
+// reading can ever land, and the driver refuses rather than spend its whole
+// duration on a machine it cannot read. The refusal names tools/cpu-host,
+// the wrapper that runs this scenario in a Linux container where those
+// files exist.
+var CPUHostScenarioV2 = ScenarioV2{
+	Name:        "cpu-host",
+	Description: "Runs the CPU monitor against the machine it is running on, unmodified (v2)",
+	Driver: func(ctx context.Context, env Env) error {
+		// cpu.stat is the sampler's primary file: a failure there fails the whole
+		// sample, so its absence means every poll errors and no reading ever lands.
+		// Refuse here rather than leaving the reader to infer that from a silent
+		// stream of read errors.
+		if _, err := os.Stat("/sys/fs/cgroup/cpu.stat"); err != nil {
+			return fmt.Errorf("this host publishes no cgroup v2 CPU files, so no reading can land: %w; run it under tools/cpu-host, which puts it in a Linux container", err)
+		}
+
+		if err := env.Client.Upsert(fsmv2cpu.Ref, nil); err != nil {
+			return fmt.Errorf("upsert cpu monitor: %w", err)
+		}
+		return awaitFirstCPUReading(ctx, env.Client)
+	},
+}

--- a/umh-core/pkg/fsmv2/examples/cpu_host_scenario_test.go
+++ b/umh-core/pkg/fsmv2/examples/cpu_host_scenario_test.go
@@ -1,0 +1,102 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package examples_test
+
+import (
+	"context"
+	"os"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/examples"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/register"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/configworker"
+)
+
+var _ = Describe("CPU host ScenarioV2", func() {
+	// The configworker deps key is process-global; a run that fails midway
+	// would otherwise leak it into every later spec in this process.
+	BeforeEach(func() {
+		DeferCleanup(func() {
+			register.ClearDeps(configworker.WorkerTypeName)
+		})
+	})
+
+	It("registers cpu-host in the merged listing the CLI reads", func() {
+		Expect(examples.ListScenarios()).To(HaveKey("cpu-host"))
+	})
+
+	It("refuses only where the host publishes no cgroup v2 CPU files, naming the tool that provides them", func() {
+		scenario, ok := examples.RegistryV2["cpu-host"]
+		Expect(ok).To(BeTrue())
+
+		logger := deps.NewNopFSMLogger()
+		store := examples.SetupStore(logger)
+
+		// This spec asserts what the machine it runs on requires, so it asks
+		// that machine the same question the driver asks: does the cgroup v2
+		// CPU accounting file exist? cpu.stat is the sampler's primary file,
+		// and a machine without it can never produce a reading, because every
+		// poll fails its read. Only one arm can run per machine — macOS and
+		// cgroup v1 hosts take the refusal, a cgroup v2 host the proceed — and
+		// neither arm skips, so a developer always sees the arm their machine
+		// exercises.
+		_, statErr := os.Stat("/sys/fs/cgroup/cpu.stat")
+
+		// The refusal arm needs almost none of this budget: the driver checks
+		// the file before it upserts anything. The proceed arm needs the
+		// worker to take and publish one reading, which is a handful of its
+		// one-second polls, plus the settle window.
+		ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+		defer cancel()
+
+		result, err := examples.Run(ctx, examples.RunConfig{
+			ScenarioV2:   scenario,
+			Duration:     time.Second,
+			TickInterval: 100 * time.Millisecond,
+			Logger:       logger,
+			Store:        store,
+		})
+
+		if statErr != nil {
+			// The driver's error returns synchronously and teardown has
+			// already finished by the time Run reports it, so there is no
+			// Done channel to wait for. The message has to name the tool,
+			// because a developer on a Mac has no other way to learn that
+			// the readings exist only inside a Linux container.
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("tools/cpu-host"))
+			return
+		}
+
+		// The readable arm: the refusal must not fire here. The run may still
+		// fail for its own reasons — a machine whose cpu.stat exists but is
+		// unreadable produces no reading either, and ends the run on the
+		// context deadline — but no failure may claim the machine publishes
+		// no cgroup v2 CPU files, because this one does.
+		if err != nil {
+			Expect(err.Error()).NotTo(ContainSubstring("tools/cpu-host"))
+			return
+		}
+
+		// A run that started must finish before the spec ends, or the
+		// supervisor it left running holds the process-global deps key and
+		// every later scenario run in this process refuses to start.
+		Eventually(result.Done, "120s").Should(BeClosed())
+	})
+})

--- a/umh-core/pkg/fsmv2/examples/cpu_host_scenario_test.go
+++ b/umh-core/pkg/fsmv2/examples/cpu_host_scenario_test.go
@@ -52,9 +52,9 @@ var _ = Describe("CPU host ScenarioV2", func() {
 		// that machine the same question the driver asks: does the cgroup v2
 		// CPU accounting file exist? cpu.stat is the sampler's primary file,
 		// and a machine without it can never produce a reading, because every
-		// poll fails its read. Only one arm can run per machine — macOS and
-		// cgroup v1 hosts take the refusal, a cgroup v2 host the proceed — and
-		// neither arm skips, so a developer always sees the arm their machine
+		// poll fails its read. Only one arm can run per machine: macOS and
+		// cgroup v1 hosts take the refusal, a cgroup v2 host the proceed.
+		// Neither arm skips, so a developer always sees the arm their machine
 		// exercises.
 		_, statErr := os.Stat("/sys/fs/cgroup/cpu.stat")
 
@@ -81,16 +81,21 @@ var _ = Describe("CPU host ScenarioV2", func() {
 			// the readings exist only inside a Linux container.
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("tools/cpu-host"))
+
 			return
 		}
 
 		// The readable arm: the refusal must not fire here. The run may still
-		// fail for its own reasons — a machine whose cpu.stat exists but is
+		// fail for its own reasons: a machine whose cpu.stat exists but is
 		// unreadable produces no reading either, and ends the run on the
-		// context deadline — but no failure may claim the machine publishes
-		// no cgroup v2 CPU files, because this one does.
+		// context deadline. Two failures are still wrong here. One is the
+		// refusal, which claims a machine with the files has none. The other
+		// is the process-global deps key still held by an earlier run, which
+		// means this scenario never started at all.
 		if err != nil {
 			Expect(err.Error()).NotTo(ContainSubstring("tools/cpu-host"))
+			Expect(err.Error()).NotTo(ContainSubstring("deps key is already published"))
+
 			return
 		}
 

--- a/umh-core/pkg/fsmv2/examples/cpu_host_scenario_test.go
+++ b/umh-core/pkg/fsmv2/examples/cpu_host_scenario_test.go
@@ -41,7 +41,11 @@ var _ = Describe("CPU host ScenarioV2", func() {
 		Expect(examples.ListScenarios()).To(HaveKey("cpu-host"))
 	})
 
-	It("refuses only where the host publishes no cgroup v2 CPU files, naming the tool that provides them", func() {
+	// Label("live") keeps this spec out of CI, because make unit-test filters
+	// live specs out: what this spec asserts depends on the machine it runs
+	// on, and nobody picks the CI machine. Plain go test applies no filter,
+	// so the spec still runs on every developer machine.
+	It("refuses only where the host publishes no cgroup v2 CPU files, naming the tool that provides them", Label("live"), func() {
 		scenario, ok := examples.RegistryV2["cpu-host"]
 		Expect(ok).To(BeTrue())
 

--- a/umh-core/pkg/fsmv2/examples/cpu_latch_scenario.go
+++ b/umh-core/pkg/fsmv2/examples/cpu_latch_scenario.go
@@ -29,8 +29,8 @@ const (
 	// cpuPressureBase carries the full note on why nothing checks that.
 	cpuLatchBase = "/sys/fs/cgroup"
 
-	// The four pressure levels, against the pressure signal's 0.20 fire mark
-	// and 0.12 clear mark.
+	// The pressure levels this scenario stages, against the pressure signal's
+	// 0.20 fire mark and 0.12 clear mark (pressureMarks in pkg/cpuhealth).
 	//
 	// cpuLatchNoise is the one the story turns on. It is UNDER the fire mark,
 	// so a fresh signal would not fire on it, and OVER the clear mark, so a
@@ -47,8 +47,9 @@ const (
 	//
 	// Capacity has to stay clear throughout, because this story is about one
 	// signal and a second fired signal would take the headline. Four cores at
-	// 30% busy leaves 4 - 1.2 - 1.0 = 1.8 cores of headroom against a mark at
-	// zero, and the machine never moves off it.
+	// 30% busy leaves 4 - 1.2 - 1.0 = 1.8 cores of headroom against a fire mark
+	// at zero, where the 1.0 is the core cpuhealth holds back as reserve
+	// (cpuReserveCores). The machine never moves off that headroom.
 	cpuLatchCores      = 4
 	cpuLatchHostBusy   = 0.30
 	cpuLatchUsageCores = 0.5
@@ -65,14 +66,15 @@ const (
 	//
 	// Measured:
 	//
-	//	the signal releases 1 reading after the calm condition starts — PSI is
-	//	a level the kernel reports rather than a rate this package averages, so
+	//	The signal releases 1 reading after the calm condition starts. PSI is a
+	//	level the kernel reports rather than a rate this package averages, so
 	//	the reduction is the newest reading and the crossing needs no window of
-	//	its own; the window only had to be covered, which it was long before
-	//	the signal fires again exactly 60 readings after that release, which is
-	//	the bar to the reading. By then the machine has been over its fire mark
-	//	for 40 readings, reported healthy, with the technical details printing
-	//	the number that would have fired it
+	//	its own; the window only had to be covered, which it was long before.
+	//
+	//	The signal fires again exactly 60 readings after that release, the span
+	//	the re-fire rule above requires. By then the machine has been over its
+	//	fire mark for 40 readings, reported healthy, with the technical details
+	//	printing the number that would have fired it.
 	cpuLatchFiringHold = 40 * time.Second
 	cpuLatchNoiseHold  = 40 * time.Second
 	cpuLatchCalmHold   = 20 * time.Second
@@ -94,11 +96,12 @@ const (
 //
 // # CLI Usage
 //
-//	go run pkg/fsmv2/cmd/runner/main.go --scenario=cpu-latch --duration=200ms --log-level=debug --dump-store
+//	go run pkg/fsmv2/cmd/runner/main.go --scenario=cpu-latch --duration=200ms --log-level=debug
 //
-// The verdict shows up on the collector's observed_changed line, which is a
-// debug line — the CPU worker declares no Health function, so its verdict never
-// moves the worker's FSM state and nothing about the verdict is logged at info.
+// On every completed poll the cpu_reading debug line carries the verdict and the
+// composed message; a failed poll never reaches it. When the worker's state
+// changes, the message also appears at info in the state_transition line's
+// reason field.
 var CPULatchScenarioV2 = ScenarioV2{
 	Name:        "cpu-latch",
 	Description: "Holds a fake machine's CPU verdict through noise, releases it on recovery, and shows the bar on re-firing (v2)",
@@ -106,9 +109,8 @@ var CPULatchScenarioV2 = ScenarioV2{
 }
 
 // driveCPULatch publishes a fake machine, spawns the CPU monitor onto it
-// through the migration-API client, and walks its pressure through four levels:
-// over the fire mark, back into the band, under the clear mark, over the fire
-// mark again.
+// through the migration-API client, and walks its pressure through the levels
+// the consts above stage.
 //
 // It judges nothing. What the worker made of each level is read back after the
 // run, out of the store's own delta history, by the spec beside this file.
@@ -166,8 +168,8 @@ func driveCPULatch(ctx context.Context, env Env) error {
 }
 
 // cpuLatchMachine is this scenario's machine at the given PSI pressure.
-// Everything except the pressure is the same in all four conditions, so the
-// four calls differ by exactly the one number the story turns on.
+// Everything except the pressure is the same in every condition, so the calls
+// differ by exactly the one number the story turns on.
 func cpuLatchMachine(pressure float64) fakebox.Condition {
 	return fakebox.Condition{
 		Cores:      cpuLatchCores,

--- a/umh-core/pkg/fsmv2/examples/cpu_latch_scenario.go
+++ b/umh-core/pkg/fsmv2/examples/cpu_latch_scenario.go
@@ -1,0 +1,179 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package examples
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/cpuhealth/fakebox"
+	fsmv2cpu "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/cpu"
+)
+
+const (
+	// cpuLatchBase is where this scenario's fake machine serves its cgroup
+	// files, and has to equal the unexported cgroupBase in pkg/fsmv2/cpu.
+	// cpuPressureBase carries the full note on why nothing checks that.
+	cpuLatchBase = "/sys/fs/cgroup"
+
+	// The four pressure levels, against the pressure signal's 0.20 fire mark
+	// and 0.12 clear mark.
+	//
+	// cpuLatchNoise is the one the story turns on. It is UNDER the fire mark,
+	// so a fresh signal would not fire on it, and OVER the clear mark, so a
+	// fired one does not release. That gap between the two marks is what stops
+	// a reading hovering at the threshold from flapping the verdict, and this
+	// scenario is the gap being used.
+	cpuLatchFiring = 0.25
+	cpuLatchNoise  = 0.15
+	cpuLatchCalm   = 0.05
+
+	// cpuLatchCores is the machine's CPU count, cpuLatchHostBusy how much of it
+	// the whole machine is using, and cpuLatchUsageCores what this instance
+	// itself uses. There is no CPU limit.
+	//
+	// Capacity has to stay clear throughout, because this story is about one
+	// signal and a second fired signal would take the headline. Four cores at
+	// 30% busy leaves 4 - 1.2 - 1.0 = 1.8 cores of headroom against a mark at
+	// zero, and the machine never moves off it.
+	cpuLatchCores      = 4
+	cpuLatchHostBusy   = 0.30
+	cpuLatchUsageCores = 0.5
+
+	// How much machine time each condition is held for. This is machine time,
+	// not wall time: see holdMachine.
+	//
+	// The lengths here are the two release rules, not taste. A fired signal
+	// releases only on a window whose Coverage is Full, which takes 60 readings
+	// (see StartPerRead), and a released signal cannot fire again until a whole
+	// span has passed since it released — another 60. So the shortest story
+	// that shows a release AND the re-fire behind it is about 120 readings
+	// long, and these holds are that plus room to sit in each condition.
+	//
+	// Measured:
+	//
+	//	the signal releases 1 reading after the calm condition starts — PSI is
+	//	a level the kernel reports rather than a rate this package averages, so
+	//	the reduction is the newest reading and the crossing needs no window of
+	//	its own; the window only had to be covered, which it was long before
+	//	the signal fires again exactly 60 readings after that release, which is
+	//	the bar to the reading. By then the machine has been over its fire mark
+	//	for 40 readings, reported healthy, with the technical details printing
+	//	the number that would have fired it
+	cpuLatchFiringHold = 40 * time.Second
+	cpuLatchNoiseHold  = 40 * time.Second
+	cpuLatchCalmHold   = 20 * time.Second
+	cpuLatchRefireHold = 60 * time.Second
+)
+
+// CPULatchScenarioV2 drives the real CPU monitor over a fake machine whose PSI
+// pressure crosses its fire mark, falls back into the band between the two
+// marks, drops under the clear mark, and rises again.
+//
+// The story is what the two marks buy and what they cost. A machine that has
+// been called degraded stays degraded while its pressure wanders below the mark
+// that fired it, so an operator is not told the trouble ended and started again
+// every few seconds. It lets go when the machine genuinely recovers. And when
+// the trouble comes back, the report is late: a released signal cannot fire
+// again for a whole window, so the machine spends that stretch over its fire
+// mark while the verdict still reads healthy and the technical details print
+// the number that would have fired it.
+//
+// # CLI Usage
+//
+//	go run pkg/fsmv2/cmd/runner/main.go --scenario=cpu-latch --duration=200ms --log-level=debug --dump-store
+//
+// The verdict shows up on the collector's observed_changed line, which is a
+// debug line — the CPU worker declares no Health function, so its verdict never
+// moves the worker's FSM state and nothing about the verdict is logged at info.
+var CPULatchScenarioV2 = ScenarioV2{
+	Name:        "cpu-latch",
+	Description: "Holds a fake machine's CPU verdict through noise, releases it on recovery, and shows the bar on re-firing (v2)",
+	Driver:      driveCPULatch,
+}
+
+// driveCPULatch publishes a fake machine, spawns the CPU monitor onto it
+// through the migration-API client, and walks its pressure through four levels:
+// over the fire mark, back into the band, under the clear mark, over the fire
+// mark again.
+//
+// It judges nothing. What the worker made of each level is read back after the
+// run, out of the store's own delta history, by the spec beside this file.
+func driveCPULatch(ctx context.Context, env Env) error {
+	firing := cpuLatchMachine(cpuLatchFiring)
+	machine := newTickingBox(cpuLatchBase, firing)
+
+	// Published before the Upsert below, because cpu.NewDeps reads both keys
+	// once, at the moment the supervisor spawns the worker; anything published
+	// after that spawn reaches nothing. The poll cadence has the same deadline:
+	// the collector reads it when the worker spawns.
+	clearDeps := machine.Deps()
+	defer clearDeps()
+
+	restorePoll := useFastCPUPoll()
+	defer restorePoll()
+
+	machine.StartPerRead(cpuMachineSecond)
+	defer machine.Stop()
+
+	announceMachine(firing)
+
+	// Nil config: CPUConfig is an empty struct, and this is the same call the
+	// config worker makes in production.
+	if err := env.Client.Upsert(fsmv2cpu.Ref, nil); err != nil {
+		return fmt.Errorf("upsert cpu monitor: %w", err)
+	}
+
+	if err := awaitFirstCPUReading(ctx, env.Client); err != nil {
+		return fmt.Errorf("wait for the cpu monitor's first reading: %w", err)
+	}
+
+	if err := holdMachine(ctx, machine, cpuLatchFiringHold); err != nil {
+		return err
+	}
+
+	for _, step := range []struct {
+		pressure float64
+		hold     time.Duration
+	}{
+		{cpuLatchNoise, cpuLatchNoiseHold},
+		{cpuLatchCalm, cpuLatchCalmHold},
+		{cpuLatchFiring, cpuLatchRefireHold},
+	} {
+		condition := cpuLatchMachine(step.pressure)
+		machine.Set(condition)
+		announceMachine(condition)
+
+		if err := holdMachine(ctx, machine, step.hold); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// cpuLatchMachine is this scenario's machine at the given PSI pressure.
+// Everything except the pressure is the same in all four conditions, so the
+// four calls differ by exactly the one number the story turns on.
+func cpuLatchMachine(pressure float64) fakebox.Condition {
+	return fakebox.Condition{
+		Cores:      cpuLatchCores,
+		HostBusy:   cpuLatchHostBusy,
+		UsageCores: cpuLatchUsageCores,
+		Pressure:   pressure,
+		PsiPresent: true,
+	}
+}

--- a/umh-core/pkg/fsmv2/examples/cpu_latch_scenario_test.go
+++ b/umh-core/pkg/fsmv2/examples/cpu_latch_scenario_test.go
@@ -89,7 +89,7 @@ var _ = Describe("CPU latch ScenarioV2", func() {
 
 		// Under the clear mark: released, and the budget dashboard prints the
 		// reading it released on.
-		released := messageAfter(history, held, "Pressure 5% (degraded above 20%)")
+		released := messageAfter(history, held, "Pressure 5% (degrades above 20%)")
 		Expect(released).To(BeNumerically(">", held),
 			"the verdict never let go on a recovered machine; readings seen: %d", len(history))
 
@@ -97,7 +97,7 @@ var _ = Describe("CPU latch ScenarioV2", func() {
 		// has released cannot fire again for a whole window. The dashboard
 		// prints 25% against a threshold of 20% while the verdict reads
 		// healthy, which is the cost of the bar rather than a rendering slip.
-		barred := messageAfter(history, released, "Pressure 25% (degraded above 20%)")
+		barred := messageAfter(history, released, "Pressure 25% (degrades above 20%)")
 		Expect(barred).To(BeNumerically(">", released),
 			"the machine never sat over its fire mark while still reported healthy; readings seen: %d", len(history))
 

--- a/umh-core/pkg/fsmv2/examples/cpu_latch_scenario_test.go
+++ b/umh-core/pkg/fsmv2/examples/cpu_latch_scenario_test.go
@@ -1,0 +1,121 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package examples_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/config"
+	fsmv2cpu "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/cpu"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/examples"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/register"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/configworker"
+)
+
+var _ = Describe("CPU latch ScenarioV2", func() {
+	// The configworker deps key is process-global; a run that fails midway
+	// would otherwise leak it into every later spec in this process.
+	BeforeEach(func() {
+		DeferCleanup(func() {
+			register.ClearDeps(configworker.WorkerTypeName)
+		})
+	})
+
+	It("registers cpu-latch in the merged listing the CLI reads", func() {
+		Expect(examples.ListScenarios()).To(HaveKey("cpu-latch"))
+	})
+
+	It("holds the degraded verdict through a reading under the fire mark and releases it under the clear mark", func() {
+		scenario, ok := examples.RegistryV2["cpu-latch"]
+		Expect(ok).To(BeTrue())
+
+		logger := deps.NewNopFSMLogger()
+		store := examples.SetupStore(logger)
+
+		// Machine time advances one second per reading, so the wall cost is
+		// the collector's cadence and a healthy run is about a second. On a
+		// machine the worker cannot read, machine time never advances, the
+		// holds never finish, and this ctx is what ends the run.
+		ctx, cancel := context.WithTimeout(context.Background(), 300*time.Second)
+		defer cancel()
+
+		result, err := examples.Run(ctx, examples.RunConfig{
+			ScenarioV2:   scenario,
+			Duration:     200 * time.Millisecond,
+			TickInterval: 100 * time.Millisecond,
+			Logger:       logger,
+			Store:        store,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Eventually(result.Done, "300s").Should(BeClosed())
+
+		// Five readings that do not coexist, checked in order out of the
+		// store's own delta history. Every percentage below is one this driver
+		// staged and nothing else stages, so each names the machine the verdict
+		// was computed from rather than only the verdict.
+		history := cpuObservationHistory(store)
+
+		// Over the fire mark: degraded, reporting the number that fired it.
+		fired := messageAfter(history, -1,
+			"spent 25% of the last minute waiting for a free CPU core")
+		Expect(fired).To(BeNumerically(">=", 0),
+			"the machine never read degraded on pressure; readings seen: %d", len(history))
+
+		// Back under the fire mark and over the clear mark. A signal that had
+		// not fired would not fire on 15%, and this one does not let go of it
+		// — which is the whole point of having two marks rather than one.
+		held := messageAfter(history, fired,
+			"spent 15% of the last minute waiting for a free CPU core")
+		Expect(held).To(BeNumerically(">", fired),
+			"the verdict did not survive a reading below the fire mark; readings seen: %d", len(history))
+
+		// Under the clear mark: released, and the budget dashboard prints the
+		// reading it released on.
+		released := messageAfter(history, held, "Pressure 5% (degraded above 20%)")
+		Expect(released).To(BeNumerically(">", held),
+			"the verdict never let go on a recovered machine; readings seen: %d", len(history))
+
+		// Over the fire mark again, and still reported healthy: a signal that
+		// has released cannot fire again for a whole window. The dashboard
+		// prints 25% against a threshold of 20% while the verdict reads
+		// healthy, which is the cost of the bar rather than a rendering slip.
+		barred := messageAfter(history, released, "Pressure 25% (degraded above 20%)")
+		Expect(barred).To(BeNumerically(">", released),
+			"the machine never sat over its fire mark while still reported healthy; readings seen: %d", len(history))
+
+		// The bar runs out and the same machine is degraded again.
+		refired := messageAfter(history, barred,
+			"spent 25% of the last minute waiting for a free CPU core")
+		Expect(refired).To(BeNumerically(">", barred),
+			"the verdict never came back; readings seen: %d", len(history))
+
+		// The box freezes when the driver returns, and a frozen box withholds
+		// every rate rather than reporting zero, so the settled verdict is the
+		// one the last condition earned.
+		var observed fsmv2.Observation[fsmv2cpu.CPUStatus]
+		Expect(store.LoadObservedTyped(context.Background(),
+			fsmv2cpu.WorkerType, config.ChildID(fsmv2cpu.InstanceName), &observed)).To(Succeed())
+
+		Expect(observed.Status.Verdict).To(Equal("degraded"))
+		Expect(observed.Status.Message).To(ContainSubstring(
+			"spent 25% of the last minute waiting for a free CPU core"))
+	})
+})

--- a/umh-core/pkg/fsmv2/examples/cpu_latch_scenario_test.go
+++ b/umh-core/pkg/fsmv2/examples/cpu_latch_scenario_test.go
@@ -24,48 +24,25 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/config"
 	fsmv2cpu "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/cpu"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/examples"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/register"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/configworker"
 )
 
 var _ = Describe("CPU latch ScenarioV2", func() {
-	// The configworker deps key is process-global; a run that fails midway
-	// would otherwise leak it into every later spec in this process.
-	BeforeEach(func() {
-		DeferCleanup(func() {
-			register.ClearDeps(configworker.WorkerTypeName)
-		})
-	})
+	clearConfigWorkerDepsEachSpec()
 
 	It("registers cpu-latch in the merged listing the CLI reads", func() {
 		Expect(examples.ListScenarios()).To(HaveKey("cpu-latch"))
 	})
 
 	It("holds the degraded verdict through a reading under the fire mark and releases it under the clear mark", func() {
-		scenario, ok := examples.RegistryV2["cpu-latch"]
-		Expect(ok).To(BeTrue())
-
-		logger := deps.NewNopFSMLogger()
-		store := examples.SetupStore(logger)
-
-		// Machine time advances one second per reading, so the wall cost is
-		// the collector's cadence and a healthy run is about a second. On a
-		// machine the worker cannot read, machine time never advances, the
-		// holds never finish, and this ctx is what ends the run.
-		ctx, cancel := context.WithTimeout(context.Background(), 300*time.Second)
-		defer cancel()
-
-		result, err := examples.Run(ctx, examples.RunConfig{
-			ScenarioV2:   scenario,
-			Duration:     200 * time.Millisecond,
-			TickInterval: 100 * time.Millisecond,
-			Logger:       logger,
-			Store:        store,
+		// On a machine the worker can read, this story costs about a second of
+		// wall time; the ctx budget is many times that.
+		store := runCPUScenario(cpuScenarioRun{
+			Name:       "cpu-latch",
+			CtxBudget:  300 * time.Second,
+			Settle:     200 * time.Millisecond,
+			DoneWithin: 300 * time.Second,
 		})
-		Expect(err).NotTo(HaveOccurred())
-		Eventually(result.Done, "300s").Should(BeClosed())
 
 		// Five readings that do not coexist, checked in order out of the
 		// store's own delta history. Every percentage below is one this driver

--- a/umh-core/pkg/fsmv2/examples/cpu_observation_history_test.go
+++ b/umh-core/pkg/fsmv2/examples/cpu_observation_history_test.go
@@ -51,8 +51,10 @@ type cpuObservation struct {
 // worker's observation holds one state at a time and the runner hands a spec
 // back a finished run, so anything a driver staged before the last condition is
 // unreachable through LoadObservedTyped. The delta history is the store's own
-// record of every field change, which is also what --dump-store prints, so
-// reading it here checks the same thing a reader of the command line sees.
+// record of every field change, and reading it here is the ONLY way to see the
+// sequence: --dump-store cannot show it, because runV2 ignores the flag and
+// warns dump_store_not_supported_for_v2, and every CPU scenario is v2. So a
+// spec sees readings a reader of the command line does not.
 //
 // Replaying rather than reading each delta alone is what makes a state whole: a
 // delta carries only the fields that changed, so a reading whose verdict moved

--- a/umh-core/pkg/fsmv2/examples/cpu_observation_history_test.go
+++ b/umh-core/pkg/fsmv2/examples/cpu_observation_history_test.go
@@ -1,0 +1,167 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// What the CPU worker's observation passed through during a run, and how to
+// find one reading in it. The three CPU scenario specs beside this file all
+// need it: each stages a sequence of machine conditions, and the readings those
+// produce do not coexist.
+
+package examples_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/cse/storage"
+	fsmv2cpu "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/cpu"
+)
+
+// cpuObservation is one state the CPU worker's observation passed through: what
+// the worker judged, and the framework's own verdict on the poll that produced
+// it. Reason and Degraded come from the framework rather than from cpuhealth,
+// and they are the only place a FAILED poll shows up — a poll that errors
+// publishes an empty Verdict and Message, so a spec reading only those two
+// cannot tell a failed read from a worker that has not started.
+type cpuObservation struct {
+	Message  string
+	Verdict  string
+	Reason   string
+	Degraded bool
+}
+
+// cpuObservationHistory replays the store's delta history into the states the
+// CPU worker's observation passed through, oldest first.
+//
+// A spec reaches for this when the readings it has to check do not coexist. The
+// worker's observation holds one state at a time and the runner hands a spec
+// back a finished run, so anything a driver staged before the last condition is
+// unreachable through LoadObservedTyped. The delta history is the store's own
+// record of every field change, which is also what --dump-store prints, so
+// reading it here checks the same thing a reader of the command line sees.
+//
+// Replaying rather than reading each delta alone is what makes a state whole: a
+// delta carries only the fields that changed, so a reading whose verdict moved
+// while its message did not would otherwise arrive with an empty message.
+//
+// Only CHANGES are kept. The worker publishes an observation on every poll and
+// its timestamp moves each time, so the store holds a delta per poll and one
+// verdict spans hundreds of them. Keeping the repeats would make "this sentence
+// came after that one" true of any two sentences that overlapped by a single
+// reading, which is most of them, and an ordering check that cannot fail is not
+// one. A state that comes BACK after a different state is a fresh entry, which
+// is what a re-fired verdict needs.
+//
+// GetDeltas serves a bounded page, so this pages to the end rather than
+// reporting the first hundred changes as the whole run.
+func cpuObservationHistory(store storage.TriangularStoreInterface) []cpuObservation {
+	GinkgoHelper()
+
+	var (
+		history    []cpuObservation
+		current    cpuObservation
+		lastSyncID int64
+	)
+
+	for {
+		resp, err := store.GetDeltas(context.Background(), storage.Subscription{LastSyncID: lastSyncID})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.RequiresBootstrap).To(BeFalse(),
+			"the store dropped the delta history this check reads")
+
+		if len(resp.Deltas) == 0 {
+			break
+		}
+
+		for _, delta := range resp.Deltas {
+			lastSyncID = delta.SyncID
+
+			if delta.WorkerType != fsmv2cpu.WorkerType || delta.Role != storage.RoleObserved || delta.Changes == nil {
+				continue
+			}
+
+			previous := current
+			applyCPUChange(&current, delta.Changes)
+
+			if len(history) == 0 || current != previous {
+				history = append(history, current)
+			}
+		}
+
+		if !resp.HasMore {
+			break
+		}
+	}
+
+	return history
+}
+
+// applyCPUChange folds one delta's changed fields into the running state. The
+// first observation ADDS every field and later ones MODIFY the few that moved,
+// so both maps are read.
+func applyCPUChange(into *cpuObservation, changes *storage.Diff) {
+	set := func(field string, value interface{}) {
+		switch field {
+		case "message":
+			into.Message = fmt.Sprint(value)
+		case "verdict":
+			into.Verdict = fmt.Sprint(value)
+		case "reason":
+			into.Reason = fmt.Sprint(value)
+		case "degraded":
+			into.Degraded = value == true
+		}
+	}
+
+	for field, value := range changes.Added {
+		set(field, value)
+	}
+
+	for field, modified := range changes.Modified {
+		set(field, modified.New)
+	}
+}
+
+// messageAfter returns the position of the first reading past after whose
+// message holds substring, or -1 when none does. Pass -1 for after to search
+// the whole run.
+//
+// The position is what a caller compares, so two sentences that arrived in the
+// wrong order fail rather than both passing on being present. Searching from a
+// position rather than from the start is also what lets a caller check a
+// sentence that comes BACK: the second time a machine says the same thing is a
+// different claim from the first, and looking from the start would find the
+// first.
+func messageAfter(history []cpuObservation, after int, substring string) int {
+	return indexAfter(history, after, substring, func(o cpuObservation) string { return o.Message })
+}
+
+// reasonAfter is messageAfter over the framework's own reason, which is where a
+// failed poll is reported.
+func reasonAfter(history []cpuObservation, after int, substring string) int {
+	return indexAfter(history, after, substring, func(o cpuObservation) string { return o.Reason })
+}
+
+func indexAfter(history []cpuObservation, after int, substring string, field func(cpuObservation) string) int {
+	for i := after + 1; i < len(history); i++ {
+		if strings.Contains(field(history[i]), substring) {
+			return i
+		}
+	}
+
+	return -1
+}

--- a/umh-core/pkg/fsmv2/examples/cpu_pressure_scenario.go
+++ b/umh-core/pkg/fsmv2/examples/cpu_pressure_scenario.go
@@ -53,11 +53,11 @@ const (
 	// The capacity signal reads headroom as cores - busy - a one-core reserve,
 	// averaged over 60 seconds, and calls the machine full below zero. Four
 	// cores at 60% busy is 4 - 2.4 - 1.0 = 0.6 cores, and that is what the run
-	// reports from its first measured reading onward, with no ramp into it: the
-	// worker's very first read has no baseline to rate against, and because the
-	// clock it is stamped from is the box's own, no machine time has passed
-	// either, so the reading is withheld rather than counted as a zero that the
-	// average would then have to climb out of.
+	// reports from its first reading onward, with no ramp into it: cpu.NewDeps
+	// takes a startup snapshot through the same sampler, which fixes the counter
+	// baselines every rate is derived from, so the worker's first poll is that
+	// sampler's second read and already carries a full rate. There is no zero
+	// for the 60-second mean to climb out of.
 	//
 	// So the run sits 0.6 cores above the mark at which this machine would be
 	// called full, and stays there. That is the story: it is a busy machine
@@ -116,12 +116,12 @@ const (
 //
 //	go run pkg/fsmv2/cmd/runner/main.go --scenario=cpu-pressure --duration=30s --log-level=debug
 //
-// Debug is what makes the answer visible. The CPU worker's MonitorSpec declares
-// no Health function, so its verdict never moves the worker's FSM state and
-// nothing about the verdict is logged at info. The collector's observed_changed
-// line, which is a debug line, is where the verdict flip shows up. Run it at
-// info and the page still carries the supervisor spawning its children between
-// the two machine conditions, but nothing about what the worker made of either.
+// Debug is what makes the answer visible. On every completed poll the
+// cpu_reading debug line carries the verdict and the composed message; a failed
+// poll never reaches it. When the worker's state changes, the message also
+// appears at info in the state_transition line's reason field. Run at info and
+// the page still carries the state transitions and the supervisor spawning its
+// children, but nothing about the readings in between.
 var CPUPressureScenarioV2 = ScenarioV2{
 	Name:        "cpu-pressure",
 	Description: "Steps a fake machine's CPU pressure over its fire mark while capacity stays clear (v2)",
@@ -184,14 +184,14 @@ func cpuPressureMachine(pressure float64) fakebox.Condition {
 }
 
 // announceMachine prints the fake machine's condition, and is the only thing
-// this scenario prints. One line goes out each time the mock changes, the
-// opening condition included, and nothing else at all: every other line on the
-// page is the supervisor's own output, so a reader can tell a stimulus from a
-// response without being told which is which.
+// this scenario prints: one line each time the mock changes, the opening
+// condition included. Every other line on the page is the supervisor's own
+// output, so a reader can tell a stimulus from a response without being told
+// which is which.
 //
-// Both lines carry the whole condition rather than only the field that moved,
-// so a reader sees for themselves that pressure is the only difference between
-// them, instead of taking a claim that it is.
+// Each line carries the whole condition rather than only the field that moved,
+// so a reader compares the lines and sees for themselves that pressure is the
+// only difference, instead of taking a claim that it is.
 func announceMachine(c fakebox.Condition) {
 	fmt.Printf("fake machine: %d cores, host %.0f%% busy, this instance %g cores, pressure %.0f%%\n",
 		c.Cores, c.HostBusy*100, c.UsageCores, c.Pressure*100)
@@ -206,7 +206,8 @@ func announceMachine(c fakebox.Condition) {
 // had spawned, and the calm condition would then be held for less time than it
 // looks.
 //
-// Verdict is empty on every tick that could not measure, so a machine the
+// A completed poll always publishes a verdict, and only a tick that could not
+// measure leaves it empty (cpu.CPUStatus.Verdict states both). So a machine the
 // worker cannot read at all never satisfies this and the driver waits out its
 // ctx. That is the honest outcome: there is no story to tell on a machine
 // nobody can read.
@@ -260,10 +261,8 @@ func holdFor(ctx context.Context, d time.Duration) error {
 // Publish FS and Clock together, which Deps does. Tick moves the counters and
 // the clock by the same amount, so once the sampler stamps from that clock, the
 // time it divides by and the counters it divides are the same quantity, and the
-// rate that comes out is the rate the condition states. Stamping from the wall
-// clock instead divides a tick's worth of counter by however long the two reads
-// happened to be apart, which at spawn can be under a millisecond: a hundredfold
-// overstatement that then sits in a 60-second mean for a minute.
+// rate that comes out is the rate the condition states. Deps carries what
+// publishing only one of the two costs.
 //
 // Everything that touches the Box's counters goes through the one mutex here:
 // the reads the collector makes, the ticks, and Set. The clock is not covered by
@@ -272,8 +271,7 @@ func holdFor(ctx context.Context, d time.Duration) error {
 // top of a read and then opens the files (read.go, ts := s.clock.Now()), so a
 // tick landing after the stamp adds counters the stamp does not account for, and
 // whichever source is read after that tick reports a rate too high by one tick's
-// worth. Only one tick can fit, so the overstatement is bounded; the wall-clock
-// version divided by a gap that could be arbitrarily short and was not.
+// worth. Only one tick can fit, so the overstatement is bounded.
 type tickingBox struct {
 	box  *fakebox.Box
 	stop chan struct{}
@@ -307,20 +305,22 @@ func newTickingBox(base string, initial fakebox.Condition) *tickingBox {
 // keys are process-global, so a driver that left either set would hand the next
 // scenario in this process its fake machine.
 //
-// Publishing the pair together is the point of this method, because one of the
-// halves fails silently on its own.
+// Publishing the pair together is the point of this method, because either half
+// on its own fails quietly.
 //
-// A filesystem with no clock is that half. Nothing errors. The sampler stamps
-// from the wall clock while the counters accrue on this box's, so it divides a
-// tick's worth of counter by however long two reads happened to be apart, which
-// at spawn is on the order of a hundred microseconds. In this scenario that
-// reads as a machine thousands of percent busy, and the 60-second mean carries
-// it for a minute. It is also exactly what a scenario copied from a pre-clock
-// one does.
+// A filesystem with no clock: nothing errors, and cpu.NewDeps falls back to the
+// real clock. The sampler then stamps from the wall clock while the counters
+// accrue on this box's, so it divides a tick's worth of counter by however long
+// two reads happened to be apart, which at spawn is on the order of a hundred
+// microseconds. In this scenario that reads as a machine thousands of percent
+// busy, and the 60-second mean carries it for a minute.
 //
-// A clock nothing advances is the loud half. Machine time stands still, the
-// sampler's elapsed is never positive, every rate is withheld, and a driver
-// waiting for the worker's first reading waits out its ctx instead.
+// A clock nothing advances: machine time stands still and the sampler's elapsed
+// is never positive, so every rate is withheld. The polls themselves still
+// succeed and still publish a verdict, so awaitFirstCPUReading is satisfied and
+// this scenario's wall-clock holds run to completion — the page carries readings
+// with no rates in them. What waits out its ctx is a driver measuring its holds
+// in machine time, which is holdMachine in cpu_filling_scenario.go.
 //
 // Publishing neither is production: the real filesystem and the real clock.
 func (t *tickingBox) Deps() (clear func()) {
@@ -352,10 +352,8 @@ func (t *tickingBox) fs() filesystem.Service {
 		//
 		// The tick lands after the sampler has stamped the read and before any
 		// file is served, so the stamp trails the counters by one tick — the
-		// SAME one tick on every read, which is what makes the deltas exact:
-		// one tick of counters over one tick of clock is the rate the condition
-		// states, with none of the straddling cpuPressureMachineTick has to
-		// bound.
+		// SAME one tick on every read. StartPerRead carries what that exactness
+		// buys a scenario.
 		if t.perRead > 0 && path == t.base+"/cpu.pressure" {
 			t.box.Tick(t.perRead)
 		}
@@ -371,12 +369,8 @@ func (t *tickingBox) fs() filesystem.Service {
 // denominated in.
 //
 // A driver whose story is measured in machine time waits against this rather
-// than against the wall clock. How much machine time a wall second buys is not
-// fixed: it is however many ticks the ticker actually delivered, and a run
-// under debug logging delivers fewer of them than a run with a discarding
-// logger. A wall-clock hold therefore covers a different stretch of the story
-// on each, while a machine-time hold covers the same stretch on both and pays
-// the difference in wall seconds instead.
+// than against the wall clock. holdMachine in cpu_filling_scenario.go is that
+// wait, and carries why wall time is not a stand-in for it.
 //
 // clock.Mock synchronises itself, so this is safe to call while the box ticks.
 func (t *tickingBox) MachineNow() time.Time {
@@ -394,13 +388,13 @@ func (t *tickingBox) Set(c fakebox.Condition) {
 	t.box.Set(c)
 }
 
-// Start advances the box by every, every, so machine time keeps pace with the
-// wall clock. Call it once.
+// Start uses every as both the ticker's wall-clock interval and the machine time
+// each tick advances, so machine time keeps pace with the wall clock. Call it
+// once.
 //
 // A ticker drops ticks under load rather than queueing them, and on the box's
 // own clock a drop withholds a tick's counters and a tick's clock together, so
-// no rate it reports is wrong. The wall-clock version had to argue that a drop
-// erred in the harmless direction; this one does not err at all.
+// no rate it reports is wrong.
 //
 // It does not lengthen the run either. Both the driver's holds and the worker's
 // polls are on the wall clock, so a drop does not buy back the time: it thins
@@ -471,23 +465,26 @@ func (t *tickingBox) startTicker(interval, advance time.Duration) {
 // Stop halts the advancing and waits for it to have halted, so no tick lands
 // after Stop returns. It ends both modes: it joins the ticker goroutine when
 // there is one, and it stops a read-driven box advancing, so the reads the
-// worker keeps making during the settle window no longer move machine time.
+// worker keeps making during the settle window no longer move machine time. The
+// settle window is the stretch a v2 scenario's --duration buys after its driver
+// returns (routeDuration, pkg/fsmv2/cmd/runner/main.go).
 //
-// A driver's defer fires this when the driver returns, which is BEFORE the
-// runner's settle window. Everything the worker reads during that window comes
-// from a stopped box — and a stopped box has stopped its clock too, so the
-// sampler's elapsed time is zero, every rate is withheld rather than recomputed,
-// and no window ages.
+// A driver's defer fires this when the driver returns, which is BEFORE that
+// window. Everything the worker reads during it comes from a stopped box — and
+// a stopped box has stopped its clock too, so the sampler's elapsed time is
+// zero, every rate is withheld rather than recomputed, and no measurement
+// window ages.
 //
 // This scenario would survive the freeze without any of that, because what
-// carries its verdict is PSI pressure, which the kernel reports as a level and
-// a Box writes rather than accrues. A frozen box keeps serving 25%.
+// carries its verdict is PSI pressure, a level rather than a rate (see Set). A
+// frozen box keeps serving 25%.
 //
-// What the stopped clock protects is the scenario that copies this one and
-// hangs its verdict on a rate. Freeze the counters while the wall clock runs and
-// its rates do not merely fall: every one of them converges on a confident zero,
-// so the page ends on an idle machine with full headroom that nothing flags as
-// unmeasured. Stopping the clock turns that into no reading at all.
+// What the stopped clock protects is a scenario whose verdict hangs on a rate
+// rather than a level, as cpu_filling_scenario.go's does. Freeze the counters
+// while the wall clock runs and its rates do not merely fall: every one of them
+// converges on a confident zero, so the page ends on an idle machine with full
+// headroom that nothing flags as unmeasured. Stopping the clock turns that into
+// no reading at all.
 func (t *tickingBox) Stop() {
 	t.mu.Lock()
 	t.perRead = 0

--- a/umh-core/pkg/fsmv2/examples/cpu_pressure_scenario.go
+++ b/umh-core/pkg/fsmv2/examples/cpu_pressure_scenario.go
@@ -1,0 +1,500 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package examples
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/benbjohnson/clock"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/cpuhealth/fakebox"
+	fsmv2cpu "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/cpu"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/fsmv2client"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/register"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/filesystem"
+)
+
+const (
+	// cpuPressureBase is where the fake machine serves its cgroup files. It has
+	// to equal the base the production sampler reads, which is the unexported
+	// cgroupBase in pkg/fsmv2/cpu. Nothing checks that they match: they are kept
+	// equal by hand, and a mismatch leaves every read failing.
+	cpuPressureBase = "/sys/fs/cgroup"
+
+	// cpuPressureCalm is one point under the pressure signal's 0.20 fire mark,
+	// so the machine starts healthy on a number that is nearly the threshold
+	// rather than nowhere near it. A start far below the mark would leave the
+	// later crossing provable by a much cruder change than the one this
+	// scenario makes.
+	cpuPressureCalm = 0.19
+
+	// cpuPressureFiring is over that fire mark, so the signal fires.
+	cpuPressureFiring = 0.25
+
+	// cpuPressureCores is the fake machine's CPU count, and cpuPressureHostBusy
+	// how much of it the whole machine is using.
+	//
+	// The capacity signal reads headroom as cores - busy - a one-core reserve,
+	// averaged over 60 seconds, and calls the machine full below zero. Four
+	// cores at 60% busy is 4 - 2.4 - 1.0 = 0.6 cores, and that is what the run
+	// reports from its first measured reading onward, with no ramp into it: the
+	// worker's very first read has no baseline to rate against, and because the
+	// clock it is stamped from is the box's own, no machine time has passed
+	// either, so the reading is withheld rather than counted as a zero that the
+	// average would then have to climb out of.
+	//
+	// So the run sits 0.6 cores above the mark at which this machine would be
+	// called full, and stays there. That is the story: it is a busy machine
+	// with capacity to spare, and what makes it degraded later has nothing to
+	// do with capacity.
+	cpuPressureCores    = 4
+	cpuPressureHostBusy = 0.60
+
+	// cpuPressureUsageCores is what this instance itself is using: 0.5 cores of
+	// the 2.4 the machine is busy with, so about a fifth of the load is ours and
+	// the rest is somebody else's. Nothing in this story turns on that split; it
+	// is set to a plausible figure rather than left at zero, which would be a
+	// machine busy with nothing.
+	cpuPressureUsageCores = 0.5
+
+	// cpuPressureMachineTick is how much machine time one tick of the ticker
+	// advances. Its ratio to the worker's one-second poll cadence is a
+	// correctness bound, not a matter of taste, and a tenth is what keeps this
+	// machine's capacity signal quiet.
+	//
+	// A tick that lands inside the sampler's read adds counters the stamp does
+	// not cover (see tickingBox), so that one reading overstates its rate by
+	// tick over poll. At a tenth, host busy reads 2.64 against a stated 2.4 and
+	// headroom bottoms out at 0.36, still clear of the mark at 0, and a
+	// 60-second mean damps even that. At a tick equal to the poll it reads
+	// 4.80, headroom is -1.80, and the machine is reported full.
+	//
+	// So a scenario parking a signal near its mark has to check this ratio
+	// against its own margin rather than inherit the number.
+	cpuPressureMachineTick = 100 * time.Millisecond
+
+	// cpuPressureHold is how long each condition is held before the story moves
+	// on. The verdict does not need it: pressure reduces by Last, so the first
+	// reading after a change already carries the new one. The page does. Two
+	// seconds is two of the worker's one-second readings, which is a short
+	// stretch at each condition rather than a single line, and a reader can see
+	// that the machine sat there rather than passed through.
+	cpuPressureHold = 2 * time.Second
+
+	// cpuPressureReadyPoll is how often the driver asks whether the worker has
+	// read the machine yet. It is well under the worker's own poll cadence, so
+	// the wait costs at most one worker poll rather than one of these.
+	cpuPressureReadyPoll = 50 * time.Millisecond
+)
+
+// CPUPressureScenarioV2 drives the real CPU monitor over a fake machine that is
+// busy but not full, and steps its PSI pressure across the mark at which the
+// pressure signal fires.
+//
+// The story is that a machine can be degraded with cores to spare, because
+// tasks are queueing rather than because capacity ran out. Sixty percent of
+// four cores leaves the capacity signal clear throughout; pressure alone moves,
+// from one point under its fire mark to over it.
+//
+// # CLI Usage
+//
+//	go run pkg/fsmv2/cmd/runner/main.go --scenario=cpu-pressure --duration=30s --log-level=debug
+//
+// Debug is what makes the answer visible. The CPU worker's MonitorSpec declares
+// no Health function, so its verdict never moves the worker's FSM state and
+// nothing about the verdict is logged at info. The collector's observed_changed
+// line, which is a debug line, is where the verdict flip shows up. Run it at
+// info and the page still carries the supervisor spawning its children between
+// the two machine conditions, but nothing about what the worker made of either.
+var CPUPressureScenarioV2 = ScenarioV2{
+	Name:        "cpu-pressure",
+	Description: "Steps a fake machine's CPU pressure over its fire mark while capacity stays clear (v2)",
+	Driver:      driveCPUPressure,
+}
+
+// driveCPUPressure publishes a fake machine, spawns the CPU monitor onto it
+// through the migration-API client, holds the calm condition, then raises the
+// pressure and holds again.
+//
+// It judges nothing. What the worker made of either condition is read back
+// after the run, from the store, by the spec beside this file.
+func driveCPUPressure(ctx context.Context, env Env) error {
+	calm := cpuPressureMachine(cpuPressureCalm)
+	machine := newTickingBox(cpuPressureBase, calm)
+
+	// Published before the Upsert below, because cpu.NewDeps reads both keys
+	// once, at the moment the supervisor spawns the worker; anything published
+	// after that spawn reaches nothing.
+	clearDeps := machine.Deps()
+	defer clearDeps()
+
+	machine.Start(cpuPressureMachineTick)
+	defer machine.Stop()
+
+	announceMachine(calm)
+
+	// Nil config: CPUConfig is an empty struct, and this is the same call the
+	// config worker makes in production.
+	if err := env.Client.Upsert(fsmv2cpu.Ref, nil); err != nil {
+		return fmt.Errorf("upsert cpu monitor: %w", err)
+	}
+
+	if err := awaitFirstCPUReading(ctx, env.Client); err != nil {
+		return fmt.Errorf("wait for the cpu monitor's first reading: %w", err)
+	}
+
+	if err := holdFor(ctx, cpuPressureHold); err != nil {
+		return err
+	}
+
+	firing := cpuPressureMachine(cpuPressureFiring)
+	machine.Set(firing)
+	announceMachine(firing)
+
+	return holdFor(ctx, cpuPressureHold)
+}
+
+// cpuPressureMachine is the machine this scenario runs on, at the given PSI
+// pressure. Everything except the pressure is the same in both conditions, so
+// the two calls differ by exactly the one number the story turns on.
+func cpuPressureMachine(pressure float64) fakebox.Condition {
+	return fakebox.Condition{
+		Cores:      cpuPressureCores,
+		HostBusy:   cpuPressureHostBusy,
+		UsageCores: cpuPressureUsageCores,
+		Pressure:   pressure,
+		PsiPresent: true,
+	}
+}
+
+// announceMachine prints the fake machine's condition, and is the only thing
+// this scenario prints. One line goes out each time the mock changes, the
+// opening condition included, and nothing else at all: every other line on the
+// page is the supervisor's own output, so a reader can tell a stimulus from a
+// response without being told which is which.
+//
+// Both lines carry the whole condition rather than only the field that moved,
+// so a reader sees for themselves that pressure is the only difference between
+// them, instead of taking a claim that it is.
+func announceMachine(c fakebox.Condition) {
+	fmt.Printf("fake machine: %d cores, host %.0f%% busy, this instance %g cores, pressure %.0f%%\n",
+		c.Cores, c.HostBusy*100, c.UsageCores, c.Pressure*100)
+}
+
+// awaitFirstCPUReading blocks until the CPU monitor has completed one reading
+// of the machine, or ctx is cancelled.
+//
+// This is a start-up gate, not a check on the answer: it waits for the worker
+// to exist and to have read something, and looks at no part of the verdict. A
+// blind sleep in its place would sometimes start the story before the worker
+// had spawned, and the calm condition would then be held for less time than it
+// looks.
+//
+// Verdict is empty on every tick that could not measure, so a machine the
+// worker cannot read at all never satisfies this and the driver waits out its
+// ctx. That is the honest outcome: there is no story to tell on a machine
+// nobody can read.
+func awaitFirstCPUReading(ctx context.Context, client *fsmv2client.FSMv2Client) error {
+	ticker := time.NewTicker(cpuPressureReadyPoll)
+	defer ticker.Stop()
+
+	for {
+		obs, err := fsmv2client.Get[fsmv2cpu.CPUStatus](ctx, client, fsmv2cpu.Ref)
+		switch {
+		case err == nil:
+			if obs.Status.Verdict != "" {
+				return nil
+			}
+		case errors.Is(err, fsmv2client.ErrNotObserved):
+			// The child has published nothing yet: retry on a later tick.
+		default:
+			return fmt.Errorf("get cpu observation: %w", err)
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+// holdFor waits d out, or returns early once ctx is cancelled. A cancelled ctx
+// is the only stop signal a driver gets and teardown cannot begin until the
+// driver returns, so every wait in here has to watch it.
+func holdFor(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+// tickingBox is a fakebox.Box that runs, and that can be read while it runs.
+//
+// A Box does neither on its own, and a worker under a supervisor needs both.
+// Its counters and its clock move only when someone calls Tick, so a Box handed
+// straight to such a worker serves a machine frozen at zero. And a Box is not
+// safe for concurrent use, while the collector reads it from its own goroutine.
+//
+// Publish FS and Clock together, which Deps does. Tick moves the counters and
+// the clock by the same amount, so once the sampler stamps from that clock, the
+// time it divides by and the counters it divides are the same quantity, and the
+// rate that comes out is the rate the condition states. Stamping from the wall
+// clock instead divides a tick's worth of counter by however long the two reads
+// happened to be apart, which at spawn can be under a millisecond: a hundredfold
+// overstatement that then sits in a 60-second mean for a minute.
+//
+// Everything that touches the Box's counters goes through the one mutex here:
+// the reads the collector makes, the ticks, and Set. The clock is not covered by
+// it and does not need to be, because clock.Mock synchronises itself. What that
+// leaves is an ordering gap rather than a race. The sampler stamps once at the
+// top of a read and then opens the files (read.go, ts := s.clock.Now()), so a
+// tick landing after the stamp adds counters the stamp does not account for, and
+// whichever source is read after that tick reports a rate too high by one tick's
+// worth. Only one tick can fit, so the overstatement is bounded; the wall-clock
+// version divided by a gap that could be arbitrarily short and was not.
+type tickingBox struct {
+	box  *fakebox.Box
+	stop chan struct{}
+	done chan struct{}
+	// base is the cgroup mount this box serves, so the read-driven mode below
+	// can recognise the file the sampler opens once per read.
+	base string
+	// perRead is how much machine time one sampler read advances the box, and
+	// zero when the box is driven by a wall-clock ticker instead. StartPerRead
+	// sets it and Stop clears it.
+	perRead time.Duration
+	// ticking records that a wall-clock ticker was started, so Stop knows
+	// whether there is a goroutine to join.
+	ticking bool
+	mu      sync.Mutex
+}
+
+// newTickingBox returns a box serving base in the condition initial describes.
+// It does not advance until Start is called.
+func newTickingBox(base string, initial fakebox.Condition) *tickingBox {
+	return &tickingBox{
+		box:  fakebox.NewBox(base, initial),
+		base: base,
+		stop: make(chan struct{}),
+		done: make(chan struct{}),
+	}
+}
+
+// Deps publishes this box's filesystem and clock for the next CPU worker the
+// supervisor spawns, and returns the function that takes both back out. Both
+// keys are process-global, so a driver that left either set would hand the next
+// scenario in this process its fake machine.
+//
+// Publishing the pair together is the point of this method, because one of the
+// halves fails silently on its own.
+//
+// A filesystem with no clock is that half. Nothing errors. The sampler stamps
+// from the wall clock while the counters accrue on this box's, so it divides a
+// tick's worth of counter by however long two reads happened to be apart, which
+// at spawn is on the order of a hundred microseconds. In this scenario that
+// reads as a machine thousands of percent busy, and the 60-second mean carries
+// it for a minute. It is also exactly what a scenario copied from a pre-clock
+// one does.
+//
+// A clock nothing advances is the loud half. Machine time stands still, the
+// sampler's elapsed is never positive, every rate is withheld, and a driver
+// waiting for the worker's first reading waits out its ctx instead.
+//
+// Publishing neither is production: the real filesystem and the real clock.
+func (t *tickingBox) Deps() (clear func()) {
+	register.SetDeps[filesystem.Service](fsmv2cpu.FilesystemDepsKey, t.fs())
+	register.SetDeps[clock.Clock](fsmv2cpu.ClockDepsKey, t.box.Clock())
+
+	return func() {
+		register.ClearDeps(fsmv2cpu.FilesystemDepsKey)
+		register.ClearDeps(fsmv2cpu.ClockDepsKey)
+	}
+}
+
+// fs returns a filesystem service serving this box, safe to read while the box
+// advances. It wraps the Box's own service rather than replacing it, so what a
+// reader gets back is whatever the Box would have served.
+func (t *tickingBox) fs() filesystem.Service {
+	inner := t.box.FS()
+
+	guarded := filesystem.NewMockFileSystem()
+	guarded.ReadFileFunc = func(ctx context.Context, path string) ([]byte, error) {
+		t.mu.Lock()
+		defer t.mu.Unlock()
+
+		// The read-driven advance. cpu.pressure is the file the sampler opens
+		// first and exactly once per read, before anything that can fail the
+		// read early, so seeing it is seeing a read begin. It ticks even when
+		// the condition makes that file unreadable, because the box serves the
+		// failure rather than skipping the open.
+		//
+		// The tick lands after the sampler has stamped the read and before any
+		// file is served, so the stamp trails the counters by one tick — the
+		// SAME one tick on every read, which is what makes the deltas exact:
+		// one tick of counters over one tick of clock is the rate the condition
+		// states, with none of the straddling cpuPressureMachineTick has to
+		// bound.
+		if t.perRead > 0 && path == t.base+"/cpu.pressure" {
+			t.box.Tick(t.perRead)
+		}
+
+		return inner.ReadFile(ctx, path)
+	}
+
+	return guarded
+}
+
+// MachineNow reads the box's own clock: the instant the sampler stamps its
+// samples from, and the one every window span and release rule downstream is
+// denominated in.
+//
+// A driver whose story is measured in machine time waits against this rather
+// than against the wall clock. How much machine time a wall second buys is not
+// fixed: it is however many ticks the ticker actually delivered, and a run
+// under debug logging delivers fewer of them than a run with a discarding
+// logger. A wall-clock hold therefore covers a different stretch of the story
+// on each, while a machine-time hold covers the same stretch on both and pays
+// the difference in wall seconds instead.
+//
+// clock.Mock synchronises itself, so this is safe to call while the box ticks.
+func (t *tickingBox) MachineNow() time.Time {
+	return t.box.Clock().Now()
+}
+
+// Set changes the condition later ticks accrue at, and takes effect on the next
+// read for anything the box states directly rather than accrues. PSI pressure
+// is one of those: the kernel reports it as a level, so a Box writes it rather
+// than accumulating it.
+func (t *tickingBox) Set(c fakebox.Condition) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.box.Set(c)
+}
+
+// Start advances the box by every, every, so machine time keeps pace with the
+// wall clock. Call it once.
+//
+// A ticker drops ticks under load rather than queueing them, and on the box's
+// own clock a drop withholds a tick's counters and a tick's clock together, so
+// no rate it reports is wrong. The wall-clock version had to argue that a drop
+// erred in the harmless direction; this one does not err at all.
+//
+// It does not lengthen the run either. Both the driver's holds and the worker's
+// polls are on the wall clock, so a drop does not buy back the time: it thins
+// the run, leaving less machine time inside each wall-clock second. The visible
+// effect is fewer sample-seconds per reading, not a longer story.
+//
+// Enough consecutive drops to span a whole poll is the case that is not merely
+// thinner. Machine time then does not advance between two reads at all, the
+// sampler's elapsed is zero, and that reading is withheld rather than served
+// low.
+func (t *tickingBox) Start(every time.Duration) {
+	t.startTicker(every, every)
+}
+
+// StartPerRead advances the box by advance once per sampler read, rather than
+// on a wall-clock ticker. Call it once, and not beside Start.
+//
+// A scenario reaches for this when it has to reach a RELEASE. A latch releases
+// only on a window whose Coverage is Full, and Coverage is the distance from
+// the oldest stored reading to the newest AFTER everything older than the span
+// has been pruned. Pruning keeps a reading landing exactly on the cutoff and
+// drops everything before it, so that distance reaches the span only when a
+// stored reading sits exactly one span before the newest. One read, one tick
+// puts every reading a whole tick from every other, so a span that is a whole
+// number of ticks is covered from the moment enough readings exist. Under a
+// wall-clock ticker the readings land wherever the two cadences happen to
+// cross, and Coverage is Full only by coincidence: measured at ten ticks to the
+// poll, on 17 readings out of 200, first at the 69th rather than the 61st.
+//
+// It is also exact rather than merely repeatable. Every reading covers one
+// tick of counters over one tick of clock, so the rate is the one the condition
+// states, with none of the straddling cpuPressureMachineTick has to bound.
+//
+// The price is that machine time now advances only while the worker is reading.
+// A driver waiting on this clock waits out its ctx if the worker stops polling,
+// and how much wall time a machine second costs is the collector's cadence
+// rather than a ticker's.
+func (t *tickingBox) StartPerRead(advance time.Duration) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.perRead = advance
+}
+
+// startTicker advances the box by advance, every interval of wall time.
+func (t *tickingBox) startTicker(interval, advance time.Duration) {
+	t.ticking = true
+
+	go func() {
+		defer close(t.done)
+
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-t.stop:
+				return
+			case <-ticker.C:
+				t.mu.Lock()
+				t.box.Tick(advance)
+				t.mu.Unlock()
+			}
+		}
+	}()
+}
+
+// Stop halts the advancing and waits for it to have halted, so no tick lands
+// after Stop returns. It ends both modes: it joins the ticker goroutine when
+// there is one, and it stops a read-driven box advancing, so the reads the
+// worker keeps making during the settle window no longer move machine time.
+//
+// A driver's defer fires this when the driver returns, which is BEFORE the
+// runner's settle window. Everything the worker reads during that window comes
+// from a stopped box — and a stopped box has stopped its clock too, so the
+// sampler's elapsed time is zero, every rate is withheld rather than recomputed,
+// and no window ages.
+//
+// This scenario would survive the freeze without any of that, because what
+// carries its verdict is PSI pressure, which the kernel reports as a level and
+// a Box writes rather than accrues. A frozen box keeps serving 25%.
+//
+// What the stopped clock protects is the scenario that copies this one and
+// hangs its verdict on a rate. Freeze the counters while the wall clock runs and
+// its rates do not merely fall: every one of them converges on a confident zero,
+// so the page ends on an idle machine with full headroom that nothing flags as
+// unmeasured. Stopping the clock turns that into no reading at all.
+func (t *tickingBox) Stop() {
+	t.mu.Lock()
+	t.perRead = 0
+	t.mu.Unlock()
+
+	if t.ticking {
+		close(t.stop)
+		<-t.done
+	}
+}

--- a/umh-core/pkg/fsmv2/examples/cpu_pressure_scenario_test.go
+++ b/umh-core/pkg/fsmv2/examples/cpu_pressure_scenario_test.go
@@ -1,0 +1,96 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package examples_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/config"
+	fsmv2cpu "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/cpu"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/examples"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/register"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/configworker"
+)
+
+var _ = Describe("CPU pressure ScenarioV2", func() {
+	// The configworker deps key is process-global; a run that fails midway
+	// would otherwise leak it into every later spec in this process.
+	BeforeEach(func() {
+		DeferCleanup(func() {
+			register.ClearDeps(configworker.WorkerTypeName)
+		})
+	})
+
+	It("registers cpu-pressure in the merged listing the CLI reads", func() {
+		Expect(examples.ListScenarios()).To(HaveKey("cpu-pressure"))
+	})
+
+	It("carries the degraded verdict into the store after the machine's pressure crosses its fire mark", func() {
+		scenario, ok := examples.RegistryV2["cpu-pressure"]
+		Expect(ok).To(BeTrue())
+
+		logger := deps.NewNopFSMLogger()
+		store := examples.SetupStore(logger)
+
+		// The ctx bounds the driver, which waits for the worker to read the
+		// machine before it holds either condition. On a machine the worker
+		// cannot read, that wait never finishes and this ctx is what ends the
+		// run, so the budget is well over the two holds the story needs.
+		ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+		defer cancel()
+
+		// Duration is the settle window after the driver returns, not the
+		// length of the run. One second is a poll's worth: enough for the
+		// store to hold a reading taken after the driver stopped, and short
+		// enough not to pad the suite.
+		result, err := examples.Run(ctx, examples.RunConfig{
+			ScenarioV2:   scenario,
+			Duration:     time.Second,
+			TickInterval: 100 * time.Millisecond,
+			Logger:       logger,
+			Store:        store,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Eventually(result.Done, "90s").Should(BeClosed())
+
+		// Read the worker's own observation back out of CSE, which is the far
+		// end of the path this scenario exists to exercise: a fake machine
+		// published into the deps registry, a supervisor-spawned worker, the
+		// real sampler, the real engine, the collector, and the store.
+		var observed fsmv2.Observation[fsmv2cpu.CPUStatus]
+		Expect(store.LoadObservedTyped(context.Background(),
+			fsmv2cpu.WorkerType, config.ChildID(fsmv2cpu.InstanceName), &observed)).To(Succeed())
+
+		Expect(observed.Status.Verdict).To(Equal("degraded"))
+
+		// The verdict alone would be satisfied by any degraded machine: a run
+		// whose capacity signal fired for its own reasons, or a real host that
+		// happened to be loaded if the driver's publish were removed. The
+		// percentage below is the pressure this driver stages and nothing else
+		// stages, so it names the machine the verdict came from.
+		//
+		// This is not a check on the message's wording, which the specs in
+		// pkg/cpuhealth pin. It is a check on which reading the verdict was
+		// computed from.
+		Expect(observed.Status.Message).To(ContainSubstring(
+			"spent 25% of the last minute waiting for a free CPU core"))
+	})
+})

--- a/umh-core/pkg/fsmv2/examples/cpu_pressure_scenario_test.go
+++ b/umh-core/pkg/fsmv2/examples/cpu_pressure_scenario_test.go
@@ -24,52 +24,27 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/config"
 	fsmv2cpu "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/cpu"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/examples"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/register"
-	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/configworker"
 )
 
 var _ = Describe("CPU pressure ScenarioV2", func() {
-	// The configworker deps key is process-global; a run that fails midway
-	// would otherwise leak it into every later spec in this process.
-	BeforeEach(func() {
-		DeferCleanup(func() {
-			register.ClearDeps(configworker.WorkerTypeName)
-		})
-	})
+	clearConfigWorkerDepsEachSpec()
 
 	It("registers cpu-pressure in the merged listing the CLI reads", func() {
 		Expect(examples.ListScenarios()).To(HaveKey("cpu-pressure"))
 	})
 
 	It("carries the degraded verdict into the store after the machine's pressure crosses its fire mark", func() {
-		scenario, ok := examples.RegistryV2["cpu-pressure"]
-		Expect(ok).To(BeTrue())
-
-		logger := deps.NewNopFSMLogger()
-		store := examples.SetupStore(logger)
-
-		// The ctx bounds the driver, which waits for the worker to read the
-		// machine before it holds either condition. On a machine the worker
-		// cannot read, that wait never finishes and this ctx is what ends the
-		// run, so the budget is well over the two holds the story needs.
-		ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
-		defer cancel()
-
-		// Duration is the settle window after the driver returns, not the
-		// length of the run. One second is a poll's worth: enough for the
-		// store to hold a reading taken after the driver stopped, and short
-		// enough not to pad the suite.
-		result, err := examples.Run(ctx, examples.RunConfig{
-			ScenarioV2:   scenario,
-			Duration:     time.Second,
-			TickInterval: 100 * time.Millisecond,
-			Logger:       logger,
-			Store:        store,
+		// This story needs two holds, and the ctx budget is well over what they
+		// cost. The settle window is a poll's worth: enough for the store to
+		// hold a reading taken after the driver stopped, and short enough not to
+		// pad the suite.
+		store := runCPUScenario(cpuScenarioRun{
+			Name:       "cpu-pressure",
+			CtxBudget:  90 * time.Second,
+			Settle:     time.Second,
+			DoneWithin: 90 * time.Second,
 		})
-		Expect(err).NotTo(HaveOccurred())
-		Eventually(result.Done, "90s").Should(BeClosed())
 
 		// Read the worker's own observation back out of CSE, which is the far
 		// end of the path this scenario exists to exercise: a fake machine

--- a/umh-core/pkg/fsmv2/examples/cpu_scenario_run_test.go
+++ b/umh-core/pkg/fsmv2/examples/cpu_scenario_run_test.go
@@ -1,0 +1,110 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The setup the CPU scenario specs beside this file share: register the
+// teardown their process-global deps key needs, run one v2 scenario to
+// completion, and hand back the store it wrote into. Every assertion stays in
+// the spec that makes it; only setup, run and teardown live here.
+
+package examples_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/cse/storage"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/examples"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/register"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/configworker"
+)
+
+// cpuTickInterval is how often the collector runs during these scenarios. The
+// CPU specs all use the same one: it sets the wall cost of a run and nothing
+// they assert on.
+const cpuTickInterval = 100 * time.Millisecond
+
+// clearConfigWorkerDepsEachSpec registers the teardown each CPU scenario needs.
+// Call it from the Describe body.
+//
+// The configworker deps key is process-global; a run that fails midway would
+// otherwise leak it into every later spec in this process.
+func clearConfigWorkerDepsEachSpec() {
+	BeforeEach(func() {
+		DeferCleanup(func() {
+			register.ClearDeps(configworker.WorkerTypeName)
+		})
+	})
+}
+
+// cpuScenarioRun is the time budget one CPU scenario spec runs under. Each spec
+// stages a different story, so every field below differs between specs and none
+// of them carries a default.
+type cpuScenarioRun struct {
+	// Name is the key the scenario registered under in examples.RegistryV2.
+	Name string
+
+	// CtxBudget bounds the driver. The driver waits for the worker's first
+	// reading of the machine before it holds any condition, and machine time
+	// advances one second per reading. On a machine the worker cannot read,
+	// machine time never advances, the holds never finish, and this budget is
+	// what ends the run. Each spec says what its own story costs on a machine
+	// that can be read.
+	CtxBudget time.Duration
+
+	// Settle is examples.RunConfig.Duration: the window after the driver
+	// returns, not the length of the run. It buys readings taken after the
+	// story ended rather than more of the story.
+	Settle time.Duration
+
+	// DoneWithin bounds the wait for the run to finish. A window shorter than
+	// CtxBudget would report a failure the ctx was about to end anyway.
+	DoneWithin time.Duration
+}
+
+// runCPUScenario runs one v2 CPU scenario to completion and returns the store it
+// wrote into.
+//
+// A caller reads either end of the run out of that store: LoadObservedTyped for
+// the observation the run settled on, cpuObservationHistory for the sequence of
+// readings it passed through.
+func runCPUScenario(run cpuScenarioRun) storage.TriangularStoreInterface {
+	GinkgoHelper()
+
+	scenario, ok := examples.RegistryV2[run.Name]
+	Expect(ok).To(BeTrue())
+
+	logger := deps.NewNopFSMLogger()
+	store := examples.SetupStore(logger)
+
+	// DeferCleanup rather than defer: the ctx has to outlive this function,
+	// because the caller reads the store after it returns.
+	ctx, cancel := context.WithTimeout(context.Background(), run.CtxBudget)
+	DeferCleanup(cancel)
+
+	result, err := examples.Run(ctx, examples.RunConfig{
+		ScenarioV2:   scenario,
+		Duration:     run.Settle,
+		TickInterval: cpuTickInterval,
+		Logger:       logger,
+		Store:        store,
+	})
+	Expect(err).NotTo(HaveOccurred())
+	Eventually(result.Done, run.DoneWithin).Should(BeClosed())
+
+	return store
+}

--- a/umh-core/pkg/fsmv2/examples/scenariov2.go
+++ b/umh-core/pkg/fsmv2/examples/scenariov2.go
@@ -75,6 +75,10 @@ var NoopScenarioV2 = ScenarioV2{
 // (enforced by the disjointness test in scenariov2_test.go, which documents
 // what breaks on a collision).
 var RegistryV2 = map[string]ScenarioV2{
-	"noop":    NoopScenarioV2,
-	"dynamic": DynamicScenarioV2,
+	"noop":         NoopScenarioV2,
+	"dynamic":      DynamicScenarioV2,
+	"cpu-pressure": CPUPressureScenarioV2,
+	"cpu-filling":  CPUFillingScenarioV2,
+	"cpu-latch":    CPULatchScenarioV2,
+	"cpu-blind":    CPUBlindScenarioV2,
 }

--- a/umh-core/pkg/fsmv2/examples/scenariov2.go
+++ b/umh-core/pkg/fsmv2/examples/scenariov2.go
@@ -81,4 +81,5 @@ var RegistryV2 = map[string]ScenarioV2{
 	"cpu-filling":  CPUFillingScenarioV2,
 	"cpu-latch":    CPULatchScenarioV2,
 	"cpu-blind":    CPUBlindScenarioV2,
+	"cpu-host":     CPUHostScenarioV2,
 }

--- a/umh-core/tools/cpu-host/README.md
+++ b/umh-core/tools/cpu-host/README.md
@@ -38,7 +38,7 @@ limiting memory changes nothing it can see.
 ./run.sh                 # no quota, 60 seconds
 CPUS=0.5 ./run.sh        # half a CPU of quota
 DURATION=10m ./run.sh    # watch longer
-LOG_LEVEL=info ./run.sh  # quieter; readings appear at debug
+LOG_LEVEL=info ./run.sh  # quieter; per-poll readings need debug
 ```
 
 Any argument is passed to `docker run` verbatim, so docker's own options
@@ -47,9 +47,14 @@ the container addressable for the load experiment below.
 
 ## What to watch
 
-The monitor's readings appear in the log as `observed_changed` lines, each
-carrying a verdict and a message. Two kinds of load move different signals,
-and telling them apart is the point of the exercise:
+The monitor runs as one worker inside the scenario runner, and its readings
+show up in that runner's log. On every completed poll the `cpu_reading` debug
+line carries the verdict and the composed message; a failed poll never
+reaches it. When the worker's state changes, the message also appears at info
+in the `state_transition` line's `reason` field.
+
+Two kinds of load move different signals, and telling them apart is the point
+of the exercise:
 
 - **Load inside the container** competes for the container's quota and
   moves the throttling signal (`nr_throttled`) and cgroup pressure (PSI).

--- a/umh-core/tools/cpu-host/README.md
+++ b/umh-core/tools/cpu-host/README.md
@@ -1,0 +1,69 @@
+# cpu-host
+
+Runs umh-core's CPU health monitor against a real Linux machine and prints
+its readings, so you can watch how it judges a machine under load. The other
+CPU example scenarios run the monitor against a fake machine whose numbers
+are chosen to trip a specific signal. This one stages nothing: the monitor
+reads whatever CPU accounting files the machine actually publishes, and its
+verdicts follow from those numbers alone.
+
+## Why a container
+
+The monitor reads the cgroup v2 file `/sys/fs/cgroup/cpu.stat` and the host
+file `/proc/stat`. Linux publishes both; macOS and Windows publish neither.
+Run the scenario directly on such a machine and it stops immediately with
+this error, because no reading can ever land there:
+
+```
+this host publishes no cgroup v2 CPU files, so no reading can land: stat
+/sys/fs/cgroup/cpu.stat: no such file or directory; run it under
+tools/cpu-host, which puts it in a Linux container
+```
+
+A container provides the files, and with a CPU quota it provides one more
+thing a bare Linux host usually lacks: a real limit, so the throttling
+signal has something to observe. The monitor reads only CPU files, so
+limiting memory changes nothing it can see.
+
+## Prerequisites
+
+- Docker
+- A Go toolchain
+- This repository checked out — the script builds the scenario runner from
+  `pkg/fsmv2/cmd/runner`
+
+## Running
+
+```bash
+./run.sh                 # no quota, 60 seconds
+CPUS=0.5 ./run.sh        # half a CPU of quota
+DURATION=10m ./run.sh    # watch longer
+LOG_LEVEL=info ./run.sh  # quieter; readings appear at debug
+```
+
+Any argument is passed to `docker run` verbatim, so docker's own options
+work without the script naming them. `--name` is the useful one: it makes
+the container addressable for the load experiment below.
+
+## What to watch
+
+The monitor's readings appear in the log as `observed_changed` lines, each
+carrying a verdict and a message. Two kinds of load move different signals,
+and telling them apart is the point of the exercise:
+
+- **Load inside the container** competes for the container's quota and
+  moves the throttling signal (`nr_throttled`) and cgroup pressure (PSI).
+  Run with a quota and a name, then spin from a second terminal:
+
+  ```bash
+  CPUS=0.5 ./run.sh --name cpu-host
+  docker exec cpu-host sh -c 'while :; do :; done'
+  ```
+
+- **Load on the host** competes for the machine's own CPUs and moves
+  host-busy and steal as read from `/proc/stat`, leaving throttling
+  untouched. Run the scenario without `CPUS` for this world: an unquota'd
+  machine can only be filled by its host.
+
+Stop the in-container load with `Ctrl+C` in the second terminal or
+`docker kill cpu-host`.

--- a/umh-core/tools/cpu-host/README.md
+++ b/umh-core/tools/cpu-host/README.md
@@ -36,7 +36,7 @@ limiting memory changes nothing it can see.
 
 ```bash
 ./run.sh                 # no quota, runs until Ctrl+C
-CPUS=0.5 ./run.sh        # half a CPU of quota
+CPUS=2 ./run.sh          # two CPUs of quota
 DURATION=60s ./run.sh    # stop on its own instead
 LOG_LEVEL=info ./run.sh  # only state changes, not every poll
 ```
@@ -82,16 +82,28 @@ of the exercise:
   own:
 
   ```bash
-  CPUS=0.5 ./run.sh --name cpu-host
-  docker exec cpu-host stress-ng --cpu 8 --timeout 60
+  CPUS=2 ./run.sh --name cpu-host
+  docker exec cpu-host stress-ng --cpu 8 --timeout 10
   ```
 
-  Eight workers against half a CPU is a large deliberate overcommit: the
-  container wants sixteen times the CPU it may have, so `nr_throttled` climbs
-  immediately rather than after a wait. `--timeout 60` stops the load on its
-  own, so the readings show the recovery as well as the onset — worth having,
-  since the pressure signal holds its verdict until the clear mark and the
-  release is the half that is easy to miss.
+  Eight workers against two CPUs is a deliberate 4x overcommit, so
+  `nr_throttled` climbs at once rather than after a wait. Ten seconds of load is
+  enough: the throttling ratio is a delta over a 60-second window, so a short
+  burst fires it, and stopping early leaves you watching the half that is easy to
+  miss.
+
+  ⚠️ **The verdict will not go back to healthy, and that is a defect rather than
+  something you are doing wrong.** Throttling decays to 0% about a minute after
+  the load stops, which is the 60-second window draining and is correct. The
+  verdict then stays `degraded` anyway: a latched signal's release is gated on a
+  window-coverage check that a jittered clock never satisfies, so nothing clears
+  it short of a restart. Measured 2026-08-27; the fix is not in this branch.
+
+  Until that lands, read `Throttling 0%` beside a `degraded` verdict as the known
+  bug, not as evidence about your machine.
+
+  Do not use `CPUS=0.5`. It is under umh-core's own minimum, so the reserves the
+  monitor subtracts leave numbers that describe no machine we support.
 
 - **Load on the host** competes for the machine's own CPUs and moves
   host-busy and steal as read from `/proc/stat`, leaving throttling

--- a/umh-core/tools/cpu-host/README.md
+++ b/umh-core/tools/cpu-host/README.md
@@ -35,11 +35,30 @@ limiting memory changes nothing it can see.
 ## Running
 
 ```bash
-./run.sh                 # no quota, 60 seconds
+./run.sh                 # no quota, runs until Ctrl+C
 CPUS=0.5 ./run.sh        # half a CPU of quota
-DURATION=10m ./run.sh    # watch longer
-LOG_LEVEL=info ./run.sh  # quieter; per-poll readings need debug
+DURATION=60s ./run.sh    # stop on its own instead
+LOG_LEVEL=info ./run.sh  # only state changes, not every poll
 ```
+
+It runs until you stop it, so you can load the machine and watch the readings
+answer while it keeps going.
+
+The runner's log carries the supervisor's own lines as well as the monitor's.
+To watch just the readings:
+
+```bash
+./run.sh --name cpu-host | grep --line-buffered cpu_reading
+```
+
+`--line-buffered` is not optional on an endless run. Without it grep holds
+output in a block buffer and prints nothing until the buffer fills, so a
+working run looks like a dead one.
+
+⚠️ Keep the pipe out of a first run. A machine that never takes a reading has
+nothing matching `cpu_reading` to print, so the filter turns a startup error
+into silence, and an empty result cannot tell you which of the two happened.
+Run it bare once, confirm readings appear, then add the pipe.
 
 Any argument is passed to `docker run` verbatim, so docker's own options
 work without the script naming them. `--name` is the useful one: it makes
@@ -58,18 +77,29 @@ of the exercise:
 
 - **Load inside the container** competes for the container's quota and
   moves the throttling signal (`nr_throttled`) and cgroup pressure (PSI).
-  Run with a quota and a name, then spin from a second terminal:
+  Run with a quota and a name, then load it from a second terminal. The
+  container has `stress-ng` installed, so that terminal needs nothing of its
+  own:
 
   ```bash
   CPUS=0.5 ./run.sh --name cpu-host
-  docker exec cpu-host sh -c 'while :; do :; done'
+  docker exec cpu-host stress-ng --cpu 8 --timeout 60
   ```
+
+  Eight workers against half a CPU is a large deliberate overcommit: the
+  container wants sixteen times the CPU it may have, so `nr_throttled` climbs
+  immediately rather than after a wait. `--timeout 60` stops the load on its
+  own, so the readings show the recovery as well as the onset — worth having,
+  since the pressure signal holds its verdict until the clear mark and the
+  release is the half that is easy to miss.
 
 - **Load on the host** competes for the machine's own CPUs and moves
   host-busy and steal as read from `/proc/stat`, leaving throttling
   untouched. Run the scenario without `CPUS` for this world: an unquota'd
   machine can only be filled by its host.
 
-Stop the in-container load with `docker kill cpu-host`. `Ctrl+C` in the
-second terminal does not do it: the interrupt stops only the `docker exec`
-client, and the load keeps running inside the container.
+A `--timeout` ends the load by itself. Without one, stop it with
+`docker kill cpu-host`: `Ctrl+C` in the second terminal stops only the
+`docker exec` client, and the load keeps running inside the container.
+
+Stop the monitor itself with `Ctrl+C` in the first terminal.

--- a/umh-core/tools/cpu-host/README.md
+++ b/umh-core/tools/cpu-host/README.md
@@ -29,7 +29,7 @@ limiting memory changes nothing it can see.
 
 - Docker
 - A Go toolchain
-- This repository checked out — the script builds the scenario runner from
+- This repository checked out. The script builds the scenario runner from
   `pkg/fsmv2/cmd/runner`
 
 ## Running
@@ -65,5 +65,6 @@ and telling them apart is the point of the exercise:
   untouched. Run the scenario without `CPUS` for this world: an unquota'd
   machine can only be filled by its host.
 
-Stop the in-container load with `Ctrl+C` in the second terminal or
-`docker kill cpu-host`.
+Stop the in-container load with `docker kill cpu-host`. `Ctrl+C` in the
+second terminal does not do it: the interrupt stops only the `docker exec`
+client, and the load keeps running inside the container.

--- a/umh-core/tools/cpu-host/run.sh
+++ b/umh-core/tools/cpu-host/run.sh
@@ -20,7 +20,9 @@
 # stock Alpine image with no toolchain and no repository mounted.
 #
 # Environment variables:
-#   CPUS       CPU quota for the container, e.g. CPUS=0.5. Unset means no
+#   CPUS       CPU quota for the container, e.g. CPUS=2. Below umh-core's
+#              own minimum the reserves leave numbers describing no machine
+#              we support, so prefer 2 over 0.5. Unset means no
 #              quota, which is the other world worth watching: no throttling
 #              signal, only host load.
 #   DURATION   How long the monitor runs after its first reading. Default 0,

--- a/umh-core/tools/cpu-host/run.sh
+++ b/umh-core/tools/cpu-host/run.sh
@@ -23,8 +23,9 @@
 #   CPUS       CPU quota for the container, e.g. CPUS=0.5. Unset means no
 #              quota, which is the other world worth watching: no throttling
 #              signal, only host load.
-#   DURATION   How long the monitor runs after its first reading
-#              (default 60s).
+#   DURATION   How long the monitor runs after its first reading. Default 0,
+#              which runs until Ctrl+C, so you can put load on the container
+#              and watch the readings answer it for as long as you like.
 #   LOG_LEVEL  Runner log level (default debug, which carries every completed
 #              poll on the cpu_reading line; info carries the verdict and its
 #              message whenever the worker's state changes).
@@ -32,6 +33,11 @@
 # Any argument is passed to docker run verbatim, so docker's own options
 # work without this script naming them (e.g. --name, to make the container
 # easy to exec into while it runs).
+#
+# The container gets stress-ng, so you can load it from a second terminal
+# without installing anything there:
+#
+#     docker exec cpu-host stress-ng --cpu 8 --timeout 60
 
 set -euo pipefail
 
@@ -54,7 +60,15 @@ fi
 docker_args+=("$@")
 docker_args+=(
   alpine:latest
-  /runner -scenario cpu-host -duration "${DURATION:-60s}" -log-level "${LOG_LEVEL:-debug}"
+  # stress-ng comes from Alpine's community repository, which the official
+  # image already has enabled. Installing it here rather than in a Dockerfile
+  # keeps this a stock image with one mounted binary. If the install fails —
+  # no network, most likely — say so and still run the monitor: only the
+  # in-container load experiment needs stress-ng.
+  sh -c 'apk add --no-cache stress-ng >/dev/null 2>&1 ||
+           echo "cpu-host: stress-ng install failed; the monitor still runs, docker exec stress-ng will not"
+         exec /runner -scenario cpu-host -duration "$1" -log-level "$2"' \
+    cpu-host "${DURATION:-0}" "${LOG_LEVEL:-debug}"
 )
 
 docker run "${docker_args[@]}"

--- a/umh-core/tools/cpu-host/run.sh
+++ b/umh-core/tools/cpu-host/run.sh
@@ -25,8 +25,9 @@
 #              signal, only host load.
 #   DURATION   How long the monitor runs after its first reading
 #              (default 60s).
-#   LOG_LEVEL  Runner log level (default debug, the level the monitor's
-#              readings appear at; info shows only supervisor activity).
+#   LOG_LEVEL  Runner log level (default debug, which carries every completed
+#              poll on the cpu_reading line; info carries the verdict and its
+#              message whenever the worker's state changes).
 #
 # Any argument is passed to docker run verbatim, so docker's own options
 # work without this script naming them (e.g. --name, to make the container

--- a/umh-core/tools/cpu-host/run.sh
+++ b/umh-core/tools/cpu-host/run.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+# Copyright 2025 UMH Systems GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Runs the cpu-host scenario in a Linux container, because the CPU monitor
+# reads cgroup v2 files that macOS and Windows machines do not publish.
+# Builds the scenario runner for Linux on this machine, then runs it in a
+# stock Alpine image with no toolchain and no repository mounted.
+#
+# Environment variables:
+#   CPUS       CPU quota for the container, e.g. CPUS=0.5. Unset means no
+#              quota, which is the other world worth watching: no throttling
+#              signal, only host load.
+#   DURATION   How long the monitor runs after its first reading
+#              (default 60s).
+#   LOG_LEVEL  Runner log level (default debug, the level the monitor's
+#              readings appear at; info shows only supervisor activity).
+#
+# Any argument is passed to docker run verbatim, so docker's own options
+# work without this script naming them (e.g. --name, to make the container
+# easy to exec into while it runs).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# Build outside the repository: go build on a main package writes its
+# output into the working directory otherwise, which would drop a binary
+# into the checkout.
+BIN="$(mktemp /tmp/cpu-host-runner.XXXXXX)"
+trap 'rm -f "$BIN"' EXIT
+
+cd "$ROOT"
+CGO_ENABLED=0 GOOS=linux GOARCH="$(go env GOARCH)" go build -o "$BIN" ./pkg/fsmv2/cmd/runner
+
+docker_args=(--rm -v "$BIN":/runner:ro)
+if [ -n "${CPUS:-}" ]; then
+  docker_args+=(--cpus="$CPUS")
+fi
+docker_args+=("$@")
+docker_args+=(
+  alpine:latest
+  /runner -scenario cpu-host -duration "${DURATION:-60s}" -log-level "${LOG_LEVEL:-debug}"
+)
+
+docker run "${docker_args[@]}"


### PR DESCRIPTION
## Problem

The CPU monitor decides whether a machine is healthy or degraded. The cases are very complex, and fsmv2 feels abstract — a developer has no way to gain confidence that for these machines, with these CPUs, these results come out.

But even a readable case list is still abstract. A developer needs to run it on their own machine, play around with it, and understand that it really works in practice.

## Shipping

1. **Four scenario CLI runner tests using a mocked filesystem, "fakebox".** `cpu-pressure`, `cpu-filling`, `cpu-latch` and `cpu-blind` each stage a machine's CPU accounting files and run the real monitor against them.

2. **A scenario that runs against your own machine**, `cpu-host`, including `tools/cpu-host/run.sh` — a tool that sets it up to run inside a Docker container so it can actually read cgroup v2 metrics.

## NOT shipping

- **No production behaviour change.** The monitor's judgement, thresholds and messages are untouched. The only change outside test and tool files is one debug log line in `Poll`.
- **The host scenario does not run in CI.** Its result depends on the machine it runs on, and nobody picks the CI machine, so it carries `Label("live")` and the unit-test target filters it out. It runs for a developer on their own machine.
- **No Makefile target and no CI wiring for `tools/`.** Deliberate — a host-dependent tool has no business in a pipeline.
