### PR TITLE
fix(cpuhealth): read every CPU threshold from the rule that owns it

### DIFF
--- a/umh-core/pkg/cpuhealth/capacity_cofire_test.go
+++ b/umh-core/pkg/cpuhealth/capacity_cofire_test.go
@@ -113,12 +113,24 @@ var _ = Describe("two capacity causes on one tick", func() {
 			// One blended sentence, not two paragraphs. Telling a customer to add
 			// CPU to a full machine and also to raise their own limit gives them a
 			// remedy that cannot work.
+			//
+			// The table below it reports the limit's own headroom, because a
+			// limit applies here, and names the mark that CLEARS it: the rule has
+			// fired, so the number deciding what happens next is the clear mark.
+			// 0.1 is 0.05 x the 2.0-core quota, read from the same pair the
+			// engine judged the tick against.
 			Expect(ComposeMessage(verdict, details)).To(Equal(
 				"CPU running near full"+
-					"\nTechnical Details: "+
+					"\n"+
 					"The machine is full and this instance's CPU limit cannot help. "+
 					"Add CPU to the machine, or reduce other software running on it. "+
-					"(This instance is also at its 2-core limit.)"),
+					"(This instance is also at its 2-core limit.)"+
+					"\nTechnical Details:\n"+
+					"Headroom -0.2 cores = 2 total - 2.0 used - 0.2 reserved (recovers above 0.1).\n"+
+					"Usage not available (not possible).\n"+
+					"Throttling not available (measuring).\n"+
+					"Pressure not available (not possible).\n"+
+					"Steal not available (not possible)."),
 				"limit row first: %v", limitFirst)
 			Expect(BlockReason(verdict.Causes, details)).To(Equal(
 				"Can't add another bridge: the machine is full. Add CPU to the machine, or reduce other software running on it, first."),

--- a/umh-core/pkg/cpuhealth/capacity_cofire_test.go
+++ b/umh-core/pkg/cpuhealth/capacity_cofire_test.go
@@ -114,11 +114,12 @@ var _ = Describe("two capacity causes on one tick", func() {
 			// CPU to a full machine and also to raise their own limit gives them a
 			// remedy that cannot work.
 			//
-			// The table below it reports the limit's own headroom, because a
-			// limit applies here, and names the mark that CLEARS it: the rule has
-			// fired, so the number deciding what happens next is the clear mark.
-			// 0.1 is 0.05 x the 2.0-core quota, read from the same pair the
-			// engine judged the tick against.
+			// The table below it reports both ceilings, because both signals are
+			// declared on this box and both fired. Each names the mark that
+			// CLEARS it: the rule has fired, so the number deciding what happens
+			// next is the clear mark. 0.5 is the machine's fixed clear mark and
+			// 0.1 is 0.05 x the 2.0-core quota, each read from the pair the
+			// engine judged that arm against.
 			Expect(ComposeMessage(verdict, details)).To(Equal(
 				"CPU running near full"+
 					"\n"+
@@ -126,7 +127,8 @@ var _ = Describe("two capacity causes on one tick", func() {
 					"Add CPU to the machine, or reduce other software running on it. "+
 					"(This instance is also at its 2-core limit.)"+
 					"\nTechnical Details:\n"+
-					"Headroom -0.2 cores = 2 total - 2.0 used - 0.2 reserved (recovers above 0.1).\n"+
+					"Machine headroom -0.8 cores = 4 total - 3.8 used - 1.0 reserved (recovers above 0.5).\n"+
+					"Instance headroom -0.2 cores = 2 total - 2.0 used - 0.2 reserved (recovers above 0.1).\n"+
 					"Usage not available (not possible).\n"+
 					"Throttling not available (measuring).\n"+
 					"Pressure not available (not possible).\n"+

--- a/umh-core/pkg/cpuhealth/message.go
+++ b/umh-core/pkg/cpuhealth/message.go
@@ -15,15 +15,22 @@
 // The customer-facing text: every sentence this package can print, and the
 // rules that pick which one.
 //
-// Every customer-visible string in this file is written down exactly once —
-// the constants below, plus the host-headroom sentence composeHealthy formats
-// inline, and one deliberate duplicate the const block names. A second copy of
-// a sentence is where drift starts.
+// Every customer-visible string in this file is written down exactly once. The
+// const block below holds the whole sentences; the Technical Details lines are
+// assembled from formats at the sites that build them, and the const block
+// names the one deliberate duplicate. A second copy of a sentence is where
+// drift starts.
 //
-// No threshold is written down here at all. Every number the Technical Details
+// No signal threshold is written down here. Every number the Technical Details
 // table states is read from the mark pair its own signal_*.go declares, which
 // is the pair the engine judges against, so the rule the message states and the
-// rule the code applies cannot come apart.
+// rule the code applies cannot come apart. That is why each pair is one var:
+// the signal_*.go files declare them and say no more about it.
+//
+// The one number this file decides for itself is the 0.05 cores at which the
+// healthy headline starts saying a box is close to being marked degraded. It is
+// a display band, not a rule the engine judges, and it is written relative to
+// hostHeadroomMarks.Fire without reading it.
 
 package cpuhealth
 
@@ -81,10 +88,10 @@ func composeHealthy(details Details) string {
 	// is withheld the message has no headline sentence left, so render the
 	// single "CPU: starting up." line over the table, where a line whose own
 	// window has not reduced yet says so rather than stating a figure nothing
-	// measured. It lasts two ticks after each start and
-	// respawn: the sampler derives no rate from its first read, and the mean
-	// over the rates after that needs two of them. It is not the zero-capacity
-	// case (a standing state) - they share a rendering path and nothing else.
+	// measured. It lasts two ticks after each start and respawn: the sampler
+	// derives no rate from its first read, and the mean over the rates after
+	// that needs two of them. It is not the zero-capacity case (a standing
+	// state): that one returns bare, this one carries the table.
 	if !usageMeasured(details) {
 		return cpuStartingUp + technicalDetails(nil, details)
 	}
@@ -133,8 +140,8 @@ func composeHealthy(details Details) string {
 			fmtCoresTotal(details.LogicalCpus), fmtCoresTotal(details.HostCpus))
 	}
 
-	// A healthy tick has no fired cause, so every rule shows the mark that
-	// would fire it.
+	// nil causes: a healthy tick has fired none, so no line states a clear
+	// mark.
 	return msg + technicalDetails(nil, details)
 }
 
@@ -262,9 +269,6 @@ type cpuRule struct {
 // contradiction: a rule still latched while its reading has fallen back under
 // its own fire mark would otherwise be shown a threshold it is already inside.
 func (r cpuRule) render() string {
-	// A fired instrument is proof the rule ran on this box, whatever the
-	// capability flag says, so a fired rule is never reported as one the box
-	// cannot run.
 	switch {
 	case !r.applies && !r.firedHere:
 		return r.label + " not available (not possible)."
@@ -313,8 +317,8 @@ func markValue(m diagnosis.Mark, unit string) string {
 }
 
 // technicalDetails renders the labelled table: the label on its own line, then
-// one line per rule the engine is judging, in a fixed order. causes is this
-// tick's fired list, and is empty on a healthy tick.
+// one line per rule in cpuRules' fixed order, whether or not this box can run
+// the rule. causes is this tick's fired list, and is empty on a healthy tick.
 //
 // A failed cgroup read (CapacityCores == 0) gets no table at all. On that tick
 // we do not know which rules apply, so a table would assert knowledge we do not
@@ -768,9 +772,10 @@ func toPercent(fraction float64) int {
 }
 
 const (
-	// The one line rendered on a tick whose usage figure is withheld (window
-	// below its floor, or the host reading absent): no headline, no advisory,
-	// no technical details.
+	// The line rendered on a tick whose usage figure is withheld (window below
+	// its floor, or the host reading absent): no headline and no advisory. The
+	// Technical Details table follows it, so an operator still sees which rules
+	// will be judged and which windows are still filling.
 	//
 	// Not cpuMonitoringUnavailable ("cgroup read failed"): on this tick the
 	// read succeeded and there is simply one sample, so claiming a read failure

--- a/umh-core/pkg/cpuhealth/message.go
+++ b/umh-core/pkg/cpuhealth/message.go
@@ -19,6 +19,11 @@
 // the constants below, plus the host-headroom sentence composeHealthy formats
 // inline, and one deliberate duplicate the const block names. A second copy of
 // a sentence is where drift starts.
+//
+// No threshold is written down here at all. Every number the Technical Details
+// table states is read from the mark pair its own signal_*.go declares, which
+// is the pair the engine judges against, so the rule the message states and the
+// rule the code applies cannot come apart.
 
 package cpuhealth
 
@@ -27,13 +32,15 @@ import (
 	"math"
 	"strconv"
 	"strings"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/diagnosis"
 )
 
-// ComposeMessage turns a Verdict and its derived Details into the two-layer
-// message: a one-line headline naming the dominant cause, then the literal
-// Technical Details separator and the curated per-cause copy (dominant first,
-// joined by a blank line). A healthy verdict yields the budget dashboard from
-// composeHealthy.
+// ComposeMessage turns a Verdict and its derived Details into the message an
+// operator reads: a one-line headline naming the dominant cause, then the
+// curated per-cause copy (dominant first, joined by a blank line), then the
+// Technical Details table. A healthy verdict yields the budget headline from
+// composeHealthy, followed by the same table.
 //
 // One paragraph per cause, except that the two capacity causes share one:
 // speaksForCapacity says which of the pair writes it.
@@ -53,72 +60,49 @@ func ComposeMessage(verdict Verdict, details Details) string {
 	}
 	body := strings.Join(parts, "\n\n")
 
-	return headline + technicalDetails + body
+	return headline + "\n" + body + technicalDetails(verdict.Causes, details)
 }
 
-// composeHealthy renders the two-layer healthy budget message. The displayed
-// components are rounded first, then headroom is derived as
-// total - used - reserve on those ALREADY-ROUNDED values, so the printed
-// arithmetic in the Technical Details headroom line is exact by construction
-// (never independently rounds Details.HeadroomCores). used/headroom/reserve
-// print with one decimal; total prints as an integer when whole. The
-// Technical Details dashboard lists only the budgets it measured: headroom
-// always, then throttle/pressure/steal each only when this tick's reading of it
-// is usable.
+// composeHealthy renders the healthy message: the budget headline, any
+// advisory the tick earned, then the Technical Details table. The displayed
+// cores figures come from coresBudget, so the printed headroom arithmetic is
+// exact by construction.
 func composeHealthy(details Details) string {
 	// Zero-capacity guard: when CapacityCores is 0, do not compose the garbled
 	// "0.0 of 0 cores, -1.0 headroom" budget dashboard. Return a safe string
 	// that conveys monitoring-unavailability; the State on the wire stays
-	// healthy per the binary contract. It is an early return, not a prefix.
+	// healthy per the binary contract. It is an early return, not a prefix, and
+	// technicalDetails withholds the table on the same condition.
 	if details.CapacityCores == 0 {
 		return cpuMonitoringUnavailable
 	}
 
-	// The healthy message reports only what it measured. Two measurement floors
-	// (one per mode) and one readability gate; when any withholds the usage
-	// figure the message has no headline sentence left, so render the single
-	// "CPU: starting up." line alone. It lasts two ticks after each start and
+	// The healthy message reports only what it measured. When the usage figure
+	// is withheld the message has no headline sentence left, so render the
+	// single "CPU: starting up." line over the table, whose every line then
+	// says which kind of absence it is. It lasts two ticks after each start and
 	// respawn: the sampler derives no rate from its first read, and the mean
 	// over the rates after that needs two of them. It is not the zero-capacity
-	// case (a standing state) — they share a rendering path and nothing else.
-	if details.LimitApplies {
-		if !details.UsageRingActive {
-			return cpuStartingUp
-		}
-	} else {
-		if !details.HostBusyRingActive || !details.HostBusyCoresAvailable {
-			return cpuStartingUp
-		}
+	// case (a standing state) - they share a rendering path and nothing else.
+	if !usageMeasured(details) {
+		return cpuStartingUp + technicalDetails(nil, details)
 	}
 
-	// The display figures. ReserveCores is read from Details in both modes —
-	// buildDetails filled it from the verdict's own reserve, never from the
-	// constant.
-	var usedDisp, reserveDisp float64
-	if details.LimitApplies {
-		usedDisp = round1(details.AvgUsageCores)
-	} else {
-		usedDisp = round1(details.AvgHostBusyCores)
-	}
-	reserveDisp = round1(details.ReserveCores)
-	totalDisp := round1(details.CapacityCores)
-	headroomDisp := round1(totalDisp - usedDisp - reserveDisp) // clears float residue, not an independent rounding
+	b := coresBudget(details)
+	usedStr := fmtCores1(b.used)
+	totalStr := fmtCoresTotal(b.total)
+	headroomStr := fmtCores1(b.headroom)
 
-	usedStr := fmtCores1(usedDisp)
-	totalStr := fmtCoresTotal(totalDisp)
-	headroomStr := fmtCores1(headroomDisp)
-	reserveStr := fmtCores1(reserveDisp)
-
-	// A sub-0.05-core quota collapses to totalDisp == 0: suppress the
+	// A sub-0.05-core quota collapses to a displayed total of 0: suppress the
 	// percentage (a division by a displayed zero) and use the no-percentage
 	// variant. The subject follows the MODE, not the column: a tiny quota is
 	// still limit mode, so it reads "This instance".
-	totalTooSmallToPct := totalDisp <= 0
+	totalTooSmallToPct := b.total <= 0
 
 	var headline string
 	if details.LimitApplies && !totalTooSmallToPct {
-		pctOfLimit := toPercent(usedDisp / totalDisp)
-		if headroomDisp < 0.05 {
+		pctOfLimit := toPercent(b.used / b.total)
+		if b.headroom < 0.05 {
 			headline = fmt.Sprintf(headlineLimitClose, usedStr, totalStr, pctOfLimit)
 		} else {
 			headline = fmt.Sprintf(headlineLimitMore, usedStr, totalStr, pctOfLimit, headroomStr)
@@ -128,7 +112,7 @@ func composeHealthy(details Details) string {
 		if details.LimitApplies {
 			subject = subjectThisInstance
 		}
-		if headroomDisp < 0.05 {
+		if b.headroom < 0.05 {
 			headline = fmt.Sprintf(headlineClose, subject, usedStr, totalStr)
 		} else {
 			headline = fmt.Sprintf(headlineMore, subject, usedStr, totalStr, headroomStr)
@@ -148,25 +132,268 @@ func composeHealthy(details Details) string {
 			fmtCoresTotal(details.LogicalCpus), fmtCoresTotal(details.HostCpus))
 	}
 
-	// The budget body. Headroom is unconditional; each of throttle, pressure
-	// and steal prints only when THIS TICK'S reading is usable. The gates
-	// are the per-signal readiness trio, never the capability flags — a
-	// LimitApplies/PressureApplies/StealApplies build prints a confident 0% for a
-	// reading that never happened.
-	budget := []string{
-		fmt.Sprintf(headroomLine, headroomStr, totalStr, usedStr, reserveStr),
-	}
-	if details.ThrottleSignalReady {
-		budget = append(budget, fmt.Sprintf(throttleLine, toPercent(details.ThrottleRatio)))
-	}
-	if details.PressureSignalReady {
-		budget = append(budget, fmt.Sprintf(pressureLine, toPercent(details.PressureAvg60)))
-	}
-	if details.StealSignalReady {
-		budget = append(budget, fmt.Sprintf(stealLine, toPercent(details.StealP95)))
+	// A healthy tick has no fired cause, so every rule shows the mark that
+	// would fire it.
+	return msg + technicalDetails(nil, details)
+}
+
+// budgetCores are the four cores figures the healthy headline and the headroom
+// line share.
+type budgetCores struct {
+	headroom float64
+	total    float64
+	used     float64
+	reserve  float64
+}
+
+// coresBudget reads those four figures out of Details. Each of total, used and
+// reserve is rounded to one decimal first, and headroom is then derived as
+// total - used - reserve from the already-rounded three, so the arithmetic the
+// headroom line prints adds up exactly; it never independently rounds
+// Details.HeadroomCores.
+//
+// ReserveCores is read from Details in both modes - buildDetails filled it from
+// the verdict's own reserve, never from the constant. The used figure follows
+// the mode: this container's own usage where a limit applies, the machine's
+// busy time where none does.
+func coresBudget(details Details) budgetCores {
+	used := round1(details.AvgHostBusyCores)
+	if details.LimitApplies {
+		used = round1(details.AvgUsageCores)
 	}
 
-	return msg + technicalDetails + strings.Join(budget, " ")
+	b := budgetCores{
+		total:   round1(details.CapacityCores),
+		used:    used,
+		reserve: round1(details.ReserveCores),
+	}
+	b.headroom = round1(b.total - b.used - b.reserve) // clears float residue, not an independent rounding
+
+	return b
+}
+
+// usageMeasured reports whether this tick produced the usage figure the
+// headroom arithmetic is built on. Two measurement floors, one per mode: an
+// outage can leave one window thin while the other fills, and a limit-mode
+// headline reads the container's own usage, so a thin host-busy window must not
+// withhold it.
+func usageMeasured(details Details) bool {
+	if details.LimitApplies {
+		return details.UsageRingActive
+	}
+
+	return details.HostBusyRingActive && details.HostBusyCoresAvailable
+}
+
+// cpuRule is one line of the Technical Details table: one rule that can degrade
+// this instance's CPU, written as what it measured against the threshold that
+// applies to it right now.
+//
+// applies and ready are the two halves Details keeps apart and forbids reading
+// as each other. applies is whether the box can run the rule at all; ready is
+// whether this tick's window produced a value. An absent line says which of the
+// two it is, because "this kernel reports no pressure statistics" and "the
+// window is still filling" send a reader to different places.
+type cpuRule struct {
+	// label opens the line, and names the rule rather than the instrument: an
+	// operator reading "Steal" need not know which of the two steal arms
+	// answered.
+	label string
+	// measured is the reading, already written in the rule's own unit - "18%",
+	// or the whole headroom subtraction.
+	measured string
+	// marks is the pair the engine judged this rule against, carried whole so
+	// the line states the live threshold rather than a copy of it.
+	marks   diagnosis.Marks
+	applies bool
+	ready   bool
+	latched bool
+}
+
+// render writes one line of the table.
+//
+// A rule that has not fired shows the mark that would fire it; a latched rule
+// shows the mark that clears it, because for a latched rule the clear mark is
+// the one that decides what happens next. It also removes an apparent
+// contradiction: a rule still latched while its reading has fallen back under
+// its own fire mark would otherwise be shown a threshold it is already inside.
+func (r cpuRule) render() string {
+	// A latch is proof the rule ran on this box, whatever the capability flag
+	// says, so a fired rule is never reported as one the box cannot run.
+	switch {
+	case !r.applies && !r.latched:
+		return r.label + " not available (not possible)."
+	case !r.ready:
+		return r.label + " not available (measuring)."
+	}
+
+	mark, verb := r.marks.Fire, "degrades"
+	if r.latched {
+		mark, verb = r.marks.Clear, "recovers"
+	}
+
+	return fmt.Sprintf("%s %s (%s %s %s).",
+		r.label, r.measured, verb, markSide(mark, r.marks.Polarity, r.latched), markValue(mark, r.marks.Unit))
+}
+
+// markSide names the side of a mark that crosses it, in the reader's words. A
+// fire mark is crossed toward the worse side and a clear mark toward the better
+// one, so a single polarity reads both ways.
+//
+// An inclusive mark counts landing exactly on it, and reads "at": "degrades at
+// 70%" for the usage rule, where 70% of the machine busy is already a full
+// machine.
+func markSide(m diagnosis.Mark, p diagnosis.Polarity, clearing bool) string {
+	if m.Inclusive {
+		return "at"
+	}
+	if (p == diagnosis.HigherIsWorse) == clearing {
+		return "below"
+	}
+
+	return "above"
+}
+
+// markValue writes a mark in the unit its own pair declares: a ratio or a
+// fraction as a percentage, cores as a plain cores figure. A unit no signal
+// declares falls through to the plain figure, which states no unit it cannot
+// vouch for.
+func markValue(m diagnosis.Mark, unit string) string {
+	switch unit {
+	case unitRatio, unitFraction:
+		return strconv.Itoa(toPercent(m.At)) + "%"
+	default:
+		return fmtCoresTotal(round1(m.At))
+	}
+}
+
+// technicalDetails renders the labelled table: the label on its own line, then
+// one line per rule, in a fixed order with every slot present. causes is this
+// tick's fired list, and is empty on a healthy tick.
+//
+// A failed cgroup read (CapacityCores == 0) gets no table at all. On that tick
+// we do not know which rules apply, so a table would assert knowledge we do not
+// have.
+func technicalDetails(causes []Cause, details Details) string {
+	if details.CapacityCores == 0 {
+		return ""
+	}
+
+	rules := cpuRules(causes, details)
+	lines := make([]string, 0, len(rules))
+	for _, r := range rules {
+		lines = append(lines, r.render())
+	}
+
+	return technicalDetailsLabel + strings.Join(lines, "\n")
+}
+
+// cpuRules lists the five rules the table reports, in the order it prints them.
+// Every rule appears in every state: a slot saying why it is absent is what
+// stops a reader taking a missing line for a rule that is fine.
+//
+// Each rule carries the mark pair its own signal_*.go declares, never a copy of
+// the numbers in it.
+func cpuRules(causes []Cause, details Details) []cpuRule {
+	b := coresBudget(details)
+
+	// Headroom is one subtraction against two ceilings, and the mode picks
+	// which: this container's own CPU limit, or the machine's cores. The
+	// figures coresBudget returned already follow the mode, so the mark pair
+	// and the latch have to follow it too.
+	headroomMarks, headroomKind, headroomInstrument := hostHeadroomMarks, CauseKindHostCpuFull, instrumentHostHeadroom
+	if details.LimitApplies {
+		headroomMarks, headroomKind, headroomInstrument = limitHeadroomMarks(details.CapacityCores), CauseKindContainerLimitFull, instrumentLimitHeadroom
+	}
+	_, headroomLatched := firedCause(causes, headroomKind, headroomInstrument)
+
+	// Steal is answered by a percentile arm and a mean arm sharing one pair.
+	// Details.StealP95 names the percentile, which reads 0 until the window
+	// holds twenty samples, so a latched episode reports the arm it fired on -
+	// the number the steal paragraph above the table already prints.
+	stealValue := details.StealP95
+	steal, stealLatched := firedCause(causes, CauseKindSteal, instrumentStealP95, instrumentStealMean)
+	if stealLatched {
+		stealValue = steal.Value
+	}
+
+	_, usageLatched := firedCause(causes, CauseKindHostCpuFull, instrumentUsageFraction)
+	_, throttleLatched := firedCause(causes, CauseKindThrottling, instrumentThrottleRatio)
+	_, pressureLatched := firedCause(causes, CauseKindPressure, instrumentPressureAvg60)
+
+	return []cpuRule{
+		{
+			label: "Headroom",
+			measured: fmt.Sprintf("%s cores = %s total - %s used - %s reserved",
+				fmtCores1(b.headroom), fmtCoresTotal(b.total), fmtCores1(b.used), fmtCores1(b.reserve)),
+			marks: headroomMarks,
+			// Every box has a ceiling, so this rule always applies. It is
+			// readable exactly when the usage figure it subtracts is.
+			applies: true,
+			ready:   usageMeasured(details),
+			latched: headroomLatched,
+		},
+		{
+			label:    "Usage",
+			measured: fmt.Sprintf("%d%% of capacity", toPercent(details.AvgUsageFraction)),
+			marks:    usageFractionMarks,
+			// usage-fraction is evidence of last resort: it is declared only
+			// where there is no quota to judge our own budget against and no PSI
+			// to read the harm off, which is exactly what
+			// Details.LimitedVisibility holds. A box with a CPU limit therefore
+			// never runs this rule.
+			applies: details.LimitedVisibility,
+			// usage-fraction reduces the same sample field over the same span as
+			// the usage-cores measurement, so one window's state answers for
+			// both.
+			ready:   details.UsageRingActive,
+			latched: usageLatched,
+		},
+		{
+			label:    "Throttling",
+			measured: fmt.Sprintf("%d%%", toPercent(details.ThrottleRatio)),
+			marks:    throttleMarks,
+			applies:  details.LimitApplies,
+			ready:    details.ThrottleSignalReady,
+			latched:  throttleLatched,
+		},
+		{
+			label:    "Pressure",
+			measured: fmt.Sprintf("%d%%", toPercent(details.PressureAvg60)),
+			marks:    pressureMarks,
+			applies:  details.PressureApplies,
+			ready:    details.PressureSignalReady,
+			latched:  pressureLatched,
+		},
+		{
+			label:    "Steal",
+			measured: fmt.Sprintf("%d%%", toPercent(stealValue)),
+			marks:    stealMarks,
+			applies:  details.StealApplies,
+			ready:    details.StealSignalReady,
+			latched:  stealLatched,
+		},
+	}
+}
+
+// firedCause returns this tick's cause for one rule, matching the kind AND one
+// of the instruments that can measure it. The pair is the key rather than the
+// kind alone: host-cpu-full fires from two instruments, each of which owns its
+// own line, so a headroom line keyed on the kind would latch on a usage-
+// fraction episode.
+func firedCause(causes []Cause, kind CauseKind, instruments ...string) (Cause, bool) {
+	for _, c := range causes {
+		if c.Kind != kind {
+			continue
+		}
+		for _, name := range instruments {
+			if c.Instrument == name {
+				return c, true
+			}
+		}
+	}
+
+	return Cause{}, false
 }
 
 // causeHeadline returns the one-line headline naming a cause kind.
@@ -466,18 +693,12 @@ const (
 	headlineClose = "CPU healthy. %s is using %s of %s cores and is close to being marked degraded."
 	headlineMore  = "CPU healthy. %s is using %s of %s cores and can use %s more before it is marked degraded."
 
-	// The unconditional headroom budget line.
-	headroomLine = "Headroom %s cores = %s total - %s used - %s reserved (degraded below 0)."
-
-	// The throttle/pressure/steal budget lines, each gated on that signal's
-	// per-tick readiness.
-	throttleLine = "Throttling %d%% (degraded above 5%%)."
-	pressureLine = "Pressure %d%% (degraded above 20%%)."
-	stealLine    = "Steal %d%% (degraded above 10%%)."
-
-	// The separator, byte-identical on the healthy and the degraded path. The
-	// literal "\nTechnical Details: ".
-	technicalDetails = "\nTechnical Details: "
+	// The label above the table, byte-identical on the healthy and the degraded
+	// path, and on its own line in both. The literal "\nTechnical Details:\n".
+	//
+	// The table's own lines are not constants: cpuRule.render assembles each one
+	// from a label, a reading and a threshold read live from the rule's marks.
+	technicalDetailsLabel = "\nTechnical Details:\n"
 
 	// The degraded headlines, one per CauseKind. headlineGeneric is the default
 	// arm, unreachable through today's five kinds but still written so the enum

--- a/umh-core/pkg/cpuhealth/message.go
+++ b/umh-core/pkg/cpuhealth/message.go
@@ -24,13 +24,11 @@
 // No signal threshold is written down here. Every number the Technical Details
 // table states is read from the mark pair its own signal_*.go declares, which
 // is the pair the engine judges against, so the rule the message states and the
-// rule the code applies cannot come apart. That is why each pair is one var:
-// the signal_*.go files declare them and say no more about it.
+// rule the code applies cannot come apart.
 //
-// The one number this file decides for itself is the 0.05 cores at which the
-// healthy headline starts saying a box is close to being marked degraded. It is
-// a display band, not a rule the engine judges, and it is written relative to
-// hostHeadroomMarks.Fire without reading it.
+// One number here is this file's own: the 0.05 cores at which the healthy
+// headline starts calling a box close to degraded. It is a display band, not a
+// rule the engine judges, and it does not read hostHeadroomMarks.
 
 package cpuhealth
 
@@ -231,8 +229,7 @@ func usageMeasured(details Details) bool {
 // applies and ready are the two halves Details keeps apart and forbids reading
 // as each other. applies is whether the box can run the rule at all; ready is
 // whether this tick's window produced a value. An absent line says which of the
-// two it is, because "this kernel reports no pressure statistics" and "the
-// window is still filling" send a reader to different places.
+// two it is.
 type cpuRule struct {
 	// label opens the line, and names the rule rather than the instrument: an
 	// operator reading "Steal" need not know which of the two steal arms
@@ -247,11 +244,8 @@ type cpuRule struct {
 	applies bool
 	ready   bool
 	// latched is whether the SIGNAL this line belongs to has fired and not yet
-	// released. It picks which of the two marks the line states. A signal holds
-	// one latch however many instruments it has, so the two lines a
-	// two-instrument signal prints state the same side of their own pairs: one
-	// question cannot have been answered yes for one of its lines and no for
-	// the other.
+	// released. It picks which of the two marks the line states, and it is read
+	// per signal, so both lines of a two-instrument signal state the same side.
 	latched bool
 	// firedHere is whether THIS line's own instrument produced one of this
 	// tick's causes, which is proof the rule ran on this box whatever the
@@ -261,13 +255,8 @@ type cpuRule struct {
 	firedHere bool
 }
 
-// render writes one line of the table.
-//
-// A rule that has not fired shows the mark that would fire it; a latched rule
-// shows the mark that clears it, because for a latched rule the clear mark is
-// the one that decides what happens next. It also removes an apparent
-// contradiction: a rule still latched while its reading has fallen back under
-// its own fire mark would otherwise be shown a threshold it is already inside.
+// render writes one line of the table: a rule that has not fired shows the mark
+// that would fire it, a latched rule the mark that clears it.
 func (r cpuRule) render() string {
 	switch {
 	case !r.applies && !r.firedHere:
@@ -285,13 +274,10 @@ func (r cpuRule) render() string {
 		r.label, r.measured, verb, markSide(mark, r.marks.Polarity, r.latched), markValue(mark, r.marks.Unit))
 }
 
-// markSide names the side of a mark that crosses it, in the reader's words. A
-// fire mark is crossed toward the worse side and a clear mark toward the better
-// one, so a single polarity reads both ways.
-//
-// An inclusive mark counts landing exactly on it, and reads "at": "degrades at
-// 70%" for the usage rule, where 70% of the machine busy is already a full
-// machine.
+// markSide names the side of a mark in the reader's words. A fire mark is
+// crossed toward the worse side and a clear mark toward the better one, so one
+// polarity reads both ways. An inclusive mark counts landing exactly on it and
+// reads "at" - "degrades at 70%", where 70% busy is already a full machine.
 func markSide(m diagnosis.Mark, p diagnosis.Polarity, clearing bool) string {
 	if m.Inclusive {
 		return "at"
@@ -342,9 +328,6 @@ func technicalDetails(causes []Cause, details Details) string {
 // is absent is what stops a reader taking a missing line for a rule that is
 // fine.
 //
-// Each rule carries the mark pair its own signal_*.go declares, never a copy of
-// the numbers in it.
-//
 // Latchedness is read per SIGNAL and the capability override per INSTRUMENT;
 // cpuRule's two fields say why.
 func cpuRules(causes []Cause, details Details) []cpuRule {
@@ -354,17 +337,10 @@ func cpuRules(causes []Cause, details Details) []cpuRule {
 	_, usageFired := firedCause(causes, CauseKindHostCpuFull, instrumentUsageFraction)
 	_, limitHeadroomFired := firedCause(causes, CauseKindContainerLimitFull, instrumentLimitHeadroom)
 
-	// Headroom is one subtraction against a ceiling, and a box can be judged
-	// against two of them at once: the machine's cores, and this container's
-	// own CPU limit. One line per ceiling the engine is judging, so a machine
-	// that filled while the container sits well inside its limit does not print
-	// the container's comfortable figure under a headline saying the machine is
-	// full.
-	//
-	// Which ceilings those are is decided in exactly one place. table_cpu.go
-	// declares a capacity signal under hostCpuFullDeclared and
-	// containerLimitFullDeclared, and the two lines below are appended under
-	// the same two predicates, read off the figures the table was built from.
+	// A box can be judged against two ceilings at once, the machine's cores and
+	// its own CPU limit, so each gets its own line: a machine that filled while
+	// the container sits well inside its limit must not print the container's
+	// comfortable figure under a headline saying the machine is full.
 	cores, quota := tableCeilings(details)
 
 	rules := make([]cpuRule, 0, 6)
@@ -444,11 +420,10 @@ func cpuRules(causes []Cause, details Details) []cpuRule {
 // headroomRule builds one headroom line: the subtraction its budget spells out,
 // against the mark pair the signal measuring that ceiling declares.
 //
-// applies is true by construction: the caller appends this line only where the
-// declared-ceiling test passed, and a ceiling that fails it gets no line at all
-// rather than an empty slot. That the box then runs the rule is the usual case,
-// not a guarantee - the test runs on this tick, the table was built at startup.
-// hostCpuFullDeclared has the case where they part.
+// applies is true by construction: the caller appends a line only where the
+// declared-ceiling test passed, and a ceiling that fails it gets no slot at
+// all. That the engine then judges the rule is the usual case, not a guarantee
+// - hostCpuFullDeclared has the exception.
 func headroomRule(label string, b budgetCores, marks diagnosis.Marks, ready, latched, firedHere bool) cpuRule {
 	return cpuRule{
 		label: label,
@@ -462,20 +437,17 @@ func headroomRule(label string, b budgetCores, marks diagnosis.Marks, ready, lat
 	}
 }
 
-// tableCeilings returns the two figures cpuTable was built from - the machine's
-// core count and this container's CPU quota - read back off Details, so the
-// table's headroom lines and the engine's capacity signals answer to the same
-// two predicates.
+// tableCeilings reads back the two figures the capacity predicates take: the
+// machine's core count and this container's CPU quota.
 //
-// A quota is on Details only through the mode: CapacityCores is the quota where
-// a limit applies and the machine's core count where none does, so a zero quota
-// is what no-limit mode means here.
+// A quota reaches Details only through the mode: CapacityCores is the quota
+// where a limit applies and the core count where none does, so zero here means
+// no-limit mode.
 //
-// Both figures are this tick's read, while cpuTable was handed the startup one.
-// Where a cpuset read at startup and stops reading later the line drops, and it
-// had no figure to print anyway. The other direction is the harmful one: a
-// cpuset that failed at startup and reads later prints a headroom line for a
-// ceiling the table never declared (ENG-5752).
+// These are this tick's read; cpuTable was handed the startup one. A cpuset
+// that failed at startup and reads later prints a headroom line for a ceiling
+// the table never declared (ENG-5752). The opposite order drops a line that had
+// no figure to print anyway.
 func tableCeilings(details Details) (cores, quota float64) {
 	if details.LimitApplies {
 		return details.LogicalCpus, details.CapacityCores
@@ -557,10 +529,9 @@ func machineWasRead(causes []Cause) bool {
 // customer given both is told to buy CPU for a machine and also to raise a
 // limit that cannot help on it.
 //
-// Where /proc/stat answered, the machine's own reading speaks, and its
-// paragraph names the container's limit in a trailing clause. Where the only
-// reading of the machine is usage-fraction's estimate from our own usage, the
-// container's own limit is the measured ceiling and speaks instead.
+// Where /proc/stat answered, the machine's reading speaks and names the limit
+// in a trailing clause. Where the only reading is usage-fraction's estimate
+// from our own usage, the container's limit is the measured ceiling and speaks.
 func speaksForCapacity(c Cause, causes []Cause) bool {
 	if !isCapacityKind(c.Kind) {
 		return true
@@ -593,12 +564,12 @@ func speakingCause(causes []Cause) Cause {
 }
 
 // causeDetails returns the curated Technical-Details copy for one cause,
-// interpolating the live number from the cause's Value or the derived Details.
-// The two capacity kinds dispatch on the cause's own instrument, and a machine
-// read full asks two further questions: whether the container is also at its
-// limit, which is the case whose two remedies have to be blended into one
-// sentence, and failing that whose load filled the machine, which
-// fullMachineDetail answers.
+// interpolating the live number from the cause's Value or from Details.
+//
+// The two capacity kinds dispatch on the cause's own instrument. A machine read
+// full then asks whether the container is at its limit too, because that case
+// blends two remedies into one sentence; failing that it asks whose load filled
+// the machine, which fullMachineDetail answers.
 func causeDetails(c Cause, causes []Cause, details Details) string {
 	switch c.Kind {
 	case CauseKindThrottling:
@@ -695,13 +666,11 @@ func fullMachineBlock(attribution Attribution, details Details) string {
 	}
 }
 
-// BlockReason returns the per-cause bridge-refusal message shown when bridge
-// creation is refused because the instance's CPU is degraded. It speaks with
-// the cause the Technical Details speak with, both through speakingCause, so
-// the two surfaces cannot hand one customer two contradictory remedies at once.
-// It reads the attribution for the same reason, and asks the ranked causes the
-// same blend question first. An unknown kind falls back to the generic degraded
-// message.
+// BlockReason returns the refusal message shown when a degraded CPU blocks
+// bridge creation. It picks its cause through speakingCause, reads the
+// attribution, and asks the same blend question, all as causeDetails does: the
+// two surfaces must not hand one customer contradictory remedies. An unknown
+// kind falls back to the generic degraded message.
 func BlockReason(causes []Cause, details Details) string {
 	if len(causes) == 0 {
 		return blockPrefix + blockGeneric

--- a/umh-core/pkg/cpuhealth/message.go
+++ b/umh-core/pkg/cpuhealth/message.go
@@ -79,8 +79,9 @@ func composeHealthy(details Details) string {
 
 	// The healthy message reports only what it measured. When the usage figure
 	// is withheld the message has no headline sentence left, so render the
-	// single "CPU: starting up." line over the table, whose every line then
-	// says which kind of absence it is. It lasts two ticks after each start and
+	// single "CPU: starting up." line over the table, where a line whose own
+	// window has not reduced yet says so rather than stating a figure nothing
+	// measured. It lasts two ticks after each start and
 	// respawn: the sampler derives no rate from its first read, and the mean
 	// over the rates after that needs two of them. It is not the zero-capacity
 	// case (a standing state) - they share a rendering path and nothing else.
@@ -137,8 +138,9 @@ func composeHealthy(details Details) string {
 	return msg + technicalDetails(nil, details)
 }
 
-// budgetCores are the four cores figures the healthy headline and the headroom
-// line share.
+// budgetCores are the four cores figures a headline and a headroom line share:
+// a ceiling, what is being used against it, what is held back, and the spare
+// that leaves.
 type budgetCores struct {
 	headroom float64
 	total    float64
@@ -146,43 +148,73 @@ type budgetCores struct {
 	reserve  float64
 }
 
-// coresBudget reads those four figures out of Details. Each of total, used and
-// reserve is rounded to one decimal first, and headroom is then derived as
-// total - used - reserve from the already-rounded three, so the arithmetic the
-// headroom line prints adds up exactly; it never independently rounds
-// Details.HeadroomCores.
-//
-// ReserveCores is read from Details in both modes - buildDetails filled it from
-// the verdict's own reserve, never from the constant. The used figure follows
-// the mode: this container's own usage where a limit applies, the machine's
-// busy time where none does.
-func coresBudget(details Details) budgetCores {
-	used := round1(details.AvgHostBusyCores)
-	if details.LimitApplies {
-		used = round1(details.AvgUsageCores)
-	}
-
+// newBudget assembles the four figures from a ceiling, a usage and a reserve.
+// Each of the three is rounded to one decimal first, and headroom is then
+// derived as total - used - reserve from the already-rounded three, so the
+// arithmetic the headroom line prints adds up exactly; it never independently
+// rounds Details.HeadroomCores.
+func newBudget(total, used, reserve float64) budgetCores {
 	b := budgetCores{
-		total:   round1(details.CapacityCores),
-		used:    used,
-		reserve: round1(details.ReserveCores),
+		total:   round1(total),
+		used:    round1(used),
+		reserve: round1(reserve),
 	}
 	b.headroom = round1(b.total - b.used - b.reserve) // clears float residue, not an independent rounding
 
 	return b
 }
 
-// usageMeasured reports whether this tick produced the usage figure the
-// headroom arithmetic is built on. Two measurement floors, one per mode: an
-// outage can leave one window thin while the other fills, and a limit-mode
-// headline reads the container's own usage, so a thin host-busy window must not
-// withhold it.
-func usageMeasured(details Details) bool {
+// machineBudget is the machine's cores against the machine's busy time, the
+// pair hostCpuFullSignal's host-headroom arm subtracts. Its reserve is the
+// fixed cpuReserveCores rather than Details.ReserveCores, because Details
+// carries one reserve and it follows the mode: on a box under a CPU limit that
+// field holds the limit's own reserve, which says nothing about the machine.
+func machineBudget(details Details) budgetCores {
+	return newBudget(details.LogicalCpus, details.AvgHostBusyCores, cpuReserveCores)
+}
+
+// instanceBudget is this container's own CPU limit against its own usage, the
+// pair containerLimitFullSignal's arm subtracts. ReserveCores is read from
+// Details rather than recomputed - buildDetails filled it from the verdict's
+// own reserve, never from the constant.
+func instanceBudget(details Details) budgetCores {
+	return newBudget(details.CapacityCores, details.AvgUsageCores, details.ReserveCores)
+}
+
+// coresBudget is the budget the healthy headline speaks in, which is the one
+// the mode makes the customer's ceiling: their own limit where one applies, the
+// machine otherwise.
+func coresBudget(details Details) budgetCores {
 	if details.LimitApplies {
-		return details.UsageRingActive
+		return instanceBudget(details)
 	}
 
+	return machineBudget(details)
+}
+
+// machineMeasured reports whether this tick produced the machine's busy figure
+// machineBudget subtracts. It needs both the window and the reading: a thin
+// window and an unreadable /proc/stat both leave the subtraction with no term.
+func machineMeasured(details Details) bool {
 	return details.HostBusyRingActive && details.HostBusyCoresAvailable
+}
+
+// instanceMeasured reports whether this tick produced the container's own usage
+// figure instanceBudget subtracts.
+func instanceMeasured(details Details) bool {
+	return details.UsageRingActive
+}
+
+// usageMeasured reports whether this tick produced the usage figure the healthy
+// headline is built on. Two measurement floors, one per mode: an outage can
+// leave one window thin while the other fills, and a limit-mode headline reads
+// the container's own usage, so a thin host-busy window must not withhold it.
+func usageMeasured(details Details) bool {
+	if details.LimitApplies {
+		return instanceMeasured(details)
+	}
+
+	return machineMeasured(details)
 }
 
 // cpuRule is one line of the Technical Details table: one rule that can degrade
@@ -207,7 +239,19 @@ type cpuRule struct {
 	marks   diagnosis.Marks
 	applies bool
 	ready   bool
+	// latched is whether the SIGNAL this line belongs to has fired and not yet
+	// released. It picks which of the two marks the line states. A signal holds
+	// one latch however many instruments it has, so the two lines a
+	// two-instrument signal prints state the same side of their own pairs: one
+	// question cannot have been answered yes for one of its lines and no for
+	// the other.
 	latched bool
+	// firedHere is whether THIS line's own instrument produced one of this
+	// tick's causes, which is proof the rule ran on this box whatever the
+	// capability flag says. It is the instrument's own firing and never its
+	// signal's: host-cpu-full answering from /proc/stat says nothing about
+	// whether our-usage-over-the-machine can be measured here.
+	firedHere bool
 }
 
 // render writes one line of the table.
@@ -218,10 +262,11 @@ type cpuRule struct {
 // contradiction: a rule still latched while its reading has fallen back under
 // its own fire mark would otherwise be shown a threshold it is already inside.
 func (r cpuRule) render() string {
-	// A latch is proof the rule ran on this box, whatever the capability flag
-	// says, so a fired rule is never reported as one the box cannot run.
+	// A fired instrument is proof the rule ran on this box, whatever the
+	// capability flag says, so a fired rule is never reported as one the box
+	// cannot run.
 	switch {
-	case !r.applies && !r.latched:
+	case !r.applies && !r.firedHere:
 		return r.label + " not available (not possible)."
 	case !r.ready:
 		return r.label + " not available (measuring)."
@@ -268,7 +313,7 @@ func markValue(m diagnosis.Mark, unit string) string {
 }
 
 // technicalDetails renders the labelled table: the label on its own line, then
-// one line per rule, in a fixed order with every slot present. causes is this
+// one line per rule the engine is judging, in a fixed order. causes is this
 // tick's fired list, and is empty on a healthy tick.
 //
 // A failed cgroup read (CapacityCores == 0) gets no table at all. On that tick
@@ -288,52 +333,64 @@ func technicalDetails(causes []Cause, details Details) string {
 	return technicalDetailsLabel + strings.Join(lines, "\n")
 }
 
-// cpuRules lists the five rules the table reports, in the order it prints them.
-// Every rule appears in every state: a slot saying why it is absent is what
-// stops a reader taking a missing line for a rule that is fine.
+// cpuRules lists the rules the table reports, in the order it prints them.
+// Every rule the engine is judging appears in every state: a slot saying why it
+// is absent is what stops a reader taking a missing line for a rule that is
+// fine.
 //
 // Each rule carries the mark pair its own signal_*.go declares, never a copy of
 // the numbers in it.
+//
+// Latchedness is read per SIGNAL and the capability override per INSTRUMENT;
+// cpuRule's two fields say why.
 func cpuRules(causes []Cause, details Details) []cpuRule {
-	b := coresBudget(details)
+	machineFull := hasKind(causes, CauseKindHostCpuFull)
+	limitFull := hasKind(causes, CauseKindContainerLimitFull)
+	_, hostHeadroomFired := firedCause(causes, CauseKindHostCpuFull, instrumentHostHeadroom)
+	_, usageFired := firedCause(causes, CauseKindHostCpuFull, instrumentUsageFraction)
+	_, limitHeadroomFired := firedCause(causes, CauseKindContainerLimitFull, instrumentLimitHeadroom)
 
-	// Headroom is one subtraction against two ceilings, and the mode picks
-	// which: this container's own CPU limit, or the machine's cores. The
-	// figures coresBudget returned already follow the mode, so the mark pair
-	// and the latch have to follow it too.
-	headroomMarks, headroomKind, headroomInstrument := hostHeadroomMarks, CauseKindHostCpuFull, instrumentHostHeadroom
-	if details.LimitApplies {
-		headroomMarks, headroomKind, headroomInstrument = limitHeadroomMarks(details.CapacityCores), CauseKindContainerLimitFull, instrumentLimitHeadroom
+	// Headroom is one subtraction against a ceiling, and a box can be judged
+	// against two of them at once: the machine's cores, and this container's
+	// own CPU limit. One line per ceiling the engine is judging, so a machine
+	// that filled while the container sits well inside its limit does not print
+	// the container's comfortable figure under a headline saying the machine is
+	// full.
+	//
+	// Which ceilings those are is decided in exactly one place. table_cpu.go
+	// declares a capacity signal under hostCpuFullDeclared and
+	// containerLimitFullDeclared, and the two lines below are appended under
+	// the same two predicates, read off the figures the table was built from.
+	cores, quota := tableCeilings(details)
+
+	rules := make([]cpuRule, 0, 6)
+	if hostCpuFullDeclared(cores) {
+		rules = append(rules, headroomRule(labelMachineHeadroom, machineBudget(details),
+			hostHeadroomMarks, machineMeasured(details), machineFull, hostHeadroomFired))
 	}
-	_, headroomLatched := firedCause(causes, headroomKind, headroomInstrument)
+	if containerLimitFullDeclared(quota) {
+		rules = append(rules, headroomRule(labelInstanceHeadroom, instanceBudget(details),
+			limitHeadroomMarks(quota), instanceMeasured(details), limitFull, limitHeadroomFired))
+	}
 
 	// Steal is answered by a percentile arm and a mean arm sharing one pair.
 	// Details.StealP95 names the percentile, which reads 0 until the window
 	// holds twenty samples, so a latched episode reports the arm it fired on -
 	// the number the steal paragraph above the table already prints.
 	stealValue := details.StealP95
-	steal, stealLatched := firedCause(causes, CauseKindSteal, instrumentStealP95, instrumentStealMean)
-	if stealLatched {
+	steal, stealFired := firedCause(causes, CauseKindSteal, instrumentStealP95, instrumentStealMean)
+	if stealFired {
 		stealValue = steal.Value
 	}
 
-	_, usageLatched := firedCause(causes, CauseKindHostCpuFull, instrumentUsageFraction)
-	_, throttleLatched := firedCause(causes, CauseKindThrottling, instrumentThrottleRatio)
-	_, pressureLatched := firedCause(causes, CauseKindPressure, instrumentPressureAvg60)
+	// The three lines below each carry a whole signal, so their signal's latch
+	// and their own instruments' firing are the same fact read twice. Steal has
+	// two instruments, but both of them feed this one line.
+	throttlingFired := hasKind(causes, CauseKindThrottling)
+	pressureFired := hasKind(causes, CauseKindPressure)
 
-	return []cpuRule{
-		{
-			label: "Headroom",
-			measured: fmt.Sprintf("%s cores = %s total - %s used - %s reserved",
-				fmtCores1(b.headroom), fmtCoresTotal(b.total), fmtCores1(b.used), fmtCores1(b.reserve)),
-			marks: headroomMarks,
-			// Every box has a ceiling, so this rule always applies. It is
-			// readable exactly when the usage figure it subtracts is.
-			applies: true,
-			ready:   usageMeasured(details),
-			latched: headroomLatched,
-		},
-		{
+	return append(rules,
+		cpuRule{
 			label:    "Usage",
 			measured: fmt.Sprintf("%d%% of capacity", toPercent(details.AvgUsageFraction)),
 			marks:    usageFractionMarks,
@@ -346,41 +403,84 @@ func cpuRules(causes []Cause, details Details) []cpuRule {
 			// usage-fraction reduces the same sample field over the same span as
 			// the usage-cores measurement, so one window's state answers for
 			// both.
-			ready:   details.UsageRingActive,
-			latched: usageLatched,
+			ready:     details.UsageRingActive,
+			latched:   machineFull,
+			firedHere: usageFired,
 		},
-		{
-			label:    "Throttling",
-			measured: fmt.Sprintf("%d%%", toPercent(details.ThrottleRatio)),
-			marks:    throttleMarks,
-			applies:  details.LimitApplies,
-			ready:    details.ThrottleSignalReady,
-			latched:  throttleLatched,
+		cpuRule{
+			label:     "Throttling",
+			measured:  fmt.Sprintf("%d%%", toPercent(details.ThrottleRatio)),
+			marks:     throttleMarks,
+			applies:   details.LimitApplies,
+			ready:     details.ThrottleSignalReady,
+			latched:   throttlingFired,
+			firedHere: throttlingFired,
 		},
-		{
-			label:    "Pressure",
-			measured: fmt.Sprintf("%d%%", toPercent(details.PressureAvg60)),
-			marks:    pressureMarks,
-			applies:  details.PressureApplies,
-			ready:    details.PressureSignalReady,
-			latched:  pressureLatched,
+		cpuRule{
+			label:     "Pressure",
+			measured:  fmt.Sprintf("%d%%", toPercent(details.PressureAvg60)),
+			marks:     pressureMarks,
+			applies:   details.PressureApplies,
+			ready:     details.PressureSignalReady,
+			latched:   pressureFired,
+			firedHere: pressureFired,
 		},
-		{
-			label:    "Steal",
-			measured: fmt.Sprintf("%d%%", toPercent(stealValue)),
-			marks:    stealMarks,
-			applies:  details.StealApplies,
-			ready:    details.StealSignalReady,
-			latched:  stealLatched,
+		cpuRule{
+			label:     "Steal",
+			measured:  fmt.Sprintf("%d%%", toPercent(stealValue)),
+			marks:     stealMarks,
+			applies:   details.StealApplies,
+			ready:     details.StealSignalReady,
+			latched:   stealFired,
+			firedHere: stealFired,
 		},
+	)
+}
+
+// headroomRule builds one headroom line: the subtraction its budget spells out,
+// against the mark pair the signal measuring that ceiling declares.
+//
+// applies is true by construction. The caller appends this line only for a
+// ceiling cpuTable declared a signal for, so the box does run the rule; a
+// ceiling it declared nothing for gets no line at all rather than a slot.
+func headroomRule(label string, b budgetCores, marks diagnosis.Marks, ready, latched, firedHere bool) cpuRule {
+	return cpuRule{
+		label: label,
+		measured: fmt.Sprintf("%s cores = %s total - %s used - %s reserved",
+			fmtCores1(b.headroom), fmtCoresTotal(b.total), fmtCores1(b.used), fmtCores1(b.reserve)),
+		marks:     marks,
+		applies:   true,
+		ready:     ready,
+		latched:   latched,
+		firedHere: firedHere,
 	}
 }
 
-// firedCause returns this tick's cause for one rule, matching the kind AND one
-// of the instruments that can measure it. The pair is the key rather than the
-// kind alone: host-cpu-full fires from two instruments, each of which owns its
-// own line, so a headroom line keyed on the kind would latch on a usage-
-// fraction episode.
+// tableCeilings returns the two figures cpuTable was built from - the machine's
+// core count and this container's CPU quota - read back off Details, so the
+// table's headroom lines and the engine's capacity signals answer to the same
+// two predicates.
+//
+// A quota is on Details only through the mode: CapacityCores is the quota where
+// a limit applies and the machine's core count where none does, so a zero quota
+// is what no-limit mode means here.
+//
+// Both figures are this tick's read, while cpuTable was handed the startup one.
+// They differ only where a cpuset that read at startup stops reading later, and
+// on that tick the line would have no figure to print anyway.
+func tableCeilings(details Details) (cores, quota float64) {
+	if details.LimitApplies {
+		return details.LogicalCpus, details.CapacityCores
+	}
+
+	return details.LogicalCpus, 0
+}
+
+// firedCause returns this tick's cause for one instrument, matching the kind
+// AND one of the instruments named. It answers "did this LINE's own instrument
+// fire", which is not the same question as "is the signal latched": hasKind
+// answers that one, and a two-instrument signal holds a single latch its two
+// lines share.
 func firedCause(causes []Cause, kind CauseKind, instruments ...string) (Cause, bool) {
 	for _, c := range causes {
 		if c.Kind != kind {
@@ -699,6 +799,14 @@ const (
 	// The table's own lines are not constants: cpuRule.render assembles each one
 	// from a label, a reading and a threshold read live from the rule's marks.
 	technicalDetailsLabel = "\nTechnical Details:\n"
+
+	// The two headroom lines' labels. A box under a CPU limit is judged against
+	// both ceilings at once and prints both lines, so each has to name whose
+	// spare cores it is counting. They borrow the two words the headlines above
+	// already use for the same pair of subjects: "This instance" and "The
+	// machine".
+	labelInstanceHeadroom = "Instance headroom"
+	labelMachineHeadroom  = "Machine headroom"
 
 	// The degraded headlines, one per CauseKind. headlineGeneric is the default
 	// arm, unreachable through today's five kinds but still written so the enum

--- a/umh-core/pkg/cpuhealth/message.go
+++ b/umh-core/pkg/cpuhealth/message.go
@@ -440,9 +440,11 @@ func cpuRules(causes []Cause, details Details) []cpuRule {
 // headroomRule builds one headroom line: the subtraction its budget spells out,
 // against the mark pair the signal measuring that ceiling declares.
 //
-// applies is true by construction. The caller appends this line only for a
-// ceiling cpuTable declared a signal for, so the box does run the rule; a
-// ceiling it declared nothing for gets no line at all rather than a slot.
+// applies is true by construction: the caller appends this line only where the
+// declared-ceiling test passed, and a ceiling that fails it gets no line at all
+// rather than an empty slot. That the box then runs the rule is the usual case,
+// not a guarantee - the test runs on this tick, the table was built at startup.
+// hostCpuFullDeclared has the case where they part.
 func headroomRule(label string, b budgetCores, marks diagnosis.Marks, ready, latched, firedHere bool) cpuRule {
 	return cpuRule{
 		label: label,
@@ -466,8 +468,10 @@ func headroomRule(label string, b budgetCores, marks diagnosis.Marks, ready, lat
 // is what no-limit mode means here.
 //
 // Both figures are this tick's read, while cpuTable was handed the startup one.
-// They differ only where a cpuset that read at startup stops reading later, and
-// on that tick the line would have no figure to print anyway.
+// Where a cpuset read at startup and stops reading later the line drops, and it
+// had no figure to print anyway. The other direction is the harmful one: a
+// cpuset that failed at startup and reads later prints a headroom line for a
+// ceiling the table never declared (ENG-5752).
 func tableCeilings(details Details) (cores, quota float64) {
 	if details.LimitApplies {
 		return details.LogicalCpus, details.CapacityCores

--- a/umh-core/pkg/cpuhealth/message.go
+++ b/umh-core/pkg/cpuhealth/message.go
@@ -70,7 +70,7 @@ func ComposeMessage(verdict Verdict, details Details) string {
 
 // composeHealthy renders the healthy message: the budget headline, any
 // advisory the tick earned, then the Technical Details table. The displayed
-// cores figures come from coresBudget, so the printed headroom arithmetic is
+// cores figures come from effectiveBudget, so the printed headroom arithmetic is
 // exact by construction.
 func composeHealthy(details Details) string {
 	// Zero-capacity guard: when CapacityCores is 0, do not compose the garbled
@@ -94,7 +94,7 @@ func composeHealthy(details Details) string {
 		return cpuStartingUp + technicalDetails(nil, details)
 	}
 
-	b := coresBudget(details)
+	b := effectiveBudget(details)
 	usedStr := fmtCores1(b.used)
 	totalStr := fmtCoresTotal(b.total)
 	headroomStr := fmtCores1(b.headroom)
@@ -143,9 +143,7 @@ func composeHealthy(details Details) string {
 	return msg + technicalDetails(nil, details)
 }
 
-// budgetCores are the four cores figures a headline and a headroom line share:
-// a ceiling, what is being used against it, what is held back, and the spare
-// that leaves.
+// budgetCores are the four cores figures a headline and a headroom line share.
 type budgetCores struct {
 	headroom float64
 	total    float64
@@ -153,11 +151,9 @@ type budgetCores struct {
 	reserve  float64
 }
 
-// newBudget assembles the four figures from a ceiling, a usage and a reserve.
-// Each of the three is rounded to one decimal first, and headroom is then
-// derived as total - used - reserve from the already-rounded three, so the
-// arithmetic the headroom line prints adds up exactly; it never independently
-// rounds Details.HeadroomCores.
+// newBudget derives headroom from the already-rounded three, so the arithmetic
+// the headroom line prints adds up exactly. It never rounds
+// Details.HeadroomCores independently.
 func newBudget(total, used, reserve float64) budgetCores {
 	b := budgetCores{
 		total:   round1(total),
@@ -169,27 +165,22 @@ func newBudget(total, used, reserve float64) budgetCores {
 	return b
 }
 
-// machineBudget is the machine's cores against the machine's busy time, the
-// pair hostCpuFullSignal's host-headroom arm subtracts. Its reserve is the
-// fixed cpuReserveCores rather than Details.ReserveCores, because Details
-// carries one reserve and it follows the mode: on a box under a CPU limit that
-// field holds the limit's own reserve, which says nothing about the machine.
+// machineBudget takes the reserve from the fixed cpuReserveCores, not from
+// Details.ReserveCores: that field follows the mode, so under a CPU limit it
+// holds the limit's reserve, which says nothing about the machine.
 func machineBudget(details Details) budgetCores {
 	return newBudget(details.LogicalCpus, details.AvgHostBusyCores, cpuReserveCores)
 }
 
-// instanceBudget is this container's own CPU limit against its own usage, the
-// pair containerLimitFullSignal's arm subtracts. ReserveCores is read from
-// Details rather than recomputed - buildDetails filled it from the verdict's
-// own reserve, never from the constant.
+// instanceBudget reads ReserveCores from Details rather than recomputing it:
+// buildDetails filled it from the verdict's own reserve, never the constant.
 func instanceBudget(details Details) budgetCores {
 	return newBudget(details.CapacityCores, details.AvgUsageCores, details.ReserveCores)
 }
 
-// coresBudget is the budget the healthy headline speaks in, which is the one
-// the mode makes the customer's ceiling: their own limit where one applies, the
-// machine otherwise.
-func coresBudget(details Details) budgetCores {
+// effectiveBudget is the customer's ceiling: their own limit where one applies,
+// the machine otherwise.
+func effectiveBudget(details Details) budgetCores {
 	if details.LimitApplies {
 		return instanceBudget(details)
 	}
@@ -197,23 +188,18 @@ func coresBudget(details Details) budgetCores {
 	return machineBudget(details)
 }
 
-// machineMeasured reports whether this tick produced the machine's busy figure
-// machineBudget subtracts. It needs both the window and the reading: a thin
-// window and an unreadable /proc/stat both leave the subtraction with no term.
+// machineMeasured needs both the window and the reading: a thin window and an
+// unreadable /proc/stat both leave the subtraction with no term.
 func machineMeasured(details Details) bool {
 	return details.HostBusyRingActive && details.HostBusyCoresAvailable
 }
 
-// instanceMeasured reports whether this tick produced the container's own usage
-// figure instanceBudget subtracts.
 func instanceMeasured(details Details) bool {
 	return details.UsageRingActive
 }
 
-// usageMeasured reports whether this tick produced the usage figure the healthy
-// headline is built on. Two measurement floors, one per mode: an outage can
-// leave one window thin while the other fills, and a limit-mode headline reads
-// the container's own usage, so a thin host-busy window must not withhold it.
+// usageMeasured has one floor per mode, because an outage can leave one window
+// thin while the other fills and a limit-mode headline reads only its own usage.
 func usageMeasured(details Details) bool {
 	if details.LimitApplies {
 		return instanceMeasured(details)
@@ -222,14 +208,12 @@ func usageMeasured(details Details) bool {
 	return machineMeasured(details)
 }
 
-// cpuRule is one line of the Technical Details table: one rule that can degrade
-// this instance's CPU, written as what it measured against the threshold that
-// applies to it right now.
+// cpuRule is one line of the Technical Details table: a rule that can degrade
+// this instance's CPU, against the threshold applying to it now.
 //
-// applies and ready are the two halves Details keeps apart and forbids reading
-// as each other. applies is whether the box can run the rule at all; ready is
-// whether this tick's window produced a value. An absent line says which of the
-// two it is.
+// applies and ready must never be read as each other: applies is whether the box
+// can run the rule at all, ready is whether this tick produced a value. An
+// absent line says which of the two it is.
 type cpuRule struct {
 	// label opens the line, and names the rule rather than the instrument: an
 	// operator reading "Steal" need not know which of the two steal arms

--- a/umh-core/pkg/cpuhealth/message_test.go
+++ b/umh-core/pkg/cpuhealth/message_test.go
@@ -417,6 +417,87 @@ var _ = Describe("the Technical Details table", func() {
 			"a rule dropped from the table is a rule the reader takes for fine")
 	})
 
+	It("should carry one headroom line per ceiling the engine is judging, decided by the predicates cpuTable declares the capacity signals with", func() {
+		// A box with no CPU limit. cpuTable declares no container-limit-full
+		// signal there, so a line for it would state a rule nothing judges and
+		// a threshold denominated in a quota that does not exist.
+		nolimit := healthyDetails()
+		nolimit.LimitApplies = false
+		nolimit.CapacityCores = 4
+		nolimit.LogicalCpus = 4
+		nolimit.ReserveCores = 1.0
+		nolimit.AvgHostBusyCores = 1.2
+		Expect(containerLimitFullDeclared(0)).To(BeFalse(), "the predicate the table appends that signal under")
+		Expect(tableRules(composeHealthy(nolimit))).To(Equal(machineOnlyRules))
+
+		// A box under a CPU limit whose cpuset could not be read. cpuTable
+		// declares no host-cpu-full signal on a non-positive core count, and the
+		// machine line has no total to subtract from.
+		noCores := healthyDetails()
+		noCores.LogicalCpus = 0
+		Expect(hostCpuFullDeclared(0)).To(BeFalse(), "the predicate the table appends that signal under")
+		Expect(tableRules(composeHealthy(noCores))).
+			To(Equal([]string{labelInstanceHeadroom, "Usage", "Throttling", "Pressure", "Steal"}))
+
+		// Both ceilings at once is the ordinary container-under-a-limit box, and
+		// it is the state in which one line for the pair could contradict the
+		// other: the machine can be full while the container sits well inside
+		// its own limit.
+		Expect(hostCpuFullDeclared(2)).To(BeTrue())
+		Expect(containerLimitFullDeclared(2)).To(BeTrue())
+		Expect(tableRules(composeHealthy(healthyDetails()))).To(Equal(bothCeilingRules))
+	})
+
+	It("should state each headroom line's own fire mark, read from the signal measuring that ceiling", func() {
+		// The two headroom lines are the ones the example table leads with, and
+		// each carries a different pair: the machine's is a fixed pair, the
+		// container's is denominated in its own quota. Both thresholds are
+		// computed here from the pair the engine judges against, so repointing a
+		// line at another signal's marks reddens this spec.
+		both := healthyDetails()
+		both.AvgHostBusyCores = 0.4
+		msg := composeHealthy(both)
+
+		Expect(msg).To(ContainSubstring(labelMachineHeadroom+" 0.6 cores = 2 total - 0.4 used - 1.0 reserved (degrades below %s).",
+			fmtCoresTotal(hostHeadroomMarks.Fire.At)))
+		Expect(msg).To(ContainSubstring(labelInstanceHeadroom+" 1.8 cores = 2 total - 0.0 used - 0.2 reserved (degrades below %s).",
+			fmtCoresTotal(limitHeadroomMarks(both.CapacityCores).Fire.At)))
+	})
+
+	It("should state each headroom line's own clear mark once its signal has latched, from the same pair", func() {
+		// The clear marks are where the two pairs differ by more than their
+		// denomination: the machine clears at a fixed half core, the container
+		// at a fraction of its quota. A line reading the other's pair states a
+		// number the engine will not release it on.
+		latched := degradedSig()
+		latched.AvgHostBusyCores = 3.5
+		msg := ComposeMessage(bothCapacityVerdict(-0.5), latched)
+
+		Expect(msg).To(ContainSubstring(labelMachineHeadroom+" -0.5 cores = 4 total - 3.5 used - 1.0 reserved (recovers above %s).",
+			fmtCoresTotal(round1(hostHeadroomMarks.Clear.At))))
+		Expect(msg).To(ContainSubstring(labelInstanceHeadroom+" 2.5 cores = 4 total - 0.5 used - 1.0 reserved (recovers above %s).",
+			fmtCoresTotal(round1(limitHeadroomMarks(latched.CapacityCores).Clear.At))))
+	})
+
+	It("should state the same side of the pair on both lines of one signal, because a signal holds one latch however many instruments it has", func() {
+		// The default docker box: no CPU limit and no pressure statistics, so
+		// host-cpu-full is judged by both of its arms and prints two lines. The
+		// machine reads full from /proc/stat while our own usage is over its own
+		// fire mark too. One question was answered yes, so neither line may
+		// state the mark that would fire it.
+		fired := limitedVisibilityDetails()
+		fired.AvgHostBusyCores = 3.2
+		fired.AvgUsageFraction = 0.75
+		msg := ComposeMessage(degradedVerdict(CauseKindHostCpuFull, instrumentHostHeadroom, -0.2), fired)
+
+		Expect(msg).To(ContainSubstring(labelMachineHeadroom+" -0.2 cores = 4 total - 3.2 used - 1.0 reserved (recovers above %s).",
+			fmtCoresTotal(round1(hostHeadroomMarks.Clear.At))))
+		Expect(msg).To(ContainSubstring("Usage 75%% of capacity (recovers below %d%%).",
+			toPercent(usageFractionMarks.Clear.At)))
+		Expect(msg).NotTo(ContainSubstring("degrades"),
+			"the arm that did not answer must not print its fire mark beside a reading that has already crossed it")
+	})
+
 	It("should say which kind of absence a missing reading is, because a kernel that reports no pressure statistics and a window still filling send a reader to different places", func() {
 		bare := healthyDetails()
 		bare.PressureApplies = false

--- a/umh-core/pkg/cpuhealth/message_test.go
+++ b/umh-core/pkg/cpuhealth/message_test.go
@@ -32,6 +32,30 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/diagnosis"
 )
 
+// tableLines returns the Technical Details table's lines, in the order the
+// message printed them, and fails when the message carries no table.
+func tableLines(msg string) []string {
+	_, table, found := strings.Cut(msg, technicalDetailsLabel)
+	Expect(found).To(BeTrue(), "the message carries no Technical Details table: %q", msg)
+
+	return strings.Split(table, "\n")
+}
+
+// tableRules returns the rule each table line reports, in order: the word the
+// line opens with.
+func tableRules(msg string) []string {
+	rules := make([]string, 0, 5)
+	for _, line := range tableLines(msg) {
+		rules = append(rules, strings.SplitN(line, " ", 2)[0])
+	}
+
+	return rules
+}
+
+// allRules is the fixed order the table prints, every slot present in every
+// state that has a table.
+var allRules = []string{"Headroom", "Usage", "Throttling", "Pressure", "Steal"}
+
 // healthyDetails builds a Details bag with every healthy-message input in a
 // usable state, so individual fields can be overridden per assertion.
 func healthyDetails() Details {
@@ -75,7 +99,8 @@ var _ = Describe("the healthy headline", func() {
 		details.AvgUsageCores = 0.3
 		msg := composeHealthy(details)
 		// 2 total - 0.3 used - 0.2 reserved = 1.5, printed exactly.
-		Expect(msg).To(ContainSubstring("Headroom 1.5 cores = 2 total - 0.3 used - 0.2 reserved (degraded below 0)."))
+		Expect(msg).To(ContainSubstring("Headroom 1.5 cores = 2 total - 0.3 used - 0.2 reserved (degrades below %s).",
+			fmtCoresTotal(limitHeadroomMarks(details.CapacityCores).Fire.At)))
 		Expect(msg).To(ContainSubstring("can use 1.5 more before it is marked degraded."))
 	})
 
@@ -187,13 +212,18 @@ var _ = Describe("the healthy message reports only what it measured", func() {
 		details.AvgHostBusyCores = 0.0
 		details.ReserveCores = 1.0
 		details.HostBusyCoresAvailable = false // read failed, window still full
-		Expect(composeHealthy(details)).To(Equal("CPU: starting up."))
+		msg := composeHealthy(details)
+		Expect(msg).To(HavePrefix(cpuStartingUp + technicalDetailsLabel))
+		Expect(msg).To(ContainSubstring("Headroom not available (measuring)."),
+			"the headroom line states no figure either, and says which kind of absence it is")
 	})
 
 	It("should not report the limit-mode usage figure when the container's own window holds too few samples to reduce, even though the reading succeeded", func() {
 		details := healthyDetails()
 		details.UsageRingActive = false
-		Expect(composeHealthy(details)).To(Equal("CPU: starting up."))
+		msg := composeHealthy(details)
+		Expect(msg).To(HavePrefix(cpuStartingUp + technicalDetailsLabel))
+		Expect(msg).To(ContainSubstring("Headroom not available (measuring)."))
 	})
 
 	It("should not report the no-limit usage figure when the host window holds too few samples to reduce, even though the reading succeeded", func() {
@@ -204,16 +234,36 @@ var _ = Describe("the healthy message reports only what it measured", func() {
 		details.ReserveCores = 1.0
 		details.HostBusyCoresAvailable = true
 		details.HostBusyRingActive = false
-		Expect(composeHealthy(details)).To(Equal("CPU: starting up."))
+		msg := composeHealthy(details)
+		Expect(msg).To(HavePrefix(cpuStartingUp + technicalDetailsLabel))
+		Expect(msg).To(ContainSubstring("Headroom not available (measuring)."))
 	})
 
 	It("should render no headline at all on a tick whose usage figure is withheld, returning through the same single-line path the zero-capacity guard uses rather than a headline with a hole in it", func() {
 		details := healthyDetails()
 		details.UsageRingActive = false
 		msg := composeHealthy(details)
-		Expect(msg).To(Equal("CPU: starting up."))
+		Expect(msg).To(HavePrefix("CPU: starting up." + technicalDetailsLabel))
 		Expect(msg).NotTo(ContainSubstring("CPU healthy."))
-		Expect(msg).NotTo(ContainSubstring("Technical Details:"))
+
+		// The table comes with it, and every line says which kind of absence it
+		// is rather than stating a figure nothing measured. On the first ticks
+		// that is what an operator wants: the rules that will be judged, and how
+		// far off each reading is.
+		startup := healthyDetails()
+		startup.UsageRingActive = false
+		startup.HostBusyRingActive = false
+		startup.ThrottleSignalReady = false
+		startup.PressureSignalReady = false
+		startup.StealSignalReady = false
+		lines := tableLines(composeHealthy(startup))
+		Expect(tableRules(composeHealthy(startup))).To(Equal(allRules))
+		for _, line := range lines {
+			Expect(line).To(SatisfyAny(
+				HaveSuffix("not available (measuring)."),
+				HaveSuffix("not available (not possible)."),
+			), "a box that has measured nothing yet may state no figure, and this line does: %q", line)
+		}
 
 		// The floors are per measurement, not one flag: a limit-mode headline uses
 		// the container's usage-cores, so a thin host-busy window must NOT
@@ -224,51 +274,141 @@ var _ = Describe("the healthy message reports only what it measured", func() {
 	})
 })
 
-var _ = Describe("the budget lines", func() {
-	It("should list the headroom budget always, and each of throttle, pressure and steal only when this tick's reading is usable", func() {
+// limitedVisibilityDetails builds the healthy bag of the one box the usage rule
+// runs on: no CPU limit to judge our own budget against, and no pressure
+// statistics to read the harm off, so our own usage over the machine's cores is
+// the last evidence left that the machine is full.
+func limitedVisibilityDetails() Details {
+	d := healthyDetails()
+	d.LimitApplies = false
+	d.LimitedVisibility = true
+	d.CapacityCores = 4
+	d.ReserveCores = 1.0
+	d.AvgHostBusyCores = 1.2
+	d.AvgUsageFraction = 0.30
+	d.ThrottleSignalReady = false
+	d.PressureApplies = false
+	d.PressureSignalReady = false
+
+	return d
+}
+
+// The Technical Details table. Every threshold asserted below is computed from
+// the mark pair the signal declares, never written as a literal. A spec that
+// pinned the literal would stay green after someone moved the mark and the
+// message started stating a rule the code no longer applies, which is the
+// defect this table exists to close: it would pin the duplication rather than
+// the constant.
+var _ = Describe("the Technical Details table", func() {
+	It("should state each rule's own fire mark, read from the signal that owns it, while the rule has not fired", func() {
 		all := healthyDetails()
 		all.ThrottleRatio = 0.02
 		all.PressureAvg60 = 0.05
 		all.StealP95 = 0.30
+		all.PressureApplies = true
+		all.StealApplies = true
 		msg := composeHealthy(all)
-		// Headroom is the only unconditional line.
-		Expect(msg).To(ContainSubstring("Headroom 1.8 cores = 2 total - 0.0 used - 0.2 reserved (degraded below 0)."))
-		Expect(msg).To(ContainSubstring("Throttling 2% (degraded above 5%)."))
-		Expect(msg).To(ContainSubstring("Pressure 5% (degraded above 20%)."))
-		Expect(msg).To(ContainSubstring("Steal 30% (degraded above 10%)."))
+
+		Expect(msg).To(ContainSubstring("Headroom 1.8 cores = 2 total - 0.0 used - 0.2 reserved (degrades below %s).",
+			fmtCoresTotal(limitHeadroomMarks(all.CapacityCores).Fire.At)))
+		Expect(msg).To(ContainSubstring("Throttling 2%% (degrades above %d%%).", toPercent(throttleMarks.Fire.At)))
+		Expect(msg).To(ContainSubstring("Pressure 5%% (degrades above %d%%).", toPercent(pressureMarks.Fire.At)))
+		Expect(msg).To(ContainSubstring("Steal 30%% (degrades above %d%%).", toPercent(stealMarks.Fire.At)))
 	})
 
-	It("should print each budget line from its signal's readiness, never from the capability flag", func() {
+	It("should state the mark that clears a rule once it has latched, because that is the number deciding what happens next", func() {
+		latched := degradedSig()
+		latched.PressureAvg60 = 0.15
+		msg := ComposeMessage(degradedVerdict(CauseKindPressure, instrumentPressureAvg60, 0.15), latched)
+
+		Expect(msg).To(ContainSubstring("Pressure 15%% (recovers below %d%%).", toPercent(pressureMarks.Clear.At)))
+		Expect(msg).NotTo(ContainSubstring("Pressure 15% (degrades"),
+			"the reading has fallen back under the fire mark while the latch holds, so naming the fire mark would read as a contradiction")
+	})
+
+	It("should report the usage rule, the second way a machine can be judged full, so a box degraded by it is not shown a table in which every listed rule looks fine", func() {
+		// The rule fires on our own usage over the machine's cores, and it is
+		// the half the table used to omit: a box degraded by it saw a headroom
+		// line sitting comfortably above its mark and nothing else.
+		quiet := limitedVisibilityDetails()
+		Expect(composeHealthy(quiet)).To(ContainSubstring("Usage 30%% of capacity (degrades at %d%%).",
+			toPercent(usageFractionMarks.Fire.At)),
+			"the mark is inclusive, so 70%% of the machine busy is already a full machine and the line reads \"at\"")
+
+		fired := limitedVisibilityDetails()
+		fired.AvgUsageFraction = 0.75
+		msg := ComposeMessage(degradedVerdict(CauseKindHostCpuFull, instrumentUsageFraction, 0.75), fired)
+		Expect(msg).To(ContainSubstring("Usage 75%% of capacity (recovers below %d%%).",
+			toPercent(usageFractionMarks.Clear.At)))
+
+		// A latch is proof the rule ran on this box, so a fired rule is never
+		// reported as one the box cannot run.
+		Expect(ComposeMessage(degradedVerdict(CauseKindHostCpuFull, instrumentUsageFraction, 0.8), degradedSig())).
+			NotTo(ContainSubstring("Usage not available (not possible)."))
+	})
+
+	It("should carry all five rules, in one order, in every state that has a table", func() {
+		Expect(tableRules(composeHealthy(healthyDetails()))).To(Equal(allRules))
+		Expect(tableRules(ComposeMessage(degradedVerdict(CauseKindSteal, instrumentStealMean, 0.18), degradedSig()))).
+			To(Equal(allRules))
+
+		thin := healthyDetails()
+		thin.UsageRingActive = false
+		Expect(tableRules(composeHealthy(thin))).To(Equal(allRules),
+			"a rule dropped from the table is a rule the reader takes for fine")
+	})
+
+	It("should say which kind of absence a missing reading is, because a kernel that reports no pressure statistics and a window still filling send a reader to different places", func() {
+		bare := healthyDetails()
+		bare.PressureApplies = false
+		bare.PressureSignalReady = false
+		Expect(composeHealthy(bare)).To(ContainSubstring("Pressure not available (not possible)."))
+
+		thin := healthyDetails()
+		thin.PressureApplies = true
+		thin.PressureSignalReady = false
+		Expect(composeHealthy(thin)).To(ContainSubstring("Pressure not available (measuring)."))
+	})
+
+	It("should read each rule's figure from its signal's readiness, and print no figure at all for a rule the box cannot run", func() {
 		// A virtualized box (StealApplies true) whose steal window has no usable
 		// value this tick must not print a confident 0% steal line.
 		vm := healthyDetails()
 		vm.StealApplies = true
 		vm.StealSignalReady = false
 		msg := composeHealthy(vm)
-		Expect(msg).NotTo(ContainSubstring("Steal"))
-		Expect(msg).To(ContainSubstring("Pressure"))
+		Expect(msg).To(ContainSubstring("Steal not available (measuring)."))
+		Expect(msg).NotTo(ContainSubstring("Steal 0%"))
 		Expect(msg).To(ContainSubstring("Headroom"))
 
 		// The throttle gate is readiness, not LimitApplies.
 		noThrottle := healthyDetails()
 		noThrottle.LimitApplies = true
 		noThrottle.ThrottleSignalReady = false
-		Expect(composeHealthy(noThrottle)).NotTo(ContainSubstring("Throttling"))
+		Expect(composeHealthy(noThrottle)).To(ContainSubstring("Throttling not available (measuring)."))
 
-		// The pressure gate is readiness, not PressureApplies.
-		noPressure := healthyDetails()
-		noPressure.PressureApplies = true
-		noPressure.PressureSignalReady = false
-		Expect(composeHealthy(noPressure)).NotTo(ContainSubstring("Pressure"))
+		// The two halves cannot stand in for each other in the other direction
+		// either: bare metal declares no steal instrument, so a steal figure
+		// there would state a rule that can never fire. The readiness flag is
+		// set here anyway, which no real box does, to pin the capability as the
+		// thing withholding the figure.
+		bareMetal := healthyDetails()
+		bareMetal.StealApplies = false
+		bareMetal.StealSignalReady = true
+		bareMetal.StealP95 = 0.30
+		Expect(composeHealthy(bareMetal)).To(ContainSubstring("Steal not available (not possible)."))
+		Expect(composeHealthy(bareMetal)).NotTo(ContainSubstring("Steal 30%"))
+	})
 
-		// Readiness is the gate, not capability: a ready steal signal prints
-		// even when StealApplies is false (they agree on bare metal, but this
-		// pins the gate to the readiness trio).
-		ready := healthyDetails()
-		ready.StealApplies = false
-		ready.StealSignalReady = true
-		ready.StealP95 = 0.30
-		Expect(composeHealthy(ready)).To(ContainSubstring("Steal 30% (degraded above 10%)."))
+	It("should carry no table at all when the cgroup read failed, because nothing on that tick says which rules apply", func() {
+		healthy := healthyDetails()
+		healthy.CapacityCores = 0
+		Expect(composeHealthy(healthy)).To(Equal(cpuMonitoringUnavailable))
+
+		degraded := degradedSig()
+		degraded.CapacityCores = 0
+		Expect(ComposeMessage(degradedVerdict(CauseKindContainerLimitFull, instrumentLimitHeadroom, 0.5), degraded)).
+			NotTo(ContainSubstring("Technical Details:"))
 	})
 })
 
@@ -284,6 +424,15 @@ func degradedSig() Details {
 		ReserveCores:           1.0,
 		LimitApplies:           true,
 		PressureApplies:        true,
+		// A box that has run long enough to degrade has filled its windows, so
+		// the Technical Details table reads figures rather than a column of
+		// "measuring".
+		UsageRingActive:     true,
+		HostBusyRingActive:  true,
+		ThrottleSignalReady: true,
+		PressureSignalReady: true,
+		StealApplies:        true,
+		StealSignalReady:    true,
 	}
 }
 
@@ -319,8 +468,21 @@ var _ = Describe("degraded copy", func() {
 		// the mean is the arm that fires in the first twenty seconds. "At peak"
 		// would be a claim about a percentile, so the sentence makes none.
 		// Asserted whole, because the wording is customer-visible copy.
+		//
+		// The steal line of the table reports the same 18% as the paragraph
+		// above it. Details.StealP95 names the percentile, which reads 0 until
+		// the window holds twenty samples, so a latched episode reports the arm
+		// it fired on instead; the two would otherwise contradict each other
+		// three lines apart.
 		msg := ComposeMessage(degradedVerdict(CauseKindSteal, instrumentStealMean, 0.18), degradedSig())
-		Expect(msg).To(Equal("CPU taken by the server\nTechnical Details: Other virtual machines on the same physical server took 18% of the CPU this instance needed over the last minute. This is outside UMH's control. On your virtualization platform, give this VM more guaranteed CPU, or reduce the other VMs sharing the server."))
+		Expect(msg).To(Equal("CPU taken by the server\n" +
+			"Other virtual machines on the same physical server took 18% of the CPU this instance needed over the last minute. This is outside UMH's control. On your virtualization platform, give this VM more guaranteed CPU, or reduce the other VMs sharing the server." +
+			"\nTechnical Details:\n" +
+			"Headroom 2.5 cores = 4 total - 0.5 used - 1.0 reserved (degrades below 0).\n" +
+			"Usage not available (not possible).\n" +
+			"Throttling 0% (degrades above 5%).\n" +
+			"Pressure 0% (degrades above 20%).\n" +
+			"Steal 18% (recovers below 6%)."))
 	})
 
 	It("should render the curated detail paragraph for each fired cause, dominant first", func() {

--- a/umh-core/pkg/cpuhealth/message_test.go
+++ b/umh-core/pkg/cpuhealth/message_test.go
@@ -41,23 +41,49 @@ func tableLines(msg string) []string {
 	return strings.Split(table, "\n")
 }
 
-// tableRules returns the rule each table line reports, in order: the word the
-// line opens with.
+// tableRules returns the rule each table line reports, in order: the label the
+// line opens with. A line opening with none of the labels the table can print
+// comes back whole, so an unexpected label fails a comparison rather than being
+// silently trimmed to its first word.
 func tableRules(msg string) []string {
-	rules := make([]string, 0, 5)
+	rules := make([]string, 0, len(bothCeilingRules))
 	for _, line := range tableLines(msg) {
-		rules = append(rules, strings.SplitN(line, " ", 2)[0])
+		rules = append(rules, ruleLabel(line))
 	}
 
 	return rules
 }
 
-// allRules is the fixed order the table prints, every slot present in every
-// state that has a table.
-var allRules = []string{"Headroom", "Usage", "Throttling", "Pressure", "Steal"}
+// ruleLabel returns the label one rendered line opens with.
+func ruleLabel(line string) string {
+	for _, label := range bothCeilingRules {
+		if strings.HasPrefix(line, label+" ") {
+			return label
+		}
+	}
+
+	return line
+}
+
+// bothCeilingRules is the fixed order the table prints on a box judged against
+// both ceilings: a container under a CPU limit, on a machine whose core count
+// read. One headroom line per ceiling, then the four slots that are present in
+// every state that has a table.
+var bothCeilingRules = []string{labelMachineHeadroom, labelInstanceHeadroom, "Usage", "Throttling", "Pressure", "Steal"}
+
+// machineOnlyRules is the same order on a box with no CPU limit, where the
+// machine is the only ceiling and the limit line would name a rule nothing is
+// judging.
+var machineOnlyRules = []string{labelMachineHeadroom, "Usage", "Throttling", "Pressure", "Steal"}
 
 // healthyDetails builds a Details bag with every healthy-message input in a
 // usable state, so individual fields can be overridden per assertion.
+//
+// It is a two-core box with a two-core limit, so both ceilings are judged and
+// the table carries both headroom lines. A no-limit assertion overrides
+// LimitApplies, CapacityCores and LogicalCpus together: buildDetails makes
+// CapacityCores the machine's core count where no limit applies, so a bag
+// setting one without the other is a box that cannot exist.
 func healthyDetails() Details {
 	return Details{
 		LimitApplies:           true,
@@ -87,6 +113,7 @@ var _ = Describe("the healthy headline", func() {
 		nolimit := healthyDetails()
 		nolimit.LimitApplies = false
 		nolimit.CapacityCores = 8
+		nolimit.LogicalCpus = 8
 		nolimit.AvgUsageCores = 0
 		nolimit.AvgHostBusyCores = 0.0
 		nolimit.ReserveCores = 1.0
@@ -99,7 +126,7 @@ var _ = Describe("the healthy headline", func() {
 		details.AvgUsageCores = 0.3
 		msg := composeHealthy(details)
 		// 2 total - 0.3 used - 0.2 reserved = 1.5, printed exactly.
-		Expect(msg).To(ContainSubstring("Headroom 1.5 cores = 2 total - 0.3 used - 0.2 reserved (degrades below %s).",
+		Expect(msg).To(ContainSubstring(labelInstanceHeadroom+" 1.5 cores = 2 total - 0.3 used - 0.2 reserved (degrades below %s).",
 			fmtCoresTotal(limitHeadroomMarks(details.CapacityCores).Fire.At)))
 		Expect(msg).To(ContainSubstring("can use 1.5 more before it is marked degraded."))
 	})
@@ -204,17 +231,38 @@ var _ = Describe("the healthy headline", func() {
 	})
 })
 
+// firstTick drives one tick through a fresh engine and returns what a two-core
+// box under a two-core limit, with pressure statistics, reports one second
+// after it starts.
+func firstTick() (Verdict, Details) {
+	engine, err := NewEngine(2, 2.0)
+	Expect(err).NotTo(HaveOccurred())
+
+	return Decide(engine, Sample{
+		Timestamp:    time.Now(),
+		CpuScope:     ScopeHost,
+		Quota:        diagnosis.Known(2.0),
+		HostBusy:     diagnosis.Known(0.4),
+		UsageCores:   diagnosis.Known(0.2),
+		LogicalCpus:  diagnosis.Known(2),
+		HostCpus:     diagnosis.Known(2),
+		PsiAvailable: true,
+		Pressure:     diagnosis.Known(0.01),
+	}, diagnosis.NewEnvironment(HasLimit, HasPressureStats))
+}
+
 var _ = Describe("the healthy message reports only what it measured", func() {
 	It("should not report host usage or headroom when the host reading is absent", func() {
 		details := healthyDetails()
 		details.LimitApplies = false
 		details.CapacityCores = 8
+		details.LogicalCpus = 8
 		details.AvgHostBusyCores = 0.0
 		details.ReserveCores = 1.0
 		details.HostBusyCoresAvailable = false // read failed, window still full
 		msg := composeHealthy(details)
 		Expect(msg).To(HavePrefix(cpuStartingUp + technicalDetailsLabel))
-		Expect(msg).To(ContainSubstring("Headroom not available (measuring)."),
+		Expect(msg).To(ContainSubstring(labelMachineHeadroom+" not available (measuring)."),
 			"the headroom line states no figure either, and says which kind of absence it is")
 	})
 
@@ -223,20 +271,23 @@ var _ = Describe("the healthy message reports only what it measured", func() {
 		details.UsageRingActive = false
 		msg := composeHealthy(details)
 		Expect(msg).To(HavePrefix(cpuStartingUp + technicalDetailsLabel))
-		Expect(msg).To(ContainSubstring("Headroom not available (measuring)."))
+		Expect(msg).To(ContainSubstring(labelInstanceHeadroom + " not available (measuring)."))
+		Expect(msg).To(ContainSubstring(labelMachineHeadroom+" 1.0 cores"),
+			"the two windows are separate: a thin usage window withholds the instance's own figure and not the machine's")
 	})
 
 	It("should not report the no-limit usage figure when the host window holds too few samples to reduce, even though the reading succeeded", func() {
 		details := healthyDetails()
 		details.LimitApplies = false
 		details.CapacityCores = 8
+		details.LogicalCpus = 8
 		details.AvgHostBusyCores = 0.0
 		details.ReserveCores = 1.0
 		details.HostBusyCoresAvailable = true
 		details.HostBusyRingActive = false
 		msg := composeHealthy(details)
 		Expect(msg).To(HavePrefix(cpuStartingUp + technicalDetailsLabel))
-		Expect(msg).To(ContainSubstring("Headroom not available (measuring)."))
+		Expect(msg).To(ContainSubstring(labelMachineHeadroom + " not available (measuring)."))
 	})
 
 	It("should render no headline at all on a tick whose usage figure is withheld, returning through the same single-line path the zero-capacity guard uses rather than a headline with a hole in it", func() {
@@ -246,23 +297,30 @@ var _ = Describe("the healthy message reports only what it measured", func() {
 		Expect(msg).To(HavePrefix("CPU: starting up." + technicalDetailsLabel))
 		Expect(msg).NotTo(ContainSubstring("CPU healthy."))
 
-		// The table comes with it, and every line says which kind of absence it
-		// is rather than stating a figure nothing measured. On the first ticks
-		// that is what an operator wants: the rules that will be judged, and how
-		// far off each reading is.
-		startup := healthyDetails()
-		startup.UsageRingActive = false
-		startup.HostBusyRingActive = false
-		startup.ThrottleSignalReady = false
-		startup.PressureSignalReady = false
-		startup.StealSignalReady = false
-		lines := tableLines(composeHealthy(startup))
-		Expect(tableRules(composeHealthy(startup))).To(Equal(allRules))
-		for _, line := range lines {
+		// The table comes with it, and no line states a figure its own window
+		// has not produced. On the first ticks that is what an operator wants:
+		// the rules that will be judged, and which of them is still filling.
+		//
+		// Driven through one real tick rather than a hand-built bag, because the
+		// windows do not all fill together and a bag can claim they do. Pressure
+		// reduces with Last over PSI's own sixty-second average, so it has a
+		// value on tick 0 while every window that has to average two readings
+		// has none. That asymmetry is the whole point of the per-rule slot.
+		verdict, details := firstTick()
+		Expect(verdict.State).To(Equal(StateHealthy), "a box that has measured nothing cannot have judged itself degraded")
+		msg = ComposeMessage(verdict, details)
+		Expect(msg).To(HavePrefix(cpuStartingUp + technicalDetailsLabel))
+		Expect(tableRules(msg)).To(Equal(bothCeilingRules))
+		Expect(msg).To(ContainSubstring("Pressure 1%% (degrades above %d%%).", toPercent(pressureMarks.Fire.At)),
+			"pressure reads on tick 0, so a table claiming it is still measuring would describe a box that does not exist")
+		for _, line := range tableLines(msg) {
+			if strings.HasPrefix(line, "Pressure ") {
+				continue
+			}
 			Expect(line).To(SatisfyAny(
 				HaveSuffix("not available (measuring)."),
 				HaveSuffix("not available (not possible)."),
-			), "a box that has measured nothing yet may state no figure, and this line does: %q", line)
+			), "no other window has reduced yet, so this line may state no figure: %q", line)
 		}
 
 		// The floors are per measurement, not one flag: a limit-mode headline uses
@@ -283,6 +341,7 @@ func limitedVisibilityDetails() Details {
 	d.LimitApplies = false
 	d.LimitedVisibility = true
 	d.CapacityCores = 4
+	d.LogicalCpus = 4
 	d.ReserveCores = 1.0
 	d.AvgHostBusyCores = 1.2
 	d.AvgUsageFraction = 0.30
@@ -309,7 +368,7 @@ var _ = Describe("the Technical Details table", func() {
 		all.StealApplies = true
 		msg := composeHealthy(all)
 
-		Expect(msg).To(ContainSubstring("Headroom 1.8 cores = 2 total - 0.0 used - 0.2 reserved (degrades below %s).",
+		Expect(msg).To(ContainSubstring(labelInstanceHeadroom+" 1.8 cores = 2 total - 0.0 used - 0.2 reserved (degrades below %s).",
 			fmtCoresTotal(limitHeadroomMarks(all.CapacityCores).Fire.At)))
 		Expect(msg).To(ContainSubstring("Throttling 2%% (degrades above %d%%).", toPercent(throttleMarks.Fire.At)))
 		Expect(msg).To(ContainSubstring("Pressure 5%% (degrades above %d%%).", toPercent(pressureMarks.Fire.At)))
@@ -347,14 +406,14 @@ var _ = Describe("the Technical Details table", func() {
 			NotTo(ContainSubstring("Usage not available (not possible)."))
 	})
 
-	It("should carry all five rules, in one order, in every state that has a table", func() {
-		Expect(tableRules(composeHealthy(healthyDetails()))).To(Equal(allRules))
+	It("should carry every rule the engine is judging, in one order, in every state that has a table", func() {
+		Expect(tableRules(composeHealthy(healthyDetails()))).To(Equal(bothCeilingRules))
 		Expect(tableRules(ComposeMessage(degradedVerdict(CauseKindSteal, instrumentStealMean, 0.18), degradedSig()))).
-			To(Equal(allRules))
+			To(Equal(bothCeilingRules))
 
 		thin := healthyDetails()
 		thin.UsageRingActive = false
-		Expect(tableRules(composeHealthy(thin))).To(Equal(allRules),
+		Expect(tableRules(composeHealthy(thin))).To(Equal(bothCeilingRules),
 			"a rule dropped from the table is a rule the reader takes for fine")
 	})
 
@@ -379,7 +438,7 @@ var _ = Describe("the Technical Details table", func() {
 		msg := composeHealthy(vm)
 		Expect(msg).To(ContainSubstring("Steal not available (measuring)."))
 		Expect(msg).NotTo(ContainSubstring("Steal 0%"))
-		Expect(msg).To(ContainSubstring("Headroom"))
+		Expect(msg).To(ContainSubstring(labelMachineHeadroom))
 
 		// The throttle gate is readiness, not LimitApplies.
 		noThrottle := healthyDetails()
@@ -418,6 +477,7 @@ var _ = Describe("the Technical Details table", func() {
 func degradedSig() Details {
 	return Details{
 		CapacityCores:          4.0,
+		LogicalCpus:            4,
 		AvgUsageCores:          0.5,
 		AvgHostBusyCores:       1.0,
 		HostBusyCoresAvailable: true,
@@ -478,7 +538,8 @@ var _ = Describe("degraded copy", func() {
 		Expect(msg).To(Equal("CPU taken by the server\n" +
 			"Other virtual machines on the same physical server took 18% of the CPU this instance needed over the last minute. This is outside UMH's control. On your virtualization platform, give this VM more guaranteed CPU, or reduce the other VMs sharing the server." +
 			"\nTechnical Details:\n" +
-			"Headroom 2.5 cores = 4 total - 0.5 used - 1.0 reserved (degrades below 0).\n" +
+			"Machine headroom 2.0 cores = 4 total - 1.0 used - 1.0 reserved (degrades below 0).\n" +
+			"Instance headroom 2.5 cores = 4 total - 0.5 used - 1.0 reserved (degrades below 0).\n" +
 			"Usage not available (not possible).\n" +
 			"Throttling 0% (degrades above 5%).\n" +
 			"Pressure 0% (degrades above 20%).\n" +

--- a/umh-core/pkg/cpuhealth/signal_pressure.go
+++ b/umh-core/pkg/cpuhealth/signal_pressure.go
@@ -27,9 +27,7 @@ import (
 )
 
 // This pair is a ratio on a 0..1 scale with capacity 1.0, marking the pressure
-// signal's fire and clear thresholds. It is the one home for both numbers: the
-// engine judges against it and the Technical Details table states it, so the
-// threshold the customer reads is the threshold that fires.
+// signal's fire and clear thresholds.
 var pressureMarks = diagnosis.Marks{
 	Fire: diagnosis.Mark{At: 0.20}, Clear: diagnosis.Mark{At: 0.12},
 	Polarity: diagnosis.HigherIsWorse, Unit: unitRatio, Worst: 1.0,

--- a/umh-core/pkg/cpuhealth/signal_pressure.go
+++ b/umh-core/pkg/cpuhealth/signal_pressure.go
@@ -26,6 +26,15 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/diagnosis"
 )
 
+// This pair is a ratio on a 0..1 scale with capacity 1.0, marking the pressure
+// signal's fire and clear thresholds. It is the one home for both numbers: the
+// engine judges against it and the Technical Details table states it, so the
+// threshold the customer reads is the threshold that fires.
+var pressureMarks = diagnosis.Marks{
+	Fire: diagnosis.Mark{At: 0.20}, Clear: diagnosis.Mark{At: 0.12},
+	Polarity: diagnosis.HigherIsWorse, Unit: unitRatio, Worst: 1.0,
+}
+
 // pressureSignal is "are our tasks waiting for a core?" PSI's avg60 is already
 // a 60-second average, so the reduction is Last and the instrument can fire on
 // tick 0.
@@ -47,13 +56,7 @@ func pressureSignal() diagnosis.Signal[Sample] {
 				Span:      60 * time.Second,
 				Reduction: diagnosis.Last,
 			},
-			Marks: diagnosis.Marks{
-				Fire:     diagnosis.Mark{At: 0.20},
-				Clear:    diagnosis.Mark{At: 0.12},
-				Polarity: diagnosis.HigherIsWorse,
-				Unit:     "ratio",
-				Worst:    1.0,
-			},
+			Marks: pressureMarks,
 		}},
 	}
 }

--- a/umh-core/pkg/cpuhealth/signal_saturation.go
+++ b/umh-core/pkg/cpuhealth/signal_saturation.go
@@ -34,6 +34,32 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/diagnosis"
 )
 
+// Marks are the two thresholds that turn a number into a yes or no: the value
+// at which an instrument starts saying yes, and the value at which it goes back
+// to saying no. They differ on purpose, so a reading sitting on the boundary
+// does not flap. Each pair below is the one home for its two numbers: the
+// engine judges against it and the Technical Details table states it, so the
+// threshold the customer reads is the threshold that fires.
+//
+// hostHeadroomMarks is the machine's spare cores. Severity 1 at −Reserve, so
+// Worst is the reserve, not the core count. Headroom is cores − hostBusy −
+// reserve and hostBusy cannot exceed cores, so the quantity bottoms out at
+// −cpuReserveCores: a wholly consumed box. Worst is negative because it lives
+// on the worse (lower) side of Fire, the same side as the value that reaches
+// it.
+var hostHeadroomMarks = diagnosis.Marks{
+	Fire: diagnosis.Mark{At: 0}, Clear: diagnosis.Mark{At: 0.5},
+	Polarity: diagnosis.LowerIsWorse, Unit: unitCores, Worst: -cpuReserveCores,
+}
+
+// usageFractionMarks is our own usage over the CPUs we may run on. 0.70 fires
+// AT the mark: exactly 70% of the machine busy is a full machine, not a
+// 69%-and-waiting one.
+var usageFractionMarks = diagnosis.Marks{
+	Fire: diagnosis.Mark{At: 0.70, Inclusive: true}, Clear: diagnosis.Mark{At: 0.60},
+	Polarity: diagnosis.HigherIsWorse, Unit: unitFraction, Worst: 1.0,
+}
+
 // hostCpuFullSignal asks "is the machine full?".
 //
 // A signal is one question. An instrument is one way to measure the answer,
@@ -86,23 +112,7 @@ func hostCpuFullSignal(cores float64) diagnosis.Signal[Sample] {
 					Span:      60 * time.Second,
 					Reduction: diagnosis.Mean,
 				},
-				// Marks are the two thresholds that turn a number into a yes or no: the
-				// value at which this instrument starts saying yes, and the value at which
-				// it goes back to saying no. They differ on purpose, so a reading sitting
-				// on the boundary does not flap.
-				Marks: diagnosis.Marks{
-					Fire:     diagnosis.Mark{At: 0},
-					Clear:    diagnosis.Mark{At: 0.5},
-					Polarity: diagnosis.LowerIsWorse,
-					Unit:     "cores",
-					// Severity 1 at −Reserve, so Worst is the reserve, not
-					// the core count. Headroom is cores − hostBusy − reserve and
-					// hostBusy cannot exceed cores, so the quantity bottoms out
-					// at −cpuReserveCores: a wholly consumed box. Worst is
-					// negative because it lives on the worse (lower) side of
-					// Fire, the same side as the value that reaches it.
-					Worst: -cpuReserveCores,
-				},
+				Marks: hostHeadroomMarks,
 			},
 			{
 				Measurement: diagnosis.Measurement[Sample]{
@@ -134,15 +144,7 @@ func hostCpuFullSignal(cores float64) diagnosis.Signal[Sample] {
 					Span:      60 * time.Second,
 					Reduction: diagnosis.Mean,
 				},
-				Marks: diagnosis.Marks{
-					// 0.70 fires AT the mark: exactly 70% of the machine busy is
-					// a full machine, not a 69%-and-waiting one.
-					Fire:     diagnosis.Mark{At: 0.70, Inclusive: true},
-					Clear:    diagnosis.Mark{At: 0.60},
-					Polarity: diagnosis.HigherIsWorse,
-					Unit:     "fraction",
-					Worst:    1.0,
-				},
+				Marks: usageFractionMarks,
 			},
 		},
 	}
@@ -202,7 +204,7 @@ func shareRefinements() []diagnosis.Signal[Sample] {
 					Fire:     diagnosis.Mark{At: 0.49},
 					Clear:    diagnosis.Mark{At: 0.505},
 					Polarity: diagnosis.LowerIsWorse,
-					Unit:     "fraction",
+					Unit:     unitFraction,
 					// Severity 1 where none of the machine's busy time is ours.
 					Worst: 0.0,
 				},
@@ -225,12 +227,30 @@ func shareRefinements() []diagnosis.Signal[Sample] {
 					Fire:     diagnosis.Mark{At: 0.51},
 					Clear:    diagnosis.Mark{At: 0.495},
 					Polarity: diagnosis.HigherIsWorse,
-					Unit:     "fraction",
+					Unit:     unitFraction,
 					// Severity 1 where all of the machine's busy time is ours.
 					Worst: 1.0,
 				},
 			}},
 		},
+	}
+}
+
+// limitHeadroomMarks is the container's spare cores against its own quota. It
+// is a function rather than a value because both of its lower numbers are
+// denominated in the quota, which varies per box. Like the two pairs above it
+// is the one home for them: the engine judges against it and the Technical
+// Details table states it.
+//
+// Same reasoning as host-headroom for Worst: usage cannot exceed the quota the
+// kernel throttles it to, so quota − usage − 0.10 × quota bottoms out at
+// −0.10 × quota. Worst is negative because it lives on the worse (lower) side
+// of Fire, the same side as the value that reaches it; a container wholly out
+// of its budget scores 1.0.
+func limitHeadroomMarks(quota float64) diagnosis.Marks {
+	return diagnosis.Marks{
+		Fire: diagnosis.Mark{At: 0}, Clear: diagnosis.Mark{At: 0.05 * quota},
+		Polarity: diagnosis.LowerIsWorse, Unit: unitCores, Worst: -0.10 * quota,
 	}
 }
 
@@ -266,19 +286,7 @@ func containerLimitFullSignal(quota float64) diagnosis.Signal[Sample] {
 				Span:      60 * time.Second,
 				Reduction: diagnosis.Mean,
 			},
-			Marks: diagnosis.Marks{
-				Fire:     diagnosis.Mark{At: 0},
-				Clear:    diagnosis.Mark{At: 0.05 * quota},
-				Polarity: diagnosis.LowerIsWorse,
-				Unit:     "cores",
-				// Same reasoning as host-headroom: usage cannot exceed the quota
-				// the kernel throttles it to, so quota − usage − 0.10 × quota
-				// bottoms out at −0.10 × quota. Worst is negative because it
-				// lives on the worse (lower) side of Fire, the same side as the
-				// value that reaches it; a container wholly out of its budget
-				// scores 1.0.
-				Worst: -0.10 * quota,
-			},
+			Marks: limitHeadroomMarks(quota),
 		}},
 	}
 }

--- a/umh-core/pkg/cpuhealth/signal_saturation.go
+++ b/umh-core/pkg/cpuhealth/signal_saturation.go
@@ -39,12 +39,8 @@ import (
 // to saying no. They differ on purpose, so a reading sitting on the boundary
 // does not flap.
 //
-// hostHeadroomMarks is the machine's spare cores. Severity 1 at −Reserve, so
-// Worst is the reserve, not the core count. Headroom is cores − hostBusy −
-// reserve and hostBusy cannot exceed cores, so the quantity bottoms out at
-// −cpuReserveCores: a wholly consumed box. Worst is negative because it lives
-// on the worse (lower) side of Fire, the same side as the value that reaches
-// it.
+// hostHeadroomMarks is the machine's spare cores, cores − hostBusy − reserve.
+// hostBusy cannot exceed cores, so the floor is −cpuReserveCores.
 var hostHeadroomMarks = diagnosis.Marks{
 	Fire: diagnosis.Mark{At: 0}, Clear: diagnosis.Mark{At: 0.5},
 	Polarity: diagnosis.LowerIsWorse, Unit: unitCores, Worst: -cpuReserveCores,
@@ -234,15 +230,9 @@ func shareRefinements() []diagnosis.Signal[Sample] {
 	}
 }
 
-// limitHeadroomMarks is the container's spare cores against its own quota. It
-// is a function rather than a value because both of its lower numbers are
-// denominated in the quota, which varies per box.
-//
-// Same reasoning as host-headroom for Worst: usage cannot exceed the quota the
-// kernel throttles it to, so quota − usage − 0.10 × quota bottoms out at
-// −0.10 × quota. Worst is negative because it lives on the worse (lower) side
-// of Fire, the same side as the value that reaches it; a container wholly out
-// of its budget scores 1.0.
+// limitHeadroomMarks is the container's spare cores against its own quota. It is
+// a function because every number below is quota-denominated: the floor is
+// −0.10 × quota.
 func limitHeadroomMarks(quota float64) diagnosis.Marks {
 	return diagnosis.Marks{
 		Fire: diagnosis.Mark{At: 0}, Clear: diagnosis.Mark{At: 0.05 * quota},

--- a/umh-core/pkg/cpuhealth/signal_saturation.go
+++ b/umh-core/pkg/cpuhealth/signal_saturation.go
@@ -37,9 +37,7 @@ import (
 // Marks are the two thresholds that turn a number into a yes or no: the value
 // at which an instrument starts saying yes, and the value at which it goes back
 // to saying no. They differ on purpose, so a reading sitting on the boundary
-// does not flap. Each pair below is the one home for its two numbers: the
-// engine judges against it and the Technical Details table states it, so the
-// threshold the customer reads is the threshold that fires.
+// does not flap.
 //
 // hostHeadroomMarks is the machine's spare cores. Severity 1 at −Reserve, so
 // Worst is the reserve, not the core count. Headroom is cores − hostBusy −
@@ -238,9 +236,7 @@ func shareRefinements() []diagnosis.Signal[Sample] {
 
 // limitHeadroomMarks is the container's spare cores against its own quota. It
 // is a function rather than a value because both of its lower numbers are
-// denominated in the quota, which varies per box. Like the two pairs above it
-// is the one home for them: the engine judges against it and the Technical
-// Details table states it.
+// denominated in the quota, which varies per box.
 //
 // Same reasoning as host-headroom for Worst: usage cannot exceed the quota the
 // kernel throttles it to, so quota − usage − 0.10 × quota bottoms out at

--- a/umh-core/pkg/cpuhealth/signal_steal.go
+++ b/umh-core/pkg/cpuhealth/signal_steal.go
@@ -30,9 +30,12 @@ import (
 // A third steal arm has to carry this same pair. A fired episode releases only
 // against the mark pair it fired under, so an arm with its own pair would hold
 // that episode forever once selection hands over to it.
+//
+// It is also the one home for both numbers: the engine judges against it and
+// the Technical Details table states it.
 var stealMarks = diagnosis.Marks{
 	Fire: diagnosis.Mark{At: 0.10}, Clear: diagnosis.Mark{At: 0.06},
-	Polarity: diagnosis.HigherIsWorse, Unit: "ratio", Worst: 1.0,
+	Polarity: diagnosis.HigherIsWorse, Unit: unitRatio, Worst: 1.0,
 }
 
 // stealSignal is "is something outside this box taking our CPU?" It carries two

--- a/umh-core/pkg/cpuhealth/signal_steal.go
+++ b/umh-core/pkg/cpuhealth/signal_steal.go
@@ -30,9 +30,6 @@ import (
 // A third steal arm has to carry this same pair. A fired episode releases only
 // against the mark pair it fired under, so an arm with its own pair would hold
 // that episode forever once selection hands over to it.
-//
-// It is also the one home for both numbers: the engine judges against it and
-// the Technical Details table states it.
 var stealMarks = diagnosis.Marks{
 	Fire: diagnosis.Mark{At: 0.10}, Clear: diagnosis.Mark{At: 0.06},
 	Polarity: diagnosis.HigherIsWorse, Unit: unitRatio, Worst: 1.0,

--- a/umh-core/pkg/cpuhealth/signal_throttling.go
+++ b/umh-core/pkg/cpuhealth/signal_throttling.go
@@ -24,10 +24,12 @@ import (
 )
 
 // This pair is a ratio on a 0..1 scale with capacity 1.0, marking the
-// throttling signal's fire and clear thresholds.
+// throttling signal's fire and clear thresholds. It is the one home for both
+// numbers: the engine judges against it and the Technical Details table states
+// it, so the threshold the customer reads is the threshold that fires.
 var throttleMarks = diagnosis.Marks{
 	Fire: diagnosis.Mark{At: 0.05}, Clear: diagnosis.Mark{At: 0.03},
-	Polarity: diagnosis.HigherIsWorse, Unit: "ratio", Worst: 1.0,
+	Polarity: diagnosis.HigherIsWorse, Unit: unitRatio, Worst: 1.0,
 }
 
 // throttlingSignal declares the table's one Counter instrument — see below

--- a/umh-core/pkg/cpuhealth/signal_throttling.go
+++ b/umh-core/pkg/cpuhealth/signal_throttling.go
@@ -24,9 +24,7 @@ import (
 )
 
 // This pair is a ratio on a 0..1 scale with capacity 1.0, marking the
-// throttling signal's fire and clear thresholds. It is the one home for both
-// numbers: the engine judges against it and the Technical Details table states
-// it, so the threshold the customer reads is the threshold that fires.
+// throttling signal's fire and clear thresholds.
 var throttleMarks = diagnosis.Marks{
 	Fire: diagnosis.Mark{At: 0.05}, Clear: diagnosis.Mark{At: 0.03},
 	Polarity: diagnosis.HigherIsWorse, Unit: unitRatio, Worst: 1.0,

--- a/umh-core/pkg/cpuhealth/table_cpu.go
+++ b/umh-core/pkg/cpuhealth/table_cpu.go
@@ -68,10 +68,12 @@ func cpuTable(cores, quota float64) diagnosis.Table[Sample] {
 // machine-wide busy time may be subtracted from cores, which is a
 // container-scoped count: see host_source.go's header.
 //
-// message.go reads this too, and that is the point of it being a function. The
-// Technical Details table prints one headroom line per capacity signal the
-// table holds, so a second copy of the condition there could come apart from
-// this one and print a line for a rule nothing is judging.
+// message.go reads this too, so the condition is spelled once. That does not
+// make the two sides agree: the table is built from the startup snapshot and
+// the message runs on the current tick. A cpuset that failed to read at startup
+// and reads later passes this test on the message side while the table holds no
+// machine-full signal, so the line states a ceiling nothing is judging
+// (ENG-5752).
 func hostCpuFullDeclared(cores float64) bool {
 	return cores > 0
 }

--- a/umh-core/pkg/cpuhealth/table_cpu.go
+++ b/umh-core/pkg/cpuhealth/table_cpu.go
@@ -68,12 +68,10 @@ func cpuTable(cores, quota float64) diagnosis.Table[Sample] {
 // machine-wide busy time may be subtracted from cores, which is a
 // container-scoped count: see host_source.go's header.
 //
-// message.go reads this too, so the condition is spelled once. That does not
-// make the two sides agree: the table is built from the startup snapshot and
-// the message runs on the current tick. A cpuset that failed to read at startup
-// and reads later passes this test on the message side while the table holds no
-// machine-full signal, so the line states a ceiling nothing is judging
-// (ENG-5752).
+// message.go reads this too, spelling the condition once but not making the
+// two sides agree: the table is built from the startup snapshot, the message
+// runs on the current tick. A cpuset that failed at startup and reads later
+// makes this true while the engine holds no signal (ENG-5752).
 func hostCpuFullDeclared(cores float64) bool {
 	return cores > 0
 }

--- a/umh-core/pkg/cpuhealth/table_cpu.go
+++ b/umh-core/pkg/cpuhealth/table_cpu.go
@@ -53,16 +53,36 @@ func cpuTable(cores, quota float64) diagnosis.Table[Sample] {
 			pressureSignal(),
 		},
 	}
-	// Only when the core count was readable. cores <= 0 means the cgroup's
-	// cpuset could not be read, so there is no capacity to be full against.
-	// Why a machine-wide busy time may be subtracted from cores, which is a
-	// container-scoped count: see host_source.go's header.
-	if cores > 0 {
+	if hostCpuFullDeclared(cores) {
 		t.Signals = append(t.Signals, hostCpuFullSignal(cores))
 	}
-	// Only when a positive quota exists; with no limit there is nothing to saturate.
-	if quota > 0 {
+	if containerLimitFullDeclared(quota) {
 		t.Signals = append(t.Signals, containerLimitFullSignal(quota))
 	}
 	return t
+}
+
+// hostCpuFullDeclared reports whether the table holds the machine-full signal.
+// It does only when the core count was readable: cores <= 0 means the cgroup's
+// cpuset could not be read, so there is no capacity to be full against. Why a
+// machine-wide busy time may be subtracted from cores, which is a
+// container-scoped count: see host_source.go's header.
+//
+// message.go reads this too, and that is the point of it being a function. The
+// Technical Details table prints one headroom line per capacity signal the
+// table holds, so a second copy of the condition there could come apart from
+// this one and print a line for a rule nothing is judging.
+func hostCpuFullDeclared(cores float64) bool {
+	return cores > 0
+}
+
+// containerLimitFullDeclared reports whether the table holds the
+// out-of-our-own-limit signal. It does only when a positive quota exists: with
+// no limit there is nothing to saturate, and Fire{At: 0} against
+// Clear{At: 0.05 x 0} is a pair NewEngine rejects.
+//
+// hostCpuFullDeclared's header says why this is a function rather than an
+// inline comparison.
+func containerLimitFullDeclared(quota float64) bool {
+	return quota > 0
 }

--- a/umh-core/pkg/cpuhealth/verdict.go
+++ b/umh-core/pkg/cpuhealth/verdict.go
@@ -73,6 +73,15 @@ const (
 // reader of one does not have to go back to the table for it.
 type Unit string
 
+// The three units the CPU mark pairs are denominated in. Each signal_*.go
+// declares one beside its marks, and the Technical Details table reads it to
+// decide whether a threshold is written as a percentage or as a cores figure.
+const (
+	unitRatio    = "ratio"
+	unitFraction = "fraction"
+	unitCores    = "cores"
+)
+
 // cpuReserveCores is the no-limit headroom reserve: one core set aside for
 // Redpanda. It is Redpanda's default maxCores (--smp), not a calibration
 // guess. buildDetails stamps it onto Details.ReserveCores, so the message

--- a/umh-core/pkg/fsmv2/cpu/cpu.go
+++ b/umh-core/pkg/fsmv2/cpu/cpu.go
@@ -80,9 +80,11 @@ type CPUStatus struct {
 	// Message is the human-readable text Poll composed by calling
 	// cpuhealth.ComposeMessage: a headline such as
 	// "CPU healthy. This instance is using 0.0 of 2 cores (0% of its limit) and
-	// can use 1.8 more before it is marked degraded.", usually followed by a
-	// Technical Details line. Short forms carry no such line, among them the
-	// "CPU: starting up." message an instance shows for its first two ticks.
+	// can use 1.8 more before it is marked degraded.", then a Technical Details
+	// table of the five rules that can degrade this instance's CPU. The
+	// "CPU: starting up." message an instance shows for its first two ticks
+	// carries the table too, with every line saying why it has no figure yet.
+	// Only a failed cgroup read renders without one.
 	Message string `json:"message"`
 
 	// Details is the measured evidence behind the verdict, filled on every tick

--- a/umh-core/pkg/fsmv2/cpu/cpu.go
+++ b/umh-core/pkg/fsmv2/cpu/cpu.go
@@ -81,10 +81,13 @@ type CPUStatus struct {
 	// cpuhealth.ComposeMessage: a headline such as
 	// "CPU healthy. This instance is using 0.0 of 2 cores (0% of its limit) and
 	// can use 1.8 more before it is marked degraded.", then a Technical Details
-	// table of the five rules that can degrade this instance's CPU. The
+	// table of the rules that can degrade this instance's CPU. A box under a
+	// CPU limit is judged against two ceilings at once, its own limit and the
+	// machine, and the table carries a headroom line for each. The
 	// "CPU: starting up." message an instance shows for its first two ticks
-	// carries the table too, with every line saying why it has no figure yet.
-	// Only a failed cgroup read renders without one.
+	// carries the table too, and a line whose window has not reduced yet says
+	// so instead of stating a figure. Only a failed cgroup read renders without
+	// a table at all.
 	Message string `json:"message"`
 
 	// Details is the measured evidence behind the verdict, filled on every tick

--- a/umh-core/pkg/fsmv2/cpu/cpu.go
+++ b/umh-core/pkg/fsmv2/cpu/cpu.go
@@ -77,25 +77,15 @@ type CPUStatus struct {
 	// or "degraded"), and empty when the tick could not measure.
 	Verdict string `json:"verdict"`
 
-	// Message is the human-readable text Poll composed by calling
-	// cpuhealth.ComposeMessage: a headline such as
-	// "CPU healthy. This instance is using 0.0 of 2 cores (0% of its limit) and
-	// can use 1.8 more before it is marked degraded.", then a Technical Details
-	// table of the rules that can degrade this instance's CPU. A box under a
-	// CPU limit is judged against two ceilings at once, its own limit and the
-	// machine, and the table carries a headroom line for each. The
-	// "CPU: starting up." message an instance shows for its first two ticks
-	// carries the table too, and a line whose window has not reduced yet says
-	// so instead of stating a figure. Only a failed cgroup read renders without
-	// a table at all.
+	// Message is what cpuhealth.ComposeMessage rendered: a headline, then a
+	// Technical Details table with one headroom line per ceiling the instance is
+	// judged against. Only a failed cgroup read renders without a table.
 	Message string `json:"message"`
 
 	// Details is the measured evidence behind the verdict, filled on every tick
-	// that could measure. It is a named field, not an embed, so its keys nest
-	// under "details" instead of flattening into the top level simple.Status
-	// merges "reason" and "degraded" into alongside "verdict" and "message".
-	// The wire shape under "details" is cpuhealth.Details' own, so a field added
-	// there reaches the wire with no change in this package.
+	// that could measure. It is a named field rather than an embed, so its keys
+	// nest under "details" instead of colliding with the "reason" and "degraded"
+	// that simple.Status flattens to the top level.
 	Details cpuhealth.Details `json:"details"`
 }
 


### PR DESCRIPTION
## Problem

The healthy state gave out detailed Technical Details, but the degraded states did not. And in a
degraded state you want to know a bit about when it triggers and when it does not.

## What we are shipping

- **Every state carries Technical Details.**
- **Each rule states its own threshold.**
- **A rule that has tripped shows what it takes to recover, not what it took to trip.**
- **Rules that cannot apply here say so, and say why** — "not possible" on a machine that cannot
  report the signal, "measuring" while the window is still filling. Previously they were absent.
- **Thresholds are read from the rule that enforces them, not copied into the message.**

## What we are NOT shipping

- **No wire change.**
- **No changelog entry.**
- **A failed cgroup read keeps its bare line.** When the read failed we do not know which rules
  apply, so a table would state more than we know.
- **A failed `/proc/stat` read still says "measuring" rather than naming the read failure.** It needs
  a third wording and a new field, and it only happens on a box that is already broken.
