### PR TITLE
fix(fsmv2): drop type arguments from generic state names

### DIFF
--- a/umh-core/pkg/fsmv2/internal/helpers/base_state.go
+++ b/umh-core/pkg/fsmv2/internal/helpers/base_state.go
@@ -71,17 +71,21 @@ func DeriveStateName(state interface{}) string {
 		t = t.Elem()
 	}
 
-	name := t.Name()
-
-	// A generic type's reflect name carries its type arguments in brackets,
-	// each spelled with its full import path. That makes the name unusable as a
-	// log field or metric label, and the "State" suffix trim below cannot match
-	// while the brackets are still there.
-	if i := strings.IndexByte(name, '['); i >= 0 {
-		name = name[:i]
-	}
+	name := stripTypeArguments(t.Name())
 
 	name = strings.TrimSuffix(name, "State")
+
+	return name
+}
+
+// stripTypeArguments drops the bracketed type arguments a generic type carries
+// in its reflect name, each of which is spelled with its full import path. That
+// makes the raw name unusable as a log field or metric label, and leaves the
+// "State" suffix unreachable behind the closing bracket.
+func stripTypeArguments(name string) string {
+	if i := strings.IndexByte(name, '['); i >= 0 {
+		return name[:i]
+	}
 
 	return name
 }

--- a/umh-core/pkg/fsmv2/internal/helpers/base_state.go
+++ b/umh-core/pkg/fsmv2/internal/helpers/base_state.go
@@ -59,8 +59,9 @@ func (b BaseState) StateNameFromType(state interface{}) string {
 }
 
 // DeriveStateName derives a state name from the given value's type name.
-// It strips the "State" suffix if present.
-// e.g., RunningState -> "Running", TryingToStartState -> "TryingToStart"
+// It drops any type arguments and then strips the "State" suffix if present.
+// e.g., RunningState -> "Running", TryingToStartState -> "TryingToStart",
+// runningState[pkg.Config,pkg.Status] -> "running"
 //
 // This is a package-level function that can be used directly without
 // needing a BaseState instance.
@@ -71,6 +72,15 @@ func DeriveStateName(state interface{}) string {
 	}
 
 	name := t.Name()
+
+	// A generic type's reflect name carries its type arguments in brackets,
+	// each spelled with its full import path. That makes the name unusable as a
+	// log field or metric label, and the "State" suffix trim below cannot match
+	// while the brackets are still there.
+	if i := strings.IndexByte(name, '['); i >= 0 {
+		name = name[:i]
+	}
+
 	name = strings.TrimSuffix(name, "State")
 
 	return name

--- a/umh-core/pkg/fsmv2/internal/helpers/base_state_test.go
+++ b/umh-core/pkg/fsmv2/internal/helpers/base_state_test.go
@@ -90,6 +90,21 @@ func (s StateWithFields) String() string {
 	return s.StateNameFromType(s)
 }
 
+// Generic test state types. A generic type's reflect name carries its type
+// arguments, so these cover the bracket-stripping path.
+
+type configArg struct{}
+
+type statusArg struct{}
+
+type genericState[A, B any] struct {
+	helpers.BaseState
+}
+
+type widget[A any] struct {
+	helpers.BaseState
+}
+
 var _ = Describe("BaseState", func() {
 	Describe("String() method", func() {
 		Context("with standard state names ending in 'State'", func() {
@@ -208,6 +223,16 @@ var _ = Describe("BaseState", func() {
 			type MyCustomType struct{}
 			state := MyCustomType{}
 			Expect(helpers.DeriveStateName(state)).To(Equal("MyCustomType"))
+		})
+
+		It("should drop the type arguments of a generic state", func() {
+			state := &genericState[configArg, statusArg]{}
+			Expect(helpers.DeriveStateName(state)).To(Equal("generic"))
+		})
+
+		It("should drop the type arguments of a generic type with no State suffix", func() {
+			state := &widget[configArg]{}
+			Expect(helpers.DeriveStateName(state)).To(Equal("widget"))
 		})
 	})
 })

--- a/umh-core/pkg/fsmv2/simple/state_test.go
+++ b/umh-core/pkg/fsmv2/simple/state_test.go
@@ -132,4 +132,16 @@ var _ = Describe("state machine", func() {
 			Expect(res.State).To(BeAssignableToTypeOf(&runningState[probeConfig, probeStatus]{}))
 		})
 	})
+
+	Describe("state names", func() {
+		// These names reach operators as log fields and as Prometheus label
+		// values on state_transitions_total. The states are generic, so their
+		// reflect names carry the full import path of every type argument
+		// unless DeriveStateName drops them.
+		It("names the states without their type arguments", func() {
+			Expect((&runningState[probeConfig, probeStatus]{}).String()).To(Equal("running"))
+			Expect((&degradedState[probeConfig, probeStatus]{}).String()).To(Equal("degraded"))
+			Expect((&stoppedState[probeConfig, probeStatus]{}).String()).To(Equal("stopped"))
+		})
+	})
 })


### PR DESCRIPTION
## Problem

The state transition logs print the full generic type name for `from_state` and `to_state`. We only
need `degraded` and `stopped`.

For reference:

    "from_state": "degradedState[github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/cpu.CPUConfig,github.com/.../cpu.CPUStatus]"

## What we are shipping

- **State names drop their type arguments**, so `from_state` and `to_state` read `degraded` and
  `stopped`.

## What we are NOT shipping

- **No change to non-generic states.** Around sixty exist and their names are byte-identical before
  and after.

⚠️ `state_transitions_total` is labelled by `from_state` and `to_state`, so this changes metric
label values as well as log text. Dashboards keyed on the old values will need updating.
