### PR TITLE
fix(diagnosis): measure window coverage from the first reading

### DIFF
--- a/umh-core/pkg/diagnosis/latch_foreign_release_test.go
+++ b/umh-core/pkg/diagnosis/latch_foreign_release_test.go
@@ -43,7 +43,7 @@ import (
 var _ = Describe("Latch release is judged on the pair the episode fired under", func() {
 	const fireSpan = 60 * time.Second
 
-	full := Coverage{span: fireSpan, covered: fireSpan}
+	full := Coverage{span: fireSpan, collectedFor: fireSpan}
 
 	// Two answers to one question, in different units and opposite directions:
 	// spare cores falling is bad (LowerIsWorse), usage fraction rising is bad

--- a/umh-core/pkg/diagnosis/latch_irregular_interval_test.go
+++ b/umh-core/pkg/diagnosis/latch_irregular_interval_test.go
@@ -22,8 +22,7 @@ import (
 )
 
 var _ = Describe("A latch driven from a real SlidingWindow", func() {
-	// windowSpan and nonDividingInterval come from sliding_window_coverage_test.go,
-	// which also pins the interval against dividing the span.
+	// windowSpan and nonDividingInterval are declared in sliding_window_coverage_test.go.
 	const (
 		ticks   = 120
 		dropsAt = 90

--- a/umh-core/pkg/diagnosis/latch_irregular_interval_test.go
+++ b/umh-core/pkg/diagnosis/latch_irregular_interval_test.go
@@ -1,0 +1,73 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package diagnosis
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("A latch driven from a real SlidingWindow", func() {
+	// windowSpan and nonDividingInterval come from sliding_window_coverage_test.go,
+	// which also pins the interval against dividing the span.
+	const (
+		ticks   = 120
+		dropsAt = 90
+	)
+
+	marks := func() Marks {
+		return Marks{
+			Fire:     Mark{At: 0.10, Inclusive: false},
+			Clear:    Mark{At: 0.06, Inclusive: false},
+			Polarity: HigherIsWorse,
+		}
+	}
+
+	It("should release once the value crosses the clear mark, on a tick interval that does not divide the span", func() {
+		w, err := NewSlidingWindow(windowSpan, windowSpan, Last, false)
+		Expect(err).NotTo(HaveOccurred())
+
+		l := NewLatch(Identity{})
+		base := time.Unix(1_000_000, 0)
+
+		firedBeforeDrop := false
+
+		for i := range ticks {
+			at := base.Add(time.Duration(i) * nonDividingInterval)
+
+			v := 0.20
+			if i >= dropsAt {
+				v = 0.02
+			}
+
+			w.Observe(Known(v), Unknown(), at)
+			l.Update("probe", w.Reduce(), w.Coverage(), marks(), at)
+
+			if i == dropsAt-1 {
+				_, firedBeforeDrop = l.Fired()
+			}
+		}
+
+		Expect(firedBeforeDrop).To(BeTrue(),
+			"the value above the fire mark never fired the latch, so the release below is not being tested at all")
+
+		_, fired := l.Fired()
+		Expect(fired).To(BeFalse(),
+			"the value sat below the clear mark for %d ticks and the window had been collecting for longer than %s, but the latch never released",
+			ticks-dropsAt, windowSpan)
+	})
+})

--- a/umh-core/pkg/diagnosis/latch_signature_test.go
+++ b/umh-core/pkg/diagnosis/latch_signature_test.go
@@ -33,7 +33,7 @@ import (
 // judged, stamped beside the marks when the latch fires.
 var _ = Describe("Latch signature", func() {
 	It("should derive its state from the reduction and the window's extent, and from no readability fact of any kind", func() {
-		// Coverage is exactly two time.Duration fields (span, covered) and
+		// Coverage is exactly two time.Duration fields (span, collectedFor) and
 		// nothing else, no bool, no Reading. The clear arm and re-fire arm are
 		// gated on these; a window that has already engaged its freeze (a second
 		// consecutive failed read) still spans its full duration, which is why

--- a/umh-core/pkg/diagnosis/latch_test.go
+++ b/umh-core/pkg/diagnosis/latch_test.go
@@ -39,8 +39,8 @@ var _ = Describe("Latch", func() {
 			Polarity: HigherIsWorse,
 		}
 	}
-	full := func() Coverage { return Coverage{span: latchSpan, covered: latchSpan} }
-	short := func() Coverage { return Coverage{span: latchSpan, covered: 30 * time.Second} }
+	full := func() Coverage { return Coverage{span: latchSpan, collectedFor: latchSpan} }
+	short := func() Coverage { return Coverage{span: latchSpan, collectedFor: 30 * time.Second} }
 
 	// Two mark pairs for one signal, in different units and opposite polarities:
 	// what an instrument change hands the latch.

--- a/umh-core/pkg/diagnosis/sliding_window.go
+++ b/umh-core/pkg/diagnosis/sliding_window.go
@@ -29,23 +29,17 @@ import (
 	"time"
 )
 
-// Coverage is how much of its span a window has collected: the span it was built
-// with, and how long readings have been arriving, capped at that span.
+// Coverage is how much of its span a window has collected, capped at that span.
 //
 // A span of TIME is not a span of READINGS: two readings far apart can report Full.
 // How many readings a judgement needs is the reduction's Min, not this.
 type Coverage struct {
-	span time.Duration
-	// covered is how long readings have been arriving, from the window's first
-	// stored reading, capped at span. NOT the extent of the readings currently
-	// held: prune removes the early ones, so what remains cannot say how long
-	// collection has been running.
-	covered time.Duration
+	span         time.Duration
+	collectedFor time.Duration
 }
 
-// Full reports whether the window has collected for its whole span: it separates a
-// filled window from one that has only just started.
-func (c Coverage) Full() bool { return c.span > 0 && c.covered >= c.span }
+// Full separates a filled window from one that has only just started.
+func (c Coverage) Full() bool { return c.span > 0 && c.collectedFor >= c.span }
 
 // SlidingWindow accumulates readings for one measured series: a time-ordered
 // slice of Points, pruned from the front once they age past the span.
@@ -255,10 +249,10 @@ func denominatorDelta(points []Point) float64 {
 // Coverage reports the window's span and how long it has been collecting, for the
 // latch arms gated on those rather than on the reduced number.
 func (w *SlidingWindow) Coverage() Coverage {
-	var covered time.Duration
+	var collectedFor time.Duration
 	if len(w.points) >= 2 {
-		covered = min(w.span, w.lastStored().Sub(w.firstStored))
+		collectedFor = min(w.span, w.lastStored().Sub(w.firstStored))
 	}
 
-	return Coverage{span: w.span, covered: covered}
+	return Coverage{span: w.span, collectedFor: collectedFor}
 }

--- a/umh-core/pkg/diagnosis/sliding_window.go
+++ b/umh-core/pkg/diagnosis/sliding_window.go
@@ -29,10 +29,11 @@ import (
 	"time"
 )
 
-// Coverage is how much of its span a window has collected, capped at that span.
+// Coverage is what a window can say about its own extent: the span it was built
+// with, and how long it has been collecting.
 //
 // A span of TIME is not a span of READINGS: two readings far apart can report Full.
-// How many readings a judgement needs is the reduction's Min, not this.
+// How many readings a judgement needs is the reduction's Min, not this type.
 type Coverage struct {
 	span         time.Duration
 	collectedFor time.Duration
@@ -129,11 +130,10 @@ func (w *SlidingWindow) prune(cutoff time.Time) {
 	w.points = w.points[i:]
 }
 
-// appendPoint stores one instant's reading; an absent or non-finite value stores
-// nothing, and callers must not pre-filter.
-// appendPoint stores one reading, and REQUIRES at to be no earlier than the
-// newest instant already held. Every reader here assumes points is ascending by
-// At, and nothing enforces it: the caller owns the clock, and Engine.Observe
+// appendPoint stores one instant's reading, and REQUIRES at to be no earlier than
+// the newest instant already held. An absent or non-finite value stores nothing,
+// and callers must not pre-filter. Every reader here assumes points is ascending
+// by At, and nothing enforces it: the caller owns the clock, and Engine.Observe
 // passes whatever instant it was handed.
 //
 // The assumption is load-bearing, so here is what a late reading actually does,
@@ -146,7 +146,7 @@ func (w *SlidingWindow) prune(cutoff time.Time) {
 //	Coverage()    10s -> 1s, so Full() flips true -> false
 //	prune()       stops at the first entry not before its cutoff, so the late
 //	              entry outlives it; and a reading earlier than the window's first
-//	              makes covered negative, which reads as not full
+//	              makes collectedFor negative, which reads as not full
 //
 // The Coverage consequence is the one that reaches behaviour: Latch's clear arm
 // is gated on Coverage.Full(), so a single late reading can withhold a release
@@ -251,7 +251,7 @@ func denominatorDelta(points []Point) float64 {
 func (w *SlidingWindow) Coverage() Coverage {
 	var collectedFor time.Duration
 	if len(w.points) >= 2 {
-		collectedFor = min(w.span, w.lastStored().Sub(w.firstStored))
+		collectedFor = w.lastStored().Sub(w.firstStored)
 	}
 
 	return Coverage{span: w.span, collectedFor: collectedFor}

--- a/umh-core/pkg/diagnosis/sliding_window.go
+++ b/umh-core/pkg/diagnosis/sliding_window.go
@@ -29,15 +29,28 @@ import (
 	"time"
 )
 
-// Coverage is how much of its span a window's readings cover: the span it was
-// built with, and oldest-to-newest of what it holds.
+// Coverage is how much of its span a window has collected: the span it was built
+// with, and how long readings have been arriving, capped at that span.
+//
+// A span of TIME is not a span of READINGS: two readings far apart can report Full.
+// The floor on how much evidence a judgement rests on is the reduction's Min, not
+// this type.
+//
+// Coverage is NOT a readability fact and must never be made into one. The latch
+// derives its state from the reduction and from this, never from a readability
+// flag, which is why Coverage is two durations and nothing else.
 type Coverage struct {
-	span    time.Duration
+	span time.Duration
+	// covered is how long readings have been arriving, measured from the window's
+	// first stored reading and capped at span. It is NOT the extent of the readings
+	// currently held: prune removes the early ones, so what remains cannot say how
+	// long collection has been running. sliding_window_coverage_test.go pins both
+	// directions — full after a span of collecting, not full before.
 	covered time.Duration
 }
 
-// Full reports whether the stored readings span the window's whole duration: it
-// separates a filled window from one that has only just started.
+// Full reports whether the window has collected for its whole span: it separates a
+// filled window from one that has only just started.
 func (c Coverage) Full() bool { return c.span > 0 && c.covered >= c.span }
 
 // SlidingWindow accumulates readings for one measured series: a time-ordered
@@ -48,6 +61,11 @@ type SlidingWindow struct {
 	span       time.Duration
 	demoteSpan time.Duration
 	counter    bool
+	// firstStored is the instant of the first reading stored since the window was
+	// last empty. A prune that empties the window leaves it set, which no reader
+	// sees: the next store re-seeds it, and Coverage reports zero below two
+	// readings.
+	firstStored time.Time
 	// lastAppendStored is whether the most recent appendPoint stored a reading.
 	// age runs before this tick's store, so there it means the previous tick.
 	lastAppendStored bool
@@ -140,8 +158,8 @@ func (w *SlidingWindow) prune(cutoff time.Time) {
 //	                                 oldest-arriving instant, not the newest
 //	Coverage()    10s -> 1s, so Full() flips true -> false
 //	prune()       stops at the first entry not before its cutoff, so the late
-//	              entry outlives it, and the extent goes negative on the very
-//	              next prune: prune(+10s) leaves [10s 1s], reading -9s
+//	              entry outlives it; and a reading earlier than the window's first
+//	              makes covered negative, which reads as not full
 //
 // The Coverage consequence is the one that reaches behaviour: Latch's clear arm
 // is gated on Coverage.Full(), so a single late reading can withhold a release
@@ -187,6 +205,11 @@ func (w *SlidingWindow) appendPoint(value, against Reading, at time.Time) {
 		if restart {
 			w.points = nil
 		}
+	}
+
+	// An empty window is a window that has just started collecting.
+	if len(w.points) == 0 {
+		w.firstStored = at
 	}
 
 	w.points = append(w.points, Point{At: at, Value: v, Against: against})
@@ -237,11 +260,12 @@ func denominatorDelta(points []Point) float64 {
 	return last - first
 }
 
-// Coverage reports how much of its span the stored readings cover.
+// Coverage reports the window's span and how long it has been collecting, for the
+// latch arms gated on those rather than on the reduced number.
 func (w *SlidingWindow) Coverage() Coverage {
 	var covered time.Duration
 	if len(w.points) >= 2 {
-		covered = w.points[len(w.points)-1].At.Sub(w.points[0].At)
+		covered = min(w.span, w.lastStored().Sub(w.firstStored))
 	}
 
 	return Coverage{span: w.span, covered: covered}

--- a/umh-core/pkg/diagnosis/sliding_window.go
+++ b/umh-core/pkg/diagnosis/sliding_window.go
@@ -33,19 +33,13 @@ import (
 // with, and how long readings have been arriving, capped at that span.
 //
 // A span of TIME is not a span of READINGS: two readings far apart can report Full.
-// The floor on how much evidence a judgement rests on is the reduction's Min, not
-// this type.
-//
-// Coverage is NOT a readability fact and must never be made into one. The latch
-// derives its state from the reduction and from this, never from a readability
-// flag, which is why Coverage is two durations and nothing else.
+// How many readings a judgement needs is the reduction's Min, not this.
 type Coverage struct {
 	span time.Duration
-	// covered is how long readings have been arriving, measured from the window's
-	// first stored reading and capped at span. It is NOT the extent of the readings
-	// currently held: prune removes the early ones, so what remains cannot say how
-	// long collection has been running. sliding_window_coverage_test.go pins both
-	// directions — full after a span of collecting, not full before.
+	// covered is how long readings have been arriving, from the window's first
+	// stored reading, capped at span. NOT the extent of the readings currently
+	// held: prune removes the early ones, so what remains cannot say how long
+	// collection has been running.
 	covered time.Duration
 }
 
@@ -62,9 +56,8 @@ type SlidingWindow struct {
 	demoteSpan time.Duration
 	counter    bool
 	// firstStored is the instant of the first reading stored since the window was
-	// last empty. A prune that empties the window leaves it set, which no reader
-	// sees: the next store re-seeds it, and Coverage reports zero below two
-	// readings.
+	// last empty. A prune that empties the window leaves it set; nothing reads it,
+	// because the next store re-seeds it and Coverage reports zero below two readings.
 	firstStored time.Time
 	// lastAppendStored is whether the most recent appendPoint stored a reading.
 	// age runs before this tick's store, so there it means the previous tick.
@@ -207,7 +200,6 @@ func (w *SlidingWindow) appendPoint(value, against Reading, at time.Time) {
 		}
 	}
 
-	// An empty window is a window that has just started collecting.
 	if len(w.points) == 0 {
 		w.firstStored = at
 	}

--- a/umh-core/pkg/diagnosis/sliding_window_coverage_test.go
+++ b/umh-core/pkg/diagnosis/sliding_window_coverage_test.go
@@ -1,0 +1,70 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package diagnosis
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// The span and tick interval the coverage specs here and the latch spec in
+// latch_irregular_interval_test.go both run at. One home, because the interval not
+// dividing the span is the property under test and a shared constant can be pinned
+// once.
+const (
+	windowSpan = 60 * time.Second
+	// A constant offset rather than random jitter, so a failure is deterministic:
+	// under random jitter a release still happens, at a random delay, and the
+	// specs flake.
+	nonDividingInterval = 1001 * time.Millisecond
+)
+
+var _ = Describe("SlidingWindow coverage", func() {
+	It("should run its specs at a tick interval that does not divide the span", func() {
+		// At 1000ms the specs that turn on this interval pass against the defect
+		// they exist to catch. That is a one-character edit, so it is pinned here
+		// rather than trusted.
+		Expect(windowSpan % nonDividingInterval).NotTo(BeZero())
+	})
+
+	It("should report a full window on a tick interval that does not divide the span", func() {
+		w, err := NewSlidingWindow(windowSpan, windowSpan, Last, false)
+		Expect(err).NotTo(HaveOccurred())
+
+		base := time.Unix(1_000_000, 0)
+		for i := range 120 {
+			w.Observe(Known(0.5), Unknown(), base.Add(time.Duration(i)*nonDividingInterval))
+		}
+
+		Expect(w.Coverage().Full()).To(BeTrue(),
+			"the window collected for longer than its span, so it should report full whatever the interval")
+	})
+
+	It("should not report a full window before it has collected for its span", func() {
+		w, err := NewSlidingWindow(windowSpan, windowSpan, Last, false)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Two readings: enough that the answer turns on the measurement rather than
+		// on the window holding too little to measure.
+		base := time.Unix(1_000_000, 0)
+		w.Observe(Known(0.5), Unknown(), base)
+		w.Observe(Known(0.5), Unknown(), base.Add(nonDividingInterval))
+
+		Expect(w.Coverage().Full()).To(BeFalse(),
+			"a window two ticks old reported a full span, so a latch could release before the window has collected for one")
+	})
+})

--- a/umh-core/pkg/diagnosis/sliding_window_coverage_test.go
+++ b/umh-core/pkg/diagnosis/sliding_window_coverage_test.go
@@ -21,23 +21,19 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-// The span and tick interval the coverage specs here and the latch spec in
-// latch_irregular_interval_test.go both run at. One home, because the interval not
-// dividing the span is the property under test and a shared constant can be pinned
-// once.
+// The span and tick interval used by the coverage specs here and by the latch spec
+// in latch_irregular_interval_test.go.
 const (
 	windowSpan = 60 * time.Second
-	// A constant offset rather than random jitter, so a failure is deterministic:
-	// under random jitter a release still happens, at a random delay, and the
-	// specs flake.
+	// A constant offset, not random jitter: under jitter a release still happens, at
+	// a random delay, and the specs flake.
 	nonDividingInterval = 1001 * time.Millisecond
 )
 
 var _ = Describe("SlidingWindow coverage", func() {
 	It("should run its specs at a tick interval that does not divide the span", func() {
-		// At 1000ms the specs that turn on this interval pass against the defect
-		// they exist to catch. That is a one-character edit, so it is pinned here
-		// rather than trusted.
+		// At 1000ms the specs keyed on this interval pass against the defect they
+		// exist to catch. A one-character edit, so it is pinned rather than trusted.
 		Expect(windowSpan % nonDividingInterval).NotTo(BeZero())
 	})
 
@@ -58,8 +54,8 @@ var _ = Describe("SlidingWindow coverage", func() {
 		w, err := NewSlidingWindow(windowSpan, windowSpan, Last, false)
 		Expect(err).NotTo(HaveOccurred())
 
-		// Two readings: enough that the answer turns on the measurement rather than
-		// on the window holding too little to measure.
+		// Two readings, so the answer turns on the measurement rather than on having
+		// too little to measure.
 		base := time.Unix(1_000_000, 0)
 		w.Observe(Known(0.5), Unknown(), base)
 		w.Observe(Known(0.5), Unknown(), base.Add(nonDividingInterval))


### PR DESCRIPTION
## Problem

Throttling never goes away once it fires — the verdict stays `degraded` long after throttling has decayed to zero, and only a restart clears it (seen with the fsmv2 CLI runner under `stress-ng`). Reason: the release check only passes when the poll interval divides the 60-second window exactly, and real intervals never do. Firing doesn't use that check, so the signal fires normally and then has no way out.

## What we are shipping

Instead of a release check that can only pass when the timing lands exactly right, the window now reports how long it has been collecting. The check passes once the window has been collecting for at least 60 seconds, not only when a reading lands exactly 60 seconds back.

## What we are NOT shipping

- **Firing still doesn't check for a full window.** That's deliberate — a signal should warn quickly and give the all-clear only on a full window.
- **Two successful reads 60 seconds apart now satisfy the release check** — thinner than before, when it needed readings spread across the whole window. How many readings a verdict actually needs is set by each signal: two for an average, twenty for a 95th percentile.
- **A test that the verdicts come out the same at any poll rate.** Stronger than the tests here, and easy to write so that it passes without testing anything, so it gets its own change.
- **Two other ways a signal can stay stuck**, both untouched: ENG-5639, where a different measurement blocks the release, and ENG-5641, where a late reading withholds one that was due.

Fixes ENG-5780
