### PR TITLE
chore: update openssl for container manually

### DIFF
--- a/umh-core/Dockerfile
+++ b/umh-core/Dockerfile
@@ -147,12 +147,9 @@ COPY --from=build /go/bin/umh-core /usr/local/bin/umh-core
 # Install coreutils (this allows date resolution beyond seconds)
 RUN apk add --no-cache coreutils
 
-ARG OPENSSL_VERSION=MUST_BE_SET_BY_MAKEFILE
 # Added manually for an Aikido finding: the alpine base image still ships openssl 3.5.7-r0.
 # Must stay after the COPY --from=downloader, which replaces this stage's root.
-RUN apk add --no-cache --upgrade \
-    libcrypto3=${OPENSSL_VERSION} \
-    libssl3=${OPENSSL_VERSION}
+RUN apk add --no-cache --upgrade libcrypto3 libssl3
 
 # Create non-root user and set ownership at build-time
 RUN adduser -D -u 1000 -s /bin/sh umhuser && \

--- a/umh-core/Dockerfile
+++ b/umh-core/Dockerfile
@@ -147,6 +147,13 @@ COPY --from=build /go/bin/umh-core /usr/local/bin/umh-core
 # Install coreutils (this allows date resolution beyond seconds)
 RUN apk add --no-cache coreutils
 
+ARG OPENSSL_VERSION=MUST_BE_SET_BY_MAKEFILE
+# Added manually for an Aikido finding: the alpine base image still ships openssl 3.5.7-r0.
+# Must stay after the COPY --from=downloader, which replaces this stage's root.
+RUN apk add --no-cache --upgrade \
+    libcrypto3=${OPENSSL_VERSION} \
+    libssl3=${OPENSSL_VERSION}
+
 # Create non-root user and set ownership at build-time
 RUN adduser -D -u 1000 -s /bin/sh umhuser && \
     mkdir -p /data/logs /data/logs/umh-core /data/services /data/benthos /data/redpanda/coredump && \

--- a/umh-core/Makefile
+++ b/umh-core/Makefile
@@ -66,6 +66,7 @@ DLV_VERSION = v1.25.1
 
 # Default values for build arguments
 NMAP_VERSION = 7.99-r0
+OPENSSL_VERSION = 3.5.8-r0
 S6_OVERLAY_VERSION = 3.2.0.2
 REDPANDA_VERSION = 24.3.18
 ## Benthos version is a tag or a sha-<commit hash> (e.g. 0.9.4 or sha-a51a685) to be used in the docker image
@@ -185,6 +186,7 @@ download-docker-binaries:
 # Used by both local builds (make build) and CI builds (make build-depot)
 VERSION_ARGS = \
 	--build-arg NMAP_VERSION=$(NMAP_VERSION) \
+	--build-arg OPENSSL_VERSION=$(OPENSSL_VERSION) \
 	--build-arg S6_OVERLAY_VERSION=$(S6_OVERLAY_VERSION) \
 	--build-arg BENTHOS_UMH_VERSION=$(BENTHOS_UMH_VERSION) \
 	--build-arg REDPANDA_VERSION=$(REDPANDA_VERSION) \
@@ -437,6 +439,7 @@ update-go-dependencies:
 # Print version variables for use in other scripts/tools
 print-versions:
 	@echo "NMAP_VERSION=$(NMAP_VERSION)"
+	@echo "OPENSSL_VERSION=$(OPENSSL_VERSION)"
 	@echo "S6_OVERLAY_VERSION=$(S6_OVERLAY_VERSION)"
 	@echo "BENTHOS_UMH_VERSION=$(BENTHOS_UMH_VERSION)"
 	@echo "REDPANDA_VERSION=$(REDPANDA_VERSION)"

--- a/umh-core/Makefile
+++ b/umh-core/Makefile
@@ -66,7 +66,6 @@ DLV_VERSION = v1.25.1
 
 # Default values for build arguments
 NMAP_VERSION = 7.99-r0
-OPENSSL_VERSION = 3.5.8-r0
 S6_OVERLAY_VERSION = 3.2.0.2
 REDPANDA_VERSION = 24.3.18
 ## Benthos version is a tag or a sha-<commit hash> (e.g. 0.9.4 or sha-a51a685) to be used in the docker image
@@ -186,7 +185,6 @@ download-docker-binaries:
 # Used by both local builds (make build) and CI builds (make build-depot)
 VERSION_ARGS = \
 	--build-arg NMAP_VERSION=$(NMAP_VERSION) \
-	--build-arg OPENSSL_VERSION=$(OPENSSL_VERSION) \
 	--build-arg S6_OVERLAY_VERSION=$(S6_OVERLAY_VERSION) \
 	--build-arg BENTHOS_UMH_VERSION=$(BENTHOS_UMH_VERSION) \
 	--build-arg REDPANDA_VERSION=$(REDPANDA_VERSION) \
@@ -439,7 +437,6 @@ update-go-dependencies:
 # Print version variables for use in other scripts/tools
 print-versions:
 	@echo "NMAP_VERSION=$(NMAP_VERSION)"
-	@echo "OPENSSL_VERSION=$(OPENSSL_VERSION)"
 	@echo "S6_OVERLAY_VERSION=$(S6_OVERLAY_VERSION)"
 	@echo "BENTHOS_UMH_VERSION=$(BENTHOS_UMH_VERSION)"
 	@echo "REDPANDA_VERSION=$(REDPANDA_VERSION)"


### PR DESCRIPTION
# Description

This should fix the aikido openssl issue as a manual workaround. Usually we should keep on track with alpine image updates, but seemingly this wasn't fixed yet.