### PR TITLE
chore(changelog): promote Unreleased to 0.44.37

### DIFF
--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## [0.44.37]
+
 ### Fixes
 
 - Topics no longer go missing from the Topic Browser when several updates arrive in quick succession


### PR DESCRIPTION
Release prep for **v0.44.37**. Renames `## Unreleased` in `umh-core/CHANGELOG.md` to `## [0.44.37]` and opens a fresh empty `## Unreleased` above it, per `umh-core/RELEASING.md` step 1. No code change.

## What 0.44.37 ships

Two Topic Browser delivery fixes, both already on `staging`:

- Topics no longer go missing when several updates arrive in quick succession
- The Topic Browser updates as data arrives instead of in bursts roughly every 10 seconds

## Why the CPU health work has no entry

`#2740` (CPU health evidence sent to the Management Console) merged today with the `skip-changelog-guard` label. Its code path is reached only when the `USE_FSMV2_CPU` environment variable is set, and that variable defaults to `false`. A user on the default configuration sees no change, so there is nothing to tell them. The flag is read once at startup, so turning it on requires a restart.

## Next steps after this merges

1. `staging` → `main` PR
2. `gh release create v0.44.37 --target main --title "v0.44.37 - <title>"`