### PR TITLE
chore(changelog): add the 0.44.38 section for benthos v0.15.2

### DIFF
--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+## [0.44.38]
+
+### Improvements
+
+- The historian output takes `value_chunk_interval` and `attribute_chunk_interval`, setting how wide a TimescaleDB chunk is for each of its two hypertables, both still defaulting to 168h. An interval applies only when a table is created, so changing it later needs `set_chunk_time_interval` on the database, and a restart warns when a configured interval no longer matches its table
+
+### Fixes
+
+- The historian output now applies compression and retention to every data contract, not only the first one. Existing historian setups are unaffected
+- The historian no longer stores `timestamp_ms` as a tag attribute, which previously wrote one attribute row per data point
+
 ## [0.44.37]
 
 ### Fixes


### PR DESCRIPTION
Release prep for **v0.44.38**. Adds a `## [0.44.38]` section to `umh-core/CHANGELOG.md` carrying the benthos-umh v0.15.2 entries. No code change.

## Why a section rather than a rename

`RELEASING.md` step 1 renames `## Unreleased` to the version being released. Here `## Unreleased` is already empty: **v0.44.37 was promoted and released earlier today**, before `#2742` landed. So the section is created directly and `## Unreleased` stays empty, which is what the next development cycle needs.

## Where the entries come from

`#2742` bumps `BENTHOS_UMH_VERSION` 0.15.1 to 0.15.2 and touches nothing else. It ships with `skip-changelog-guard`, and by the convention in the repo root `CLAUDE.md` its PR body **is** the changelog text. The Linear ids in that body are stripped here, because this changelog carries none anywhere in the file.

## Why this is a second release rather than part of 0.44.37

`#2742` was ejected from the merge queue at 12:43:26Z on a Depot `internal: internal error` during `build / Build and Push`. That was infrastructure, not the PR: the same commit `d3fe06d7` had already built successfully at PR level. While it was out of the queue, the 0.44.37 promotion merged, so the benthos work moves to its own release rather than being retro-fitted into a section that was already promoted.

## Pre-checks against staging

| Check | Result |
|---|---|
| `## Unreleased` empty | yes |
| `## [0.44.38]` non-empty | yes |
| `BENTHOS_UMH_VERSION` on staging | `0.15.2` |
| `ENG-` refs in the new section | 0 |

The version pin and the changelog text are checked together on purpose. Text alone would let notes describing benthos 0.15.2 pass while the Makefile still pinned 0.15.1, which would ship release notes for code the release does not contain.

## After this merges

```bash
gh release create v0.44.38 --target staging \
  --title "v0.44.38 - Historian Chunk Intervals and Retention Fixes"
```

`--target staging` matches v0.44.36 and v0.44.37, both of which were tagged that way with the full automation running.