### PR TITLE
test(integration): reproduce the fsmv2 nmap connection staleness bug

### DIFF
--- a/umh-core/.gitignore
+++ b/umh-core/.gitignore
@@ -2,6 +2,9 @@ data/
 
 integration/umh-config
 
+# Pulled from the private ManagementConsole repo by `make pull-managementconsole`
+integration/managementconsole
+
 *.test
 
 .docker-cache

--- a/umh-core/Makefile
+++ b/umh-core/Makefile
@@ -432,6 +432,49 @@ redpanda-extended-test: pre-test
 badssl-test: pre-test
 	go run github.com/onsi/ginkgo/v2/ginkgo -r --tags=test --label-filter='tls' --fail-fast ./...
 
+###############################################################################
+# ManagementConsole integration dependencies
+#
+# The connection-staleness integration tests drive umh-core through the *real*
+# ManagementConsole backend + router, run as local Go processes exactly the way
+# ManagementConsole's own Playwright e2e suite runs them. That source lives in
+# the private united-manufacturing-hub/ManagementConsole repo, so we pull only
+# the folders needed to build the two binaries using the developer's `gh`
+# credentials. Access to that repo is therefore required to run these tests.
+###############################################################################
+MC_REPO ?= united-manufacturing-hub/ManagementConsole
+MC_REF ?= staging
+MC_DIR := $(SRC_ROOT)/umh-core/integration/managementconsole
+
+.PHONY: pull-managementconsole connection-staleness-test
+
+pull-managementconsole: ## Pull backend+router source from the private ManagementConsole repo (needs `gh` access)
+	@command -v gh >/dev/null 2>&1 || { echo "❌ gh CLI not found — install https://cli.github.com"; exit 1; }
+	@gh auth status >/dev/null 2>&1 || { echo "❌ Not logged in to GitHub — run: gh auth login"; exit 1; }
+	@echo "📥 Pulling ManagementConsole ($(MC_REF)) backend+router into $(MC_DIR) ..."
+	@rm -rf "$(MC_DIR)"
+	@mkdir -p "$(MC_DIR)"
+	@TOKEN=$$(gh auth token) && \
+	  git clone --quiet --no-checkout --filter=blob:none --depth 1 --branch "$(MC_REF)" \
+	    "https://x-access-token:$$TOKEN@github.com/$(MC_REPO).git" "$(MC_DIR)" && \
+	  git -C "$(MC_DIR)" sparse-checkout init --no-cone && \
+	  printf '%s\n' '/backend/' '!/backend/backend' '/router/' '/shared/' '/cryptolib/' '/frontend/static/requirements.json' \
+	    > "$(MC_DIR)/.git/info/sparse-checkout" && \
+	  git -C "$(MC_DIR)" checkout --quiet && \
+	  git -C "$(MC_DIR)" remote set-url origin "https://github.com/$(MC_REPO).git"
+	@rm -f "$(MC_DIR)/backend/backend"
+	@printf '✅ ManagementConsole source ready (commit %s)\n' "$$(git -C '$(MC_DIR)' rev-parse --short HEAD)"
+
+# Runs the fsmv1+fsmv2 connection-edit staleness specs against the real
+# ManagementConsole backend+router. Pulls the source first (idempotent) and
+# leaves the intentionally-red fsmv2 spec out of --fail-fast by using its own
+# label so a failure there does not abort the fsmv1 spec.
+connection-staleness-test: pull-managementconsole build-protobuf
+	FORCE_DOCKER=true VERSION=$(VERSION) MC_DIR="$(MC_DIR)" \
+	  go run github.com/onsi/ginkgo/v2/ginkgo -r --tags=test \
+	  --skip-package=managementconsole \
+	  --label-filter='connection-staleness' --timeout=30m ./integration/...
+
 update-go-dependencies:
 	go get -u ./...
 	go mod tidy

--- a/umh-core/integration/connection_edit_staleness_test.go
+++ b/umh-core/integration/connection_edit_staleness_test.go
@@ -1,0 +1,441 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration_test
+
+// Full-instance integration test for the NMAP_BACKEND=fsmv2 stale-observation
+// bug across a bridge (protocolConverter) connection edit.
+//
+// A connection-only bridge (a protocolConverter with a connection template but
+// NO read/write DFC) reaches the ACCEPTED state starting_failed_dfc_missing when
+// its connection is up. The edit-protocol-converter action, for the DFCType
+// "empty" path, treats {active, idle, starting_failed_dfc_missing} as "rolled
+// out successfully".
+//
+// Scenario driven here end-to-end against a REAL container:
+//  1. Boot umh-core with a bridge whose connection nmap-probes a GOOD target
+//     (127.0.0.1:8080, the always-open in-container metrics server).
+//  2. Wait for the bridge to settle into an accepted state.
+//  3. Send an edit-protocol-converter ACTION (via the REAL ManagementConsole
+//     backend+router) that re-points the connection at a KNOWN-BAD target
+//     (127.0.0.1:65000, a closed port).
+//  4. Observe the terminal action-reply the agent pushes back.
+//
+// CORRECT behavior (fsmv1): editing the target restarts the S6 nmap service, the
+// probe of the bad target reports the port closed, the connection goes down, the
+// bridge leaves the accepted state, awaitRollout times out and rolls back →
+// terminal reply = action-failure.
+//
+// BUGGY behavior (fsmv2): the adapter serves the stale "open" scan of the OLD
+// target (keyed by an unchanged child ref, still Fresh by age), so the bridge
+// briefly reads healthy and stays in the accepted state → awaitRollout reports
+// action-success. This is WRONG.
+//
+// Both specs ASSERT the terminal reply is action-failure:
+//   - the fsmv1 spec PASSES (green) — correct behavior.
+//   - the fsmv2 spec is RED on purpose: it reproduces the bug (the agent pushes
+//     action-success). It must flip to green once the staleness bug is fixed.
+//     This mirrors the deliberately-red unit test in
+//     pkg/fsmv2/nmap/nmap_staleness_integration_test.go.
+//
+// These specs are NOT under Label("integration") (that suite runs --fail-fast,
+// which the intentionally-red fsmv2 spec would abort). Run them with:
+//
+//	make connection-staleness-test
+//
+// (which first runs `make pull-managementconsole` to fetch the backend+router
+// source from the private repo using your `gh` credentials, then runs:
+//
+//	FORCE_DOCKER=true VERSION=dev MC_DIR=... go run github.com/onsi/ginkgo/v2/ginkgo \
+//	  -r --tags=test --skip-package=managementconsole \
+//	  --label-filter='connection-staleness' --timeout=30m ./integration/...)
+//
+// --skip-package=managementconsole keeps ginkgo's -r discovery out of the pulled
+// ManagementConsole source tree (integration/managementconsole/), whose Go
+// packages otherwise fail to compile under the test runner (e.g. the
+// demo_simulator_v3 //go:embed requirements.json, present only at binary-build
+// time).
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"gopkg.in/yaml.v3"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/connectionserviceconfig"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/dataflowcomponentserviceconfig"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/protocolconverterserviceconfig"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/redpandaserviceconfig"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/variables"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/models"
+)
+
+const (
+	stalenessBridgeName = "bridge-conn"
+
+	// GOOD target: the in-container metrics server always listens on 8080.
+	stalenessGoodIP   = "127.0.0.1"
+	stalenessGoodPort = uint32(8080)
+
+	// BAD target: a closed port on loopback.
+	stalenessBadIP   = "127.0.0.1"
+	stalenessBadPort = uint32(65000)
+
+	// stalenessTagProcessorJS is the read DFC's tag_processor body. Static (no
+	// template variables) so the deployed template and the edit action's readDFC
+	// render to the same benthos config, keeping compareProtocolConverterDFCConfig
+	// a match across the edit. Uses the canonical _historian data contract.
+	stalenessTagProcessorJS = `msg.meta.location_path = "test-enterprise";
+msg.meta.data_contract = "_historian";
+msg.meta.tag_name = "my_data";
+msg.payload = msg.payload;
+return msg;`
+)
+
+// buildStalenessConfig builds a config.yaml with:
+//   - a communicator pointed at the real router (plain HTTP, insecure TLS),
+//   - one connection-only bridge targeting the GOOD target, desired "active",
+//   - redpanda active (a bridge only reaches starting_failed_dfc_missing once
+//     redpanda is healthy — see pkg/fsm/protocolconverter/reconcile.go).
+func buildStalenessConfig(apiURL string) string {
+	redpandaCfg := config.RedpandaConfig{
+		FSMInstanceConfig: config.FSMInstanceConfig{
+			Name:            "redpanda",
+			DesiredFSMState: "active",
+		},
+		RedpandaServiceConfig: redpandaserviceconfig.RedpandaServiceConfig{},
+	}
+	redpandaCfg.RedpandaServiceConfig.Resources.MaxCores = 1
+	redpandaCfg.RedpandaServiceConfig.Resources.MemoryPerCoreInBytes = 1024 * 1024 * 1024 * 2 // 2GB
+
+	// The bridge body for the root protocol converter. On disk a ROOT protocol
+	// converter (TemplateRef == Name) does NOT carry its body inline: the config
+	// parser (convertYamlToSpec, pkg/config/yamlParsing.go) resolves TemplateRef
+	// against the top-level templates.protocolConverter map and errors if the
+	// entry is missing — which silently empties the whole config. So the body
+	// lives here and the PC entry only references it.
+	//
+	// The bridge carries a READ dataflowcomponent so its accepted FSM state is
+	// gated on connection health. A connection-only bridge sits at the accepted
+	// state starting_failed_dfc_missing regardless of whether nmap sees the
+	// target up or down, so an edit to a dead target still "succeeds" — the bug
+	// cannot surface. With a read DFC the bridge only reaches active/idle while
+	// the connection is up (pkg/fsm/protocolconverter reconcile checks
+	// IsConnectionUp before the DFC), so re-pointing to a dead target drops it to
+	// degraded_connection/starting_connection, and awaitRollout (the DFCTypeRead
+	// path in edit-protocolconverter.go accepts only {active,idle}) fails. The
+	// output is intentionally omitted — the read DFC's egress is forced to the
+	// UNS publisher at render time (config_customized.go).
+	bridgeTemplate := protocolconverterserviceconfig.ProtocolConverterServiceConfigTemplate{
+		ConnectionServiceConfig: connectionserviceconfig.ConnectionServiceConfigTemplate{
+			NmapTemplate: &connectionserviceconfig.NmapConfigTemplate{
+				Target: "{{ .IP }}",
+				Port:   "{{ .PORT }}",
+			},
+		},
+		DataflowComponentReadServiceConfig: dataflowcomponentserviceconfig.DataflowComponentServiceConfig{
+			BenthosConfig: dataflowcomponentserviceconfig.BenthosConfig{
+				Input: map[string]any{
+					"generate": map[string]any{
+						"count":    0,
+						"interval": "1s",
+						"mapping":  `root = "hello world"`,
+					},
+				},
+				Pipeline: map[string]any{
+					"processors": []any{
+						map[string]any{"tag_processor": map[string]any{"defaults": stalenessTagProcessorJS}},
+					},
+				},
+				Buffer: map[string]any{"none": map[string]any{}},
+			},
+		},
+	}
+
+	full := config.FullConfig{
+		Templates: config.TemplatesConfig{
+			ProtocolConverter: map[string]any{
+				stalenessBridgeName: bridgeTemplate,
+			},
+		},
+		Agent: config.AgentConfig{
+			MetricsPort: 8080,
+			Location:    map[int]string{0: "test-enterprise"},
+			CommunicatorConfig: config.CommunicatorConfig{
+				APIURL:           apiURL,
+				AuthToken:        "test-token",
+				AllowInsecureTLS: true,
+			},
+		},
+		ProtocolConverter: []config.ProtocolConverterConfig{
+			{
+				FSMInstanceConfig: config.FSMInstanceConfig{
+					Name:            stalenessBridgeName,
+					DesiredFSMState: "active",
+				},
+				ProtocolConverterServiceConfig: protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec{
+					// TemplateRef == Name marks this bridge as a template ROOT (the
+					// body is in templates.protocolConverter above). A root is also
+					// required for the edit: AtomicEditProtocolConverter rejects
+					// editing a non-root child (pkg/config/protocolconverter.go), so
+					// the deployed bridge must be a root for the edit to reach
+					// awaitRollout.
+					TemplateRef: stalenessBridgeName,
+					Variables: variables.VariableBundle{
+						User: map[string]any{
+							"IP":   stalenessGoodIP,
+							"PORT": strconv.FormatUint(uint64(stalenessGoodPort), 10),
+						},
+					},
+					Location: map[string]string{
+						"0": "test-enterprise",
+					},
+				},
+			},
+		},
+		Internal: config.InternalConfig{
+			Redpanda: redpandaCfg,
+			TopicBrowser: config.TopicBrowserConfig{
+				FSMInstanceConfig: config.FSMInstanceConfig{
+					Name:            "topic-browser",
+					DesiredFSMState: "stopped",
+				},
+			},
+		},
+	}
+
+	out, err := yaml.Marshal(full)
+	Expect(err).NotTo(HaveOccurred())
+
+	return string(out)
+}
+
+// stalenessReadDFCActionPayload builds the "readDFC" object for the edit action,
+// matching the read DFC deployed in buildStalenessConfig's template. The input
+// and processor bodies are raw benthos YAML strings (marshaled so indentation of
+// the tag_processor block scalar is correct), which is the wire form the edit
+// action parses (dataflow-component-parser.go). No output is set — the read DFC's
+// egress is forced to the UNS publisher at render time. Keeping the body
+// identical to the deployed template makes compareProtocolConverterDFCConfig a
+// match across the edit, so success/failure hinges purely on the PC's FSM state
+// (and thus connection health), which is what distinguishes the nmap backends.
+func stalenessReadDFCActionPayload() map[string]any {
+	genData, err := yaml.Marshal(map[string]any{
+		"generate": map[string]any{
+			"count":    0,
+			"interval": "1s",
+			"mapping":  `root = "hello world"`,
+		},
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	procData, err := yaml.Marshal(map[string]any{
+		"tag_processor": map[string]any{"defaults": stalenessTagProcessorJS},
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	return map[string]any{
+		"state": "active",
+		"inputs": map[string]any{
+			"type": "generate",
+			"data": string(genData),
+		},
+		"pipeline": map[string]any{
+			"processors": map[string]any{
+				"0": map[string]any{
+					"type": "tag_processor",
+					"data": string(procData),
+				},
+			},
+		},
+	}
+}
+
+// bridgeReachedAcceptedState reports whether the bridge has reached one of the
+// accepted states for an "active" desired state. FSM state transitions are
+// written to the container's INTERNAL log (/data/logs/umh-core/current), not to
+// the docker stdout log, so this reads that file via `docker exec cat`. The
+// system snapshot logger prints "<name>: <currentState> → <desiredState>".
+func bridgeReachedAcceptedState() bool {
+	out, err := runDockerCommand("exec", getContainerName(), "cat", "/data/logs/umh-core/current")
+	if err != nil {
+		return false
+	}
+
+	for _, accepted := range []string{
+		stalenessBridgeName + ": starting_failed_dfc_missing",
+		stalenessBridgeName + ": idle",
+		stalenessBridgeName + ": active",
+	} {
+		if strings.Contains(out, accepted) {
+			GinkgoWriter.Printf("NMAP backend reached accepted state: %s", accepted)
+			return true
+		}
+	}
+
+	return false
+}
+
+// runConnectionEditStalenessSpec registers a full Ordered spec (BeforeAll boots
+// the container + real ManagementConsole stack, It drives the edit, AfterAll tears down) for the
+// given NMAP_BACKEND. It is invoked once per backend so each backend gets its
+// own independent container so a red fsmv2 result does not skip fsmv1.
+func runConnectionEditStalenessSpec(nmapBackend string) {
+	var backend *mcStack
+
+	BeforeAll(func() {
+		// The container encodes messages with corev1 (cmd/main.go); the test
+		// process must match so the container can decode our action and we can
+		// decode its replies. The backend relays Content opaquely.
+		encodingChooseCorev1()
+
+		var err error
+
+		backend, err = newMCStack(context.Background())
+		Expect(err).NotTo(HaveOccurred())
+
+		GinkgoWriter.Printf("ManagementConsole stack up, router at %s (NMAP_BACKEND=%s)\n", backend.apiURL(), nmapBackend)
+
+		// Extra `docker create` args:
+		//   - select the nmap backend,
+		//   - force the FSMv2 transport on (it hosts the fsmv2client the fsmv2 nmap
+		//     manager reads from),
+		//   - enable the communicator via API_URL/AUTH_TOKEN env. This is how
+		//     production umh-core (and ManagementConsole's docker.ts) wires the
+		//     backend connection: pkg/config/env.go reads API_URL/AUTH_TOKEN and
+		//     they gate the communicator at cmd/main.go:283. AUTH_TOKEN is the RAW
+		//     token; umh-core hashes it to LoginHash before sending, and mcStack
+		//     seeds that same hash.
+		//   - ALLOW_INSECURE_TLS for the plain-HTTP router,
+		//   - and let the container dial the host-bound router.
+		extraCreateArgs = []string{
+			"-e", "NMAP_BACKEND=" + nmapBackend,
+			"-e", "USE_FSMV2_TRANSPORT=true",
+			"-e", "API_URL=" + backend.apiURL(),
+			"-e", "AUTH_TOKEN=" + mcAuthToken,
+			"-e", "ALLOW_INSECURE_TLS=true",
+			"--add-host=host.docker.internal:host-gateway",
+		}
+
+		cfg := buildStalenessConfig(backend.apiURL())
+
+		err = BuildAndRunContainer(cfg, DEFAULT_MEMORY, DEFAULT_CPUS)
+		if err != nil {
+			printContainerDebugInfo()
+			Expect(err).NotTo(HaveOccurred(), "Container startup failed")
+		}
+
+		Expect(waitForMetrics()).To(Succeed(), "Metrics endpoint should be available")
+	})
+
+	AfterAll(func() {
+		PrintLogsAndStopContainer()
+
+		if backend != nil {
+			backend.stop()
+		}
+
+		extraCreateArgs = nil
+		skipConfigCopy = false
+
+		if !CurrentSpecReport().Failed() {
+			cleanupTmpDirs(getContainerName())
+		}
+	})
+
+	It("rolls back the connection edit to a bad target (terminal reply = action-failure)", func() {
+		By("waiting for the container to log in to the ManagementConsole backend")
+		Eventually(func() bool {
+			return backend.loginSeen()
+		}, 120*time.Second, 1*time.Second).Should(BeTrue(),
+			"container must complete login against the ManagementConsole backend")
+
+		time.Sleep(10 * time.Second)
+
+		By("waiting for the bridge to settle into an accepted state with the GOOD connection")
+		Eventually(bridgeReachedAcceptedState, 300*time.Second, 2*time.Second).Should(BeTrue(),
+			"bridge must reach starting_failed_dfc_missing/idle/active with the good target before editing")
+
+		By("enqueuing an edit-protocol-converter action re-pointing the connection at the BAD target")
+
+		time.Sleep(10 * time.Second)
+
+		actionUUID := uuid.New()
+		pcUUID := dataflowcomponentserviceconfig.GenerateUUIDFromName(stalenessBridgeName)
+
+		// The edit MUST carry the read DFC too. edit-protocolconverter.go derives
+		// DFCType from the payload: a connection-only edit → DFCTypeEmpty (the
+		// non-connection-gated rollout that accepts starting_failed_dfc_missing).
+		// Re-sending the read DFC keeps it DFCTypeRead, whose rollout accepts only
+		// {active,idle} — reachable only while the connection is up.
+		Expect(backend.enqueueEditProtocolConverter(
+			actionUUID, pcUUID, stalenessBridgeName, stalenessBadIP, stalenessBadPort,
+			stalenessReadDFCActionPayload(),
+		)).To(Succeed())
+
+		By("waiting for a terminal action-reply for the edit action")
+		Eventually(func() bool {
+			_, terminal := backend.terminalReplyState(actionUUID)
+
+			return terminal
+		}, 150*time.Second, 1*time.Second).Should(BeTrue(),
+			"the edit action must produce a terminal action-reply (success or failure)")
+
+		finalState, _ := backend.terminalReplyState(actionUUID)
+		dump := backend.replyDump(actionUUID)
+
+		// Surface the full reply history unconditionally (visible with `-v`) so a
+		// pass/fail can be attributed to the real rollout outcome rather than an
+		// early/spurious failure (e.g. "not found", parse/validation error).
+		AddReportEntry(fmt.Sprintf("NMAP_BACKEND=%s edit action-reply history", nmapBackend), strings.Join(dump, "\n"))
+		GinkgoWriter.Printf("NMAP_BACKEND=%s terminal action-reply for %s: %q\nfull history:\n  %s\n",
+			nmapBackend, actionUUID, finalState, strings.Join(dump, "\n  "))
+
+		// Guard against a false result: the edit must actually reach awaitRollout
+		// (the stage that polls the connection/nmap health), not fail earlier at
+		// parse/validate/persist. awaitRollout emits a distinctive
+		// "Waiting for bridge <name> to be active..." reply; without it, a
+		// terminal action-failure is an early/spurious failure that would make the
+		// fsmv2 spec pass for the WRONG reason and mask the staleness bug.
+		Expect(dump).To(ContainElement(ContainSubstring("Waiting for bridge")),
+			"edit must reach awaitRollout (the connection-health poll); a terminal reply without a "+
+				"'Waiting for bridge' reply is an early/spurious failure, not a real rollout result")
+
+		// CORRECT behavior: a connection edit to a closed port must NOT report
+		// success. fsmv1 satisfies this (green). fsmv2 currently reports
+		// action-success (RED) because the adapter serves the stale "open" scan
+		// of the OLD target across the edit — this spec reproduces the bug and
+		// must flip to green once the staleness bug is fixed.
+		Expect(finalState).To(Equal(models.ActionFinishedWithFailure),
+			"connection edit to a bad target must fail/rollback; a non-failure terminal reply "+
+				"(action-success) is the NMAP_BACKEND=fsmv2 staleness bug")
+	})
+}
+
+var _ = Describe("Connection edit staleness - NMAP_BACKEND=fsmv1 (correct, expected GREEN)",
+	Ordered, Label("connection-staleness"), func() {
+		runConnectionEditStalenessSpec("fsmv1")
+	})
+
+var _ = Describe("Connection edit staleness - NMAP_BACKEND=fsmv2 (BUG, expected RED until fixed)",
+	Ordered, Label("connection-staleness"), func() {
+		runConnectionEditStalenessSpec("fsmv2")
+	})

--- a/umh-core/integration/connection_edit_staleness_test.go
+++ b/umh-core/integration/connection_edit_staleness_test.go
@@ -29,11 +29,11 @@ package integration_test
 //  2. Wait for the bridge to settle into an accepted state.
 //  3. Send an edit-protocol-converter ACTION (via the REAL ManagementConsole
 //     backend+router) that re-points the connection at a KNOWN-BAD target
-//     (127.0.0.1:65000, a closed port).
+//     (an unrouted TEST-NET-2 address).
 //  4. Observe the terminal action-reply the agent pushes back.
 //
 // CORRECT behavior (fsmv1): editing the target restarts the S6 nmap service, the
-// probe of the bad target reports the port closed, the connection goes down, the
+// probe of the bad target reports the port unreachable, the connection goes down, the
 // bridge leaves the accepted state, awaitRollout times out and rolls back →
 // terminal reply = action-failure.
 //
@@ -95,9 +95,13 @@ const (
 	stalenessGoodIP   = "127.0.0.1"
 	stalenessGoodPort = uint32(8080)
 
-	// BAD target: a closed port on loopback.
-	stalenessBadIP   = "127.0.0.1"
-	stalenessBadPort = uint32(65000)
+	// BAD target: TEST-NET-2 (RFC 5737), which is not routed, so the dial is
+	// dropped rather than refused and blocks until the observation timeout. A
+	// closed loopback port instead refuses instantly, which closes the stale
+	// window before the rollout can sample it.
+	// https://datatracker.ietf.org/doc/html/rfc5737#section-3
+	stalenessBadIP   = "198.51.100.1"
+	stalenessBadPort = uint32(445)
 
 	// stalenessTagProcessorJS is the read DFC's tag_processor body. Static (no
 	// template variables) so the deployed template and the edit action's readDFC
@@ -419,7 +423,7 @@ func runConnectionEditStalenessSpec(nmapBackend string) {
 			"edit must reach awaitRollout (the connection-health poll); a terminal reply without a "+
 				"'Waiting for bridge' reply is an early/spurious failure, not a real rollout result")
 
-		// CORRECT behavior: a connection edit to a closed port must NOT report
+		// CORRECT behavior: a connection edit to an unreachable target must NOT report
 		// success. fsmv1 satisfies this (green). fsmv2 currently reports
 		// action-success (RED) because the adapter serves the stale "open" scan
 		// of the OLD target across the edit — this spec reproduces the bug and

--- a/umh-core/integration/docker_test_helpers.go
+++ b/umh-core/integration/docker_test_helpers.go
@@ -54,6 +54,20 @@ var (
 var imageNameOnce sync.Once
 var imageName string
 
+// extraCreateArgs holds additional `docker create` arguments (e.g. extra `-e`
+// env flags or `--add-host`) injected just before the image name. Tests set it
+// in their BeforeAll to customize the container without touching every existing
+// caller. An empty slice leaves the create command identical to the default, so
+// existing integration tests are unaffected.
+var extraCreateArgs []string
+
+// skipConfigCopy tells BuildAndRunContainer not to `docker cp` the config into
+// the container. Set this when a test bind-mounts /data/config.yaml via
+// extraCreateArgs: `docker cp` onto a bind-mounted file fails with
+// "device or resource busy". The default (false) preserves the docker-cp
+// behavior for every existing caller.
+var skipConfigCopy bool
+
 func getImageName() string {
 	imageNameOnce.Do(func() {
 		imageName = "umh-core:latest-" + time.Now().Format("20060102150405")
@@ -168,6 +182,15 @@ func writeConfigFile(yamlContent string, containerName ...string) error {
 		return fmt.Errorf("failed to write config file: %w", err)
 	}
 
+	// WriteFile's mode is reduced by the process umask (typically 0022 → 0644).
+	// Force 0666 so the container user (uid 1000) can rewrite the docker-cp'd
+	// config on startup — the agent persists the env-merged config on load
+	// (LoadConfigWithEnvOverrides), and a 0644 root-owned copy would fail that
+	// write and crash-loop the agent before the communicator logs in.
+	if err := os.Chmod(configPath, 0o666); err != nil {
+		return fmt.Errorf("failed to chmod config file: %w", err)
+	}
+
 	// If container name is provided, also write directly to container
 	if len(containerName) > 0 && containerName[0] != "" {
 		container := containerName[0]
@@ -177,6 +200,13 @@ func writeConfigFile(yamlContent string, containerName ...string) error {
 		tmpFile := configPath + ".tmp"
 		if err := os.WriteFile(tmpFile, []byte(yamlContent), 0o666); err != nil {
 			return fmt.Errorf("failed to write temp config file: %w", err)
+		}
+
+		// Force 0666 (WriteFile is umask-reduced); docker cp preserves the mode,
+		// so the container's config.yaml lands world-writable and the agent (uid
+		// 1000) can rewrite it without waiting for the post-start chmod.
+		if err := os.Chmod(tmpFile, 0o666); err != nil {
+			return fmt.Errorf("failed to chmod temp config file: %w", err)
 		}
 
 		defer func() {
@@ -252,6 +282,17 @@ func buildContainer() error {
 	GinkgoWriter.Println("Docker build successful")
 
 	return nil
+}
+
+// umhLogLevel returns the LOGGING_LEVEL passed to the container-under-test.
+// Defaults to "debug"; override with the UMH_LOG_LEVEL env var (e.g.
+// UMH_LOG_LEVEL=info) when running the integration tests.
+func umhLogLevel() string {
+	if lvl := os.Getenv("UMH_LOG_LEVEL"); lvl != "" {
+		return lvl
+	}
+
+	return "debug"
 }
 
 // BuildAndRunContainer rebuilds your Docker image, starts the container, etc.
@@ -356,20 +397,25 @@ func BuildAndRunContainer(configYaml string, memory string, cpus uint) error {
 	// grant 40 ms every 20 ms → an average of 2 fully-loaded logical cores.
 	cpuQuota := cpus * cpuPeriod
 
-	out, err = runDockerCommand(
+	createArgs := []string{
 		"create",
 		"--name", containerName,
-		"-e", "LOGGING_LEVEL=debug",
+		"-e", "LOGGING_LEVEL=" + umhLogLevel(),
 		// Map the host ports to the container's fixed ports
 		"-p", fmt.Sprintf("%d:8080", metricsPrt), // Map host's dynamic port to container's fixed metrics port
 		"-p", fmt.Sprintf("%d:8082", goldenPrt), // Map host's dynamic port to container's golden service port
 		"--memory", memory,
 		"--cpu-period", strconv.FormatUint(uint64(cpuPeriod), 10), // 20 ms CFS window
 		"--cpu-quota", strconv.FormatUint(uint64(cpuQuota), 10), // e.g. 40 ms budget ⇒ 2 vCPUs
-		"-v", tmpRedpandaDir+":/data/redpanda",
-		"-v", tmpLogsDir+":/data/logs",
-		getImageName(),
-	)
+		"-v", tmpRedpandaDir + ":/data/redpanda",
+		"-v", tmpLogsDir + ":/data/logs",
+	}
+	// Inject any test-supplied extra create args (extra env, --add-host, ...)
+	// immediately before the image name. Empty slice → unchanged behavior.
+	createArgs = append(createArgs, extraCreateArgs...)
+	createArgs = append(createArgs, getImageName())
+
+	out, err = runDockerCommand(createArgs...)
 	if err != nil {
 		GinkgoWriter.Printf("Container creation failed: %v\n", err)
 		GinkgoWriter.Printf("Container create output:\n%s\n", out)
@@ -379,12 +425,19 @@ func BuildAndRunContainer(configYaml string, memory string, cpus uint) error {
 
 	GinkgoWriter.Printf("Container created with ID: %s\n", strings.TrimSpace(out))
 
-	// 6. Copy the config file to the container BEFORE starting it
-	GinkgoWriter.Println("Copying config file to container...")
+	// 6. Copy the config file to the container BEFORE starting it. When the
+	// caller bind-mounts /data/config.yaml, skip the copy (docker cp onto a
+	// bind-mounted file fails "device or resource busy"); the host file backing
+	// the mount was already written by the caller.
+	if skipConfigCopy {
+		GinkgoWriter.Println("Skipping config copy (config.yaml is bind-mounted)...")
+	} else {
+		GinkgoWriter.Println("Copying config file to container...")
 
-	err = writeConfigFile(configYaml, containerName)
-	if err != nil {
-		return fmt.Errorf("failed to write config to container: %w", err)
+		err = writeConfigFile(configYaml, containerName)
+		if err != nil {
+			return fmt.Errorf("failed to write config to container: %w", err)
+		}
 	}
 
 	// 7. Start the container

--- a/umh-core/integration/managementconsole_stack_test.go
+++ b/umh-core/integration/managementconsole_stack_test.go
@@ -1,0 +1,794 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration_test
+
+// mcStack boots the REAL ManagementConsole backend + router (built from source
+// pulled by `make pull-managementconsole`) and drives a real umh-core container
+// through them end-to-end, exactly the way ManagementConsole's own Playwright
+// e2e suite runs them: backend and router as local Go processes, Postgres and
+// Redis as throwaway Docker containers.
+//
+//	                 test process (the "user")
+//	          POST /api/v2/user/push  |  GET /api/v2/user/pull
+//	                                  v
+//	  umh-core container ──▶ router (:R) ──/api──▶ backend (:B) ──▶ Postgres + Redis
+//	   login/pull/push        strips /api          v2/instance/*, v2/user/*
+//
+// The backend is a passthrough relay for the message Content, so umh-core keeps
+// using its own corev1 codec (base64(JSON), no encryption) — the same wire the
+// old fakeBackend used. What is now REAL: instance login against a DB row,
+// JWT-scoped user auth, and the v3 Redis message queue routing.
+//
+// mcStack mirrors the method surface of the old fakeBackend
+// (apiURL/loginSeen/enqueueEditProtocolConverter/terminalReplyState/replyDump)
+// so the staleness spec is unchanged apart from the constructor.
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	. "github.com/onsi/ginkgo/v2"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/communicator/backend_api_structs"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/communicator/pkg/encoding"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/communicator/pkg/hash"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/models"
+)
+
+const (
+	// mcAuthToken is the raw auth token; it MUST match the AuthToken set in
+	// buildStalenessConfig. umh-core sends LoginHash(mcAuthToken) as the Bearer
+	// token, so that hash is what we seed into instances.auth_token.
+	mcAuthToken = "test-token"
+
+	// mcUserEmail is the seeded user's email. The edit action carries it, the
+	// agent echoes it on its reply, and the backend uses it to route the reply
+	// to this user's queue (mq:v3:live:user:<userID>).
+	mcUserEmail = "harness-user@umh.test"
+
+	mcPGImage    = "postgres:15.4"
+	mcRedisImage = "redis:7-alpine"
+	mcDBName     = "management-console"
+	mcRedisPass  = "management-console"
+)
+
+// mcBuild* memoize the one-time build of the backend + router binaries so both
+// staleness specs (fsmv1, fsmv2) reuse them instead of rebuilding per spec.
+var (
+	mcBuildOnce  sync.Once
+	mcBackendBin string
+	mcRouterBin  string
+	mcBuildErr   error
+)
+
+type mcStack struct {
+	jwtSecret      string
+	instanceUUID   uuid.UUID
+	userEmail      string
+	userID         int64
+	sessionVersion string
+	userCookie     string // minted USER_SCOPE JWT, sent as the `token` cookie
+
+	pgPort      int
+	redisPort   int
+	backendPort int
+	routerPort  int
+
+	pgContainer    string
+	redisContainer string
+
+	backendProc *exec.Cmd
+	routerProc  *exec.Cmd
+
+	mu        sync.Mutex
+	replies   map[uuid.UUID]models.ActionReplyState
+	replyMsgs map[uuid.UUID][]string
+
+	stopPoll chan struct{}
+	pollDone chan struct{}
+
+	logDir string
+}
+
+// mcDir returns the directory holding the pulled ManagementConsole source
+// (backend/, router/, shared/, cryptolib/, frontend/static/requirements.json).
+// Defaults to ./managementconsole next to the integration package; overridable
+// with MC_DIR (the Makefile passes it).
+func mcDir() (string, error) {
+	if d := os.Getenv("MC_DIR"); d != "" {
+		return d, nil
+	}
+
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(wd, "managementconsole"), nil
+}
+
+// mcFreePort grabs an ephemeral TCP port and releases it. There is a small race
+// between release and reuse, acceptable for a serial integration test.
+func mcFreePort() (int, error) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
+	}
+
+	defer func() { _ = ln.Close() }()
+
+	return ln.Addr().(*net.TCPAddr).Port, nil
+}
+
+// buildMCBinaries builds the backend and router binaries once from the pulled
+// source. It fails with an actionable message if the source is missing.
+func buildMCBinaries() (string, string, error) {
+	mcBuildOnce.Do(func() {
+		dir, err := mcDir()
+		if err != nil {
+			mcBuildErr = err
+
+			return
+		}
+
+		backendDir := filepath.Join(dir, "backend")
+		routerDir := filepath.Join(dir, "router")
+
+		if _, err := os.Stat(backendDir); err != nil {
+			mcBuildErr = fmt.Errorf("ManagementConsole source not found at %s (run `make pull-managementconsole`): %w", dir, err)
+
+			return
+		}
+
+		// The backend build embeds frontend/static/requirements.json into the
+		// demo simulator; copy it in first (mirrors `make copy_requirements_json`).
+		reqSrc := filepath.Join(dir, "frontend", "static", "requirements.json")
+
+		reqDst := filepath.Join(backendDir, "cmd", "demo_simulator_v3", "requirements.json")
+		if data, err := os.ReadFile(reqSrc); err == nil {
+			_ = os.WriteFile(reqDst, data, 0o644)
+		}
+
+		binDir, err := os.MkdirTemp("", "mc-bins-")
+		if err != nil {
+			mcBuildErr = err
+
+			return
+		}
+
+		mcBackendBin = filepath.Join(binDir, "mc-backend")
+		mcRouterBin = filepath.Join(binDir, "mc-router")
+
+		for _, b := range []struct {
+			out, srcDir string
+		}{
+			{mcBackendBin, backendDir},
+			{mcRouterBin, routerDir},
+		} {
+			// -mod=mod: the pulled tree ships no vendor/ dir, so resolve modules
+			// against the module cache / GOPROXY.
+			cmd := exec.Command("go", "build", "-mod=mod", "-o", b.out, "./cmd")
+			cmd.Dir = b.srcDir
+
+			cmd.Env = append(os.Environ(), "GOFLAGS=-mod=mod")
+			if out, err := cmd.CombinedOutput(); err != nil {
+				mcBuildErr = fmt.Errorf("go build in %s failed: %w\n%s", b.srcDir, err, out)
+
+				return
+			}
+		}
+	})
+
+	return mcBackendBin, mcRouterBin, mcBuildErr
+}
+
+// newMCStack boots Postgres, Redis, the backend and the router, seeds a
+// loginable instance, and starts a background poller that drains the user
+// queue. The caller must call stop() when done.
+func newMCStack(ctx context.Context) (*mcStack, error) {
+	backendBin, routerBin, err := buildMCBinaries()
+	if err != nil {
+		return nil, err
+	}
+
+	secretBytes := make([]byte, 32)
+	if _, err := rand.Read(secretBytes); err != nil {
+		return nil, err
+	}
+
+	s := &mcStack{
+		jwtSecret:    hex.EncodeToString(secretBytes),
+		instanceUUID: uuid.New(),
+		userEmail:    mcUserEmail,
+		replies:      make(map[uuid.UUID]models.ActionReplyState),
+		replyMsgs:    make(map[uuid.UUID][]string),
+		stopPoll:     make(chan struct{}),
+		pollDone:     make(chan struct{}),
+	}
+
+	for _, p := range []*int{&s.pgPort, &s.redisPort, &s.backendPort, &s.routerPort} {
+		port, err := mcFreePort()
+		if err != nil {
+			return nil, err
+		}
+
+		*p = port
+	}
+
+	s.logDir, err = os.MkdirTemp("", "mc-logs-")
+	if err != nil {
+		return nil, err
+	}
+
+	suffix := uuid.New().String()[:8]
+	s.pgContainer = "mc-pg-" + suffix
+	s.redisContainer = "mc-redis-" + suffix
+
+	// Postgres + Redis containers.
+	if _, err := runDockerCommand("run", "-d", "--name", s.pgContainer,
+		"-e", "POSTGRES_PASSWORD=password", "-e", "POSTGRES_DB="+mcDBName,
+		"-p", fmt.Sprintf("%d:5432", s.pgPort), mcPGImage); err != nil {
+		return nil, fmt.Errorf("start postgres: %w", err)
+	}
+
+	if _, err := runDockerCommand("run", "-d", "--name", s.redisContainer,
+		"-p", fmt.Sprintf("%d:6379", s.redisPort), mcRedisImage,
+		"redis-server", "--requirepass", mcRedisPass); err != nil {
+		return nil, fmt.Errorf("start redis: %w", err)
+	}
+
+	if err := s.waitForPostgres(ctx); err != nil {
+		return nil, err
+	}
+
+	// Backend (migrates the schema on boot).
+	if err := s.startBackend(backendBin); err != nil {
+		return nil, err
+	}
+
+	if err := mcWaitHTTP(fmt.Sprintf("http://127.0.0.1:%d/v2/health", s.backendPort), 90*time.Second); err != nil {
+		return nil, fmt.Errorf("backend never became healthy: %w", err)
+	}
+
+	// Seed one company + user + instance (all in the same company so the user is
+	// authorized to push to the instance and the reply routes back).
+	if err := s.seed(ctx); err != nil {
+		return nil, err
+	}
+
+	s.userCookie, err = mintUserJWT(s.jwtSecret, s.userEmail, s.userID, s.sessionVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	// Router (thin reverse proxy; boots on placeholder R2 creds).
+	if err := s.startRouter(routerBin); err != nil {
+		return nil, err
+	}
+
+	if err := mcWaitHTTP(fmt.Sprintf("http://127.0.0.1:%d/api/v2/health", s.routerPort), 60*time.Second); err != nil {
+		return nil, fmt.Errorf("router never became healthy: %w", err)
+	}
+
+	go s.pollUserQueue()
+
+	return s, nil
+}
+
+func (s *mcStack) dbURL() string {
+	return fmt.Sprintf("host=127.0.0.1 port=%d user=postgres password=password dbname=%s sslmode=disable", s.pgPort, mcDBName)
+}
+
+func (s *mcStack) pgxURL() string {
+	return fmt.Sprintf("postgres://postgres:password@127.0.0.1:%d/%s?sslmode=disable", s.pgPort, mcDBName)
+}
+
+func (s *mcStack) redisURL() string {
+	return fmt.Sprintf("redis://default:%s@127.0.0.1:%d/0", mcRedisPass, s.redisPort)
+}
+
+func (s *mcStack) waitForPostgres(ctx context.Context) error {
+	deadline := time.Now().Add(60 * time.Second)
+	for time.Now().Before(deadline) {
+		connCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+
+		conn, err := pgx.Connect(connCtx, s.pgxURL())
+		if err == nil {
+			_, pingErr := conn.Exec(connCtx, "SELECT 1")
+			_ = conn.Close(connCtx)
+
+			cancel()
+
+			if pingErr == nil {
+				return nil
+			}
+		} else {
+			cancel()
+		}
+
+		time.Sleep(1 * time.Second)
+	}
+
+	return fmt.Errorf("postgres on port %d not ready in time", s.pgPort)
+}
+
+func (s *mcStack) startBackend(bin string) error {
+	dir, _ := mcDir()
+
+	cmd := exec.Command(bin)
+	cmd.Dir = filepath.Join(dir, "backend")
+
+	cmd.Env = append(os.Environ(),
+		"TESTING=true",
+		"LOGGING_LEVEL=DEBUG",
+		fmt.Sprintf("PORT=%d", s.backendPort),
+		"JWT_SECRET_KEY="+s.jwtSecret,
+		"DATABASE_URL="+s.dbURL(),
+		"REDIS_URL="+s.redisURL(),
+		// Auth0 is only used by the user-login routes we never touch; dummy values
+		// are enough for the instance + user push/pull paths.
+		"AUTH0_DOMAIN=dev.example.com",
+		"AUTH0_CLIENT_ID=dummy",
+	)
+
+	logFile, err := os.Create(filepath.Join(s.logDir, "backend.log"))
+	if err != nil {
+		return err
+	}
+
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start backend: %w", err)
+	}
+
+	s.backendProc = cmd
+
+	return nil
+}
+
+func (s *mcStack) startRouter(bin string) error {
+	dir, _ := mcDir()
+
+	cmd := exec.Command(bin)
+	cmd.Dir = filepath.Join(dir, "router")
+
+	cmd.Env = append(os.Environ(),
+		fmt.Sprintf("PORT=%d", s.routerPort),
+		fmt.Sprintf("CUSTOM_API_URL=http://127.0.0.1:%d", s.backendPort),
+		"CUSTOM_FRONTEND_URL=http://127.0.0.1:1420",
+		"LOGGING_LEVEL=DEVELOPMENT",
+		// r2.SetupR2 only constructs S3 clients (no boot-time network call), so
+		// placeholder credentials let the router boot. The /api forward path never
+		// touches R2.
+		"R2_ACCOUNT_ID=placeholder",
+		"R2_ACCESS_KEY_ID_OCI=placeholder",
+		"R2_ACCESS_KEY_SECRET_OCI=placeholder",
+		"R2_ACCESS_KEY_ID_BINARIES=placeholder",
+		"R2_ACCESS_KEY_SECRET_BINARIES=placeholder",
+		"R2_ACCESS_KEY_ID_STATIC_BINARIES=placeholder",
+		"R2_ACCESS_KEY_SECRET_STATIC_BINARIES=placeholder",
+	)
+
+	logFile, err := os.Create(filepath.Join(s.logDir, "router.log"))
+	if err != nil {
+		return err
+	}
+
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start router: %w", err)
+	}
+
+	s.routerProc = cmd
+
+	return nil
+}
+
+// seed inserts the minimal rows for a successful instance login and an
+// authorized user push: one company, one user (same company), one instance
+// (same company) whose auth_token is LoginHash(mcAuthToken).
+func (s *mcStack) seed(ctx context.Context) error {
+	conn, err := pgx.Connect(ctx, s.pgxURL())
+	if err != nil {
+		return fmt.Errorf("seed connect: %w", err)
+	}
+
+	defer func() { _ = conn.Close(ctx) }()
+
+	var companyID int64
+	if err := conn.QueryRow(ctx,
+		`INSERT INTO companies (created_at, updated_at, uuid, name)
+		 VALUES (now(), now(), $1, $2) RETURNING id`,
+		uuid.New().String(), "HarnessCo",
+	).Scan(&companyID); err != nil {
+		return fmt.Errorf("seed company: %w", err)
+	}
+
+	// session_version must be set and match the minted token: GET /v2/user/pull
+	// resolves the user by numeric id and rejects the token if the row's
+	// session_version is nil or differs (auth.go ValidateTokenMiddleware).
+	s.sessionVersion = uuid.New().String()
+	if err := conn.QueryRow(ctx,
+		`INSERT INTO users (created_at, updated_at, email, password, company_id, session_version)
+		 VALUES (now(), now(), $1, $2, $3, $4) RETURNING id`,
+		s.userEmail, "seeded-no-login", companyID, s.sessionVersion,
+	).Scan(&s.userID); err != nil {
+		return fmt.Errorf("seed user: %w", err)
+	}
+
+	// umh-core sends Bearer LoginHash(token) = Sha3(Sha3(token)); the backend
+	// compares that literal value against instances.auth_token.
+	authTokenHash := hash.Sha3Hash(hash.Sha3Hash(mcAuthToken))
+	if _, err := conn.Exec(ctx,
+		`INSERT INTO instances (created_at, updated_at, uuid, auth_token, name, verified, company_id)
+		 VALUES (now(), now(), $1, $2, $3, false, $4)`,
+		s.instanceUUID.String(), authTokenHash, "HarnessInstance", companyID,
+	); err != nil {
+		return fmt.Errorf("seed instance: %w", err)
+	}
+
+	return nil
+}
+
+// mintUserJWT hand-signs a HS256 USER_SCOPE token carrying the numeric user_id
+// and the row's session_version. POST /v2/user/push resolves by email, but GET
+// /v2/user/pull resolves by numeric id and enforces the session_version match,
+// so both must be present (auth.go ValidateTokenMiddleware).
+func mintUserJWT(secret, email string, userID int64, sessionVersion string) (string, error) {
+	now := time.Now()
+
+	encode := func(v any) (string, error) {
+		b, err := json.Marshal(v)
+		if err != nil {
+			return "", err
+		}
+
+		return base64.RawURLEncoding.EncodeToString(b), nil
+	}
+
+	header, err := encode(map[string]string{"alg": "HS256", "typ": "JWT"})
+	if err != nil {
+		return "", err
+	}
+
+	claims, err := encode(map[string]any{
+		"scope":              "user",
+		"email":              email,
+		"user_id":            userID,
+		"session_version":    sessionVersion,
+		"original_issued_at": now.Unix(),
+		"iat":                now.Unix(),
+		"exp":                now.Add(24 * time.Hour).Unix(),
+	})
+	if err != nil {
+		return "", err
+	}
+
+	signingInput := header + "." + claims
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write([]byte(signingInput))
+	sig := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+
+	return signingInput + "." + sig, nil
+}
+
+// apiURL is the base URL umh-core (inside the container) uses to reach the
+// router. The path already includes /api so the router forwards to the backend
+// (umh-core appends /v2/instance/... to this base).
+func (s *mcStack) apiURL() string {
+	return fmt.Sprintf("http://host.docker.internal:%d/api", s.routerPort)
+}
+
+// hostRouterURL is the base URL the TEST process (on the host) uses to reach the
+// router.
+func (s *mcStack) hostRouterURL() string {
+	return fmt.Sprintf("http://127.0.0.1:%d/api", s.routerPort)
+}
+
+// enqueueEditProtocolConverter sends an edit-protocol-converter action to the
+// instance by POSTing it to the real backend's user-push endpoint (through the
+// router), authenticated with the minted user cookie.
+// If readDFC is non-nil it is attached under the "readDFC" key so the edited
+// bridge keeps a non-empty DFC type (connection-gated rollout); a nil readDFC
+// produces a connection-only edit (DFCType empty).
+func (s *mcStack) enqueueEditProtocolConverter(actionUUID, pcUUID uuid.UUID, pcName, ip string, port uint32, readDFC map[string]any) error {
+	actionPayload := map[string]any{
+		"uuid": pcUUID.String(),
+		"name": pcName,
+		"connection": map[string]any{
+			"ip":   ip,
+			"port": port,
+		},
+		"location": map[string]any{
+			"0": "test-enterprise",
+		},
+	}
+
+	if readDFC != nil {
+		actionPayload["readDFC"] = readDFC
+	}
+
+	messageContent := models.UMHMessageContent{
+		MessageType: models.Action,
+		Payload: models.ActionMessagePayload{
+			ActionType:    models.EditProtocolConverter,
+			ActionUUID:    actionUUID,
+			ActionPayload: actionPayload,
+		},
+	}
+
+	encoded, err := encoding.EncodeMessageFromUserToUMHInstance(messageContent)
+	if err != nil {
+		return fmt.Errorf("encode action: %w", err)
+	}
+
+	payload := backend_api_structs.PushPayload{
+		UMHMessages: []models.UMHMessage{
+			{
+				Email:        s.userEmail,
+				InstanceUUID: s.instanceUUID,
+				Content:      encoded,
+			},
+		},
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, s.hostRouterURL()+"/v2/user/push", strings.NewReader(string(body)))
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: "token", Value: s.userCookie})
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("user push: %w", err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("user push returned status %d", resp.StatusCode)
+	}
+
+	return nil
+}
+
+// pollUserQueue continuously drains GET /v2/user/pull (which RPOPs the user
+// queue) and records every action-reply, since replies arrive over time and the
+// pull consumes them.
+func (s *mcStack) pollUserQueue() {
+	defer close(s.pollDone)
+
+	client := &http.Client{Timeout: 30 * time.Second}
+
+	for {
+		select {
+		case <-s.stopPoll:
+			return
+		default:
+		}
+
+		req, err := http.NewRequest(http.MethodGet, s.hostRouterURL()+"/v2/user/pull", nil)
+		if err != nil {
+			time.Sleep(500 * time.Millisecond)
+
+			continue
+		}
+
+		req.AddCookie(&http.Cookie{Name: "token", Value: s.userCookie})
+		req.Header.Set("X-Features", "longpoll")
+
+		resp, err := client.Do(req)
+		if err != nil {
+			time.Sleep(500 * time.Millisecond)
+
+			continue
+		}
+
+		if resp.StatusCode == http.StatusOK {
+			var payload backend_api_structs.PullPayload
+			if err := json.NewDecoder(resp.Body).Decode(&payload); err == nil {
+				for _, msg := range payload.UMHMessages {
+					s.recordReply(msg)
+				}
+			}
+		}
+
+		_ = resp.Body.Close()
+	}
+}
+
+// recordReply decodes one pulled message and, if it is an action-reply, records
+// its state keyed by the action UUID.
+func (s *mcStack) recordReply(msg models.UMHMessage) {
+	if msg.Content == "" {
+		return
+	}
+
+	content, err := encoding.DecodeMessageFromUMHInstanceToUser(msg.Content)
+	if err != nil {
+		return
+	}
+
+	if content.MessageType != models.ActionReply {
+		return
+	}
+
+	raw, err := json.Marshal(content.Payload)
+	if err != nil {
+		return
+	}
+
+	var reply models.ActionReplyMessagePayload
+	if err := json.Unmarshal(raw, &reply); err != nil {
+		return
+	}
+
+	s.mu.Lock()
+	s.replies[reply.ActionUUID] = reply.ActionReplyState
+	s.replyMsgs[reply.ActionUUID] = append(s.replyMsgs[reply.ActionUUID],
+		fmt.Sprintf("%s: %v", reply.ActionReplyState, reply.ActionReplyPayload))
+	s.mu.Unlock()
+}
+
+// replyDump returns the ordered "state: message" history captured for the action.
+func (s *mcStack) replyDump(actionUUID uuid.UUID) []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	out := make([]string, len(s.replyMsgs[actionUUID]))
+	copy(out, s.replyMsgs[actionUUID])
+
+	return out
+}
+
+// terminalReplyState returns the captured reply state for the action and whether
+// it is terminal (action-success or action-failure).
+func (s *mcStack) terminalReplyState(actionUUID uuid.UUID) (models.ActionReplyState, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	state, ok := s.replies[actionUUID]
+	if !ok {
+		return "", false
+	}
+
+	terminal := state == models.ActionFinishedSuccessfull || state == models.ActionFinishedWithFailure
+
+	return state, terminal
+}
+
+// loginSeen reports whether the container has completed at least one instance
+// login. The backend flips instances.verified to true on first login
+// (instance_login.go), so we poll that flag.
+func (s *mcStack) loginSeen() bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	conn, err := pgx.Connect(ctx, s.pgxURL())
+	if err != nil {
+		return false
+	}
+
+	defer func() { _ = conn.Close(ctx) }()
+
+	var verified bool
+	if err := conn.QueryRow(ctx,
+		`SELECT verified FROM instances WHERE uuid = $1`, s.instanceUUID.String(),
+	).Scan(&verified); err != nil {
+		return false
+	}
+
+	return verified
+}
+
+// stop tears down the poller, the two processes and the two containers, and
+// surfaces the backend/router logs on failure.
+func (s *mcStack) stop() {
+	if s.stopPoll != nil {
+		close(s.stopPoll)
+
+		select {
+		case <-s.pollDone:
+		case <-time.After(5 * time.Second):
+		}
+	}
+
+	if CurrentSpecReport().Failed() {
+		s.dumpLog("backend.log")
+		s.dumpLog("router.log")
+	}
+
+	for _, p := range []*exec.Cmd{s.routerProc, s.backendProc} {
+		if p != nil && p.Process != nil {
+			_ = p.Process.Kill()
+			_, _ = p.Process.Wait()
+		}
+	}
+
+	for _, name := range []string{s.pgContainer, s.redisContainer} {
+		if name != "" {
+			_, _ = runDockerCommand("rm", "-f", name)
+		}
+	}
+
+	if s.logDir != "" {
+		_ = os.RemoveAll(s.logDir)
+	}
+}
+
+func (s *mcStack) dumpLog(name string) {
+	data, err := os.ReadFile(filepath.Join(s.logDir, name))
+	if err != nil {
+		return
+	}
+
+	GinkgoWriter.Printf("\n===== ManagementConsole %s =====\n%s\n===== end %s =====\n", name, string(data), name)
+}
+
+// encodingChooseCorev1 selects the corev1 encoder for this (test) process so it
+// matches the encoder the container selects in cmd/main.go. Messages are
+// base64(JSON) with no encryption. The backend relays Content opaquely, so this
+// codec governs both the action we send and the replies we decode.
+func encodingChooseCorev1() {
+	encoding.ChooseEncoder(encoding.EncodingCorev1)
+}
+
+// mcWaitHTTP polls url until it returns any HTTP response (2xx/4xx both mean the
+// server is up) or the timeout elapses.
+func mcWaitHTTP(url string, timeout time.Duration) error {
+	client := &http.Client{Timeout: 3 * time.Second}
+	deadline := time.Now().Add(timeout)
+
+	for time.Now().Before(deadline) {
+		resp, err := client.Get(url)
+		if err == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode < 500 {
+				return nil
+			}
+		}
+
+		time.Sleep(1 * time.Second)
+	}
+
+	return fmt.Errorf("%s not reachable within %s", url, timeout)
+}

--- a/umh-core/pkg/fsm/nmap/nmap_staleness_integration_test.go
+++ b/umh-core/pkg/fsm/nmap/nmap_staleness_integration_test.go
@@ -1,0 +1,210 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nmap_test
+
+// FSMv1 counterpart of the NMAP_BACKEND=fsmv2 stale-observation bug
+// (pkg/fsmv2/nmap/nmap_staleness_integration_test.go). It mirrors the same
+// scenario — a bridge connection edited from a healthy target to a known-bad
+// one — and proves that the fsmv1 nmap backend does NOT exhibit the bug: after
+// the edit it never reports the connection open from the old target's scan.
+//
+// Why fsmv1 is correct: the operational state is derived every reconcile from
+// the observation the live S6-supervised nmap service produces for the CURRENT
+// target. reconcileRunningStates only stays open while isNmapHealthy holds
+// (a recent, non-errored scan from a running service — actions.go) and
+// checkPortState still reads "open" (reconcile.go). Editing the target
+// reconfigures/restarts that S6 service (UpdateNmapInS6Manager), so the next
+// observation reflects the new target: while the restarted scanner has not yet
+// completed a scan the instance drops to degraded, and once the bad target is
+// scanned it reads closed. There is no per-name observation store that can
+// serve a stale "open" of the old target, which is exactly what the fsmv2
+// adapter does via its unchanged child ref.
+//
+// This drives the REAL read path: a real NmapManager (NewNmapManager) fed the
+// edit through the SystemSnapshot config path (CurrentConfig.Internal.Nmap,
+// the same channel ManagementConsole uses), reconciling a single instance whose
+// only stubbed dependency is the nmap service — the mock stands in for the live
+// S6 scanner and returns the scan the current target would yield.
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/nmapserviceconfig"
+	publicfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
+	nmapfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/nmap"
+	nmapsvc "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/nmap"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/serviceregistry"
+)
+
+var _ = Describe("NMAP_BACKEND=fsmv1 fresh observation across a connection edit", func() {
+	const (
+		name        = "bridge-conn"
+		port uint16 = 502
+
+		goodTarget = "192.0.2.10" // stands in for the healthy target
+		badTarget  = "192.0.2.99" // the known-bad target the edit points at
+	)
+
+	var (
+		ctx         context.Context
+		now         time.Time
+		mockService *nmapsvc.MockNmapService
+		mgr         *nmapfsm.NmapManager
+		services    *serviceregistry.Registry
+	)
+
+	// nmapConfig builds an enabled (open == running) config.NmapConfig for the
+	// given target. The instance name is stable across targets, matching the
+	// connection-only edit the fsmv2 test exercises.
+	nmapConfig := func(target string) config.NmapConfig {
+		return config.NmapConfig{
+			FSMInstanceConfig: config.FSMInstanceConfig{
+				Name:            name,
+				DesiredFSMState: nmapfsm.OperationalStateOpen,
+			},
+			NmapServiceConfig: nmapserviceconfig.NmapServiceConfig{
+				Target: target,
+				Port:   port,
+			},
+		}
+	}
+
+	// snapshotWith puts the config at the path the manager reads, exactly as the
+	// agent hands the edited config.yaml to the FSM layer.
+	snapshotWith := func(cfg config.NmapConfig) publicfsm.SystemSnapshot {
+		return publicfsm.SystemSnapshot{
+			SnapshotTime: now,
+			CurrentConfig: config.FullConfig{
+				Internal: config.InternalConfig{Nmap: []config.NmapConfig{cfg}},
+			},
+		}
+	}
+
+	// setScan makes the mock nmap service report the given port scan, the way
+	// the live S6 scanner would after scanning the current target.
+	setScan := func(portState string, running bool) {
+		mockService.ExistingServices[name] = true
+		mockService.ServiceStates[name] = &nmapsvc.ServiceInfo{
+			NmapStatus: nmapsvc.NmapServiceInfo{
+				IsRunning: running,
+				LastScan: &nmapsvc.NmapScanResult{
+					Timestamp:  now,
+					PortResult: nmapsvc.PortResult{State: portState, Port: port},
+				},
+			},
+		}
+	}
+
+	// setRestarting makes the mock report a scanner that has been reconfigured
+	// and restarted for a new target but has not produced a completed scan yet:
+	// no LastScan, not running. isNmapHealthy rejects this, so the instance
+	// cannot remain open.
+	setRestarting := func() {
+		mockService.ExistingServices[name] = true
+		mockService.ServiceStates[name] = &nmapsvc.ServiceInfo{
+			NmapStatus: nmapsvc.NmapServiceInfo{
+				IsRunning: false,
+				LastScan:  nil,
+			},
+		}
+	}
+
+	// currentState reads the fsmv1 operational state the connection FSM would see.
+	currentState := func() string {
+		inst, found := mgr.GetInstance(name)
+		Expect(found).To(BeTrue(), "instance %q must exist in the manager", name)
+
+		return inst.GetCurrentFSMState()
+	}
+
+	// reconcile runs one manager tick against the given config with a deadline'd
+	// context (the base manager requires one).
+	reconcile := func(cfg config.NmapConfig) {
+		rctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+
+		_, _ = mgr.Reconcile(rctx, snapshotWith(cfg), services)
+	}
+
+	// driveUntil reconciles the given config until the instance reaches target
+	// or the attempt budget is exhausted.
+	driveUntil := func(cfg config.NmapConfig, target string) {
+		for range 40 {
+			if currentState() == target {
+				return
+			}
+
+			reconcile(cfg)
+		}
+
+		Expect(currentState()).To(Equal(target),
+			"instance did not reach %q within the attempt budget", target)
+	}
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		now = time.Now()
+
+		mockService = nmapsvc.NewMockNmapService()
+		mockService.GetConfigResult = nmapConfig(goodTarget).NmapServiceConfig
+		services = serviceregistry.NewMockRegistry()
+
+		// Real manager (real compare/setConfig) driving a single instance whose
+		// nmap service is the mock. The manager applies edits from the snapshot
+		// via its real setConfig path.
+		mgr = nmapfsm.NewNmapManager("staleness-test")
+
+		inst := nmapfsm.NewNmapInstance(nmapConfig(goodTarget))
+		inst.SetService(mockService)
+		mgr.AddInstanceForTest(name, inst)
+	})
+
+	It("does not report the connection open after the target is edited to a bad host (fsmv1 is correct)", func() {
+		// 1. Deploy the healthy connection: the scanner reports the good target
+		//    open, and the instance settles in open.
+		setScan(string(nmapfsm.PortStateOpen), true)
+		driveUntil(nmapConfig(goodTarget), nmapfsm.OperationalStateOpen)
+		Expect(currentState()).To(Equal(nmapfsm.OperationalStateOpen),
+			"the healthy connection must read open before the edit")
+
+		// 2. Edit the connection to a known-bad target. Only the target changes;
+		//    the instance name is unchanged. Editing the target reconfigures and
+		//    restarts the S6 nmap service, so the old open scan of the GOOD
+		//    target no longer applies and no completed scan of the bad target
+		//    exists yet.
+		setRestarting()
+
+		// 3. A target change must not keep the connection open: fsmv1 derives
+		//    the state from the current scanner observation, so with the scanner
+		//    restarted it drops out of open. This PASSES (GREEN) — fsmv1 never
+		//    serves the old target's stale open, unlike the fsmv2 adapter.
+		driveUntil(nmapConfig(badTarget), nmapfsm.OperationalStateDegraded)
+		Expect(currentState()).NotTo(Equal(nmapfsm.OperationalStateOpen),
+			"a connection edited to a bad target must not read open from the old target's scan")
+
+		// 4. Once the restarted scanner actually scans the bad target (closed),
+		//    the instance reads closed — confirming the earlier drop was the
+		//    real state, not a stale-open window.
+		setScan(string(nmapfsm.PortStateClosed), true)
+		driveUntil(nmapConfig(badTarget), nmapfsm.OperationalStateClosed)
+		Expect(currentState()).To(Equal(nmapfsm.OperationalStateClosed),
+			"after the bad target is scanned the connection reads closed")
+	})
+})

--- a/umh-core/pkg/fsm/nmap/nmap_suite_test.go
+++ b/umh-core/pkg/fsm/nmap/nmap_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nmap_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestNmapFSM(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Nmap FSM Suite")
+}

--- a/umh-core/pkg/fsmv2/nmap/nmap_staleness_integration_test.go
+++ b/umh-core/pkg/fsmv2/nmap/nmap_staleness_integration_test.go
@@ -1,0 +1,180 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fsmv2nmap_test
+
+// Integration test for the NMAP_BACKEND=fsmv2 stale-observation bug (ENG,
+// edit-protocol-converter connection-only edit).
+//
+// Symptom: editing a bridge's connection to a KNOWN-BAD target briefly reports
+// a healthy/open connection ONCE, so EditProtocolConverterAction.awaitRollout
+// (pkg/communicator/actions/edit-protocolconverter.go, DFCTypeEmpty path) sees
+// active/idle and returns success instead of failing. Only reproduces with the
+// fsmv2 nmap backend; fsmv1 is fine.
+//
+// Root cause exercised here: the fsmv2 adapter reads the child observation by
+// ref {WorkerType:"nmap", Name}. The name does not change when only the target
+// changes, so the ref (and its CSE key) is identical across the edit. The prior
+// scan of the GOOD target is still in the store with a recent CollectedAt, so
+// fsmv2client.GetFresh classifies it Fresh purely by age
+// (pkg/fsmv2/fsmv2client/fsmv2client.go:163) — it never checks whether the
+// observation belongs to the current target. AdaptedInstance.resolve therefore
+// runs the Fresh rung and mapFresh maps the stale "open" to OperationalStateOpen
+// (pkg/fsmv2/adapter/instance.go:230, pkg/fsmv2/nmap/manager.go:76). The
+// connection reads healthy until the worker re-polls the bad target.
+//
+// This test drives the REAL read path: a real TriangularStore over an in-memory
+// persistence backend, a real fsmv2client, and the real adapter WorkerManager
+// built by NewFsmv2NmapManager. It writes observations exactly as the collector
+// does (SaveObserved), so nothing here is stubbed except the poll cadence, which
+// is stepped by hand to make the transient window deterministic.
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/nmapserviceconfig"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/cse/storage"
+	publicfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
+	nmapfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/nmap"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/adapter"
+	fsmv2config "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/config"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/fsmv2client"
+	fsmv2nmap "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/nmap"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/simple"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/supervisor/testutil"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/configworker/dynamicchildren"
+)
+
+var _ = Describe("NMAP_BACKEND=fsmv2 stale observation across a connection edit", func() {
+	const (
+		name        = "bridge-conn"
+		port uint16 = 502
+
+		goodTarget = "192.0.2.10" // stands in for the healthy target
+		badTarget  = "192.0.2.99" // the known-bad target the edit points at
+	)
+
+	var (
+		ctx   context.Context
+		store *storage.TriangularStore
+		mgr   *adapter.WorkerManager[config.NmapConfig, simple.Status[fsmv2nmap.NmapStatus]]
+	)
+
+	// nmapConfig builds an enabled (running) config.NmapConfig for the given target.
+	nmapConfig := func(target string) config.NmapConfig {
+		return config.NmapConfig{
+			FSMInstanceConfig: config.FSMInstanceConfig{
+				Name:            name,
+				DesiredFSMState: "running",
+			},
+			NmapServiceConfig: nmapserviceconfig.NmapServiceConfig{
+				Target: target,
+				Port:   port,
+			},
+		}
+	}
+
+	// snapshotWith puts the configs at the path the manager reads.
+	snapshotWith := func(cfgs ...config.NmapConfig) publicfsm.SystemSnapshot {
+		return publicfsm.SystemSnapshot{
+			CurrentConfig: config.FullConfig{
+				Internal: config.InternalConfig{Nmap: cfgs},
+			},
+		}
+	}
+
+	// writeScan persists an observation the way the collector does: an
+	// Observation[simple.Status[NmapStatus]] under the ref's CSE key
+	// (workerType "nmap", id ChildID(name)), stamped now so it reads Fresh.
+	writeScan := func(portState string, running bool) {
+		obs := fsmv2.Observation[simple.Status[fsmv2nmap.NmapStatus]]{
+			CollectedAt: time.Now(),
+			Status: simple.Status[fsmv2nmap.NmapStatus]{
+				Result: fsmv2nmap.NmapStatus{
+					PortState: portState,
+					IsRunning: running,
+					Port:      port,
+				},
+			},
+		}
+
+		_, err := store.SaveObserved(ctx, fsmv2nmap.WorkerType, fsmv2config.ChildID(name), obs)
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	// currentState reads the fsmv1 operational state the connection FSM would see.
+	currentState := func() string {
+		state, err := mgr.GetCurrentFSMState(name)
+		Expect(err).NotTo(HaveOccurred())
+
+		return state
+	}
+
+	BeforeEach(func() {
+		ctx = context.Background()
+
+		// Real store + real client (writer for child specs, store as StateReader).
+		store = testutil.CreateTriangularStoreForWorkerType(fsmv2nmap.WorkerType)
+		writer := dynamicchildren.NewWriter()
+		fsmv2client.SetClient(fsmv2client.NewFSMv2Client(writer, store))
+
+		mgr = fsmv2nmap.NewFsmv2NmapManager("staleness-test")
+	})
+
+	AfterEach(func() {
+		fsmv2client.SetClient(nil)
+	})
+
+	It("reports the connection open once after the target is edited to a bad host (BUG)", func() {
+		// 1. Deploy the healthy connection: reconcile upserts the worker, and its
+		//    first scan of the good target lands open.
+		err, _ := mgr.Reconcile(ctx, snapshotWith(nmapConfig(goodTarget)), nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		writeScan(string(nmapfsm.PortStateOpen), true)
+		Expect(currentState()).To(Equal(nmapfsm.OperationalStateOpen),
+			"the healthy connection must read open before the edit")
+
+		// 2. Edit the connection to a known-bad target. Only the target changed,
+		//    so the worker name — and therefore the ref/CSE key — is identical.
+		//    The worker has not re-polled the bad target yet, so the store still
+		//    holds the open scan of the GOOD target.
+		err, _ = mgr.Reconcile(ctx, snapshotWith(nmapConfig(badTarget)), nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		// 3. A target change must invalidate the prior observation: the manager
+		//    must NOT serve the open scan of the OLD target for the new bad
+		//    target. Until the bad target is actually scanned this must read
+		//    starting/degraded, never open.
+		//
+		//    This currently FAILS (RED): the stale open scan is still Fresh
+		//    (recent CollectedAt) and keyed by the unchanged ref, so the manager
+		//    reports open — the single healthy tick that lets awaitRollout's
+		//    DFCTypeEmpty path treat the edit as succeeded.
+		Expect(currentState()).NotTo(Equal(nmapfsm.OperationalStateOpen),
+			"a connection edited to a bad target must not read open from the old target's stale scan")
+
+		// 4. Once the worker actually scans the bad target (closed), the manager
+		//    corrects — confirming the earlier open was purely the stale window.
+		writeScan(string(nmapfsm.PortStateClosed), false)
+		Expect(currentState()).To(Equal(nmapfsm.OperationalStateClosed),
+			"after the bad target is scanned the connection reads closed")
+	})
+})


### PR DESCRIPTION
> **Superseded by #2751.** The container harness here (`integration/managementconsole_stack_test.go`,
> `integration/docker_test_helpers.go`) is byte-identical to #2751's, and
> `integration/connection_edit_staleness_test.go` covers the same path as #2751's
> `integration/connection_edit_rollback_test.go` — fsmv1 and fsmv2 driven through the real
> ManagementConsole backend, a bridge with a read flow edited to an unreachable target,
> asserting `ActionFinishedWithFailure`. #2751's version is the post-fix one, so it is the
> one that lands. The pkg-level specs here are covered by #2708's `manager_test.go` specs
> ("reflects the scan, not the requested config", "records the target and port it dialed").

## Problem

Editing a bridge's connection to an unreachable address reports a successful deploy. With `NMAP_BACKEND=fsmv2` the connection briefly still reads the *old* target's scan, so the rollout sees a healthy bridge and accepts the edit. The overview page then shows the connection degraded, but the deploy already claimed success. Nothing in the suite caught this.

## What we are shipping

- An integration spec that drives the whole path — real ManagementConsole backend and router, real container, a real edit-protocol-converter action — once per nmap backend. `fsmv1` rolls back and passes; `fsmv2` replies action-success and fails on the bug.
- A fast unit-level spec for the same defect that steps the poll cadence by hand, so it is deterministic and runs in 0.2s.
- `make connection-staleness-test`, which pulls the ManagementConsole backend and router source and runs both specs. It sits outside the `integration` label because that suite runs `--fail-fast`, which the intentionally-red fsmv2 spec would abort.

The bad target is an unrouted TEST-NET-2 address rather than a closed loopback port. A refused dial resolves in microseconds and closes the stale window before the rollout can sample it, which made the spec pass without reproducing anything.

Verified: `fsmv2` fails in 63s on the terminal reply, `fsmv1` passes in 79s, and the unit spec fails on every run.

## What we are NOT shipping

The fix. `GetFresh` classifies an observation by age alone and never checks whether it belongs to the current target, so a leftover scan of a previous target is served as fresh. That belongs in the fsmv2 framework rather than in the nmap worker, so every other worker benefits — see ENG-5580.

Also left alone: the spec's guard proves the action reached the rollout wait, not that a failure came from connection health. A green there stays weaker evidence than the unit spec, and worth tightening if this test is to be load-bearing after the fix.

Refs ENG-4839
