### PR TITLE
test(integration): prove the connection check rolls back an edit to an unreachable target

### DIFF
--- a/umh-core/.gitignore
+++ b/umh-core/.gitignore
@@ -2,6 +2,9 @@ data/
 
 integration/umh-config
 
+# Pulled from the private ManagementConsole repo by `make pull-managementconsole`
+integration/managementconsole
+
 *.test
 
 .docker-cache

--- a/umh-core/.gitignore
+++ b/umh-core/.gitignore
@@ -3,7 +3,7 @@ data/
 integration/umh-config
 
 # Pulled from the private ManagementConsole repo by `make pull-managementconsole`
-integration/managementconsole
+integration/.managementconsole
 
 *.test
 

--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Editing a bridge's connection to a port that does not answer now fails and restores the previous configuration, instead of reporting a successful deploy. The deploy waits for a scan that finds the new port open, so a port that is closed or filtered is no longer accepted
 - Repointing a bridge to a different host on the same port is now checked too. The deploy waits for a scan taken after the change, so the previous host's scan can no longer satisfy it
-- The check now covers a bridge that already has a read or write flow, not only one without flows. Editing a flow without changing the connection is unaffected
+- Editing a bridge that already has a read or write flow now verifies the new connection as well, not only a bridge without flows. Such an edit previously reported success as soon as the flow was applied, even when the new address never answered
 
 ## [0.44.38]
 

--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Editing a bridge's connection to a port that does not answer now fails and restores the previous configuration, instead of reporting a successful deploy. The deploy waits for a scan that finds the new port open, so a port that is closed or filtered is no longer accepted
 - Repointing a bridge to a different host on the same port is now checked too. The deploy waits for a scan taken after the change, so the previous host's scan can no longer satisfy it
+- The check now covers a bridge that already has a read or write flow, not only one without flows. Editing a flow without changing the connection is unaffected
 
 ## [0.44.38]
 

--- a/umh-core/Makefile
+++ b/umh-core/Makefile
@@ -233,7 +233,7 @@ else
     INTEGRATION_REPORT_FLAG :=
 endif
 
-UNIT_LABEL_FILTER := !integration && !redpanda-extended && !tls && !live
+UNIT_LABEL_FILTER := !integration && !redpanda-extended && !tls && !live && !connection-edit-rollback
 # Explicit list: excludes integration/ (requires Docker; has its own make target)
 UNIT_TEST_PKGS := ./cmd/... ./internal/... ./pkg/... ./test/...
 # Package that runs its Ginkgo suite in parallel (--procs); must be kept separate
@@ -428,6 +428,49 @@ redpanda-extended-test: pre-test
 
 badssl-test: pre-test
 	go run github.com/onsi/ginkgo/v2/ginkgo -r --tags=test --label-filter='tls' --fail-fast ./...
+
+###############################################################################
+# ManagementConsole integration dependencies
+#
+# The connection-edit-rollback specs drive umh-core through the *real*
+# ManagementConsole backend + router, run as local Go processes exactly the way
+# ManagementConsole's own Playwright e2e suite runs them. That source lives in
+# the private united-manufacturing-hub/ManagementConsole repo, so we pull only
+# the folders needed to build the two binaries using the developer's `gh`
+# credentials. Access to that repo is therefore required to run these tests.
+###############################################################################
+MC_REPO ?= united-manufacturing-hub/ManagementConsole
+MC_REF ?= staging
+MC_DIR := $(SRC_ROOT)/umh-core/integration/managementconsole
+
+.PHONY: pull-managementconsole connection-rollback-test
+
+pull-managementconsole: ## Pull backend+router source from the private ManagementConsole repo (needs `gh` access)
+	@command -v gh >/dev/null 2>&1 || { echo "❌ gh CLI not found — install https://cli.github.com"; exit 1; }
+	@gh auth status >/dev/null 2>&1 || { echo "❌ Not logged in to GitHub — run: gh auth login"; exit 1; }
+	@echo "📥 Pulling ManagementConsole ($(MC_REF)) backend+router into $(MC_DIR) ..."
+	@rm -rf "$(MC_DIR)"
+	@mkdir -p "$(MC_DIR)"
+	@TOKEN=$$(gh auth token) && \
+	  git clone --quiet --no-checkout --filter=blob:none --depth 1 --branch "$(MC_REF)" \
+	    "https://x-access-token:$$TOKEN@github.com/$(MC_REPO).git" "$(MC_DIR)" && \
+	  git -C "$(MC_DIR)" sparse-checkout init --no-cone && \
+	  printf '%s\n' '/backend/' '!/backend/backend' '/router/' '/shared/' '/cryptolib/' '/frontend/static/requirements.json' \
+	    > "$(MC_DIR)/.git/info/sparse-checkout" && \
+	  git -C "$(MC_DIR)" checkout --quiet && \
+	  git -C "$(MC_DIR)" remote set-url origin "https://github.com/$(MC_REPO).git"
+	@rm -f "$(MC_DIR)/backend/backend"
+	@printf '✅ ManagementConsole source ready (commit %s)\n' "$$(git -C '$(MC_DIR)' rev-parse --short HEAD)"
+
+# Runs the fsmv1+fsmv2 connection-edit rollback specs against the real
+# ManagementConsole backend+router. Pulls the source first (idempotent).
+# --skip-package keeps ginkgo's -r discovery out of the pulled ManagementConsole
+# tree, whose packages do not compile under the test runner.
+connection-rollback-test: pull-managementconsole build-protobuf
+	FORCE_DOCKER=true VERSION=$(VERSION) MC_DIR="$(MC_DIR)" \
+	  go run github.com/onsi/ginkgo/v2/ginkgo -r --tags=test \
+	  --skip-package=managementconsole \
+	  --label-filter='connection-edit-rollback' --timeout=30m ./integration/...
 
 update-go-dependencies:
 	go get -u ./...

--- a/umh-core/Makefile
+++ b/umh-core/Makefile
@@ -441,13 +441,16 @@ badssl-test: pre-test
 ###############################################################################
 MC_REPO ?= united-manufacturing-hub/ManagementConsole
 MC_REF ?= staging
-MC_DIR := $(SRC_ROOT)/umh-core/integration/managementconsole
+# Dot-prefixed on purpose: both `go ./...` and ginkgo's own -r directory walk
+# skip names starting with a dot, so the pulled tree cannot be discovered as a
+# package by any other target in this Makefile.
+MC_DIR := $(SRC_ROOT)/umh-core/integration/.managementconsole
 
 .PHONY: pull-managementconsole connection-rollback-test
 
 pull-managementconsole: ## Pull backend+router source from the private ManagementConsole repo (needs `gh` access)
 	@command -v gh >/dev/null 2>&1 || { echo "❌ gh CLI not found — install https://cli.github.com"; exit 1; }
-	@gh auth status >/dev/null 2>&1 || { echo "❌ Not logged in to GitHub — run: gh auth login"; exit 1; }
+	@gh auth status >/dev/null 2>&1 || { echo "❌ Not logged in to GitHub. Locally: gh auth login. In CI: export GH_TOKEN with read access to $(MC_REPO)"; exit 1; }
 	@echo "📥 Pulling ManagementConsole ($(MC_REF)) backend+router into $(MC_DIR) ..."
 	@rm -rf "$(MC_DIR)"
 	@mkdir -p "$(MC_DIR)"
@@ -463,9 +466,10 @@ pull-managementconsole: ## Pull backend+router source from the private Managemen
 	@printf '✅ ManagementConsole source ready (commit %s)\n' "$$(git -C '$(MC_DIR)' rev-parse --short HEAD)"
 
 # Runs the fsmv1+fsmv2 connection-edit rollback specs against the real
-# ManagementConsole backend+router. Pulls the source first (idempotent).
-# --skip-package keeps ginkgo's -r discovery out of the pulled ManagementConsole
-# tree, whose packages do not compile under the test runner.
+# ManagementConsole backend+router. Re-clones the source on every run, so it
+# needs network access and `gh` auth each time.
+# --skip-package is belt and braces: MC_DIR is dot-prefixed, which already keeps
+# the pulled tree out of the -r walk.
 connection-rollback-test: pull-managementconsole build-protobuf
 	FORCE_DOCKER=true VERSION=$(VERSION) MC_DIR="$(MC_DIR)" \
 	  go run github.com/onsi/ginkgo/v2/ginkgo -r --tags=test \

--- a/umh-core/Makefile
+++ b/umh-core/Makefile
@@ -432,8 +432,8 @@ badssl-test: pre-test
 ###############################################################################
 # ManagementConsole integration dependencies
 #
-# The connection-edit-rollback specs drive umh-core through the *real*
-# ManagementConsole backend + router, run as local Go processes exactly the way
+# The connection-edit-rollback specs drive umh-core through the ManagementConsole
+# backend and router, run as local Go processes the way
 # ManagementConsole's own Playwright e2e suite runs them. That source lives in
 # the private united-manufacturing-hub/ManagementConsole repo, so we pull only
 # the folders needed to build the two binaries using the developer's `gh`

--- a/umh-core/integration/connection_edit_rollback_test.go
+++ b/umh-core/integration/connection_edit_rollback_test.go
@@ -38,6 +38,9 @@ import (
 const (
 	rollbackBridgeName = "bridge-conn"
 
+	// 8080 is the agent's own metrics port (see buildRollbackConfig), which is
+	// what makes this endpoint answer inside the container. Change one and the
+	// pre-edit wait below fails naming the bridge, not the port.
 	rollbackReachableIP   = "127.0.0.1"
 	rollbackReachablePort = uint32(8080)
 
@@ -179,10 +182,10 @@ func buildRollbackConfig(apiURL string) string {
 	return string(out)
 }
 
-func lastBridgeState() string {
+func lastBridgeState() (string, error) {
 	out, err := runDockerCommand("exec", getContainerName(), "cat", "/data/logs/umh-core/current")
 	if err != nil {
-		return ""
+		return "", fmt.Errorf("failed to read the agent log from the container: %w", err)
 	}
 
 	marker := rollbackBridgeName + ": "
@@ -205,7 +208,7 @@ func lastBridgeState() string {
 		state = fields[0]
 	}
 
-	return state
+	return state, nil
 }
 
 func runConnectionEditRollbackSpec(nmapBackend string) {
@@ -241,6 +244,7 @@ func runConnectionEditRollbackSpec(nmapBackend string) {
 
 	AfterAll(func() {
 		PrintLogsAndStopContainer()
+		CleanupDockerBuildCache()
 
 		if backend != nil {
 			backend.stop()
@@ -274,14 +278,19 @@ func runConnectionEditRollbackSpec(nmapBackend string) {
 		)).To(Succeed())
 
 		By("waiting for a terminal action-reply")
+
+		var finalState models.ActionReplyState
+
 		Eventually(func() bool {
-			_, terminal := backend.terminalReplyState(actionUUID)
+			state, terminal := backend.lastReplyState(actionUUID)
+			if terminal {
+				finalState = state
+			}
 
 			return terminal
 		}, 150*time.Second, 1*time.Second).Should(BeTrue(),
 			"the edit must produce a terminal action-reply")
 
-		finalState, _ := backend.terminalReplyState(actionUUID)
 		replies := backend.replyDump(actionUUID)
 
 		AddReportEntry(fmt.Sprintf("NMAP_BACKEND=%s reply history", nmapBackend), strings.Join(replies, "\n"))
@@ -291,7 +300,48 @@ func runConnectionEditRollbackSpec(nmapBackend string) {
 				"at parse/validate/persist, and says nothing about the connection")
 
 		Expect(finalState).To(Equal(models.ActionFinishedWithFailure),
-			"an edit to an unreachable target must fail and roll back")
+			"an edit to an unreachable target must fail")
+
+		// A terminal failure alone does not say the previous configuration came
+		// back: awaitRollout reports the same state when the rollback itself
+		// fails, and when it aborts on a render error without dialling anything.
+		// Only the message separates them.
+		Expect(replies).To(ContainElement(ContainSubstring("Rolled back to previous configuration")),
+			"the previous configuration must be restored, and the reply must say so")
+		Expect(replies).NotTo(ContainElement(ContainSubstring("Rolling back to previous configuration failed")),
+			"the rollback itself must succeed")
+
+		By("editing back to the reachable target")
+
+		goodActionUUID := uuid.New()
+
+		Expect(backend.enqueueEditProtocolConverter(
+			goodActionUUID, bridgeUUID, rollbackBridgeName,
+			rollbackReachableIP, rollbackReachablePort,
+			rollbackReadDFCPayload(),
+		)).To(Succeed())
+
+		// The positive control. Without it, a harness that fails every edit for
+		// its own reasons satisfies everything above.
+		var goodState models.ActionReplyState
+
+		Eventually(func() bool {
+			state, terminal := backend.lastReplyState(goodActionUUID)
+			if terminal {
+				goodState = state
+			}
+
+			return terminal
+		}, 150*time.Second, 1*time.Second).Should(BeTrue(),
+			"the second edit must produce a terminal action-reply")
+
+		goodReplies := backend.replyDump(goodActionUUID)
+
+		AddReportEntry(fmt.Sprintf("NMAP_BACKEND=%s reply history (edit back)", nmapBackend), strings.Join(goodReplies, "\n"))
+
+		Expect(goodState).To(Equal(models.ActionFinishedSuccessfull),
+			"an edit to a reachable target must succeed, or the check rejects everything and the "+
+				"assertions above prove nothing")
 	})
 }
 

--- a/umh-core/integration/connection_edit_rollback_test.go
+++ b/umh-core/integration/connection_edit_rollback_test.go
@@ -1,0 +1,306 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration_test
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"gopkg.in/yaml.v3"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/connectionserviceconfig"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/dataflowcomponentserviceconfig"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/protocolconverterserviceconfig"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/redpandaserviceconfig"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/variables"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/models"
+)
+
+const (
+	rollbackBridgeName = "bridge-conn"
+
+	rollbackReachableIP   = "127.0.0.1"
+	rollbackReachablePort = uint32(8080)
+
+	// TEST-NET-2 is not routed, so the dial is dropped rather than refused and
+	// blocks until the observation timeout. A closed port is refused instantly,
+	// which lets a scan of the new target land before the rollout reads the
+	// connection, and the spec then passes without exercising the rollout at all.
+	// https://datatracker.ietf.org/doc/html/rfc5737#section-3
+	rollbackUnreachableIP   = "198.51.100.1"
+	rollbackUnreachablePort = uint32(445)
+
+	rollbackTagProcessorJS = `msg.meta.location_path = "test-enterprise";
+msg.meta.data_contract = "_historian";
+msg.meta.tag_name = "my_data";
+msg.payload = msg.payload;
+return msg;`
+)
+
+func rollbackReadDFC() dataflowcomponentserviceconfig.DataflowComponentServiceConfig {
+	return dataflowcomponentserviceconfig.DataflowComponentServiceConfig{
+		BenthosConfig: dataflowcomponentserviceconfig.BenthosConfig{
+			Input: map[string]any{
+				"generate": map[string]any{
+					"count":    0,
+					"interval": "1s",
+					"mapping":  `root = "hello world"`,
+				},
+			},
+			Pipeline: map[string]any{
+				"processors": []any{
+					map[string]any{"tag_processor": map[string]any{"defaults": rollbackTagProcessorJS}},
+				},
+			},
+			Buffer: map[string]any{"none": map[string]any{}},
+		},
+	}
+}
+
+func rollbackReadDFCPayload() map[string]any {
+	generateData, err := yaml.Marshal(map[string]any{
+		"generate": map[string]any{
+			"count":    0,
+			"interval": "1s",
+			"mapping":  `root = "hello world"`,
+		},
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	processorData, err := yaml.Marshal(map[string]any{
+		"tag_processor": map[string]any{"defaults": rollbackTagProcessorJS},
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	return map[string]any{
+		"state": "active",
+		"inputs": map[string]any{
+			"type": "generate",
+			"data": string(generateData),
+		},
+		"pipeline": map[string]any{
+			"processors": map[string]any{
+				"0": map[string]any{
+					"type": "tag_processor",
+					"data": string(processorData),
+				},
+			},
+		},
+	}
+}
+
+func buildRollbackConfig(apiURL string) string {
+	redpandaConfig := config.RedpandaConfig{
+		FSMInstanceConfig: config.FSMInstanceConfig{
+			Name:            "redpanda",
+			DesiredFSMState: "active",
+		},
+		RedpandaServiceConfig: redpandaserviceconfig.RedpandaServiceConfig{},
+	}
+	redpandaConfig.RedpandaServiceConfig.Resources.MaxCores = 1
+	redpandaConfig.RedpandaServiceConfig.Resources.MemoryPerCoreInBytes = 2 * 1024 * 1024 * 1024
+
+	bridgeTemplate := protocolconverterserviceconfig.ProtocolConverterServiceConfigTemplate{
+		ConnectionServiceConfig: connectionserviceconfig.ConnectionServiceConfigTemplate{
+			NmapTemplate: &connectionserviceconfig.NmapConfigTemplate{
+				Target: "{{ .IP }}",
+				Port:   "{{ .PORT }}",
+			},
+		},
+		DataflowComponentReadServiceConfig: rollbackReadDFC(),
+	}
+
+	full := config.FullConfig{
+		Templates: config.TemplatesConfig{
+			ProtocolConverter: map[string]any{
+				rollbackBridgeName: bridgeTemplate,
+			},
+		},
+		Agent: config.AgentConfig{
+			MetricsPort: 8080,
+			Location:    map[int]string{0: "test-enterprise"},
+			CommunicatorConfig: config.CommunicatorConfig{
+				APIURL:           apiURL,
+				AuthToken:        mcAuthToken,
+				AllowInsecureTLS: true,
+			},
+		},
+		ProtocolConverter: []config.ProtocolConverterConfig{
+			{
+				FSMInstanceConfig: config.FSMInstanceConfig{
+					Name:            rollbackBridgeName,
+					DesiredFSMState: "active",
+				},
+				ProtocolConverterServiceConfig: protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec{
+					TemplateRef: rollbackBridgeName,
+					Variables: variables.VariableBundle{
+						User: map[string]any{
+							"IP":   rollbackReachableIP,
+							"PORT": strconv.FormatUint(uint64(rollbackReachablePort), 10),
+						},
+					},
+					Location: map[string]string{"0": "test-enterprise"},
+				},
+			},
+		},
+		Internal: config.InternalConfig{
+			Redpanda: redpandaConfig,
+			TopicBrowser: config.TopicBrowserConfig{
+				FSMInstanceConfig: config.FSMInstanceConfig{
+					Name:            "topic-browser",
+					DesiredFSMState: "stopped",
+				},
+			},
+		},
+	}
+
+	out, err := yaml.Marshal(full)
+	Expect(err).NotTo(HaveOccurred())
+
+	return string(out)
+}
+
+func lastBridgeState() string {
+	out, err := runDockerCommand("exec", getContainerName(), "cat", "/data/logs/umh-core/current")
+	if err != nil {
+		return ""
+	}
+
+	marker := rollbackBridgeName + ": "
+	state := ""
+
+	for _, line := range strings.Split(out, "\n") {
+		index := strings.LastIndex(line, marker)
+		if index < 0 {
+			continue
+		}
+
+		// Only the snapshot logger's state lines carry the arrow. The marker also
+		// appears in s6 dependency and service-status lines, which would otherwise
+		// win whenever they happen to come last in the file.
+		fields := strings.Fields(line[index+len(marker):])
+		if len(fields) < 2 || fields[1] != "\u2192" {
+			continue
+		}
+
+		state = fields[0]
+	}
+
+	return state
+}
+
+func runConnectionEditRollbackSpec(nmapBackend string) {
+	var backend *mcStack
+
+	BeforeAll(func() {
+		encodingChooseCorev1()
+
+		var err error
+
+		backend, err = newMCStack(context.Background())
+		Expect(err).NotTo(HaveOccurred())
+
+		GinkgoWriter.Printf("ManagementConsole stack up, router at %s (NMAP_BACKEND=%s)\n", backend.apiURL(), nmapBackend)
+
+		extraCreateArgs = []string{
+			"-e", "NMAP_BACKEND=" + nmapBackend,
+			"-e", "USE_FSMV2_TRANSPORT=true",
+			"-e", "API_URL=" + backend.apiURL(),
+			"-e", "AUTH_TOKEN=" + mcAuthToken,
+			"-e", "ALLOW_INSECURE_TLS=true",
+			"--add-host=host.docker.internal:host-gateway",
+		}
+
+		err = BuildAndRunContainer(buildRollbackConfig(backend.apiURL()), DEFAULT_MEMORY, DEFAULT_CPUS)
+		if err != nil {
+			printContainerDebugInfo()
+			Expect(err).NotTo(HaveOccurred(), "Container startup failed")
+		}
+
+		Expect(waitForMetrics()).To(Succeed(), "Metrics endpoint should be available")
+	})
+
+	AfterAll(func() {
+		PrintLogsAndStopContainer()
+
+		if backend != nil {
+			backend.stop()
+		}
+
+		extraCreateArgs = nil
+
+		if !CurrentSpecReport().Failed() {
+			cleanupTmpDirs(getContainerName())
+		}
+	})
+
+	It("fails the edit and rolls back", func() {
+		By("waiting for the container to log in to the ManagementConsole backend")
+		Eventually(backend.loginSeen, 120*time.Second, 1*time.Second).Should(BeTrue(),
+			"container must complete login against the ManagementConsole backend")
+
+		By("waiting for the bridge to run with the reachable target")
+		Eventually(lastBridgeState, 300*time.Second, 2*time.Second).Should(BeElementOf("idle", "active"),
+			"bridge must run with the reachable target before the edit")
+
+		By("re-pointing the connection at the unreachable target")
+
+		actionUUID := uuid.New()
+		bridgeUUID := dataflowcomponentserviceconfig.GenerateUUIDFromName(rollbackBridgeName)
+
+		Expect(backend.enqueueEditProtocolConverter(
+			actionUUID, bridgeUUID, rollbackBridgeName,
+			rollbackUnreachableIP, rollbackUnreachablePort,
+			rollbackReadDFCPayload(),
+		)).To(Succeed())
+
+		By("waiting for a terminal action-reply")
+		Eventually(func() bool {
+			_, terminal := backend.terminalReplyState(actionUUID)
+
+			return terminal
+		}, 150*time.Second, 1*time.Second).Should(BeTrue(),
+			"the edit must produce a terminal action-reply")
+
+		finalState, _ := backend.terminalReplyState(actionUUID)
+		replies := backend.replyDump(actionUUID)
+
+		AddReportEntry(fmt.Sprintf("NMAP_BACKEND=%s reply history", nmapBackend), strings.Join(replies, "\n"))
+
+		Expect(replies).To(ContainElement(ContainSubstring("Waiting for bridge")),
+			"the edit must reach the rollout wait; a terminal reply without it failed earlier, "+
+				"at parse/validate/persist, and says nothing about the connection")
+
+		Expect(finalState).To(Equal(models.ActionFinishedWithFailure),
+			"an edit to an unreachable target must fail and roll back")
+	})
+}
+
+var _ = Describe("Connection edit to an unreachable target - NMAP_BACKEND=fsmv1",
+	Ordered, Label("connection-edit-rollback"), func() {
+		runConnectionEditRollbackSpec("fsmv1")
+	})
+
+var _ = Describe("Connection edit to an unreachable target - NMAP_BACKEND=fsmv2",
+	Ordered, Label("connection-edit-rollback"), func() {
+		runConnectionEditRollbackSpec("fsmv2")
+	})

--- a/umh-core/integration/docker_test_helpers.go
+++ b/umh-core/integration/docker_test_helpers.go
@@ -54,6 +54,20 @@ var (
 var imageNameOnce sync.Once
 var imageName string
 
+// extraCreateArgs holds additional `docker create` arguments (e.g. extra `-e`
+// env flags or `--add-host`) injected just before the image name. Tests set it
+// in their BeforeAll to customize the container without touching every existing
+// caller. An empty slice leaves the create command identical to the default, so
+// existing integration tests are unaffected.
+var extraCreateArgs []string
+
+// skipConfigCopy tells BuildAndRunContainer not to `docker cp` the config into
+// the container. Set this when a test bind-mounts /data/config.yaml via
+// extraCreateArgs: `docker cp` onto a bind-mounted file fails with
+// "device or resource busy". The default (false) preserves the docker-cp
+// behavior for every existing caller.
+var skipConfigCopy bool
+
 func getImageName() string {
 	imageNameOnce.Do(func() {
 		imageName = "umh-core:latest-" + time.Now().Format("20060102150405")
@@ -168,6 +182,15 @@ func writeConfigFile(yamlContent string, containerName ...string) error {
 		return fmt.Errorf("failed to write config file: %w", err)
 	}
 
+	// WriteFile's mode is reduced by the process umask (typically 0022 → 0644).
+	// Force 0666 so the container user (uid 1000) can rewrite the docker-cp'd
+	// config on startup — the agent persists the env-merged config on load
+	// (LoadConfigWithEnvOverrides), and a 0644 root-owned copy would fail that
+	// write and crash-loop the agent before the communicator logs in.
+	if err := os.Chmod(configPath, 0o666); err != nil {
+		return fmt.Errorf("failed to chmod config file: %w", err)
+	}
+
 	// If container name is provided, also write directly to container
 	if len(containerName) > 0 && containerName[0] != "" {
 		container := containerName[0]
@@ -177,6 +200,13 @@ func writeConfigFile(yamlContent string, containerName ...string) error {
 		tmpFile := configPath + ".tmp"
 		if err := os.WriteFile(tmpFile, []byte(yamlContent), 0o666); err != nil {
 			return fmt.Errorf("failed to write temp config file: %w", err)
+		}
+
+		// Force 0666 (WriteFile is umask-reduced); docker cp preserves the mode,
+		// so the container's config.yaml lands world-writable and the agent (uid
+		// 1000) can rewrite it without waiting for the post-start chmod.
+		if err := os.Chmod(tmpFile, 0o666); err != nil {
+			return fmt.Errorf("failed to chmod temp config file: %w", err)
 		}
 
 		defer func() {
@@ -252,6 +282,17 @@ func buildContainer() error {
 	GinkgoWriter.Println("Docker build successful")
 
 	return nil
+}
+
+// umhLogLevel returns the LOGGING_LEVEL passed to the container-under-test.
+// Defaults to "debug"; override with the UMH_LOG_LEVEL env var (e.g.
+// UMH_LOG_LEVEL=info) when running the integration tests.
+func umhLogLevel() string {
+	if lvl := os.Getenv("UMH_LOG_LEVEL"); lvl != "" {
+		return lvl
+	}
+
+	return "debug"
 }
 
 // BuildAndRunContainer rebuilds your Docker image, starts the container, etc.
@@ -356,20 +397,25 @@ func BuildAndRunContainer(configYaml string, memory string, cpus uint) error {
 	// grant 40 ms every 20 ms → an average of 2 fully-loaded logical cores.
 	cpuQuota := cpus * cpuPeriod
 
-	out, err = runDockerCommand(
+	createArgs := []string{
 		"create",
 		"--name", containerName,
-		"-e", "LOGGING_LEVEL=debug",
+		"-e", "LOGGING_LEVEL=" + umhLogLevel(),
 		// Map the host ports to the container's fixed ports
 		"-p", fmt.Sprintf("%d:8080", metricsPrt), // Map host's dynamic port to container's fixed metrics port
 		"-p", fmt.Sprintf("%d:8082", goldenPrt), // Map host's dynamic port to container's golden service port
 		"--memory", memory,
 		"--cpu-period", strconv.FormatUint(uint64(cpuPeriod), 10), // 20 ms CFS window
 		"--cpu-quota", strconv.FormatUint(uint64(cpuQuota), 10), // e.g. 40 ms budget ⇒ 2 vCPUs
-		"-v", tmpRedpandaDir+":/data/redpanda",
-		"-v", tmpLogsDir+":/data/logs",
-		getImageName(),
-	)
+		"-v", tmpRedpandaDir + ":/data/redpanda",
+		"-v", tmpLogsDir + ":/data/logs",
+	}
+	// Inject any test-supplied extra create args (extra env, --add-host, ...)
+	// immediately before the image name. Empty slice → unchanged behavior.
+	createArgs = append(createArgs, extraCreateArgs...)
+	createArgs = append(createArgs, getImageName())
+
+	out, err = runDockerCommand(createArgs...)
 	if err != nil {
 		GinkgoWriter.Printf("Container creation failed: %v\n", err)
 		GinkgoWriter.Printf("Container create output:\n%s\n", out)
@@ -379,12 +425,19 @@ func BuildAndRunContainer(configYaml string, memory string, cpus uint) error {
 
 	GinkgoWriter.Printf("Container created with ID: %s\n", strings.TrimSpace(out))
 
-	// 6. Copy the config file to the container BEFORE starting it
-	GinkgoWriter.Println("Copying config file to container...")
+	// 6. Copy the config file to the container BEFORE starting it. When the
+	// caller bind-mounts /data/config.yaml, skip the copy (docker cp onto a
+	// bind-mounted file fails "device or resource busy"); the host file backing
+	// the mount was already written by the caller.
+	if skipConfigCopy {
+		GinkgoWriter.Println("Skipping config copy (config.yaml is bind-mounted)...")
+	} else {
+		GinkgoWriter.Println("Copying config file to container...")
 
-	err = writeConfigFile(configYaml, containerName)
-	if err != nil {
-		return fmt.Errorf("failed to write config to container: %w", err)
+		err = writeConfigFile(configYaml, containerName)
+		if err != nil {
+			return fmt.Errorf("failed to write config to container: %w", err)
+		}
 	}
 
 	// 7. Start the container

--- a/umh-core/integration/docker_test_helpers.go
+++ b/umh-core/integration/docker_test_helpers.go
@@ -54,19 +54,10 @@ var (
 var imageNameOnce sync.Once
 var imageName string
 
-// extraCreateArgs holds additional `docker create` arguments (e.g. extra `-e`
-// env flags or `--add-host`) injected just before the image name. Tests set it
-// in their BeforeAll to customize the container without touching every existing
-// caller. An empty slice leaves the create command identical to the default, so
-// existing integration tests are unaffected.
+// extraCreateArgs holds additional `docker create` arguments injected just
+// before the image name. It is process-global and unguarded, so a spec that
+// sets it must clear it again and the package must keep running serially.
 var extraCreateArgs []string
-
-// skipConfigCopy tells BuildAndRunContainer not to `docker cp` the config into
-// the container. Set this when a test bind-mounts /data/config.yaml via
-// extraCreateArgs: `docker cp` onto a bind-mounted file fails with
-// "device or resource busy". The default (false) preserves the docker-cp
-// behavior for every existing caller.
-var skipConfigCopy bool
 
 func getImageName() string {
 	imageNameOnce.Do(func() {
@@ -282,12 +273,11 @@ func buildContainer() error {
 	return nil
 }
 
-// umhLogLevel returns the LOGGING_LEVEL passed to the container-under-test.
-// Defaults to "debug"; override with the UMH_LOG_LEVEL env var (e.g.
-// UMH_LOG_LEVEL=info) when running the integration tests.
+// umhLogLevel returns the container's LOGGING_LEVEL, "debug" unless UMH_LOG_LEVEL
+// overrides it. Specs that read state out of the agent log need info or below.
 func umhLogLevel() string {
-	if lvl := os.Getenv("UMH_LOG_LEVEL"); lvl != "" {
-		return lvl
+	if level := os.Getenv("UMH_LOG_LEVEL"); level != "" {
+		return level
 	}
 
 	return "debug"
@@ -351,6 +341,15 @@ func BuildAndRunContainer(configYaml string, memory string, cpus uint) error {
 	// 3. Run container WITHOUT mounting the config file (but we do need to mount the /data/redpanda folder, otherwise it cannot start)
 	tmpRedpandaDir := filepath.Join(getTmpDir(), containerName, "redpanda")
 	tmpLogsDir := filepath.Join(getTmpDir(), containerName, "logs")
+
+	// The container name is memoized per process, so two Describes in one run
+	// share these directories. cleanupTmpDirs only runs when the spec passed, so
+	// without this a failed run leaves its log file in place and the next
+	// container starts on top of it, where a spec reading state out of the log
+	// can match the previous run's last line.
+	if err := os.RemoveAll(filepath.Join(getTmpDir(), containerName)); err != nil {
+		return fmt.Errorf("failed to clear the container's temporary directories: %w", err)
+	}
 
 	// 4. Create the directories with permissions that allow container user (UID 1000) to write
 	if err := os.MkdirAll(tmpRedpandaDir, 0o777); err != nil {
@@ -421,19 +420,12 @@ func BuildAndRunContainer(configYaml string, memory string, cpus uint) error {
 
 	GinkgoWriter.Printf("Container created with ID: %s\n", strings.TrimSpace(out))
 
-	// 6. Copy the config file to the container BEFORE starting it. When the
-	// caller bind-mounts /data/config.yaml, skip the copy (docker cp onto a
-	// bind-mounted file fails "device or resource busy"); the host file backing
-	// the mount was already written by the caller.
-	if skipConfigCopy {
-		GinkgoWriter.Println("Skipping config copy (config.yaml is bind-mounted)...")
-	} else {
-		GinkgoWriter.Println("Copying config file to container...")
+	// 6. Copy the config file to the container BEFORE starting it.
+	GinkgoWriter.Println("Copying config file to container...")
 
-		err = writeConfigFile(configYaml, containerName)
-		if err != nil {
-			return fmt.Errorf("failed to write config to container: %w", err)
-		}
+	err = writeConfigFile(configYaml, containerName)
+	if err != nil {
+		return fmt.Errorf("failed to write config to container: %w", err)
 	}
 
 	// 7. Start the container

--- a/umh-core/integration/docker_test_helpers.go
+++ b/umh-core/integration/docker_test_helpers.go
@@ -184,7 +184,7 @@ func writeConfigFile(yamlContent string, containerName ...string) error {
 
 	// WriteFile's mode is reduced by the process umask (typically 0022 → 0644).
 	// Force 0666 so the container user (uid 1000) can rewrite the docker-cp'd
-	// config on startup — the agent persists the env-merged config on load
+	// config on startup: the agent persists the env-merged config on load
 	// (LoadConfigWithEnvOverrides), and a 0644 root-owned copy would fail that
 	// write and crash-loop the agent before the communicator logs in.
 	if err := os.Chmod(configPath, 0o666); err != nil {

--- a/umh-core/integration/docker_test_helpers.go
+++ b/umh-core/integration/docker_test_helpers.go
@@ -202,9 +202,7 @@ func writeConfigFile(yamlContent string, containerName ...string) error {
 			return fmt.Errorf("failed to write temp config file: %w", err)
 		}
 
-		// Force 0666 (WriteFile is umask-reduced); docker cp preserves the mode,
-		// so the container's config.yaml lands world-writable and the agent (uid
-		// 1000) can rewrite it without waiting for the post-start chmod.
+		// Same umask reason as above; docker cp preserves the mode.
 		if err := os.Chmod(tmpFile, 0o666); err != nil {
 			return fmt.Errorf("failed to chmod temp config file: %w", err)
 		}
@@ -410,8 +408,6 @@ func BuildAndRunContainer(configYaml string, memory string, cpus uint) error {
 		"-v", tmpRedpandaDir + ":/data/redpanda",
 		"-v", tmpLogsDir + ":/data/logs",
 	}
-	// Inject any test-supplied extra create args (extra env, --add-host, ...)
-	// immediately before the image name. Empty slice → unchanged behavior.
 	createArgs = append(createArgs, extraCreateArgs...)
 	createArgs = append(createArgs, getImageName())
 

--- a/umh-core/integration/managementconsole_stack_test.go
+++ b/umh-core/integration/managementconsole_stack_test.go
@@ -1,0 +1,794 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration_test
+
+// mcStack boots the REAL ManagementConsole backend + router (built from source
+// pulled by `make pull-managementconsole`) and drives a real umh-core container
+// through them end-to-end, exactly the way ManagementConsole's own Playwright
+// e2e suite runs them: backend and router as local Go processes, Postgres and
+// Redis as throwaway Docker containers.
+//
+//	                 test process (the "user")
+//	          POST /api/v2/user/push  |  GET /api/v2/user/pull
+//	                                  v
+//	  umh-core container ──▶ router (:R) ──/api──▶ backend (:B) ──▶ Postgres + Redis
+//	   login/pull/push        strips /api          v2/instance/*, v2/user/*
+//
+// The backend is a passthrough relay for the message Content, so umh-core keeps
+// using its own corev1 codec (base64(JSON), no encryption) — the same wire the
+// old fakeBackend used. What is now REAL: instance login against a DB row,
+// JWT-scoped user auth, and the v3 Redis message queue routing.
+//
+// mcStack mirrors the method surface of the old fakeBackend
+// (apiURL/loginSeen/enqueueEditProtocolConverter/terminalReplyState/replyDump)
+// so the staleness spec is unchanged apart from the constructor.
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	. "github.com/onsi/ginkgo/v2"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/communicator/backend_api_structs"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/communicator/pkg/encoding"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/communicator/pkg/hash"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/models"
+)
+
+const (
+	// mcAuthToken is the raw auth token; it MUST match the AuthToken set in
+	// buildStalenessConfig. umh-core sends LoginHash(mcAuthToken) as the Bearer
+	// token, so that hash is what we seed into instances.auth_token.
+	mcAuthToken = "test-token"
+
+	// mcUserEmail is the seeded user's email. The edit action carries it, the
+	// agent echoes it on its reply, and the backend uses it to route the reply
+	// to this user's queue (mq:v3:live:user:<userID>).
+	mcUserEmail = "harness-user@umh.test"
+
+	mcPGImage    = "postgres:15.4"
+	mcRedisImage = "redis:7-alpine"
+	mcDBName     = "management-console"
+	mcRedisPass  = "management-console"
+)
+
+// mcBuild* memoize the one-time build of the backend + router binaries so both
+// staleness specs (fsmv1, fsmv2) reuse them instead of rebuilding per spec.
+var (
+	mcBuildOnce  sync.Once
+	mcBackendBin string
+	mcRouterBin  string
+	mcBuildErr   error
+)
+
+type mcStack struct {
+	jwtSecret      string
+	instanceUUID   uuid.UUID
+	userEmail      string
+	userID         int64
+	sessionVersion string
+	userCookie     string // minted USER_SCOPE JWT, sent as the `token` cookie
+
+	pgPort      int
+	redisPort   int
+	backendPort int
+	routerPort  int
+
+	pgContainer    string
+	redisContainer string
+
+	backendProc *exec.Cmd
+	routerProc  *exec.Cmd
+
+	mu        sync.Mutex
+	replies   map[uuid.UUID]models.ActionReplyState
+	replyMsgs map[uuid.UUID][]string
+
+	stopPoll chan struct{}
+	pollDone chan struct{}
+
+	logDir string
+}
+
+// mcDir returns the directory holding the pulled ManagementConsole source
+// (backend/, router/, shared/, cryptolib/, frontend/static/requirements.json).
+// Defaults to ./managementconsole next to the integration package; overridable
+// with MC_DIR (the Makefile passes it).
+func mcDir() (string, error) {
+	if d := os.Getenv("MC_DIR"); d != "" {
+		return d, nil
+	}
+
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(wd, "managementconsole"), nil
+}
+
+// mcFreePort grabs an ephemeral TCP port and releases it. There is a small race
+// between release and reuse, acceptable for a serial integration test.
+func mcFreePort() (int, error) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
+	}
+
+	defer func() { _ = ln.Close() }()
+
+	return ln.Addr().(*net.TCPAddr).Port, nil
+}
+
+// buildMCBinaries builds the backend and router binaries once from the pulled
+// source. It fails with an actionable message if the source is missing.
+func buildMCBinaries() (string, string, error) {
+	mcBuildOnce.Do(func() {
+		dir, err := mcDir()
+		if err != nil {
+			mcBuildErr = err
+
+			return
+		}
+
+		backendDir := filepath.Join(dir, "backend")
+		routerDir := filepath.Join(dir, "router")
+
+		if _, err := os.Stat(backendDir); err != nil {
+			mcBuildErr = fmt.Errorf("ManagementConsole source not found at %s (run `make pull-managementconsole`): %w", dir, err)
+
+			return
+		}
+
+		// The backend build embeds frontend/static/requirements.json into the
+		// demo simulator; copy it in first (mirrors `make copy_requirements_json`).
+		reqSrc := filepath.Join(dir, "frontend", "static", "requirements.json")
+
+		reqDst := filepath.Join(backendDir, "cmd", "demo_simulator_v3", "requirements.json")
+		if data, err := os.ReadFile(reqSrc); err == nil {
+			_ = os.WriteFile(reqDst, data, 0o644)
+		}
+
+		binDir, err := os.MkdirTemp("", "mc-bins-")
+		if err != nil {
+			mcBuildErr = err
+
+			return
+		}
+
+		mcBackendBin = filepath.Join(binDir, "mc-backend")
+		mcRouterBin = filepath.Join(binDir, "mc-router")
+
+		for _, b := range []struct {
+			out, srcDir string
+		}{
+			{mcBackendBin, backendDir},
+			{mcRouterBin, routerDir},
+		} {
+			// -mod=mod: the pulled tree ships no vendor/ dir, so resolve modules
+			// against the module cache / GOPROXY.
+			cmd := exec.Command("go", "build", "-mod=mod", "-o", b.out, "./cmd")
+			cmd.Dir = b.srcDir
+
+			cmd.Env = append(os.Environ(), "GOFLAGS=-mod=mod")
+			if out, err := cmd.CombinedOutput(); err != nil {
+				mcBuildErr = fmt.Errorf("go build in %s failed: %w\n%s", b.srcDir, err, out)
+
+				return
+			}
+		}
+	})
+
+	return mcBackendBin, mcRouterBin, mcBuildErr
+}
+
+// newMCStack boots Postgres, Redis, the backend and the router, seeds a
+// loginable instance, and starts a background poller that drains the user
+// queue. The caller must call stop() when done.
+func newMCStack(ctx context.Context) (*mcStack, error) {
+	backendBin, routerBin, err := buildMCBinaries()
+	if err != nil {
+		return nil, err
+	}
+
+	secretBytes := make([]byte, 32)
+	if _, err := rand.Read(secretBytes); err != nil {
+		return nil, err
+	}
+
+	s := &mcStack{
+		jwtSecret:    hex.EncodeToString(secretBytes),
+		instanceUUID: uuid.New(),
+		userEmail:    mcUserEmail,
+		replies:      make(map[uuid.UUID]models.ActionReplyState),
+		replyMsgs:    make(map[uuid.UUID][]string),
+		stopPoll:     make(chan struct{}),
+		pollDone:     make(chan struct{}),
+	}
+
+	for _, p := range []*int{&s.pgPort, &s.redisPort, &s.backendPort, &s.routerPort} {
+		port, err := mcFreePort()
+		if err != nil {
+			return nil, err
+		}
+
+		*p = port
+	}
+
+	s.logDir, err = os.MkdirTemp("", "mc-logs-")
+	if err != nil {
+		return nil, err
+	}
+
+	suffix := uuid.New().String()[:8]
+	s.pgContainer = "mc-pg-" + suffix
+	s.redisContainer = "mc-redis-" + suffix
+
+	// Postgres + Redis containers.
+	if _, err := runDockerCommand("run", "-d", "--name", s.pgContainer,
+		"-e", "POSTGRES_PASSWORD=password", "-e", "POSTGRES_DB="+mcDBName,
+		"-p", fmt.Sprintf("%d:5432", s.pgPort), mcPGImage); err != nil {
+		return nil, fmt.Errorf("start postgres: %w", err)
+	}
+
+	if _, err := runDockerCommand("run", "-d", "--name", s.redisContainer,
+		"-p", fmt.Sprintf("%d:6379", s.redisPort), mcRedisImage,
+		"redis-server", "--requirepass", mcRedisPass); err != nil {
+		return nil, fmt.Errorf("start redis: %w", err)
+	}
+
+	if err := s.waitForPostgres(ctx); err != nil {
+		return nil, err
+	}
+
+	// Backend (migrates the schema on boot).
+	if err := s.startBackend(backendBin); err != nil {
+		return nil, err
+	}
+
+	if err := mcWaitHTTP(fmt.Sprintf("http://127.0.0.1:%d/v2/health", s.backendPort), 90*time.Second); err != nil {
+		return nil, fmt.Errorf("backend never became healthy: %w", err)
+	}
+
+	// Seed one company + user + instance (all in the same company so the user is
+	// authorized to push to the instance and the reply routes back).
+	if err := s.seed(ctx); err != nil {
+		return nil, err
+	}
+
+	s.userCookie, err = mintUserJWT(s.jwtSecret, s.userEmail, s.userID, s.sessionVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	// Router (thin reverse proxy; boots on placeholder R2 creds).
+	if err := s.startRouter(routerBin); err != nil {
+		return nil, err
+	}
+
+	if err := mcWaitHTTP(fmt.Sprintf("http://127.0.0.1:%d/api/v2/health", s.routerPort), 60*time.Second); err != nil {
+		return nil, fmt.Errorf("router never became healthy: %w", err)
+	}
+
+	go s.pollUserQueue()
+
+	return s, nil
+}
+
+func (s *mcStack) dbURL() string {
+	return fmt.Sprintf("host=127.0.0.1 port=%d user=postgres password=password dbname=%s sslmode=disable", s.pgPort, mcDBName)
+}
+
+func (s *mcStack) pgxURL() string {
+	return fmt.Sprintf("postgres://postgres:password@127.0.0.1:%d/%s?sslmode=disable", s.pgPort, mcDBName)
+}
+
+func (s *mcStack) redisURL() string {
+	return fmt.Sprintf("redis://default:%s@127.0.0.1:%d/0", mcRedisPass, s.redisPort)
+}
+
+func (s *mcStack) waitForPostgres(ctx context.Context) error {
+	deadline := time.Now().Add(60 * time.Second)
+	for time.Now().Before(deadline) {
+		connCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+
+		conn, err := pgx.Connect(connCtx, s.pgxURL())
+		if err == nil {
+			_, pingErr := conn.Exec(connCtx, "SELECT 1")
+			_ = conn.Close(connCtx)
+
+			cancel()
+
+			if pingErr == nil {
+				return nil
+			}
+		} else {
+			cancel()
+		}
+
+		time.Sleep(1 * time.Second)
+	}
+
+	return fmt.Errorf("postgres on port %d not ready in time", s.pgPort)
+}
+
+func (s *mcStack) startBackend(bin string) error {
+	dir, _ := mcDir()
+
+	cmd := exec.Command(bin)
+	cmd.Dir = filepath.Join(dir, "backend")
+
+	cmd.Env = append(os.Environ(),
+		"TESTING=true",
+		"LOGGING_LEVEL=DEBUG",
+		fmt.Sprintf("PORT=%d", s.backendPort),
+		"JWT_SECRET_KEY="+s.jwtSecret,
+		"DATABASE_URL="+s.dbURL(),
+		"REDIS_URL="+s.redisURL(),
+		// Auth0 is only used by the user-login routes we never touch; dummy values
+		// are enough for the instance + user push/pull paths.
+		"AUTH0_DOMAIN=dev.example.com",
+		"AUTH0_CLIENT_ID=dummy",
+	)
+
+	logFile, err := os.Create(filepath.Join(s.logDir, "backend.log"))
+	if err != nil {
+		return err
+	}
+
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start backend: %w", err)
+	}
+
+	s.backendProc = cmd
+
+	return nil
+}
+
+func (s *mcStack) startRouter(bin string) error {
+	dir, _ := mcDir()
+
+	cmd := exec.Command(bin)
+	cmd.Dir = filepath.Join(dir, "router")
+
+	cmd.Env = append(os.Environ(),
+		fmt.Sprintf("PORT=%d", s.routerPort),
+		fmt.Sprintf("CUSTOM_API_URL=http://127.0.0.1:%d", s.backendPort),
+		"CUSTOM_FRONTEND_URL=http://127.0.0.1:1420",
+		"LOGGING_LEVEL=DEVELOPMENT",
+		// r2.SetupR2 only constructs S3 clients (no boot-time network call), so
+		// placeholder credentials let the router boot. The /api forward path never
+		// touches R2.
+		"R2_ACCOUNT_ID=placeholder",
+		"R2_ACCESS_KEY_ID_OCI=placeholder",
+		"R2_ACCESS_KEY_SECRET_OCI=placeholder",
+		"R2_ACCESS_KEY_ID_BINARIES=placeholder",
+		"R2_ACCESS_KEY_SECRET_BINARIES=placeholder",
+		"R2_ACCESS_KEY_ID_STATIC_BINARIES=placeholder",
+		"R2_ACCESS_KEY_SECRET_STATIC_BINARIES=placeholder",
+	)
+
+	logFile, err := os.Create(filepath.Join(s.logDir, "router.log"))
+	if err != nil {
+		return err
+	}
+
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start router: %w", err)
+	}
+
+	s.routerProc = cmd
+
+	return nil
+}
+
+// seed inserts the minimal rows for a successful instance login and an
+// authorized user push: one company, one user (same company), one instance
+// (same company) whose auth_token is LoginHash(mcAuthToken).
+func (s *mcStack) seed(ctx context.Context) error {
+	conn, err := pgx.Connect(ctx, s.pgxURL())
+	if err != nil {
+		return fmt.Errorf("seed connect: %w", err)
+	}
+
+	defer func() { _ = conn.Close(ctx) }()
+
+	var companyID int64
+	if err := conn.QueryRow(ctx,
+		`INSERT INTO companies (created_at, updated_at, uuid, name)
+		 VALUES (now(), now(), $1, $2) RETURNING id`,
+		uuid.New().String(), "HarnessCo",
+	).Scan(&companyID); err != nil {
+		return fmt.Errorf("seed company: %w", err)
+	}
+
+	// session_version must be set and match the minted token: GET /v2/user/pull
+	// resolves the user by numeric id and rejects the token if the row's
+	// session_version is nil or differs (auth.go ValidateTokenMiddleware).
+	s.sessionVersion = uuid.New().String()
+	if err := conn.QueryRow(ctx,
+		`INSERT INTO users (created_at, updated_at, email, password, company_id, session_version)
+		 VALUES (now(), now(), $1, $2, $3, $4) RETURNING id`,
+		s.userEmail, "seeded-no-login", companyID, s.sessionVersion,
+	).Scan(&s.userID); err != nil {
+		return fmt.Errorf("seed user: %w", err)
+	}
+
+	// umh-core sends Bearer LoginHash(token) = Sha3(Sha3(token)); the backend
+	// compares that literal value against instances.auth_token.
+	authTokenHash := hash.Sha3Hash(hash.Sha3Hash(mcAuthToken))
+	if _, err := conn.Exec(ctx,
+		`INSERT INTO instances (created_at, updated_at, uuid, auth_token, name, verified, company_id)
+		 VALUES (now(), now(), $1, $2, $3, false, $4)`,
+		s.instanceUUID.String(), authTokenHash, "HarnessInstance", companyID,
+	); err != nil {
+		return fmt.Errorf("seed instance: %w", err)
+	}
+
+	return nil
+}
+
+// mintUserJWT hand-signs a HS256 USER_SCOPE token carrying the numeric user_id
+// and the row's session_version. POST /v2/user/push resolves by email, but GET
+// /v2/user/pull resolves by numeric id and enforces the session_version match,
+// so both must be present (auth.go ValidateTokenMiddleware).
+func mintUserJWT(secret, email string, userID int64, sessionVersion string) (string, error) {
+	now := time.Now()
+
+	encode := func(v any) (string, error) {
+		b, err := json.Marshal(v)
+		if err != nil {
+			return "", err
+		}
+
+		return base64.RawURLEncoding.EncodeToString(b), nil
+	}
+
+	header, err := encode(map[string]string{"alg": "HS256", "typ": "JWT"})
+	if err != nil {
+		return "", err
+	}
+
+	claims, err := encode(map[string]any{
+		"scope":              "user",
+		"email":              email,
+		"user_id":            userID,
+		"session_version":    sessionVersion,
+		"original_issued_at": now.Unix(),
+		"iat":                now.Unix(),
+		"exp":                now.Add(24 * time.Hour).Unix(),
+	})
+	if err != nil {
+		return "", err
+	}
+
+	signingInput := header + "." + claims
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write([]byte(signingInput))
+	sig := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+
+	return signingInput + "." + sig, nil
+}
+
+// apiURL is the base URL umh-core (inside the container) uses to reach the
+// router. The path already includes /api so the router forwards to the backend
+// (umh-core appends /v2/instance/... to this base).
+func (s *mcStack) apiURL() string {
+	return fmt.Sprintf("http://host.docker.internal:%d/api", s.routerPort)
+}
+
+// hostRouterURL is the base URL the TEST process (on the host) uses to reach the
+// router.
+func (s *mcStack) hostRouterURL() string {
+	return fmt.Sprintf("http://127.0.0.1:%d/api", s.routerPort)
+}
+
+// enqueueEditProtocolConverter sends an edit-protocol-converter action to the
+// instance by POSTing it to the real backend's user-push endpoint (through the
+// router), authenticated with the minted user cookie.
+// If readDFC is non-nil it is attached under the "readDFC" key so the edited
+// bridge keeps a non-empty DFC type (connection-gated rollout); a nil readDFC
+// produces a connection-only edit (DFCType empty).
+func (s *mcStack) enqueueEditProtocolConverter(actionUUID, pcUUID uuid.UUID, pcName, ip string, port uint32, readDFC map[string]any) error {
+	actionPayload := map[string]any{
+		"uuid": pcUUID.String(),
+		"name": pcName,
+		"connection": map[string]any{
+			"ip":   ip,
+			"port": port,
+		},
+		"location": map[string]any{
+			"0": "test-enterprise",
+		},
+	}
+
+	if readDFC != nil {
+		actionPayload["readDFC"] = readDFC
+	}
+
+	messageContent := models.UMHMessageContent{
+		MessageType: models.Action,
+		Payload: models.ActionMessagePayload{
+			ActionType:    models.EditProtocolConverter,
+			ActionUUID:    actionUUID,
+			ActionPayload: actionPayload,
+		},
+	}
+
+	encoded, err := encoding.EncodeMessageFromUserToUMHInstance(messageContent)
+	if err != nil {
+		return fmt.Errorf("encode action: %w", err)
+	}
+
+	payload := backend_api_structs.PushPayload{
+		UMHMessages: []models.UMHMessage{
+			{
+				Email:        s.userEmail,
+				InstanceUUID: s.instanceUUID,
+				Content:      encoded,
+			},
+		},
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, s.hostRouterURL()+"/v2/user/push", strings.NewReader(string(body)))
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: "token", Value: s.userCookie})
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("user push: %w", err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("user push returned status %d", resp.StatusCode)
+	}
+
+	return nil
+}
+
+// pollUserQueue continuously drains GET /v2/user/pull (which RPOPs the user
+// queue) and records every action-reply, since replies arrive over time and the
+// pull consumes them.
+func (s *mcStack) pollUserQueue() {
+	defer close(s.pollDone)
+
+	client := &http.Client{Timeout: 30 * time.Second}
+
+	for {
+		select {
+		case <-s.stopPoll:
+			return
+		default:
+		}
+
+		req, err := http.NewRequest(http.MethodGet, s.hostRouterURL()+"/v2/user/pull", nil)
+		if err != nil {
+			time.Sleep(500 * time.Millisecond)
+
+			continue
+		}
+
+		req.AddCookie(&http.Cookie{Name: "token", Value: s.userCookie})
+		req.Header.Set("X-Features", "longpoll")
+
+		resp, err := client.Do(req)
+		if err != nil {
+			time.Sleep(500 * time.Millisecond)
+
+			continue
+		}
+
+		if resp.StatusCode == http.StatusOK {
+			var payload backend_api_structs.PullPayload
+			if err := json.NewDecoder(resp.Body).Decode(&payload); err == nil {
+				for _, msg := range payload.UMHMessages {
+					s.recordReply(msg)
+				}
+			}
+		}
+
+		_ = resp.Body.Close()
+	}
+}
+
+// recordReply decodes one pulled message and, if it is an action-reply, records
+// its state keyed by the action UUID.
+func (s *mcStack) recordReply(msg models.UMHMessage) {
+	if msg.Content == "" {
+		return
+	}
+
+	content, err := encoding.DecodeMessageFromUMHInstanceToUser(msg.Content)
+	if err != nil {
+		return
+	}
+
+	if content.MessageType != models.ActionReply {
+		return
+	}
+
+	raw, err := json.Marshal(content.Payload)
+	if err != nil {
+		return
+	}
+
+	var reply models.ActionReplyMessagePayload
+	if err := json.Unmarshal(raw, &reply); err != nil {
+		return
+	}
+
+	s.mu.Lock()
+	s.replies[reply.ActionUUID] = reply.ActionReplyState
+	s.replyMsgs[reply.ActionUUID] = append(s.replyMsgs[reply.ActionUUID],
+		fmt.Sprintf("%s: %v", reply.ActionReplyState, reply.ActionReplyPayload))
+	s.mu.Unlock()
+}
+
+// replyDump returns the ordered "state: message" history captured for the action.
+func (s *mcStack) replyDump(actionUUID uuid.UUID) []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	out := make([]string, len(s.replyMsgs[actionUUID]))
+	copy(out, s.replyMsgs[actionUUID])
+
+	return out
+}
+
+// terminalReplyState returns the captured reply state for the action and whether
+// it is terminal (action-success or action-failure).
+func (s *mcStack) terminalReplyState(actionUUID uuid.UUID) (models.ActionReplyState, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	state, ok := s.replies[actionUUID]
+	if !ok {
+		return "", false
+	}
+
+	terminal := state == models.ActionFinishedSuccessfull || state == models.ActionFinishedWithFailure
+
+	return state, terminal
+}
+
+// loginSeen reports whether the container has completed at least one instance
+// login. The backend flips instances.verified to true on first login
+// (instance_login.go), so we poll that flag.
+func (s *mcStack) loginSeen() bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	conn, err := pgx.Connect(ctx, s.pgxURL())
+	if err != nil {
+		return false
+	}
+
+	defer func() { _ = conn.Close(ctx) }()
+
+	var verified bool
+	if err := conn.QueryRow(ctx,
+		`SELECT verified FROM instances WHERE uuid = $1`, s.instanceUUID.String(),
+	).Scan(&verified); err != nil {
+		return false
+	}
+
+	return verified
+}
+
+// stop tears down the poller, the two processes and the two containers, and
+// surfaces the backend/router logs on failure.
+func (s *mcStack) stop() {
+	if s.stopPoll != nil {
+		close(s.stopPoll)
+
+		select {
+		case <-s.pollDone:
+		case <-time.After(5 * time.Second):
+		}
+	}
+
+	if CurrentSpecReport().Failed() {
+		s.dumpLog("backend.log")
+		s.dumpLog("router.log")
+	}
+
+	for _, p := range []*exec.Cmd{s.routerProc, s.backendProc} {
+		if p != nil && p.Process != nil {
+			_ = p.Process.Kill()
+			_, _ = p.Process.Wait()
+		}
+	}
+
+	for _, name := range []string{s.pgContainer, s.redisContainer} {
+		if name != "" {
+			_, _ = runDockerCommand("rm", "-f", name)
+		}
+	}
+
+	if s.logDir != "" {
+		_ = os.RemoveAll(s.logDir)
+	}
+}
+
+func (s *mcStack) dumpLog(name string) {
+	data, err := os.ReadFile(filepath.Join(s.logDir, name))
+	if err != nil {
+		return
+	}
+
+	GinkgoWriter.Printf("\n===== ManagementConsole %s =====\n%s\n===== end %s =====\n", name, string(data), name)
+}
+
+// encodingChooseCorev1 selects the corev1 encoder for this (test) process so it
+// matches the encoder the container selects in cmd/main.go. Messages are
+// base64(JSON) with no encryption. The backend relays Content opaquely, so this
+// codec governs both the action we send and the replies we decode.
+func encodingChooseCorev1() {
+	encoding.ChooseEncoder(encoding.EncodingCorev1)
+}
+
+// mcWaitHTTP polls url until it returns any HTTP response (2xx/4xx both mean the
+// server is up) or the timeout elapses.
+func mcWaitHTTP(url string, timeout time.Duration) error {
+	client := &http.Client{Timeout: 3 * time.Second}
+	deadline := time.Now().Add(timeout)
+
+	for time.Now().Before(deadline) {
+		resp, err := client.Get(url)
+		if err == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode < 500 {
+				return nil
+			}
+		}
+
+		time.Sleep(1 * time.Second)
+	}
+
+	return fmt.Errorf("%s not reachable within %s", url, timeout)
+}

--- a/umh-core/integration/managementconsole_stack_test.go
+++ b/umh-core/integration/managementconsole_stack_test.go
@@ -14,11 +14,10 @@
 
 package integration_test
 
-// mcStack boots the REAL ManagementConsole backend + router (built from source
-// pulled by `make pull-managementconsole`) and drives a real umh-core container
-// through them end-to-end, exactly the way ManagementConsole's own Playwright
-// e2e suite runs them: backend and router as local Go processes, Postgres and
-// Redis as throwaway Docker containers.
+// mcStack boots the ManagementConsole backend and router from source pulled by
+// `make pull-managementconsole` and drives a umh-core container through them,
+// the way ManagementConsole's own Playwright suite runs them: both as local Go
+// processes, with Postgres and Redis as throwaway Docker containers.
 //
 //	                 test process (the "user")
 //	          POST /api/v2/user/push  |  GET /api/v2/user/pull
@@ -27,9 +26,7 @@ package integration_test
 //	   login/pull/push        strips /api          v2/instance/*, v2/user/*
 //
 // The backend is a passthrough relay for the message Content, so umh-core keeps
-// using its own corev1 codec (base64(JSON), no encryption). What is real here
-// and cannot be faked: instance login against a DB row, JWT-scoped user auth,
-// and the v3 Redis message queue routing.
+// using its own corev1 codec (base64(JSON), no encryption).
 
 import (
 	"context"

--- a/umh-core/integration/managementconsole_stack_test.go
+++ b/umh-core/integration/managementconsole_stack_test.go
@@ -27,13 +27,9 @@ package integration_test
 //	   login/pull/push        strips /api          v2/instance/*, v2/user/*
 //
 // The backend is a passthrough relay for the message Content, so umh-core keeps
-// using its own corev1 codec (base64(JSON), no encryption) — the same wire the
-// old fakeBackend used. What is now REAL: instance login against a DB row,
-// JWT-scoped user auth, and the v3 Redis message queue routing.
-//
-// mcStack mirrors the method surface of the old fakeBackend
-// (apiURL/loginSeen/enqueueEditProtocolConverter/terminalReplyState/replyDump)
-// so the staleness spec is unchanged apart from the constructor.
+// using its own corev1 codec (base64(JSON), no encryption). What is real here
+// and cannot be faked: instance login against a DB row, JWT-scoped user auth,
+// and the v3 Redis message queue routing.
 
 import (
 	"context"
@@ -64,9 +60,9 @@ import (
 )
 
 const (
-	// mcAuthToken is the raw auth token; it MUST match the AuthToken set in
-	// buildStalenessConfig. umh-core sends LoginHash(mcAuthToken) as the Bearer
-	// token, so that hash is what we seed into instances.auth_token.
+	// mcAuthToken is the raw auth token; it MUST match the AuthToken in the
+	// container config a spec builds. umh-core sends LoginHash(mcAuthToken) as
+	// the Bearer token, so that hash is what we seed into instances.auth_token.
 	mcAuthToken = "test-token"
 
 	// mcUserEmail is the seeded user's email. The edit action carries it, the
@@ -81,7 +77,7 @@ const (
 )
 
 // mcBuild* memoize the one-time build of the backend + router binaries so both
-// staleness specs (fsmv1, fsmv2) reuse them instead of rebuilding per spec.
+// backend specs (fsmv1, fsmv2) reuse them instead of rebuilding per spec.
 var (
 	mcBuildOnce  sync.Once
 	mcBackendBin string
@@ -721,7 +717,7 @@ func (s *mcStack) loginSeen() bool {
 }
 
 // stop tears down the poller, the two processes and the two containers, and
-// surfaces the backend/router logs on failure.
+// prints the backend and router logs on failure.
 func (s *mcStack) stop() {
 	if s.stopPoll != nil {
 		close(s.stopPoll)

--- a/umh-core/integration/managementconsole_stack_test.go
+++ b/umh-core/integration/managementconsole_stack_test.go
@@ -104,12 +104,15 @@ type mcStack struct {
 	backendProc *exec.Cmd
 	routerProc  *exec.Cmd
 
-	mu        sync.Mutex
-	replies   map[uuid.UUID]models.ActionReplyState
-	replyMsgs map[uuid.UUID][]string
+	mu                    sync.Mutex
+	replies               map[uuid.UUID]models.ActionReplyState
+	terminalStates        map[uuid.UUID]models.ActionReplyState
+	replyMsgs             map[uuid.UUID][]string
+	lastPullFailureReason string
 
 	stopPoll chan struct{}
 	pollDone chan struct{}
+	polling  bool
 
 	logDir string
 }
@@ -144,8 +147,6 @@ func mcFreePort() (int, error) {
 	return ln.Addr().(*net.TCPAddr).Port, nil
 }
 
-// buildMCBinaries builds the backend and router binaries once from the pulled
-// source.
 func buildMCBinaries() (string, string, error) {
 	mcBuildOnce.Do(func() {
 		dir, err := mcDir()
@@ -169,13 +170,26 @@ func buildMCBinaries() (string, string, error) {
 		reqSrc := filepath.Join(dir, "frontend", "static", "requirements.json")
 
 		reqDst := filepath.Join(backendDir, "cmd", "demo_simulator_v3", "requirements.json")
-		if data, err := os.ReadFile(reqSrc); err == nil {
-			_ = os.WriteFile(reqDst, data, 0o644)
+
+		data, err := os.ReadFile(reqSrc)
+		if err != nil {
+			mcBuildErr = fmt.Errorf("read %s, which the backend build embeds: %w", reqSrc, err)
+
+			return
 		}
 
-		binDir, err := os.MkdirTemp("", "mc-bins-")
-		if err != nil {
-			mcBuildErr = err
+		if err := os.WriteFile(reqDst, data, 0o644); err != nil {
+			mcBuildErr = fmt.Errorf("write %s: %w", reqDst, err)
+
+			return
+		}
+
+		// One fixed directory rather than a fresh MkdirTemp per run: the binaries
+		// are memoized for the whole process and nothing owns them afterwards, so
+		// a per-run directory accumulates a backend and a router on every run.
+		binDir := filepath.Join(os.TempDir(), "umh-mc-bins")
+		if err := os.MkdirAll(binDir, 0o755); err != nil {
+			mcBuildErr = fmt.Errorf("create %s: %w", binDir, err)
 
 			return
 		}
@@ -221,13 +235,14 @@ func newMCStack(ctx context.Context) (*mcStack, error) {
 	}
 
 	s := &mcStack{
-		jwtSecret:    hex.EncodeToString(secretBytes),
-		instanceUUID: uuid.New(),
-		userEmail:    mcUserEmail,
-		replies:      make(map[uuid.UUID]models.ActionReplyState),
-		replyMsgs:    make(map[uuid.UUID][]string),
-		stopPoll:     make(chan struct{}),
-		pollDone:     make(chan struct{}),
+		jwtSecret:      hex.EncodeToString(secretBytes),
+		instanceUUID:   uuid.New(),
+		userEmail:      mcUserEmail,
+		replies:        make(map[uuid.UUID]models.ActionReplyState),
+		terminalStates: make(map[uuid.UUID]models.ActionReplyState),
+		replyMsgs:      make(map[uuid.UUID][]string),
+		stopPoll:       make(chan struct{}),
+		pollDone:       make(chan struct{}),
 	}
 
 	for _, p := range []*int{&s.pgPort, &s.redisPort, &s.backendPort, &s.routerPort} {
@@ -248,7 +263,24 @@ func newMCStack(ctx context.Context) (*mcStack, error) {
 	s.pgContainer = "mc-pg-" + suffix
 	s.redisContainer = "mc-redis-" + suffix
 
-	// Postgres + Redis containers.
+	// Every failure below returns a nil stack, so the caller has nothing to call
+	// stop() on. The container names carry a fresh suffix per run, so a later run
+	// cannot reclaim them by name either, and stop() is what prints the backend
+	// and router logs. Without this the most likely failure, a backend that never
+	// reports healthy, leaves two containers holding four ports and takes its own
+	// diagnosis with it.
+	booted := false
+
+	defer func() {
+		if booted {
+			return
+		}
+
+		s.dumpLog("backend.log")
+		s.dumpLog("router.log")
+		s.stop()
+	}()
+
 	if _, err := runDockerCommand("run", "-d", "--name", s.pgContainer,
 		"-e", "POSTGRES_PASSWORD=password", "-e", "POSTGRES_DB="+mcDBName,
 		"-p", fmt.Sprintf("%d:5432", s.pgPort), mcPGImage); err != nil {
@@ -265,7 +297,7 @@ func newMCStack(ctx context.Context) (*mcStack, error) {
 		return nil, err
 	}
 
-	// Backend (migrates the schema on boot).
+	// The backend migrates the schema on boot.
 	if err := s.startBackend(backendBin); err != nil {
 		return nil, err
 	}
@@ -285,7 +317,7 @@ func newMCStack(ctx context.Context) (*mcStack, error) {
 		return nil, err
 	}
 
-	// Router (thin reverse proxy; boots on placeholder R2 creds).
+	// The router is a thin reverse proxy and boots on placeholder R2 credentials.
 	if err := s.startRouter(routerBin); err != nil {
 		return nil, err
 	}
@@ -294,7 +326,11 @@ func newMCStack(ctx context.Context) (*mcStack, error) {
 		return nil, fmt.Errorf("router never became healthy: %w", err)
 	}
 
+	s.polling = true
+
 	go s.pollUserQueue()
+
+	booted = true
 
 	return s, nil
 }
@@ -337,7 +373,10 @@ func (s *mcStack) waitForPostgres(ctx context.Context) error {
 }
 
 func (s *mcStack) startBackend(bin string) error {
-	dir, _ := mcDir()
+	dir, err := mcDir()
+	if err != nil {
+		return fmt.Errorf("locate the pulled ManagementConsole source: %w", err)
+	}
 
 	cmd := exec.Command(bin)
 	cmd.Dir = filepath.Join(dir, "backend")
@@ -373,7 +412,10 @@ func (s *mcStack) startBackend(bin string) error {
 }
 
 func (s *mcStack) startRouter(bin string) error {
-	dir, _ := mcDir()
+	dir, err := mcDir()
+	if err != nil {
+		return fmt.Errorf("locate the pulled ManagementConsole source: %w", err)
+	}
 
 	cmd := exec.Command(bin)
 	cmd.Dir = filepath.Join(dir, "router")
@@ -432,9 +474,6 @@ func (s *mcStack) seed(ctx context.Context) error {
 		return fmt.Errorf("seed company: %w", err)
 	}
 
-	// session_version must be set and match the minted token: GET /v2/user/pull
-	// resolves the user by numeric id and rejects the token if the row's
-	// session_version is nil or differs (auth.go ValidateTokenMiddleware).
 	s.sessionVersion = uuid.New().String()
 	if err := conn.QueryRow(ctx,
 		`INSERT INTO users (created_at, updated_at, email, password, company_id, session_version)
@@ -507,18 +546,13 @@ func (s *mcStack) apiURL() string {
 	return fmt.Sprintf("http://host.docker.internal:%d/api", s.routerPort)
 }
 
-// hostRouterURL is the base URL the TEST process (on the host) uses to reach the
-// router.
 func (s *mcStack) hostRouterURL() string {
 	return fmt.Sprintf("http://127.0.0.1:%d/api", s.routerPort)
 }
 
-// enqueueEditProtocolConverter sends an edit-protocol-converter action to the
-// instance by POSTing it to the real backend's user-push endpoint (through the
-// router), authenticated with the minted user cookie.
-// If readDFC is non-nil it is attached under the "readDFC" key so the edited
-// bridge keeps a non-empty DFC type (connection-gated rollout); a nil readDFC
-// produces a connection-only edit (DFCType empty).
+// enqueueEditProtocolConverter posts an edit-protocol-converter action to the
+// backend's user-push endpoint through the router, authenticated with the minted
+// user cookie.
 func (s *mcStack) enqueueEditProtocolConverter(actionUUID, pcUUID uuid.UUID, pcName, ip string, port uint32, readDFC map[string]any) error {
 	actionPayload := map[string]any{
 		"uuid": pcUUID.String(),
@@ -532,9 +566,7 @@ func (s *mcStack) enqueueEditProtocolConverter(actionUUID, pcUUID uuid.UUID, pcN
 		},
 	}
 
-	if readDFC != nil {
-		actionPayload["readDFC"] = readDFC
-	}
+	actionPayload["readDFC"] = readDFC
 
 	messageContent := models.UMHMessageContent{
 		MessageType: models.Action,
@@ -614,26 +646,58 @@ func (s *mcStack) pollUserQueue() {
 
 		resp, err := client.Do(req)
 		if err != nil {
+			s.notePullFailure(err.Error())
 			time.Sleep(500 * time.Millisecond)
 
 			continue
 		}
 
-		if resp.StatusCode == http.StatusOK {
-			var payload backend_api_structs.PullPayload
-			if err := json.NewDecoder(resp.Body).Decode(&payload); err == nil {
-				for _, msg := range payload.UMHMessages {
-					s.recordReply(msg)
-				}
-			}
+		if resp.StatusCode != http.StatusOK {
+			// A rejected pull is not retried faster than a failed one. Without
+			// the sleep an auth failure answers instantly and this loop floods
+			// the router for the whole wait, on the same host whose CPU the
+			// bridge needs to converge inside the rollout budget.
+			s.notePullFailure(fmt.Sprintf("pull returned status %d", resp.StatusCode))
+			_ = resp.Body.Close()
+			time.Sleep(500 * time.Millisecond)
+
+			continue
+		}
+
+		var payload backend_api_structs.PullPayload
+		if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+			// The pull pops the queue, so a batch lost here is lost for good and
+			// the spec would otherwise report a missing reply.
+			s.notePullFailure("decode: " + err.Error())
+		}
+
+		for _, msg := range payload.UMHMessages {
+			s.recordReply(msg)
 		}
 
 		_ = resp.Body.Close()
 	}
 }
 
-// recordReply decodes one pulled message and, if it is an action-reply, records
-// its state keyed by the action UUID.
+// notePullFailure keeps the most recent pull failure so a spec that times out
+// waiting for a reply can say why the queue went quiet.
+func (s *mcStack) notePullFailure(reason string) {
+	s.mu.Lock()
+	s.lastPullFailureReason = reason
+	s.mu.Unlock()
+
+	GinkgoWriter.Printf("user-queue pull failed: %s\n", reason)
+}
+
+// lastPullFailure returns the most recent pull failure, or "" if every pull has
+// succeeded.
+func (s *mcStack) lastPullFailure() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.lastPullFailureReason
+}
+
 func (s *mcStack) recordReply(msg models.UMHMessage) {
 	if msg.Content == "" {
 		return
@@ -641,6 +705,8 @@ func (s *mcStack) recordReply(msg models.UMHMessage) {
 
 	content, err := encoding.DecodeMessageFromUMHInstanceToUser(msg.Content)
 	if err != nil {
+		GinkgoWriter.Printf("dropped a pulled message: decode failed: %v\n", err)
+
 		return
 	}
 
@@ -650,22 +716,36 @@ func (s *mcStack) recordReply(msg models.UMHMessage) {
 
 	raw, err := json.Marshal(content.Payload)
 	if err != nil {
+		GinkgoWriter.Printf("dropped an action-reply: re-marshal failed: %v\n", err)
+
 		return
 	}
 
 	var reply models.ActionReplyMessagePayload
 	if err := json.Unmarshal(raw, &reply); err != nil {
+		GinkgoWriter.Printf("dropped an action-reply: unmarshal failed: %v\n", err)
+
 		return
 	}
 
 	s.mu.Lock()
-	s.replies[reply.ActionUUID] = reply.ActionReplyState
+	// A terminal state is kept once seen. The pull returns batches, so a queued
+	// non-terminal reply can arrive after the terminal one and would otherwise
+	// overwrite it, leaving the spec waiting out its timeout.
+	if _, done := s.terminalStates[reply.ActionUUID]; !done {
+		s.replies[reply.ActionUUID] = reply.ActionReplyState
+
+		if reply.ActionReplyState == models.ActionFinishedSuccessfull ||
+			reply.ActionReplyState == models.ActionFinishedWithFailure {
+			s.terminalStates[reply.ActionUUID] = reply.ActionReplyState
+		}
+	}
+
 	s.replyMsgs[reply.ActionUUID] = append(s.replyMsgs[reply.ActionUUID],
 		fmt.Sprintf("%s: %v", reply.ActionReplyState, reply.ActionReplyPayload))
 	s.mu.Unlock()
 }
 
-// replyDump returns the ordered "state: message" history captured for the action.
 func (s *mcStack) replyDump(actionUUID uuid.UUID) []string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -676,32 +756,35 @@ func (s *mcStack) replyDump(actionUUID uuid.UUID) []string {
 	return out
 }
 
-// terminalReplyState returns the captured reply state for the action and whether
-// it is terminal (action-success or action-failure).
-func (s *mcStack) terminalReplyState(actionUUID uuid.UUID) (models.ActionReplyState, bool) {
+// lastReplyState returns the most recent reply state for the action and whether
+// it is terminal, meaning action-success or action-failure. Once a terminal
+// reply has arrived that state is what it returns.
+func (s *mcStack) lastReplyState(actionUUID uuid.UUID) (models.ActionReplyState, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
+	if state, done := s.terminalStates[actionUUID]; done {
+		return state, true
+	}
 
 	state, ok := s.replies[actionUUID]
 	if !ok {
 		return "", false
 	}
 
-	terminal := state == models.ActionFinishedSuccessfull || state == models.ActionFinishedWithFailure
-
-	return state, terminal
+	return state, false
 }
 
 // loginSeen reports whether the container has completed at least one instance
 // login. The backend flips instances.verified to true on first login
 // (instance_login.go), so we poll that flag.
-func (s *mcStack) loginSeen() bool {
+func (s *mcStack) loginSeen() (bool, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 
 	conn, err := pgx.Connect(ctx, s.pgxURL())
 	if err != nil {
-		return false
+		return false, fmt.Errorf("connect to the seeded database: %w", err)
 	}
 
 	defer func() { _ = conn.Close(ctx) }()
@@ -710,16 +793,16 @@ func (s *mcStack) loginSeen() bool {
 	if err := conn.QueryRow(ctx,
 		`SELECT verified FROM instances WHERE uuid = $1`, s.instanceUUID.String(),
 	).Scan(&verified); err != nil {
-		return false
+		return false, fmt.Errorf("read instances.verified: %w", err)
 	}
 
-	return verified
+	return verified, nil
 }
 
 // stop tears down the poller, the two processes and the two containers, and
 // prints the backend and router logs on failure.
 func (s *mcStack) stop() {
-	if s.stopPoll != nil {
+	if s.polling {
 		close(s.stopPoll)
 
 		select {
@@ -754,6 +837,8 @@ func (s *mcStack) stop() {
 func (s *mcStack) dumpLog(name string) {
 	data, err := os.ReadFile(filepath.Join(s.logDir, name))
 	if err != nil {
+		GinkgoWriter.Printf("no %s to show: %v\n", name, err)
+
 		return
 	}
 
@@ -774,17 +859,30 @@ func mcWaitHTTP(url string, timeout time.Duration) error {
 	client := &http.Client{Timeout: 3 * time.Second}
 	deadline := time.Now().Add(timeout)
 
+	lastReason := "no attempt completed"
+
 	for time.Now().Before(deadline) {
 		resp, err := client.Get(url)
-		if err == nil {
-			_ = resp.Body.Close()
-			if resp.StatusCode < 500 {
-				return nil
-			}
+		if err != nil {
+			lastReason = err.Error()
+
+			time.Sleep(1 * time.Second)
+
+			continue
 		}
+
+		_ = resp.Body.Close()
+
+		// 2xx only. These routes belong to the pulled ManagementConsole tree, so
+		// a renamed route there would answer 404 and read as healthy.
+		if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+			return nil
+		}
+
+		lastReason = fmt.Sprintf("status %d", resp.StatusCode)
 
 		time.Sleep(1 * time.Second)
 	}
 
-	return fmt.Errorf("%s not reachable within %s", url, timeout)
+	return fmt.Errorf("%s not reachable within %s, last attempt: %s", url, timeout, lastReason)
 }

--- a/umh-core/integration/managementconsole_stack_test.go
+++ b/umh-core/integration/managementconsole_stack_test.go
@@ -145,7 +145,7 @@ func mcFreePort() (int, error) {
 }
 
 // buildMCBinaries builds the backend and router binaries once from the pulled
-// source. It fails with an actionable message if the source is missing.
+// source.
 func buildMCBinaries() (string, string, error) {
 	mcBuildOnce.Do(func() {
 		dir, err := mcDir()

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter.go
@@ -639,27 +639,32 @@ func (a *EditProtocolConverterAction) awaitRollout(previousConfig config.Protoco
 				found = true
 				currentStateReason = "current state: " + instance.CurrentState
 
-				if a.dfcType == DFCTypeEmpty {
-					// Unreachable while applyMutation forces the bridge active.
-					// Kept because a stopped bridge stops its nmap service and
-					// would never report the new port.
-					if desiredPCState != protocolconverter.OperationalStateStopped {
-						if waitingFor := a.connectionCheckWait(newConfig, pcSnapshot); waitingFor != "" {
-							currentStateReason = waitingFor
-							SendActionReply(
-								a.instanceUUID,
-								a.userEmail,
-								a.actionUUID,
-								models.ActionExecuting,
-								RemainingPrefixSec(remainingSeconds)+currentStateReason,
-								a.outboundChannel,
-								models.EditProtocolConverter,
-							)
+				// Runs before the DFC config comparison below, so a bridge whose target
+				// was never dialed is reported as a connection problem rather than a
+				// dataflow component one.
+				//
+				// An edit that carries no connection is exempt, so a bridge whose
+				// target is unreachable stays editable, including the edit that stops
+				// its flows. get-protocolconverter fills Connection.IP from the
+				// deployed spec, so a console edit may never hit that (ENG-5858).
+				if a.connectionIP != "" {
+					if waitingFor := a.connectionCheckWait(newConfig, pcSnapshot); waitingFor != "" {
+						currentStateReason = waitingFor
+						SendActionReply(
+							a.instanceUUID,
+							a.userEmail,
+							a.actionUUID,
+							models.ActionExecuting,
+							RemainingPrefixSec(remainingSeconds)+currentStateReason,
+							a.outboundChannel,
+							models.EditProtocolConverter,
+						)
 
-							continue
-						}
+						continue
 					}
+				}
 
+				if a.dfcType == DFCTypeEmpty {
 					// Check if the protocol converter has reached the desired state
 					hasReachedDesiredState := false
 

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter_awaitrollout_test.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter_awaitrollout_test.go
@@ -230,7 +230,7 @@ var _ = Describe("EditProtocolConverter awaitRollout (connection check)", func()
 
 	It("reports failure when the port was scanned but found filtered", func() {
 		// The connection FSM defines up as open and counts filtered (and all
-		// five non-open states) as down. Requiring open here makes the gate
+		// five non-open states) as down. Requiring open here makes the check
 		// agree with that definition rather than inventing a second one.
 		stageSnapshot("dest.example.com", "dest.example.com", protocolconverter.OperationalStateStartingFailedDFCMissing, string(nmapservice.PortStateFiltered))
 
@@ -519,7 +519,7 @@ var _ = Describe("EditProtocolConverter awaitRollout (connection check)", func()
 		mu.Lock()
 		defer mu.Unlock()
 
-		// The replies are the only record of WHETHER the gate accepted and on
+		// The replies are the only record of WHETHER the check accepted and on
 		// which tick, so they are decoded to text rather than counted.
 		out := make([]string, 0, len(msgs))
 
@@ -538,7 +538,7 @@ var _ = Describe("EditProtocolConverter awaitRollout (connection check)", func()
 	It("POSITIVE CONTROL: a read-DFC edit whose scan has caught up is accepted", func() {
 		// Establishes that this harness can reach the read path's acceptance at
 		// all. Without it the next spec's "was not accepted" could be satisfied by
-		// the DFC config comparison blocking the gate for an unrelated reason, and
+		// the DFC config comparison blocking the check for an unrelated reason, and
 		// would pass while proving nothing. The two specs differ in exactly one
 		// value: the observed nmap target.
 		stageReadDFCSnapshot("dest.example.com", "dest.example.com", protocolconverter.OperationalStateActive, string(nmapservice.PortStateOpen))
@@ -549,7 +549,7 @@ var _ = Describe("EditProtocolConverter awaitRollout (connection check)", func()
 		Expect(replies).To(ContainElement(ContainSubstring("read DFC configuration verified")),
 			"the read path's acceptance must be reachable in this harness, or the next spec proves nothing")
 		Expect(elapsed).To(BeNumerically("<", 4*time.Second),
-			"against a 6s budget: a gate that withholds acceptance from a healthy read-DFC edit is worse "+
+			"against a 6s budget: a check that withholds acceptance from a healthy read-DFC edit is worse "+
 				"than the bug it replaces, so this must not creep towards the timeout")
 	})
 

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter_awaitrollout_test.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter_awaitrollout_test.go
@@ -498,6 +498,24 @@ var _ = Describe("EditProtocolConverter awaitRollout (connection check)", func()
 		_, _, err := a.Execute()
 		elapsed := time.Since(start)
 
+		// ConsumeOutboundMessages appends to msgs on its own goroutine, so a reply
+		// the action sent just before Execute returned may not have arrived yet.
+		// Wait until it stops appending before snapshotting. Without this a spec
+		// asserting a reply is PRESENT flakes under load, and, worse, a spec
+		// asserting a reply is ABSENT passes vacuously.
+		prev := -1
+
+		Eventually(func() bool {
+			mu.Lock()
+			n := len(msgs)
+			mu.Unlock()
+
+			settled := n == prev
+			prev = n
+
+			return settled
+		}, "3s", "50ms").Should(BeTrue(), "the reply consumer never stopped appending")
+
 		mu.Lock()
 		defer mu.Unlock()
 

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter_awaitrollout_test.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter_awaitrollout_test.go
@@ -15,6 +15,7 @@
 package actions_test
 
 import (
+	"fmt"
 	"sync"
 	"time"
 
@@ -23,7 +24,9 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/communicator/actions"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/communicator/pkg/encoding"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/benthosserviceconfig"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/connectionserviceconfig"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/dataflowcomponentserviceconfig"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/nmapserviceconfig"
@@ -31,11 +34,14 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/config/variables"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/constants"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm"
+	benthosfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/benthos"
 	connfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/connection"
+	dfcfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/dataflowcomponent"
 	nmapfsm "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/nmap"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsm/protocolconverter"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/models"
 	connsvc "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/connection"
+	dfcsvc "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/dataflowcomponent"
 	nmapservice "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/nmap"
 	protocolconvertersvc "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/protocolconverter"
 )
@@ -58,31 +64,27 @@ var _ = Describe("EditProtocolConverter awaitRollout (connection check)", func()
 
 	// Desired and observed sides are staged independently, so a spec can stage a
 	// connection edited to a target whose scan has not caught up yet.
-	stageSnapshotScannedAt := func(desiredTarget string, observedTarget string, pcState string, portState string, scannedPort uint16, scannedAt time.Time) {
-		observed := &protocolconverter.ProtocolConverterObservedStateSnapshot{
-			ServiceInfo: protocolconvertersvc.ServiceInfo{
-				ConnectionObservedState: connfsm.ConnectionObservedState{
-					ObservedConnectionConfig: connectionserviceconfig.ConnectionServiceConfig{
-						NmapServiceConfig: nmapserviceconfig.NmapServiceConfig{
-							Target: desiredTarget,
-							Port:   scannedPort,
-						},
+	observedConnection := func(desiredTarget string, observedTarget string, portState string, scannedPort uint16, scannedAt time.Time) connfsm.ConnectionObservedState {
+		return connfsm.ConnectionObservedState{
+			ObservedConnectionConfig: connectionserviceconfig.ConnectionServiceConfig{
+				NmapServiceConfig: nmapserviceconfig.NmapServiceConfig{
+					Target: desiredTarget,
+					Port:   scannedPort,
+				},
+			},
+			ServiceInfo: connsvc.ServiceInfo{
+				NmapObservedState: nmapfsm.NmapObservedState{
+					ObservedNmapServiceConfig: nmapserviceconfig.NmapServiceConfig{
+						Target: observedTarget,
+						Port:   scannedPort,
 					},
-					ServiceInfo: connsvc.ServiceInfo{
-						NmapObservedState: nmapfsm.NmapObservedState{
-							ObservedNmapServiceConfig: nmapserviceconfig.NmapServiceConfig{
-								Target: observedTarget,
-								Port:   scannedPort,
-							},
-							ServiceInfo: nmapservice.ServiceInfo{
-								NmapStatus: nmapservice.NmapServiceInfo{
-									LastScan: &nmapservice.NmapScanResult{
-										Timestamp: scannedAt,
-										PortResult: nmapservice.PortResult{
-											State: portState,
-											Port:  scannedPort,
-										},
-									},
+					ServiceInfo: nmapservice.ServiceInfo{
+						NmapStatus: nmapservice.NmapServiceInfo{
+							LastScan: &nmapservice.NmapScanResult{
+								Timestamp: scannedAt,
+								PortResult: nmapservice.PortResult{
+									State: portState,
+									Port:  scannedPort,
 								},
 							},
 						},
@@ -90,6 +92,11 @@ var _ = Describe("EditProtocolConverter awaitRollout (connection check)", func()
 				},
 			},
 		}
+	}
+
+	// publish installs observed as the bridge's LastObservedState with the given
+	// PC FSM state.
+	publish := func(pcState string, observed *protocolconverter.ProtocolConverterObservedStateSnapshot) {
 		snapMgr.UpdateSnapshot(&fsm.SystemSnapshot{
 			Managers: map[string]fsm.ManagerSnapshot{
 				constants.ProtocolConverterManagerName: &actions.MockManagerSnapshot{
@@ -102,6 +109,16 @@ var _ = Describe("EditProtocolConverter awaitRollout (connection check)", func()
 						},
 					},
 				},
+			},
+		})
+	}
+
+	// Only the connection half is observed, which is all the connection branch
+	// reads.
+	stageSnapshotScannedAt := func(desiredTarget string, observedTarget string, pcState string, portState string, scannedPort uint16, scannedAt time.Time) {
+		publish(pcState, &protocolconverter.ProtocolConverterObservedStateSnapshot{
+			ServiceInfo: protocolconvertersvc.ServiceInfo{
+				ConnectionObservedState: observedConnection(desiredTarget, observedTarget, portState, scannedPort, scannedAt),
 			},
 		})
 	}
@@ -211,6 +228,17 @@ var _ = Describe("EditProtocolConverter awaitRollout (connection check)", func()
 			"a scanned-but-closed port must not be reported as a successful rollout")
 	})
 
+	It("reports failure when the port was scanned but found filtered", func() {
+		// The connection FSM defines up as open and counts filtered (and all
+		// five non-open states) as down. Requiring open here makes the gate
+		// agree with that definition rather than inventing a second one.
+		stageSnapshot("dest.example.com", "dest.example.com", protocolconverter.OperationalStateStartingFailedDFCMissing, string(nmapservice.PortStateFiltered))
+
+		_, err := runAwaitRollout("dest.example.com")
+		Expect(err).To(HaveOccurred(),
+			"a filtered port is down by the connection FSM's own definition and must not report success")
+	})
+
 	It("reports failure when the only open scan on record predates the edit", func() {
 		// Stages the window where the observed endpoint already echoes the new
 		// scan script and the scan says open, yet nothing has dialed it.
@@ -233,49 +261,17 @@ var _ = Describe("EditProtocolConverter awaitRollout (connection check)", func()
 		// would redden only the healthy spec. This one catches that swap.
 		observed := &protocolconverter.ProtocolConverterObservedStateSnapshot{
 			ServiceInfo: protocolconvertersvc.ServiceInfo{
-				ConnectionObservedState: connfsm.ConnectionObservedState{
-					ObservedConnectionConfig: connectionserviceconfig.ConnectionServiceConfig{
-						NmapServiceConfig: nmapserviceconfig.NmapServiceConfig{
-							Target: "dest.example.com",
-							Port:   port,
-						},
-					},
-					ServiceInfo: connsvc.ServiceInfo{
-						NmapObservedState: nmapfsm.NmapObservedState{
-							ObservedNmapServiceConfig: nmapserviceconfig.NmapServiceConfig{
-								Target: "dest.example.com",
-								Port:   port,
-							},
-							ServiceInfo: nmapservice.ServiceInfo{
-								NmapStatus: nmapservice.NmapServiceInfo{
-									IsRunning: true,
-									LastScan: &nmapservice.NmapScanResult{
-										PortResult: nmapservice.PortResult{
-											State: string(nmapservice.PortStateClosed),
-											Port:  port,
-										},
-									},
-								},
-							},
-						},
-					},
-				},
+				ConnectionObservedState: observedConnection(
+					"dest.example.com",
+					"dest.example.com",
+					string(nmapservice.PortStateClosed),
+					port,
+					time.Now().Add(time.Minute),
+				),
 			},
 		}
-		snapMgr.UpdateSnapshot(&fsm.SystemSnapshot{
-			Managers: map[string]fsm.ManagerSnapshot{
-				constants.ProtocolConverterManagerName: &actions.MockManagerSnapshot{
-					Instances: map[string]*fsm.FSMInstanceSnapshot{
-						probeName: {
-							ID:                probeName,
-							CurrentState:      protocolconverter.OperationalStateStartingFailedDFCMissing,
-							DesiredState:      protocolconverter.OperationalStateActive,
-							LastObservedState: observed,
-						},
-					},
-				},
-			},
-		})
+		observed.ServiceInfo.ConnectionObservedState.ServiceInfo.NmapObservedState.ServiceInfo.NmapStatus.IsRunning = true
+		publish(protocolconverter.OperationalStateStartingFailedDFCMissing, observed)
 
 		_, err := runAwaitRollout("dest.example.com")
 		Expect(err).To(HaveOccurred(),
@@ -373,5 +369,197 @@ var _ = Describe("EditProtocolConverter awaitRollout (connection check)", func()
 			Expect(elapsed).To(BeNumerically("<", 5*time.Second),
 				"a healthy edit of a templated connection must not wait out the rollout timeout")
 		})
+	})
+
+	// --- the read-DFC path -----------------------------------------------------
+	//
+	// Every spec above drives an edit with no dataflow component, which
+	// awaitRollout classifies as DFCTypeEmpty and gates on the nmap scan. An edit
+	// that carries a read DFC takes an entirely different branch: the nmap check
+	// lives inside `if a.dfcType == DFCTypeEmpty`, so on the read path it never
+	// runs, and acceptance is decided by the protocolconverter's CurrentState
+	// alone. These two specs pin that difference in-process.
+	//
+	// caughtUpReadDFCBenthos is the Benthos config a converged bridge observes for
+	// the read DFC in runAwaitRolloutRead's payload: the payload's own generate
+	// input and tag_processor, plus the downsampler that renderConfig appends to
+	// every timeseries pipeline. The values were read off renderDesiredDFCConfig
+	// for that exact payload, because compareSingleDFCConfig accepts only a
+	// comparator-equal match and the appended downsampler is invisible in the
+	// payload. Output is deliberately absent: the read comparison nils both sides'
+	// Output before comparing, since the read DFC's egress is forced to the UNS
+	// publisher at render time.
+	caughtUpReadDFCBenthos := benthosserviceconfig.BenthosServiceConfig{
+		Input: map[string]interface{}{
+			"generate": map[string]interface{}{
+				"count":    0,
+				"interval": "1s",
+				"mapping":  `root = "hello world"`,
+			},
+		},
+		Pipeline: map[string]interface{}{
+			"processors": []interface{}{
+				map[string]interface{}{
+					"tag_processor": map[string]interface{}{
+						"defaults": "msg.meta.location_path = \"probe\";\nmsg.meta.data_contract = \"_raw\";\nreturn msg;\n",
+					},
+				},
+				map[string]interface{}{"downsampler": map[string]interface{}{}},
+			},
+		},
+		Buffer: map[string]interface{}{"none": map[string]interface{}{}},
+	}
+
+	// stageReadDFCSnapshot stages a bridge that carries a read DFC. Beyond the
+	// connection half it stages the two things the read branch needs before it can
+	// reach its accepted-state check:
+	//
+	//   - ObservedProtocolConverterSpecConfig with a connection template.
+	//     renderDesiredDFCConfig renders the whole spec, and ConvertTemplateToRuntime
+	//     rejects an absent connection template outright ("connection template is nil
+	//     or empty"), so without it every tick fails to render rather than comparing.
+	//   - the observed read-DFC Benthos config. compareSingleDFCConfig treats a nil
+	//     observed Input as "Benthos is still starting" and returns false before it
+	//     ever renders, so a snapshot without it can never be accepted.
+	//
+	// The spec's variables hold the PRE-EDIT connection values on purpose: the
+	// observed spec lags the persisted edit by one or more control-loop cycles, and
+	// renderDesiredDFCConfig is expected to overlay the edit's own IP/PORT on top.
+	stageReadDFCSnapshot := func(desiredTarget string, observedTarget string, pcState string, portState string) {
+		publish(pcState, &protocolconverter.ProtocolConverterObservedStateSnapshot{
+			ObservedProtocolConverterSpecConfig: protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec{
+				Config: protocolconverterserviceconfig.ProtocolConverterServiceConfigTemplate{
+					ConnectionServiceConfig: connectionserviceconfig.ConnectionServiceConfigTemplate{
+						NmapTemplate: &connectionserviceconfig.NmapConfigTemplate{
+							Target: "{{ .IP }}",
+							Port:   "{{ .PORT }}",
+						},
+					},
+				},
+				Variables: variables.VariableBundle{
+					User: map[string]interface{}{"IP": "src.example.com", "PORT": "443"},
+				},
+			},
+			ServiceInfo: protocolconvertersvc.ServiceInfo{
+				ConnectionObservedState:       observedConnection(desiredTarget, observedTarget, portState, port, time.Now().Add(time.Minute)),
+				DataflowComponentReadFSMState: protocolconverter.OperationalStateActive,
+				DataflowComponentReadObservedState: dfcfsm.DataflowComponentObservedState{
+					ServiceInfo: dfcsvc.ServiceInfo{
+						BenthosObservedState: benthosfsm.BenthosObservedState{
+							ObservedBenthosServiceConfig: caughtUpReadDFCBenthos,
+						},
+					},
+				},
+			},
+		})
+	}
+
+	// runAwaitRolloutRead is runAwaitRollout plus a read DFC in the payload, which
+	// is what flips deriveDFCType to "read".
+	runAwaitRolloutRead := func(ip string) (time.Duration, error, []string) {
+		a := actions.NewEditProtocolConverterAction(
+			"probe@example.com", uuid.New(), uuid.New(), outbound, mockCfg, snapMgr)
+		a.SetTickInterval(tickInterval)
+		a.SetAwaitTimeout(6 * time.Second)
+
+		payload := map[string]interface{}{
+			"name": probeName,
+			"uuid": probeUUID.String(),
+			"connection": map[string]interface{}{
+				"ip":   ip,
+				"port": port,
+			},
+			"readDFC": map[string]interface{}{
+				"state": "active",
+				"inputs": map[string]interface{}{
+					"type": "generate",
+					"data": "generate:\n  count: 0\n  interval: 1s\n  mapping: root = \"hello world\"\n",
+				},
+				// pipeline.processors is required by buildReadDFCServiceConfig; a
+				// read DFC without it is rejected before dfcType is ever derived.
+				"pipeline": map[string]interface{}{
+					"processors": map[string]interface{}{
+						"0": map[string]interface{}{
+							"type": "tag_processor",
+							"data": "tag_processor:\n  defaults: |\n    msg.meta.location_path = \"probe\";\n    msg.meta.data_contract = \"_raw\";\n    return msg;\n",
+						},
+					},
+				},
+			},
+		}
+		Expect(a.Parse(payload)).To(Succeed())
+		Expect(a.Validate()).To(Succeed())
+		Expect(a.GetDFCType()).To(Equal("read"),
+			"this spec is about the read-DFC branch; if the payload no longer yields a read DFC it is testing the wrong path")
+
+		start := time.Now()
+		_, _, err := a.Execute()
+		elapsed := time.Since(start)
+
+		mu.Lock()
+		defer mu.Unlock()
+
+		// The replies are the only record of WHETHER the gate accepted and on
+		// which tick, so they are decoded to text rather than counted.
+		out := make([]string, 0, len(msgs))
+
+		for _, m := range msgs {
+			dec, decErr := encoding.DecodeMessageFromUMHInstanceToUser(m.Content)
+			if decErr != nil {
+				continue
+			}
+
+			out = append(out, fmt.Sprintf("%v", dec.Payload))
+		}
+
+		return elapsed, err, out
+	}
+
+	It("POSITIVE CONTROL: a read-DFC edit whose scan has caught up is accepted", func() {
+		// Establishes that this harness can reach the read path's acceptance at
+		// all. Without it the next spec's "was not accepted" could be satisfied by
+		// the DFC config comparison blocking the gate for an unrelated reason, and
+		// would pass while proving nothing. The two specs differ in exactly one
+		// value: the observed nmap target.
+		stageReadDFCSnapshot("dest.example.com", "dest.example.com", protocolconverter.OperationalStateActive, string(nmapservice.PortStateOpen))
+
+		_, err, replies := runAwaitRolloutRead("dest.example.com")
+
+		Expect(err).NotTo(HaveOccurred(), "a read-DFC edit whose scan agrees with the request must be accepted")
+		Expect(replies).To(ContainElement(ContainSubstring("read DFC configuration verified")),
+			"the read path's acceptance must be reachable in this harness, or the next spec proves nothing")
+	})
+
+	// PENDING (XIt) because it reproduces ENG-5580 and therefore fails on today's
+	// code: it asserts the behaviour the fix must introduce, so it cannot be left
+	// enabled without a red suite. The fix that makes the read branch withhold
+	// acceptance until the requested target has been scanned must flip this back to
+	// It — a fix that leaves it pending has not been verified against the bug.
+	// Verified red before it was marked pending: the run reported the reply
+	// "bridge successfully activated with state 'active', read DFC configuration
+	// verified", i.e. it failed because the edit was ACCEPTED, not because of a
+	// timeout or a render failure.
+	XIt("does not accept a read-DFC edit while the scan still shows the previous target", func() {
+		// The reported bug (ENG-5580), in-process and deterministic. The bridge is
+		// edited to dest.example.com; the protocolconverter still carries its
+		// pre-edit CurrentState of active, and the scan still shows the OLD target
+		// as open. Correct behaviour is to withhold acceptance until the requested
+		// target has actually been scanned.
+		//
+		// Today this FAILS: the read branch reads only CurrentState, so it accepts
+		// on the first tick against the pre-edit snapshot. That failure is the
+		// point — it is the deterministic form of a race the container harness
+		// reproduces only intermittently, and it depends on no log capture.
+		stageReadDFCSnapshot("dest.example.com", "src.example.com", protocolconverter.OperationalStateActive, string(nmapservice.PortStateOpen))
+
+		elapsed, err, replies := runAwaitRolloutRead("dest.example.com")
+
+		Expect(replies).NotTo(ContainElement(ContainSubstring("read DFC configuration verified")),
+			"the edit was accepted while the only scan on record still described the PREVIOUS target: "+
+				"the read branch gates on the protocolconverter's CurrentState, which still held its pre-edit value")
+		Expect(err).To(HaveOccurred(),
+			"an edit must not report success before the requested target has been scanned")
+		Expect(elapsed).To(BeNumerically(">", time.Second),
+			"acceptance on the first tick means the pre-edit snapshot was taken as evidence about the new config")
 	})
 })

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter_awaitrollout_test.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter_awaitrollout_test.go
@@ -560,10 +560,10 @@ var _ = Describe("EditProtocolConverter awaitRollout (connection check)", func()
 		// as open. Correct behaviour is to withhold acceptance until the requested
 		// target has actually been scanned.
 		//
-		// Today this FAILS: the read branch reads only CurrentState, so it accepts
-		// on the first tick against the pre-edit snapshot. That failure is the
-		// point — it is the deterministic form of a race the container harness
-		// reproduces only intermittently, and it depends on no log capture.
+		// Without the check above the DFC comparison, the read branch reads only
+		// CurrentState and accepts on the first tick against the pre-edit
+		// snapshot. This is the deterministic form of a race the container
+		// harness reproduces only intermittently, and it needs no log capture.
 		stageReadDFCSnapshot("dest.example.com", "src.example.com", protocolconverter.OperationalStateActive, string(nmapservice.PortStateOpen))
 
 		elapsed, err, replies := runAwaitRolloutRead("dest.example.com")
@@ -581,9 +581,9 @@ var _ = Describe("EditProtocolConverter awaitRollout (connection check)", func()
 		// PLACEMENT GUARD. The spec above cannot tell where the connection check
 		// sits: staged below the DFC config comparison it would still pass, because
 		// that comparison matches in that spec's case and the check then runs
-		// anyway. This spec stages the case that separates the two positions — the
+		// anyway. This spec stages the case that separates the two positions: the
 		// observed read DFC has not started (nil Input, which the comparison reads
-		// as "Benthos is still starting") AND the scan still shows the previous
+		// as "Benthos is still starting") and the scan still shows the previous
 		// target.
 		//
 		// With the connection check above the comparison, the operator is told the
@@ -605,7 +605,7 @@ var _ = Describe("EditProtocolConverter awaitRollout (connection check)", func()
 				},
 			},
 			ServiceInfo: protocolconvertersvc.ServiceInfo{
-				ConnectionObservedState:       observedConnection("dest.example.com", "src.example.com", string(nmapsvc.PortStateOpen), port, time.Now().Add(time.Minute)),
+				ConnectionObservedState:       observedConnection("dest.example.com", "src.example.com", string(nmapservice.PortStateOpen), port, time.Now().Add(time.Minute)),
 				DataflowComponentReadFSMState: protocolconverter.OperationalStateActive,
 			},
 		})
@@ -624,10 +624,10 @@ var _ = Describe("EditProtocolConverter awaitRollout (connection check)", func()
 		// the connection: otherwise a bridge whose target is unreachable can never
 		// be edited at all, including the edit that stops its flows.
 		//
-		// The scan here still shows the PREVIOUS target — the same staging the
-		// ENG-5580 spec above rejects. The only difference is that this payload
+		// The scan here still shows the previous target, the same staging the
+		// read-path spec above rejects. The only difference is that this payload
 		// carries no connection.
-		stageReadDFCSnapshot("dest.example.com", "src.example.com", protocolconverter.OperationalStateActive, string(nmapsvc.PortStateOpen))
+		stageReadDFCSnapshot("dest.example.com", "src.example.com", protocolconverter.OperationalStateActive, string(nmapservice.PortStateOpen))
 
 		elapsed, err, replies := runAwaitRolloutRead("")
 

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter_awaitrollout_test.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter_awaitrollout_test.go
@@ -465,10 +465,6 @@ var _ = Describe("EditProtocolConverter awaitRollout (connection check)", func()
 		payload := map[string]interface{}{
 			"name": probeName,
 			"uuid": probeUUID.String(),
-			"connection": map[string]interface{}{
-				"ip":   ip,
-				"port": port,
-			},
 			"readDFC": map[string]interface{}{
 				"state": "active",
 				"inputs": map[string]interface{}{
@@ -487,6 +483,12 @@ var _ = Describe("EditProtocolConverter awaitRollout (connection check)", func()
 				},
 			},
 		}
+		// An empty ip stands for "the payload carried no connection block at all",
+		// which is what an edit that only changes a flow looks like.
+		if ip != "" {
+			payload["connection"] = map[string]interface{}{"ip": ip, "port": port}
+		}
+
 		Expect(a.Parse(payload)).To(Succeed())
 		Expect(a.Validate()).To(Succeed())
 		Expect(a.GetDFCType()).To(Equal("read"),
@@ -523,23 +525,17 @@ var _ = Describe("EditProtocolConverter awaitRollout (connection check)", func()
 		// value: the observed nmap target.
 		stageReadDFCSnapshot("dest.example.com", "dest.example.com", protocolconverter.OperationalStateActive, string(nmapservice.PortStateOpen))
 
-		_, err, replies := runAwaitRolloutRead("dest.example.com")
+		elapsed, err, replies := runAwaitRolloutRead("dest.example.com")
 
 		Expect(err).NotTo(HaveOccurred(), "a read-DFC edit whose scan agrees with the request must be accepted")
 		Expect(replies).To(ContainElement(ContainSubstring("read DFC configuration verified")),
 			"the read path's acceptance must be reachable in this harness, or the next spec proves nothing")
+		Expect(elapsed).To(BeNumerically("<", 4*time.Second),
+			"against a 6s budget: a gate that withholds acceptance from a healthy read-DFC edit is worse "+
+				"than the bug it replaces, so this must not creep towards the timeout")
 	})
 
-	// PENDING (XIt) because it reproduces ENG-5580 and therefore fails on today's
-	// code: it asserts the behaviour the fix must introduce, so it cannot be left
-	// enabled without a red suite. The fix that makes the read branch withhold
-	// acceptance until the requested target has been scanned must flip this back to
-	// It — a fix that leaves it pending has not been verified against the bug.
-	// Verified red before it was marked pending: the run reported the reply
-	// "bridge successfully activated with state 'active', read DFC configuration
-	// verified", i.e. it failed because the edit was ACCEPTED, not because of a
-	// timeout or a render failure.
-	XIt("does not accept a read-DFC edit while the scan still shows the previous target", func() {
+	It("does not accept a read-DFC edit while the scan still shows the previous target", func() {
 		// The reported bug (ENG-5580), in-process and deterministic. The bridge is
 		// edited to dest.example.com; the protocolconverter still carries its
 		// pre-edit CurrentState of active, and the scan still shows the OLD target
@@ -561,5 +557,65 @@ var _ = Describe("EditProtocolConverter awaitRollout (connection check)", func()
 			"an edit must not report success before the requested target has been scanned")
 		Expect(elapsed).To(BeNumerically(">", time.Second),
 			"acceptance on the first tick means the pre-edit snapshot was taken as evidence about the new config")
+	})
+
+	It("names the stale scan, not the dataflow component, when neither has caught up", func() {
+		// PLACEMENT GUARD. The spec above cannot tell where the connection check
+		// sits: staged below the DFC config comparison it would still pass, because
+		// that comparison matches in that spec's case and the check then runs
+		// anyway. This spec stages the case that separates the two positions — the
+		// observed read DFC has not started (nil Input, which the comparison reads
+		// as "Benthos is still starting") AND the scan still shows the previous
+		// target.
+		//
+		// With the connection check above the comparison, the operator is told the
+		// scan has not caught up. Below it, the comparison's own wait returns first
+		// and the scan is never mentioned, so the reply blames the dataflow
+		// component for a connection that was never dialed.
+		publish(protocolconverter.OperationalStateActive, &protocolconverter.ProtocolConverterObservedStateSnapshot{
+			ObservedProtocolConverterSpecConfig: protocolconverterserviceconfig.ProtocolConverterServiceConfigSpec{
+				Config: protocolconverterserviceconfig.ProtocolConverterServiceConfigTemplate{
+					ConnectionServiceConfig: connectionserviceconfig.ConnectionServiceConfigTemplate{
+						NmapTemplate: &connectionserviceconfig.NmapConfigTemplate{
+							Target: "{{ .IP }}",
+							Port:   "{{ .PORT }}",
+						},
+					},
+				},
+				Variables: variables.VariableBundle{
+					User: map[string]interface{}{"IP": "src.example.com", "PORT": "443"},
+				},
+			},
+			ServiceInfo: protocolconvertersvc.ServiceInfo{
+				ConnectionObservedState:       observedConnection("dest.example.com", "src.example.com", string(nmapsvc.PortStateOpen), port, time.Now().Add(time.Minute)),
+				DataflowComponentReadFSMState: protocolconverter.OperationalStateActive,
+			},
+		})
+
+		_, err, replies := runAwaitRolloutRead("dest.example.com")
+
+		Expect(err).To(HaveOccurred(), "neither the scan nor the dataflow component has caught up")
+		Expect(replies).To(ContainElement(ContainSubstring("waiting for nmap to scan dest.example.com")),
+			"the connection check must run before the dataflow component comparison, or a bridge whose "+
+				"target was never dialed is reported as a dataflow component problem")
+	})
+
+	It("does not wait for a scan when the edit carries no connection", func() {
+		// The exemption that keeps a broken bridge editable. An edit that changes
+		// only a flow has no new endpoint to verify, so it must not be held up by
+		// the connection: otherwise a bridge whose target is unreachable can never
+		// be edited at all, including the edit that stops its flows.
+		//
+		// The scan here still shows the PREVIOUS target — the same staging the
+		// ENG-5580 spec above rejects. The only difference is that this payload
+		// carries no connection.
+		stageReadDFCSnapshot("dest.example.com", "src.example.com", protocolconverter.OperationalStateActive, string(nmapsvc.PortStateOpen))
+
+		elapsed, err, replies := runAwaitRolloutRead("")
+
+		Expect(err).NotTo(HaveOccurred(), "an edit that does not touch the connection must not be blocked by it")
+		Expect(replies).To(ContainElement(ContainSubstring("read DFC configuration verified")))
+		Expect(elapsed).To(BeNumerically("<", 4*time.Second),
+			"against a 6s budget: this edit has nothing to wait for")
 	})
 })


### PR DESCRIPTION
Top of the stack: #2708 → #2716 → **#2751**. Umbrella: ENG-5853.

## Problem

The connection check has unit coverage only. Nothing drives it through the real ManagementConsole backend, which is where the symptom was reported: an edit to an unreachable target answering `action-success`.

## What we are shipping

- A container harness that runs the ManagementConsole backend and router as local Go processes, the way ManagementConsole's own Playwright suite runs them, with the private source pulled through `gh` (`make pull-managementconsole`). What it makes real, and what a fake backend cannot: instance login against a database row, JWT-scoped user auth, and the v3 Redis message queue routing the reply back.
- One spec, run once per nmap backend: a bridge with a read flow edited to an unreachable target must reply `action-failure`, and the reply history must name the successful rollback. A terminal failure alone does not prove the restore, because `awaitRollout` reports the same state when the rollback itself fails and when it aborts on a render error without dialling anything.
- The edit back to the reachable target, as the positive control: without it a harness that fails every edit satisfies the spec above.
- `make connection-rollback-test`.

## What we are NOT shipping

- Any CI wiring. The `connection-edit-rollback` label is excluded from `make unit-test`, and `make integration-test` filters on `integration`, so no job runs these specs. They need `gh` access to the private ManagementConsole repo and a 30-minute timeout, so that may be deliberate. If it is not, this needs a workflow.
- Red-then-green in this PR's own CI. These specs assert the fixed behaviour and are green on this branch; the failing baseline lives in #2708's `pkg/fsmv2/nmap/manager_test.go` and `pkg/communicator/actions/edit-protocolconverter_awaitrollout_test.go`.

Part of ENG-5853


