### PR TITLE
docs: a C4 model of umh-core

### DIFF
--- a/umh-core/.dockerignore
+++ b/umh-core/.dockerignore
@@ -15,6 +15,7 @@ metrics.txt
 .gitattributes
 
 # Documentation and non-code assets
+architecture/
 docs/
 examples/
 changelog-images/

--- a/umh-core/architecture/.gitignore
+++ b/umh-core/architecture/.gitignore
@@ -1,0 +1,9 @@
+# LikeC4 build and export output. umh-core.c4 is the only source.
+out/
+dist/
+*.mmd
+*.puml
+*.d2
+*.dot
+*.json
+node_modules/

--- a/umh-core/architecture/README.md
+++ b/umh-core/architecture/README.md
@@ -1,0 +1,141 @@
+# Architecture model
+
+A [C4](https://c4model.com) model of umh-core, written in
+[LikeC4](https://likec4.dev). One model in `umh-core.c4`, three views generated
+from it.
+
+This is internal developer documentation. It sits outside `umh-core/docs/`,
+which is the GitBook space published to docs.umh.app and requires every page to
+be listed in its `SUMMARY.md`.
+
+## The diagrams
+
+Three views, one per C4 level. Open them all with `npx likec4 start`.
+
+### `context` — level 1, 5 boxes
+
+Who talks to umh-core and which side opens the connection. The OT engineer,
+ManagementConsole, the industrial device, and whatever external system a bridge
+writes to.
+
+Read it for one thing: every arrow to the cloud points outward. The engineer
+reaches the gateway through the console, never by connecting to it.
+
+### `containers` — level 2, 15 boxes
+
+What actually runs inside the Docker container. Twelve boxes inside the system
+boundary: the agent, the benthos read and write flows, the topic browser, the
+monitors, the nmap scanner, Redpanda, and the three stores. Plus the three
+external systems, for context.
+
+This is the view to show someone new. "One Docker container" and "one process"
+sound like the same thing until you see this, and the answer is 73 processes on
+a 16-bridge instance. The nmap scanner carries an `fsmv1-only` tag because it
+does not exist on the fsmv2 backend, where the agent dials the target itself.
+
+### `agentComponents` — level 3, 14 boxes
+
+How the single Go process is organised. Eleven components, plus
+ManagementConsole, `config.yaml` and the s6 log directories at the edges to show
+what the process reads and writes.
+
+The reason this view exists is the FSMv1 and FSMv2 trees sitting side by side
+with the adapter between them. That split is the hardest thing to discover from
+the code and it is invisible at level 2.
+
+### Level 4
+
+C4's fourth level is code, and Simon Brown's own guidance is to generate it on
+demand rather than maintain it. There is a separate FSMv2 deep-dive page with a
+package dependency graph, the tick loop and an end-to-end observation trace. It
+is not in this repository and has no permanent home yet.
+
+## Working with it
+
+```sh
+cd umh-core/architecture
+
+npx likec4 start        # http://localhost:5173, hot-reloads on save
+npx likec4 validate     # exit 1 with file and line on a broken model
+npx likec4 gen mermaid -o ./out
+npx likec4 export png -o ./out
+```
+
+Run `validate` in CI. There is a Docker image, `ghcr.io/likec4/likec4`, if you
+would rather not use Node.
+
+## Editing the model
+
+Two rules.
+
+The element kinds are exactly `person`, `softwareSystem`, `container`, `store`
+and `component`. LikeC4 does not enforce C4's abstraction levels, so a sixth
+kind is how the hierarchy stops being C4.
+
+The legend is generated. Every element kind declares a `notation` line, and
+LikeC4 renders those as a key in the viewer and the built site. Change the
+`notation` string rather than adding a notation table here.
+
+## Acronyms used in the diagrams
+
+| | |
+|---|---|
+| **UNS** | Unified Namespace. The Kafka topic `umh.messages` that every bridge publishes into. |
+| **FSM** | Finite state machine. FSMv1 and FSMv2 are the two generations of the state-machine layer, both shipping today. |
+| **DFC** | Dataflow component. The unit a bridge's read flow and write flow are each made of. |
+| **s6** | The supervision suite that runs every process in the container. |
+| **PLC** | Programmable logic controller. |
+| **OPC UA, Modbus, S7** | Industrial protocols a bridge uses to reach a device. |
+| **Bridge** | Also called a protocol converter, including in the code (`protocolconverter`). The two are synonyms. |
+
+## What the model asserts, and how to check it
+
+**Every service container is a real s6 service.** The three stores
+(`config.yaml`, `s6 log directories`, `Redpanda storage`) are filesystem
+locations, not processes, and never appear under `/run/service`. Every other box
+maps to a directory there, and the names are built by the `getS6ServiceName`
+functions in `pkg/service/<service>/<service>.go`. To list the live set:
+
+```sh
+docker exec <instance> sh -c \
+  'for d in /run/service/*/; do printf "%-72s %s\n" "$(basename $d)" "$(/command/s6-svstat $d)"; done'
+```
+
+That listing shows two things the model does not draw, both expected.
+`s6-linux-init-shutdownd`, `s6rc-fdholder` and `s6rc-oneshot-runner` belong to
+the s6 overlay itself. Standalone dataflow components and stream processors
+appear only once a user configures one.
+
+**The agent opens every outbound connection.** ManagementConsole never dials
+in. The agent logs in and then pulls actions and pushes status against
+`/v2/instance/*` (`pkg/communicator/api/v2/http/requester.go`), which is why
+`context` has no inbound arrow. The agent does bind `:8080` for Prometheus
+metrics, and `:8090` for GraphQL when enabled, but nothing in the control plane
+dials them.
+
+**The triangular store is in memory.** It is a component of the agent process,
+not a store container, because the only implementation is
+`pkg/persistence/memory`. A restart loses it, which is why a freshly started
+worker resolves as `NeverObserved` instead of reading back its last known state.
+
+**Benthos configs are rendered to disk.** Each service gets its own
+`/run/service/<service>/config/benthos.yaml`, written from `config.yaml` with
+variables expanded. They are regenerated rather than edited, so they are not a
+source of truth, but they are on disk and readable.
+
+## Counting services
+
+Bridge-scoped processes are drawn once each. How many exist per bridge depends
+on the nmap backend: four under `NMAP_BACKEND=fsmv2` (a read flow, a write flow
+and a monitor for each), and five under the fsmv1 default, which adds the nmap
+scanner. There is no monitor for the scanner; its FSM parses the scanner's own
+log.
+
+Constant overhead is six services: the topic browser and its monitor, Redpanda
+and its monitor, and the agent and its log. The s6 overlay adds three more
+(`s6-linux-init-shutdownd`, `s6rc-fdholder`, `s6rc-oneshot-runner`).
+
+A 16-bridge instance therefore runs 73 services on fsmv2 and 89 on fsmv1.
+Verified against a live fsmv2 instance: 16 read flows, 16 write flows, 32 flow
+monitors, the topic browser and its monitor, two Redpanda services, two agent
+services, three s6 overlay services.

--- a/umh-core/architecture/README.md
+++ b/umh-core/architecture/README.md
@@ -38,7 +38,7 @@ per-bridge group is drawn once and instantiated sixteen times. The nmap scanner
 carries an `fsmv1-only` tag because it does not exist on the fsmv2 backend,
 where the agent dials the target itself.
 
-### `agentComponents` — level 3, 15 boxes in four groups
+### `agentComponents` — level 3, 16 boxes in four groups
 
 How the single Go process is organised, plus ManagementConsole, `config.yaml`
 and the s6 log directories at the edges to show what the process reads and
@@ -46,13 +46,14 @@ writes.
 
 The shape to notice is two independent drivers. The FSMv1 reconcile loop and the
 FSMv2 supervisor each run on their own clock, the supervisor on its own
-goroutine at a 100 ms tick (`cmd/main.go:311`), and neither calls the other.
+goroutine (`cmd/main.go:311`) at a 100 ms tick (`:808`), and neither calls the
+other.
 They meet only at the triangular store, which the adapter reads on FSMv1's
 behalf. That is the hardest thing to discover from the code and it is invisible
 at level 2.
 
-The entrypoint and the config manager sit outside both groups, because both
-drivers use them.
+The entrypoint, the config manager and container health sit outside both
+groups, because both drivers use them.
 
 ### Level 4
 

--- a/umh-core/architecture/README.md
+++ b/umh-core/architecture/README.md
@@ -12,7 +12,12 @@ be listed in its `SUMMARY.md`.
 
 Three views, one per C4 level. Open them all with `npx likec4 start`.
 
-### `context` — level 1, 5 boxes
+The level-1 view is named `index`, which makes it the landing view. LikeC4
+auto-generates a landscape view when a model declares no `index`, and for a
+model with a single system in focus that landscape and the C4 context diagram
+are the same picture.
+
+### `index` — level 1, 5 boxes
 
 Who talks to umh-core and which side opens the connection. The OT engineer,
 ManagementConsole, the industrial device, and whatever external system a bridge
@@ -21,17 +26,17 @@ writes to.
 Read it for one thing: every arrow to the cloud points outward. The engineer
 reaches the gateway through the console, never by connecting to it.
 
-### `containers` — level 2, 15 boxes
+### `containers` — level 2, 15 boxes in three groups
 
-What actually runs inside the Docker container. Twelve boxes inside the system
-boundary: the agent, the benthos read and write flows, the topic browser, the
-monitors, the nmap scanner, Redpanda, and the three stores. Plus the three
-external systems, for context.
+What actually runs inside the Docker container, grouped by how many of each
+exist: one per bridge, one per instance, and the three things on disk.
 
 This is the view to show someone new. "One Docker container" and "one process"
 sound like the same thing until you see this, and the answer is 73 processes on
-a 16-bridge instance. The nmap scanner carries an `fsmv1-only` tag because it
-does not exist on the fsmv2 backend, where the agent dials the target itself.
+a 16-bridge instance. The grouping is where that number comes from: the
+per-bridge group is drawn once and instantiated sixteen times. The nmap scanner
+carries an `fsmv1-only` tag because it does not exist on the fsmv2 backend,
+where the agent dials the target itself.
 
 ### `agentComponents` — level 3, 14 boxes
 

--- a/umh-core/architecture/README.md
+++ b/umh-core/architecture/README.md
@@ -38,15 +38,21 @@ per-bridge group is drawn once and instantiated sixteen times. The nmap scanner
 carries an `fsmv1-only` tag because it does not exist on the fsmv2 backend,
 where the agent dials the target itself.
 
-### `agentComponents` — level 3, 14 boxes
+### `agentComponents` — level 3, 15 boxes in four groups
 
-How the single Go process is organised. Eleven components, plus
-ManagementConsole, `config.yaml` and the s6 log directories at the edges to show
-what the process reads and writes.
+How the single Go process is organised, plus ManagementConsole, `config.yaml`
+and the s6 log directories at the edges to show what the process reads and
+writes.
 
-The reason this view exists is the FSMv1 and FSMv2 trees sitting side by side
-with the adapter between them. That split is the hardest thing to discover from
-the code and it is invisible at level 2.
+The shape to notice is two independent drivers. The FSMv1 reconcile loop and the
+FSMv2 supervisor each run on their own clock, the supervisor on its own
+goroutine at a 100 ms tick (`cmd/main.go:311`), and neither calls the other.
+They meet only at the triangular store, which the adapter reads on FSMv1's
+behalf. That is the hardest thing to discover from the code and it is invisible
+at level 2.
+
+The entrypoint and the config manager sit outside both groups, because both
+drivers use them.
 
 ### Level 4
 

--- a/umh-core/architecture/umh-core.c4
+++ b/umh-core/architecture/umh-core.c4
@@ -122,6 +122,18 @@ model {
         loop and the cloud transport. Runs as the s6 service named umh-core.
       '''
 
+      entrypoint = component 'Process entrypoint' {
+        technology 'Go'
+        description '''
+          Builds the dependency graph at startup and starts both drivers: the
+          FSMv1 reconcile loop, and the FSMv2 application supervisor on its own
+          goroutine with a 100 ms tick. The two never call each other.
+        '''
+        metadata {
+          package 'cmd/main.go'
+        }
+      }
+
       communicator = component 'Communicator' {
         technology 'Go'
         description '''
@@ -383,6 +395,10 @@ model {
 
   // ---- components of the agent ----
 
+  umhCore.agent.entrypoint -> umhCore.agent.communicator 'starts'
+  umhCore.agent.entrypoint -> umhCore.agent.controlLoop 'starts'
+  umhCore.agent.entrypoint -> umhCore.agent.fsmv2Runtime 'starts on its own goroutine' '100 ms tick'
+
   umhCore.agent.communicator -> managementConsole 'logs in, pulls, pushes' 'HTTPS'
   umhCore.agent.communicator -> umhCore.agent.actions 'hands off one queued action'
   umhCore.agent.communicator -> umhCore.agent.fsmv1 'reads snapshots to build the status push'
@@ -478,13 +494,17 @@ views {
   view agentComponents of umhCore.agent {
     title 'L3 - Inside the agent process'
     description '''
-      How the single Go process is organised, in four groups: what talks to the
-      cloud, what owns the configuration, what decides, and what writes to disk.
-      The FSMv1 tree and the FSMv2 runtime sit side by side in the third group,
-      with the adapter between them. That split is invisible at L2.
+      How the single Go process is organised. The shape to notice is two
+      independent drivers: the FSMv1 reconcile loop, and the FSMv2 supervisor on
+      its own goroutine at a 100 ms tick. Neither calls the other. They meet
+      only at the triangular store, which the adapter reads on FSMv1's behalf.
+      The entrypoint and the config manager sit outside both, because both
+      drivers use them.
     '''
 
     include managementConsole, umhCore.configFile, umhCore.s6Logs
+
+    include umhCore.agent.entrypoint, umhCore.agent.configManager
 
     group 'Cloud transport' {
       include
@@ -492,17 +512,16 @@ views {
         umhCore.agent.actions
     }
 
-    group 'Configuration' {
+    group 'Driver one: the FSMv1 reconcile loop' {
       include
-        umhCore.agent.configManager,
-        umhCore.agent.controlLoop
+        umhCore.agent.controlLoop,
+        umhCore.agent.fsmv1
     }
 
-    group 'State machines' {
+    group 'Driver two: the FSMv2 supervisor' {
       include
-        umhCore.agent.fsmv1,
-        umhCore.agent.fsmv1Adapter,
         umhCore.agent.fsmv2Runtime,
+        umhCore.agent.fsmv1Adapter,
         umhCore.agent.triangularStore
     }
 

--- a/umh-core/architecture/umh-core.c4
+++ b/umh-core/architecture/umh-core.c4
@@ -1,0 +1,496 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// C4 model of umh-core. LikeC4 does not enforce C4's abstraction levels, so the
+// element kinds below are declared to match them exactly and nothing else may be
+// added: person, softwareSystem, container, store, component. A store is a
+// container-level element in C4 terms; it is a separate kind here only so the
+// generated legend can say that it is not a running process.
+
+specification {
+
+  color signal #16607f
+  color legacy #8f5d14
+  color neutral #6d7d87
+
+  element person {
+    notation 'Person. A human role, outside every system boundary.'
+    style {
+      shape person
+      color signal
+    }
+  }
+
+  element softwareSystem {
+    notation 'Software system. The highest level of abstraction.'
+    style {
+      color signal
+    }
+  }
+
+  element container {
+    notation 'Container. A separately runnable process. Every one is an s6 service under /run/service.'
+    style {
+      color sky
+    }
+  }
+
+  element store {
+    notation 'Store. A container-level element that holds data rather than running. Never appears under /run/service.'
+    style {
+      shape storage
+      color legacy
+    }
+  }
+
+  element component {
+    notation 'Component. A grouping of responsibility inside a single process.'
+    style {
+      shape rectangle
+      color indigo
+    }
+  }
+
+  tag external {
+    color neutral
+  }
+
+  tag fsmv1-only {
+    color amber
+  }
+
+  relationship supervises {
+    title 'supervises'
+    notation 'Creates the s6 service directory, starts it, and removes it.'
+  }
+}
+
+model {
+
+  otEngineer = person 'OT engineer' {
+    description '''
+      Operational-technology engineer. Configures bridges and reads instance
+      status through the cloud console, never by logging into the gateway.
+    '''
+  }
+
+  managementConsole = softwareSystem 'ManagementConsole' {
+    #external
+    description '''
+      Cloud control plane. Holds the fleet, renders the bridge wizard, and
+      queues actions for each instance.
+    '''
+  }
+
+  device = softwareSystem 'Industrial device' {
+    #external
+    description '''
+      PLC (programmable logic controller), gateway or historian endpoint,
+      reachable over OPC UA, Modbus, S7 and similar industrial protocols.
+    '''
+  }
+
+  externalSink = softwareSystem 'External sink' {
+    #external
+    description '''
+      A system a bridge writes to rather than reads from, such as the
+      historian's TimescaleDB.
+    '''
+  }
+
+  umhCore = softwareSystem 'umh-core' {
+    description '''
+      Edge gateway. One Docker container running an s6 supervision tree.
+      config.yaml is the source of truth for everything inside it.
+    '''
+
+    agent = container 'umh-core agent' {
+      technology 'Go'
+      description '''
+        Single process holding every FSM (finite state machine), the reconcile
+        loop and the cloud transport. Runs as the s6 service named umh-core.
+      '''
+
+      communicator = component 'Communicator' {
+        technology 'Go'
+        description '''
+          Logs in, pulls queued actions and pushes status. The agent dials out;
+          ManagementConsole never dials in.
+        '''
+        metadata {
+          package 'pkg/communicator'
+        }
+      }
+
+      actions = component 'Actions dispatcher' {
+        technology 'Go'
+        description '''
+          Executes one queued action: parse the payload, change the config, then
+          wait for the FSM to confirm the rollout before reporting success.
+        '''
+        metadata {
+          package 'pkg/communicator/actions'
+        }
+      }
+
+      configManager = component 'Config manager' {
+        technology 'Go'
+        description '''
+          Reads and rewrites config.yaml under a lock, taking a backup after
+          each write. The only writer inside the agent.
+        '''
+        metadata {
+          package 'pkg/config'
+        }
+      }
+
+      controlLoop = component 'Reconcile loop' {
+        technology 'Go'
+        description '''
+          One reconcile cycle at a time; within a cycle the manager tree fans
+          out across goroutines. Keeps observed state converging on config.yaml.
+        '''
+        metadata {
+          package 'pkg/control'
+        }
+      }
+
+      fsmv1 = component 'FSMv1 manager tree' {
+        technology 'Go'
+        description '''
+          The original state-machine layer. One manager per service type, each
+          owning the instances of that type.
+        '''
+        metadata {
+          package 'pkg/fsm'
+        }
+      }
+
+      fsmv2Runtime = component 'FSMv2 runtime' {
+        technology 'Go'
+        description '''
+          The replacement state-machine layer. Supervisor, one collector
+          goroutine per worker, and the asynchronous action executor.
+        '''
+        metadata {
+          package 'pkg/fsmv2/supervisor'
+        }
+      }
+
+      fsmv1Adapter = component 'FSMv1 adapter' {
+        technology 'Go'
+        description '''
+          Presents an FSMv2 worker as an FSMv1 manager and instance, so FSMv1
+          call sites are unchanged. Reads observations through the store client,
+          never through the supervisor.
+        '''
+        metadata {
+          package 'pkg/fsmv2/adapter'
+        }
+      }
+
+      triangularStore = component 'Triangular store' {
+        technology 'Go, in-memory'
+        description '''
+          Holds the three faces of every worker: Identity, Desired, Observed.
+          The collector is the only steady-state writer of Observed; the
+          supervisor seeds one initial observation when a worker is added.
+          In memory only: a restart loses it.
+        '''
+        metadata {
+          package 'pkg/cse/storage, pkg/persistence/memory'
+        }
+      }
+
+      serviceLayer = component 'Service layer' {
+        technology 'Go'
+        description '''
+          Renders what the FSM asks for into files on disk: benthos configs from
+          templates, and nmap scan scripts. Parses service logs back into
+          observed state.
+        '''
+        metadata {
+          package 'pkg/service'
+        }
+      }
+
+      s6Manager = component 'S6 service manager' {
+        technology 'Go'
+        description '''
+          Creates, updates and removes s6 service directories, and reads their
+          logs.
+        '''
+        metadata {
+          package 'pkg/service/s6'
+        }
+      }
+
+      registry = component 'Service registry' {
+        technology 'Go'
+        description '''
+          Filesystem access and port allocation, injected into every service so
+          tests can substitute them.
+        '''
+        metadata {
+          package 'pkg/serviceregistry, pkg/portmanager'
+        }
+      }
+    }
+
+    agentLog = container 'umh-core-log' {
+      technology 's6-log'
+      description 'Log service for the agent process. A 5 x 10 MB ring, unlike every other service.'
+    }
+
+    benthosRead = container 'Benthos read flow' {
+      technology 'benthos-umh'
+      description '''
+        One process per bridge that has a read flow. Speaks the industrial
+        protocol and publishes into the UNS (Unified Namespace).
+        Service name benthos-dataflow-read-protocolconverter-{bridge}.
+      '''
+    }
+
+    benthosWrite = container 'Benthos write flow' {
+      technology 'benthos-umh'
+      description '''
+        One process per bridge that has a write flow. Consumes from the UNS and
+        writes outward. Usually down (exitcode 0), because most bridges have
+        no write flow.
+      '''
+    }
+
+    topicBrowser = container 'Topic browser' {
+      technology 'benthos-umh'
+      description '''
+        One process per instance, not per bridge. Consumes umh.messages and
+        serves the topic tree to the console. Present on every instance,
+        including one with no bridges at all.
+      '''
+    }
+
+    benthosMonitor = container 'Benthos monitor' {
+      technology 'sh, curl'
+      description '''
+        A shell loop, one per benthos process. Curls /ping, /ready, /version and
+        /metrics once a second and writes gzip-then-hex blocks to its own log.
+      '''
+    }
+
+    nmapScanner = container 'Nmap scanner' {
+      #fsmv1-only
+      technology 'nmap'
+      description '''
+        One process per connection, on the FSMv1 backend only. Loops
+        nmap -n -Pn against the bridge's target and writes marker-delimited
+        results to its log. Under NMAP_BACKEND=fsmv2 this process does not
+        exist and the agent dials the target itself.
+      '''
+    }
+
+    redpanda = container 'Redpanda' {
+      technology 'Redpanda'
+      description '''
+        Embedded Kafka-compatible broker carrying the UNS topic umh.messages.
+        One per instance, shared by every bridge.
+      '''
+    }
+
+    redpandaMonitor = container 'Redpanda monitor' {
+      technology 'sh, curl'
+      description 'Health poller for the broker. Same poll loop as the benthos monitor.'
+    }
+
+    configFile = store 'config.yaml' {
+      technology 'YAML on /data'
+      description '''
+        The source of truth. Every benthos config is rendered from it into that
+        service's own directory at /run/service/{service}/config/benthos.yaml,
+        and is regenerated rather than edited.
+      '''
+    }
+
+    s6Logs = store 's6 log directories' {
+      technology 's6-log on /data/logs'
+      description '''
+        A per-service ring of 20 files, uncapped in size except for the benthos
+        monitors, which cap each file at 64 kB. A monitor's findings reach the agent
+        through these files.
+      '''
+    }
+
+    redpandaStorage = store 'Redpanda storage' {
+      technology 'Disk on /data/redpanda'
+      description 'Broker log segments.'
+    }
+  }
+
+  // ---- system context ----
+
+  otEngineer -> managementConsole 'configures bridges, reads status'
+  umhCore -> managementConsole 'pulls actions, pushes status' 'HTTPS'
+  umhCore -> device 'reads and writes process data'
+  umhCore -> externalSink 'writes to external systems'
+
+  // ---- containers ----
+
+  umhCore.agent -> managementConsole 'logs in, pulls actions, pushes status' 'HTTPS /v2/instance/*'
+  umhCore.agent -> umhCore.configFile 'reads, and rewrites under a lock on an accepted edit'
+  umhCore.agent -> umhCore.agentLog 'writes stdout and stderr'
+  umhCore.agent -[supervises]-> umhCore.benthosRead 'renders its config, then supervises'
+  umhCore.agent -[supervises]-> umhCore.benthosWrite 'renders its config, then supervises'
+  umhCore.agent -[supervises]-> umhCore.topicBrowser 'renders its config, then supervises'
+  umhCore.agent -[supervises]-> umhCore.benthosMonitor 'supervises'
+  umhCore.agent -[supervises]-> umhCore.nmapScanner 'generates the scan script, then supervises' {
+    #fsmv1-only
+  }
+  umhCore.agent -[supervises]-> umhCore.redpanda 'supervises'
+  umhCore.agent -[supervises]-> umhCore.redpandaMonitor 'supervises'
+  umhCore.agent -> umhCore.s6Logs 'reads and parses, to derive observed state'
+  umhCore.agent -> device 'dials the target port once a second' 'FSMv2 nmap backend'
+
+  umhCore.benthosMonitor -> umhCore.benthosRead 'polls four health endpoints' 'HTTP, 1 Hz'
+  umhCore.benthosMonitor -> umhCore.benthosWrite 'polls four health endpoints' 'HTTP, 1 Hz'
+  umhCore.benthosMonitor -> umhCore.topicBrowser 'polls four health endpoints' 'HTTP, 1 Hz'
+  umhCore.benthosMonitor -> umhCore.s6Logs 'writes gzip-then-hex blocks'
+  umhCore.nmapScanner -> device 'scans the configured port' 'nmap' {
+    #fsmv1-only
+  }
+  umhCore.nmapScanner -> umhCore.s6Logs 'writes marker-delimited scan results' {
+    #fsmv1-only
+  }
+  umhCore.redpandaMonitor -> umhCore.redpanda 'polls health'
+  umhCore.redpandaMonitor -> umhCore.s6Logs 'writes health blocks'
+
+  umhCore.benthosRead -> device 'reads process data' 'OPC UA, Modbus, S7'
+  umhCore.benthosRead -> umhCore.redpanda 'publishes to umh.messages'
+  umhCore.benthosWrite -> umhCore.redpanda 'consumes from umh.messages'
+  umhCore.benthosWrite -> device 'writes process data'
+  umhCore.benthosWrite -> externalSink 'writes historized tags'
+  umhCore.topicBrowser -> umhCore.redpanda 'consumes umh.messages to build the topic tree'
+  umhCore.redpanda -> umhCore.redpandaStorage 'persists log segments'
+
+  // ---- components of the agent ----
+
+  umhCore.agent.communicator -> managementConsole 'logs in, pulls, pushes' 'HTTPS'
+  umhCore.agent.communicator -> umhCore.agent.actions 'hands off one queued action'
+  umhCore.agent.communicator -> umhCore.agent.fsmv1 'reads snapshots to build the status push'
+
+  umhCore.agent.actions -> umhCore.agent.configManager 'changes the bridge entry'
+  umhCore.agent.actions -> umhCore.agent.fsmv1 'polls snapshots to confirm the rollout, or rolls the edit back'
+
+  umhCore.agent.controlLoop -> umhCore.agent.configManager 'reads the desired configuration'
+  umhCore.agent.controlLoop -> umhCore.agent.fsmv1 'ticks the manager tree once per cycle'
+
+  umhCore.agent.configManager -> umhCore.configFile 'reads and writes'
+
+  umhCore.agent.fsmv1 -> umhCore.agent.serviceLayer 'creates, updates and removes services'
+  umhCore.agent.fsmv1 -> umhCore.agent.fsmv1Adapter 'drives nmap workers' 'when NMAP_BACKEND=fsmv2'
+
+  umhCore.agent.fsmv1Adapter -> umhCore.agent.triangularStore 'reads observations, classified by age'
+  umhCore.agent.fsmv2Runtime -> umhCore.agent.triangularStore 'writes Observed, reads Desired'
+  umhCore.agent.fsmv2Runtime -> device 'dials the target port' 'nmap worker Poll'
+
+  umhCore.agent.serviceLayer -> umhCore.agent.s6Manager 'asks for service directories'
+  umhCore.agent.serviceLayer -> umhCore.agent.registry 'allocates ports, reaches the filesystem'
+  umhCore.agent.serviceLayer -> umhCore.s6Logs 'reads and parses monitor output'
+
+  umhCore.agent.s6Manager -[supervises]-> umhCore.benthosRead 'supervises'
+  umhCore.agent.s6Manager -[supervises]-> umhCore.benthosWrite 'supervises'
+  umhCore.agent.s6Manager -[supervises]-> umhCore.topicBrowser 'supervises'
+  umhCore.agent.s6Manager -[supervises]-> umhCore.benthosMonitor 'supervises'
+  umhCore.agent.s6Manager -[supervises]-> umhCore.nmapScanner 'supervises' {
+    #fsmv1-only
+  }
+  umhCore.agent.s6Manager -[supervises]-> umhCore.redpanda 'supervises'
+  umhCore.agent.s6Manager -[supervises]-> umhCore.redpandaMonitor 'supervises'
+}
+
+views {
+
+  view context of umhCore {
+    title 'L1 - System context'
+    description '''
+      Who talks to umh-core, and which side opens the connection. The engineer
+      reaches the gateway only through the cloud console; nothing dials in.
+    '''
+
+    include otEngineer, managementConsole, device, externalSink, umhCore
+
+    style * {
+      color signal
+    }
+    style otEngineer {
+      shape person
+    }
+    autoLayout LeftRight
+  }
+
+  view containers of umhCore {
+    title 'L2 - Containers'
+    description '''
+      The s6 supervision tree. Every box except the three stores is a real
+      service directory under /run/service. Bridge-scoped processes are drawn
+      once; in practice there is one read flow, one write flow and two monitors
+      per bridge.
+    '''
+
+    include
+      managementConsole, device, externalSink,
+      umhCore.*
+
+    autoLayout TopBottom
+  }
+
+  view agentComponents of umhCore.agent {
+    title 'L3 - Inside the agent process'
+    description '''
+      How the single Go process is organised, in four groups: what talks to the
+      cloud, what owns the configuration, what decides, and what writes to disk.
+      The FSMv1 tree and the FSMv2 runtime sit side by side in the third group,
+      with the adapter between them. That split is invisible at L2.
+    '''
+
+    include managementConsole, umhCore.configFile, umhCore.s6Logs
+
+    group 'Cloud transport' {
+      include
+        umhCore.agent.communicator,
+        umhCore.agent.actions
+    }
+
+    group 'Configuration' {
+      include
+        umhCore.agent.configManager,
+        umhCore.agent.controlLoop
+    }
+
+    group 'State machines' {
+      include
+        umhCore.agent.fsmv1,
+        umhCore.agent.fsmv1Adapter,
+        umhCore.agent.fsmv2Runtime,
+        umhCore.agent.triangularStore
+    }
+
+    group 'Writing to disk' {
+      include
+        umhCore.agent.serviceLayer,
+        umhCore.agent.s6Manager,
+        umhCore.agent.registry
+    }
+
+    autoLayout TopBottom
+  }
+}

--- a/umh-core/architecture/umh-core.c4
+++ b/umh-core/architecture/umh-core.c4
@@ -225,6 +225,20 @@ model {
         }
       }
 
+      containerHealth = component 'Container health' {
+        technology 'Go'
+        description '''
+          Reads the container's cgroup CPU counters, judges pressure and
+          saturation, and ranks the likely causes. The verdict reaches the
+          console in the status push, and blocks new bridges while resources are
+          limited. Has an FSMv2 worker too, the same dual-backend pattern as
+          nmap.
+        '''
+        metadata {
+          package 'pkg/cpuhealth, pkg/diagnosis, pkg/service/container_monitor, pkg/fsmv2/cpu'
+        }
+      }
+
       serviceLayer = component 'Service layer' {
         technology 'Go'
         description '''
@@ -233,7 +247,7 @@ model {
           observed state.
         '''
         metadata {
-          package 'pkg/service'
+          package 'pkg/service (except container_monitor)'
         }
       }
 
@@ -418,6 +432,9 @@ model {
   umhCore.agent.fsmv2Runtime -> umhCore.agent.triangularStore 'writes Observed, reads Desired'
   umhCore.agent.fsmv2Runtime -> device 'dials the target port' 'nmap worker Poll'
 
+  umhCore.agent.fsmv1 -> umhCore.agent.containerHealth 'reconciles the container monitor'
+  umhCore.agent.communicator -> umhCore.agent.containerHealth 'reads the CPU verdict for the status push'
+
   umhCore.agent.serviceLayer -> umhCore.agent.s6Manager 'asks for service directories'
   umhCore.agent.serviceLayer -> umhCore.agent.registry 'allocates ports, reaches the filesystem'
   umhCore.agent.serviceLayer -> umhCore.s6Logs 'reads and parses monitor output'
@@ -504,7 +521,10 @@ views {
 
     include managementConsole, umhCore.configFile, umhCore.s6Logs
 
-    include umhCore.agent.entrypoint, umhCore.agent.configManager
+    include
+      umhCore.agent.entrypoint,
+      umhCore.agent.configManager,
+      umhCore.agent.containerHealth
 
     group 'Cloud transport' {
       include

--- a/umh-core/architecture/umh-core.c4
+++ b/umh-core/architecture/umh-core.c4
@@ -419,7 +419,7 @@ model {
 
 views {
 
-  view context of umhCore {
+  view index of umhCore {
     title 'L1 - System context'
     description '''
       Who talks to umh-core, and which side opens the connection. The engineer
@@ -440,15 +440,37 @@ views {
   view containers of umhCore {
     title 'L2 - Containers'
     description '''
-      The s6 supervision tree. Every box except the three stores is a real
-      service directory under /run/service. Bridge-scoped processes are drawn
-      once; in practice there is one read flow, one write flow and two monitors
-      per bridge.
+      The s6 supervision tree, grouped by how many of each exist. Every box
+      except the three stores is a real service directory under /run/service.
+      The per-bridge group is drawn once but instantiated per bridge, which is
+      how sixteen bridges become seventy-three processes.
     '''
 
-    include
-      managementConsole, device, externalSink,
-      umhCore.*
+    include managementConsole, device, externalSink
+
+    group 'One per bridge' {
+      include
+        umhCore.benthosRead,
+        umhCore.benthosWrite,
+        umhCore.benthosMonitor,
+        umhCore.nmapScanner
+    }
+
+    group 'One per instance' {
+      include
+        umhCore.agent,
+        umhCore.agentLog,
+        umhCore.topicBrowser,
+        umhCore.redpanda,
+        umhCore.redpandaMonitor
+    }
+
+    group 'On disk' {
+      include
+        umhCore.configFile,
+        umhCore.s6Logs,
+        umhCore.redpandaStorage
+    }
 
     autoLayout TopBottom
   }


### PR DESCRIPTION
## Problem

There was no comprehensive overview of the umh-core architecture. A newcomer
reads "one Docker container" and concludes it is one process; a 16-bridge
instance runs 73.

## What we are shipping

A [C4](https://c4model.com) model in `umh-core/architecture/`, three views, and
a README recording what each claim rests on and how to check it against a
running instance. `npx likec4 start` from that directory browses them.

Two things the model makes visible that are hard to find in the code:

- **Level 2** groups processes by how many of each exist — per bridge, per
  instance, on disk. That grouping is where 73 comes from.
- **Level 3** shows two independent drivers. The FSMv1 reconcile loop and the
  FSMv2 supervisor run on separate clocks, the supervisor on its own goroutine
  at a 100 ms tick, and neither calls the other. They meet only at the
  triangular store.

LikeC4 rather than Structurizr, whose `cli` and `lite` images are end-of-life,
whose viewer does not reload on edit, and neither of whose export formats can
carry a legend.

## What we are NOT shipping

- No drift test. The join between service names and model boxes needs a
  hand-maintained map, which is the thing such a test would replace. The README
  documents the manual check.
- No level 4, per C4's own guidance to generate the code level on demand.
- The FSMv2 workers are not broken out. Level 3 draws the supervisor as one box,
  the same choice made for the FSMv1 manager tree. Enumerating them wants its
  own view rather than more boxes in this one.
- Two documentation errors this work uncovered, tracked in ENG-5891.
