### PR TITLE
docs(control): correct the ControlLoop threading comment

### DIFF
--- a/umh-core/pkg/control/loop.go
+++ b/umh-core/pkg/control/loop.go
@@ -79,8 +79,10 @@ import (
 // 2. Managers continuously reconcile actual state with desired state
 // 3. Changes propagate in sequence until the system stabilizes
 //
-// This single-threaded design ensures deterministic behavior while the
-// time-sliced approach allows responsive handling of multiple components.
+// Ticks never overlap: Reconcile runs synchronously from the ticker and waits
+// for every manager before returning. Within a tick the managers reconcile
+// concurrently through an errgroup capped at MaxConcurrentFSMOperations, so
+// state a manager touches must be safe for concurrent access.
 type ControlLoop struct {
 	configManager     config.ConfigManager
 	logger            *zap.SugaredLogger


### PR DESCRIPTION
## Problem

`pkg/control/loop.go:82` described the reconcile loop as single-threaded. It is
not, and that is the word someone relies on when deciding whether two managers
can touch the same state.

## What we are shipping

The corrected comment. `Reconcile` builds an `errgroup` and launches every
manager in the batch on its own goroutine (`loop.go:398-427`), capped at
`MaxConcurrentFSMOperations`, which is 1000 and so effectively uncapped.

Ticks genuinely do not overlap, because `Execute` calls `Reconcile`
synchronously from the ticker and `Reconcile` blocks on `errorgroup.Wait()`.
The old comment's conclusion held; its stated reason did not.

Comment only, no behaviour change, so it needs the `skip-changelog-guard` label.

## What we are NOT shipping

The other half of ENG-5891. The workspace-root `CLAUDE.md` claims benthos
configs are "never stored" when each service has its own rendered
`/run/service/<service>/config/benthos.yaml`, but that file is not under version
control in this repository, so it cannot be fixed by a PR here. The in-repo
`CLAUDE.md:486` says something different and correct, and is left alone.

Part of ENG-5891.
