### PR TITLE
docs(eng-5132): CPU Health page for the preview CPU reporting

### DIFF
--- a/umh-core/docs/SUMMARY.md
+++ b/umh-core/docs/SUMMARY.md
@@ -43,6 +43,7 @@
         * [nginx](production/deployment/docker-compose/additional-services/nginx.md)
       * [Updating](production/deployment/docker-compose/updating.md)
   * [Sizing Guide](production/sizing-guide.md)
+  * [CPU Health](production/cpu-health.md)
   * [High Availability](production/high-availability.md)
   * [Metrics](production/metrics.md)
   * [Migration from Classic](production/migration-from-classic.md)

--- a/umh-core/docs/production/cpu-health.md
+++ b/umh-core/docs/production/cpu-health.md
@@ -1,0 +1,64 @@
+# CPU Health
+
+{% hint style="info" %}
+**Preview.** The CPU reporting on this page needs UMH Core v0.44.37 or later, started with
+`USE_FSMV2_CPU=true` and `USE_FSMV2_TRANSPORT=true`. Both are read once at startup, so changing
+them requires a container restart. Without them, the instance keeps the older reporting: it is
+marked degraded whenever CPU usage stays above 70% of the cores it may use, whether or not any
+work is actually being delayed.
+{% endhint %}
+
+CPU health is based on one question: does this container have a CPU limit? (a Docker `--cpus` or Kubernetes CPU limit). The answer decides what UMH measures against.
+
+With no limit, the whole machine is the ceiling. UMH watches how busy the machine is (60-second average) and reports degraded when less than about one core is free. At that point everything on the box, UMH included, starts waiting for CPU. Next to the machine total, the view shows the container's own usage, so you can see roughly what is UMH and what is everything else.
+
+With a limit set, the limit is the ceiling. UMH measures headroom against those cores, not the machine, and reports degraded when the reserve is used up (under 10% of the limit) or the kernel throttles the container. A full machine can still slow the container below its limit, so where UMH can see the machine, it warns on that too.
+
+High CPU usage alone is not a problem: an instance can run at high utilization and stay healthy as long as there is spare headroom, meaning a free core on the host or room under the limit. *Busy* is not the same as *starved* or *full*. UMH degrades when the reserve is used up (less than one host core free, or under 10% of the limit) or when work is actually being delayed; where the system reports them, it shows the three sharp signals: throttling, pressure, and steal. These are kernel-defined facts, not interpretations. (For the reasoning, see our write-up on [why average CPU utilization is the wrong signal](https://www.theocharis.dev/blog/why-we-should-get-rid-of-average-cpu-utilization/).)
+
+## What each CPU status means
+
+| Status | What it means | What to do |
+|--------|---------------|------------|
+| **CPU healthy** | The instance has the CPU it needs. Usage is shown for context (for example, "1.2 of 4 cores"). | Nothing. |
+| **CPU healthy, limited visibility** | The instance looks fine, but UMH can't fully measure CPU health here: no CPU limit is set and the operating system isn't reporting CPU-pressure statistics. | To turn on full monitoring, set a CPU limit for the instance, or enable Linux pressure stats (boot the OS with `psi=1`). |
+| **CPU limited** | The instance hit its CPU limit and was paused until the next scheduling cycle (for example, in 12% of cycles over the last minute). Work is being delayed. | Raise the instance's CPU limit, or reduce the load on it. |
+| **CPU contention** | Tasks inside the instance spent time waiting for a free CPU core (for example, 23% of the last minute). | Reduce the load on the instance, or give it more CPU. If other workloads share this server, they may be competing for it. |
+| **CPU taken by the server** | Other virtual machines on the same physical server took CPU this instance needed. This is outside UMH's control. | On your virtualization platform, give this VM more guaranteed CPU, or reduce the other VMs sharing the server. |
+| **CPU running near full** | The host or the container's CPU limit is exhausted: there is no room to absorb the next burst of work. With host stats readable, this fires when less than one core is free. Without host stats (no `/proc/stat`), it fires at a coarser proxy: sustained container usage above 70% of the machine's cores. The Technical Details body names the specific sub-case (host full, limit exhausted, or high usage without host stats). | Add CPU capacity, reduce load, or raise the instance's CPU limit. If the host is full but this container isn't the cause, other software on the host is competing: give UMH dedicated CPU (reserve or pin cores), or reduce what else runs here. A CPU limit caps UMH; it does not protect it from neighbors. If UMH could not confirm starvation directly (no CPU limit, no pressure stats), setting a limit or enabling Linux pressure stats (`psi=1`) adds the richer starvation causes on top. |
+
+{% hint style="info" %}
+**No CPU limit and no pressure stats?** UMH says so plainly ("limited visibility") rather than
+guessing. Setting a CPU limit on the instance, or booting the operating system with `psi=1`, lets
+UMH measure starvation directly and turns on full CPU health monitoring.
+{% endhint %}
+
+## When UMH refuses a new bridge
+
+When CPU is in any of the "something's wrong" states above, UMH won't start an additional bridge on
+the instance, because a new bridge would only compete for CPU that's already short. The refusal
+message names the same cause and fix as the status, for example:
+
+```
+Can't add another bridge: this instance is already hitting its CPU limit. Raise the limit or reduce load first.
+```
+
+This is separate from the *capacity* ceiling (how many bridges a given number of CPU cores can hold).
+For that, see the [Sizing Guide](./sizing-guide.md). Note that the capacity number is a ceiling, not
+a guarantee: because real CPU use varies per bridge, UMH can refuse a bridge on CPU health before you
+reach it.
+
+## How UMH decides
+
+UMH judges CPU health over the last 60 seconds, not on instantaneous readings. A brief spike
+won't flip the status, and a status won't clear until the reading comes back past a second,
+healthier threshold, so the status stays stable instead of flickering between healthy and degraded.
+
+## Glossary
+
+| Term | Meaning |
+|------|---------|
+| **Throttling** | The system caps each container to its CPU limit in short, repeating periods (about 100 ms). If the container needs more within a period, it's paused until the next one, so even a workload whose average looks fine can be paused during bursts. Frequent pausing means work waits. |
+| **CPU pressure** | How much time tasks spent waiting for a free CPU core (Linux Pressure Stall Information, PSI). High pressure means CPU is the bottleneck. |
+| **CPU steal** | Time the hypervisor gave this machine's CPU to other virtual machines (or, on burstable cloud instances, the point where your CPU credits run out). High steal means the server is oversubscribed. |
+| **Host contention** | CPU used by software outside UMH on the same machine. UMH can't see what those processes are, only that they're using CPU it needs. |

--- a/umh-core/docs/production/sizing-guide.md
+++ b/umh-core/docs/production/sizing-guide.md
@@ -59,6 +59,8 @@ Since every bridge has different resource requirements (OPC UA with 10,000 tags 
 - **Memory Usage**: Blocks if memory exceeds 80%
 - **Disk Usage**: Blocks if disk exceeds 85%
 
+For what each CPU status means and how CPU health is judged, see [CPU Health](./cpu-health.md).
+
 **Redpanda CPU Utilization:**
 UMH Core runs Redpanda with the `--overprovisioned` flag, which optimizes CPU usage for containerized environments. This disables Seastar's busy-polling reactor model, reducing idle CPU usage from 100% to near-zero when not processing messages. The trade-off is slightly higher latency (microseconds to low milliseconds), which is acceptable for manufacturing data that doesn't require sub-millisecond response times. This is required because UMH Core runs in Docker where CPU pinning doesn't work effectively, and Redpanda shares the container with other processes.
 


### PR DESCRIPTION
## Problem

The new CPU reporting shipped in umh-core without any documentation. A customer who sees "CPU taken by the server" or "Can't add another bridge: the machine is full" has nowhere to look up what it means, and the sizing guide is the only page that mentions CPU at all. The page existed on the closed #2613 and went nowhere when that PR closed.

## What we are shipping

- A **CPU Health** page under Production: what each status means and what to do about it, when UMH refuses a new bridge, and a glossary for throttling, CPU pressure, steal and host contention.
- The page is written for the preview it currently is. `USE_FSMV2_CPU` defaults to `false` (`container_monitor.go:95`), and with it off an instance is still marked degraded above 70% of its usable cores (`judgeLegacyCPUUsage`, `CPUHighThresholdPercent = 70.0`). The callout names both the flags needed and the default behaviour, so the page is not describing something no installation has.
- A one-line cross-link from the sizing guide.

Every status name, threshold and example message on the page was read off `pkg/cpuhealth` on `staging`, not off the closed PR.

## What we are NOT shipping

- **No sizing changes.** The 2 → 4 vCPU bump is ENG-5504 and its stated reason is the headroom reserve of a model that is not yet the default. It stays its own PR.
- **No rewrite of the sizing guide's CPU-blocking bullets.** They describe the default 70% behaviour, which is still what a default build does. They become wrong the day the flag flips, and that edit belongs with the flag flip.
- **No changelog entry.** Docs-only, and the preview itself is already announced in the Console changelog. Carries `skip-changelog-guard`.

Part of ENG-5132
