### PR TITLE
feat(cpuhealth): read CPU accounting on cgroup v1 hosts

### DIFF
--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Instances on hosts whose CPU accounting sits outside the container's own cgroup are no longer reported as degraded, which previously blocked every bridge on them. CPU monitoring reads as unavailable on such a host instead
+- CPU usage, limit and throttling now read on hosts using the older cgroup v1 hierarchy, such as RHEL 8 and CentOS 7, where the CPU panel previously showed N/A. Pressure stays unavailable there, since that kernel publishes no per-container pressure figure
 
 ## [0.44.38]
 

--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Instances on hosts whose CPU accounting sits outside the container's own cgroup are no longer reported as degraded, which previously blocked every bridge on them. CPU monitoring reads as unavailable on such a host instead
+
 ## [0.44.38]
 
 ### Improvements
@@ -19,7 +23,6 @@
 
 - Topics no longer go missing from the Topic Browser when several updates arrive in quick succession
 - The Topic Browser now updates as data arrives instead of in bursts roughly every 10 seconds
-- Instances on hosts whose CPU accounting sits outside the container's own cgroup are no longer reported as degraded, which previously blocked every bridge on them. CPU monitoring reads as unavailable on such a host instead
 
 ## [0.44.36]
 

--- a/umh-core/CHANGELOG.md
+++ b/umh-core/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 - Topics no longer go missing from the Topic Browser when several updates arrive in quick succession
 - The Topic Browser now updates as data arrives instead of in bursts roughly every 10 seconds
+- Instances on hosts whose CPU accounting sits outside the container's own cgroup are no longer reported as degraded, which previously blocked every bridge on them. CPU monitoring reads as unavailable on such a host instead
 
 ## [0.44.36]
 

--- a/umh-core/pkg/cpuhealth/cgroup_layout.go
+++ b/umh-core/pkg/cpuhealth/cgroup_layout.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/diagnosis"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/filesystem"
 )
 
 // cgroupReader is one cgroup's CPU accounting. An implementation owns the
@@ -38,4 +39,44 @@ type cgroupReader interface {
 	// advanceUsageRate advances the baseline to ts and returns this tick's rate
 	// in cores.
 	advanceUsageRate(ts time.Time, usage diagnosis.Reading) diagnosis.Reading
+}
+
+// v1CPUDirs are the directories a v1 cpu controller is mounted at, in the order
+// probed. systemd mounts cpu and cpuacct together; a runtime may not.
+var v1CPUDirs = []string{"cpu,cpuacct", "cpu"}
+
+// cgroupLayout is the hierarchy a mount turned out to be.
+type cgroupLayout int
+
+const (
+	// layoutNone means neither shape matched. A box with no CPU accounting
+	// reads this way, and so does one probed before its mount appeared, so it
+	// is never final.
+	layoutNone cgroupLayout = iota
+	layoutV2
+	layoutV1
+)
+
+// resolveLayout reports the hierarchy under base, and for v1 the controller
+// directory cpu.stat was found in. Where cpu.stat sits is the discriminant.
+func resolveLayout(ctx context.Context, fs filesystem.Service, base string) (layout cgroupLayout, cpuDir string) {
+	if fileExists(ctx, fs, base+"/cpu.stat") {
+		return layoutV2, ""
+	}
+
+	for _, dir := range v1CPUDirs {
+		if fileExists(ctx, fs, base+"/"+dir+"/cpu.stat") {
+			return layoutV1, dir
+		}
+	}
+
+	return layoutNone, ""
+}
+
+// fileExists counts a filesystem error as absent: a path that cannot be checked
+// identifies no hierarchy.
+func fileExists(ctx context.Context, fs filesystem.Service, path string) bool {
+	exists, err := fs.FileExists(ctx, path)
+
+	return err == nil && exists
 }

--- a/umh-core/pkg/cpuhealth/cgroup_layout.go
+++ b/umh-core/pkg/cpuhealth/cgroup_layout.go
@@ -1,0 +1,41 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The reader interface the sampler holds, and the readers behind it.
+package cpuhealth
+
+import (
+	"context"
+	"time"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/diagnosis"
+)
+
+// cgroupReader is one cgroup's CPU accounting. An implementation owns the
+// usage-rate baseline, the one fact that has to persist across ticks.
+type cgroupReader interface {
+	// readQuota reads the CPU limit in cores. See cgroupSource.readQuota for
+	// what present, present-zero and absent each mean.
+	readQuota(ctx context.Context) (quotaRead, ReadOutcome)
+	// readStat yields the usage total and both throttle counters. A non-nil
+	// error says why there are none.
+	readStat(ctx context.Context) (statRead, error)
+	// readPSI reads this tick's pressure fraction as a 0..1 figure.
+	readPSI(ctx context.Context) (frac float64, err error)
+	// readCpuset counts the CPUs this cgroup may run on.
+	readCpuset(ctx context.Context) (count int, err error)
+	// advanceUsageRate advances the baseline to ts and returns this tick's rate
+	// in cores.
+	advanceUsageRate(ts time.Time, usage diagnosis.Reading) diagnosis.Reading
+}

--- a/umh-core/pkg/cpuhealth/cgroup_layout_test.go
+++ b/umh-core/pkg/cpuhealth/cgroup_layout_test.go
@@ -1,0 +1,123 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Which hierarchy the sampler resolved. The same container image runs on a v2
+// host and a v1 one, so the layout is read off the filesystem: where cpu.stat
+// sits is the discriminant. It is asked once, unless nothing matched.
+package cpuhealth_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/cpuhealth"
+)
+
+var _ = Describe("the resolved cgroup layout", func() {
+	It("reads the v2 files when cpu.stat sits at the base", func() {
+		smp, err := v1Sampler(v1Files{
+			cgroupBase + "/cpu.stat": "usage_usec 5000000\nnr_periods 10\nnr_throttled 1\n",
+			cgroupBase + "/cpu.max":  "200000 100000\n",
+		}).Read(context.Background())
+
+		Expect(err).NotTo(HaveOccurred())
+		usage, ok := smp.UsageUsec.Get()
+		Expect(ok).To(BeTrue(), "a v2 mount's usage comes from cpu.stat itself")
+		Expect(usage).To(Equal(5_000_000.0))
+		quota, ok := smp.Quota.Get()
+		Expect(ok).To(BeTrue(), "a v2 mount's limit comes from cpu.max")
+		Expect(quota).To(Equal(2.0))
+	})
+
+	It("reads the split controller directories a runtime mounts separately", func() {
+		// systemd mounts the two controllers together as cpu,cpuacct; a
+		// container runtime may bind-mount cpu and cpuacct at their own paths,
+		// so each is probed for on its own.
+		smp, err := v1Sampler(v1Files{
+			cgroupBase + "/cpu/cpu.stat":          "nr_periods 10\nnr_throttled 2\n",
+			cgroupBase + "/cpu/cpu.cfs_quota_us":  "400000\n",
+			cgroupBase + "/cpu/cpu.cfs_period_us": "100000\n",
+			cgroupBase + "/cpuacct/cpuacct.usage": "7000000000\n",
+		}).Read(context.Background())
+
+		Expect(err).NotTo(HaveOccurred())
+		quota, ok := smp.Quota.Get()
+		Expect(ok).To(BeTrue())
+		Expect(quota).To(Equal(4.0))
+		usage, ok := smp.UsageUsec.Get()
+		Expect(ok).To(BeTrue(), "cpuacct is probed for separately from cpu")
+		Expect(usage).To(Equal(7_000_000.0))
+		throttled, ok := smp.NrThrottled.Get()
+		Expect(ok).To(BeTrue())
+		Expect(throttled).To(Equal(2.0))
+	})
+
+	It("reads nothing, and does not fail, where neither hierarchy answers", func() {
+		smp, err := v1Sampler(v1Files{}).Read(context.Background())
+
+		Expect(err).NotTo(HaveOccurred(), "an unidentifiable mount is not a failed sample")
+		_, ok := smp.UsageUsec.Get()
+		Expect(ok).To(BeFalse())
+		_, ok = smp.Quota.Get()
+		Expect(ok).To(BeFalse())
+	})
+
+	It("probes once and keeps the answer, and keeps probing while nothing answers", func() {
+		statPath := cgroupBase + "/cpu,cpuacct/cpu.stat"
+
+		// The fixture counts the probes, so "asked once" is asserted rather than
+		// inferred. Read is called from this goroutine only.
+		probes := 0
+		fs := serveFiles(v1Files{statPath: "nr_periods 10\nnr_throttled 0\n"})
+		served := fs.FileExistsFunc
+		fs.FileExistsFunc = func(ctx context.Context, path string) (bool, error) {
+			probes++
+
+			return served(ctx, path)
+		}
+
+		sampler := cpuhealth.NewLinuxSampler(fs, cgroupBase)
+		_, err := sampler.Read(context.Background())
+		Expect(err).NotTo(HaveOccurred())
+		afterFirst := probes
+		Expect(afterFirst).To(BeNumerically(">", 0), "the first tick has to ask")
+
+		_, err = sampler.Read(context.Background())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(probes).To(Equal(afterFirst),
+			"an identified layout is kept, so later ticks ask nothing")
+
+		// Nothing answers this one, so every tick asks again rather than
+		// writing the box off for the life of the process.
+		blankProbes := 0
+		blank := serveFiles(v1Files{})
+		blank.FileExistsFunc = func(_ context.Context, _ string) (bool, error) {
+			blankProbes++
+
+			return false, nil
+		}
+
+		blankSampler := cpuhealth.NewLinuxSampler(blank, cgroupBase)
+		_, err = blankSampler.Read(context.Background())
+		Expect(err).NotTo(HaveOccurred())
+		afterBlankFirst := blankProbes
+
+		_, err = blankSampler.Read(context.Background())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(blankProbes).To(BeNumerically(">", afterBlankFirst),
+			"an unidentified mount is probed again next tick")
+	})
+})

--- a/umh-core/pkg/cpuhealth/cgroup_source.go
+++ b/umh-core/pkg/cpuhealth/cgroup_source.go
@@ -63,19 +63,26 @@ type usageBaseline struct {
 // Timestamp and never time.Now(); Read in read.go says why both sources have to
 // divide by the same elapsed time.
 func (c *cgroupSource) advanceUsageRate(ts time.Time, usage diagnosis.Reading) diagnosis.Reading {
+	return c.usageBase.advance(ts, usage)
+}
+
+// advance is the derivation itself, shared by both hierarchies' readers. Both
+// hand it microseconds, so the divisor is the same either way.
+func (b *usageBaseline) advance(ts time.Time, usage diagnosis.Reading) diagnosis.Reading {
 	rate := diagnosis.Unknown()
-	if c.usageBase.have {
+	if b.have {
 		// A rising cumulative counter over a positive elapsed time derives an
 		// instantaneous rate; a falling one has been reset, so no rate.
-		if u, ok := usage.Get(); ok && u >= c.usageBase.usage {
-			if elapsed := ts.Sub(c.usageBase.time).Seconds(); elapsed > 0 {
-				rate = diagnosis.Known((u - c.usageBase.usage) / 1e6 / elapsed)
+		if u, ok := usage.Get(); ok && u >= b.usage {
+			if elapsed := ts.Sub(b.time).Seconds(); elapsed > 0 {
+				rate = diagnosis.Known((u - b.usage) / 1e6 / elapsed)
 			}
 		}
 	}
 	if u, ok := usage.Get(); ok {
-		c.usageBase = usageBaseline{usage: u, time: ts, have: true}
+		*b = usageBaseline{usage: u, time: ts, have: true}
 	}
+
 	return rate
 }
 
@@ -148,7 +155,9 @@ type statRead struct {
 func (c *cgroupSource) readStat(ctx context.Context) (statRead, error) {
 	failed := statRead{Usage: diagnosis.Unknown(), Periods: diagnosis.Unknown(), Throttled: diagnosis.Unknown()}
 
-	data, err := c.fs.ReadFile(ctx, c.base+"/cpu.stat")
+	path := c.base + "/cpu.stat"
+
+	data, err := c.fs.ReadFile(ctx, path)
 	if err != nil {
 		return failed, err
 	}
@@ -156,15 +165,15 @@ func (c *cgroupSource) readStat(ctx context.Context) (statRead, error) {
 
 	usage, err := parseCounter(data, "usage_usec")
 	if err != nil {
-		return failed, err
+		return failed, fmt.Errorf("%s: %w", path, err)
 	}
 	periods, err := parseCounter(data, "nr_periods")
 	if err != nil {
-		return failed, err
+		return failed, fmt.Errorf("%s: %w", path, err)
 	}
 	throttled, err := parseCounter(data, "nr_throttled")
 	if err != nil {
-		return failed, err
+		return failed, fmt.Errorf("%s: %w", path, err)
 	}
 
 	return statRead{Usage: usage, Periods: periods, Throttled: throttled, Raw: string(data)}, nil
@@ -229,7 +238,14 @@ func (c *cgroupSource) readCpuset(ctx context.Context) (count int, err error) {
 	if err != nil {
 		return 0, err
 	}
-	text := strings.TrimSpace(string(data))
+
+	return countCPUList(string(data))
+}
+
+// countCPUList counts the CPU ids a cpuset file names. Both hierarchies write
+// the same list format, so both readers count it the same way.
+func countCPUList(list string) (count int, err error) {
+	text := strings.TrimSpace(list)
 	if text == "" {
 		return 0, errEmptyRead
 	}

--- a/umh-core/pkg/cpuhealth/cgroup_source.go
+++ b/umh-core/pkg/cpuhealth/cgroup_source.go
@@ -183,7 +183,7 @@ func parseCounter(data []byte, key string) (diagnosis.Reading, error) {
 		if len(fields) >= 2 && fields[0] == key {
 			v, err := strconv.ParseFloat(fields[1], 64)
 			if err != nil {
-				return diagnosis.Unknown(), fmt.Errorf("unparsable %s value %q: %w", key, fields[1], err)
+				return diagnosis.Unknown(), fmt.Errorf("%w: %s value %q: %w", errUnparsableRead, key, fields[1], err)
 			}
 			return diagnosis.Known(v), nil
 		}

--- a/umh-core/pkg/cpuhealth/cgroup_source.go
+++ b/umh-core/pkg/cpuhealth/cgroup_source.go
@@ -39,10 +39,6 @@ type cgroupSource struct {
 	base string
 
 	usageBase usageBaseline
-
-	// psiAvailable is sticky: set true on the first successful cpu.pressure
-	// read and never cleared, even when a later read fails.
-	psiAvailable bool
 }
 
 // newCgroupSource returns a cgroupSource reading via fs from base.
@@ -276,8 +272,8 @@ const (
 
 // readRawFile returns a file's text verbatim, with the outcome that says why
 // there is none.
-func (c *cgroupSource) readRawFile(ctx context.Context, path string) (string, ReadOutcome) {
-	data, err := c.fs.ReadFile(ctx, path)
+func readRawFile(ctx context.Context, fs filesystem.Service, path string) (string, ReadOutcome) {
+	data, err := fs.ReadFile(ctx, path)
 	if err != nil {
 		return "", classifyRead(err)
 	}
@@ -288,8 +284,8 @@ func (c *cgroupSource) readRawFile(ctx context.Context, path string) (string, Re
 // readBaseDirEntryCount keeps only the entry count. A mounted cgroup v2 tree
 // holds dozens of files, so a directory holding two or three says the mount is
 // not the one we expect. An unlistable directory yields -1, never 0.
-func (c *cgroupSource) readBaseDirEntryCount(ctx context.Context) (int, ReadOutcome) {
-	entries, err := c.fs.ReadDir(ctx, c.base)
+func readBaseDirEntryCount(ctx context.Context, fs filesystem.Service, base string) (int, ReadOutcome) {
+	entries, err := fs.ReadDir(ctx, base)
 	if err != nil {
 		return -1, classifyRead(err)
 	}

--- a/umh-core/pkg/cpuhealth/cgroup_v1_source.go
+++ b/umh-core/pkg/cpuhealth/cgroup_v1_source.go
@@ -1,0 +1,170 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The same CPU accounting cgroupSource reads, as cgroup v1 writes it. Three
+// things differ. The files sit under a directory per controller. The CPU limit
+// is two files, and spells no-limit as -1 rather than "max". The usage total is
+// nanoseconds in cpuacct.usage rather than microseconds in cpu.stat.
+//
+// v1 publishes no per-cgroup pressure file. The machine-wide
+// /proc/pressure/cpu is not read in its place: it measures the whole machine,
+// and Sample.Pressure is cgroup-scoped.
+//
+// https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v1/cpu.html and
+// https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v1/cpuacct.html.
+package cpuhealth
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/diagnosis"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/filesystem"
+)
+
+// cgroupV1Source reads one cgroup's CPU accounting from a v1 hierarchy. cpuDir
+// is the controller directory cpu.stat was found in.
+type cgroupV1Source struct {
+	fs     filesystem.Service
+	base   string
+	cpuDir string
+
+	usageBase usageBaseline
+}
+
+func newCgroupV1Source(fs filesystem.Service, base, cpuDir string) *cgroupV1Source {
+	return &cgroupV1Source{fs: fs, base: base, cpuDir: cpuDir}
+}
+
+// readQuota reads cpu.cfs_quota_us, the microseconds of CPU time allowed per
+// period, over cpu.cfs_period_us. A positive quota reads as a capacity in
+// cores, -1 as a present no-limit, and either file unreadable as absent.
+func (c *cgroupV1Source) readQuota(ctx context.Context) (quotaRead, ReadOutcome) {
+	quota, raw, err := c.readInt(ctx, c.path(c.cpuDir, "cpu.cfs_quota_us"))
+	if err != nil {
+		return quotaRead{Limit: diagnosis.Unknown(), Raw: raw}, classifyRead(err)
+	}
+
+	if quota <= 0 {
+		// -1 means uncapped: a definite no-limit, never a positive capacity.
+		return quotaRead{Limit: diagnosis.Known(0.0), Raw: raw}, ReadOK
+	}
+
+	period, _, err := c.readInt(ctx, c.path(c.cpuDir, "cpu.cfs_period_us"))
+	if err != nil {
+		return quotaRead{Limit: diagnosis.Unknown(), Raw: raw}, classifyRead(err)
+	}
+	if period <= 0 {
+		return quotaRead{Limit: diagnosis.Unknown(), Raw: raw}, ReadUnparsable
+	}
+
+	return quotaRead{Limit: diagnosis.Known(float64(quota) / float64(period)), Raw: raw}, ReadOK
+}
+
+// readStat reads cpu.stat, which carries the same nr_periods and nr_throttled
+// keys v2 does. The usage total comes from cpuacct.usage instead, so a cpu.stat
+// that will not open still leaves usage readable.
+func (c *cgroupV1Source) readStat(ctx context.Context) (statRead, error) {
+	usage := c.readUsage(ctx)
+	failed := statRead{Usage: usage, Periods: diagnosis.Unknown(), Throttled: diagnosis.Unknown()}
+	path := c.path(c.cpuDir, "cpu.stat")
+
+	data, err := c.fs.ReadFile(ctx, path)
+	if err != nil {
+		return failed, err
+	}
+	failed.Raw = string(data)
+
+	periods, err := parseCounter(data, "nr_periods")
+	if err != nil {
+		return failed, fmt.Errorf("%s: %w", path, err)
+	}
+	throttled, err := parseCounter(data, "nr_throttled")
+	if err != nil {
+		return failed, fmt.Errorf("%s: %w", path, err)
+	}
+
+	return statRead{Usage: usage, Periods: periods, Throttled: throttled, Raw: string(data)}, nil
+}
+
+// readUsage reads cpuacct.usage, the cumulative CPU time used. v1 writes it in
+// nanoseconds and Sample.UsageUsec is microseconds. Both mount points are
+// tried, since a runtime may mount cpuacct on its own.
+func (c *cgroupV1Source) readUsage(ctx context.Context) diagnosis.Reading {
+	for _, dir := range []string{c.cpuDir, "cpuacct"} {
+		nanoseconds, _, err := c.readInt(ctx, c.path(dir, "cpuacct.usage"))
+		if err != nil {
+			continue
+		}
+
+		return diagnosis.Known(float64(nanoseconds) / 1e3)
+	}
+
+	return diagnosis.Unknown()
+}
+
+// readPSI reports no pressure: v1 publishes no per-cgroup pressure file.
+func (c *cgroupV1Source) readPSI(context.Context) (frac float64, err error) {
+	return 0, errNoPressureFile
+}
+
+// readCpuset counts the CPUs in the cgroup's cpuset. Tasks run on the set the
+// kernel narrowed, cpuset.effective_cpus, so it is read before the written
+// cpuset.cpus.
+func (c *cgroupV1Source) readCpuset(ctx context.Context) (count int, err error) {
+	for _, name := range []string{"cpuset.effective_cpus", "cpuset.cpus"} {
+		data, readErr := c.fs.ReadFile(ctx, c.path("cpuset", name))
+		if readErr != nil {
+			err = readErr
+
+			continue
+		}
+
+		if count, err = countCPUList(string(data)); err == nil {
+			return count, nil
+		}
+	}
+
+	return 0, err
+}
+
+// advanceUsageRate derives this tick's usage rate in cores from the baseline it
+// replaces, exactly as cgroupSource does.
+func (c *cgroupV1Source) advanceUsageRate(ts time.Time, usage diagnosis.Reading) diagnosis.Reading {
+	return c.usageBase.advance(ts, usage)
+}
+
+func (c *cgroupV1Source) path(dir, name string) string {
+	return c.base + "/" + dir + "/" + name
+}
+
+// readInt reads one file holding a single integer, and returns its text so a
+// value that will not parse is still reportable.
+func (c *cgroupV1Source) readInt(ctx context.Context, path string) (value int64, raw string, err error) {
+	data, err := c.fs.ReadFile(ctx, path)
+	if err != nil {
+		return 0, "", err
+	}
+	raw = string(data)
+
+	value, err = strconv.ParseInt(strings.TrimSpace(raw), 10, 64)
+	if err != nil {
+		return 0, raw, errUnparsableRead
+	}
+
+	return value, raw, nil
+}

--- a/umh-core/pkg/cpuhealth/read.go
+++ b/umh-core/pkg/cpuhealth/read.go
@@ -114,6 +114,12 @@ func (s *linuxSampler) Read(ctx context.Context) (Sample, error) {
 		// degraded over a file it was never going to have.
 		return smp, fmt.Errorf("parse %s/cpu.stat: %w", s.cgroup.base, statErr)
 	}
+	// A cancelled tick fails every read, which is the same shape as a host with
+	// none of these files. Without this the sample reports the second.
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return smp, ctxErr
+	}
+
 	smp.NrPeriods = stat.Periods
 	smp.NrThrottled = stat.Throttled
 	smp.UsageUsec = stat.Usage

--- a/umh-core/pkg/cpuhealth/read.go
+++ b/umh-core/pkg/cpuhealth/read.go
@@ -69,8 +69,12 @@ type linuxSampler struct {
 	fs   filesystem.Service
 	base string
 
-	cgroup cgroupReader
-	host   *hostSource
+	// cgroup is non-nil from construction, holding the v2 reader until the
+	// probe says otherwise, so no call site has to guard it.
+	cgroup   cgroupReader
+	resolved bool
+
+	host *hostSource
 
 	// psiAvailable is sticky: set true on the first successful cpu.pressure
 	// read and never cleared, even when a later read fails. It belongs to the
@@ -92,6 +96,8 @@ func (s *linuxSampler) Read(ctx context.Context) (Sample, error) {
 	// that event needs this evidence as much as any other.
 	s.recordEvidence(ctx, &smp)
 
+	cgroup := s.reader(ctx)
+
 	// Stamped once, here, and passed to both sources: neither cgroup nor host
 	// calls time.Now() itself, so both rate derivations divide by the same
 	// elapsed time and Decide never compares a machine-wide mean against a
@@ -101,7 +107,7 @@ func (s *linuxSampler) Read(ctx context.Context) (Sample, error) {
 
 	// cpu.pressure: PSI presence is sticky once seen; this tick's read success
 	// is Pressure's own Reading, absent when the read fails this tick.
-	frac, psiErr := s.cgroup.readPSI(ctx)
+	frac, psiErr := cgroup.readPSI(ctx)
 	if psiErr != nil {
 		smp.Pressure = diagnosis.Unknown()
 	} else {
@@ -111,7 +117,7 @@ func (s *linuxSampler) Read(ctx context.Context) (Sample, error) {
 	smp.record(OpCPUPressure, classifyRead(psiErr))
 	smp.PsiAvailable = s.psiAvailable
 
-	stat, statErr := s.cgroup.readStat(ctx)
+	stat, statErr := cgroup.readStat(ctx)
 	// Assigned before the early return below: this text is what would not parse.
 	smp.CPUStatRaw = stat.Raw
 	statResult := statOutcome(stat, statErr)
@@ -122,7 +128,7 @@ func (s *linuxSampler) Read(ctx context.Context) (Sample, error) {
 		// different thing: the three readings below stay absent and the sample
 		// carries on, so a host keeping its CPU accounting elsewhere is not
 		// degraded over a file it was never going to have.
-		return smp, fmt.Errorf("parse %s/cpu.stat: %w", s.base, statErr)
+		return smp, fmt.Errorf("parse cpu.stat: %w", statErr)
 	}
 	// A cancelled tick fails every read, which is the same shape as a host with
 	// none of these files. Without this the sample reports the second.
@@ -133,7 +139,7 @@ func (s *linuxSampler) Read(ctx context.Context) (Sample, error) {
 	smp.NrPeriods = stat.Periods
 	smp.NrThrottled = stat.Throttled
 	smp.UsageUsec = stat.Usage
-	smp.UsageCores = s.cgroup.advanceUsageRate(ts, stat.Usage)
+	smp.UsageCores = cgroup.advanceUsageRate(ts, stat.Usage)
 
 	// Host signals: the first /proc/stat read fixes a baseline and publishes
 	// neither; a read after that publishes this tick's instantaneous host-busy
@@ -165,7 +171,7 @@ func (s *linuxSampler) Read(ctx context.Context) (Sample, error) {
 	smp.Virtualized = virtualized
 	smp.record(OpProcCpuinfo, cpuinfoOutcome)
 
-	quota, cpuMaxOutcome := s.cgroup.readQuota(ctx)
+	quota, cpuMaxOutcome := cgroup.readQuota(ctx)
 	smp.Quota = quota.Limit
 	smp.CPUMaxRaw = quota.Raw
 	smp.record(OpCPUMax, cpuMaxOutcome)
@@ -179,7 +185,7 @@ func (s *linuxSampler) Read(ctx context.Context) (Sample, error) {
 // 8 CPUs". A failed cpuset read reads ScopeUnknown with LogicalCpus absent,
 // never a silent ScopeHost on a known machine count.
 func (s *linuxSampler) recordCPUScope(ctx context.Context, smp *Sample, machine float64) {
-	allowed, cpusetErr := s.cgroup.readCpuset(ctx)
+	allowed, cpusetErr := s.reader(ctx).readCpuset(ctx)
 	smp.record(OpCpusetCPUs, classifyRead(cpusetErr))
 	if cpusetErr != nil {
 		smp.LogicalCpus = diagnosis.Unknown()
@@ -196,6 +202,27 @@ func (s *linuxSampler) recordCPUScope(ctx context.Context, smp *Sample, machine 
 	}
 
 	smp.CpuScope = ScopeAffinity
+}
+
+// reader returns the cgroup reader for this mount, probing the filesystem the
+// first time. A mount neither shape matched is probed again next tick: the
+// container can start before its cgroup is mounted, and writing the box off for
+// the life of the process would leave it unmeasured after the mount appeared.
+func (s *linuxSampler) reader(ctx context.Context) cgroupReader {
+	if s.resolved {
+		return s.cgroup
+	}
+
+	switch layout, cpuDir := resolveLayout(ctx, s.fs, s.base); layout {
+	case layoutV1:
+		s.cgroup = newCgroupV1Source(s.fs, s.base, cpuDir)
+		s.resolved = true
+	case layoutV2:
+		s.resolved = true
+	case layoutNone:
+	}
+
+	return s.cgroup
 }
 
 // recordEvidence puts the three evidence reads on smp: the text of

--- a/umh-core/pkg/cpuhealth/read.go
+++ b/umh-core/pkg/cpuhealth/read.go
@@ -104,11 +104,15 @@ func (s *linuxSampler) Read(ctx context.Context) (Sample, error) {
 	stat, statErr := s.cgroup.readStat(ctx)
 	// Assigned before the early return below: this text is what would not parse.
 	smp.CPUStatRaw = stat.Raw
-	smp.record(OpCPUStat, statOutcome(stat, statErr))
-	if statErr != nil {
-		// cpu.stat is primary: a read failure there fails the WHOLE sample,
-		// never a silent drop of the throttle counters as absent no-signal.
-		return smp, fmt.Errorf("read %s/cpu.stat: %w", s.cgroup.base, statErr)
+	statResult := statOutcome(stat, statErr)
+	smp.record(OpCPUStat, statResult)
+	if statResult == ReadUnparsable {
+		// A cpu.stat that opens and does not parse is corrupt, and every number
+		// derived from it would be a guess. A cpu.stat that will not open is a
+		// different thing: the three readings below stay absent and the sample
+		// carries on, so a host keeping its CPU accounting elsewhere is not
+		// degraded over a file it was never going to have.
+		return smp, fmt.Errorf("parse %s/cpu.stat: %w", s.cgroup.base, statErr)
 	}
 	smp.NrPeriods = stat.Periods
 	smp.NrThrottled = stat.Throttled

--- a/umh-core/pkg/cpuhealth/read.go
+++ b/umh-core/pkg/cpuhealth/read.go
@@ -53,6 +53,8 @@ const (
 // NewLinuxSampler returns a Sampler reading via fs from base.
 func NewLinuxSampler(fs filesystem.Service, base string) Sampler {
 	return &linuxSampler{
+		fs:     fs,
+		base:   base,
 		cgroup: newCgroupSource(fs, base),
 		host:   newHostSource(fs),
 	}
@@ -64,8 +66,16 @@ func NewLinuxSampler(fs filesystem.Service, base string) Sampler {
 // exists only to stamp the tick's single Timestamp and derive CPU scope, the
 // one fact that needs both sources' reads to compute.
 type linuxSampler struct {
-	cgroup *cgroupSource
+	fs   filesystem.Service
+	base string
+
+	cgroup cgroupReader
 	host   *hostSource
+
+	// psiAvailable is sticky: set true on the first successful cpu.pressure
+	// read and never cleared, even when a later read fails. It belongs to the
+	// machine rather than to a reader, which is why it is held here.
+	psiAvailable bool
 }
 
 // Read samples the cgroup at base from cpu.max, the container's CPU limit: a
@@ -95,11 +105,11 @@ func (s *linuxSampler) Read(ctx context.Context) (Sample, error) {
 	if psiErr != nil {
 		smp.Pressure = diagnosis.Unknown()
 	} else {
-		s.cgroup.psiAvailable = true
+		s.psiAvailable = true
 		smp.Pressure = diagnosis.Known(frac)
 	}
 	smp.record(OpCPUPressure, classifyRead(psiErr))
-	smp.PsiAvailable = s.cgroup.psiAvailable
+	smp.PsiAvailable = s.psiAvailable
 
 	stat, statErr := s.cgroup.readStat(ctx)
 	// Assigned before the early return below: this text is what would not parse.
@@ -112,7 +122,7 @@ func (s *linuxSampler) Read(ctx context.Context) (Sample, error) {
 		// different thing: the three readings below stay absent and the sample
 		// carries on, so a host keeping its CPU accounting elsewhere is not
 		// degraded over a file it was never going to have.
-		return smp, fmt.Errorf("parse %s/cpu.stat: %w", s.cgroup.base, statErr)
+		return smp, fmt.Errorf("parse %s/cpu.stat: %w", s.base, statErr)
 	}
 	// A cancelled tick fails every read, which is the same shape as a host with
 	// none of these files. Without this the sample reports the second.
@@ -192,15 +202,15 @@ func (s *linuxSampler) recordCPUScope(ctx context.Context, smp *Sample, machine 
 // cgroup.controllers and /proc/self/cgroup, and the base directory's entry
 // count. None of them is parsed or judged here.
 func (s *linuxSampler) recordEvidence(ctx context.Context, smp *Sample) {
-	controllers, controllersOutcome := s.cgroup.readRawFile(ctx, s.cgroup.base+cgroupControllersFile)
+	controllers, controllersOutcome := readRawFile(ctx, s.fs, s.base+cgroupControllersFile)
 	smp.CgroupControllersRaw = controllers
 	smp.record(OpCgroupControllers, controllersOutcome)
 
-	procSelf, procSelfOutcome := s.cgroup.readRawFile(ctx, procSelfCgroupPath)
+	procSelf, procSelfOutcome := readRawFile(ctx, s.fs, procSelfCgroupPath)
 	smp.ProcSelfCgroupRaw = procSelf
 	smp.record(OpProcSelfCgroup, procSelfOutcome)
 
-	baseEntries, baseDirOutcome := s.cgroup.readBaseDirEntryCount(ctx)
+	baseEntries, baseDirOutcome := readBaseDirEntryCount(ctx, s.fs, s.base)
 	smp.BaseDirEntryCount = baseEntries
 	smp.record(OpBaseDir, baseDirOutcome)
 }

--- a/umh-core/pkg/cpuhealth/read_cancelled_test.go
+++ b/umh-core/pkg/cpuhealth/read_cancelled_test.go
@@ -1,0 +1,46 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cpuhealth_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/cpuhealth"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/filesystem"
+)
+
+var _ = Describe("a cancelled tick", func() {
+	It("fails the read rather than reporting a box with no cgroup", func() {
+		// filesystem.DefaultService checks the context, so a cancelled tick
+		// fails every read. That is the same shape as a host with none of these
+		// files, and without this the sampler reports the second when it saw
+		// the first: an instance shutting down would look unmeasurable.
+		const base = "/sys/fs/cgroup"
+
+		fs := filesystem.NewMockFileSystem()
+		fs.ReadFileFunc = func(ctx context.Context, _ string) ([]byte, error) {
+			return nil, ctx.Err()
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		_, err := cpuhealth.NewLinuxSampler(fs, base).Read(ctx)
+		Expect(err).To(MatchError(context.Canceled))
+	})
+})

--- a/umh-core/pkg/cpuhealth/read_outcome.go
+++ b/umh-core/pkg/cpuhealth/read_outcome.go
@@ -16,6 +16,7 @@ package cpuhealth
 
 import (
 	"errors"
+	"fmt"
 	"io/fs"
 )
 
@@ -45,6 +46,10 @@ const (
 var (
 	errEmptyRead      = errors.New("cpuhealth: file empty")
 	errUnparsableRead = errors.New("cpuhealth: content did not parse")
+	// errNoPressureFile is what a hierarchy with no per-cgroup pressure file
+	// returns. It wraps fs.ErrNotExist so it classifies as ReadMissing, the
+	// cause a kernel without PSI already produces, which reports nothing.
+	errNoPressureFile = fmt.Errorf("cpuhealth: hierarchy publishes no cpu.pressure: %w", fs.ErrNotExist)
 )
 
 // classifyRead maps an unrecognised error to ReadError rather than to the

--- a/umh-core/pkg/cpuhealth/read_outcome_test.go
+++ b/umh-core/pkg/cpuhealth/read_outcome_test.go
@@ -138,6 +138,25 @@ var _ = Describe("a failed read reports its cause", func() {
 
 	// readQuota and readVirtualized return a ReadOutcome, not an error: neither
 	// has an `ok bool` to replace, so presence stays on the existing return.
+	Describe("readStat", func() {
+		statPath := base + "/cpu.stat"
+
+		It("reports ENOENT as a not-exist error", func() {
+			_, err := newCgroupSource(oneFile(statPath, nil, pathErr(statPath, syscall.ENOENT)), base).readStat(ctx)
+			Expect(err).To(MatchError(fs.ErrNotExist))
+		})
+
+		It("reports EACCES as a permission error", func() {
+			_, err := newCgroupSource(oneFile(statPath, nil, pathErr(statPath, syscall.EACCES)), base).readStat(ctx)
+			Expect(err).To(MatchError(fs.ErrPermission))
+		})
+
+		It("reports a non-numeric counter as unparsable", func() {
+			_, err := newCgroupSource(oneFile(statPath, []byte("usage_usec abc\n"), nil), base).readStat(ctx)
+			Expect(err).To(MatchError(errUnparsableRead))
+		})
+	})
+
 	Describe("readQuota", func() {
 		maxPath := base + "/cpu.max"
 

--- a/umh-core/pkg/cpuhealth/read_record_test.go
+++ b/umh-core/pkg/cpuhealth/read_record_test.go
@@ -76,6 +76,19 @@ var _ = Describe("the sample records what each read produced", func() {
 		return smp
 	}
 
+	// readWith replaces the content of the named files, for the failures a
+	// filesystem error cannot express: a file that reads fine and holds
+	// something no reader can use.
+	readWith := func(content map[string][]byte) Sample {
+		files := healthyFiles(base)
+		for path, data := range content {
+			files[path] = data
+		}
+		smp, _ := NewLinuxSampler(fsServing(files, nil), base).Read(ctx)
+
+		return smp
+	}
+
 	// Structural, not a hand-written length: a new read operation added to
 	// allReadOps without being recorded fails here.
 	It("records exactly one entry per declared read operation", func() {
@@ -128,13 +141,27 @@ var _ = Describe("the sample records what each read produced", func() {
 		Expect(outcomeFor(smp, OpCpusetCPUs)).To(Equal(ReadNotAttempted))
 	})
 
-	It("marks every downstream read not_attempted when cpu.stat failed", func() {
-		// cpu.stat is the one read whose failure returns from Read, so the reads
-		// after it never happen.
+	It("records the reads after a cpu.stat that will not open, since they still happen", func() {
+		// A cpu.stat that will not open no longer returns from Read, so every
+		// read after it runs and records its own cause. not_attempted here would
+		// claim files were never opened that were.
 		statPath := base + "/cpu.stat"
 		smp := read(map[string]error{statPath: &fs.PathError{Op: "open", Path: statPath, Err: syscall.ENOENT}})
 
 		Expect(outcomeFor(smp, OpCPUStat)).To(Equal(ReadMissing))
+		for _, op := range []ReadOp{OpProcStat, OpCpusetCPUs, OpProcCpuinfo, OpCPUMax} {
+			Expect(outcomeFor(smp, op)).NotTo(Equal(ReadNotAttempted),
+				"read %q runs whether or not cpu.stat opened", op)
+		}
+	})
+
+	It("marks every downstream read not_attempted when cpu.stat will not parse", func() {
+		// An unparsable cpu.stat is the one failure that returns from Read, so
+		// the reads after it never happen.
+		statPath := base + "/cpu.stat"
+		smp := readWith(map[string][]byte{statPath: []byte("usage_usec abc\n")})
+
+		Expect(outcomeFor(smp, OpCPUStat)).To(Equal(ReadUnparsable))
 		for _, op := range []ReadOp{OpProcStat, OpCpusetCPUs, OpProcCpuinfo, OpCPUMax} {
 			Expect(outcomeFor(smp, op)).To(Equal(ReadNotAttempted),
 				"read %q happens after cpu.stat, which returned early", op)

--- a/umh-core/pkg/cpuhealth/read_throttle_test.go
+++ b/umh-core/pkg/cpuhealth/read_throttle_test.go
@@ -15,9 +15,9 @@
 // The sampler reads both throttle counters (nr_periods,
 // nr_throttled) out of the SAME cpu.stat bytes it reads for usage — never a
 // second cpu.stat read — and marks either counter unavailable when it is absent
-// from cpu.stat or fails to parse, never a trusted 0. cpu.stat is primary: a
-// READ failure there fails the whole sample, the first time Read's error is
-// live. Drives the real sampler over a fake filesystem so every branch is
+// from cpu.stat or fails to parse, never a trusted 0. A cpu.stat that will not
+// open leaves its three readings absent; only one that opens and does not parse
+// fails the sample. Drives the real sampler over a fake filesystem so every branch is
 // reachable; the mock counts cpu.stat reads so the single-read contract is
 // asserted too.
 package cpuhealth_test
@@ -25,11 +25,14 @@ package cpuhealth_test
 import (
 	"context"
 	"errors"
+	"io/fs"
+	"syscall"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/cpuhealth"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/diagnosis"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/filesystem"
 )
 
@@ -58,7 +61,7 @@ var _ = Describe("throttle counters", func() {
 		return cpuhealth.NewLinuxSampler(fs, base), &reads
 	}
 
-	It("reads both throttle counters from the same cpu.stat, marks either unavailable when absent or unparsable, and fails the whole sample when cpu.stat cannot be read", func() {
+	It("reads both throttle counters from the same cpu.stat, marks either unavailable when absent, and fails the sample only when cpu.stat will not parse", func() {
 		ctx := context.Background()
 
 		// Both counters present. The throttle facts and the usage total all come
@@ -97,11 +100,37 @@ var _ = Describe("throttle counters", func() {
 		_, err = sampler.Read(ctx)
 		Expect(err).To(HaveOccurred(), "an unparsable cpu.stat value must fail the whole sample")
 
-		// cpu.stat is PRIMARY: a read failure there fails the WHOLE sample — the
-		// first time Read's error is live — rather than silently dropping the
-		// counters as if they were an absent no-signal.
-		sampler, _ = newSampler(nil, errors.New("permission denied"))
-		_, err = sampler.Read(ctx)
-		Expect(err).To(HaveOccurred(), "a cpu.stat read failure must fail the whole sample")
+		// A cpu.stat that will not open leaves its three readings absent and
+		// fails nothing. A host that keeps its CPU accounting somewhere else has
+		// no such file, and failing there degrades the instance over a file the
+		// box was never going to have.
+		sampler, _ = newSampler(nil, pathErr(base+"/cpu.stat", syscall.EACCES))
+		s, err = sampler.Read(ctx)
+		Expect(err).NotTo(HaveOccurred(), "a cpu.stat that will not open must not fail the sample")
+
+		_, ok = s.UsageUsec.Get()
+		Expect(ok).To(BeFalse(), "an unread usage total must be absent, not a trusted 0")
+		_, ok = s.NrPeriods.Get()
+		Expect(ok).To(BeFalse())
+		_, ok = s.NrThrottled.Get()
+		Expect(ok).To(BeFalse())
+
+		// The reading going absent is not the whole story: without the cause on
+		// the sample, nothing downstream can tell this box from one whose
+		// cpu.stat read fine and held nothing.
+		Expect(s.Reads).To(ContainElement(cpuhealth.ReadResult{
+			Op:      cpuhealth.OpCPUStat,
+			Outcome: cpuhealth.ReadPermissionDenied,
+		}))
+
+		// Every other field of the sample still reads. A quota was served, so
+		// losing cpu.stat must not cost the capacity that came from cpu.max.
+		Expect(s.Quota).To(Equal(diagnosis.Known(2.0)))
 	})
 })
+
+// pathErr is the shape a real filesystem returns, and the shape errors.Is needs
+// to tell a missing file from an unreadable one.
+func pathErr(path string, errno syscall.Errno) error {
+	return &fs.PathError{Op: "open", Path: path, Err: errno}
+}

--- a/umh-core/pkg/cpuhealth/read_v1_pressure_test.go
+++ b/umh-core/pkg/cpuhealth/read_v1_pressure_test.go
@@ -1,0 +1,48 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Pressure on cgroup v1: there is none, and the machine-wide /proc/pressure/cpu
+// is not read in its place. That absence puts such a box on the
+// limited-visibility arm, where usage-fraction answers for host-cpu-full.
+package cpuhealth_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/cpuhealth"
+)
+
+var _ = Describe("pressure on cgroup v1", func() {
+	It("reports no pressure, and never claims the kernel published any", func() {
+		smp, err := v1Sampler(v1Files{
+			"/sys/fs/cgroup/cpu,cpuacct/cpu.stat": "nr_periods 10\nnr_throttled 0\n",
+			// Served, and still not read: the v1 source has no pressure file to
+			// read, and this is the machine-wide one.
+			"/proc/pressure/cpu": "some avg10=1.00 avg60=42.00 avg300=1.00 total=1\n",
+		}).Read(context.Background())
+
+		Expect(err).NotTo(HaveOccurred())
+		_, ok := smp.Pressure.Get()
+		Expect(ok).To(BeFalse(), "a machine-wide pressure figure must not reach a cgroup-scoped field")
+		Expect(smp.PsiAvailable).To(BeFalse())
+
+		env := cpuhealth.DeriveEnvironment(smp)
+		Expect(env.Has(cpuhealth.HasPressureStats)).To(BeFalse())
+		Expect(env.Has(cpuhealth.HasLimitedVisibility)).To(BeTrue(),
+			"no quota and no pressure is the limited-visibility arm")
+	})
+})

--- a/umh-core/pkg/cpuhealth/read_v1_quota_test.go
+++ b/umh-core/pkg/cpuhealth/read_v1_quota_test.go
@@ -1,0 +1,108 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The cgroup v1 CPU limit. v1 splits what v2 writes on one cpu.max line across
+// cpu.cfs_quota_us and cpu.cfs_period_us, and spells no-limit as -1 rather than
+// "max". Both have to reach Quota as the same readings the v2 file does.
+package cpuhealth_test
+
+import (
+	"context"
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/cpuhealth"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/filesystem"
+)
+
+// cgroupBase is the mount every fixture in these specs serves under.
+const cgroupBase = "/sys/fs/cgroup"
+
+// v1Files is one cgroup tree: path to contents. Any path absent from the map is
+// unreadable.
+type v1Files map[string]string
+
+// serveFiles returns a filesystem serving exactly files. FileExists answers for
+// the served paths only, or every mock reports a v2 mount. Reads go through the
+// map on every call, so a spec can change a counter between two Reads.
+func serveFiles(files v1Files) *filesystem.MockFileSystem {
+	fs := filesystem.NewMockFileSystem()
+	fs.FileExistsFunc = func(_ context.Context, path string) (bool, error) {
+		_, served := files[path]
+
+		return served, nil
+	}
+	fs.ReadFileFunc = func(_ context.Context, path string) ([]byte, error) {
+		content, served := files[path]
+		if !served {
+			return nil, errors.New("no such file or directory")
+		}
+
+		return []byte(content), nil
+	}
+
+	return fs
+}
+
+// v1Sampler returns a sampler over serveFiles(files).
+func v1Sampler(files v1Files) cpuhealth.Sampler {
+	return cpuhealth.NewLinuxSampler(serveFiles(files), cgroupBase)
+}
+
+var _ = Describe("the cgroup v1 CPU limit", func() {
+	const (
+		statPath   = "/sys/fs/cgroup/cpu,cpuacct/cpu.stat"
+		quotaPath  = "/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_quota_us"
+		periodPath = "/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_period_us"
+	)
+
+	It("reads a positive quota as a capacity in cores", func() {
+		smp, err := v1Sampler(v1Files{
+			statPath:   "nr_periods 10\nnr_throttled 1\n",
+			quotaPath:  "200000\n",
+			periodPath: "100000\n",
+		}).Read(context.Background())
+
+		Expect(err).NotTo(HaveOccurred())
+		quota, ok := smp.Quota.Get()
+		Expect(ok).To(BeTrue(), "two readable v1 files name a limit")
+		Expect(quota).To(Equal(2.0))
+	})
+
+	It("reads a quota of -1 as a present no-limit, the way v2 reads max", func() {
+		smp, err := v1Sampler(v1Files{
+			statPath:   "nr_periods 10\nnr_throttled 0\n",
+			quotaPath:  "-1\n",
+			periodPath: "100000\n",
+		}).Read(context.Background())
+
+		Expect(err).NotTo(HaveOccurred())
+		quota, ok := smp.Quota.Get()
+		Expect(ok).To(BeTrue(), "an uncapped v1 cgroup is a definite no-limit, not a no-signal")
+		Expect(quota).To(BeZero())
+	})
+
+	It("leaves the quota absent when either file is unreadable", func() {
+		smp, err := v1Sampler(v1Files{
+			statPath:  "nr_periods 10\nnr_throttled 0\n",
+			quotaPath: "200000\n",
+		}).Read(context.Background())
+
+		Expect(err).NotTo(HaveOccurred())
+		_, ok := smp.Quota.Get()
+		Expect(ok).To(BeFalse(), "a quota with no period is no capacity, never a bare 200000")
+	})
+})

--- a/umh-core/pkg/cpuhealth/read_v1_scope_test.go
+++ b/umh-core/pkg/cpuhealth/read_v1_scope_test.go
@@ -1,0 +1,84 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The CPUs a cgroup v1 container may run on. v1 keeps the set under its own
+// cpuset controller directory and names the kernel-narrowed one
+// cpuset.effective_cpus, where v2 writes cpuset.cpus.effective at the base.
+package cpuhealth_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/cpuhealth"
+)
+
+var _ = Describe("the CPUs a cgroup v1 container may run on", func() {
+	const (
+		statPath      = "/sys/fs/cgroup/cpu,cpuacct/cpu.stat"
+		effectivePath = "/sys/fs/cgroup/cpuset/cpuset.effective_cpus"
+		writtenPath   = "/sys/fs/cgroup/cpuset/cpuset.cpus"
+		// Four CPUs, of the eight the fixture /proc/stat reports.
+		procStat = "cpu  100 0 100 1000 0 0 0 0 0 0\n" +
+			"cpu0 1 0 1 1 0 0 0 0 0 0\ncpu1 1 0 1 1 0 0 0 0 0 0\n" +
+			"cpu2 1 0 1 1 0 0 0 0 0 0\ncpu3 1 0 1 1 0 0 0 0 0 0\n" +
+			"cpu4 1 0 1 1 0 0 0 0 0 0\ncpu5 1 0 1 1 0 0 0 0 0 0\n" +
+			"cpu6 1 0 1 1 0 0 0 0 0 0\ncpu7 1 0 1 1 0 0 0 0 0 0\n"
+	)
+
+	It("counts the effective cpuset, and reads a strict subset of the machine as pinned", func() {
+		smp, err := v1Sampler(v1Files{
+			statPath:      "nr_periods 10\nnr_throttled 0\n",
+			effectivePath: "0-3\n",
+			"/proc/stat":  procStat,
+		}).Read(context.Background())
+
+		Expect(err).NotTo(HaveOccurred())
+		logical, ok := smp.LogicalCpus.Get()
+		Expect(ok).To(BeTrue())
+		Expect(logical).To(Equal(4.0))
+		Expect(smp.CpuScope).To(Equal(cpuhealth.ScopeAffinity),
+			"four of the machine's eight CPUs is a pinned container")
+	})
+
+	It("falls back to the written cpuset when the effective one is absent", func() {
+		smp, err := v1Sampler(v1Files{
+			statPath:     "nr_periods 10\nnr_throttled 0\n",
+			writtenPath:  "0-7\n",
+			"/proc/stat": procStat,
+		}).Read(context.Background())
+
+		Expect(err).NotTo(HaveOccurred())
+		logical, ok := smp.LogicalCpus.Get()
+		Expect(ok).To(BeTrue(), "cpuset.cpus answers where cpuset.effective_cpus does not")
+		Expect(logical).To(Equal(8.0))
+		Expect(smp.CpuScope).To(Equal(cpuhealth.ScopeHost),
+			"a set covering every machine CPU is the whole machine")
+	})
+
+	It("leaves the scope unknown when no cpuset is readable", func() {
+		smp, err := v1Sampler(v1Files{
+			statPath:     "nr_periods 10\nnr_throttled 0\n",
+			"/proc/stat": procStat,
+		}).Read(context.Background())
+
+		Expect(err).NotTo(HaveOccurred())
+		_, ok := smp.LogicalCpus.Get()
+		Expect(ok).To(BeFalse())
+		Expect(smp.CpuScope).To(Equal(cpuhealth.ScopeUnknown),
+			"an unreadable cpuset is never a silent whole-machine scope")
+	})
+})

--- a/umh-core/pkg/cpuhealth/read_v1_throttle_test.go
+++ b/umh-core/pkg/cpuhealth/read_v1_throttle_test.go
@@ -1,0 +1,52 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The cgroup v1 throttle counters. v1 uses the same nr_periods and nr_throttled
+// key names v2 does, under its cpu controller directory, so only the path
+// differs.
+package cpuhealth_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("the cgroup v1 throttle counters", func() {
+	const statPath = "/sys/fs/cgroup/cpu,cpuacct/cpu.stat"
+
+	It("reads both counters from the v1 cpu controller's cpu.stat", func() {
+		smp, err := v1Sampler(v1Files{
+			statPath: "nr_periods 1000\nnr_throttled 50\nthrottled_time 1234567\n",
+		}).Read(context.Background())
+
+		Expect(err).NotTo(HaveOccurred())
+		periods, ok := smp.NrPeriods.Get()
+		Expect(ok).To(BeTrue())
+		Expect(periods).To(Equal(1000.0))
+		throttled, ok := smp.NrThrottled.Get()
+		Expect(ok).To(BeTrue())
+		Expect(throttled).To(Equal(50.0))
+	})
+
+	It("fails the sample when a counter cannot be parsed", func() {
+		_, err := v1Sampler(v1Files{
+			statPath: "nr_periods not-a-number\nnr_throttled 3\n",
+		}).Read(context.Background())
+
+		Expect(err).To(HaveOccurred(), "a v1 cpu.stat that does not parse is corrupt, the same as a v2 one")
+		Expect(err.Error()).To(ContainSubstring(statPath), "the error names the file that failed, not the v2 path")
+	})
+})

--- a/umh-core/pkg/cpuhealth/read_v1_usage_rate_test.go
+++ b/umh-core/pkg/cpuhealth/read_v1_usage_rate_test.go
@@ -1,0 +1,70 @@
+// Copyright 2025 UMH Systems GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Usage as a rate, read from cgroup v1: cpuacct.usage in nanoseconds rather than
+// cpu.stat's microseconds, converted once at the read. Elapsed time comes from
+// the returned snapshots' own Timestamps, which makes the arithmetic exact
+// against the real clock.
+package cpuhealth_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("usage as a rate on cgroup v1", func() {
+	const (
+		statPath  = cgroupBase + "/cpu,cpuacct/cpu.stat"
+		usagePath = cgroupBase + "/cpu,cpuacct/cpuacct.usage"
+	)
+
+	It("converts the nanosecond total to microseconds and derives the rate from two reads", func() {
+		ctx := context.Background()
+		// Five seconds of CPU time, as the nanoseconds the kernel writes.
+		files := v1Files{
+			statPath:  "nr_periods 1000\nnr_throttled 5\n",
+			usagePath: "5000000000\n",
+		}
+		sampler := v1Sampler(files)
+
+		first, err := sampler.Read(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		usage, ok := first.UsageUsec.Get()
+		Expect(ok).To(BeTrue(), "cpuacct.usage is the v1 usage total")
+		Expect(usage).To(Equal(5_000_000.0), "nanoseconds reach UsageUsec as microseconds")
+		_, ok = first.UsageCores.Get()
+		Expect(ok).To(BeFalse(), "the first read fixes a baseline and derives no rate")
+
+		// One more second of CPU time, the way a live counter moves between reads.
+		files[usagePath] = "6000000000\n"
+
+		second, err := sampler.Read(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		rate, ok := second.UsageCores.Get()
+		Expect(ok).To(BeTrue(), "the second read has an edge to subtract from")
+		elapsed := second.Timestamp.Sub(first.Timestamp).Seconds()
+		Expect(rate).To(BeNumerically("~", 1.0/elapsed, 1e-6),
+			"one second of CPU time over the elapsed interval is the rate in cores")
+	})
+
+	It("leaves usage absent when cpuacct.usage cannot be read", func() {
+		smp, err := v1Sampler(v1Files{statPath: "nr_periods 10\nnr_throttled 0\n"}).Read(context.Background())
+
+		Expect(err).NotTo(HaveOccurred())
+		_, ok := smp.UsageUsec.Get()
+		Expect(ok).To(BeFalse(), "no cpuacct.usage is no usage, never a trusted 0")
+	})
+})

--- a/umh-core/pkg/cpuhealth/sample.go
+++ b/umh-core/pkg/cpuhealth/sample.go
@@ -148,8 +148,8 @@ type Sample struct {
 	Reads []ReadResult
 }
 
-// Sampler reads one tick of CPU health signals: a cgroup's own accounting
-// (cpu.max, cpu.stat, cpu.pressure, cpuset.cpus.effective) and the host's
+// Sampler reads one tick of CPU health signals: a cgroup's own accounting,
+// from either hierarchy, and the host's
 // machine-wide state (/proc/stat, /proc/cpuinfo, and the DMI identity files),
 // both stamped with the one Timestamp the tick was read at. A file it cannot
 // read leaves its readings absent; only an unparsable cpu.stat and a cancelled

--- a/umh-core/pkg/cpuhealth/sample.go
+++ b/umh-core/pkg/cpuhealth/sample.go
@@ -151,7 +151,9 @@ type Sample struct {
 // Sampler reads one tick of CPU health signals: a cgroup's own accounting
 // (cpu.max, cpu.stat, cpu.pressure, cpuset.cpus.effective) and the host's
 // machine-wide state (/proc/stat, /proc/cpuinfo, and the DMI identity files),
-// both stamped with the one Timestamp the tick was read at.
+// both stamped with the one Timestamp the tick was read at. A file it cannot
+// read leaves its readings absent; only an unparsable cpu.stat and a cancelled
+// tick return an error.
 type Sampler interface {
 	Read(ctx context.Context) (Sample, error)
 }

--- a/umh-core/pkg/cpuhealth/snapshot_test.go
+++ b/umh-core/pkg/cpuhealth/snapshot_test.go
@@ -66,7 +66,7 @@ var _ = Describe("one snapshot per tick", func() {
 		return cpuhealth.NewLinuxSampler(fs, base)
 	}
 
-	It("stamps one timestamp, builds the environment from three facts, and fails the whole snapshot only on cpu.stat", func() {
+	It("stamps one timestamp, builds the environment from three facts, and fails the whole snapshot only on an unparsable cpu.stat", func() {
 		// a real Read builds every field off one read, and the
 		// snapshot is constructible from OUTSIDE pkg/diagnosis through Known and
 		// Unknown. The single Timestamp is set once per tick.
@@ -138,8 +138,9 @@ var _ = Describe("one snapshot per tick", func() {
 		Expect(smp2.NrPeriods).To(Equal(diagnosis.Known(10)))
 		Expect(smp2.NrThrottled).To(Equal(diagnosis.Known(2)))
 
-		// a fake filesystem whose cpu.stat is missing returns a non-nil
-		// error and no usable snapshot.
+		// a fake filesystem whose cpu.stat is missing returns err == nil with
+		// the three readings taken from it absent, the same as any other source
+		// failing.
 		noStat := sampler(func(fs *filesystem.MockFileSystem) {
 			fs.ReadFileFunc = func(ctx context.Context, path string) ([]byte, error) {
 				if path == base+"/cpu.stat" {
@@ -152,8 +153,12 @@ var _ = Describe("one snapshot per tick", func() {
 				return inner, err
 			}
 		})
-		_, err = noStat.Read(ctx)
-		Expect(err).To(HaveOccurred())
+		smp3, err := noStat.Read(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(smp3.UsageUsec).To(Equal(diagnosis.Unknown()))
+		Expect(smp3.NrPeriods).To(Equal(diagnosis.Unknown()))
+		Expect(smp3.NrThrottled).To(Equal(diagnosis.Unknown()))
+		Expect(smp3.Quota).To(Equal(diagnosis.Known(2)), "a lost cpu.stat must not cost the quota cpu.max carried")
 
 		// a fake filesystem whose cpu.stat is readable but whose
 		// value cannot be parsed (non-numeric usage_usec) also fails the

--- a/umh-core/pkg/fsmv2/cpu/cpu_filesystem_injection_test.go
+++ b/umh-core/pkg/fsmv2/cpu/cpu_filesystem_injection_test.go
@@ -22,6 +22,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/cpuhealth"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/register"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/filesystem"
@@ -48,6 +49,28 @@ func (stubFilesystem) ReadDir(context.Context, string) ([]os.DirEntry, error) {
 	return nil, errRefusedByStub
 }
 
+// stubStatMarker is a cpu.stat counter value no cgroup writes, so an error
+// quoting it names the stub below as the filesystem that was read.
+const stubStatMarker = "not-a-number-from-the-stub"
+
+// markedStatFilesystem serves one cpu.stat carrying stubStatMarker and refuses
+// every other read.
+type markedStatFilesystem struct {
+	filesystem.Service
+}
+
+func (markedStatFilesystem) ReadFile(_ context.Context, path string) ([]byte, error) {
+	if path == cgroupBase+"/cpu.stat" {
+		return []byte("usage_usec " + stubStatMarker + "\n"), nil
+	}
+
+	return nil, errRefusedByStub
+}
+
+func (markedStatFilesystem) ReadDir(context.Context, string) ([]os.DirEntry, error) {
+	return nil, errRefusedByStub
+}
+
 var _ = Describe("the filesystem the CPU worker reads", func() {
 	newBaseDeps := func() (deps.Identity, *deps.BaseDependencies) {
 		id := deps.Identity{ID: "cpu-filesystem-injection", WorkerType: WorkerType}
@@ -58,7 +81,7 @@ var _ = Describe("the filesystem the CPU worker reads", func() {
 	It("samples through a published filesystem rather than the real one", func() {
 		// The registry outlives the spec and SetDeps overwrites, so publishing
 		// without clearing hands this stub to every later spec.
-		register.SetDeps[filesystem.Service](FilesystemDepsKey, stubFilesystem{})
+		register.SetDeps[filesystem.Service](FilesystemDepsKey, markedStatFilesystem{})
 		DeferCleanup(register.ClearDeps, FilesystemDepsKey)
 
 		id, bd := newBaseDeps()
@@ -66,9 +89,22 @@ var _ = Describe("the filesystem the CPU worker reads", func() {
 
 		_, err := Poll(context.Background(), d, CPUConfig{})
 		Expect(err).To(HaveOccurred(),
-			"the published stub refuses cpu.stat, so the sample must fail")
-		Expect(err).To(MatchError(errRefusedByStub),
-			"only the published stub words a failure this way; the real filesystem never does")
+			"the published stub serves a cpu.stat that cannot parse, so the sample must fail")
+		Expect(err.Error()).To(ContainSubstring(stubStatMarker),
+			"only the published stub serves this counter value; the real cgroup never does")
+	})
+
+	It("reports a filesystem that refuses every read as healthy and unmeasured, not degraded", func() {
+		// A failed poll degrades the instance and blocks every bridge on it. A
+		// host that keeps its CPU accounting outside this cgroup has none of
+		// these files, so the poll succeeds carrying no capacity instead.
+		register.SetDeps[filesystem.Service](FilesystemDepsKey, stubFilesystem{})
+		DeferCleanup(register.ClearDeps, FilesystemDepsKey)
+
+		id, bd := newBaseDeps()
+		status, err := Poll(context.Background(), NewDeps(id, bd), CPUConfig{})
+		Expect(err).NotTo(HaveOccurred(), "an unreadable cgroup must not degrade the instance")
+		Expect(status.Verdict.State).To(Equal(cpuhealth.StateHealthy))
 	})
 
 	It("falls back to the real filesystem when nothing was published", func() {

--- a/umh-core/pkg/fsmv2/cpu/cpu_filesystem_injection_test.go
+++ b/umh-core/pkg/fsmv2/cpu/cpu_filesystem_injection_test.go
@@ -43,6 +43,12 @@ func (stubFilesystem) ReadFile(context.Context, string) ([]byte, error) {
 	return nil, errRefusedByStub
 }
 
+// FileExists refuses the layout probe too, keeping the contract: every access
+// fails, in a way no real filesystem words.
+func (stubFilesystem) FileExists(context.Context, string) (bool, error) {
+	return false, errRefusedByStub
+}
+
 // ReadDir refuses the sampler's directory listing, keeping the contract: every
 // access fails, in a way no real filesystem words.
 func (stubFilesystem) ReadDir(context.Context, string) ([]os.DirEntry, error) {
@@ -69,6 +75,12 @@ func (markedStatFilesystem) ReadFile(_ context.Context, path string) ([]byte, er
 
 func (markedStatFilesystem) ReadDir(context.Context, string) ([]os.DirEntry, error) {
 	return nil, errRefusedByStub
+}
+
+// FileExists answers for the one file this stub serves, so the probe resolves a
+// v2 mount and readStat opens it.
+func (markedStatFilesystem) FileExists(_ context.Context, path string) (bool, error) {
+	return path == cgroupBase+"/cpu.stat", nil
 }
 
 var _ = Describe("the filesystem the CPU worker reads", func() {

--- a/umh-core/pkg/fsmv2/cpu/cpu_read_report_test.go
+++ b/umh-core/pkg/fsmv2/cpu/cpu_read_report_test.go
@@ -98,6 +98,14 @@ type reportFS struct {
 	reads *int
 }
 
+// FileExists answers the layout probe from the same file map ReadFile serves,
+// so a fixture holding the v2 files resolves as a v2 mount.
+func (f reportFS) FileExists(ctx context.Context, p string) (bool, error) {
+	data, err := f.ReadFile(ctx, p)
+
+	return err == nil && data != nil, nil
+}
+
 func (f reportFS) ReadFile(ctx context.Context, p string) ([]byte, error) {
 	*f.reads++
 

--- a/umh-core/pkg/fsmv2/cpu/cpu_read_report_test.go
+++ b/umh-core/pkg/fsmv2/cpu/cpu_read_report_test.go
@@ -185,6 +185,14 @@ func buildPollable(errFn func(string) error) (*[]recorded, *CPUDeps) {
 	return events, d
 }
 
+// buildReportEvents is buildWithFiles plus read errors, for the specs that need
+// one file to fail to open while another fails to parse.
+func buildReportEvents(overrides map[string]error, fileOverrides map[string][]byte) *[]recorded {
+	events, _, _, _ := buildReport(overrides, fileOverrides, nil)
+
+	return events
+}
+
 func buildWithFiles(fileOverrides map[string][]byte) *[]recorded {
 	events, _, _, _ := buildReport(nil, fileOverrides, nil)
 

--- a/umh-core/pkg/fsmv2/cpu/cpu_sample_failed_test.go
+++ b/umh-core/pkg/fsmv2/cpu/cpu_sample_failed_test.go
@@ -23,19 +23,29 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-// cpu.stat is the one read whose failure voids the whole sample; the others drop
-// one signal and leave the measurement usable. The verb says which, so the issue
-// title tells a reader whether any measurement exists.
+// A cpu.stat that opens and will not parse is the one read whose failure voids
+// the whole sample; every other failure drops one signal and leaves the
+// measurement usable. The verb says which, so the issue title tells a reader
+// whether any measurement exists.
 var _ = Describe("cpu.stat reports under a verb that says what its failure cost", func() {
 	statPath := cgroupBase + "/cpu.stat"
 
-	It("uses sample_failed when the read itself failed", func() {
+	It("uses sample_failed when the file would not parse", func() {
+		events := buildWithFiles(map[string][]byte{statPath: []byte("usage_usec abc\n")})
+
+		Expect(msgs(events)).To(ConsistOf("cpu::sample_failed::cpu_stat::unparsable"),
+			"one event: the four reads after cpu.stat never happened, so they have nothing to report")
+	})
+
+	It("uses read_failed when the file will not open, since the sample survives it", func() {
+		// A host that keeps its CPU accounting outside this cgroup has no
+		// cpu.stat, and the sample is still usable without it. sample_failed
+		// here would tell a reader no measurement exists when one does.
 		events, _, _ := build(map[string]error{
 			statPath: &fs.PathError{Op: "open", Path: statPath, Err: syscall.ENOENT},
 		})
 
-		Expect(msgs(events)).To(ConsistOf("cpu::sample_failed::cpu_stat::missing"),
-			"one event: the four reads after cpu.stat never happened, so they have nothing to report")
+		Expect(msgs(events)).To(ConsistOf("cpu::read_failed::cpu_stat::missing"))
 	})
 
 	It("leaves a failed PSI read under read_failed when cpu.stat voided the sample", func() {
@@ -43,14 +53,14 @@ var _ = Describe("cpu.stat reports under a verb that says what its failure cost"
 		// tick cost one signal, so its own event must not claim the sample died
 		// with it: the verb belongs to the read it is reported under.
 		pressurePath := cgroupBase + "/cpu.pressure"
-		events, _, _ := build(map[string]error{
-			pressurePath: &fs.PathError{Op: "open", Path: pressurePath, Err: syscall.EACCES},
-			statPath:     &fs.PathError{Op: "open", Path: statPath, Err: syscall.ENOENT},
-		})
+		events := buildReportEvents(
+			map[string]error{pressurePath: &fs.PathError{Op: "open", Path: pressurePath, Err: syscall.EACCES}},
+			map[string][]byte{statPath: []byte("usage_usec abc\n")},
+		)
 
 		Expect(msgs(events)).To(ConsistOf(
 			"cpu::read_failed::cpu_pressure::permission_denied",
-			"cpu::sample_failed::cpu_stat::missing",
+			"cpu::sample_failed::cpu_stat::unparsable",
 		))
 	})
 


### PR DESCRIPTION
Stacked on #2758. Review that one first; this PR's base is its branch, so the diff here is only the v1 work.

## Problem

#2758 stops a cgroup v1 host from reporting CPU as degraded, but it has nothing to report either: the panel says CPU monitoring is unavailable, because every file the sampler knows about is a cgroup v2 file. RHEL 8 mounts v1 by default, so those hosts get no CPU figures at all.

## What we are shipping

- The sampler reads whichever hierarchy the host mounts. Which one is resolved from the filesystem on the first tick, by asking where `cpu.stat` sits, and kept for the process's life because a container's cgroup mount cannot change under it.
- A v1 host now supplies usage, both throttle counters, the CPU limit and the cpuset, so throttling, container-limit-full and host-cpu-full all have their numbers back.
- Three v1 spellings are resolved inside the v1 source and reach nothing below it: the limit as two files with `-1` for uncapped, the usage total as nanoseconds in `cpuacct.usage`, and the `cpu`/`cpuacct` controllers being probed for separately, since systemd mounts them together and a container runtime may not.

## What we are NOT shipping

- No pressure on v1. It publishes no per-cgroup pressure file, and the machine-wide `/proc/pressure/cpu` is deliberately not read in its place, because a machine-scoped number in a container-scoped field is the confusion `Scope` exists to prevent. Such a host lands on the limited-visibility arm the package already has, where usage-fraction answers host-cpu-full.
- No v1 memory. `cgroup_memory.go` still assumes v2 and wants its own ticket.

Part of ENG-5906