### PR TITLE
refactor: report every event through the telemetry registry

### DIFF
--- a/umh-core/pkg/communicator/actions/actions.go
+++ b/umh-core/pkg/communicator/actions/actions.go
@@ -35,6 +35,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/metrics"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/models"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/sentry"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/telemetry"
 	"go.uber.org/zap"
 )
 
@@ -134,10 +135,9 @@ func HandleActionMessage(instanceUUID uuid.UUID, payload models.ActionMessagePay
 	action := newActionFromPayloadFn(instanceUUID, payload, sender, outboundChannel, systemSnapshotManager, configManager, log, fsmLogger)
 	if action == nil {
 		log.Errorf("Unknown action type: %s", payload.ActionType)
-		fsmLogger.SentryWarn(
+		fsmLogger.Sentry(telemetry.Actions.UnknownType,
 			deps.FeatureFSMv1Communicator,
-			communicatorHierarchyPath,
-			"unknown action type",
+			communicatorHierarchyPath, nil,
 			deps.String("action_type", string(payload.ActionType)),
 			deps.String("action_uuid", payload.ActionUUID.String()),
 		)
@@ -161,7 +161,7 @@ func HandleActionMessage(instanceUUID uuid.UUID, payload models.ActionMessagePay
 		log.Errorf("Error parsing action payload: %s", err)
 
 		if isLogToSentry {
-			fsmLogger.SentryError(deps.FeatureDisableReadFlows, "", err, "protocol_converter_parse_failed")
+			fsmLogger.Sentry(telemetry.Communicator.Bridge.ParseFailed, deps.FeatureDisableReadFlows, "", err)
 		}
 
 		return
@@ -176,7 +176,7 @@ func HandleActionMessage(instanceUUID uuid.UUID, payload models.ActionMessagePay
 		log.Errorf("Error validating action payload: %s", err)
 
 		if isLogToSentry {
-			fsmLogger.SentryError(deps.FeatureDisableReadFlows, "", err, "protocol_converter_validate_failed")
+			fsmLogger.Sentry(telemetry.Communicator.Bridge.ValidateFailed, deps.FeatureDisableReadFlows, "", err)
 		}
 
 		return
@@ -189,7 +189,7 @@ func HandleActionMessage(instanceUUID uuid.UUID, payload models.ActionMessagePay
 		log.Errorf("Error executing action: %s", err)
 
 		if isLogToSentry {
-			fsmLogger.SentryError(deps.FeatureDisableReadFlows, "", err, "protocol_converter_execute_failed")
+			fsmLogger.Sentry(telemetry.Communicator.Bridge.ExecuteFailed, deps.FeatureDisableReadFlows, "", err)
 		}
 
 		return
@@ -240,11 +240,10 @@ func recoverActionPanic(
 				defer func() { _ = recover() }()
 
 				if fsmLogger != nil {
-					fsmLogger.SentryError(
+					fsmLogger.Sentry(telemetry.Communicator.ActionHandler.DoublePanic,
 						deps.FeatureFSMv1Communicator,
 						communicatorHierarchyPath,
 						fmt.Errorf("action handler double panic: primary=%v secondary=%v", r, r2),
-						"action_handler_double_panic",
 						deps.String("action_type", string(payload.ActionType)),
 						deps.String("action_uuid", payload.ActionUUID.String()),
 					)
@@ -252,7 +251,7 @@ func recoverActionPanic(
 			}()
 
 			fmt.Fprintf(os.Stderr,
-				"action_handler_double_panic: action=%s uuid=%s primary=%v secondary=%v\n",
+				"communicator::action_handler::double_panic: action=%s uuid=%s primary=%v secondary=%v\n",
 				payload.ActionType, payload.ActionUUID.String(), r, r2)
 		}
 	}()
@@ -265,11 +264,10 @@ func recoverActionPanic(
 	// so the primary panic always reaches the dashboard even if metrics
 	// or reply generation fails.
 	if fsmLogger != nil {
-		fsmLogger.SentryError(
+		fsmLogger.Sentry(telemetry.Communicator.ActionHandler.Panic,
 			deps.FeatureFSMv1Communicator,
 			communicatorHierarchyPath,
 			fmt.Errorf("action handler panic: %w", panicErr),
-			"action_handler_panic",
 			deps.String("action_type", string(payload.ActionType)),
 			deps.String("action_uuid", payload.ActionUUID.String()),
 			deps.String("panic_type", panicType),
@@ -298,18 +296,17 @@ func recoverActionPanic(
 		// reply ever arrives) and engineering only sees the panic event, not
 		// the follow-on failure. Stderr line kept as last-resort fallback.
 		if fsmLogger != nil {
-			fsmLogger.SentryError(
+			fsmLogger.Sentry(telemetry.Communicator.ActionHandler.PanicReplyGenerationFailed,
 				deps.FeatureFSMv1Communicator,
 				communicatorHierarchyPath,
 				err,
-				"action_handler_panic_reply_generation_failed",
 				deps.String("action_type", string(payload.ActionType)),
 				deps.String("action_uuid", payload.ActionUUID.String()),
 			)
 		}
 
 		fmt.Fprintf(os.Stderr,
-			"action_handler_panic_reply_generation_failed: action=%s uuid=%s err=%v\n",
+			"communicator::action_handler::panic_reply_generation_failed: action=%s uuid=%s err=%v\n",
 			payload.ActionType, payload.ActionUUID.String(), err)
 
 		return

--- a/umh-core/pkg/communicator/actions/actions_recovery_test.go
+++ b/umh-core/pkg/communicator/actions/actions_recovery_test.go
@@ -283,7 +283,7 @@ func TestRecoverActionPanicDoublePanicGuard(t *testing.T) {
 		recoverActionPanic(errors.New("primary"), uuid.New(), "user@example.com", payload, bad, out)
 	})
 
-	if !strings.Contains(stderr, "action_handler_double_panic") {
+	if !strings.Contains(stderr, "communicator::action_handler::double_panic") {
 		t.Errorf("expected stderr to contain action_handler_double_panic; got %q", stderr)
 	}
 }
@@ -302,11 +302,7 @@ func (l *countingPanickingFSMLogger) Sentry(id telemetry.Identifier, feature dep
 		return
 	}
 
-	l.SentryError(feature, hp, cause, id.Tag, fields...)
-}
-func (l *countingPanickingFSMLogger) SentryWarn(deps.Feature, string, string, ...deps.Field) {}
-func (l *countingPanickingFSMLogger) SentryError(feature deps.Feature, hp string, err error, msg string, fields ...deps.Field) {
-	l.calls = append(l.calls, capturedSentryError{feature, hp, err, msg, fields})
+	l.calls = append(l.calls, capturedSentryError{feature, hp, cause, id.Tag, fields})
 	if len(l.calls) == 1 {
 		panic("primary sentry boom")
 	}
@@ -332,7 +328,7 @@ func TestRecoverActionPanicDoublePanicGuardFiresWhenMetricPanics(t *testing.T) {
 		recoverActionPanic(errors.New("primary"), uuid.New(), "user@example.com", payload, deps.NewFSMLogger(log), out)
 	})
 
-	if !strings.Contains(stderr, "action_handler_double_panic") {
+	if !strings.Contains(stderr, "communicator::action_handler::double_panic") {
 		t.Errorf("expected stderr to contain action_handler_double_panic; got %q", stderr)
 	}
 }
@@ -350,7 +346,7 @@ func TestRecoverActionPanicDoublePanicGuardReattemptsSentry(t *testing.T) {
 		recoverActionPanic(errors.New("primary"), uuid.New(), "user@example.com", payload, bad, out)
 	})
 
-	if !strings.Contains(stderr, "action_handler_double_panic") {
+	if !strings.Contains(stderr, "communicator::action_handler::double_panic") {
 		t.Errorf("expected stderr to contain action_handler_double_panic; got %q", stderr)
 	}
 
@@ -359,7 +355,7 @@ func TestRecoverActionPanicDoublePanicGuardReattemptsSentry(t *testing.T) {
 	}
 
 	secondary := bad.calls[1]
-	if secondary.msg != "action_handler_double_panic" {
+	if secondary.msg != "communicator::action_handler::double_panic" {
 		t.Errorf("want secondary msg=action_handler_double_panic, got %q", secondary.msg)
 	}
 
@@ -389,16 +385,12 @@ func (l *capturingFSMLogger) Sentry(id telemetry.Identifier, feature deps.Featur
 		return
 	}
 
-	l.SentryError(feature, hp, cause, id.Tag, fields...)
-}
-func (l *capturingFSMLogger) SentryWarn(deps.Feature, string, string, ...deps.Field) {}
-func (l *capturingFSMLogger) SentryError(feature deps.Feature, hp string, err error, msg string, fields ...deps.Field) {
-	l.calls = append(l.calls, capturedSentryError{feature, hp, err, msg, fields})
+	l.calls = append(l.calls, capturedSentryError{feature, hp, cause, id.Tag, fields})
 }
 func (l *capturingFSMLogger) With(...deps.Field) deps.FSMLogger { return l }
 
 func TestRecoverActionPanicLogsSentryFields(t *testing.T) {
-	// T2.6 — Sentry event "action_handler_panic" is logged with the required
+	// T2.6 — Sentry event "communicator::action_handler::panic" is logged with the required
 	// fields, and stack_trace is non-empty (debug.Stack() caveat noted in
 	// recoverActionPanic).
 	actionUUID := uuid.New()
@@ -424,7 +416,7 @@ func TestRecoverActionPanicLogsSentryFields(t *testing.T) {
 		t.Errorf("want hierarchyPath=fsmv1.Communicator, got %q", call.hierarchyPath)
 	}
 
-	if call.msg != "action_handler_panic" {
+	if call.msg != "communicator::action_handler::panic" {
 		t.Errorf("want msg=action_handler_panic, got %q", call.msg)
 	}
 
@@ -469,10 +461,6 @@ func (l panickingFSMLogger) Sentry(id telemetry.Identifier, _ deps.Feature, _ st
 		return
 	}
 
-	panic("logger boom")
-}
-func (panickingFSMLogger) SentryWarn(deps.Feature, string, string, ...deps.Field) {}
-func (panickingFSMLogger) SentryError(deps.Feature, string, error, string, ...deps.Field) {
 	panic("logger boom")
 }
 func (l panickingFSMLogger) With(...deps.Field) deps.FSMLogger { return l }

--- a/umh-core/pkg/communicator/actions/actions_sentry_wiring_test.go
+++ b/umh-core/pkg/communicator/actions/actions_sentry_wiring_test.go
@@ -23,6 +23,7 @@ import (
 
 	deps "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
 	fsmv2sentry "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/sentry"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/telemetry"
 )
 
 // TestCommunicatorFSMLoggerWiredToSentryHook locks the invariant that the
@@ -70,11 +71,13 @@ func TestCommunicatorFSMLoggerWiredToSentryHook(t *testing.T) {
 		t.Fatal("unexpected: precheck fingerprint already seen")
 	}
 
-	// Fire the SentryError through the FSMLogger. If the hook is wired,
+	// Fire the event through the FSMLogger. If the hook is wired,
 	// SentryHook.Write intercepts the entry, computes the fingerprint
 	// (same formula as expectedFingerprint above), and calls
 	// ShouldCapture which records the timestamp in debouncer.lastSeen.
-	logger.SentryError(feature, communicatorHierarchyPath, testErr, eventName)
+	logger.Sentry(
+		telemetry.Identifier{Tag: eventName, Brief: eventName, Severity: telemetry.SeverityError},
+		feature, communicatorHierarchyPath, testErr)
 
 	// Post-assert: a fresh ShouldCapture call with the SAME fingerprint
 	// must return false (within the 5-min window) because the hook
@@ -82,6 +85,6 @@ func TestCommunicatorFSMLoggerWiredToSentryHook(t *testing.T) {
 	// (i.e., we regressed back to a bare FSMLogger), the lastSeen map
 	// is empty for this fingerprint and ShouldCapture returns true.
 	if communicatorSentryHook.Debouncer().ShouldCapture(expectedFingerprint) {
-		t.Errorf("SentryHook did not intercept FSMLogger.SentryError — communicatorFSMLogger() is not wrapping the logger with the hook")
+		t.Errorf("SentryHook did not intercept FSMLogger.Sentry — communicatorFSMLogger() is not wrapping the logger with the hook")
 	}
 }

--- a/umh-core/pkg/communicator/actions/deploy-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/deploy-protocolconverter.go
@@ -54,6 +54,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/logger"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/models"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/telemetry"
 )
 
 // DeployProtocolConverterAction implements the Action interface for deploying a
@@ -169,7 +170,7 @@ func (a *DeployProtocolConverterAction) Execute() (interface{}, map[string]inter
 		errorMsg := fmt.Sprintf("Failed to create protocol converter configuration: %v", err)
 		SendActionReply(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedWithFailure,
 			errorMsg, a.outboundChannel, models.DeployProtocolConverter)
-		a.fsmLogger.SentryError(deps.FeatureDisableReadFlows, "", err, "deploy_protocol_converter_create_config_failed",
+		a.fsmLogger.Sentry(telemetry.Communicator.Bridge.Deploy.CreateConfigFailed, deps.FeatureDisableReadFlows, "", err,
 			deps.String("name", a.payload.Name))
 
 		return nil, nil, fmt.Errorf("%s", errorMsg)
@@ -190,7 +191,7 @@ func (a *DeployProtocolConverterAction) Execute() (interface{}, map[string]inter
 		errorMsg := fmt.Sprintf("Failed to add Bridge: %v", err)
 		SendActionReply(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedWithFailure,
 			errorMsg, a.outboundChannel, models.DeployProtocolConverter)
-		a.fsmLogger.SentryError(deps.FeatureDeploymentSaveConfig, "", err, "deploy_protocol_converter_add_failed",
+		a.fsmLogger.Sentry(telemetry.Communicator.Bridge.Deploy.AddFailed, deps.FeatureDeploymentSaveConfig, "", err,
 			deps.String("pcConfig", pcConfig.String()))
 
 		return nil, nil, fmt.Errorf("%s", errorMsg)
@@ -244,7 +245,7 @@ func (a *DeployProtocolConverterAction) Execute() (interface{}, map[string]inter
 				models.DeployProtocolConverter,
 				nil,
 			)
-			a.fsmLogger.SentryError(deps.FeatureDeploymentSaveConfig, "", err, "deploy_protocol_converter_wait_failed",
+			a.fsmLogger.Sentry(telemetry.Communicator.Bridge.Deploy.WaitFailed, deps.FeatureDeploymentSaveConfig, "", err,
 				deps.String("pcConfig", pcConfig.String()),
 				deps.String("desiredState", pcConfig.DesiredFSMState))
 
@@ -253,7 +254,7 @@ func (a *DeployProtocolConverterAction) Execute() (interface{}, map[string]inter
 
 			currentConfig, getErr := a.configManager.GetConfig(stopCtx, 0)
 			if getErr != nil {
-				a.fsmLogger.SentryError(deps.FeatureDeploymentSaveConfig, "", getErr, "deploy_protocol_converter_stop_on_failure_get_config_failed",
+				a.fsmLogger.Sentry(telemetry.Communicator.Bridge.Deploy.StopOnFailureGetConfigFailed, deps.FeatureDeploymentSaveConfig, "", getErr,
 					deps.String("name", a.payload.Name))
 
 				return nil, nil, err
@@ -297,7 +298,7 @@ func (a *DeployProtocolConverterAction) Execute() (interface{}, map[string]inter
 			}
 
 			if _, editErr := a.configManager.AtomicEditProtocolConverter(stopCtx, pcUUID, pcToStop); editErr != nil {
-				a.fsmLogger.SentryError(deps.FeatureDeploymentSaveConfig, "", editErr, "deploy_protocol_converter_stop_on_failure_failed",
+				a.fsmLogger.Sentry(telemetry.Communicator.Bridge.Deploy.StopOnFailureFailed, deps.FeatureDeploymentSaveConfig, "", editErr,
 					deps.String("name", a.payload.Name))
 			}
 
@@ -452,7 +453,7 @@ func (a *DeployProtocolConverterAction) waitForComponentToAppear(desiredState st
 				errorMsg += ". Please check system load or component configuration and try again"
 			}
 
-			a.fsmLogger.SentryWarn(deps.FeatureDeploymentSaveConfig, "", "deploy_protocol_converter_timeout",
+			a.fsmLogger.Sentry(telemetry.Communicator.Bridge.Deploy.Timeout, deps.FeatureDeploymentSaveConfig, "", nil,
 				deps.String("name", a.payload.Name),
 				deps.String("desiredState", desiredState),
 				deps.String("lastStatusReason", lastStatusReason))

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter.go
@@ -55,6 +55,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/models"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/protocolconverter/runtime_config"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/s6"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/telemetry"
 )
 
 var errBridgeNotFound = errors.New("not found")
@@ -328,7 +329,7 @@ func (a *EditProtocolConverterAction) Execute() (interface{}, map[string]interfa
 
 		SendActionReplyV2(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedWithFailure,
 			errorMsg, errCode, nil, a.outboundChannel, models.EditProtocolConverter, nil)
-		a.fsmLogger.SentryError(deps.FeatureDisableReadFlows, "", err, "edit_protocol_converter_apply_mutation_failed",
+		a.fsmLogger.Sentry(telemetry.Communicator.Bridge.Edit.ApplyMutationFailed, deps.FeatureDisableReadFlows, "", err,
 			deps.String("new pcConfig", newSpec.String()))
 
 		return nil, nil, fmt.Errorf("%s", errorMsg)
@@ -339,7 +340,7 @@ func (a *EditProtocolConverterAction) Execute() (interface{}, map[string]interfa
 		errorMsg := fmt.Sprintf("Failed to persist configuration changes: %v", err)
 		SendActionReply(a.instanceUUID, a.userEmail, a.actionUUID, models.ActionFinishedWithFailure,
 			errorMsg, a.outboundChannel, models.EditProtocolConverter)
-		a.fsmLogger.SentryError(deps.FeatureDisableReadFlows, "", err, "edit_protocol_converter_persist_config_failed",
+		a.fsmLogger.Sentry(telemetry.Communicator.Bridge.Edit.PersistConfigFailed, deps.FeatureDisableReadFlows, "", err,
 			deps.String("new pcConfig", newSpec.String()),
 			deps.String("old pcConfig", oldConfig.String()))
 
@@ -359,7 +360,7 @@ func (a *EditProtocolConverterAction) Execute() (interface{}, map[string]interfa
 			// pre-existing paths (plain timeout, Benthos config error) keep
 			// it on top for continuity with established alerting.
 			if !a.rolloutSentryReported {
-				a.fsmLogger.SentryError(deps.FeatureDisableReadFlows, "", err, "edit_protocol_converter_rollout_failed",
+				a.fsmLogger.Sentry(telemetry.Communicator.Bridge.Edit.RolloutFailed, deps.FeatureDisableReadFlows, "", err,
 					deps.String("new pcConfig", newSpec.String()),
 					deps.String("old pcConfig", oldConfig.String()))
 			}
@@ -564,7 +565,7 @@ func (a *EditProtocolConverterAction) awaitRollout(pcConfig config.ProtocolConve
 			if rollbackErr != nil {
 				a.actionLogger.Errorf("Failed to rollback to previous configuration: %v", rollbackErr)
 				stateMessage := fmt.Sprintf("Bridge '%s' edit timeout reached. It did not become %s in time. Rolling back to previous configuration failed: %v", a.name, desiredPCState, rollbackErr)
-				a.fsmLogger.SentryError(deps.FeatureDisableReadFlows, "", rollbackErr, "edit_protocol_converter_rollback_failed",
+				a.fsmLogger.Sentry(telemetry.Communicator.Bridge.Edit.RollbackFailed, deps.FeatureDisableReadFlows, "", rollbackErr,
 					deps.String("pcConfig", pcConfig.String()))
 
 				return models.ErrRetryRollbackTimeout, fmt.Errorf("%s", stateMessage)
@@ -575,7 +576,7 @@ func (a *EditProtocolConverterAction) awaitRollout(pcConfig config.ProtocolConve
 				stateMessage += fmt.Sprintf(" (root cause: %v)", a.lastRenderErr)
 			}
 
-			a.fsmLogger.SentryWarn(deps.FeatureDisableReadFlows, "", "edit_protocol_converter_rollback_on_timeout",
+			a.fsmLogger.Sentry(telemetry.Communicator.Bridge.Edit.RollbackOnTimeout, deps.FeatureDisableReadFlows, "", nil,
 				deps.String("pcConfig", pcConfig.String()),
 				deps.String("desiredPCState", desiredPCState),
 			)
@@ -772,7 +773,7 @@ func (a *EditProtocolConverterAction) awaitRollout(pcConfig config.ProtocolConve
 							rollbackErr := a.rollbackEdit(pcConfig)
 							if rollbackErr != nil {
 								a.actionLogger.Errorf("failed to roll back protocol converter %s: %v", a.name, rollbackErr)
-								a.fsmLogger.SentryError(deps.FeatureDisableReadFlows, "", rollbackErr, "edit_protocol_converter_render_failure_rollback_failed",
+								a.fsmLogger.Sentry(telemetry.Communicator.Bridge.Edit.RenderFailureRollbackFailed, deps.FeatureDisableReadFlows, "", rollbackErr,
 									deps.String("protocolConverter", a.name),
 									deps.String("protocolConverterUUID", a.protocolConverterUUID.String()),
 									deps.String("renderErr", renderErr.Error()))
@@ -788,7 +789,7 @@ func (a *EditProtocolConverterAction) awaitRollout(pcConfig config.ProtocolConve
 								)
 							}
 
-							a.fsmLogger.SentryWarn(deps.FeatureDisableReadFlows, "", "edit_protocol_converter_render_failure_rolled_back",
+							a.fsmLogger.Sentry(telemetry.Communicator.Bridge.Edit.RenderFailureRolledBack, deps.FeatureDisableReadFlows, "", nil,
 								deps.String("protocolConverter", a.name),
 								deps.String("protocolConverterUUID", a.protocolConverterUUID.String()),
 								deps.String("renderErr", renderErr.Error()))
@@ -920,13 +921,13 @@ func (a *EditProtocolConverterAction) awaitRollout(pcConfig config.ProtocolConve
 					err := a.rollbackEdit(pcConfig)
 					if err != nil {
 						a.actionLogger.Errorf("failed to roll back protocol converter %s: %v", a.name, err)
-						a.fsmLogger.SentryError(deps.FeatureDisableReadFlows, "", err, "edit_protocol_converter_config_error_rollback_failed",
+						a.fsmLogger.Sentry(telemetry.Communicator.Bridge.Edit.ConfigErrorRollbackFailed, deps.FeatureDisableReadFlows, "", err,
 							deps.String("pcConfig", pcConfig.String()))
 
 						return models.ErrConfigFileInvalid, fmt.Errorf("bridge '%s' has invalid configuration but could not be rolled back: %w. Please check your logs and consider manually restoring the previous configuration", a.name, err)
 					}
 
-					a.fsmLogger.SentryWarn(deps.FeatureDisableReadFlows, "", "edit_protocol_converter_config_error_rolled_back",
+					a.fsmLogger.Sentry(telemetry.Communicator.Bridge.Edit.ConfigErrorRolledBack, deps.FeatureDisableReadFlows, "", nil,
 						deps.String("pcConfig", pcConfig.String()))
 
 					return models.ErrConfigFileInvalid, fmt.Errorf("bridge '%s' was rolled back to its previous configuration due to configuration errors. Please check the component logs, fix the configuration issues, and try editing again", a.name)

--- a/umh-core/pkg/communicator/actions/edit-protocolconverter_test.go
+++ b/umh-core/pkg/communicator/actions/edit-protocolconverter_test.go
@@ -78,14 +78,6 @@ func (l *recordingFSMLogger) Sentry(id telemetry.Identifier, _ deps.Feature, _ s
 	l.record(id.Tag, fields)
 }
 
-func (l *recordingFSMLogger) SentryWarn(feature deps.Feature, hierarchyPath string, msg string, fields ...deps.Field) {
-	l.record(msg, fields)
-}
-
-func (l *recordingFSMLogger) SentryError(feature deps.Feature, hierarchyPath string, err error, msg string, fields ...deps.Field) {
-	l.record(msg, fields)
-}
-
 func (l *recordingFSMLogger) With(fields ...deps.Field) deps.FSMLogger { return l }
 
 func (l *recordingFSMLogger) record(name string, fields []deps.Field) {
@@ -1971,9 +1963,9 @@ var _ = Describe("EditProtocolConverter", func() {
 				Expect(rollingBack).To(Equal(1))
 
 				events := sentryRec.eventNames()
-				Expect(events).To(ContainElement("edit_protocol_converter_render_failure_rolled_back"))
-				Expect(events).NotTo(ContainElement("edit_protocol_converter_rollout_failed"))
-				rolledBack := sentryRec.eventsNamed("edit_protocol_converter_render_failure_rolled_back")
+				Expect(events).To(ContainElement("communicator::bridge::edit::render_failure_rolled_back"))
+				Expect(events).NotTo(ContainElement("communicator::bridge::edit::rollout_failed"))
+				rolledBack := sentryRec.eventsNamed("communicator::bridge::edit::render_failure_rolled_back")
 				Expect(rolledBack).To(HaveLen(1))
 				Expect(rolledBack[0].fieldKeys()).To(ConsistOf(
 					"protocolConverter", "protocolConverterUUID", "renderErr"))
@@ -2096,9 +2088,9 @@ var _ = Describe("EditProtocolConverter", func() {
 				Expect(final.message).To(ContainSubstring("yaml:"))
 
 				events := sentryRec.eventNames()
-				Expect(events).To(ContainElement("edit_protocol_converter_render_failure_rollback_failed"))
-				Expect(events).NotTo(ContainElement("edit_protocol_converter_rollout_failed"))
-				failed := sentryRec.eventsNamed("edit_protocol_converter_render_failure_rollback_failed")
+				Expect(events).To(ContainElement("communicator::bridge::edit::render_failure_rollback_failed"))
+				Expect(events).NotTo(ContainElement("communicator::bridge::edit::rollout_failed"))
+				failed := sentryRec.eventsNamed("communicator::bridge::edit::render_failure_rollback_failed")
 				Expect(failed).To(HaveLen(1))
 				Expect(failed[0].fieldKeys()).To(ConsistOf(
 					"protocolConverter", "protocolConverterUUID", "renderErr"))
@@ -2193,7 +2185,7 @@ var _ = Describe("EditProtocolConverter", func() {
 				Expect(execErr).To(HaveOccurred())
 				Expect(execErr.Error()).To(ContainSubstring("did not become"))
 
-				Expect(sentryRec.eventNames()).To(ContainElement("edit_protocol_converter_rollout_failed"))
+				Expect(sentryRec.eventNames()).To(ContainElement("communicator::bridge::edit::rollout_failed"))
 
 				final := finalFailureReply()
 				Expect(final.errorCode).To(Equal(models.ErrRetryRollbackTimeout))
@@ -2454,8 +2446,8 @@ var _ = Describe("EditProtocolConverter", func() {
 				Expect(progressWithRender).NotTo(BeEmpty())
 
 				events := sentryRec.eventNames()
-				Expect(events).To(ContainElement("edit_protocol_converter_render_failure_rolled_back"))
-				Expect(events).NotTo(ContainElement("edit_protocol_converter_rollout_failed"))
+				Expect(events).To(ContainElement("communicator::bridge::edit::render_failure_rolled_back"))
+				Expect(events).NotTo(ContainElement("communicator::bridge::edit::rollout_failed"))
 			})
 
 			// ── ENG-5103 templateVars/connectionIP divergence specs ──────────────

--- a/umh-core/pkg/config/manager.go
+++ b/umh-core/pkg/config/manager.go
@@ -44,6 +44,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/metrics"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/models"
 	filesystem "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/filesystem"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/telemetry"
 )
 
 const (
@@ -269,8 +270,7 @@ func (m *FileConfigManager) GetConfigWithOverwritesOrCreateNew(ctx context.Conte
 	exists, err := m.fsService.FileExists(ctx, m.configPath)
 	switch {
 	case err != nil:
-		m.logger.SentryWarn(deps.FeatureFSMv1ConfigManager, configManagerHierarchyPath,
-			"config_file_exists_check_failed", deps.String("path", m.configPath), deps.Err(err))
+		m.logger.Sentry(telemetry.Config.File.ExistsCheckFailed, deps.FeatureFSMv1ConfigManager, configManagerHierarchyPath, err, deps.String("path", m.configPath))
 
 		return FullConfig{}, fmt.Errorf("failed to check config file existence: %w", err)
 	case exists:
@@ -507,8 +507,7 @@ func (m *FileConfigManager) readAndParseConfig(ctx context.Context) (FullConfig,
 	// Validate the location map
 	// This ensures downstream code doesn't panic when trying to access the location map
 	if config.Agent.Location == nil {
-		m.logger.SentryWarn(deps.FeatureFSMv1ConfigManager, configManagerHierarchyPath,
-			"config_missing_location_map", deps.String("path", m.configPath))
+		m.logger.Sentry(telemetry.Config.Agent.LocationMapMissing, deps.FeatureFSMv1ConfigManager, configManagerHierarchyPath, nil, deps.String("path", m.configPath))
 
 		config.Agent.Location = make(map[int]string)
 	}
@@ -516,8 +515,7 @@ func (m *FileConfigManager) readAndParseConfig(ctx context.Context) (FullConfig,
 	// Validate that the release channel is valid
 	// This prevent weird values from being set by the user
 	if config.Agent.ReleaseChannel != ReleaseChannelNightly && config.Agent.ReleaseChannel != ReleaseChannelStable && config.Agent.ReleaseChannel != ReleaseChannelEnterprise {
-		m.logger.SentryWarn(deps.FeatureFSMv1ConfigManager, configManagerHierarchyPath,
-			"config_invalid_release_channel", deps.String("release_channel", string(config.Agent.ReleaseChannel)))
+		m.logger.Sentry(telemetry.Config.Agent.ReleaseChannelInvalid, deps.FeatureFSMv1ConfigManager, configManagerHierarchyPath, nil, deps.String("release_channel", string(config.Agent.ReleaseChannel)))
 		config.Agent.ReleaseChannel = "n/a"
 	}
 
@@ -723,8 +721,8 @@ func (m *FileConfigManagerWithBackoff) GetConfig(ctx context.Context, tick uint6
 
 		// Log additional information for permanent failures
 		if m.backoffManager.IsPermanentlyFailed() {
-			m.configManager.logger.SentryError(deps.FeatureFSMv1ConfigManager, configManagerHierarchyPath,
-				m.backoffManager.GetLastError(), "config_manager_permanently_failed",
+			m.configManager.logger.Sentry(telemetry.Config.Manager.PermanentlyFailed, deps.FeatureFSMv1ConfigManager, configManagerHierarchyPath,
+				m.backoffManager.GetLastError(),
 				deps.String("path", m.configManager.configPath))
 		}
 
@@ -1232,8 +1230,7 @@ func (m *FileConfigManager) createConfigBackup(ctx context.Context) {
 	exists, err := m.fsService.FileExists(ctx, m.configPath)
 	if err != nil || !exists {
 		if err != nil {
-			m.logger.SentryWarn(deps.FeatureFSMv1ConfigManager, configManagerHierarchyPath,
-				"config_backup_exists_check_failed", deps.Err(err))
+			m.logger.Sentry(telemetry.Config.Backup.ExistsCheckFailed, deps.FeatureFSMv1ConfigManager, configManagerHierarchyPath, err)
 		}
 
 		return
@@ -1241,15 +1238,13 @@ func (m *FileConfigManager) createConfigBackup(ctx context.Context) {
 
 	content, err := m.fsService.ReadFile(ctx, m.configPath)
 	if err != nil {
-		m.logger.SentryWarn(deps.FeatureFSMv1ConfigManager, configManagerHierarchyPath,
-			"config_backup_read_failed", deps.Err(err))
+		m.logger.Sentry(telemetry.Config.Backup.ReadFailed, deps.FeatureFSMv1ConfigManager, configManagerHierarchyPath, err)
 
 		return
 	}
 
 	if err := m.fsService.EnsureDirectory(ctx, constants.ConfigBackupDir); err != nil {
-		m.logger.SentryWarn(deps.FeatureFSMv1ConfigManager, configManagerHierarchyPath,
-			"config_backup_dir_create_failed", deps.Err(err))
+		m.logger.Sentry(telemetry.Config.Backup.DirCreateFailed, deps.FeatureFSMv1ConfigManager, configManagerHierarchyPath, err)
 
 		return
 	}
@@ -1262,8 +1257,7 @@ func (m *FileConfigManager) createConfigBackup(ctx context.Context) {
 	backupPath := filepath.Join(constants.ConfigBackupDir, filename)
 
 	if err := m.fsService.WriteFile(ctx, backupPath, content, 0666); err != nil {
-		m.logger.SentryWarn(deps.FeatureFSMv1ConfigManager, configManagerHierarchyPath,
-			"config_backup_write_failed", deps.Err(err))
+		m.logger.Sentry(telemetry.Config.Backup.WriteFailed, deps.FeatureFSMv1ConfigManager, configManagerHierarchyPath, err)
 
 		return
 	}
@@ -1278,8 +1272,7 @@ func (m *FileConfigManager) createConfigBackup(ctx context.Context) {
 func (m *FileConfigManager) getLatestBackupContent(ctx context.Context) []byte {
 	entries, err := m.fsService.ReadDir(ctx, constants.ConfigBackupDir)
 	if err != nil {
-		m.logger.SentryWarn(deps.FeatureFSMv1ConfigManager, configManagerHierarchyPath,
-			"config_backup_dir_read_failed", deps.Err(err))
+		m.logger.Sentry(telemetry.Config.Backup.DirReadFailed, deps.FeatureFSMv1ConfigManager, configManagerHierarchyPath, err)
 
 		return nil
 	}
@@ -1308,8 +1301,7 @@ func (m *FileConfigManager) getLatestBackupContent(ctx context.Context) []byte {
 
 	data, err := m.fsService.ReadFile(ctx, filepath.Join(constants.ConfigBackupDir, latest))
 	if err != nil {
-		m.logger.SentryWarn(deps.FeatureFSMv1ConfigManager, configManagerHierarchyPath,
-			"config_backup_latest_read_failed", deps.Err(err))
+		m.logger.Sentry(telemetry.Config.Backup.LatestReadFailed, deps.FeatureFSMv1ConfigManager, configManagerHierarchyPath, err)
 
 		return nil
 	}
@@ -1444,8 +1436,7 @@ func (m *FileConfigManagerWithBackoff) AtomicDeleteHistorian(ctx context.Context
 func (m *FileConfigManager) cleanupOldBackups(ctx context.Context) {
 	entries, err := m.fsService.ReadDir(ctx, constants.ConfigBackupDir)
 	if err != nil {
-		m.logger.SentryWarn(deps.FeatureFSMv1ConfigManager, configManagerHierarchyPath,
-			"config_backup_cleanup_dir_read_failed", deps.Err(err))
+		m.logger.Sentry(telemetry.Config.Backup.Cleanup.DirReadFailed, deps.FeatureFSMv1ConfigManager, configManagerHierarchyPath, err)
 
 		return
 	}
@@ -1474,8 +1465,7 @@ func (m *FileConfigManager) cleanupOldBackups(ctx context.Context) {
 	toRemove := yamlFiles[:len(yamlFiles)-constants.ConfigBackupMaxEntries]
 	for _, name := range toRemove {
 		if err := m.fsService.Remove(ctx, filepath.Join(constants.ConfigBackupDir, name)); err != nil {
-			m.logger.SentryWarn(deps.FeatureFSMv1ConfigManager, configManagerHierarchyPath,
-				"config_backup_cleanup_remove_failed", deps.String("file", name), deps.Err(err))
+			m.logger.Sentry(telemetry.Config.Backup.Cleanup.RemoveFailed, deps.FeatureFSMv1ConfigManager, configManagerHierarchyPath, err, deps.String("file", name))
 		}
 	}
 }

--- a/umh-core/pkg/cse/storage/save.go
+++ b/umh-core/pkg/cse/storage/save.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/persistence"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/telemetry"
 )
 
 // SaveOptions configures role-specific behavior for saveWithDelta.
@@ -199,8 +200,7 @@ func (ts *TriangularStore) saveWithDelta(
 				}
 			}
 
-			ts.logger.SentryWarn(deps.FeatureCSE, hierarchyPath, "delta_append_failed",
-				deps.Err(appendErr),
+			ts.logger.Sentry(telemetry.Cse.Delta.AppendFailed, deps.FeatureCSE, hierarchyPath, appendErr,
 				deps.String("role", opts.Role))
 		}
 	}

--- a/umh-core/pkg/cse/storage/triangular.go
+++ b/umh-core/pkg/cse/storage/triangular.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/persistence"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/telemetry"
 )
 
 // ErrMalformedDelta is a sentinel error for delta documents with missing or invalid fields.
@@ -1248,8 +1249,7 @@ func (ts *TriangularStore) GetDeltas(ctx context.Context, sub Subscription) (Del
 	if ts.deltaStore != nil {
 		entries, err := ts.deltaStore.GetAllSince(ctx, sub.LastSyncID, deltaLimit)
 		if err != nil {
-			ts.logger.SentryWarn(deps.FeatureCSE, "", "delta_query_fallback_to_bootstrap",
-				deps.Err(err),
+			ts.logger.Sentry(telemetry.Cse.Delta.QueryFallbackToBootstrap, deps.FeatureCSE, "", err,
 				deps.Int64("lastSyncID", sub.LastSyncID),
 				deps.Int64("currentSyncID", currentSyncID),
 				deps.Int64("syncLag", currentSyncID-sub.LastSyncID))

--- a/umh-core/pkg/fsmv2/adapter/manager.go
+++ b/umh-core/pkg/fsmv2/adapter/manager.go
@@ -27,6 +27,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/fsmv2client"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/configworker/dynamicchildren"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/serviceregistry"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/telemetry"
 )
 
 // stoppedState is the desired-state literal that disables a config: a config
@@ -334,13 +335,13 @@ func (m *WorkerManager[TConfig, TStatus]) applyDesired(client *fsmv2client.FSMv2
 
 	cfgMap, err := m.spec.CfgFor(cfg)
 	if err != nil {
-		m.spec.Log.SentryWarn(deps.FeatureForWorker(m.spec.WorkerType), name, "build spec failed, will retry next tick", deps.String("worker", name), deps.Err(err))
+		m.spec.Log.Sentry(telemetry.Adapter.Child.SpecBuildFailed, deps.FeatureForWorker(m.spec.WorkerType), name, err, deps.String("worker", name))
 
 		return false
 	}
 
 	if err := client.Upsert(m.refFor(cfg), cfgMap); err != nil {
-		m.spec.Log.SentryWarn(deps.FeatureForWorker(m.spec.WorkerType), name, "upsert failed, will retry next tick", deps.String("worker", name), deps.Err(err))
+		m.spec.Log.Sentry(telemetry.Adapter.Child.UpsertFailed, deps.FeatureForWorker(m.spec.WorkerType), name, err, deps.String("worker", name))
 
 		return false
 	}

--- a/umh-core/pkg/fsmv2/cpu/cpu.go
+++ b/umh-core/pkg/fsmv2/cpu/cpu.go
@@ -28,6 +28,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/simple"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/configworker/dynamicchildren"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/service/filesystem"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/telemetry"
 )
 
 const (
@@ -167,8 +168,7 @@ func NewDeps(_ deps.Identity, bd *deps.BaseDependencies) *CPUDeps {
 func containerOrHostLimit(ctx context.Context, s cpuhealth.Sampler, bd *deps.BaseDependencies) (cores, quota float64) {
 	smp, err := s.Read(ctx)
 	if err != nil {
-		bd.GetLogger().SentryWarn(deps.FeatureSupportCPU, bd.GetHierarchyPath(),
-			"cpu: startup cgroup snapshot failed; quota signals omitted", deps.Err(err))
+		bd.GetLogger().Sentry(telemetry.Cpu.Startup.SnapshotFailed, deps.FeatureSupportCPU, bd.GetHierarchyPath(), err)
 	}
 
 	if lc, ok := smp.LogicalCpus.Get(); ok {

--- a/umh-core/pkg/fsmv2/deps/logger.go
+++ b/umh-core/pkg/fsmv2/deps/logger.go
@@ -39,15 +39,6 @@ type FSMLogger interface {
 	// so the Sentry event always has a readable sentence under its title.
 	Sentry(id telemetry.Identifier, feature Feature, hierarchyPath string, cause error, fields ...Field)
 
-	// SentryWarn logs at WARN level with required Feature and hierarchyPath for Sentry routing.
-	// Pass empty string for hierarchyPath when no worker hierarchy exists (e.g., runner-level code).
-	SentryWarn(feature Feature, hierarchyPath string, msg string, fields ...Field)
-
-	// SentryError logs at ERROR level with required Feature, hierarchyPath, and error for Sentry.
-	// The err parameter is captured as a Sentry exception with stack trace.
-	// Pass empty string for hierarchyPath when no worker hierarchy exists.
-	SentryError(feature Feature, hierarchyPath string, err error, msg string, fields ...Field)
-
 	// With returns a new FSMLogger with additional context fields.
 	// All logs from the returned logger include these fields.
 	With(fields ...Field) FSMLogger
@@ -100,13 +91,13 @@ func Any(key string, val any) Field {
 }
 
 // Err creates a Field with an error value using the standard "error" key.
-// Use this for additional errors beyond the primary error in SentryError.
+// Use this for additional errors beyond the primary error in Sentry.
 func Err(err error) Field {
 	return Field{Key: "error", Value: err}
 }
 
 // HierarchyPath creates a Field for the worker hierarchy path.
-// For SentryWarn/SentryError, use the dedicated hierarchyPath parameter instead.
+// For Sentry, use the dedicated hierarchyPath parameter instead.
 func HierarchyPath(path string) Field {
 	return Field{Key: "hierarchy_path", Value: path}
 }

--- a/umh-core/pkg/fsmv2/deps/logger_impl.go
+++ b/umh-core/pkg/fsmv2/deps/logger_impl.go
@@ -124,33 +124,6 @@ func (l *zapLogger) Sentry(id telemetry.Identifier, feature Feature, hierarchyPa
 	l.sugar.Errorw(id.Tag, fieldsToArgs(l.baseFields, allFields)...)
 }
 
-func (l *zapLogger) SentryWarn(feature Feature, hierarchyPath string, msg string, fields ...Field) {
-	allFields := make([]Field, 0, 2+len(fields))
-	allFields = append(allFields, Field{Key: "feature", Value: string(feature)})
-
-	if hierarchyPath != "" {
-		allFields = append(allFields, Field{Key: "hierarchy_path", Value: hierarchyPath})
-	}
-
-	allFields = append(allFields, fields...)
-	l.sugar.Warnw(msg, fieldsToArgs(l.baseFields, allFields)...)
-}
-
-func (l *zapLogger) SentryError(feature Feature, hierarchyPath string, err error, msg string, fields ...Field) {
-	allFields := make([]Field, 0, 3+len(fields))
-	allFields = append(allFields, Field{Key: "feature", Value: string(feature)})
-
-	if hierarchyPath != "" {
-		allFields = append(allFields, Field{Key: "hierarchy_path", Value: hierarchyPath})
-	}
-
-	// Pass error as bare value. SugaredLogger.sweetenFields detects the error interface
-	// and creates zapcore.ErrorType, which ExtractErrorFromFields in sentry/hook.go relies on.
-	allFields = append(allFields, Field{Key: "error", Value: err})
-	allFields = append(allFields, fields...)
-	l.sugar.Errorw(msg, fieldsToArgs(l.baseFields, allFields)...)
-}
-
 func (l *zapLogger) With(fields ...Field) FSMLogger {
 	newBaseFields := make([]Field, len(l.baseFields)+len(fields))
 	copy(newBaseFields, l.baseFields)

--- a/umh-core/pkg/fsmv2/deps/logger_noop.go
+++ b/umh-core/pkg/fsmv2/deps/logger_noop.go
@@ -37,10 +37,6 @@ func (l *nopLogger) Info(_ string, _ ...Field) {}
 
 func (l *nopLogger) Sentry(_ telemetry.Identifier, _ Feature, _ string, _ error, _ ...Field) {}
 
-func (l *nopLogger) SentryWarn(_ Feature, _ string, _ string, _ ...Field) {}
-
-func (l *nopLogger) SentryError(_ Feature, _ string, _ error, _ string, _ ...Field) {}
-
 func (l *nopLogger) With(_ ...Field) FSMLogger {
 	return l
 }

--- a/umh-core/pkg/fsmv2/deps/logger_test.go
+++ b/umh-core/pkg/fsmv2/deps/logger_test.go
@@ -24,6 +24,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/telemetry"
 )
 
 func parseLine(buf *bytes.Buffer) map[string]interface{} {
@@ -50,7 +51,7 @@ var _ = Describe("zapLogger field propagation", func() {
 	It("SentryError produces JSON with feature, error, and msg fields", func() {
 		logger := deps.NewJSONFSMLogger(buf, deps.LevelDebug)
 		testErr := errors.New("something broke")
-		logger.SentryError(deps.FeatureFSMv2, "root/worker-1(helloworld)", testErr, "lifecycle failed")
+		logger.Sentry(telemetry.Identifier{Tag: "lifecycle failed", Brief: "lifecycle failed", Severity: telemetry.SeverityError}, deps.FeatureFSMv2, "root/worker-1(helloworld)", testErr)
 
 		m := parseLine(buf)
 		Expect(m).To(HaveKeyWithValue("msg", "lifecycle failed"))
@@ -62,7 +63,7 @@ var _ = Describe("zapLogger field propagation", func() {
 
 	It("SentryWarn produces JSON with feature and msg fields", func() {
 		logger := deps.NewJSONFSMLogger(buf, deps.LevelDebug)
-		logger.SentryWarn(deps.FeatureFSMv2, "root/worker-1(helloworld)", "reconciliation slow")
+		logger.Sentry(telemetry.Identifier{Tag: "reconciliation slow", Brief: "reconciliation slow", Severity: telemetry.SeverityWarning}, deps.FeatureFSMv2, "root/worker-1(helloworld)", nil)
 
 		m := parseLine(buf)
 		Expect(m).To(HaveKeyWithValue("msg", "reconciliation slow"))
@@ -74,7 +75,7 @@ var _ = Describe("zapLogger field propagation", func() {
 	It("SentryError omits hierarchy_path when empty", func() {
 		logger := deps.NewJSONFSMLogger(buf, deps.LevelDebug)
 		testErr := errors.New("something broke")
-		logger.SentryError(deps.FeatureFSMv2, "", testErr, "lifecycle failed")
+		logger.Sentry(telemetry.Identifier{Tag: "lifecycle failed", Brief: "lifecycle failed", Severity: telemetry.SeverityError}, deps.FeatureFSMv2, "", testErr)
 
 		m := parseLine(buf)
 		Expect(m).NotTo(HaveKey("hierarchy_path"))
@@ -82,7 +83,7 @@ var _ = Describe("zapLogger field propagation", func() {
 
 	It("SentryWarn omits hierarchy_path when empty", func() {
 		logger := deps.NewJSONFSMLogger(buf, deps.LevelDebug)
-		logger.SentryWarn(deps.FeatureFSMv2, "", "reconciliation slow")
+		logger.Sentry(telemetry.Identifier{Tag: "reconciliation slow", Brief: "reconciliation slow", Severity: telemetry.SeverityWarning}, deps.FeatureFSMv2, "", nil)
 
 		m := parseLine(buf)
 		Expect(m).NotTo(HaveKey("hierarchy_path"))
@@ -152,9 +153,9 @@ var _ = Describe("nopLogger contract", func() {
 		Expect(func() {
 			logger.Debug("debug")
 			logger.Info("info")
-			logger.SentryWarn(deps.FeatureExamples, "", "warn")
-			logger.SentryWarn(deps.FeatureFSMv2, "", "health warn")
-			logger.SentryError(deps.FeatureFSMv2, "", testErr, "action error")
+			logger.Sentry(telemetry.Identifier{Tag: "warn", Brief: "warn", Severity: telemetry.SeverityWarning}, deps.FeatureExamples, "", nil)
+			logger.Sentry(telemetry.Identifier{Tag: "health warn", Brief: "health warn", Severity: telemetry.SeverityWarning}, deps.FeatureFSMv2, "", nil)
+			logger.Sentry(telemetry.Identifier{Tag: "action error", Brief: "action error", Severity: telemetry.SeverityError}, deps.FeatureFSMv2, "", testErr)
 		}).NotTo(Panic())
 	})
 

--- a/umh-core/pkg/fsmv2/doc.go
+++ b/umh-core/pkg/fsmv2/doc.go
@@ -84,8 +84,8 @@
 //   - Permanent failures: Return SignalNeedsRestart from state.Next() instead.
 //   - Expected conditions: For example, "already connected" is success.
 //
-// For Sentry error reporting, use [deps.FSMLogger.SentryError] and
-// [deps.FSMLogger.SentryWarn] which enforce required parameters at compile time.
+// For Sentry error reporting, use [deps.FSMLogger.Sentry], which takes a
+// declared [telemetry.Identifier] and enforces its parameters at compile time.
 //
 // ## DesiredState constraints
 //

--- a/umh-core/pkg/fsmv2/examples/persistence_scenario.go
+++ b/umh-core/pkg/fsmv2/examples/persistence_scenario.go
@@ -26,6 +26,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/application"
 	persistenceworker "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/persistence"
 	persistencesnapshot "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/persistence/snapshot"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/telemetry"
 )
 
 type PersistenceRunConfig struct {
@@ -153,8 +154,7 @@ children:
 		var observed fsmv2.Observation[persistencesnapshot.PersistenceStatus]
 		if loadErr := store.LoadObservedTyped(loadCtx, "persistence", "persistence-001", &observed); loadErr != nil {
 			if !errors.Is(loadErr, context.Canceled) {
-				logger.SentryWarn(deps.FeatureExamples, "", "failed to load persistence observed state",
-					deps.Err(loadErr))
+				logger.Sentry(telemetry.Examples.Persistence.ObservedStateLoadFailed, deps.FeatureExamples, "", loadErr)
 			}
 		} else {
 			workerMetrics := observed.Metrics.Worker

--- a/umh-core/pkg/fsmv2/examples/persistence_scenario_test.go
+++ b/umh-core/pkg/fsmv2/examples/persistence_scenario_test.go
@@ -272,7 +272,7 @@ var _ = Describe("Persistence Scenario caller-ctx cancellation", func() {
 		// loop shared the caller's ctx, the cancel would kill it before
 		// Shutdown, and every drain phase would wait out its timeout and
 		// emit this warning.
-		Expect(logContainsEvent(logBuf.String(), "graceful_shutdown_timeout")).To(BeFalse(),
+		Expect(logContainsEvent(logBuf.String(), "supervisor::shutdown::timeout")).To(BeFalse(),
 			"the supervisor must drain via a live tick loop, not time out against a dead one")
 	})
 })

--- a/umh-core/pkg/fsmv2/examples/runner.go
+++ b/umh-core/pkg/fsmv2/examples/runner.go
@@ -28,6 +28,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/configworker"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/configworker/dynamicchildren"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/persistence/memory"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/telemetry"
 
 	_ "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/certfetcher"
 	_ "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/certfetcher/state"
@@ -136,8 +137,7 @@ func Run(ctx context.Context, cfg RunConfig) (*RunResult, error) {
 
 		startSyncID, err = cfg.Store.GetLatestSyncID(ctx)
 		if err != nil {
-			cfg.Logger.SentryWarn(deps.FeatureExamples, "", "sync_id_fetch_failed",
-				deps.Err(err),
+			cfg.Logger.Sentry(telemetry.Examples.Runner.SyncIdFetchFailed, deps.FeatureExamples, "", err,
 				deps.String("impact", "dump_shows_all_changes"))
 		}
 	}
@@ -207,8 +207,7 @@ func Run(ctx context.Context, cfg RunConfig) (*RunResult, error) {
 
 			dump, err := DumpScenario(dumpCtx, cfg.Store, startSyncID)
 			if err != nil {
-				cfg.Logger.SentryWarn(deps.FeatureExamples, "", "scenario_dump_failed",
-					deps.Err(err))
+				cfg.Logger.Sentry(telemetry.Examples.Scenario.DumpFailed, deps.FeatureExamples, "", err)
 			} else {
 				fmt.Print(dump.FormatHuman())
 			}
@@ -259,7 +258,7 @@ func runV2(ctx context.Context, cfg RunConfig) (*RunResult, error) {
 	}
 
 	if cfg.DumpStore {
-		cfg.Logger.SentryWarn(deps.FeatureExamples, "", "dump_store_not_supported_for_v2",
+		cfg.Logger.Sentry(telemetry.Examples.Store.DumpUnsupportedForV2, deps.FeatureExamples, "", nil,
 			deps.String("scenario", cfg.ScenarioV2.Name),
 			deps.String("impact", "no_store_dump_printed"))
 	}

--- a/umh-core/pkg/fsmv2/examples/runner_v1_cancel_test.go
+++ b/umh-core/pkg/fsmv2/examples/runner_v1_cancel_test.go
@@ -78,7 +78,7 @@ var _ = Describe("v1 YAML runner caller-ctx cancellation", func() {
 		// loop shared the caller's ctx, the cancel would kill it before
 		// Shutdown, and every drain phase would wait out its timeout and
 		// emit this warning.
-		Expect(logContainsEvent(logBuf.String(), "graceful_shutdown_timeout")).To(BeFalse(),
+		Expect(logContainsEvent(logBuf.String(), "supervisor::shutdown::timeout")).To(BeFalse(),
 			"the supervisor must drain via a live tick loop, not time out against a dead one")
 	})
 })

--- a/umh-core/pkg/fsmv2/examples/scenariov2_test.go
+++ b/umh-core/pkg/fsmv2/examples/scenariov2_test.go
@@ -219,7 +219,7 @@ var _ = Describe("ScenarioV2 framework", func() {
 
 		// A silently ignored DumpStore lets a developer misread "no dump
 		// printed" as "no store changes", so the gap must be logged.
-		Expect(logContainsEvent(logBuf.String(), "dump_store_not_supported_for_v2")).To(BeTrue(),
+		Expect(logContainsEvent(logBuf.String(), "examples::store::dump_unsupported_for_v2")).To(BeTrue(),
 			"runV2 must warn that DumpStore is ignored for v2 scenarios")
 	})
 
@@ -279,7 +279,7 @@ var _ = Describe("ScenarioV2 framework", func() {
 		// loop shared the caller's ctx, the cancel would kill it before
 		// Shutdown, and every drain phase would wait out its timeout and
 		// emit this warning.
-		Expect(logContainsEvent(logBuf.String(), "graceful_shutdown_timeout")).To(BeFalse(),
+		Expect(logContainsEvent(logBuf.String(), "supervisor::shutdown::timeout")).To(BeFalse(),
 			"the supervisor must drain via a live tick loop, not time out against a dead one")
 	})
 

--- a/umh-core/pkg/fsmv2/integration/cascade_scenario_test.go
+++ b/umh-core/pkg/fsmv2/integration/cascade_scenario_test.go
@@ -142,7 +142,7 @@ func verifyCascadeChildrenCreated(t *integration.TestLogger) {
 	}
 
 	// Also check failure logs as indicator of child activity
-	failureLogs := t.GetLogsMatching("connect_failed_simulated")
+	failureLogs := t.GetLogsMatching("workers::connect::failed_simulated")
 	for _, entry := range failureLogs {
 		worker := ""
 
@@ -165,7 +165,7 @@ func verifyCascadeChildrenCreated(t *integration.TestLogger) {
 
 // verifyCascadeChildrenFailed checks that children experienced failures.
 func verifyCascadeChildrenFailed(t *integration.TestLogger) {
-	failureLogs := t.GetLogsMatching("connect_failed_simulated")
+	failureLogs := t.GetLogsMatching("workers::connect::failed_simulated")
 
 	childFailures := 0
 
@@ -285,7 +285,7 @@ func verifyCascadeParentStateTransitions(t *integration.TestLogger) {
 
 // verifyCascadeMultipleChildrenIndependent checks that multiple children fail independently.
 func verifyCascadeMultipleChildrenIndependent(t *integration.TestLogger) {
-	failureLogs := t.GetLogsMatching("connect_failed_simulated")
+	failureLogs := t.GetLogsMatching("workers::connect::failed_simulated")
 
 	child0Failures := 0
 	child1Failures := 0
@@ -355,7 +355,7 @@ func verifyCascadeAllChildrenMustRecover(t *integration.TestLogger) {
 
 // verifyCascadeChildFailureCounts checks that each child fails expected number of times.
 func verifyCascadeChildFailureCounts(t *integration.TestLogger) {
-	failureLogs := t.GetLogsMatching("connect_failed_simulated")
+	failureLogs := t.GetLogsMatching("workers::connect::failed_simulated")
 
 	childFailures := make(map[string]int)
 

--- a/umh-core/pkg/fsmv2/integration/concurrent_scenario_test.go
+++ b/umh-core/pkg/fsmv2/integration/concurrent_scenario_test.go
@@ -32,8 +32,8 @@ import (
 // race detector banner ("DATA RACE"), the runtime's "concurrent map" fatal, and the
 // word-boundary tokens for "race condition", "deadlock", and "panic". Word boundaries
 // keep it from firing on substrings of unrelated event names — notably
-// "graceful_shutdown_timeout" (contains "race" inside "graceful") and
-// "graceful_shutdown_budget_exhausted", both of which the shutdown-budget cascade can
+// "supervisor::shutdown::timeout" (contains "race" inside "graceful") and
+// "supervisor::shutdown::budget_exhausted", both of which the shutdown-budget cascade can
 // emit under load and which a plain strings.Contains("race") check misreads as a race.
 var interferenceSignatureRE = regexp.MustCompile(`(?i)\b(data race|race condition|concurrent map|deadlock|panic)\b`)
 
@@ -161,8 +161,8 @@ func verifyConcurrentNoInterference(t *integration.TestLogger) {
 
 	// Known timing-related issues that are acceptable
 	knownIssues := []string{
-		"data_stale",
-		"collector_observation_failed",
+		"supervisor::freshness::data_stale",
+		"supervisor::collector::observation_failed",
 	}
 
 	unexpectedErrors := []string{}

--- a/umh-core/pkg/fsmv2/integration/configerror_scenario_test.go
+++ b/umh-core/pkg/fsmv2/integration/configerror_scenario_test.go
@@ -134,7 +134,7 @@ func verifyConfigTypeMismatchWorker(t *integration.TestLogger) {
 // Note: When max_failures: "three" is parsed, YAML gives 0, so GetMaxFailures() returns default 3.
 func verifyConfigFailingDefaults(t *integration.TestLogger) {
 	// Look for any failing worker logs (might have different name format)
-	failureLogs := t.GetLogsMatching("connect_failed_simulated")
+	failureLogs := t.GetLogsMatching("workers::connect::failed_simulated")
 
 	// Also check for workers containing "failing-defaults" or "failing"
 	failingDefaultsLogs := t.GetLogsWithFieldContaining("worker", "failing")

--- a/umh-core/pkg/fsmv2/integration/failing_scenario_test.go
+++ b/umh-core/pkg/fsmv2/integration/failing_scenario_test.go
@@ -117,7 +117,7 @@ func verifyRecoveryWorkerSucceeds(t *integration.TestLogger) {
 
 // verifyPermanentWorkerStaysStuck checks that the permanent failure worker keeps failing.
 func verifyPermanentWorkerStaysStuck(t *integration.TestLogger) {
-	failedLogs := t.GetLogsMatching("connect_failed_simulated")
+	failedLogs := t.GetLogsMatching("workers::connect::failed_simulated")
 
 	// Count failures for permanent worker
 	permanentFailures := 0
@@ -160,7 +160,7 @@ func verifyPermanentWorkerStaysStuck(t *integration.TestLogger) {
 
 // verifyActionFailuresLogged checks that action failures include attempt counts.
 func verifyActionFailuresLogged(t *integration.TestLogger) {
-	failedLogs := t.GetLogsMatching("connect_failed_simulated")
+	failedLogs := t.GetLogsMatching("workers::connect::failed_simulated")
 
 	Expect(failedLogs).ToNot(BeEmpty(),
 		"Expected at least one connect_failed_simulated log")

--- a/umh-core/pkg/fsmv2/integration/panic_scenario_test.go
+++ b/umh-core/pkg/fsmv2/integration/panic_scenario_test.go
@@ -85,7 +85,7 @@ func verifyPanicWorkerCreated(t *integration.TestLogger) {
 
 // verifyPanicWasCaught checks that the panic was caught and logged.
 func verifyPanicWasCaught(t *integration.TestLogger) {
-	panicLogs := t.GetLogsMatching("action_panic")
+	panicLogs := t.GetLogsMatching("supervisor::action::panic")
 
 	Expect(panicLogs).ToNot(BeEmpty(),
 		"Expected at least one action_panic log entry")

--- a/umh-core/pkg/fsmv2/integration/scenarios_test.go
+++ b/umh-core/pkg/fsmv2/integration/scenarios_test.go
@@ -109,8 +109,8 @@ func verifyNoErrorsOrWarnings(t *integration.TestLogger) {
 
 	// Known timing-related issues during test scenarios
 	knownIssues := []string{
-		"data_stale",                   // Observation collector may report stale data briefly
-		"collector_observation_failed", // Collector may fail temporarily during shutdown
+		"supervisor::freshness::data_stale",                   // Observation collector may report stale data briefly
+		"supervisor::collector::observation_failed", // Collector may fail temporarily during shutdown
 		// The worker-removal handler stops a worker's collector after deleting
 		// the worker from the registry; Shutdown's drain sees the empty registry,
 		// cancels the supervisor ctx, and the collector self-stops before the
@@ -642,7 +642,7 @@ func verifyChildCountMatches(store storage.TriangularStoreInterface) {
 // verifyNoActionFailures verifies no action execution failures or panics occurred.
 func verifyNoActionFailures(t *integration.TestLogger) {
 	failures := t.GetLogsMatching("action_execution_failed")
-	panics := t.GetLogsMatching("action_panic")
+	panics := t.GetLogsMatching("supervisor::action::panic")
 
 	Expect(failures).To(BeEmpty(),
 		fmt.Sprintf("Found %d action execution failures", len(failures)))

--- a/umh-core/pkg/fsmv2/integration/timeout_scenario_test.go
+++ b/umh-core/pkg/fsmv2/integration/timeout_scenario_test.go
@@ -125,7 +125,7 @@ func verifyTimeoutSlowWorker(t *integration.TestLogger) {
 
 // verifyTimeoutRetryWorker checks that the retry worker demonstrates retry pattern.
 func verifyTimeoutRetryWorker(t *integration.TestLogger) {
-	failureLogs := t.GetLogsMatching("connect_failed_simulated")
+	failureLogs := t.GetLogsMatching("workers::connect::failed_simulated")
 
 	retryFailures := 0
 
@@ -175,7 +175,7 @@ func verifyTimeoutRetryWorker(t *integration.TestLogger) {
 
 // verifyTimeoutCombinedWorker checks the combined slow + retry pattern.
 func verifyTimeoutCombinedWorker(t *integration.TestLogger) {
-	failureLogs := t.GetLogsMatching("connect_failed_simulated")
+	failureLogs := t.GetLogsMatching("workers::connect::failed_simulated")
 
 	combinedFailures := 0
 

--- a/umh-core/pkg/fsmv2/sentry/architecture_test.go
+++ b/umh-core/pkg/fsmv2/sentry/architecture_test.go
@@ -86,11 +86,10 @@ WRONG:
 loses the error chain and Sentry's ability to group related errors.
 
 CORRECT:
-  logger.SentryError(feature, hierarchyPath, err, "operation_failed")
-  logger.SentryWarn(feature, hierarchyPath, "problem detected", deps.Err(err))
+  logger.Sentry(telemetry.Supervisor.Action.Failed, feature, hierarchyPath, err)
 
 WRONG:
-  logger.SentryError(feature, hierarchyPath, err, "failed", deps.String("detail", err.Error()))
+  logger.Sentry(telemetry.Supervisor.Action.Failed, feature, hierarchyPath, err, deps.String("detail", err.Error()))
   logger.Info("failed", deps.String("error", someErr.Error()))
 
 The error chain is important for debugging and Sentry grouping. Always pass

--- a/umh-core/pkg/fsmv2/sentry/doc.go
+++ b/umh-core/pkg/fsmv2/sentry/doc.go
@@ -17,12 +17,12 @@
 // The SentryHook wraps a zapcore.Core and intercepts warn/error-level log
 // entries, forwarding them to Sentry with fingerprinting and debouncing.
 //
-// Production code uses [deps.FSMLogger] methods (SentryWarn, SentryError)
+// Production code uses [deps.FSMLogger.Sentry]
 // which inject "feature", "hierarchy_path", and "error" fields that this hook extracts.
 //
 // # How Errors Appear in Sentry
 //
-//   - Title: event_name (e.g., "action_failed")
+//   - Title: event_name (e.g., "supervisor::action::failed")
 //   - Subtitle: error message
 //   - Tags: feature, event_name, error_types, fsm_version, worker_type, worker_chain, action_name
 //   - Contexts["umh_context"]: all remaining fields (reason, duration_ms, capacity, etc.)

--- a/umh-core/pkg/fsmv2/sentry/hook.go
+++ b/umh-core/pkg/fsmv2/sentry/hook.go
@@ -149,10 +149,10 @@ func (h *SentryHook) captureToSentry(entry zapcore.Entry, fields []zapcore.Field
 	}
 
 	// Add error as exception with event_name as the Type (appears as title in Sentry UI).
-	// The title displays "action_failed" instead of "*fmt.wrapError".
+	// The title displays "supervisor::action::failed" instead of "*fmt.wrapError".
 	if err != nil {
 		exception := sentry.Exception{
-			Type:  entry.Message, // "action_failed" - becomes the title
+			Type:  entry.Message, // "supervisor::action::failed" - becomes the title
 			Value: err.Error(),   // "connection failed: ..." - becomes subtitle
 		}
 
@@ -513,8 +513,7 @@ func IsInternalFrame(frame sentry.Frame) bool {
 
 	if strings.Contains(frame.Function, "captureToSentry") ||
 		strings.Contains(frame.Function, "SentryHook.Write") ||
-		strings.Contains(frame.Function, "SentryError") ||
-		strings.Contains(frame.Function, "SentryWarn") ||
+		strings.Contains(frame.Function, "zapLogger).Sentry") ||
 		strings.Contains(frame.Function, "zapcore.") {
 		return true
 	}

--- a/umh-core/pkg/fsmv2/sentry/hook_test.go
+++ b/umh-core/pkg/fsmv2/sentry/hook_test.go
@@ -26,6 +26,7 @@ import (
 	sentrygo "github.com/getsentry/sentry-go"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/sentry"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/telemetry"
 
 	//nolint:revive // dot import for Ginkgo DSL
 	. "github.com/onsi/ginkgo/v2"
@@ -136,6 +137,17 @@ main.second()
 			frame := sentrygo.Frame{
 				Module:   "runtime/debug",
 				Function: "Stack",
+			}
+			Expect(sentry.IsInternalFrame(frame)).To(BeTrue())
+		})
+
+		It("should filter the logger's own Sentry method", func() {
+			// The filter names the method, so a rename leaves the logger as the
+			// innermost application frame and every event's culprit becomes the
+			// logger rather than the code that reported it.
+			frame := sentrygo.Frame{
+				Module:   "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps",
+				Function: "deps.(*zapLogger).Sentry",
 			}
 			Expect(sentry.IsInternalFrame(frame)).To(BeTrue())
 		})
@@ -501,7 +513,7 @@ var _ = Describe("SentryHook Integration with Mock Transport", func() {
 			wrappedErr := fmt.Errorf("connection failed: %w", rootErr)
 
 			// When: logged with error fields
-			logger.Errorw("action_failed",
+			logger.Errorw("supervisor::action::failed",
 				"feature", "communicator",
 				"error", wrappedErr)
 
@@ -522,7 +534,7 @@ var _ = Describe("SentryHook Integration with Mock Transport", func() {
 			err3 := fmt.Errorf("layer 3: %w", err2)
 
 			// When: logged
-			logger.Errorw("action_failed",
+			logger.Errorw("supervisor::action::failed",
 				"feature", "fsmv2",
 				"error", err3)
 
@@ -570,7 +582,7 @@ var _ = Describe("SentryHook Integration with Mock Transport", func() {
 			err := errors.New("specific error message")
 
 			// When: logged
-			logger.Errorw("action_failed",
+			logger.Errorw("supervisor::action::failed",
 				"feature", "fsmv2",
 				"error", err)
 
@@ -581,7 +593,7 @@ var _ = Describe("SentryHook Integration with Mock Transport", func() {
 
 			event := store.GetLast()
 			Expect(event).NotTo(BeNil())
-			Expect(event.Message).To(Equal("action_failed"))
+			Expect(event.Message).To(Equal("supervisor::action::failed"))
 		})
 
 		It("attaches stacktrace to exception when stack field is present", func() {
@@ -594,7 +606,7 @@ github.com/example/pkg/executor.executeWork()
 	/app/executor.go:142 +0x1a
 `
 			// When: logged with stack field (like action_executor does for panics)
-			logger.Errorw("action_panic",
+			logger.Errorw("supervisor::action::panic",
 				"feature", "fsmv2",
 				"error", err)
 			// Add stack field separately to match action_executor pattern
@@ -641,7 +653,7 @@ github.com/example/pkg/executor.executeWork()
 			derivedLogger := logger.With("worker", "test-worker-123")
 
 			// Log an error through the derived logger
-			derivedLogger.Errorw("action_failed",
+			derivedLogger.Errorw("supervisor::action::failed",
 				"feature", "fsmv2",
 				"error", io.EOF)
 
@@ -652,7 +664,7 @@ github.com/example/pkg/executor.executeWork()
 
 			event := store.GetLast()
 			Expect(event).NotTo(BeNil())
-			Expect(event.Message).To(Equal("action_failed"))
+			Expect(event.Message).To(Equal("supervisor::action::failed"))
 			Expect(event.Exception).NotTo(BeEmpty(), "Error should be captured as Exception")
 		})
 
@@ -751,9 +763,9 @@ github.com/example/pkg/executor.executeWork()
 			err2 := context.DeadlineExceeded
 
 			// When: both logged
-			logger.Errorw("action_failed", "feature", "fsmv2", "error", err1)
+			logger.Errorw("supervisor::action::failed", "feature", "fsmv2", "error", err1)
 			time.Sleep(10 * time.Millisecond)
-			logger.Errorw("action_failed", "feature", "fsmv2", "error", err2)
+			logger.Errorw("supervisor::action::failed", "feature", "fsmv2", "error", err2)
 
 			// Then: different fingerprints
 			Eventually(func() int {
@@ -783,9 +795,9 @@ github.com/example/pkg/executor.executeWork()
 			err := io.EOF
 
 			// When: both logged
-			logger.Errorw("action_failed", "feature", "fsmv2", "error", err)
+			logger.Errorw("supervisor::action::failed", "feature", "fsmv2", "error", err)
 			time.Sleep(10 * time.Millisecond)
-			logger.Errorw("action_failed", "feature", "communicator", "error", err)
+			logger.Errorw("supervisor::action::failed", "feature", "communicator", "error", err)
 
 			// Then: different fingerprints due to different features
 			Eventually(func() int {
@@ -801,7 +813,7 @@ github.com/example/pkg/executor.executeWork()
 
 	Describe("Per-Fingerprint Debouncing", func() {
 		It("captures first event", func() {
-			logger.Errorw("action_failed", "feature", "fsmv2", "error", io.EOF)
+			logger.Errorw("supervisor::action::failed", "feature", "fsmv2", "error", io.EOF)
 
 			Eventually(func() int {
 				return store.Len()
@@ -810,8 +822,8 @@ github.com/example/pkg/executor.executeWork()
 
 		It("debounces duplicate within window", func() {
 			// Both use same feature, same error, same message → same fingerprint
-			logger.Errorw("action_failed", "feature", "fsmv2", "error", io.EOF)
-			logger.Errorw("action_failed", "feature", "fsmv2", "error", io.EOF)
+			logger.Errorw("supervisor::action::failed", "feature", "fsmv2", "error", io.EOF)
+			logger.Errorw("supervisor::action::failed", "feature", "fsmv2", "error", io.EOF)
 
 			// Wait a bit for any async processing
 			time.Sleep(100 * time.Millisecond)
@@ -834,7 +846,7 @@ github.com/example/pkg/executor.executeWork()
 			logger = zap.New(wrappedCore).Sugar()
 
 			// First event
-			logger.Errorw("action_failed", "feature", "fsmv2", "error", io.EOF)
+			logger.Errorw("supervisor::action::failed", "feature", "fsmv2", "error", io.EOF)
 
 			Eventually(func() int {
 				return store.Len()
@@ -844,7 +856,7 @@ github.com/example/pkg/executor.executeWork()
 			time.Sleep(100 * time.Millisecond)
 
 			// Second event after window
-			logger.Errorw("action_failed", "feature", "fsmv2", "error", io.EOF)
+			logger.Errorw("supervisor::action::failed", "feature", "fsmv2", "error", io.EOF)
 
 			Eventually(func() int {
 				return store.Len()
@@ -853,8 +865,8 @@ github.com/example/pkg/executor.executeWork()
 
 		It("debounces different fingerprints independently", func() {
 			// Different features = different fingerprints = both captured
-			logger.Errorw("action_failed", "feature", "fsmv2", "error", io.EOF)
-			logger.Errorw("action_failed", "feature", "communicator", "error", io.EOF)
+			logger.Errorw("supervisor::action::failed", "feature", "fsmv2", "error", io.EOF)
+			logger.Errorw("supervisor::action::failed", "feature", "communicator", "error", io.EOF)
 
 			Eventually(func() int {
 				return store.Len()
@@ -864,7 +876,7 @@ github.com/example/pkg/executor.executeWork()
 
 	Describe("Hierarchy Path Auto-Tagging", func() {
 		It("extracts fsm_version=v2, worker_type, and worker_chain from fsmv2 path", func() {
-			logger.Errorw("action_failed",
+			logger.Errorw("supervisor::action::failed",
 				"feature", "communicator",
 				"error", io.EOF,
 				"hierarchy_path", "app(application)/worker(communicator)")
@@ -881,7 +893,7 @@ github.com/example/pkg/executor.executeWork()
 		})
 
 		It("extracts fsm_version=v1 from legacy path", func() {
-			logger.Errorw("action_failed",
+			logger.Errorw("supervisor::action::failed",
 				"feature", "legacy",
 				"error", io.EOF,
 				"hierarchy_path", "Enterprise.Site.Area.WorkCell")
@@ -898,7 +910,7 @@ github.com/example/pkg/executor.executeWork()
 		})
 
 		It("handles empty hierarchy path gracefully", func() {
-			logger.Errorw("action_failed",
+			logger.Errorw("supervisor::action::failed",
 				"feature", "fsmv2",
 				"error", io.EOF)
 
@@ -916,7 +928,7 @@ github.com/example/pkg/executor.executeWork()
 
 	Describe("Tag Extraction", func() {
 		It("sets feature tag", func() {
-			logger.Errorw("action_failed",
+			logger.Errorw("supervisor::action::failed",
 				"feature", "communicator",
 				"error", io.EOF)
 
@@ -1033,7 +1045,7 @@ var _ = Describe("Contexts Catch-All", func() {
 	})
 
 	It("captures extra fields in Contexts['umh_context']", func() {
-		logger.Errorw("action_failed",
+		logger.Errorw("supervisor::action::failed",
 			"feature", "fsmv2",
 			"error", io.EOF,
 			"reason", "timeout",
@@ -1051,7 +1063,7 @@ var _ = Describe("Contexts Catch-All", func() {
 	})
 
 	It("excludes handled keys from Contexts", func() {
-		logger.Errorw("action_panic",
+		logger.Errorw("supervisor::action::panic",
 			"feature", "fsmv2",
 			"error", io.EOF,
 			"hierarchy_path", "app(application)/w(communicator)",
@@ -1080,7 +1092,7 @@ var _ = Describe("Contexts Catch-All", func() {
 	})
 
 	It("excludes 'error' from Contexts when typed error is present", func() {
-		logger.Errorw("action_failed",
+		logger.Errorw("supervisor::action::failed",
 			"feature", "fsmv2",
 			"error", io.EOF,
 			"reason", "test")
@@ -1127,7 +1139,7 @@ var _ = Describe("Contexts Catch-All", func() {
 	})
 
 	It("captures panic_value in Contexts instead of Extra", func() {
-		logger.Errorw("action_panic",
+		logger.Errorw("supervisor::action::panic",
 			"feature", "fsmv2",
 			"error", errors.New("panicked"),
 			"panic", "runtime error: nil pointer",
@@ -1261,7 +1273,7 @@ var _ = Describe("Tag Truncation", func() {
 		}
 		// error_types for 15 wraps + 1 base: ~16 types * ~20 chars = ~320 chars
 
-		logger.Errorw("action_failed",
+		logger.Errorw("supervisor::action::failed",
 			"feature", "fsmv2",
 			"error", err)
 
@@ -1277,7 +1289,7 @@ var _ = Describe("Tag Truncation", func() {
 	It("does not truncate error_types under 200 chars", func() {
 		err := fmt.Errorf("wrap: %w", io.EOF)
 
-		logger.Errorw("action_failed",
+		logger.Errorw("supervisor::action::failed",
 			"feature", "fsmv2",
 			"error", err)
 
@@ -1332,9 +1344,32 @@ var _ = Describe("FSMLogger to Sentry Event Mapping", func() {
 		}
 	})
 
+	// The capstone for the telemetry registry: one call with a generated
+	// identifier and no error of its own, all the way to the event the transport
+	// would have sent. The unit specs prove each piece; only an assertion here
+	// fails if the pieces stop being wired together.
+	It("carries a declared identifier's tag, level and brief onto the event", func() {
+		fsmLogger.Sentry(telemetry.Supervisor.Collector.Stopped, deps.FeatureFSMv2, "app(application)/w1(helloworld)", nil)
+
+		Eventually(func() int {
+			return store.Len()
+		}, time.Second, 10*time.Millisecond).Should(BeNumerically(">=", 1))
+
+		event := store.GetLast()
+		Expect(event.Tags).To(HaveKeyWithValue("event_name", "supervisor::collector::stopped"))
+		Expect(event.Tags).To(HaveKeyWithValue("feature", "fsmv2"))
+		Expect(event.Level).To(Equal(sentrygo.LevelWarning))
+		Expect(event.Exception).NotTo(BeEmpty())
+		Expect(event.Exception[0].Type).To(Equal("supervisor::collector::stopped"))
+		// The brief is the only readable sentence on an event whose caller had
+		// no error, so a triager reads it under the title rather than grepping
+		// the repo for what the tag means.
+		Expect(event.Exception[0].Value).To(Equal(telemetry.Supervisor.Collector.Stopped.Brief))
+	})
+
 	It("SentryError produces exception with correct type and value", func() {
 		testErr := fmt.Errorf("connection refused: %w", io.EOF)
-		fsmLogger.SentryError(deps.FeatureFSMv2, "app(application)/w1(helloworld)", testErr, "action_failed",
+		fsmLogger.Sentry(telemetry.Supervisor.Action.Failed, deps.FeatureFSMv2, "app(application)/w1(helloworld)", testErr,
 			deps.ActionName("connect"))
 
 		Eventually(func() int {
@@ -1343,12 +1378,12 @@ var _ = Describe("FSMLogger to Sentry Event Mapping", func() {
 
 		event := store.GetLast()
 		Expect(event.Exception).NotTo(BeEmpty())
-		Expect(event.Exception[0].Type).To(Equal("action_failed"))
+		Expect(event.Exception[0].Type).To(Equal("supervisor::action::failed"))
 		Expect(event.Exception[0].Value).To(ContainSubstring("connection refused"))
 	})
 
 	It("SentryError sets feature tag", func() {
-		fsmLogger.SentryError(deps.FeatureFSMv2, "", io.EOF, "action_failed")
+		fsmLogger.Sentry(telemetry.Supervisor.Action.Failed, deps.FeatureFSMv2, "", io.EOF)
 
 		Eventually(func() int {
 			return store.Len()
@@ -1359,20 +1394,20 @@ var _ = Describe("FSMLogger to Sentry Event Mapping", func() {
 	})
 
 	It("SentryError sets event_name tag from message", func() {
-		fsmLogger.SentryError(deps.FeatureFSMv2, "", io.EOF, "action_failed")
+		fsmLogger.Sentry(telemetry.Supervisor.Action.Failed, deps.FeatureFSMv2, "", io.EOF)
 
 		Eventually(func() int {
 			return store.Len()
 		}, time.Second, 10*time.Millisecond).Should(BeNumerically(">=", 1))
 
 		event := store.GetLast()
-		Expect(event.Tags["event_name"]).To(Equal("action_failed"))
+		Expect(event.Tags["event_name"]).To(Equal("supervisor::action::failed"))
 	})
 
 	It("SentryError extracts error types from wrapped chain", func() {
 		rootErr := errors.New("root cause")
 		wrapped := fmt.Errorf("layer: %w", rootErr)
-		fsmLogger.SentryError(deps.FeatureFSMv2, "", wrapped, "action_failed")
+		fsmLogger.Sentry(telemetry.Supervisor.Action.Failed, deps.FeatureFSMv2, "", wrapped)
 
 		Eventually(func() int {
 			return store.Len()
@@ -1384,7 +1419,7 @@ var _ = Describe("FSMLogger to Sentry Event Mapping", func() {
 	})
 
 	It("SentryError with hierarchy_path derives fsm_version, worker_type, and worker_chain", func() {
-		fsmLogger.SentryError(deps.FeatureForWorker("communicator"), "app(application)/worker(communicator)", io.EOF, "action_failed")
+		fsmLogger.Sentry(telemetry.Supervisor.Action.Failed, deps.FeatureForWorker("communicator"), "app(application)/worker(communicator)", io.EOF)
 
 		Eventually(func() int {
 			return store.Len()
@@ -1397,8 +1432,12 @@ var _ = Describe("FSMLogger to Sentry Event Mapping", func() {
 		Expect(event.Tags["worker_chain"]).To(Equal("application/communicator"))
 	})
 
-	It("SentryWarn captures at warn level without exception", func() {
-		fsmLogger.SentryWarn(deps.FeatureFSMv2, "", "collector_unresponsive",
+	It("captures a warning-severity identifier at warn level, with the brief as its exception", func() {
+		// A warn-level event used to arrive with no exception at all, which left
+		// the issue with a title and nothing under it. The brief is synthesized
+		// into the error so there is always a readable sentence; the level and
+		// the tag are unchanged.
+		fsmLogger.Sentry(telemetry.Identifier{Tag: "collector_unresponsive", Brief: "A collector stopped answering.", Severity: telemetry.SeverityWarning}, deps.FeatureFSMv2, "", nil,
 			deps.Attempts(3))
 
 		Eventually(func() int {
@@ -1407,14 +1446,16 @@ var _ = Describe("FSMLogger to Sentry Event Mapping", func() {
 
 		event := store.GetLast()
 		Expect(event.Level).To(Equal(sentrygo.LevelWarning))
-		Expect(event.Exception).To(BeEmpty())
 		Expect(event.Tags["feature"]).To(Equal("fsmv2"))
 		Expect(event.Tags["event_name"]).To(Equal("collector_unresponsive"))
+		Expect(event.Exception).To(HaveLen(1))
+		Expect(event.Exception[0].Type).To(Equal("collector_unresponsive"))
+		Expect(event.Exception[0].Value).To(Equal("A collector stopped answering."))
 	})
 
 	It("With() context is preserved through FSMLogger", func() {
 		scoped := fsmLogger.With(deps.WorkerID("test-worker"))
-		scoped.SentryError(deps.FeatureFSMv2, "", io.EOF, "worker_failed")
+		scoped.Sentry(telemetry.Identifier{Tag: "worker_failed", Brief: "worker_failed", Severity: telemetry.SeverityError}, deps.FeatureFSMv2, "", io.EOF)
 
 		Eventually(func() int {
 			return store.Len()
@@ -1427,8 +1468,7 @@ var _ = Describe("FSMLogger to Sentry Event Mapping", func() {
 	It("SentryWarn with deps.Err still extracts typed error into Exception", func() {
 		// deps.Err() creates a typed error field that zap preserves as ErrorType.
 		// ExtractErrorFromFields finds it, so even SentryWarn produces an Exception.
-		fsmLogger.SentryWarn(deps.FeatureFSMv2, "", "shutdown_failed",
-			deps.Err(errors.New("connection reset")))
+		fsmLogger.Sentry(telemetry.Identifier{Tag: "shutdown_failed", Brief: "shutdown_failed", Severity: telemetry.SeverityWarning}, deps.FeatureFSMv2, "", errors.New("connection reset"))
 
 		Eventually(func() int {
 			return store.Len()
@@ -1440,7 +1480,7 @@ var _ = Describe("FSMLogger to Sentry Event Mapping", func() {
 	})
 
 	It("SentryError with extra fields captures them in Contexts", func() {
-		fsmLogger.SentryError(deps.FeatureFSMv2, "", io.EOF, "action_failed",
+		fsmLogger.Sentry(telemetry.Supervisor.Action.Failed, deps.FeatureFSMv2, "", io.EOF,
 			deps.Attempts(3), deps.String("reason", "timeout"))
 
 		Eventually(func() int {

--- a/umh-core/pkg/fsmv2/supervisor/api.go
+++ b/umh-core/pkg/fsmv2/supervisor/api.go
@@ -28,6 +28,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/supervisor/internal/execution"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/supervisor/metrics"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/persistence"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/telemetry"
 )
 
 // AddWorker adds a new worker to the supervisor's registry.
@@ -57,7 +58,7 @@ func (s *Supervisor[TObserved, TDesired]) AddWorker(identity deps.Identity, work
 	defer s.mu.Unlock()
 
 	if _, exists := s.workers[identity.ID]; exists {
-		s.logger.SentryWarn(deps.FeatureFSMv2, identity.HierarchyPath, "worker_add_rejected",
+		s.logger.Sentry(telemetry.Supervisor.Worker.AddRejected, deps.FeatureFSMv2, identity.HierarchyPath, nil,
 			deps.Reason("already_exists"))
 
 		return errors.New("worker already exists")
@@ -86,20 +87,19 @@ func (s *Supervisor[TObserved, TDesired]) AddWorker(identity deps.Identity, work
 		// reconciliation cycle. Hard errors (parse failures, type mismatches, YAML
 		// validation issues) are NOT wrapped with ErrVariablesNotPropagated and bubble
 		// up below so they don't get silently swallowed at startup.
-		s.logger.SentryWarn(deps.FeatureFSMv2, identity.HierarchyPath, "worker_add_derive_desired_fallback_to_nil",
-			deps.Err(err))
+		s.logger.Sentry(telemetry.Supervisor.Worker.AddDeriveDesiredFallbackToNil, deps.FeatureFSMv2, identity.HierarchyPath, err)
 		initialDesired, err = worker.DeriveDesiredState(nil)
 	}
 
 	if err != nil {
-		s.logger.SentryError(deps.FeatureFSMv2, identity.HierarchyPath, err, "worker_add_derive_desired_failed")
+		s.logger.Sentry(telemetry.Supervisor.Worker.AddDeriveDesiredFailed, deps.FeatureFSMv2, identity.HierarchyPath, err)
 
 		return fmt.Errorf("failed to derive initial desired state: %w", err)
 	}
 
 	observed, err := worker.CollectObservedState(ctx, initialDesired)
 	if err != nil {
-		s.logger.SentryError(deps.FeatureFSMv2, identity.HierarchyPath, err, "worker_add_collect_observed_failed")
+		s.logger.Sentry(telemetry.Supervisor.Worker.AddCollectObservedFailed, deps.FeatureFSMv2, identity.HierarchyPath, err)
 
 		return fmt.Errorf("failed to collect initial observed state: %w", err)
 	}
@@ -113,8 +113,7 @@ func (s *Supervisor[TObserved, TDesired]) AddWorker(identity deps.Identity, work
 		}); ok {
 			observed = setter.SetCollectedAt(time.Now())
 		} else {
-			s.logger.SentryWarn(deps.FeatureFSMv2, identity.HierarchyPath,
-				"worker_add_zero_timestamp_not_settable",
+			s.logger.Sentry(telemetry.Supervisor.Worker.AddZeroTimestampNotSettable, deps.FeatureFSMv2, identity.HierarchyPath, nil,
 				deps.String("type", fmt.Sprintf("%T", observed)))
 		}
 	}
@@ -126,7 +125,7 @@ func (s *Supervisor[TObserved, TDesired]) AddWorker(identity deps.Identity, work
 		"hierarchy_path": identity.HierarchyPath,
 	}
 	if err := s.store.SaveIdentity(ctx, s.workerType, identity.ID, identityDoc); err != nil {
-		s.logger.SentryError(deps.FeatureFSMv2, identity.HierarchyPath, err, "worker_add_save_identity_failed")
+		s.logger.Sentry(telemetry.Supervisor.Worker.AddSaveIdentityFailed, deps.FeatureFSMv2, identity.HierarchyPath, err)
 
 		return fmt.Errorf("failed to save identity: %w", err)
 	}
@@ -135,14 +134,14 @@ func (s *Supervisor[TObserved, TDesired]) AddWorker(identity deps.Identity, work
 
 	observedJSON, err := json.Marshal(observed)
 	if err != nil {
-		s.logger.SentryError(deps.FeatureFSMv2, identity.HierarchyPath, err, "worker_add_marshal_observed_failed")
+		s.logger.Sentry(telemetry.Supervisor.Worker.AddMarshalObservedFailed, deps.FeatureFSMv2, identity.HierarchyPath, err)
 
 		return fmt.Errorf("failed to marshal observed state: %w", err)
 	}
 
 	observedDoc := make(persistence.Document)
 	if err := json.Unmarshal(observedJSON, &observedDoc); err != nil {
-		s.logger.SentryError(deps.FeatureFSMv2, identity.HierarchyPath, err, "worker_add_unmarshal_observed_failed")
+		s.logger.Sentry(telemetry.Supervisor.Worker.AddUnmarshalObservedFailed, deps.FeatureFSMv2, identity.HierarchyPath, err)
 
 		return fmt.Errorf("failed to unmarshal observed state to document: %w", err)
 	}
@@ -163,7 +162,7 @@ func (s *Supervisor[TObserved, TDesired]) AddWorker(identity deps.Identity, work
 
 	_, err = s.store.SaveObserved(ctx, s.workerType, identity.ID, observedDoc)
 	if err != nil {
-		s.logger.SentryError(deps.FeatureFSMv2, identity.HierarchyPath, err, "worker_add_save_observed_failed")
+		s.logger.Sentry(telemetry.Supervisor.Worker.AddSaveObservedFailed, deps.FeatureFSMv2, identity.HierarchyPath, err)
 
 		return fmt.Errorf("failed to save initial observation: %w", err)
 	}
@@ -172,14 +171,14 @@ func (s *Supervisor[TObserved, TDesired]) AddWorker(identity deps.Identity, work
 
 	desiredJSON, err := json.Marshal(initialDesired)
 	if err != nil {
-		s.logger.SentryError(deps.FeatureFSMv2, identity.HierarchyPath, err, "worker_add_marshal_desired_failed")
+		s.logger.Sentry(telemetry.Supervisor.Worker.AddMarshalDesiredFailed, deps.FeatureFSMv2, identity.HierarchyPath, err)
 
 		return fmt.Errorf("failed to marshal desired state: %w", err)
 	}
 
 	desiredDoc := make(persistence.Document)
 	if err := json.Unmarshal(desiredJSON, &desiredDoc); err != nil {
-		s.logger.SentryError(deps.FeatureFSMv2, identity.HierarchyPath, err, "worker_add_unmarshal_desired_failed")
+		s.logger.Sentry(telemetry.Supervisor.Worker.AddUnmarshalDesiredFailed, deps.FeatureFSMv2, identity.HierarchyPath, err)
 
 		return fmt.Errorf("failed to unmarshal desired state to document: %w", err)
 	}
@@ -188,7 +187,7 @@ func (s *Supervisor[TObserved, TDesired]) AddWorker(identity deps.Identity, work
 
 	_, err = s.store.SaveDesired(ctx, s.workerType, identity.ID, desiredDoc)
 	if err != nil {
-		s.logger.SentryError(deps.FeatureFSMv2, identity.HierarchyPath, err, "worker_add_save_desired_failed")
+		s.logger.Sentry(telemetry.Supervisor.Worker.AddSaveDesiredFailed, deps.FeatureFSMv2, identity.HierarchyPath, err)
 
 		return fmt.Errorf("failed to save initial desired state: %w", err)
 	}
@@ -236,8 +235,7 @@ func (s *Supervisor[TObserved, TDesired]) AddWorker(identity deps.Identity, work
 
 			var desired TDesired
 			if err := s.store.LoadDesiredTyped(ctx, s.workerType, identity.ID, &desired); err != nil {
-				s.logger.SentryWarn(deps.FeatureFSMv2, identity.HierarchyPath, "shutdown_requested_load_failed",
-					deps.Err(err))
+				s.logger.Sentry(telemetry.Supervisor.Shutdown.RequestedLoadFailed, deps.FeatureFSMv2, identity.HierarchyPath, err)
 
 				return true
 			}
@@ -356,8 +354,7 @@ func (s *Supervisor[TObserved, TDesired]) AddWorker(identity deps.Identity, work
 					return nil, fsmv2.ErrNoDesiredState
 				}
 
-				s.logger.SentryWarn(deps.FeatureFSMv2, identity.HierarchyPath, "desired_state_load_failed",
-					deps.Err(err))
+				s.logger.Sentry(telemetry.Supervisor.DesiredState.LoadFailedOnCollect, deps.FeatureFSMv2, identity.HierarchyPath, err)
 
 				return nil, err
 			}
@@ -459,7 +456,7 @@ func (s *Supervisor[TObserved, TDesired]) RemoveWorker(ctx context.Context, work
 	if !exists {
 		s.mu.Unlock()
 
-		s.logger.SentryWarn(deps.FeatureFSMv2, hierarchyPath, "worker_remove_not_found",
+		s.logger.Sentry(telemetry.Supervisor.Worker.RemoveNotFound, deps.FeatureFSMv2, hierarchyPath, nil,
 			deps.String("target_worker_id", workerID))
 
 		return errors.New("worker not found")

--- a/umh-core/pkg/fsmv2/supervisor/drain_budget_cascade_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/drain_budget_cascade_test.go
@@ -327,7 +327,7 @@ var _ = Describe("Graceful drain budget cascading (CLAUDE.md §Graceful Shutdown
 		// Assertion 1: an in-progress graceful drain must not be truncated.
 		// Under a flat budget the mid level WOULD arm 1×base while its worker
 		// needs 1.1×base, so graceful_shutdown_timeout would fire spuriously.
-		Expect(containsLogEvent(logOutput, "graceful_shutdown_timeout")).To(BeFalse(),
+		Expect(containsLogEvent(logOutput, "supervisor::shutdown::timeout")).To(BeFalse(),
 			"graceful_shutdown_timeout was logged: a level armed a flat %v budget instead of the cascaded "+
 				"height-based budget, truncating a drain that still needed 0.1×base to emit SignalNeedsRemoval", cascadeDrainBase)
 
@@ -425,7 +425,7 @@ var _ = Describe("Graceful drain budget cascading (CLAUDE.md §Graceful Shutdown
 		// own drain starts), then the root with 3×base. Any further entry —
 		// a leaf warn (1×base) or a duplicate — is a spurious warn: a level
 		// armed a flat 1×base budget instead of its cascaded one.
-		warns := findLogEvents(logOutput, "graceful_shutdown_timeout")
+		warns := findLogEvents(logOutput, "supervisor::shutdown::timeout")
 		Expect(warns).To(HaveLen(2),
 			"expected exactly two graceful_shutdown_timeout warns (stuck mid, stuck root), got %d: %v", len(warns), warns)
 		Expect(warns[0]["timeout"]).To(Equal((2 * cascadeTruncationBase).String()),
@@ -537,7 +537,7 @@ var _ = Describe("Graceful drain budget cascading (CLAUDE.md §Graceful Shutdown
 		// by fingerprint, not by reading fields. The mids drain in
 		// map-iteration order, but they are identical, so both timeout
 		// entries carry 2×base.
-		warns := findLogEvents(logOutput, "graceful_shutdown_timeout")
+		warns := findLogEvents(logOutput, "supervisor::shutdown::timeout")
 		Expect(warns).To(HaveLen(2),
 			"expected exactly two graceful_shutdown_timeout warns (the two stuck mids), got %d: %v", len(warns), warns)
 		Expect(warns[0]["timeout"]).To(Equal((2 * cascadeTruncationBase).String()),
@@ -545,7 +545,7 @@ var _ = Describe("Graceful drain budget cascading (CLAUDE.md §Graceful Shutdown
 		Expect(warns[1]["timeout"]).To(Equal((2 * cascadeTruncationBase).String()),
 			"expected the second warn to carry a mid level's cascaded budget (2×base)")
 
-		exhausted := findLogEvents(logOutput, "graceful_shutdown_budget_exhausted")
+		exhausted := findLogEvents(logOutput, "supervisor::shutdown::budget_exhausted")
 		Expect(exhausted).To(HaveLen(1),
 			"expected exactly one graceful_shutdown_budget_exhausted warn (the pre-spent root), got %d: %v", len(exhausted), exhausted)
 
@@ -656,11 +656,11 @@ var _ = Describe("Graceful drain budget cascading (CLAUDE.md §Graceful Shutdown
 		// stuck — those three warn graceful_shutdown_timeout. The zero-worker
 		// root's 2×base budget was spent entirely by its children, so it
 		// warns the distinct graceful_shutdown_budget_exhausted event.
-		warns := findLogEvents(logOutput, "graceful_shutdown_timeout")
+		warns := findLogEvents(logOutput, "supervisor::shutdown::timeout")
 		Expect(warns).To(HaveLen(3),
 			"expected exactly three graceful_shutdown_timeout warns (the three stuck children), got %d: %v", len(warns), warns)
 
-		exhausted := findLogEvents(logOutput, "graceful_shutdown_budget_exhausted")
+		exhausted := findLogEvents(logOutput, "supervisor::shutdown::budget_exhausted")
 		Expect(exhausted).To(HaveLen(1),
 			"expected exactly one graceful_shutdown_budget_exhausted warn (the zero-worker root), got %d: %v", len(exhausted), exhausted)
 
@@ -765,9 +765,9 @@ var _ = Describe("Graceful drain budget cascading (CLAUDE.md §Graceful Shutdown
 
 		logOutput := buf.String()
 
-		Expect(findLogEvents(logOutput, "graceful_shutdown_timeout")).To(BeEmpty(),
+		Expect(findLogEvents(logOutput, "supervisor::shutdown::timeout")).To(BeEmpty(),
 			"graceful_shutdown_timeout was logged: a zero-worker level whose child drained within budget must exit warn-free")
-		Expect(findLogEvents(logOutput, "graceful_shutdown_budget_exhausted")).To(BeEmpty(),
+		Expect(findLogEvents(logOutput, "supervisor::shutdown::budget_exhausted")).To(BeEmpty(),
 			"graceful_shutdown_budget_exhausted was logged: the child's prompt drain left budget to spare, so the exhaustion warn fired on a non-exhausted budget")
 	})
 })

--- a/umh-core/pkg/fsmv2/supervisor/drain_outcome_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/drain_outcome_test.go
@@ -97,7 +97,7 @@ var _ = Describe("DrainOutcomeClean (ENG-4971 structured drain-outcome signal)",
 		// Pin the flag to the real timeout signal: the warn must have fired,
 		// so DrainOutcomeClean=false reflects an actual unclean drain, not a
 		// coincidental default.
-		Expect(findLogEvents(logOutput, "graceful_shutdown_timeout")).ToNot(BeEmpty(),
+		Expect(findLogEvents(logOutput, "supervisor::shutdown::timeout")).ToNot(BeEmpty(),
 			"expected graceful_shutdown_timeout to be logged for a worker that ignores shutdown")
 
 		Expect(root.DrainOutcomeClean()).To(BeFalse(),
@@ -156,7 +156,7 @@ var _ = Describe("DrainOutcomeClean (ENG-4971 structured drain-outcome signal)",
 
 		logOutput := buf.String()
 
-		Expect(findLogEvents(logOutput, "graceful_shutdown_timeout")).To(BeEmpty(),
+		Expect(findLogEvents(logOutput, "supervisor::shutdown::timeout")).To(BeEmpty(),
 			"a worker that honors shutdown must drain warn-free")
 
 		Expect(root.DrainOutcomeClean()).To(BeTrue(),
@@ -193,7 +193,7 @@ var _ = Describe("DrainOutcomeClean (ENG-4971 structured drain-outcome signal)",
 		// the slack absorbs: no warn, drain stays clean.
 		root.TestRecordPostJoinBudgetOverrun(budget+supervisor.TestDrainTickInterval()/2, budget, 0, false)
 
-		Expect(findLogEvents(buf.String(), "graceful_shutdown_budget_exhausted")).To(BeEmpty(),
+		Expect(findLogEvents(buf.String(), "supervisor::shutdown::budget_exhausted")).To(BeEmpty(),
 			"post-join overhead within drainBudget+slack must not fire graceful_shutdown_budget_exhausted")
 		Expect(root.DrainOutcomeClean()).To(BeTrue(),
 			"a drain whose total elapsed lands inside drainBudget+slack must report clean")
@@ -205,7 +205,7 @@ var _ = Describe("DrainOutcomeClean (ENG-4971 structured drain-outcome signal)",
 		// A genuine overrun, larger than any plausible join overhead, still warns.
 		root.TestRecordPostJoinBudgetOverrun(budget+2*supervisor.TestDrainTickInterval(), budget, 0, false)
 
-		Expect(findLogEvents(buf.String(), "graceful_shutdown_budget_exhausted")).ToNot(BeEmpty(),
+		Expect(findLogEvents(buf.String(), "supervisor::shutdown::budget_exhausted")).ToNot(BeEmpty(),
 			"an overrun beyond drainBudget+slack must fire graceful_shutdown_budget_exhausted")
 		Expect(root.DrainOutcomeClean()).To(BeFalse(),
 			"an overrun beyond the slack must report not-clean")
@@ -218,7 +218,7 @@ var _ = Describe("DrainOutcomeClean (ENG-4971 structured drain-outcome signal)",
 		// graceful_shutdown_timeout in the drain loop does not double-report here.
 		root.TestRecordPostJoinBudgetOverrun(budget+2*supervisor.TestDrainTickInterval(), budget, 0, true)
 
-		Expect(findLogEvents(buf.String(), "graceful_shutdown_budget_exhausted")).To(BeEmpty(),
+		Expect(findLogEvents(buf.String(), "supervisor::shutdown::budget_exhausted")).To(BeEmpty(),
 			"a prior drain-phase warn must short-circuit the post-join re-check")
 	})
 })

--- a/umh-core/pkg/fsmv2/supervisor/internal/collection/collector.go
+++ b/umh-core/pkg/fsmv2/supervisor/internal/collection/collector.go
@@ -30,6 +30,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/supervisor/internal/panicutil"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/supervisor/metrics"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/persistence"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/telemetry"
 )
 
 type collectorState int
@@ -173,7 +174,7 @@ func (c *Collector[TObserved]) TriggerNow() {
 	c.mu.RUnlock()
 
 	if !running {
-		c.config.Logger.SentryWarn(deps.FeatureForWorker(c.config.Identity.WorkerType), c.config.Identity.HierarchyPath, "collector_trigger_now_failed",
+		c.config.Logger.Sentry(telemetry.Supervisor.Collector.TriggerNowFailed, deps.FeatureForWorker(c.config.Identity.WorkerType), c.config.Identity.HierarchyPath, nil,
 			deps.Reason("not_running"),
 			deps.String("current_state", c.state.String()))
 
@@ -200,7 +201,7 @@ func (c *Collector[TObserved]) Restart() {
 	c.mu.RUnlock()
 
 	if !running {
-		c.config.Logger.SentryWarn(deps.FeatureForWorker(c.config.Identity.WorkerType), c.config.Identity.HierarchyPath, "collector_restart_failed",
+		c.config.Logger.Sentry(telemetry.Supervisor.Collector.RestartSkippedNotRunning, deps.FeatureForWorker(c.config.Identity.WorkerType), c.config.Identity.HierarchyPath, nil,
 			deps.Reason("not_running"),
 			deps.String("current_state", c.state.String()))
 
@@ -226,12 +227,12 @@ func (c *Collector[TObserved]) Restart() {
 	// Error handling preserved for future extensibility (e.g., context validation, resource allocation).
 	if parentCtx != nil {
 		if err := c.Start(parentCtx); err != nil {
-			c.config.Logger.SentryError(deps.FeatureForWorker(c.config.Identity.WorkerType), c.config.Identity.HierarchyPath, err, "collector_restart_start_failed")
+			c.config.Logger.Sentry(telemetry.Supervisor.Collector.RestartStartFailed, deps.FeatureForWorker(c.config.Identity.WorkerType), c.config.Identity.HierarchyPath, err)
 		} else {
 			c.config.Logger.Info("collector_restart_complete")
 		}
 	} else {
-		c.config.Logger.SentryError(deps.FeatureForWorker(c.config.Identity.WorkerType), c.config.Identity.HierarchyPath, errors.New("no_parent_context"), "collector_restart_failed")
+		c.config.Logger.Sentry(telemetry.Supervisor.Collector.RestartNoParentContext, deps.FeatureForWorker(c.config.Identity.WorkerType), c.config.Identity.HierarchyPath, errors.New("no_parent_context"))
 	}
 }
 
@@ -261,7 +262,7 @@ func (c *Collector[TObserved]) Stop(ctx context.Context) {
 
 	select {
 	case <-doneChan:
-		c.config.Logger.Debug("collector_stopped",
+		c.config.Logger.Debug(telemetry.Supervisor.Collector.Stopped.Tag,
 			deps.String("result", "success"))
 	case <-ctx.Done():
 		// Phase-4 teardown cancels this ctx and races the collector goroutine's
@@ -270,14 +271,14 @@ func (c *Collector[TObserved]) Stop(ctx context.Context) {
 		// at Debug. A non-cancellation ctx error would be unexpected and stays a
 		// warn.
 		if errors.Is(ctx.Err(), context.Canceled) {
-			c.config.Logger.Debug("collector_stopped",
+			c.config.Logger.Debug(telemetry.Supervisor.Collector.Stopped.Tag,
 				deps.String("result", "context_cancelled"))
 		} else {
-			c.config.Logger.SentryWarn(deps.FeatureForWorker(c.config.Identity.WorkerType), c.config.Identity.HierarchyPath, "collector_stopped",
+			c.config.Logger.Sentry(telemetry.Supervisor.Collector.Stopped, deps.FeatureForWorker(c.config.Identity.WorkerType), c.config.Identity.HierarchyPath, nil,
 				deps.String("result", "context_cancelled"))
 		}
 	case <-stopTimer.C:
-		c.config.Logger.SentryWarn(deps.FeatureForWorker(c.config.Identity.WorkerType), c.config.Identity.HierarchyPath, "collector_stopped",
+		c.config.Logger.Sentry(telemetry.Supervisor.Collector.Stopped, deps.FeatureForWorker(c.config.Identity.WorkerType), c.config.Identity.HierarchyPath, nil,
 			deps.String("result", "timeout"))
 	}
 }
@@ -296,7 +297,7 @@ func (c *Collector[TObserved]) CollectFinalObservation(ctx context.Context) erro
 		currentState := c.state.String()
 		c.mu.RUnlock()
 
-		c.config.Logger.SentryWarn(deps.FeatureForWorker(c.config.Identity.WorkerType), c.config.Identity.HierarchyPath, "collector_final_observation_skipped",
+		c.config.Logger.Sentry(telemetry.Supervisor.Collector.FinalObservationSkipped, deps.FeatureForWorker(c.config.Identity.WorkerType), c.config.Identity.HierarchyPath, nil,
 			deps.Reason("not_running"),
 			deps.String("current_state", currentState))
 
@@ -324,11 +325,12 @@ func (c *Collector[TObserved]) CollectFinalObservation(ctx context.Context) erro
 		// notably context.DeadlineExceeded means the collection overran
 		// ObservationTimeout (a genuinely stuck collector), which must stay visible.
 		if errors.Is(err, context.Canceled) {
-			c.config.Logger.Debug("collector_final_observation_failed",
+			// Tag, not a literal: both branches report the same event, and only
+			// the level differs.
+			c.config.Logger.Debug(telemetry.Supervisor.Collector.FinalObservationFailed.Tag,
 				deps.Err(err))
 		} else {
-			c.config.Logger.SentryWarn(deps.FeatureForWorker(c.config.Identity.WorkerType), c.config.Identity.HierarchyPath, "collector_final_observation_failed",
-				deps.Err(err))
+			c.config.Logger.Sentry(telemetry.Supervisor.Collector.FinalObservationFailed, deps.FeatureForWorker(c.config.Identity.WorkerType), c.config.Identity.HierarchyPath, err)
 		}
 
 		return err
@@ -384,7 +386,7 @@ func (c *Collector[TObserved]) observationLoop() {
 			c.collectionMu.Unlock()
 
 			if err != nil {
-				c.config.Logger.SentryError(deps.FeatureForWorker(c.config.Identity.WorkerType), c.config.Identity.HierarchyPath, err, "collector_observation_failed",
+				c.config.Logger.Sentry(telemetry.Supervisor.Collector.ObservationFailed, deps.FeatureForWorker(c.config.Identity.WorkerType), c.config.Identity.HierarchyPath, err,
 					deps.String("trigger", "restart"))
 			}
 
@@ -398,7 +400,7 @@ func (c *Collector[TObserved]) observationLoop() {
 			c.collectionMu.Unlock()
 
 			if err != nil {
-				c.config.Logger.SentryError(deps.FeatureForWorker(c.config.Identity.WorkerType), c.config.Identity.HierarchyPath, err, "collector_observation_failed",
+				c.config.Logger.Sentry(telemetry.Supervisor.Collector.ObservationFailed, deps.FeatureForWorker(c.config.Identity.WorkerType), c.config.Identity.HierarchyPath, err,
 					deps.String("trigger", "ticker"))
 			}
 
@@ -543,7 +545,7 @@ func (c *Collector[TObserved]) collectAndSaveObservedState(ctx context.Context) 
 	observedTyped, ok := observed.(TObserved)
 	if !ok {
 		err := fmt.Errorf("observed state type mismatch: expected %T, got %T", *new(TObserved), observed)
-		c.config.Logger.SentryError(deps.FeatureForWorker(c.config.Identity.WorkerType), c.config.Identity.HierarchyPath, err, "collector_type_mismatch",
+		c.config.Logger.Sentry(telemetry.Supervisor.Collector.TypeMismatch, deps.FeatureForWorker(c.config.Identity.WorkerType), c.config.Identity.HierarchyPath, err,
 			deps.String("expected_type", fmt.Sprintf("%T", *new(TObserved))),
 			deps.String("actual_type", fmt.Sprintf("%T", observed)))
 
@@ -567,8 +569,7 @@ func (c *Collector[TObserved]) collectAndSaveObservedState(ctx context.Context) 
 
 	changed, err := c.config.Store.SaveObserved(ctx, c.config.Identity.WorkerType, c.config.Identity.ID, observedDoc)
 	if err != nil {
-		c.config.Logger.SentryWarn(deps.FeatureForWorker(c.config.Identity.WorkerType), c.config.Identity.HierarchyPath, "collector_save_failed",
-			deps.Err(err))
+		c.config.Logger.Sentry(telemetry.Supervisor.Collector.SaveFailed, deps.FeatureForWorker(c.config.Identity.WorkerType), c.config.Identity.HierarchyPath, err)
 
 		return err
 	}
@@ -714,7 +715,7 @@ func (c *Collector[TObserved]) handleCollectorPanic(r interface{}) (err error) {
 			func() {
 				defer func() { recover() }() //nolint:errcheck // recover() return value is intentionally unused in safety net
 
-				logger.SentryError(deps.FeatureForWorker(c.config.Identity.WorkerType), hierarchyPath, err, "collector_double_panic",
+				logger.Sentry(telemetry.Supervisor.Collector.DoublePanic, deps.FeatureForWorker(c.config.Identity.WorkerType), hierarchyPath, err,
 					deps.String("stack", string(debug.Stack())))
 			}()
 		}
@@ -725,7 +726,7 @@ func (c *Collector[TObserved]) handleCollectorPanic(r interface{}) (err error) {
 
 	metrics.RecordPanicRecovery(hierarchyPath, panicType)
 
-	logger.SentryError(deps.FeatureForWorker(c.config.Identity.WorkerType), hierarchyPath, err, "collector_panic",
+	logger.Sentry(telemetry.Supervisor.Collector.Panic, deps.FeatureForWorker(c.config.Identity.WorkerType), hierarchyPath, err,
 		deps.Field{Key: "panic_value", Value: fmt.Sprintf("%v", r)},
 		deps.Field{Key: "panic_type", Value: panicType},
 		deps.Field{Key: "stack_trace", Value: string(debug.Stack())})

--- a/umh-core/pkg/fsmv2/supervisor/internal/collection/collector_logseverity_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/internal/collection/collector_logseverity_test.go
@@ -65,14 +65,6 @@ func (l *severityCapturingLogger) Sentry(id telemetry.Identifier, _ deps.Feature
 	l.record("sentryerror", id.Tag)
 }
 
-func (l *severityCapturingLogger) SentryWarn(_ deps.Feature, _ string, msg string, _ ...deps.Field) {
-	l.record("sentrywarn", msg)
-}
-
-func (l *severityCapturingLogger) SentryError(_ deps.Feature, _ string, _ error, msg string, _ ...deps.Field) {
-	l.record("sentryerror", msg)
-}
-
 func (l *severityCapturingLogger) With(_ ...deps.Field) deps.FSMLogger { return l }
 
 // levelFor returns the level the given message was logged at, or "" if it was
@@ -188,9 +180,9 @@ var _ = Describe("Collector log severity", func() {
 			err := collector.CollectFinalObservation(expiredCtx)
 			Expect(err).To(MatchError(context.DeadlineExceeded))
 
-			Expect(logger.levelFor("collector_final_observation_failed")).To(Equal("sentrywarn"),
+			Expect(logger.levelFor("supervisor::collector::final_observation_failed")).To(Equal("sentrywarn"),
 				"a DeadlineExceeded final observation is a genuinely stuck collector and must stay visible in Sentry, not Debug")
-			Expect(logger.has("debug", "collector_final_observation_failed")).To(BeFalse(),
+			Expect(logger.has("debug", "supervisor::collector::final_observation_failed")).To(BeFalse(),
 				"only context.Canceled (the shutdown race) is downgraded to Debug; DeadlineExceeded must not be")
 		})
 
@@ -226,9 +218,9 @@ var _ = Describe("Collector log severity", func() {
 			err := collector.CollectFinalObservation(cancelledCtx)
 			Expect(err).To(MatchError(context.Canceled))
 
-			Expect(logger.levelFor("collector_final_observation_failed")).To(Equal("debug"),
+			Expect(logger.levelFor("supervisor::collector::final_observation_failed")).To(Equal("debug"),
 				"context.Canceled is the benign shutdown race and must be downgraded to Debug")
-			Expect(logger.has("sentrywarn", "collector_final_observation_failed")).To(BeFalse(),
+			Expect(logger.has("sentrywarn", "supervisor::collector::final_observation_failed")).To(BeFalse(),
 				"context.Canceled must not raise a SentryWarn (that would re-noise Sentry on clean shutdown)")
 		})
 	})

--- a/umh-core/pkg/fsmv2/supervisor/internal/collection/collector_panic_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/internal/collection/collector_panic_test.go
@@ -82,7 +82,7 @@ var _ = Describe("Collector Panic Recovery", func() {
 				"Collector should still be running after panic recovery")
 
 			// Verify panic was logged
-			panicLogs := filterCollectorLogs(observedLogs, "collector_panic")
+			panicLogs := filterCollectorLogs(observedLogs, "supervisor::collector::panic")
 			Expect(panicLogs).ToNot(BeEmpty(), "Expected collector_panic log entry")
 
 			cancel()
@@ -126,7 +126,7 @@ var _ = Describe("Collector Panic Recovery", func() {
 
 			time.Sleep(200 * time.Millisecond)
 
-			panicLogs := filterCollectorLogs(observedLogs, "collector_panic")
+			panicLogs := filterCollectorLogs(observedLogs, "supervisor::collector::panic")
 			Expect(panicLogs).ToNot(BeEmpty())
 
 			panicLog := panicLogs[0]
@@ -177,7 +177,7 @@ var _ = Describe("Collector Panic Type Classification", func() {
 
 		time.Sleep(200 * time.Millisecond)
 
-		panicLogs := filterCollectorLogs(observedLogs, "collector_panic")
+		panicLogs := filterCollectorLogs(observedLogs, "supervisor::collector::panic")
 		Expect(panicLogs).ToNot(BeEmpty())
 
 		panicLog := panicLogs[0]
@@ -224,7 +224,7 @@ var _ = Describe("Collector Panic Type Classification", func() {
 
 		time.Sleep(200 * time.Millisecond)
 
-		panicLogs := filterCollectorLogs(observedLogs, "collector_panic")
+		panicLogs := filterCollectorLogs(observedLogs, "supervisor::collector::panic")
 		Expect(panicLogs).ToNot(BeEmpty())
 
 		panicLog := panicLogs[0]
@@ -299,8 +299,6 @@ func (p *panicOnSentryErrorCollectorLogger) Sentry(id telemetry.Identifier, _ de
 	}
 }
 
-func (p *panicOnSentryErrorCollectorLogger) SentryWarn(_ deps.Feature, _ string, _ string, _ ...deps.Field) {
-}
 func (p *panicOnSentryErrorCollectorLogger) SentryError(_ deps.Feature, _ string, _ error, _ string, _ ...deps.Field) {
 	if !p.panicked.Load() {
 		p.panicked.Store(true)

--- a/umh-core/pkg/fsmv2/supervisor/internal/execution/action_executor.go
+++ b/umh-core/pkg/fsmv2/supervisor/internal/execution/action_executor.go
@@ -25,6 +25,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/supervisor/metrics"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/telemetry"
 )
 
 const (
@@ -179,7 +180,7 @@ func (ae *ActionExecutor) executeWorkWithRecovery(ctx context.Context, work acti
 			err = fmt.Errorf("action panicked: %v", r)
 			status = "panic"
 
-			ae.logger.SentryError(deps.FeatureForWorker(ae.identity.WorkerType), ae.identity.HierarchyPath, err, "action_panic",
+			ae.logger.Sentry(telemetry.Supervisor.Action.Panic, deps.FeatureForWorker(ae.identity.WorkerType), ae.identity.HierarchyPath, err,
 				deps.CorrelationID(work.actionID),
 				deps.ActionName(work.action.Name()),
 				deps.Int64("timeout_ms", work.timeout.Milliseconds()),
@@ -258,13 +259,13 @@ func (ae *ActionExecutor) executeWorkWithRecovery(ctx context.Context, work acti
 		if errors.Is(err, context.DeadlineExceeded) {
 			metrics.RecordActionTimeout(ae.identity.HierarchyPath, work.action.Name())
 
-			ae.logger.SentryError(deps.FeatureForWorker(ae.identity.WorkerType), ae.identity.HierarchyPath, err, "action_failed",
+			ae.logger.Sentry(telemetry.Supervisor.Action.Failed, deps.FeatureForWorker(ae.identity.WorkerType), ae.identity.HierarchyPath, err,
 				deps.CorrelationID(work.actionID),
 				deps.ActionName(work.action.Name()),
 				deps.DurationMs(duration.Milliseconds()),
 				deps.Int64("timeout_ms", work.timeout.Milliseconds()))
 		} else {
-			ae.logger.SentryError(deps.FeatureForWorker(ae.identity.WorkerType), ae.identity.HierarchyPath, err, "action_failed",
+			ae.logger.Sentry(telemetry.Supervisor.Action.Failed, deps.FeatureForWorker(ae.identity.WorkerType), ae.identity.HierarchyPath, err,
 				deps.CorrelationID(work.actionID),
 				deps.ActionName(work.action.Name()),
 				deps.DurationMs(duration.Milliseconds()))
@@ -288,7 +289,7 @@ func (ae *ActionExecutor) EnqueueAction(actionID string, action fsmv2.Action[any
 		inProgressCount := len(ae.inProgress)
 		ae.mu.Unlock()
 
-		ae.logger.SentryWarn(deps.FeatureForWorker(ae.identity.WorkerType), ae.identity.HierarchyPath, "action_enqueue_rejected",
+		ae.logger.Sentry(telemetry.Supervisor.Action.EnqueueRejected, deps.FeatureForWorker(ae.identity.WorkerType), ae.identity.HierarchyPath, nil,
 			deps.CorrelationID(actionID),
 			deps.ActionName(action.Name()),
 			deps.Reason("executor_stopped"),
@@ -301,7 +302,7 @@ func (ae *ActionExecutor) EnqueueAction(actionID string, action fsmv2.Action[any
 	if _, exists := ae.inProgress[actionID]; exists {
 		ae.mu.Unlock()
 
-		ae.logger.SentryWarn(deps.FeatureForWorker(ae.identity.WorkerType), ae.identity.HierarchyPath, "action_enqueue_rejected",
+		ae.logger.Sentry(telemetry.Supervisor.Action.EnqueueRejected, deps.FeatureForWorker(ae.identity.WorkerType), ae.identity.HierarchyPath, nil,
 			deps.CorrelationID(actionID),
 			deps.ActionName(action.Name()),
 			deps.Reason("already_in_progress"))
@@ -346,7 +347,7 @@ func (ae *ActionExecutor) EnqueueAction(actionID string, action fsmv2.Action[any
 		ae.mu.Unlock()
 
 		queueErr := errors.New("action queue full")
-		ae.logger.SentryError(deps.FeatureForWorker(ae.identity.WorkerType), ae.identity.HierarchyPath, queueErr, "action_queue_full",
+		ae.logger.Sentry(telemetry.Supervisor.Action.QueueFull, deps.FeatureForWorker(ae.identity.WorkerType), ae.identity.HierarchyPath, queueErr,
 			deps.CorrelationID(actionID),
 			deps.ActionName(action.Name()),
 			deps.Capacity(cap(ae.actionQueue)),
@@ -407,7 +408,7 @@ func (ae *ActionExecutor) metricsReporter(ctx context.Context) {
 			for _, stuck := range stuckActions {
 				if stuck.forceRemove {
 					metrics.RecordStuckActionForceRemoved(ae.identity.HierarchyPath, stuck.actionName)
-					ae.logger.SentryError(deps.FeatureForWorker(ae.identity.WorkerType), ae.identity.HierarchyPath, fmt.Errorf("action %s stuck for %dms (timeout %dms), force-removed", stuck.actionName, stuck.elapsedMs, stuck.timeoutMs), "stuck_action_force_removed",
+					ae.logger.Sentry(telemetry.Supervisor.Action.StuckForceRemoved, deps.FeatureForWorker(ae.identity.WorkerType), ae.identity.HierarchyPath, fmt.Errorf("action %s stuck for %dms (timeout %dms), force-removed", stuck.actionName, stuck.elapsedMs, stuck.timeoutMs),
 						deps.Field{Key: "action_id", Value: stuck.actionID},
 						deps.Field{Key: "action_name", Value: stuck.actionName},
 						deps.Field{Key: "elapsed_ms", Value: stuck.elapsedMs},
@@ -424,7 +425,7 @@ func (ae *ActionExecutor) metricsReporter(ctx context.Context) {
 					}
 				} else {
 					metrics.RecordStuckActionDetected(ae.identity.HierarchyPath, stuck.actionName)
-					ae.logger.SentryWarn(deps.FeatureForWorker(ae.identity.WorkerType), ae.identity.HierarchyPath, "stuck_action_detected",
+					ae.logger.Sentry(telemetry.Supervisor.Action.StuckDetected, deps.FeatureForWorker(ae.identity.WorkerType), ae.identity.HierarchyPath, nil,
 						deps.Field{Key: "action_id", Value: stuck.actionID},
 						deps.Field{Key: "action_name", Value: stuck.actionName},
 						deps.Field{Key: "elapsed_ms", Value: stuck.elapsedMs},

--- a/umh-core/pkg/fsmv2/supervisor/internal/execution/stuck_action_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/internal/execution/stuck_action_test.go
@@ -71,7 +71,7 @@ var _ = Describe("Stuck Action Detection", func() {
 			// So by ~400ms the first metrics check after 2x should fire
 			time.Sleep(600 * time.Millisecond)
 
-			stuckLogs := filterStuckActionLogs(observedLogs, "stuck_action_detected")
+			stuckLogs := filterStuckActionLogs(observedLogs, "supervisor::action::stuck_detected")
 			Expect(stuckLogs).ToNot(BeEmpty(), "Expected stuck_action_detected log entry")
 
 			stuckLog := stuckLogs[0]
@@ -112,7 +112,7 @@ var _ = Describe("Stuck Action Detection", func() {
 
 			time.Sleep(500 * time.Millisecond)
 
-			stuckLogs := filterStuckActionLogs(observedLogs, "stuck_action_detected")
+			stuckLogs := filterStuckActionLogs(observedLogs, "supervisor::action::stuck_detected")
 			Expect(stuckLogs).To(BeEmpty(), "No stuck action logs expected for fast action")
 		})
 	})
@@ -159,7 +159,7 @@ var _ = Describe("Stuck Action Force-Removal", func() {
 		Expect(executor.HasActionInProgress("stuck-force")).To(BeFalse(),
 			"Stuck entry should be force-removed after 3x timeout")
 
-		removedLogs := filterStuckActionLogs(observedLogs, "stuck_action_force_removed")
+		removedLogs := filterStuckActionLogs(observedLogs, "supervisor::action::stuck_force_removed")
 		Expect(removedLogs).ToNot(BeEmpty(), "Expected stuck_action_force_removed log entry")
 		removedLog := removedLogs[0]
 		Expect(removedLog.ContextMap()).To(HaveKey("action_name"))
@@ -366,7 +366,7 @@ var _ = Describe("Stuck Action Deduplication", func() {
 		// Metrics fires every 100ms, so after 800ms we'd have ~6 ticks past the threshold
 		time.Sleep(800 * time.Millisecond)
 
-		stuckLogs := filterStuckActionLogs(observedLogs, "stuck_action_detected")
+		stuckLogs := filterStuckActionLogs(observedLogs, "supervisor::action::stuck_detected")
 		Expect(stuckLogs).To(HaveLen(1), "Expected exactly 1 stuck_action_detected log, got %d", len(stuckLogs))
 	})
 
@@ -408,10 +408,10 @@ var _ = Describe("Stuck Action Deduplication", func() {
 		// enqueue (worker must pick up action and add to inProgress map) and
 		// the metrics tick that detects stuck actions.
 		Eventually(func() int {
-			return len(filterStuckActionLogs(observedLogs, "stuck_action_detected"))
+			return len(filterStuckActionLogs(observedLogs, "supervisor::action::stuck_detected"))
 		}, 5*time.Second, 50*time.Millisecond).Should(Equal(2), "Expected exactly 2 stuck_action_detected logs (one per action)")
 
-		stuckLogs := filterStuckActionLogs(observedLogs, "stuck_action_detected")
+		stuckLogs := filterStuckActionLogs(observedLogs, "supervisor::action::stuck_detected")
 		actionNames := map[string]bool{}
 		for _, log := range stuckLogs {
 			name, _ := log.ContextMap()["action_name"].(string)

--- a/umh-core/pkg/fsmv2/supervisor/internal/health/freshness.go
+++ b/umh-core/pkg/fsmv2/supervisor/internal/health/freshness.go
@@ -21,6 +21,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/persistence"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/telemetry"
 )
 
 // FreshnessChecker validates observation data age against thresholds.
@@ -59,7 +60,7 @@ func (f *FreshnessChecker) extractTimestamp(snapshot *fsmv2.Snapshot) (time.Time
 	// Fall back to Document lookup for raw document access
 	doc, ok := snapshot.Observed.(persistence.Document)
 	if !ok {
-		f.logger.SentryWarn(deps.FeatureForWorker(f.workerType), snapshot.Identity.HierarchyPath, "observed_state_type_unknown",
+		f.logger.Sentry(telemetry.Supervisor.ObservedState.TypeUnknown, deps.FeatureForWorker(f.workerType), snapshot.Identity.HierarchyPath, nil,
 			deps.String("type", fmt.Sprintf("%T", snapshot.Observed)),
 			deps.String("action", "assuming_fresh"))
 
@@ -69,7 +70,7 @@ func (f *FreshnessChecker) extractTimestamp(snapshot *fsmv2.Snapshot) (time.Time
 	// Check collected_at field (JSON-serialized from struct's CollectedAt)
 	ts, exists := doc["collected_at"]
 	if !exists {
-		f.logger.SentryWarn(deps.FeatureForWorker(f.workerType), snapshot.Identity.HierarchyPath, "observed_state_missing_timestamp",
+		f.logger.Sentry(telemetry.Supervisor.ObservedState.MissingTimestamp, deps.FeatureForWorker(f.workerType), snapshot.Identity.HierarchyPath, nil,
 			deps.String("action", "assuming_fresh"))
 
 		return time.Time{}, false
@@ -85,7 +86,7 @@ func (f *FreshnessChecker) extractTimestamp(snapshot *fsmv2.Snapshot) (time.Time
 	case string:
 		collectedAt, err := time.Parse(time.RFC3339Nano, v)
 		if err != nil {
-			f.logger.SentryWarn(deps.FeatureForWorker(f.workerType), snapshot.Identity.HierarchyPath, "observed_state_invalid_timestamp",
+			f.logger.Sentry(telemetry.Supervisor.ObservedState.InvalidTimestamp, deps.FeatureForWorker(f.workerType), snapshot.Identity.HierarchyPath, nil,
 				deps.String("value", v),
 				deps.String("action", "assuming_fresh"))
 
@@ -94,7 +95,7 @@ func (f *FreshnessChecker) extractTimestamp(snapshot *fsmv2.Snapshot) (time.Time
 
 		return collectedAt, true
 	default:
-		f.logger.SentryWarn(deps.FeatureForWorker(f.workerType), snapshot.Identity.HierarchyPath, "observed_state_unknown_timestamp_type",
+		f.logger.Sentry(telemetry.Supervisor.ObservedState.UnknownTimestampType, deps.FeatureForWorker(f.workerType), snapshot.Identity.HierarchyPath, nil,
 			deps.String("type", fmt.Sprintf("%T", v)),
 			deps.String("action", "assuming_fresh"))
 
@@ -139,7 +140,7 @@ func (f *FreshnessChecker) IsTimeout(snapshot *fsmv2.Snapshot) bool {
 	isTimedOut := age >= f.timeout
 
 	if isTimedOut {
-		f.logger.SentryWarn(deps.FeatureForWorker(f.workerType), snapshot.Identity.HierarchyPath, "observed_state_timeout",
+		f.logger.Sentry(telemetry.Supervisor.ObservedState.Timeout, deps.FeatureForWorker(f.workerType), snapshot.Identity.HierarchyPath, nil,
 			deps.Duration("age", age),
 			deps.Int64("age_ms", age.Milliseconds()),
 			deps.Duration("threshold", f.timeout),

--- a/umh-core/pkg/fsmv2/supervisor/lifecycle.go
+++ b/umh-core/pkg/fsmv2/supervisor/lifecycle.go
@@ -28,6 +28,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/supervisor/internal/execution"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/supervisor/metrics"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/persistence"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/telemetry"
 )
 
 // Start starts the supervisor goroutines.
@@ -99,7 +100,7 @@ func (s *Supervisor[TObserved, TDesired]) startWorkerRunners(ctx context.Context
 
 	for _, workerCtx := range s.workers {
 		if err := workerCtx.collector.Start(ctx); err != nil {
-			s.logger.SentryError(deps.FeatureFSMv2, workerCtx.identity.HierarchyPath, err, "collector_start_failed")
+			s.logger.Sentry(telemetry.Supervisor.Collector.StartFailed, deps.FeatureFSMv2, workerCtx.identity.HierarchyPath, err)
 		}
 
 		workerCtx.executor.Start(ctx)
@@ -179,7 +180,7 @@ func (s *Supervisor[TObserved, TDesired]) tickLoop(ctx context.Context) {
 						deps.HierarchyPath(s.GetHierarchyPath()),
 						deps.Err(err))
 				} else {
-					s.logger.SentryError(deps.FeatureFSMv2, s.GetHierarchyPath(), err, "tick_error")
+					s.logger.Sentry(telemetry.Supervisor.Tick.Error, deps.FeatureFSMv2, s.GetHierarchyPath(), err)
 				}
 			}
 		}
@@ -329,8 +330,7 @@ func (s *Supervisor[TObserved, TDesired]) Shutdown() {
 		// Request graceful shutdown on all workers
 		for _, workerID := range workerIDs {
 			if err := s.requestShutdown(shutdownCtx, workerID, "supervisor_shutdown"); err != nil {
-				s.logger.SentryWarn(deps.FeatureFSMv2, s.GetHierarchyPath(), "graceful_shutdown_request_failed",
-					deps.Err(err))
+				s.logger.Sentry(telemetry.Supervisor.Shutdown.GracefulRequestFailed, deps.FeatureFSMv2, s.GetHierarchyPath(), err)
 			}
 		}
 
@@ -369,12 +369,13 @@ func (s *Supervisor[TObserved, TDesired]) Shutdown() {
 
 				// Event name per the rule above childDrainElapsed: a budget the
 				// children pre-spent is exhaustion, not an own-worker timeout.
-				event := "graceful_shutdown_timeout"
+				event := telemetry.Supervisor.Shutdown.Timeout
 				if childDrainElapsed >= drainBudget {
-					event = "graceful_shutdown_budget_exhausted"
+					event = telemetry.Supervisor.Shutdown.BudgetExhausted
 				}
 
-				s.logger.SentryWarn(deps.FeatureFSMv2, s.GetHierarchyPath(), event,
+				s.logger.Sentry(event, deps.FeatureFSMv2, s.GetHierarchyPath(),
+					nil,
 					deps.Duration("timeout", drainBudget),
 					deps.Duration("child_drain_elapsed", childDrainElapsed),
 					deps.Int("remaining_worker_count", remainingCount))
@@ -399,7 +400,7 @@ func (s *Supervisor[TObserved, TDesired]) Shutdown() {
 				remainingCount := len(s.workers)
 				s.mu.RUnlock()
 
-				s.logger.SentryWarn(deps.FeatureFSMv2, s.GetHierarchyPath(), "graceful_shutdown_force_exit",
+				s.logger.Sentry(telemetry.Supervisor.Shutdown.ForceExit, deps.FeatureFSMv2, s.GetHierarchyPath(), nil,
 					deps.Int("remaining_worker_count", remainingCount))
 
 				// The operator forced the exit; the post-join budget re-check
@@ -425,7 +426,7 @@ func (s *Supervisor[TObserved, TDesired]) Shutdown() {
 		remainingCount := len(s.workers)
 		s.mu.RUnlock()
 
-		s.logger.SentryWarn(deps.FeatureFSMv2, s.GetHierarchyPath(), "graceful_shutdown_budget_exhausted",
+		s.logger.Sentry(telemetry.Supervisor.Shutdown.BudgetExhausted, deps.FeatureFSMv2, s.GetHierarchyPath(), nil,
 			deps.Duration("timeout", drainBudget),
 			deps.Duration("child_drain_elapsed", childDrainElapsed),
 			deps.Int("remaining_worker_count", remainingCount))
@@ -502,7 +503,7 @@ func (s *Supervisor[TObserved, TDesired]) recordPostJoinBudgetOverrun(totalDrain
 		return
 	}
 
-	s.logger.SentryWarn(deps.FeatureFSMv2, s.GetHierarchyPath(), "graceful_shutdown_budget_exhausted",
+	s.logger.Sentry(telemetry.Supervisor.Shutdown.BudgetExhausted, deps.FeatureFSMv2, s.GetHierarchyPath(), nil,
 		deps.Duration("timeout", drainBudget),
 		deps.Duration("child_drain_elapsed", childDrainElapsed),
 		deps.Duration("total_drain_elapsed", totalDrainElapsed))
@@ -702,8 +703,7 @@ func (s *Supervisor[TObserved, TDesired]) RequestShutdown(ctx context.Context, r
 
 	for _, workerID := range workerIDs {
 		if err := s.requestShutdown(ctx, workerID, reason); err != nil {
-			s.logger.SentryWarn(deps.FeatureFSMv2, s.GetHierarchyPath(), "shutdown_request_failed",
-				deps.Err(err))
+			s.logger.Sentry(telemetry.Supervisor.Shutdown.RequestFailedInCascade, deps.FeatureFSMv2, s.GetHierarchyPath(), err)
 		}
 	}
 
@@ -732,7 +732,7 @@ func (s *Supervisor[TObserved, TDesired]) handleWorkerRestart(ctx context.Contex
 		s.mu.RUnlock()
 
 		err := errors.New("worker not found for restart")
-		s.logger.SentryError(deps.FeatureFSMv2, s.GetHierarchyPathUnlocked(), err, "worker_restart_not_found",
+		s.logger.Sentry(telemetry.Supervisor.Worker.RestartNotFound, deps.FeatureFSMv2, s.GetHierarchyPathUnlocked(), err,
 			deps.String("target_worker_id", workerID))
 
 		return err
@@ -778,8 +778,7 @@ func (s *Supervisor[TObserved, TDesired]) handleWorkerRestart(ctx context.Contex
 
 	// 2. Clear shutdown flag in storage BEFORE creating new worker.
 	if err := s.clearShutdownRequested(ctx, workerID); err != nil {
-		s.logger.SentryWarn(deps.FeatureFSMv2, identity.HierarchyPath, "restart_clear_shutdown_failed",
-			deps.Err(err))
+		s.logger.Sentry(telemetry.Supervisor.Restart.ClearShutdownFailed, deps.FeatureFSMv2, identity.HierarchyPath, err)
 		// Continue anyway - the new worker might still work
 	}
 
@@ -816,7 +815,7 @@ func (s *Supervisor[TObserved, TDesired]) handleWorkerRestart(ctx context.Contex
 
 		if collector != nil {
 			if err := collector.Start(supervisorCtx); err != nil {
-				s.logger.SentryError(deps.FeatureFSMv2, identity.HierarchyPath, err, "restart_collector_start_failed")
+				s.logger.Sentry(telemetry.Supervisor.Restart.CollectorStartFailed, deps.FeatureFSMv2, identity.HierarchyPath, err)
 			}
 		}
 

--- a/umh-core/pkg/fsmv2/supervisor/lifecycle_shutdown_action_gate_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/lifecycle_shutdown_action_gate_test.go
@@ -187,7 +187,7 @@ var _ = Describe("Shutdown reap past action gating (ENG-4971)", func() {
 		// Assertion 3: the timeout warn must NOT fire. The Shutdown() loop logs
 		// graceful_shutdown_timeout and runs its full budget only when a worker
 		// never reaches SignalNeedsRemoval, which is exactly the blocked-gate case.
-		Expect(containsLogEvent(buf.String(), "graceful_shutdown_timeout")).To(BeFalse(),
+		Expect(containsLogEvent(buf.String(), "supervisor::shutdown::timeout")).To(BeFalse(),
 			"graceful_shutdown_timeout was logged: the Shutdown() loop timed out because the gated worker never ran its shutdown check")
 	})
 

--- a/umh-core/pkg/fsmv2/supervisor/lifecycle_shutdown_circuit_gate_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/lifecycle_shutdown_circuit_gate_test.go
@@ -163,7 +163,7 @@ var _ = Describe("Shutdown reap past an open infrastructure circuit (ENG-4971)",
 		// Assertion 3: the timeout warn must NOT fire. The drain logs
 		// graceful_shutdown_timeout and runs its full budget only when a worker
 		// never reaches SignalNeedsRemoval — exactly the blocked-gate case.
-		Expect(containsLogEvent(buf.String(), "graceful_shutdown_timeout")).To(BeFalse(),
+		Expect(containsLogEvent(buf.String(), "supervisor::shutdown::timeout")).To(BeFalse(),
 			"graceful_shutdown_timeout was logged: the drain timed out because the open circuit blocked the worker's shutdown check")
 
 		// Assertion 4: no false recovery log. Gating the whole circuit-breaker

--- a/umh-core/pkg/fsmv2/supervisor/lifecycle_shutdown_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/lifecycle_shutdown_test.go
@@ -172,7 +172,7 @@ var _ = Describe("Shutdown drain regression", func() {
 
 			// Assertion 3: graceful_shutdown_timeout warn must NOT be emitted.
 			logOutput := buf.String()
-			Expect(containsLogEvent(logOutput, "graceful_shutdown_timeout")).To(BeFalse(),
+			Expect(containsLogEvent(logOutput, "supervisor::shutdown::timeout")).To(BeFalse(),
 				"graceful_shutdown_timeout was logged, indicating the timeout fired instead of draining")
 		})
 	})
@@ -222,7 +222,7 @@ var _ = Describe("Shutdown drain regression", func() {
 
 			// Assertion 3: graceful_shutdown_timeout warn IS present, with remaining_worker_count > 0.
 			logOutput := buf.String()
-			entry := findLogEvent(logOutput, "graceful_shutdown_timeout")
+			entry := findLogEvent(logOutput, "supervisor::shutdown::timeout")
 			Expect(entry).ToNot(BeNil(), "expected graceful_shutdown_timeout warn to be logged")
 			if entry != nil {
 				count, ok := entry["remaining_worker_count"]
@@ -344,11 +344,11 @@ var _ = Describe("Shutdown drain regression", func() {
 
 			// Assertion 2: the dedicated force-exit log event fires.
 			logOutput := buf.String()
-			Expect(containsLogEvent(logOutput, "graceful_shutdown_force_exit")).To(BeTrue(),
+			Expect(containsLogEvent(logOutput, "supervisor::shutdown::force_exit")).To(BeTrue(),
 				"expected graceful_shutdown_force_exit log; ForceExit branch did not fire")
 
 			// Assertion 3: the timeout path must NOT have fired (forceExit wins).
-			Expect(containsLogEvent(logOutput, "graceful_shutdown_timeout")).To(BeFalse(),
+			Expect(containsLogEvent(logOutput, "supervisor::shutdown::timeout")).To(BeFalse(),
 				"graceful_shutdown_timeout fired; ForceExit should have won the race")
 		})
 	})

--- a/umh-core/pkg/fsmv2/supervisor/panic_recovery_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/panic_recovery_test.go
@@ -68,7 +68,7 @@ var _ = Describe("Tick Loop Panic Recovery", func() {
 				Expect(err.Error()).To(ContainSubstring("tick panic"))
 
 				// Verify panic was logged with ErrorFields pattern
-				panicLogs := filterLogs(observedLogs, "tick_panic")
+				panicLogs := filterLogs(observedLogs, "supervisor::tick::panic")
 				Expect(panicLogs).ToNot(BeEmpty(), "Expected tick_panic log entry")
 
 				panicLog := panicLogs[0]
@@ -137,7 +137,7 @@ var _ = Describe("Tick Loop Panic Recovery", func() {
 				err = s.TestTick(context.Background())
 				Expect(err).To(HaveOccurred())
 
-				panicLogs := filterLogs(observedLogs, "tick_panic")
+				panicLogs := filterLogs(observedLogs, "supervisor::tick::panic")
 				Expect(panicLogs).ToNot(BeEmpty())
 				Expect(panicLogs[0].ContextMap()["panic_type"]).To(Equal("string_panic"))
 			})
@@ -174,7 +174,7 @@ var _ = Describe("Tick Loop Panic Recovery", func() {
 				// Verify error chain is preserved
 				Expect(errors.Is(err, testErr)).To(BeTrue(), "Error chain should be preserved")
 
-				panicLogs := filterLogs(observedLogs, "tick_panic")
+				panicLogs := filterLogs(observedLogs, "supervisor::tick::panic")
 				Expect(panicLogs).ToNot(BeEmpty())
 				Expect(panicLogs[0].ContextMap()["panic_type"]).To(Equal("error_panic"))
 			})
@@ -206,7 +206,7 @@ var _ = Describe("Tick Loop Panic Recovery", func() {
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("tick panic"))
 
-				panicLogs := filterLogs(observedLogs, "tick_panic")
+				panicLogs := filterLogs(observedLogs, "supervisor::tick::panic")
 				Expect(panicLogs).ToNot(BeEmpty())
 				// In Go 1.21+, panic(nil) creates *runtime.PanicNilError which is an error type
 				Expect(panicLogs[0].ContextMap()["panic_type"]).To(Equal("error_panic"))
@@ -240,7 +240,7 @@ var _ = Describe("Tick Loop Panic Recovery", func() {
 				Expect(err.Error()).To(ContainSubstring("tick panic"))
 				Expect(err.Error()).To(ContainSubstring("42"))
 
-				panicLogs := filterLogs(observedLogs, "tick_panic")
+				panicLogs := filterLogs(observedLogs, "supervisor::tick::panic")
 				Expect(panicLogs).ToNot(BeEmpty())
 				Expect(panicLogs[0].ContextMap()["panic_type"]).To(Equal("unknown_panic"))
 			})
@@ -357,7 +357,7 @@ var _ = Describe("Panic Escalation", func() {
 
 			Expect(s.TestIsPanicCircuitOpen()).To(BeTrue(), "3 panics should open panic circuit")
 
-			circuitLogs := filterLogs(observedLogs, "panic_circuit_open")
+			circuitLogs := filterLogs(observedLogs, "supervisor::panic_circuit::open")
 			Expect(circuitLogs).ToNot(BeEmpty(), "Expected panic_circuit_open log entry")
 			circuitLog := circuitLogs[0]
 			Expect(circuitLog.ContextMap()["feature"]).To(Equal("fsmv2"))
@@ -501,10 +501,6 @@ func (p *panicOnSentryErrorLogger) Sentry(id telemetry.Identifier, _ deps.Featur
 	}
 
 	panic("logger Sentry panicked")
-}
-func (p *panicOnSentryErrorLogger) SentryWarn(_ deps.Feature, _ string, _ string, _ ...deps.Field) {}
-func (p *panicOnSentryErrorLogger) SentryError(_ deps.Feature, _ string, _ error, _ string, _ ...deps.Field) {
-	panic("logger SentryError panicked")
 }
 func (p *panicOnSentryErrorLogger) With(fields ...deps.Field) deps.FSMLogger { return p }
 

--- a/umh-core/pkg/fsmv2/supervisor/reconciliation.go
+++ b/umh-core/pkg/fsmv2/supervisor/reconciliation.go
@@ -32,6 +32,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/supervisor/internal/panicutil"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/supervisor/metrics"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/persistence"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/telemetry"
 )
 
 // ErrPanicCircuitOpen is returned when the tick is suppressed because the panic circuit breaker is open.
@@ -130,7 +131,7 @@ func (s *Supervisor[TObserved, TDesired]) tickWorker(ctx context.Context, worker
 
 	storageSnapshot, err := s.store.LoadSnapshot(ctx, s.workerType, workerID)
 	if err != nil {
-		s.logger.SentryError(deps.FeatureFSMv2, workerCtx.identity.HierarchyPath, err, "snapshot_load_failed")
+		s.logger.Sentry(telemetry.Supervisor.Snapshot.LoadFailed, deps.FeatureFSMv2, workerCtx.identity.HierarchyPath, err)
 
 		return fmt.Errorf("failed to load snapshot: %w", err)
 	}
@@ -144,7 +145,7 @@ func (s *Supervisor[TObserved, TDesired]) tickWorker(ctx context.Context, worker
 
 	err = s.store.LoadObservedTyped(ctx, s.workerType, workerID, &observed)
 	if err != nil {
-		s.logger.SentryError(deps.FeatureFSMv2, workerCtx.identity.HierarchyPath, err, "observed_state_load_failed")
+		s.logger.Sentry(telemetry.Supervisor.ObservedState.LoadFailed, deps.FeatureFSMv2, workerCtx.identity.HierarchyPath, err)
 
 		return fmt.Errorf("failed to load typed observed state: %w", err)
 	}
@@ -153,7 +154,7 @@ func (s *Supervisor[TObserved, TDesired]) tickWorker(ctx context.Context, worker
 
 	err = s.store.LoadDesiredTyped(ctx, s.workerType, workerID, &desired)
 	if err != nil {
-		s.logger.SentryError(deps.FeatureFSMv2, workerCtx.identity.HierarchyPath, err, "desired_state_load_failed")
+		s.logger.Sentry(telemetry.Supervisor.DesiredState.LoadFailed, deps.FeatureFSMv2, workerCtx.identity.HierarchyPath, err)
 
 		return fmt.Errorf("failed to load typed desired state: %w", err)
 	}
@@ -225,11 +226,11 @@ func (s *Supervisor[TObserved, TDesired]) tickWorker(ctx context.Context, worker
 			if restartCount >= s.collectorHealth.maxRestartAttempts {
 				// Max attempts reached - escalate to shutdown (Layer 3)
 				maxAttemptsErr := fmt.Errorf("collector unresponsive after %d restart attempts", s.collectorHealth.maxRestartAttempts)
-				s.logger.SentryError(deps.FeatureForWorker(s.workerType), s.GetHierarchyPathUnlocked(), maxAttemptsErr, "collector_unresponsive_max_attempts",
+				s.logger.Sentry(telemetry.Supervisor.Collector.UnresponsiveMaxAttempts, deps.FeatureForWorker(s.workerType), s.GetHierarchyPathUnlocked(), maxAttemptsErr,
 					deps.Attempts(s.collectorHealth.maxRestartAttempts))
 
 				if shutdownErr := s.requestShutdown(ctx, workerID, maxAttemptsErr.Error()); shutdownErr != nil {
-					s.logger.SentryError(deps.FeatureForWorker(s.workerType), workerCtx.identity.HierarchyPath, shutdownErr, "shutdown_request_failed")
+					s.logger.Sentry(telemetry.Supervisor.Shutdown.RequestFailed, deps.FeatureForWorker(s.workerType), workerCtx.identity.HierarchyPath, shutdownErr)
 				}
 
 				return errors.New("collector unresponsive, shutdown requested")
@@ -243,7 +244,7 @@ func (s *Supervisor[TObserved, TDesired]) tickWorker(ctx context.Context, worker
 				maxAttempts := s.collectorHealth.maxRestartAttempts
 				s.mu.RUnlock()
 
-				s.logger.SentryError(deps.FeatureForWorker(s.workerType), workerCtx.identity.HierarchyPath, err, "collector_restart_failed",
+				s.logger.Sentry(telemetry.Supervisor.Collector.RestartFailed, deps.FeatureForWorker(s.workerType), workerCtx.identity.HierarchyPath, err,
 					deps.Int("restart_attempt", restartAttempt),
 					deps.Int("max_attempts", maxAttempts))
 
@@ -388,7 +389,7 @@ func (s *Supervisor[TObserved, TDesired]) tickWorker(ctx context.Context, worker
 			deps.String("action_id", actionID))
 
 		if err := workerCtx.executor.EnqueueAction(actionID, result.Action, workerDeps); err != nil {
-			s.logger.SentryError(deps.FeatureForWorker(s.workerType), workerCtx.identity.HierarchyPath, err, "action_enqueue_failed",
+			s.logger.Sentry(telemetry.Supervisor.Action.EnqueueFailed, deps.FeatureForWorker(s.workerType), workerCtx.identity.HierarchyPath, err,
 				deps.String("action_id", actionID))
 
 			return fmt.Errorf("failed to enqueue action: %w", err)
@@ -500,7 +501,7 @@ func (s *Supervisor[TObserved, TDesired]) tickWorker(ctx context.Context, worker
 	workerCtx.mu.RUnlock()
 
 	if err := s.processSignal(ctx, workerID, result.Signal); err != nil {
-		s.logger.SentryError(deps.FeatureFSMv2, workerCtx.identity.HierarchyPath, err, "signal_processing_failed",
+		s.logger.Sentry(telemetry.Supervisor.Signal.ProcessingFailed, deps.FeatureFSMv2, workerCtx.identity.HierarchyPath, err,
 			deps.Int("signal", int(result.Signal)))
 
 		return fmt.Errorf("signal processing failed: %w", err)
@@ -553,7 +554,7 @@ func (s *Supervisor[TObserved, TDesired]) tick(ctx context.Context) (err error) 
 					func() {
 						defer func() { _ = recover() }()
 
-						s.logger.SentryError(deps.FeatureFSMv2, "unknown", err, "tick_double_panic",
+						s.logger.Sentry(telemetry.Supervisor.Tick.DoublePanic, deps.FeatureFSMv2, "unknown", err,
 							deps.String("stack", string(debug.Stack())))
 					}()
 				}
@@ -565,7 +566,7 @@ func (s *Supervisor[TObserved, TDesired]) tick(ctx context.Context) (err error) 
 			hierarchyPath := s.GetHierarchyPathUnlocked()
 			metrics.RecordPanicRecovery(hierarchyPath, panicType)
 
-			s.logger.SentryError(deps.FeatureFSMv2, hierarchyPath, err, "tick_panic",
+			s.logger.Sentry(telemetry.Supervisor.Tick.Panic, deps.FeatureFSMv2, hierarchyPath, err,
 				deps.WorkerType(s.workerType),
 				deps.Field{Key: "panic_type", Value: panicType},
 				deps.Field{Key: "stack_trace", Value: string(debug.Stack())})
@@ -573,7 +574,7 @@ func (s *Supervisor[TObserved, TDesired]) tick(ctx context.Context) (err error) 
 			if s.panicTracker.RecordPanic() {
 				s.panicCircuitOpen.Store(true)
 				panicCount := s.panicTracker.PanicCount()
-				s.logger.SentryWarn(deps.FeatureFSMv2, hierarchyPath, "panic_circuit_open",
+				s.logger.Sentry(telemetry.Supervisor.PanicCircuit.Open, deps.FeatureFSMv2, hierarchyPath, nil,
 					deps.WorkerType(s.workerType),
 					deps.Field{Key: "panic_count", Value: panicCount})
 			}
@@ -584,7 +585,7 @@ func (s *Supervisor[TObserved, TDesired]) tick(ctx context.Context) (err error) 
 	if s.panicCircuitOpen.Load() {
 		if s.panicTracker.PanicCount() == 0 {
 			s.panicCircuitOpen.Store(false)
-			s.logger.SentryWarn(deps.FeatureFSMv2, s.GetHierarchyPathUnlocked(), "panic_circuit_auto_reset",
+			s.logger.Sentry(telemetry.Supervisor.PanicCircuit.AutoReset, deps.FeatureFSMv2, s.GetHierarchyPathUnlocked(), nil,
 				deps.WorkerType(s.workerType))
 		} else {
 			s.logger.Debug("tick_suppressed_panic_circuit_open",
@@ -642,7 +643,7 @@ func (s *Supervisor[TObserved, TDesired]) tick(ctx context.Context) (err error) 
 					logFields = append(logFields, deps.String("failed_child", childErr.ChildName))
 				}
 
-				s.logger.SentryError(deps.FeatureFSMv2, s.GetHierarchyPathUnlocked(), err, "circuit_breaker_opened",
+				s.logger.Sentry(telemetry.Supervisor.CircuitBreaker.Opened, deps.FeatureFSMv2, s.GetHierarchyPathUnlocked(), err,
 					logFields...)
 				metrics.RecordCircuitOpen(s.GetHierarchyPathUnlocked(), true)
 			}
@@ -651,7 +652,7 @@ func (s *Supervisor[TObserved, TDesired]) tick(ctx context.Context) (err error) 
 				attempts := s.healthChecker.backoff.GetAttempts()
 				nextDelay := s.healthChecker.backoff.NextDelay()
 
-				s.logger.SentryWarn(deps.FeatureFSMv2, s.GetHierarchyPathUnlocked(), "circuit_breaker_retry_scheduled",
+				s.logger.Sentry(telemetry.Supervisor.CircuitBreaker.RetryScheduled, deps.FeatureFSMv2, s.GetHierarchyPathUnlocked(), nil,
 					deps.String("failed_child", childErr.ChildName),
 					deps.Attempts(attempts),
 					deps.Int("max_attempts", s.healthChecker.maxAttempts),
@@ -660,14 +661,14 @@ func (s *Supervisor[TObserved, TDesired]) tick(ctx context.Context) (err error) 
 					deps.String("recovery_status", s.getRecoveryStatus()))
 
 				if attempts == 4 {
-					s.logger.SentryWarn(deps.FeatureFSMv2, s.GetHierarchyPathUnlocked(), "escalation_warning_one_retry_remaining",
+					s.logger.Sentry(telemetry.Supervisor.Escalation.OneRetryRemaining, deps.FeatureFSMv2, s.GetHierarchyPathUnlocked(), nil,
 						deps.String("child_name", childErr.ChildName),
 						deps.Int("attempts_remaining", 1),
 						deps.String("total_downtime", s.healthChecker.backoff.GetTotalDowntime().String()))
 				}
 
 				if attempts >= 5 {
-					s.logger.SentryError(deps.FeatureFSMv2, s.GetHierarchyPathUnlocked(), childErr, "escalation_required",
+					s.logger.Sentry(telemetry.Supervisor.Escalation.Required, deps.FeatureFSMv2, s.GetHierarchyPathUnlocked(), childErr,
 						deps.String("child_name", childErr.ChildName),
 						deps.Int("max_attempts", 5),
 						deps.String("total_downtime", s.healthChecker.backoff.GetTotalDowntime().String()),
@@ -796,7 +797,7 @@ func (s *Supervisor[TObserved, TDesired]) tick(ctx context.Context) (err error) 
 		templateDuration := time.Since(templateStart)
 
 		if err != nil {
-			s.logger.SentryError(deps.FeatureFSMv2, s.GetHierarchyPathUnlocked(), err, "template_rendering_failed",
+			s.logger.Sentry(telemetry.Supervisor.Spec.TemplateRenderingFailed, deps.FeatureFSMv2, s.GetHierarchyPathUnlocked(), err,
 				deps.DurationMs(templateDuration.Milliseconds()))
 			metrics.RecordTemplateRenderingDuration(s.GetHierarchyPathUnlocked(), "error", templateDuration)
 			metrics.RecordTemplateRenderingError(s.GetHierarchyPathUnlocked(), "derivation_failed")
@@ -834,13 +835,11 @@ func (s *Supervisor[TObserved, TDesired]) tick(ctx context.Context) (err error) 
 	if userSpecWithVars.Config != "" || len(userSpecWithVars.Variables.User) > 0 {
 		userSpecBytes, marshalErr := json.Marshal(userSpecWithVars)
 		if marshalErr != nil {
-			s.logger.SentryWarn(deps.FeatureFSMv2, s.GetHierarchyPathUnlocked(), "original_user_spec_marshal_failed",
-				deps.Err(marshalErr))
+			s.logger.Sentry(telemetry.Supervisor.Spec.OriginalUserMarshalFailed, deps.FeatureFSMv2, s.GetHierarchyPathUnlocked(), marshalErr)
 		} else {
 			var userSpecMap map[string]any
 			if unmarshalErr := json.Unmarshal(userSpecBytes, &userSpecMap); unmarshalErr != nil {
-				s.logger.SentryWarn(deps.FeatureFSMv2, s.GetHierarchyPathUnlocked(), "original_user_spec_unmarshal_failed",
-					deps.Err(unmarshalErr))
+				s.logger.Sentry(telemetry.Supervisor.Spec.OriginalUserUnmarshalFailed, deps.FeatureFSMv2, s.GetHierarchyPathUnlocked(), unmarshalErr)
 			} else {
 				desiredDoc["originalUserSpec"] = userSpecMap
 			}
@@ -880,8 +879,7 @@ func (s *Supervisor[TObserved, TDesired]) tick(ctx context.Context) (err error) 
 	if err != nil {
 		// Log the error but continue with the tick - the system can recover on the next tick
 		// The tickWorker will use the previously saved desired state
-		s.logger.SentryWarn(deps.FeatureFSMv2, s.GetHierarchyPathUnlocked(), "derived_desired_state_save_failed",
-			deps.Err(err))
+		s.logger.Sentry(telemetry.Supervisor.DesiredState.DerivedSaveFailed, deps.FeatureFSMv2, s.GetHierarchyPathUnlocked(), err)
 	} else {
 		// Per-tick log moved to TRACE for scalability
 		s.logTrace("derived_desired_state_saved")
@@ -924,8 +922,7 @@ func (s *Supervisor[TObserved, TDesired]) tick(ctx context.Context) (err error) 
 			hash, err := spec.Hash()
 			if err != nil {
 				// If hashing fails, always validate to be safe
-				s.logger.SentryWarn(deps.FeatureFSMv2, s.GetHierarchyPathUnlocked(), "spec_hash_failed",
-					deps.Err(err),
+				s.logger.Sentry(telemetry.Supervisor.Spec.HashFailed, deps.FeatureFSMv2, s.GetHierarchyPathUnlocked(), err,
 					deps.String("spec", spec.Name))
 				specsToValidate = append(specsToValidate, spec)
 
@@ -939,7 +936,7 @@ func (s *Supervisor[TObserved, TDesired]) tick(ctx context.Context) (err error) 
 
 		if len(specsToValidate) > 0 {
 			if err := config.ValidateChildSpecs(specsToValidate, registry); err != nil {
-				s.logger.SentryError(deps.FeatureFSMv2, s.GetHierarchyPathUnlocked(), err, "child_spec_validation_failed")
+				s.logger.Sentry(telemetry.Supervisor.Child.SpecValidationFailed, deps.FeatureFSMv2, s.GetHierarchyPathUnlocked(), err)
 
 				return fmt.Errorf("invalid child specifications: %w", err)
 			}
@@ -949,8 +946,7 @@ func (s *Supervisor[TObserved, TDesired]) tick(ctx context.Context) (err error) 
 				hash, err := spec.Hash()
 				if err != nil {
 					// Skip caching if hash fails - will revalidate next time
-					s.logger.SentryWarn(deps.FeatureFSMv2, s.GetHierarchyPathUnlocked(), "spec_hash_cache_failed",
-						deps.Err(err),
+					s.logger.Sentry(telemetry.Supervisor.Spec.HashCacheFailed, deps.FeatureFSMv2, s.GetHierarchyPathUnlocked(), err,
 						deps.String("spec", spec.Name))
 
 					continue
@@ -999,7 +995,7 @@ func (s *Supervisor[TObserved, TDesired]) tick(ctx context.Context) (err error) 
 
 	for _, child := range childrenToTick {
 		if err := child.tick(ctx); err != nil {
-			s.logger.SentryError(deps.FeatureFSMv2, s.GetHierarchyPathUnlocked(), err, "child_tick_failed")
+			s.logger.Sentry(telemetry.Supervisor.Child.TickFailed, deps.FeatureFSMv2, s.GetHierarchyPathUnlocked(), err)
 			// Continue with other children
 		}
 	}
@@ -1083,7 +1079,7 @@ func (s *Supervisor[TObserved, TDesired]) processSignal(ctx context.Context, wor
 		if !exists {
 			s.mu.Unlock()
 
-			s.logger.SentryWarn(deps.FeatureFSMv2, s.GetHierarchyPathUnlocked(), "worker_removal_not_found",
+			s.logger.Sentry(telemetry.Supervisor.Worker.RemovalNotFound, deps.FeatureFSMv2, s.GetHierarchyPathUnlocked(), nil,
 				deps.String("target_worker_id", workerID))
 
 			return errors.New("worker not found in registry")
@@ -1158,8 +1154,7 @@ func (s *Supervisor[TObserved, TDesired]) processSignal(ctx context.Context, wor
 
 		// Request graceful shutdown - worker will go through cleanup states
 		if err := s.requestShutdown(ctx, workerID, "restart_requested"); err != nil {
-			s.logger.SentryWarn(deps.FeatureFSMv2, s.GetHierarchyPathUnlocked(), "restart_shutdown_request_failed",
-				deps.Err(err),
+			s.logger.Sentry(telemetry.Supervisor.Restart.ShutdownRequestFailed, deps.FeatureFSMv2, s.GetHierarchyPathUnlocked(), err,
 				deps.String("target_worker_id", workerID))
 			// Continue anyway - we want to restart even if request fails
 		}
@@ -1167,7 +1162,7 @@ func (s *Supervisor[TObserved, TDesired]) processSignal(ctx context.Context, wor
 		return nil
 	default:
 		unknownSignalErr := fmt.Errorf("unknown signal: %d", signal)
-		s.logger.SentryError(deps.FeatureFSMv2, s.GetHierarchyPathUnlocked(), unknownSignalErr, "unknown_signal_received",
+		s.logger.Sentry(telemetry.Supervisor.Signal.UnknownReceived, deps.FeatureFSMv2, s.GetHierarchyPathUnlocked(), unknownSignalErr,
 			deps.String("target_worker_id", workerID),
 			deps.Int("signal", int(signal)))
 
@@ -1188,7 +1183,7 @@ func (s *Supervisor[TObserved, TDesired]) checkRestartTimeouts(ctx context.Conte
 		}
 
 		if time.Since(requestedAt) > DefaultGracefulRestartTimeout {
-			s.logger.SentryWarn(deps.FeatureFSMv2, s.GetHierarchyPathUnlocked(), "restart_graceful_timeout",
+			s.logger.Sentry(telemetry.Supervisor.Restart.GracefulTimeout, deps.FeatureFSMv2, s.GetHierarchyPathUnlocked(), nil,
 				deps.String("target_worker_id", workerID),
 				deps.Duration("timeout", DefaultGracefulRestartTimeout),
 				deps.Duration("waited", time.Since(requestedAt)))
@@ -1325,14 +1320,13 @@ func (s *Supervisor[TObserved, TDesired]) restartCollector(ctx context.Context, 
 			escalationRisk = "imminent"
 		}
 
-		s.logger.SentryWarn(deps.FeatureForWorker(s.workerType), s.GetHierarchyPathUnlocked(), "collector_restarting",
-			deps.Err(fmt.Errorf("collector restart attempt %d of %d", restartCount, maxRestartAttempts)),
+		s.logger.Sentry(telemetry.Supervisor.Collector.Restarting, deps.FeatureForWorker(s.workerType), s.GetHierarchyPathUnlocked(), fmt.Errorf("collector restart attempt %d of %d", restartCount, maxRestartAttempts),
 			deps.Int("restart_attempt", restartCount),
 			deps.Int("max_attempts", maxRestartAttempts),
 			deps.Duration("backoff", backoff),
 			deps.String("escalation_risk", escalationRisk))
 	} else {
-		s.logger.SentryWarn(deps.FeatureForWorker(s.workerType), s.GetHierarchyPathUnlocked(), "collector_restarting",
+		s.logger.Sentry(telemetry.Supervisor.Collector.Restarting, deps.FeatureForWorker(s.workerType), s.GetHierarchyPathUnlocked(), nil,
 			deps.Int("restart_attempt", restartCount),
 			deps.Int("max_attempts", maxRestartAttempts),
 			deps.Duration("backoff", backoff))
@@ -1344,7 +1338,7 @@ func (s *Supervisor[TObserved, TDesired]) restartCollector(ctx context.Context, 
 
 	if !exists {
 		notFoundErr := errors.New("worker not found")
-		s.logger.SentryError(deps.FeatureForWorker(s.workerType), s.GetHierarchyPathUnlocked(), notFoundErr, "collector_restart_worker_not_found",
+		s.logger.Sentry(telemetry.Supervisor.Collector.RestartWorkerNotFound, deps.FeatureForWorker(s.workerType), s.GetHierarchyPathUnlocked(), notFoundErr,
 			deps.String("target_worker_id", workerID))
 
 		return notFoundErr
@@ -1375,7 +1369,7 @@ func (s *Supervisor[TObserved, TDesired]) checkDataFreshness(snapshot *fsmv2.Sna
 	}
 
 	if !hasTimestamp {
-		s.logger.SentryWarn(deps.FeatureForWorker(s.workerType), snapshot.Identity.HierarchyPath, "snapshot_missing_timestamp",
+		s.logger.Sentry(telemetry.Supervisor.Snapshot.MissingTimestamp, deps.FeatureForWorker(s.workerType), snapshot.Identity.HierarchyPath, nil,
 			deps.Reason("Snapshot.Observed does not implement GetTimestamp()"),
 			deps.String("impact", "cannot check freshness"))
 
@@ -1389,13 +1383,13 @@ func (s *Supervisor[TObserved, TDesired]) checkDataFreshness(snapshot *fsmv2.Sna
 	isShuttingDown := !s.started.Load()
 
 	if s.freshnessChecker.IsTimeout(snapshot) {
-		s.logFreshnessWarning(isShuttingDown, snapshot.Identity.HierarchyPath, "data_timeout", age, s.collectorHealth.timeout)
+		s.logFreshnessWarning(isShuttingDown, snapshot.Identity.HierarchyPath, telemetry.Supervisor.Freshness.DataTimeout, age, s.collectorHealth.timeout)
 
 		return false
 	}
 
 	if !s.freshnessChecker.Check(snapshot) {
-		s.logFreshnessWarning(isShuttingDown, snapshot.Identity.HierarchyPath, "data_stale", age, s.collectorHealth.staleThreshold)
+		s.logFreshnessWarning(isShuttingDown, snapshot.Identity.HierarchyPath, telemetry.Supervisor.Freshness.DataStale, age, s.collectorHealth.staleThreshold)
 
 		return false
 	}
@@ -1403,17 +1397,21 @@ func (s *Supervisor[TObserved, TDesired]) checkDataFreshness(snapshot *fsmv2.Sna
 	return true
 }
 
-// logFreshnessWarning logs a data freshness issue at DEBUG during shutdown (expected) or SentryWarn otherwise.
-func (s *Supervisor[TObserved, TDesired]) logFreshnessWarning(isShuttingDown bool, hierarchyPath, msg string, age, threshold time.Duration) {
+// logFreshnessWarning logs a data freshness issue at DEBUG during shutdown,
+// where staleness is expected, and reports it otherwise.
+func (s *Supervisor[TObserved, TDesired]) logFreshnessWarning(isShuttingDown bool, hierarchyPath string, id telemetry.Identifier, age, threshold time.Duration) {
 	if isShuttingDown {
-		s.logger.Debug(msg+"_during_shutdown",
+		s.logger.Debug(id.Tag+"_during_shutdown",
 			deps.Duration("age", age),
 			deps.Duration("threshold", threshold))
-	} else {
-		s.logger.SentryWarn(deps.FeatureForWorker(s.workerType), hierarchyPath, msg,
-			deps.Duration("age", age),
-			deps.Duration("threshold", threshold))
+
+		return
 	}
+
+	s.logger.Sentry(id, deps.FeatureForWorker(s.workerType), hierarchyPath,
+		nil,
+		deps.Duration("age", age),
+		deps.Duration("threshold", threshold))
 }
 
 func (s *Supervisor[TObserved, TDesired]) logHeartbeat() {
@@ -1550,7 +1548,7 @@ func (s *Supervisor[TObserved, TDesired]) reconcileChildren(specs []config.Child
 			// Use factory to create child supervisor with proper type
 			rawSupervisor, err := factory.NewSupervisorByType(spec.WorkerType, childConfig)
 			if err != nil {
-				s.logger.SentryError(deps.FeatureFSMv2, s.GetHierarchyPathUnlocked(), err, "child_supervisor_creation_failed",
+				s.logger.Sentry(telemetry.Supervisor.Child.SupervisorCreationFailed, deps.FeatureFSMv2, s.GetHierarchyPathUnlocked(), err,
 					deps.String("child_name", spec.Name))
 
 				continue
@@ -1559,7 +1557,7 @@ func (s *Supervisor[TObserved, TDesired]) reconcileChildren(specs []config.Child
 			childSupervisor, ok := rawSupervisor.(SupervisorInterface)
 			if !ok {
 				typeErr := fmt.Errorf("factory returned %T (expected SupervisorInterface)", rawSupervisor)
-				s.logger.SentryError(deps.FeatureFSMv2, s.GetHierarchyPathUnlocked(), typeErr, "factory_invalid_supervisor_type",
+				s.logger.Sentry(telemetry.Supervisor.Factory.InvalidSupervisorType, deps.FeatureFSMv2, s.GetHierarchyPathUnlocked(), typeErr,
 					deps.String("child_name", spec.Name))
 
 				continue
@@ -1603,7 +1601,7 @@ func (s *Supervisor[TObserved, TDesired]) reconcileChildren(specs []config.Child
 			// Use mergedDeps to include both parent and child-specific dependencies
 			childWorker, err := factory.NewWorkerByType(spec.WorkerType, childIdentity, s.baseLogger, s.store, mergedDeps)
 			if err != nil {
-				s.logger.SentryError(deps.FeatureFSMv2, childPath, err, "child_worker_creation_failed",
+				s.logger.Sentry(telemetry.Supervisor.Child.WorkerCreationFailed, deps.FeatureFSMv2, childPath, err,
 					deps.String("child_name", spec.Name),
 					deps.WorkerType(spec.WorkerType))
 
@@ -1612,7 +1610,7 @@ func (s *Supervisor[TObserved, TDesired]) reconcileChildren(specs []config.Child
 
 			// Add worker to child supervisor
 			if err := childSupervisor.AddWorker(childIdentity, childWorker); err != nil {
-				s.logger.SentryError(deps.FeatureFSMv2, childPath, err, "child_supervisor_add_worker_failed",
+				s.logger.Sentry(telemetry.Supervisor.Child.SupervisorAddWorkerFailed, deps.FeatureFSMv2, childPath, err,
 					deps.String("child_name", spec.Name))
 
 				continue
@@ -1626,8 +1624,7 @@ func (s *Supervisor[TObserved, TDesired]) reconcileChildren(specs []config.Child
 				FieldShutdownRequested: false,
 			}
 			if _, err := s.store.SaveDesired(childDesiredCtx, spec.WorkerType, childIdentity.ID, desiredDoc); err != nil {
-				s.logger.SentryWarn(deps.FeatureFSMv2, childPath, "child_initial_desired_state_save_failed",
-					deps.Err(err),
+				s.logger.Sentry(telemetry.Supervisor.Child.InitialDesiredStateSaveFailed, deps.FeatureFSMv2, childPath, err,
 					deps.String("child_name", spec.Name))
 			}
 
@@ -1647,7 +1644,7 @@ func (s *Supervisor[TObserved, TDesired]) reconcileChildren(specs []config.Child
 				if childCtx.Err() == nil {
 					childSupervisor.StartAsChild(childCtx)
 				} else {
-					s.logger.SentryWarn(deps.FeatureFSMv2, s.GetHierarchyPathUnlocked(), "child_start_skipped_context_cancelled",
+					s.logger.Sentry(telemetry.Supervisor.Child.StartSkippedContextCancelled, deps.FeatureFSMv2, s.GetHierarchyPathUnlocked(), nil,
 						deps.String("child_name", spec.Name))
 				}
 			}
@@ -1681,8 +1678,7 @@ func (s *Supervisor[TObserved, TDesired]) reconcileChildren(specs []config.Child
 				// Child continues ticking and will emit SignalNeedsRemoval when ready
 				ctx := context.Background()
 				if err := child.RequestShutdown(ctx, "removed_from_specs"); err != nil {
-					s.logger.SentryWarn(deps.FeatureFSMv2, s.GetHierarchyPathUnlocked(), "child_shutdown_request_failed",
-						deps.Err(err),
+					s.logger.Sentry(telemetry.Supervisor.Child.ShutdownRequestFailed, deps.FeatureFSMv2, s.GetHierarchyPathUnlocked(), err,
 						deps.String("child_name", name))
 				}
 			}
@@ -1852,10 +1848,9 @@ func (s *Supervisor[TObserved, TDesired]) handleDisableMappingError(spec config.
 
 	// Sentry key intentionally retains the historical "reducer" name to keep
 	// issue grouping stable across the applyDisableMapping rename.
-	s.logger.SentryWarn(deps.FeatureFSMv2, s.GetHierarchyPathUnlocked(), "reducer_error",
+	s.logger.Sentry(telemetry.Supervisor.Reducer.Error, deps.FeatureFSMv2, s.GetHierarchyPathUnlocked(), err,
 		deps.String("child_name", spec.Name),
 		deps.String("error_class", errClass),
-		deps.Err(err),
 		deps.Int("suppressed_count", entry.count))
 }
 

--- a/umh-core/pkg/fsmv2/supervisor/run_detach_test.go
+++ b/umh-core/pkg/fsmv2/supervisor/run_detach_test.go
@@ -197,10 +197,10 @@ var _ = Describe("Run(ctx) cancel with live nested workers (ENG-4971)", func() {
 		// cancel, no level can reap its workers, so every level burns its full
 		// budget and warns. A live drain of prompt-stopping workers never
 		// reaches any budget.
-		Expect(containsLogEvent(logOutput, "graceful_shutdown_timeout")).To(BeFalse(),
+		Expect(containsLogEvent(logOutput, "supervisor::shutdown::timeout")).To(BeFalse(),
 			"graceful_shutdown_timeout was logged: Run's ctx cancel killed the tick loop before Shutdown drained, "+
 				"so the drain waited on worker removals only the dead loop could perform (ENG-4971 dead-loop drain)")
-		Expect(containsLogEvent(logOutput, "graceful_shutdown_budget_exhausted")).To(BeFalse(),
+		Expect(containsLogEvent(logOutput, "supervisor::shutdown::budget_exhausted")).To(BeFalse(),
 			"graceful_shutdown_budget_exhausted was logged: child drains burned the whole budget, "+
 				"which a live drain of prompt-stopping workers never does")
 

--- a/umh-core/pkg/fsmv2/workers/configworker/worker.go
+++ b/umh-core/pkg/fsmv2/workers/configworker/worker.go
@@ -48,6 +48,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/register"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/configworker/dynamicchildren"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/configworker/snapshot"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/telemetry"
 
 	// Blank-import the state subpackage so its init() registers the initial
 	// state before the supervisor ticks the worker.
@@ -164,8 +165,7 @@ func (w *ConfigworkerWorker) reconcileCPU(ctx context.Context) {
 	}
 
 	if err := syncCPU(client, w.cpuEnabled); err != nil {
-		w.Logger().SentryWarn(deps.FeatureSupportCPU, w.Identity().HierarchyPath,
-			"cpu watch: upsert failed", deps.Err(err))
+		w.Logger().Sentry(telemetry.Workers.Config.Watch.CpuUpsertFailed, deps.FeatureSupportCPU, w.Identity().HierarchyPath, err)
 	}
 }
 
@@ -200,15 +200,13 @@ func (w *ConfigworkerWorker) reconcileHistorian(ctx context.Context) {
 
 	cfg, err := w.configManager.GetConfig(ctx, 0)
 	if err != nil {
-		w.Logger().SentryWarn(deps.FeatureSupportHistorian, w.Identity().HierarchyPath,
-			"config watch: failed to read config", deps.Err(err))
+		w.Logger().Sentry(telemetry.Workers.Config.Watch.ReadFailed, deps.FeatureSupportHistorian, w.Identity().HierarchyPath, err)
 
 		return
 	}
 
 	if err := syncHistorian(client, cfg); err != nil {
-		w.Logger().SentryWarn(deps.FeatureSupportHistorian, w.Identity().HierarchyPath,
-			"historian watch: upsert failed", deps.Err(err))
+		w.Logger().Sentry(telemetry.Workers.Config.Watch.HistorianUpsertFailed, deps.FeatureSupportHistorian, w.Identity().HierarchyPath, err)
 	}
 }
 

--- a/umh-core/pkg/fsmv2/workers/example/examplechild/worker.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplechild/worker.go
@@ -23,6 +23,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/config"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/register"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/telemetry"
 )
 
 // ChildWorker implements the FSM v2 Worker interface for resource management.
@@ -57,8 +58,7 @@ func NewChildWorker(
 
 	conn, err := connectionPool.Acquire()
 	if err != nil {
-		logger.SentryWarn(deps.FeatureExamples, identity.HierarchyPath, "initial_connection_failed",
-			deps.Err(err))
+		logger.Sentry(telemetry.Workers.Connect.InitialFailed, deps.FeatureExamples, identity.HierarchyPath, err)
 	}
 
 	w.connection = conn

--- a/umh-core/pkg/fsmv2/workers/example/examplefailing/action/connect.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplefailing/action/connect.go
@@ -22,6 +22,7 @@ import (
 
 	depspkg "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
 	examplefailing "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/examplefailing"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/telemetry"
 )
 
 const ConnectActionName = "connect"
@@ -70,7 +71,7 @@ func (a *ConnectAction) Execute(ctx context.Context, depsAny any) error {
 		)
 
 		if attempts <= maxFailures {
-			logger.SentryWarn(depspkg.FeatureExamples, deps.GetHierarchyPath(), "connect_failed_simulated",
+			logger.Sentry(telemetry.Workers.Connect.FailedSimulated, depspkg.FeatureExamples, deps.GetHierarchyPath(), nil,
 				depspkg.Int("attempt", attempts),
 				depspkg.Int("max_failures", maxFailures),
 				depspkg.Int("remaining", maxFailures-attempts),

--- a/umh-core/pkg/fsmv2/workers/example/examplefailing/worker.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplefailing/worker.go
@@ -23,6 +23,7 @@ import (
 	fsmv2types "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/config"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/register"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/telemetry"
 )
 
 const workerTypeName = "examplefailing"
@@ -59,8 +60,7 @@ func NewFailingWorker(
 
 	conn, err := connectionPool.Acquire()
 	if err != nil {
-		logger.SentryWarn(deps.FeatureExamples, identity.HierarchyPath, "initial_connection_failed",
-			deps.Err(err))
+		logger.Sentry(telemetry.Workers.Connect.InitialFailed, deps.FeatureExamples, identity.HierarchyPath, err)
 	}
 
 	w.connection = conn

--- a/umh-core/pkg/fsmv2/workers/example/examplepanic/action/connect.go
+++ b/umh-core/pkg/fsmv2/workers/example/examplepanic/action/connect.go
@@ -19,6 +19,7 @@ import (
 
 	depspkg "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
 	example_panic "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/examplepanic"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/telemetry"
 )
 
 const ConnectActionName = "connect"
@@ -36,7 +37,7 @@ func (a *ConnectAction) Execute(ctx context.Context, depsAny any) error {
 	logger := deps.GetLogger()
 
 	if deps.IsShouldPanic() {
-		logger.SentryWarn(depspkg.FeatureExamples, deps.GetHierarchyPath(), "simulating_panic",
+		logger.Sentry(telemetry.Workers.Transport.SimulatingPanic, depspkg.FeatureExamples, deps.GetHierarchyPath(), nil,
 			depspkg.ActionName("connect"),
 			depspkg.Reason("should_panic_flag_set"))
 		panic("simulated panic in connect action")

--- a/umh-core/pkg/fsmv2/workers/example/exampleslow/action/connect.go
+++ b/umh-core/pkg/fsmv2/workers/example/exampleslow/action/connect.go
@@ -21,6 +21,7 @@ import (
 
 	depspkg "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
 	example_slow "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/example/exampleslow"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/telemetry"
 )
 
 const ConnectActionName = "connect"
@@ -46,7 +47,7 @@ func (a *ConnectAction) Execute(ctx context.Context, depsAny any) error {
 		case <-time.After(time.Duration(delaySeconds) * time.Second):
 			logger.Info("Connect delay completed successfully")
 		case <-ctx.Done():
-			logger.SentryWarn(depspkg.FeatureExamples, deps.GetHierarchyPath(), "connect_cancelled_during_delay",
+			logger.Sentry(telemetry.Workers.Connect.CancelledDuringDelay, depspkg.FeatureExamples, deps.GetHierarchyPath(), nil,
 				depspkg.String("reason", "context_done"),
 				depspkg.Int("delay_seconds", delaySeconds))
 

--- a/umh-core/pkg/fsmv2/workers/persistence/worker.go
+++ b/umh-core/pkg/fsmv2/workers/persistence/worker.go
@@ -28,6 +28,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/register"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/persistence/snapshot"
 	persistencepkg "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/persistence"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/telemetry"
 
 	// Blank import registers the "persistence" initial state via
 	// fsmv2.RegisterInitialState in state/state_stopped.go init().
@@ -141,8 +142,7 @@ func (w *PersistenceWorker) CollectObservedState(ctx context.Context, _ fsmv2.De
 		} else if errors.Is(err, persistencepkg.ErrNotFound) && !d.IsObservedStateLoaded() {
 			d.GetLogger().Debug("no previous observed state found, using zero-value defaults")
 		} else {
-			d.GetLogger().SentryWarn(deps.FeatureForWorker(d.GetWorkerType()), d.GetHierarchyPath(), "previous_observed_load_failed",
-				deps.Err(err),
+			d.GetLogger().Sentry(telemetry.Workers.Transport.PreviousObservedLoadFailed, deps.FeatureForWorker(d.GetWorkerType()), d.GetHierarchyPath(), err,
 				deps.String("worker_type", d.GetWorkerType()),
 				deps.String("worker_id", d.GetWorkerID()))
 		}

--- a/umh-core/pkg/fsmv2/workers/transport/action/authenticate.go
+++ b/umh-core/pkg/fsmv2/workers/transport/action/authenticate.go
@@ -24,6 +24,7 @@ import (
 	httpTransport "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/http"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/snapshot"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/types"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/telemetry"
 )
 
 const (
@@ -126,15 +127,15 @@ func (a *AuthenticateAction) Execute(ctx context.Context, depsAny any) error {
 
 		// Persistent errors get an immediate first-occurrence SentryWarn.
 		// Transient errors are silent -- the failurerate.Tracker in RecordAuthError
-		// fires SentryWarn("persistent_auth_failure") if they sustain.
+		// reports workers::auth::persistent_failure if they sustain.
 		if !errType.IsTransient() && deps.GetPersistentAuthErrorCount() == 1 {
-			deps.GetLogger().SentryWarn(depspkg.FeatureForWorker(deps.GetWorkerType()), deps.GetHierarchyPath(), "authentication_failed",
+			deps.GetLogger().Sentry(telemetry.Workers.Auth.Failed, depspkg.FeatureForWorker(deps.GetWorkerType()), deps.GetHierarchyPath(), nil,
 				depspkg.Err(err), depspkg.String("errorType", errType.String()))
 		}
 
 		// Return nil for classified TransportErrors. The state machine reads ConsecutiveErrors
 		// and LastErrorType from the snapshot for backoff decisions (StartingState.Next()).
-		// Returning nil suppresses the executor's SentryError("action_failed"), which is
+		// Returning nil suppresses the executor's supervisor::action::failed, which is
 		// appropriate because auth failures are expected business errors, not programming
 		// errors.
 		return nil
@@ -160,7 +161,7 @@ func (a *AuthenticateAction) Execute(ctx context.Context, depsAny any) error {
 		)
 		deps.SetAuthenticatedUUID(authResp.InstanceUUID)
 	} else {
-		logger.SentryWarn(depspkg.FeatureForWorker(deps.GetWorkerType()), deps.GetHierarchyPath(), "instance_uuid_missing_in_auth_response",
+		logger.Sentry(telemetry.Workers.Auth.InstanceUuidMissing, depspkg.FeatureForWorker(deps.GetWorkerType()), deps.GetHierarchyPath(), nil,
 			depspkg.String("instance_name", authResp.InstanceName),
 			depspkg.Bool("has_token", authResp.Token != ""))
 	}

--- a/umh-core/pkg/fsmv2/workers/transport/action/authenticate_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/action/authenticate_test.go
@@ -400,7 +400,7 @@ var _ = Describe("AuthenticateAction", func() {
 			err := act.Execute(ctx, dependencies)
 			Expect(err).NotTo(HaveOccurred())
 
-			// Persistent errors fire SentryWarn("authentication_failed") on first occurrence
+			// Persistent errors fire SentryWarn("workers::auth::failed") on first occurrence
 			// (persistentAuthErrorCount == 1) via the !IsTransient() guard.
 			Expect(dependencies.GetLastErrorType()).To(Equal(types.ErrorTypeInvalidToken))
 			Expect(dependencies.GetConsecutiveErrors()).To(Equal(1))
@@ -479,12 +479,12 @@ var _ = Describe("AuthenticateAction", func() {
 				err := act.Execute(ctx, spyDeps)
 				Expect(err).NotTo(HaveOccurred())
 			}
-			Expect(spy.sentryWarnMsgs).NotTo(ContainElement("persistent_auth_failure"),
+			Expect(spy.sentryWarnMsgs).NotTo(ContainElement("workers::auth::persistent_failure"),
 				"tracker should not fire before MinSamples=5")
 
 			err := act.Execute(ctx, spyDeps)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(spy.sentryWarnMsgs).To(ContainElement("persistent_auth_failure"),
+			Expect(spy.sentryWarnMsgs).To(ContainElement("workers::auth::persistent_failure"),
 				"tracker should fire persistent_auth_failure after 5 consecutive failures")
 
 			sentryCountBefore := len(spy.sentryWarnMsgs)
@@ -559,11 +559,6 @@ type spyLogger struct {
 func (s *spyLogger) Sentry(id telemetry.Identifier, _ deps.Feature, _ string, _ error, _ ...deps.Field) {
 	s.sentryWarnCount++
 	s.sentryWarnMsgs = append(s.sentryWarnMsgs, id.Tag)
-}
-
-func (s *spyLogger) SentryWarn(_ deps.Feature, _ string, msg string, _ ...deps.Field) {
-	s.sentryWarnCount++
-	s.sentryWarnMsgs = append(s.sentryWarnMsgs, msg)
 }
 
 func (s *spyLogger) With(_ ...deps.Field) deps.FSMLogger { return s }

--- a/umh-core/pkg/fsmv2/workers/transport/dependencies.go
+++ b/umh-core/pkg/fsmv2/workers/transport/dependencies.go
@@ -23,6 +23,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps/retry"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps/retry/failurerate"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/types"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/telemetry"
 )
 
 // ChildFailureRateConfig is the shared failurerate.Config for push and pull
@@ -36,7 +37,7 @@ var ChildFailureRateConfig = failurerate.Config{
 }
 
 // AuthFailureRateConfig controls when the tracker fires a one-shot
-// SentryWarn("persistent_auth_failure") during auth failure episodes.
+// workers::auth::persistent_failure during auth failure episodes.
 //
 // Because auth uses Reset() on success (not RecordOutcome(true)), the
 // window only ever contains failures during an episode. The failure rate
@@ -147,7 +148,7 @@ func (d *TransportDependencies) RecordError() {
 
 // RecordAuthError records a typed auth error and feeds the auth failure rate
 // tracker. If the tracker's one-shot fires (sustained failures crossing the
-// MinSamples threshold), a SentryWarn("persistent_auth_failure") is emitted.
+// MinSamples threshold), workers::auth::persistent_failure is reported.
 func (d *TransportDependencies) RecordAuthError(errType types.ErrorType, retryAfter time.Duration) {
 	d.RecordTypedError(errType, retryAfter)
 
@@ -158,7 +159,7 @@ func (d *TransportDependencies) RecordAuthError(errType types.ErrorType, retryAf
 	}
 
 	if d.authFailureRate.RecordOutcome(false) {
-		d.BaseDependencies.GetLogger().SentryWarn(deps.FeatureForWorker(d.GetWorkerType()), d.GetHierarchyPath(), "persistent_auth_failure",
+		d.BaseDependencies.GetLogger().Sentry(telemetry.Workers.Auth.PersistentFailure, deps.FeatureForWorker(d.GetWorkerType()), d.GetHierarchyPath(), nil,
 			deps.String("error_type", errType.String()),
 			deps.Float64("failure_rate", d.authFailureRate.FailureRate()))
 	}
@@ -247,7 +248,7 @@ func (d *TransportDependencies) GetOutboundChan() <-chan *types.UMHMessage {
 func (d *TransportDependencies) GetInboundChanStats() (capacity int, length int) {
 	provider := GetChannelProvider()
 	if provider == nil {
-		d.GetLogger().SentryWarn(deps.FeatureForWorker(d.GetWorkerType()), d.GetHierarchyPath(), "channel_provider_not_initialized",
+		d.GetLogger().Sentry(telemetry.Workers.Transport.ChannelProviderNotInitialized, deps.FeatureForWorker(d.GetWorkerType()), d.GetHierarchyPath(), nil,
 			deps.WorkerID(d.GetWorkerID()))
 
 		return 0, 0

--- a/umh-core/pkg/fsmv2/workers/transport/pull/action/pull.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/action/pull.go
@@ -23,6 +23,7 @@ import (
 	depspkg "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/pull/snapshot"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/types"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/telemetry"
 )
 
 // PullActionName identifies the pull action in FSM action results.
@@ -81,7 +82,7 @@ func (a *PullAction) Execute(ctx context.Context, depsAny any) error {
 	if len(pending) > 0 {
 		inChan := pullDeps.GetInboundChan()
 		if inChan == nil {
-			pullDeps.GetLogger().SentryWarn(depspkg.FeatureForWorker(pullDeps.GetWorkerType()), pullDeps.GetHierarchyPath(), "pull_skipped_nil_inbound_chan_pending_delivery")
+			pullDeps.GetLogger().Sentry(telemetry.Workers.Pull.SkippedNilInboundChanWithPending, depspkg.FeatureForWorker(pullDeps.GetWorkerType()), pullDeps.GetHierarchyPath(), nil)
 			pullDeps.StorePendingMessages(pending)
 
 			return nil
@@ -112,7 +113,7 @@ func (a *PullAction) Execute(ctx context.Context, depsAny any) error {
 	// Phase 2: Backpressure check
 	inChan := pullDeps.GetInboundChan()
 	if inChan == nil {
-		pullDeps.GetLogger().SentryWarn(depspkg.FeatureForWorker(pullDeps.GetWorkerType()), pullDeps.GetHierarchyPath(), "pull_skipped_nil_inbound_chan")
+		pullDeps.GetLogger().Sentry(telemetry.Workers.Pull.SkippedNilInboundChan, depspkg.FeatureForWorker(pullDeps.GetWorkerType()), pullDeps.GetHierarchyPath(), nil)
 
 		return nil
 	}
@@ -129,7 +130,7 @@ func (a *PullAction) Execute(ctx context.Context, depsAny any) error {
 	}
 
 	if shouldSkip && !wasBackpressured {
-		pullDeps.GetLogger().SentryWarn(depspkg.FeatureForWorker(pullDeps.GetWorkerType()), pullDeps.GetHierarchyPath(), "backpressure_entering",
+		pullDeps.GetLogger().Sentry(telemetry.Workers.Transport.BackpressureEntering, depspkg.FeatureForWorker(pullDeps.GetWorkerType()), pullDeps.GetHierarchyPath(), nil,
 			depspkg.Int("available", available), depspkg.Int("threshold", ExpectedBatchSize))
 		pullDeps.SetBackpressured(true)
 		metrics.SetGauge(depspkg.GaugeBackpressureActive, 1)
@@ -137,7 +138,7 @@ func (a *PullAction) Execute(ctx context.Context, depsAny any) error {
 	}
 
 	if !shouldSkip && wasBackpressured {
-		pullDeps.GetLogger().SentryWarn(depspkg.FeatureForWorker(pullDeps.GetWorkerType()), pullDeps.GetHierarchyPath(), "backpressure_exiting",
+		pullDeps.GetLogger().Sentry(telemetry.Workers.Transport.BackpressureExiting, depspkg.FeatureForWorker(pullDeps.GetWorkerType()), pullDeps.GetHierarchyPath(), nil,
 			depspkg.Int("available", available), depspkg.Int("low_water_mark", ExpectedBatchSize*LowWaterMarkMultiplier))
 		pullDeps.SetBackpressured(false)
 		metrics.SetGauge(depspkg.GaugeBackpressureActive, 0)

--- a/umh-core/pkg/fsmv2/workers/transport/pull/dependencies.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/dependencies.go
@@ -25,6 +25,7 @@ import (
 	transport_pkg "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/pull/snapshot"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/types"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/telemetry"
 )
 
 // maxPendingMessages caps the pending buffer to prevent unbounded memory growth
@@ -118,7 +119,7 @@ func (d *PullDependencies) RecordTypedError(errType types.ErrorType, retryAfter 
 			fields = append(fields, deps.String("error_detail", errorDetail))
 		}
 
-		d.BaseDependencies.GetLogger().SentryWarn(deps.FeatureForWorker(d.GetWorkerType()), d.GetHierarchyPath(), "persistent_pull_failure",
+		d.BaseDependencies.GetLogger().Sentry(telemetry.Workers.Pull.PersistentFailure, deps.FeatureForWorker(d.GetWorkerType()), d.GetHierarchyPath(), nil,
 			fields...)
 	}
 }
@@ -145,7 +146,7 @@ func (d *PullDependencies) RecordError() {
 	d.parentDeps.RecordError()
 
 	if d.failureRate.RecordOutcome(false) {
-		d.BaseDependencies.GetLogger().SentryWarn(deps.FeatureForWorker(d.GetWorkerType()), d.GetHierarchyPath(), "persistent_pull_failure",
+		d.BaseDependencies.GetLogger().Sentry(telemetry.Workers.Pull.PersistentFailure, deps.FeatureForWorker(d.GetWorkerType()), d.GetHierarchyPath(), nil,
 			deps.Float64("failure_rate", d.failureRate.FailureRate()))
 	}
 }
@@ -209,7 +210,7 @@ func (d *PullDependencies) StorePendingMessages(msgs []*types.UMHMessage) {
 	if len(d.pendingMessages) > maxPendingMessages {
 		dropped := len(d.pendingMessages) - maxPendingMessages
 		d.pendingMessages = d.pendingMessages[len(d.pendingMessages)-maxPendingMessages:]
-		d.BaseDependencies.GetLogger().SentryWarn(deps.FeatureForWorker(d.GetWorkerType()), d.GetHierarchyPath(), "pending_buffer_overflow",
+		d.BaseDependencies.GetLogger().Sentry(telemetry.Workers.Transport.PendingBufferOverflow, deps.FeatureForWorker(d.GetWorkerType()), d.GetHierarchyPath(), nil,
 			deps.Int("dropped", dropped), deps.Int("cap", maxPendingMessages))
 		d.MetricsRecorder().IncrementCounter(deps.CounterMessagesDropped, int64(dropped))
 	}

--- a/umh-core/pkg/fsmv2/workers/transport/pull/dependencies_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/dependencies_test.go
@@ -439,7 +439,7 @@ var _ = Describe("RecordTypedError status_code and error_detail emission (pull)"
 
 		m := parsePersistentPullFailureLinePull(buf)
 		Expect(m).NotTo(BeNil())
-		Expect(m["msg"]).To(Equal("persistent_pull_failure"))
+		Expect(m["msg"]).To(Equal("workers::pull::persistent_failure"))
 		Expect(m["error_type"]).To(Equal("server_error"))
 		Expect(m["failure_rate"]).To(BeNumerically(">", 0))
 		Expect(m["status_code"]).To(BeEquivalentTo(502))
@@ -460,7 +460,7 @@ var _ = Describe("RecordTypedError status_code and error_detail emission (pull)"
 
 		m := parsePersistentPullFailureLinePull(buf)
 		Expect(m).NotTo(BeNil())
-		Expect(m["msg"]).To(Equal("persistent_pull_failure"))
+		Expect(m["msg"]).To(Equal("workers::pull::persistent_failure"))
 		Expect(m["error_type"]).To(Equal("network"))
 		_, hasStatusCode := m["status_code"]
 		Expect(hasStatusCode).To(BeFalse())
@@ -490,7 +490,7 @@ func parsePersistentPullFailureLinePull(buf *bytes.Buffer) map[string]interface{
 			continue
 		}
 
-		if msg, ok := m["msg"].(string); ok && msg == "persistent_pull_failure" {
+		if msg, ok := m["msg"].(string); ok && msg == "workers::pull::persistent_failure" {
 			return m
 		}
 	}

--- a/umh-core/pkg/fsmv2/workers/transport/pull/worker.go
+++ b/umh-core/pkg/fsmv2/workers/transport/pull/worker.go
@@ -26,6 +26,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/register"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/pull/snapshot"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/pull/state"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/telemetry"
 
 	transport_pkg "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport"
 )
@@ -175,16 +176,15 @@ func init() {
 		func(id deps.Identity, logger deps.FSMLogger, sr deps.StateReader) *PullDependencies {
 			parentDeps := register.GetDeps[*transport_pkg.TransportDependencies]("transport")
 			if parentDeps == nil {
-				logger.SentryError(deps.FeatureForWorker("pull"), id.HierarchyPath,
-					errors.New("parent transport deps not published"),
-					"pull_parent_transport_deps_missing")
+				logger.Sentry(telemetry.Workers.Pull.ParentTransportDepsMissing, deps.FeatureForWorker("pull"), id.HierarchyPath,
+					errors.New("parent transport deps not published"))
 
 				return nil
 			}
 
 			d, err := NewPullDependencies(parentDeps, deps.NewBaseDependencies(logger, sr, id))
 			if err != nil {
-				logger.SentryError(deps.FeatureForWorker("pull"), id.HierarchyPath, err, "pull_dependencies_creation_failed")
+				logger.Sentry(telemetry.Workers.Pull.DependenciesCreationFailed, deps.FeatureForWorker("pull"), id.HierarchyPath, err)
 
 				return nil
 			}

--- a/umh-core/pkg/fsmv2/workers/transport/push/action/push.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/action/push.go
@@ -23,6 +23,7 @@ import (
 	depspkg "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/deps"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/push/snapshot"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/types"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/telemetry"
 )
 
 const PushActionName = "push"
@@ -253,7 +254,7 @@ func (a *PushAction) retryPending(ctx context.Context, t types.Transport, pushDe
 			// is adding the type to IsTransient() or isRecoverableByParent(),
 			// not retrying unknowns here. SentryWarn fires on every drop so
 			// a spike is visible in Sentry.
-			pushDeps.GetLogger().SentryWarn(depspkg.FeatureForWorker(pushDeps.GetWorkerType()), pushDeps.GetHierarchyPath(), "dropping_poison_message",
+			pushDeps.GetLogger().Sentry(telemetry.Workers.Transport.PoisonMessageDropped, depspkg.FeatureForWorker(pushDeps.GetWorkerType()), pushDeps.GetHierarchyPath(), nil,
 				depspkg.String("errorType", errType.String()),
 				depspkg.Err(err),
 				depspkg.Int("remaining", len(pending)-i-1))

--- a/umh-core/pkg/fsmv2/workers/transport/push/capstone_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/capstone_test.go
@@ -67,7 +67,7 @@ var _ = Describe("ENG-5275 incident reproduction (P8 capstone)", func() {
 		// Gateway" and "nginx" preserved).
 		m := parseLastJSONLine(buf)
 		Expect(m).NotTo(BeNil())
-		Expect(m["msg"]).To(Equal("persistent_push_failure"))
+		Expect(m["msg"]).To(Equal("workers::push::persistent_failure"))
 		Expect(m["status_code"]).To(BeEquivalentTo(502))
 		Expect(m["error_detail"]).To(ContainSubstring("502 Bad Gateway"))
 		Expect(m["error_detail"]).To(ContainSubstring("nginx"))

--- a/umh-core/pkg/fsmv2/workers/transport/push/dependencies.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/dependencies.go
@@ -25,6 +25,7 @@ import (
 	transport_pkg "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/push/snapshot"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/types"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/telemetry"
 )
 
 const maxPendingMessages = 1000
@@ -109,7 +110,7 @@ func (d *PushDependencies) RecordTypedError(errType types.ErrorType, retryAfter 
 			fields = append(fields, deps.String("error_detail", errorDetail))
 		}
 
-		d.BaseDependencies.GetLogger().SentryWarn(deps.FeatureForWorker(d.GetWorkerType()), d.GetHierarchyPath(), "persistent_push_failure",
+		d.BaseDependencies.GetLogger().Sentry(telemetry.Workers.Push.PersistentFailure, deps.FeatureForWorker(d.GetWorkerType()), d.GetHierarchyPath(), nil,
 			fields...)
 	}
 }
@@ -136,7 +137,7 @@ func (d *PushDependencies) RecordError() {
 	d.parentDeps.RecordError()
 
 	if d.failureRate.RecordOutcome(false) {
-		d.BaseDependencies.GetLogger().SentryWarn(deps.FeatureForWorker(d.GetWorkerType()), d.GetHierarchyPath(), "persistent_push_failure",
+		d.BaseDependencies.GetLogger().Sentry(telemetry.Workers.Push.PersistentFailure, deps.FeatureForWorker(d.GetWorkerType()), d.GetHierarchyPath(), nil,
 			deps.Float64("failure_rate", d.failureRate.FailureRate()))
 	}
 }
@@ -200,7 +201,7 @@ func (d *PushDependencies) StorePendingMessages(msgs []*types.UMHMessage) {
 	if len(d.pendingMessages) > maxPendingMessages {
 		dropped := len(d.pendingMessages) - maxPendingMessages
 		d.pendingMessages = d.pendingMessages[len(d.pendingMessages)-maxPendingMessages:]
-		d.BaseDependencies.GetLogger().SentryWarn(deps.FeatureForWorker(d.GetWorkerType()), d.GetHierarchyPath(), "pending_buffer_overflow",
+		d.BaseDependencies.GetLogger().Sentry(telemetry.Workers.Transport.PendingBufferOverflow, deps.FeatureForWorker(d.GetWorkerType()), d.GetHierarchyPath(), nil,
 			deps.Int("dropped", dropped), deps.Int("cap", maxPendingMessages))
 		d.MetricsRecorder().IncrementCounter(deps.CounterMessagesDropped, int64(dropped))
 	}

--- a/umh-core/pkg/fsmv2/workers/transport/push/dependencies_test.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/dependencies_test.go
@@ -374,7 +374,7 @@ var _ = Describe("RecordTypedError status_code and error_detail emission", func(
 		Expect(d.GetLastErrorDetail()).To(Equal(detail))
 
 		m := parseLastJSONLine(buf)
-		Expect(m["msg"]).To(Equal("persistent_push_failure"))
+		Expect(m["msg"]).To(Equal("workers::push::persistent_failure"))
 		Expect(m["status_code"]).To(BeEquivalentTo(502))
 		Expect(m["error_detail"]).To(Equal(detail))
 	})
@@ -386,7 +386,7 @@ var _ = Describe("RecordTypedError status_code and error_detail emission", func(
 
 		m := parseLastJSONLine(buf)
 		Expect(m).NotTo(BeNil())
-		Expect(m["msg"]).To(Equal("persistent_push_failure"))
+		Expect(m["msg"]).To(Equal("workers::push::persistent_failure"))
 		Expect(m["error_type"]).To(Equal("network"))
 		_, hasStatusCode := m["status_code"]
 		Expect(hasStatusCode).To(BeFalse())

--- a/umh-core/pkg/fsmv2/workers/transport/push/worker.go
+++ b/umh-core/pkg/fsmv2/workers/transport/push/worker.go
@@ -26,6 +26,7 @@ import (
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/register"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/push/snapshot"
 	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport/push/state"
+	"github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/telemetry"
 
 	transport_pkg "github.com/united-manufacturing-hub/united-manufacturing-hub/umh-core/pkg/fsmv2/workers/transport"
 )
@@ -175,16 +176,15 @@ func init() {
 		func(id deps.Identity, logger deps.FSMLogger, sr deps.StateReader) *PushDependencies {
 			parentDeps := register.GetDeps[*transport_pkg.TransportDependencies]("transport")
 			if parentDeps == nil {
-				logger.SentryError(deps.FeatureForWorker("push"), id.HierarchyPath,
-					errors.New("parent transport deps not published"),
-					"push_parent_transport_deps_missing")
+				logger.Sentry(telemetry.Workers.Push.ParentTransportDepsMissing, deps.FeatureForWorker("push"), id.HierarchyPath,
+					errors.New("parent transport deps not published"))
 
 				return nil
 			}
 
 			d, err := NewPushDependencies(parentDeps, deps.NewBaseDependencies(logger, sr, id))
 			if err != nil {
-				logger.SentryError(deps.FeatureForWorker("push"), id.HierarchyPath, err, "push_dependencies_creation_failed")
+				logger.Sentry(telemetry.Workers.Push.DependenciesCreationFailed, deps.FeatureForWorker("push"), id.HierarchyPath, err)
 
 				return nil
 			}


### PR DESCRIPTION
## Problem

The PR below this one added the registry and `FSMLogger.Sentry`, but nothing used
them: every one of the 165 call sites still passed a message string, and
`SentryWarn`/`SentryError` still existed to accept one.

## What we are shipping

- **All 165 call sites report through the registry**, so an unregistered event can
  no longer be emitted. The old two methods are gone.
- **Three names become seven.** `collector_restart_failed`,
  `desired_state_load_failed` and `shutdown_request_failed` each covered several
  conditions, so a restart on a stopped collector is now a different event from one
  that failed after exhausting its attempts. No site silently changed level.
- **The eight prose names get tags**, so `config watch: failed to read config`
  becomes `config::watch::read_failed`.

## What we are NOT shipping

- **Every alert rule and saved search keyed on `event_name` needs updating.** All
  149 names change and each existing issue's history is orphaned under its old name.
  Unavoidable once the names change, and not something to do halfway.
- **Three call sites do change level**, because the names they shared covered
  different conditions. Called out above.
- `cpu::startup::snapshot_failed` exists only for a call that PR #2744 removes. It
  can go once that merges.

## Reading order

One converted call site, then skim. The message argument became the identifier and
moved to the front, the error moved to fourth, and `deps.Err(err)` passed as a field
became the cause. The compiler checked the other 164. The two interesting ones are
`supervisor/reconciliation.go`'s `logFreshnessWarning` and `lifecycle.go`'s drain
loop, where a computed message became a choice between two identifiers.
